### PR TITLE
[TRTLLM-6756][feat] Add Beam Search to TorchSampler

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -436,6 +436,7 @@ def create_autodeploy_executor(ad_config: LlmArgs, tokenizer: Optional[Tokenizer
         max_total_draft_tokens=max_total_draft_tokens,
         max_num_sequences=max_num_sequences,
         max_beam_width=ad_config.max_beam_width,
+        disable_overlap_scheduler=ad_config.disable_overlap_scheduler,
     )
     sampler = TorchSampler(sampler_args)
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -827,7 +827,7 @@ def create_py_executor_instance(
 def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
                               max_batch_size: int,
                               speculative_config: SpeculativeConfig,
-                              max_beam_width: int,
+                              max_beam_width: int, use_overlap_scheduler: bool,
                               disable_flashinfer_sampling: bool):
     max_num_sequences = max_batch_size * mapping.pp_size
     max_draft_len = (0 if speculative_config is None else
@@ -835,14 +835,13 @@ def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
     max_total_draft_tokens = (0 if speculative_config is None else
                               speculative_config.max_total_draft_tokens)
 
-    return TorchSampler.Args(
-        max_seq_len=max_seq_len,
-        max_draft_len=max_draft_len,
-        max_total_draft_tokens=max_total_draft_tokens,
-        max_num_sequences=max_num_sequences,
-        max_beam_width=max_beam_width,
+    return TorchSampler.Args(max_seq_len=max_seq_len,
+                             max_draft_len=max_draft_len,
+                             max_total_draft_tokens=max_total_draft_tokens,
+                             max_num_sequences=max_num_sequences,
+                             max_beam_width=max_beam_width,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
-    )
+                             use_overlap_scheduler=use_overlap_scheduler)
 
 
 def instantiate_sampler(
@@ -865,6 +864,8 @@ def instantiate_sampler(
         max_batch_size=max_batch_size,
         speculative_config=speculative_config,
         max_beam_width=max_beam_width,
+        use_overlap_scheduler=not pytorch_backend_config.
+        disable_overlap_scheduler,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
     )
     decoding_mode = get_decoding_mode(decoding_config=decoding_config,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -824,11 +824,15 @@ def create_py_executor_instance(
         virtual_memory_pools=virtual_memory_pools)
 
 
-def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
-                              max_batch_size: int,
-                              speculative_config: SpeculativeConfig,
-                              max_beam_width: int, use_overlap_scheduler: bool,
-                              disable_flashinfer_sampling: bool):
+def create_torch_sampler_args(
+    mapping: Mapping,
+    *,
+    max_seq_len: int,
+    max_batch_size: int,
+    speculative_config: SpeculativeConfig,
+    max_beam_width: int,
+    use_overlap_scheduler: bool,
+    disable_flashinfer_sampling: bool):
     max_num_sequences = max_batch_size * mapping.pp_size
     max_draft_len = (0 if speculative_config is None else
                      speculative_config.max_draft_len)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -832,7 +832,8 @@ def create_torch_sampler_args(
     speculative_config: SpeculativeConfig,
     max_beam_width: int,
     disable_overlap_scheduler: bool,
-    disable_flashinfer_sampling: bool):
+    disable_flashinfer_sampling: bool,
+):
     max_num_sequences = max_batch_size * mapping.pp_size
     max_draft_len = (0 if speculative_config is None else
                      speculative_config.max_draft_len)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -869,8 +869,7 @@ def instantiate_sampler(
         max_batch_size=max_batch_size,
         speculative_config=speculative_config,
         max_beam_width=max_beam_width,
-        disable_overlap_scheduler=pytorch_backend_config.
-        disable_overlap_scheduler,
+        disable_overlap_scheduler=llm_args.disable_overlap_scheduler,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
     )
     decoding_mode = get_decoding_mode(decoding_config=decoding_config,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -831,7 +831,7 @@ def create_torch_sampler_args(
     max_batch_size: int,
     speculative_config: SpeculativeConfig,
     max_beam_width: int,
-    use_overlap_scheduler: bool,
+    disable_overlap_scheduler: bool,
     disable_flashinfer_sampling: bool):
     max_num_sequences = max_batch_size * mapping.pp_size
     max_draft_len = (0 if speculative_config is None else
@@ -839,13 +839,14 @@ def create_torch_sampler_args(
     max_total_draft_tokens = (0 if speculative_config is None else
                               speculative_config.max_total_draft_tokens)
 
-    return TorchSampler.Args(max_seq_len=max_seq_len,
-                             max_draft_len=max_draft_len,
-                             max_total_draft_tokens=max_total_draft_tokens,
-                             max_num_sequences=max_num_sequences,
-                             max_beam_width=max_beam_width,
+    return TorchSampler.Args(
+        max_seq_len=max_seq_len,
+        max_draft_len=max_draft_len,
+        max_total_draft_tokens=max_total_draft_tokens,
+        max_num_sequences=max_num_sequences,
+        max_beam_width=max_beam_width,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
-                             use_overlap_scheduler=use_overlap_scheduler)
+        disable_overlap_scheduler=disable_overlap_scheduler)
 
 
 def instantiate_sampler(
@@ -868,7 +869,7 @@ def instantiate_sampler(
         max_batch_size=max_batch_size,
         speculative_config=speculative_config,
         max_beam_width=max_beam_width,
-        use_overlap_scheduler=not pytorch_backend_config.
+        disable_overlap_scheduler=pytorch_backend_config.
         disable_overlap_scheduler,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
     )

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -198,9 +198,16 @@ class SampleStateWithMMResult:
     data: MultimodalResult
 
 
-class RequestGroupKey(Generic[GenericStrategyKeyType], NamedTuple):
+@dataclass(kw_only=True, frozen=True)
+class RequestGroupKey(Generic[GenericStrategyKeyType]):
     strategy: GenericStrategyKeyType
     speculation_needs_probs: bool
+
+    def __iter__(self):
+        return iter((self.strategy, self.speculation_needs_probs))
+
+    def __len__(self):
+        return 2
 
 
 class RequestGroupValue(NamedTuple):

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -43,23 +43,9 @@ BeamSearchForPrefill: TypeAlias = tuple[Literal["beam_search_for_prefill"], int,
 BeamSearch: TypeAlias = tuple[Literal["beam_search"], int, float]
 GREEDY: Greedy = ("greedy", None)
 
-Strategy: TypeAlias = TopK | TopP | Greedy | TopKTopP | TemperatureOnly | BeamSearchForPrefill | BeamSearch
-
-
-@dataclass(kw_only=True)
-class StrategyMetadata:
-    pass
-
-
-@dataclass(kw_only=True)
-class BeamSearchMetadata(StrategyMetadata):
-    cache_indirection: torch.Tensor
-    cache_indirection_buffer: torch.Tensor
-    cum_log_probs: torch.Tensor
-    seq_slots: torch.Tensor
-    seq_lens: torch.Tensor
-    finished_beams: torch.Tensor
-    end_ids: torch.Tensor
+Strategy: TypeAlias = (
+    TopK | TopP | Greedy | TopKTopP | TemperatureOnly | BeamSearchForPrefill | BeamSearch
+)
 
 
 @dataclass(kw_only=True)

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
@@ -35,6 +35,7 @@ from .sampling_utils import (
     GREEDY,
     GroupedStrategySampler,
     Strategy,
+    StrategyMetadata,
     TemperatureOnly,
     TopK,
     TopKTopP,
@@ -598,6 +599,7 @@ class FlashInferGroupedStrategySampler(GroupedStrategySampler[Type[_StrategyImpl
         group_logit_indices: Optional[torch.Tensor] = None,
         generator: Optional[torch.Generator] = None,
         return_probs: bool,
+        group_metadata: StrategyMetadata | None = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         if group_logit_indices is None:
             assert logits.size(0) == len(strategies)

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -237,6 +237,7 @@ class MTPSampler(TorchSampler):
         seq_slots = args.max_num_sequences
         max_tokens = args.max_total_draft_tokens + 1
         self.max_beam_width = args.max_beam_width
+        assert self.max_beam_width == 1, "beam width must be 1 for MTP"
 
         self.store = self.Store(
             new_tokens=int_tensor((max_tokens, seq_slots, self.max_beam_width)),

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -13,7 +13,7 @@ from ..model_config import ModelConfig
 from ..pyexecutor.guided_decoder import CapturableGuidedDecoder
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import BaseResourceManager, SlotManager
-from ..pyexecutor.sampler import (BEAM, MAX_BEAM_WIDTH, SampleState,
+from ..pyexecutor.sampler import (DEFAULT_BEAM_IDX, SampleState,
                                   SampleStateTensors, TorchSampler, add_token,
                                   int_tensor)
 from ..pyexecutor.scheduler import ScheduledRequests
@@ -236,10 +236,11 @@ class MTPSampler(TorchSampler):
 
         seq_slots = args.max_num_sequences
         max_tokens = args.max_total_draft_tokens + 1
+        max_beam_width = args.max_beam_width
 
         self.store = self.Store(
-            new_tokens=int_tensor((max_tokens, seq_slots, MAX_BEAM_WIDTH)),
-            next_new_tokens=int_tensor((max_tokens, seq_slots, MAX_BEAM_WIDTH)),
+            new_tokens=int_tensor((max_tokens, seq_slots, max_beam_width)),
+            next_new_tokens=int_tensor((max_tokens, seq_slots, max_beam_width)),
             next_draft_tokens=int_tensor(
                 (seq_slots, args.max_total_draft_tokens)),
             new_tokens_lens=int_tensor((seq_slots, )),
@@ -266,7 +267,7 @@ class MTPSampler(TorchSampler):
         new_tokens = state.host.new_tokens.tolist()
         new_tokens_lens_list = state.host.new_tokens_lens.tolist()
         next_draft_tokens_list = state.host.next_draft_tokens.tolist()
-        beam_idx = BEAM
+        beam_idx = DEFAULT_BEAM_IDX
         for req in state.scheduled_requests.context_requests:
             if req.state == LlmRequestState.GENERATION_COMPLETE or req.context_remaining_length != 0:
                 continue

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -126,8 +126,8 @@ def check_logprobs(beam: CompletionOutput, sampling_params: SamplingParams,
             beam.logprobs
         ) == generated_tokens, f"expected {generated_tokens} logprobs, but got {len(beam.logprobs)}"
         log_sum = 0.0
-        for seq_idx, logprob_dict in enumerate(beam.logprobs):
-            for logprob_idx, logprob_value in logprob_dict.items():
+        for logprob_dict in (beam.logprobs):
+            for logprob_value in logprob_dict.values():
                 log_sum += logprob_value.logprob
         assert log_sum == beam.cumulative_logprob, f"expected {beam.cumulative_logprob} logprob, but got {log_sum}"
     else:
@@ -233,7 +233,9 @@ def validate_outputs(llm: LLM, input_prompts: list[list[int]],
         validate_output(output, input_prompts[output_idx], sampling_params)
 
 
+###########################################################################
 # End to end tests
+###########################################################################
 
 
 @pytest.mark.parametrize("return_log_probs", [True, False])
@@ -422,7 +424,8 @@ def test_beam_search_sampling_batch_basic():
     # Run beam search sampling
     next_tokens, softmax = beam_search_sampling_batch(
         logits=logits,
-        beam_width=beam_width,
+        beam_width_in=beam_width,
+        beam_width_out=beam_width,
         beam_search_args=beam_search_args,
         temperature=temperature,
         generator=None,
@@ -612,7 +615,7 @@ def test_create_beam_history():
         0,
         vocab_size,
         (beam_width, num_generated_tokens, original_logprobs.shape[-1]),
-        dtype=torch.float32)
+        dtype=torch.int32)
     assert (original_logprobs != 0).sum(
     ) > 0, "Original log probs must not only contain zeros. Otherwise change the seed."
     assert (original_logprob_indices).sum(

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -13,251 +13,29 @@
 # limitations under the License.
 
 import pathlib as _pl
-from typing import Any
 
 import pytest
 import torch
-from transformers.configuration_utils import PretrainedConfig
+from test_beam_search_util import (BeamSearchTestOutput, DummyConfigLoader,
+                                   DummyWeightLoader, get_expected_outputs)
 from utils.llm_data import llm_models_root
 from utils.util import force_ampere
 
 from tensorrt_llm import LLM, SamplingParams
-from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
 from tensorrt_llm._torch.models.checkpoints import HfCheckpointLoader
-from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
-    BaseConfigLoader
-from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
-    BaseWeightLoader
-from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
-    BaseWeightMapper
-from tensorrt_llm._torch.models.modeling_utils import (
-    ModelConfig, register_auto_model, register_checkpoint_weight_loader,
-    register_config_loader)
+from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
+                                                        SamplingConfig)
+from tensorrt_llm._torch.pyexecutor.sampler import TorchSampler
+from tensorrt_llm._torch.pyexecutor.sampling_utils import (
+    BeamSearchMetadata, beam_search_sampling_batch)
 from tensorrt_llm.executor import RequestError
 from tensorrt_llm.executor.result import CompletionOutput, GenerationResult
 from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig
 
 
-# Define a dummy model to create deterministic outputs for the test
-class DummyConfig(PretrainedConfig):
-
-    def __init__(self):
-        self.architectures: list[str] = ["DummyModel"]
-        self.torch_dtype: torch.dtype = torch.float16
-        self.num_key_value_heads: int = 16
-        self.num_attention_heads: int = 16
-        self.hidden_size: int = 256
-        self.vocab_size: int = 1000
-        self.num_hidden_layers: int = 1
-
-    @property
-    def head_dim(self) -> int:
-        return self.hidden_size // self.num_attention_heads
-
-
-@register_auto_model("DummyModel")
-class DummyModel(torch.nn.Module):
-
-    def __init__(self, model_config: ModelConfig):
-        super().__init__()
-        self.dtype = model_config.pretrained_config.torch_dtype
-        self.model_config = model_config
-
-    def infer_max_seq_len(self):
-        return 2048
-
-    @property
-    def config(self):
-        return self.model_config.pretrained_config
-
-    def forward(self,
-                *args,
-                input_ids: torch.Tensor,
-                position_ids: torch.Tensor,
-                attn_metadata: AttentionMetadata,
-                return_context_logits: bool = False,
-                **kwargs) -> torch.Tensor:
-        num_batch_tokens = input_ids.size(0)
-
-        vocab_size = self.config.vocab_size
-        last_tokens = torch.cumsum(
-            attn_metadata.seq_lens_cuda,
-            dim=0,
-            dtype=torch.long,
-        ) - 1
-
-        # Logits: fixed values for testing
-        logits = torch.zeros((num_batch_tokens, vocab_size), device='cuda')
-        indices = torch.arange(num_batch_tokens, device='cuda')
-
-        # multiply the scores with input_ids to prevent paths like AB and BA to have the same score.
-        # Score the next 4 tokens starting from the current input token.
-        logits[indices, input_ids % vocab_size] += 0.1 * input_ids
-        logits[indices, (input_ids + 1) % vocab_size] += 0.2 * input_ids
-        logits[indices, (input_ids + 2) % vocab_size] += 0.3 * input_ids
-        logits[indices, (input_ids + 3) % vocab_size] += 0.4 * input_ids
-
-        # Logits shape depends on return_context_logits flag
-        if not return_context_logits:
-            # For context logits, return logits for all positions
-            logits = logits[last_tokens]
-
-        num_context_requests = attn_metadata.num_contexts
-        # each beam has its own attn_metadata.seq_lens_cuda entry
-        num_generation_requests = (last_tokens.shape[0] - num_context_requests
-                                   ) // attn_metadata.beam_width
-        num_requests = num_generation_requests + num_context_requests
-
-        # return cache indirection, as additional model output.
-        # each sequence should only return a 1D cache indirection tensor
-        context_cache_indirection = attn_metadata.cache_indirection[:
-                                                                    num_context_requests,
-                                                                    0]
-        generation_cache_indirection = attn_metadata.cache_indirection[
-            num_context_requests:num_requests].view(
-                num_generation_requests * attn_metadata.beam_width,
-                attn_metadata.cache_indirection.shape[-1])
-        return {
-            "logits":
-            logits,
-            "cache_indirection":
-            torch.cat([context_cache_indirection, generation_cache_indirection],
-                      dim=0),
-        }
-
-    def load_weights(self,
-                     weights: dict,
-                     weight_mapper: BaseWeightMapper | None = None,
-                     skip_modules: list[str] = []):
-        pass
-
-
-@register_checkpoint_weight_loader("DUMMY_FORMAT")
-class DummyWeightLoader(BaseWeightLoader):
-
-    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
-        """Load weights from your dummy format.
-        Args:
-            checkpoint_dir: Directory containing checkpoint files
-            **kwargs: Additional loading parameters
-        Returns:
-            Dictionary mapping parameter names to tensors
-        """
-        weights = {}
-
-        return weights
-
-
-@register_config_loader("DUMMY_FORMAT")
-class DummyConfigLoader(BaseConfigLoader):
-
-    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
-        """Load and parse configuration from your dummy format.
-        Args:
-            checkpoint_dir: Directory containing configuration files
-            **kwargs: Additional loading parameters
-        Returns:
-            ModelConfig object containing parsed configuration
-        """
-        return ModelConfig(pretrained_config=DummyConfig())
-
-
 @pytest.fixture(scope="module")
 def input_prompts():
     return [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-
-class BeamSearchTestOutput:
-
-    def __init__(self, outputs: torch.Tensor, cache_indirection: torch.Tensor):
-        self.outputs = outputs
-        self.cache_indirection = cache_indirection
-
-
-def get_expected_outputs(start_token: int,
-                         num_iterations: int = 4,
-                         vocab_size: int = 1000) -> BeamSearchTestOutput:
-    """Get the expected outputs for the given start token, number of iterations, vocabulary size
-       This function only works for a beam width of 2.
-
-       arguments:
-       - start_token: the token to start the generation from. This is the last token of the input prompt.
-       - num_iterations: the number of iterations to generate
-       - vocab_size: the size of the vocabulary
-       returns:
-       - BeamSearchTestOutput: a named tuple containing the expected outputs and cache indirection
-           - expected_outputs: the expected outputs for the given start token, number of iterations, vocabulary size
-           - expected_cache_indirection: the expected cache indirection for the given start token, number of iterations, vocabulary size
-    """
-    expected_outputs = []
-    expected_cache_indirection = []
-
-    # These scores are deterministically set to the 4 tokens following the current input token (see model forward pass)
-    base_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
-    # extend the base scores to the full vocabulary size to calculate the correct softmax scores
-    full_scores = torch.zeros(vocab_size)
-    full_scores[:base_scores.shape[0]] = base_scores
-
-    # calculate the softmax scores for the first token
-    softmax_score = torch.log_softmax(full_scores * start_token, dim=-1)
-    # get the top 2 offsets => these will become beam 0 and beam 1
-    # The base scores are at the start of the full scores. So we can use their index as offset.
-    top_offset, second_best_offset = torch.topk(softmax_score, k=2,
-                                                dim=-1).indices
-
-    # First iteration
-    expected_outputs = [[start_token + top_offset],
-                        [start_token + second_best_offset]]
-    expected_cache_indirection = [[0], [1]]
-    beam_scores = [softmax_score[top_offset], softmax_score[second_best_offset]]
-
-    for i in range(1, num_iterations):
-        # calculate the softmax scores for the next token
-        softmax_score_0 = torch.log_softmax(full_scores *
-                                            expected_outputs[0][-1],
-                                            dim=-1)
-        softmax_score_1 = torch.log_softmax(full_scores *
-                                            expected_outputs[1][-1],
-                                            dim=-1)
-
-        # For the given setup: Beam 0 will always select the highest scoring token, which is at offset 3.
-        # naming: score_<beam_id><offset>
-        score_03 = softmax_score_0[top_offset] + beam_scores[0]
-
-        # beam 1 will either select the highest scoring token of beam 1, or the second highest scoring token of beam 0.
-        score_02 = softmax_score_0[second_best_offset] + beam_scores[0]
-        score_13 = softmax_score_1[top_offset] + beam_scores[1]
-
-        # This should always be true
-        assert score_03 >= score_13
-        # If beam 1 selects the highest scoring token of beam 1, we update the beam scores and cache indirection
-        if score_13 >= score_02:
-            expected_outputs[1].append(expected_outputs[1][-1] + top_offset)
-            beam_scores[1] = score_13
-        else:
-            # Beam 1 drops its old beam and changes to beam 0 and selects the second highest scoring token of beam 0.
-            for j in range(i):
-                expected_outputs[1][j] = expected_outputs[0][j]
-                if i < num_iterations - 1:
-                    # Avoid swapping in the last iteration, as the cache indirection provided by the model is returned before this change.
-                    expected_cache_indirection[1][
-                        j] = expected_cache_indirection[0][j]
-            expected_outputs[1].append(expected_outputs[0][-1] +
-                                       second_best_offset)
-            beam_scores[1] = score_02
-
-        # Update Beam 0
-        beam_scores[0] = score_03
-        expected_outputs[0].append(expected_outputs[0][-1] + top_offset)
-
-        # Update cache indirection if necessary
-        if i < num_iterations - 1:
-            expected_cache_indirection[0].append(0)
-            expected_cache_indirection[1].append(1)
-
-    return BeamSearchTestOutput(
-        outputs=torch.tensor(expected_outputs),
-        cache_indirection=torch.tensor(expected_cache_indirection))
 
 
 @pytest.fixture(scope="module")
@@ -318,7 +96,10 @@ def llm_cuda_graph(fixed_params, input_prompts, sampler_type, model_kwargs):
         disable_overlap_scheduler=False,
         cuda_graph_config=CudaGraphConfig(batch_sizes=[1, 2, 4, 8],
                                           enable_padding=True),
+        sampler_type=sampler_type,
     )
+    yield llm
+    llm.shutdown()
 
 
 def check_generation_logits(beam: CompletionOutput,
@@ -432,17 +213,25 @@ def validate_outputs(llm: LLM, input_prompts: list[list[int]],
         validate_output(output, input_prompts[output_idx], sampling_params)
 
 
+# End to end tests
+
+
 @pytest.mark.parametrize("return_log_probs", [True, False])
 @pytest.mark.parametrize("gather_generation_logits", [True, False])
 @pytest.mark.parametrize("gather_context_logits", [True, False])
 @pytest.mark.parametrize("num_output_beams", [1, 2])
 @pytest.mark.parametrize("num_prompts", [1, 2])
 @pytest.mark.threadleak(enabled=False)
-def test_beam_search_output_shapes(gather_context_logits: bool,
-                                   gather_generation_logits: bool,
-                                   return_log_probs: bool,
-                                   num_output_beams: int, num_prompts: int, llm,
-                                   fixed_params, input_prompts) -> None:
+def test_beam_search_e2e(
+    gather_context_logits: bool,
+    gather_generation_logits: bool,
+    return_log_probs: bool,
+    num_output_beams: int,
+    num_prompts: int,
+    llm,
+    fixed_params,
+    input_prompts,
+) -> None:
     if return_log_probs and num_prompts > 1 and llm.args.sampler_type == "TRTLLMSampler":
         pytest.skip(
             "Beam search currently does not support return_log_probs with multiple prompts"
@@ -470,10 +259,16 @@ def test_beam_search_output_shapes(gather_context_logits: bool,
 @pytest.mark.parametrize("num_output_beams", [1, 2])
 @pytest.mark.parametrize("num_prompts", [1, 2, 3])
 @pytest.mark.threadleak(enabled=False)
-def test_beam_search_output_shapes_cuda_graph_and_overlap(
-        gather_context_logits: bool, gather_generation_logits: bool,
-        return_log_probs: bool, num_output_beams: int, num_prompts: int,
-        llm_cuda_graph, fixed_params, input_prompts) -> None:
+def test_beam_search_e2e_cuda_graph_and_overlap(
+    gather_context_logits: bool,
+    gather_generation_logits: bool,
+    return_log_probs: bool,
+    num_output_beams: int,
+    num_prompts: int,
+    llm_cuda_graph,
+    fixed_params,
+    input_prompts,
+) -> None:
     if return_log_probs and num_prompts > 1 and llm_cuda_graph.args.sampler_type == "TRTLLMSampler":
         pytest.skip(
             "Beam search currently does not support return_log_probs with multiple prompts"
@@ -493,6 +288,391 @@ def test_beam_search_output_shapes_cuda_graph_and_overlap(
     )
     validate_outputs(llm_cuda_graph, input_prompts[:num_prompts],
                      sampling_params)
+
+
+# Unit tests
+class GeneralTestParams:
+    # Test Parameters for the update_beam_history and finish_beams tests
+    beam_width = 3
+    max_beam_width = 4
+    max_batch_size = 5
+    max_seq_len = 123
+    input_tokens = [20, 21, 22, 23, 24]
+    prompt_len = len(input_tokens)
+    num_generated_tokens = 5
+    seq_len = prompt_len + num_generated_tokens
+    num_logprobs = 1
+    seq_slot = 4
+    end_id = 99
+    batch_size = 2
+    vocab_size = 100
+
+
+def test_beam_search_sampling_batch_basic():
+    """Test basic beam search sampling functionality."""
+
+    test_params = GeneralTestParams()
+    batch_size = test_params.batch_size
+    beam_width = test_params.beam_width
+    vocab_size = test_params.vocab_size
+    max_batch_size = test_params.max_batch_size
+    seq_len = test_params.seq_len
+    temperature = 1.0
+
+    # Create logits: [batch_size * beam_width, vocab_size]
+    torch.manual_seed(42)
+    logits = torch.randn((batch_size * beam_width, vocab_size),
+                         dtype=torch.float32)
+    for entry in range(batch_size * beam_width):
+        assert (logits[entry] != logits[entry, 0]).sum(
+        ) > 0, "Logits of a sequence must not only contain the same value. Otherwise change the seed."
+
+    # get the top tokens and beams for each request
+    logprobs = torch.log_softmax(logits, dim=-1)
+    logprobs = logprobs.view(batch_size, beam_width * vocab_size)
+    top_values, top_indices = torch.topk(logprobs,
+                                         k=beam_width,
+                                         dim=-1,
+                                         sorted=True)
+
+    top_tokens = top_indices % vocab_size
+    top_beams = top_indices // vocab_size
+
+    # create a randomly filled cache indirection
+    cache_indirection = torch.randint(0,
+                                      beam_width,
+                                      (max_batch_size, beam_width, seq_len),
+                                      dtype=torch.int32)
+    assert cache_indirection.sum(
+    ) > 0, "Cache indirection must not only contain zeros. Otherwise change the seed."
+    # create a result tensor for the cache indirection that will be updated by the beam search sampling
+    cache_indirection_result = cache_indirection.clone()
+    # Fill this buffer with invalid values
+    cache_indirection_buffer = torch.full((max_batch_size, beam_width, seq_len),
+                                          -1,
+                                          dtype=torch.int32)
+
+    # create a zero filled cumulative log probs
+    cum_log_probs = torch.zeros((max_batch_size, beam_width),
+                                dtype=torch.float32)
+    # create a result tensor for the cumulative log probs that will be updated by the beam search sampling
+    cum_log_probs_result = cum_log_probs.clone()
+
+    # add an offset, so that seq slots is not just the first few entries
+    seq_slots = torch.arange(
+        batch_size, dtype=torch.int64) + (max_batch_size - batch_size) // 2
+    seq_lens = torch.full((batch_size, ), seq_len, dtype=torch.int32)
+
+    finished_beams = torch.zeros((max_batch_size, beam_width),
+                                 dtype=torch.int32)
+    finished_beams_result = finished_beams.clone()
+    end_ids = torch.tensor([vocab_size - 1] * batch_size, dtype=torch.int32)
+
+    # Create BeamSearchMetadata
+    beam_search_args = BeamSearchMetadata(
+        cache_indirection=cache_indirection_result,
+        cache_indirection_buffer=cache_indirection_buffer,
+        cum_log_probs=cum_log_probs_result,
+        seq_slots=seq_slots,
+        seq_lens=seq_lens,
+        finished_beams=finished_beams_result,
+        end_ids=end_ids,
+    )
+
+    # Run beam search sampling
+    next_tokens, softmax = beam_search_sampling_batch(
+        logits=logits,
+        beam_width=beam_width,
+        beam_search_args=beam_search_args,
+        temperature=temperature,
+        generator=None,
+        return_probs=True,
+    )
+
+    # Validate output shapes
+    expected_tokens_shape = (batch_size, beam_width)
+    assert next_tokens.shape == expected_tokens_shape, (
+        f"Expected shape {expected_tokens_shape}, got {next_tokens.shape}")
+    expected_softmax_shape = (batch_size, beam_width, vocab_size)
+    assert softmax.shape == expected_softmax_shape, (
+        f"Expected shape {expected_softmax_shape}, got {softmax.shape}")
+
+    # Validate tokens are within vocab range
+    assert torch.all(next_tokens >= 0) and torch.all(
+        next_tokens < vocab_size), "Tokens out of vocab range"
+
+    # Validate softmax probabilities sum to 1
+    torch.testing.assert_close(softmax.sum(dim=-1),
+                               torch.ones(batch_size, beam_width))
+
+    # Validate cache indirection was updated
+    for req_idx, seq_slot in enumerate(seq_slots):
+        for beam_idx in range(beam_width):
+            ideal_beam = top_beams[req_idx][beam_idx]
+            torch.testing.assert_close(
+                cache_indirection_result[seq_slot, beam_idx, :seq_len],
+                cache_indirection[seq_slot, ideal_beam, :seq_len])
+    # Validate cache indirection buffer was updated
+    for req_idx, seq_slot in enumerate(seq_slots):
+        for beam_idx in range(beam_width):
+            torch.testing.assert_close(
+                cache_indirection_buffer[seq_slot, beam_idx, :],
+                cache_indirection[seq_slot, beam_idx, :])
+    # Validate cumulative log probs were updated
+    for req_idx, seq_slot in enumerate(seq_slots):
+        for beam_idx in range(beam_width):
+            predecessor_beam = top_beams[req_idx][beam_idx]
+            old_scores = cum_log_probs[seq_slot, predecessor_beam]
+            new_scores = cum_log_probs_result[seq_slot, beam_idx]
+            torch.testing.assert_close(
+                new_scores, old_scores + torch.log_softmax(
+                    logits[req_idx * beam_width + predecessor_beam],
+                    dim=-1)[top_tokens[req_idx][beam_idx]])
+    # Validate finished beams were updated: TODO -- This test currently always passes, as finished beams is always 0.
+    for req_idx, seq_slot in enumerate(seq_slots):
+        for beam_idx in range(beam_width):
+            predecessor_beam = top_beams[req_idx][beam_idx]
+            torch.testing.assert_close(
+                finished_beams_result[seq_slot, beam_idx],
+                finished_beams[seq_slot, predecessor_beam])
+
+
+def get_default_request(test_params: GeneralTestParams) -> LlmRequest:
+    sampling_params = SamplingParams(n=test_params.beam_width,
+                                     best_of=test_params.beam_width,
+                                     use_beam_search=True)
+    return LlmRequest(request_id=0,
+                      seq_slot=test_params.seq_slot,
+                      max_new_tokens=test_params.num_generated_tokens,
+                      input_tokens=test_params.input_tokens,
+                      end_id=test_params.end_id,
+                      sampling_config=SamplingConfig(
+                          sampling_params._get_sampling_config()),
+                      return_log_probs=test_params.num_logprobs > 0,
+                      num_logprobs=test_params.num_logprobs,
+                      is_streaming=False)
+
+
+def get_default_sampler(test_params: GeneralTestParams) -> TorchSampler:
+    sampler = TorchSampler(
+        TorchSampler.Args(
+            max_seq_len=test_params.max_seq_len,
+            max_draft_len=0,
+            max_num_sequences=test_params.max_batch_size,
+            max_beam_width=test_params.max_beam_width,
+            max_total_draft_tokens=0,
+            disable_overlap_scheduler=True,
+        ))
+    max_beam_width = sampler.max_beam_width
+    max_seq_len = sampler.max_seq_len
+    max_batch_size = sampler.max_num_sequences
+
+    # perform assertion tests for the selected parameter
+    assert max_beam_width > test_params.beam_width, "Max beam width must be greater than beam width"
+    assert max_seq_len > test_params.seq_len, "Max sequence length must be greater than sequence length"
+    assert max_batch_size > test_params.batch_size, "Max batch size must be greater than batch size"
+    assert max_batch_size > test_params.seq_slot, "Max batch size must be greater than sequence slot"
+    assert sampler.store.cache_indirection.shape == (
+        max_batch_size, max_beam_width,
+        max_seq_len), "Cache indirection shape mismatch"
+    assert sampler.store.original_tokens.shape == (
+        max_batch_size, max_beam_width,
+        max_seq_len), "Original tokens shape mismatch"
+    return sampler
+
+
+def test_create_beam_history():
+    """Test TorchSampler._create_beam_history method.
+
+    This test verifies that beam history is correctly reconstructed by following
+    the cache_indirection backwards to obtain the correct token sequence.
+    """
+    test_params = GeneralTestParams()
+    request = get_default_request(test_params)
+    sampler = get_default_sampler(test_params)
+
+    # Extract parameters from the test parameters
+    beam_width = test_params.beam_width
+    prompt_len = test_params.prompt_len
+    num_generated_tokens = test_params.num_generated_tokens
+    seq_slot = test_params.seq_slot
+    vocab_size = test_params.vocab_size
+    num_logprobs = test_params.num_logprobs
+    cache_indirection = sampler.store.cache_indirection
+    original_tokens = sampler.store.original_tokens
+    original_logprobs = torch.zeros(
+        (beam_width, num_generated_tokens, num_logprobs),
+        dtype=torch.float32,
+        device=original_tokens.device)
+    original_logprob_indices = torch.zeros(
+        (beam_width, num_generated_tokens, num_logprobs),
+        dtype=torch.int32,
+        device=original_tokens.device)
+    original_cum_logprobs = sampler.store.cum_log_probs
+
+    # Fill the request with some random tokens that will be overwritten by the beam search sampling
+    request.set_generated_tokens(
+        torch.randint(0,
+                      vocab_size, (beam_width, num_generated_tokens),
+                      dtype=torch.int32).tolist())
+    # random fill
+    torch.manual_seed(42)
+    original_tokens[seq_slot, :beam_width, prompt_len:prompt_len +
+                    num_generated_tokens] = torch.randint(
+                        0,
+                        beam_width, (beam_width, num_generated_tokens),
+                        dtype=torch.int32)
+    assert original_tokens.sum(
+    ) > 0, "Original tokens must not only contain zeros. Otherwise change the seed."
+
+    original_logprobs[:beam_width] = torch.randn(
+        (beam_width, num_generated_tokens, original_logprobs.shape[-1]),
+        dtype=torch.float32)
+    original_logprob_indices[:beam_width] = torch.randint(
+        0,
+        vocab_size,
+        (beam_width, num_generated_tokens, original_logprobs.shape[-1]),
+        dtype=torch.float32)
+    assert (original_logprobs != 0).sum(
+    ) > 0, "Original log probs must not only contain zeros. Otherwise change the seed."
+    assert (original_logprob_indices).sum(
+    ) > 0, "Original log prob indices must not only contain zeros. Otherwise change the seed."
+
+    # set the logprobs in the request:
+    token_logprobs = sampler._convert_logprobs_tensor_to_list(
+        original_logprob_indices[:beam_width], original_logprobs[:beam_width])
+    request.py_result.set_log_probs(
+        token_logprobs,
+        cum_log_probs=torch.zeros_like(
+            original_cum_logprobs[seq_slot, :beam_width]).tolist())
+
+    original_cum_logprobs[seq_slot, :beam_width] = torch.randn(
+        (beam_width, ), dtype=torch.float32)
+    assert (original_cum_logprobs != 0).sum(
+    ) > 0, "Original cumulative log probs must not only contain zeros. Otherwise change the seed."
+
+    cache_indirection[seq_slot, :beam_width, prompt_len:prompt_len +
+                      num_generated_tokens] = torch.randint(
+                          0,
+                          beam_width, (beam_width, num_generated_tokens),
+                          dtype=torch.int32)
+    assert cache_indirection[
+        seq_slot, :beam_width,
+        prompt_len:prompt_len + num_generated_tokens].sum(
+        ) > 0, "Deterministic offsets must not only contain zeros. Otherwise change the seed."
+
+    # test
+    beam_history = sampler._create_beam_history(request)
+
+    # expected selection:
+    # Currently beam history only contains the generated tokens, not the prompt tokens.
+    expected_tokens = torch.zeros(
+        (sampler.max_beam_width, num_generated_tokens),
+        dtype=torch.int32,
+        device=original_tokens.device)
+    expected_logprobs = torch.zeros(
+        (beam_width, num_generated_tokens, original_logprobs.shape[-1]),
+        dtype=torch.float32,
+        device=original_logprobs.device)
+    for gen_idx in range(num_generated_tokens):
+        token_idx = prompt_len + gen_idx
+        expected_tokens[:, gen_idx] = original_tokens[
+            seq_slot, cache_indirection[seq_slot, :, token_idx], token_idx]
+        expected_logprobs[:, gen_idx] = original_logprobs[cache_indirection[
+            seq_slot, :beam_width, token_idx], gen_idx]
+
+    torch.testing.assert_close(beam_history.tokens[:beam_width],
+                               expected_tokens[:beam_width])
+    # test logprobs as well
+    torch.testing.assert_close(beam_history.logprobs[:beam_width],
+                               expected_logprobs[:beam_width])
+    torch.testing.assert_close(beam_history.cum_logprobs[:beam_width],
+                               original_cum_logprobs[seq_slot, :beam_width])
+
+    return
+
+
+def test_finish_beams():
+    """Test TorchSampler._finish_beams method.
+
+    This test verifies that beams are correctly finalized.
+    """
+
+    test_params = GeneralTestParams()
+    beam_width = test_params.beam_width
+    num_generated_tokens = test_params.num_generated_tokens
+    seq_len = test_params.seq_len
+    end_id = test_params.end_id
+    batch_size = test_params.batch_size
+    vocab_size = test_params.vocab_size
+    num_logprobs = 1
+    request = get_default_request(test_params)
+    sampler = get_default_sampler(test_params)
+    store_device = sampler.store.cache_indirection.device
+
+    request.set_generated_tokens(
+        torch.randint(0,
+                      vocab_size, (beam_width, num_generated_tokens),
+                      dtype=torch.int32).tolist())
+
+    torch.manual_seed(42)
+    # Do not keep end_id tokens in the tensor. This would interfere with the test.
+    tokens = torch.randint(
+        0,
+        end_id, (batch_size, sampler.max_beam_width, num_generated_tokens),
+        dtype=torch.int32,
+        device=store_device)
+    logprobs = torch.randn((batch_size, sampler.max_beam_width,
+                            num_generated_tokens, num_logprobs),
+                           dtype=torch.float32,
+                           device=store_device)
+    cum_logprobs = logprobs[..., 0].sum(dim=-1)
+
+    # assert that the  buffers are different from zero. Otherwise the test may pass if the function does not work.
+    assert tokens.sum(
+    ) > 0, "Tokens must not only contain zeros. Otherwise change the seed."
+    assert torch.any(logprobs != 0) and torch.any(
+        cum_logprobs != 0
+    ), "Log probs and cumulative log probs must not only contain zeros. Otherwise change the seed."
+
+    tokens[batch_size - 1, 0,
+           seq_len // 2:] = end_id  # simulate early finished beam
+
+    for batch_idx in range(batch_size):
+        beam_history = sampler.BeamHistory(
+            tokens=tokens[batch_idx, :beam_width],
+            logprobs=logprobs[batch_idx, :beam_width],
+            cum_logprobs=cum_logprobs[batch_idx, :beam_width])
+        request.py_return_log_probs = False
+        prompt_len = request.py_prompt_len
+        sampler._finalize_beam(request, beam_history, is_finished=False)
+        final_tokens = torch.tensor(request.get_tokens(),
+                                    device=store_device,
+                                    dtype=torch.int32)[:, prompt_len:]
+        torch.testing.assert_close(final_tokens, tokens[batch_idx, :beam_width])
+        sampler._finalize_beam(request, beam_history, is_finished=True)
+
+        if batch_idx == batch_size - 1:
+            # In case of a finished beam, with several end tokens, these tokens should be removed from the output.
+            # TODO -- add a testcase for the special case, where a request finished due to END_ID.
+            final_tokens_1p = torch.tensor(request.get_tokens()[1:],
+                                           device=store_device,
+                                           dtype=torch.int32)[:, prompt_len:]
+            final_tokens_0 = torch.tensor(request.get_tokens()[0],
+                                          device=store_device,
+                                          dtype=torch.int32)[prompt_len:]
+            torch.testing.assert_close(final_tokens_1p, tokens[batch_idx,
+                                                               1:beam_width])
+            torch.testing.assert_close(final_tokens_0.shape[0], seq_len // 2)
+            torch.testing.assert_close(final_tokens_0, tokens[batch_idx,
+                                                              0, :seq_len // 2])
+
+        else:
+            final_tokens = torch.tensor(request.get_tokens(),
+                                        device=store_device,
+                                        dtype=torch.int32)[:, prompt_len:]
+            torch.testing.assert_close(final_tokens,
+                                       tokens[batch_idx, :beam_width])
 
 
 @force_ampere  # Save H100 resource

--- a/tests/unittest/_torch/sampler/test_beam_search_util.py
+++ b/tests/unittest/_torch/sampler/test_beam_search_util.py
@@ -18,20 +18,19 @@ import torch
 from transformers.configuration_utils import PretrainedConfig
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
-from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
-    BaseConfigLoader
-from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
-    BaseWeightLoader
-from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
-    BaseWeightMapper
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
 from tensorrt_llm._torch.models.modeling_utils import (
-    ModelConfig, register_auto_model, register_checkpoint_weight_loader,
-    register_config_loader)
+    ModelConfig,
+    register_auto_model,
+    register_checkpoint_weight_loader,
+    register_config_loader,
+)
 
 
 # Define a dummy model to create deterministic outputs for the test
 class DummyConfig(PretrainedConfig):
-
     def __init__(self):
         self.architectures: list[str] = ["DummyModel"]
         self.torch_dtype: torch.dtype = torch.float16
@@ -48,7 +47,6 @@ class DummyConfig(PretrainedConfig):
 
 @register_auto_model("DummyModel")
 class DummyModel(torch.nn.Module):
-
     def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.dtype = model_config.pretrained_config.torch_dtype
@@ -61,25 +59,30 @@ class DummyModel(torch.nn.Module):
     def config(self):
         return self.model_config.pretrained_config
 
-    def forward(self,
-                *args,
-                input_ids: torch.Tensor,
-                position_ids: torch.Tensor,
-                attn_metadata: AttentionMetadata,
-                return_context_logits: bool = False,
-                **kwargs) -> torch.Tensor:
+    def forward(
+        self,
+        *args,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        return_context_logits: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
         num_batch_tokens = input_ids.size(0)
 
         vocab_size = self.config.vocab_size
-        last_tokens = torch.cumsum(
-            attn_metadata.seq_lens_cuda,
-            dim=0,
-            dtype=torch.long,
-        ) - 1
+        last_tokens = (
+            torch.cumsum(
+                attn_metadata.seq_lens_cuda,
+                dim=0,
+                dtype=torch.long,
+            )
+            - 1
+        )
 
         # Logits: fixed values for testing
-        logits = torch.zeros((num_batch_tokens, vocab_size), device='cuda')
-        indices = torch.arange(num_batch_tokens, device='cuda')
+        logits = torch.zeros((num_batch_tokens, vocab_size), device="cuda")
+        indices = torch.arange(num_batch_tokens, device="cuda")
 
         # multiply the scores with input_ids to prevent paths like AB and BA to have the same score.
         # Score the next 4 tokens starting from the current input token.
@@ -95,37 +98,38 @@ class DummyModel(torch.nn.Module):
 
         num_context_requests = attn_metadata.num_contexts
         # each beam has its own attn_metadata.seq_lens_cuda entry
-        num_generation_requests = (last_tokens.shape[0] - num_context_requests
-                                   ) // attn_metadata.beam_width
+        num_generation_requests = (
+            last_tokens.shape[0] - num_context_requests
+        ) // attn_metadata.beam_width
         num_requests = num_generation_requests + num_context_requests
 
         # return cache indirection, as additional model output.
         # each sequence should only return a 1D cache indirection tensor
-        context_cache_indirection = attn_metadata.cache_indirection[:
-                                                                    num_context_requests,
-                                                                    0]
+        context_cache_indirection = attn_metadata.cache_indirection[:num_context_requests, 0]
         generation_cache_indirection = attn_metadata.cache_indirection[
-            num_context_requests:num_requests].view(
-                num_generation_requests * attn_metadata.beam_width,
-                attn_metadata.cache_indirection.shape[-1])
+            num_context_requests:num_requests
+        ].view(
+            num_generation_requests * attn_metadata.beam_width,
+            attn_metadata.cache_indirection.shape[-1],
+        )
         return {
-            "logits":
-            logits,
-            "cache_indirection":
-            torch.cat([context_cache_indirection, generation_cache_indirection],
-                      dim=0),
+            "logits": logits,
+            "cache_indirection": torch.cat(
+                [context_cache_indirection, generation_cache_indirection], dim=0
+            ),
         }
 
-    def load_weights(self,
-                     weights: dict,
-                     weight_mapper: BaseWeightMapper | None = None,
-                     skip_modules: list[str] = []):
+    def load_weights(
+        self,
+        weights: dict,
+        weight_mapper: BaseWeightMapper | None = None,
+        skip_modules: list[str] = [],
+    ):
         pass
 
 
 @register_checkpoint_weight_loader("DUMMY_FORMAT")
 class DummyWeightLoader(BaseWeightLoader):
-
     def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
         """Load weights from your dummy format.
         Args:
@@ -141,7 +145,6 @@ class DummyWeightLoader(BaseWeightLoader):
 
 @register_config_loader("DUMMY_FORMAT")
 class DummyConfigLoader(BaseConfigLoader):
-
     def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
         """Load and parse configuration from your dummy format.
         Args:
@@ -154,26 +157,26 @@ class DummyConfigLoader(BaseConfigLoader):
 
 
 class BeamSearchTestOutput:
-
     def __init__(self, outputs: torch.Tensor, cache_indirection: torch.Tensor):
         self.outputs = outputs
         self.cache_indirection = cache_indirection
 
 
-def get_expected_outputs(start_token: int,
-                         num_iterations: int = 4,
-                         vocab_size: int = 1000) -> BeamSearchTestOutput:
+def get_expected_outputs(
+    start_token: int, num_iterations: int = 4, vocab_size: int = 1000
+) -> BeamSearchTestOutput:
     """Get the expected outputs for the given start token, number of iterations, vocabulary size
-       This function only works for a beam width of 2.
+    This function only works for a beam width of 2.
 
-       arguments:
-       - start_token: the token to start the generation from. This is the last token of the input prompt.
-       - num_iterations: the number of iterations to generate
-       - vocab_size: the size of the vocabulary
-       returns:
-       - BeamSearchTestOutput: a named tuple containing the expected outputs and cache indirection
-           - expected_outputs: the expected outputs for the given start token, number of iterations, vocabulary size
-           - expected_cache_indirection: the expected cache indirection for the given start token, number of iterations, vocabulary size
+    arguments:
+    - start_token: the token to start the generation from. This is the last token of the input prompt.
+    - num_iterations: the number of iterations to generate
+    - vocab_size: the size of the vocabulary
+    returns:
+    - BeamSearchTestOutput: a named tuple containing the expected outputs and cache indirection
+        - expected_outputs: the expected outputs for the given start token, number of iterations, vocabulary size
+        - expected_cache_indirection: the expected cache indirection for the
+                                      given start token, number of iterations, vocabulary size
     """
     expected_outputs = []
     expected_cache_indirection = []
@@ -182,29 +185,23 @@ def get_expected_outputs(start_token: int,
     base_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
     # extend the base scores to the full vocabulary size to calculate the correct softmax scores
     full_scores = torch.zeros(vocab_size)
-    full_scores[:base_scores.shape[0]] = base_scores
+    full_scores[: base_scores.shape[0]] = base_scores
 
     # calculate the softmax scores for the first token
     softmax_score = torch.log_softmax(full_scores * start_token, dim=-1)
     # get the top 2 offsets => these will become beam 0 and beam 1
     # The base scores are at the start of the full scores. So we can use their index as offset.
-    top_offset, second_best_offset = torch.topk(softmax_score, k=2,
-                                                dim=-1).indices
+    top_offset, second_best_offset = torch.topk(softmax_score, k=2, dim=-1).indices
 
     # First iteration
-    expected_outputs = [[start_token + top_offset],
-                        [start_token + second_best_offset]]
+    expected_outputs = [[start_token + top_offset], [start_token + second_best_offset]]
     expected_cache_indirection = [[0], [1]]
     beam_scores = [softmax_score[top_offset], softmax_score[second_best_offset]]
 
     for i in range(1, num_iterations):
         # calculate the softmax scores for the next token
-        softmax_score_0 = torch.log_softmax(full_scores *
-                                            expected_outputs[0][-1],
-                                            dim=-1)
-        softmax_score_1 = torch.log_softmax(full_scores *
-                                            expected_outputs[1][-1],
-                                            dim=-1)
+        softmax_score_0 = torch.log_softmax(full_scores * expected_outputs[0][-1], dim=-1)
+        softmax_score_1 = torch.log_softmax(full_scores * expected_outputs[1][-1], dim=-1)
 
         # For the given setup: Beam 0 will always select the highest scoring token, which is at offset 3.
         # naming: score_<beam_id><offset>
@@ -225,11 +222,10 @@ def get_expected_outputs(start_token: int,
             for j in range(i):
                 expected_outputs[1][j] = expected_outputs[0][j]
                 if i < num_iterations - 1:
-                    # Avoid swapping in the last iteration, as the cache indirection provided by the model is returned before this change.
-                    expected_cache_indirection[1][
-                        j] = expected_cache_indirection[0][j]
-            expected_outputs[1].append(expected_outputs[0][-1] +
-                                       second_best_offset)
+                    # Avoid swapping in the last iteration, as the cache indirection
+                    # provided by the model is returned before this change.
+                    expected_cache_indirection[1][j] = expected_cache_indirection[0][j]
+            expected_outputs[1].append(expected_outputs[0][-1] + second_best_offset)
             beam_scores[1] = score_02
 
         # Update Beam 0
@@ -243,4 +239,5 @@ def get_expected_outputs(start_token: int,
 
     return BeamSearchTestOutput(
         outputs=torch.tensor(expected_outputs),
-        cache_indirection=torch.tensor(expected_cache_indirection))
+        cache_indirection=torch.tensor(expected_cache_indirection),
+    )

--- a/tests/unittest/_torch/sampler/test_beam_search_util.py
+++ b/tests/unittest/_torch/sampler/test_beam_search_util.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import (
+    ModelConfig, register_auto_model, register_checkpoint_weight_loader,
+    register_config_loader)
+
+
+# Define a dummy model to create deterministic outputs for the test
+class DummyConfig(PretrainedConfig):
+
+    def __init__(self):
+        self.architectures: list[str] = ["DummyModel"]
+        self.torch_dtype: torch.dtype = torch.float16
+        self.num_key_value_heads: int = 16
+        self.num_attention_heads: int = 16
+        self.hidden_size: int = 256
+        self.vocab_size: int = 1000
+        self.num_hidden_layers: int = 1
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+
+@register_auto_model("DummyModel")
+class DummyModel(torch.nn.Module):
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__()
+        self.dtype = model_config.pretrained_config.torch_dtype
+        self.model_config = model_config
+
+    def infer_max_seq_len(self):
+        return 2048
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(self,
+                *args,
+                input_ids: torch.Tensor,
+                position_ids: torch.Tensor,
+                attn_metadata: AttentionMetadata,
+                return_context_logits: bool = False,
+                **kwargs) -> torch.Tensor:
+        num_batch_tokens = input_ids.size(0)
+
+        vocab_size = self.config.vocab_size
+        last_tokens = torch.cumsum(
+            attn_metadata.seq_lens_cuda,
+            dim=0,
+            dtype=torch.long,
+        ) - 1
+
+        # Logits: fixed values for testing
+        logits = torch.zeros((num_batch_tokens, vocab_size), device='cuda')
+        indices = torch.arange(num_batch_tokens, device='cuda')
+
+        # multiply the scores with input_ids to prevent paths like AB and BA to have the same score.
+        # Score the next 4 tokens starting from the current input token.
+        logits[indices, input_ids % vocab_size] += 0.1 * input_ids
+        logits[indices, (input_ids + 1) % vocab_size] += 0.2 * input_ids
+        logits[indices, (input_ids + 2) % vocab_size] += 0.3 * input_ids
+        logits[indices, (input_ids + 3) % vocab_size] += 0.4 * input_ids
+
+        # Logits shape depends on return_context_logits flag
+        if not return_context_logits:
+            # For context logits, return logits for all positions
+            logits = logits[last_tokens]
+
+        num_context_requests = attn_metadata.num_contexts
+        # each beam has its own attn_metadata.seq_lens_cuda entry
+        num_generation_requests = (last_tokens.shape[0] - num_context_requests
+                                   ) // attn_metadata.beam_width
+        num_requests = num_generation_requests + num_context_requests
+
+        # return cache indirection, as additional model output.
+        # each sequence should only return a 1D cache indirection tensor
+        context_cache_indirection = attn_metadata.cache_indirection[:
+                                                                    num_context_requests,
+                                                                    0]
+        generation_cache_indirection = attn_metadata.cache_indirection[
+            num_context_requests:num_requests].view(
+                num_generation_requests * attn_metadata.beam_width,
+                attn_metadata.cache_indirection.shape[-1])
+        return {
+            "logits":
+            logits,
+            "cache_indirection":
+            torch.cat([context_cache_indirection, generation_cache_indirection],
+                      dim=0),
+        }
+
+    def load_weights(self,
+                     weights: dict,
+                     weight_mapper: BaseWeightMapper | None = None,
+                     skip_modules: list[str] = []):
+        pass
+
+
+@register_checkpoint_weight_loader("DUMMY_FORMAT")
+class DummyWeightLoader(BaseWeightLoader):
+
+    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
+        """Load weights from your dummy format.
+        Args:
+            checkpoint_dir: Directory containing checkpoint files
+            **kwargs: Additional loading parameters
+        Returns:
+            Dictionary mapping parameter names to tensors
+        """
+        weights = {}
+
+        return weights
+
+
+@register_config_loader("DUMMY_FORMAT")
+class DummyConfigLoader(BaseConfigLoader):
+
+    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        """Load and parse configuration from your dummy format.
+        Args:
+            checkpoint_dir: Directory containing configuration files
+            **kwargs: Additional loading parameters
+        Returns:
+            ModelConfig object containing parsed configuration
+        """
+        return ModelConfig(pretrained_config=DummyConfig())
+
+
+class BeamSearchTestOutput:
+
+    def __init__(self, outputs: torch.Tensor, cache_indirection: torch.Tensor):
+        self.outputs = outputs
+        self.cache_indirection = cache_indirection
+
+
+def get_expected_outputs(start_token: int,
+                         num_iterations: int = 4,
+                         vocab_size: int = 1000) -> BeamSearchTestOutput:
+    """Get the expected outputs for the given start token, number of iterations, vocabulary size
+       This function only works for a beam width of 2.
+
+       arguments:
+       - start_token: the token to start the generation from. This is the last token of the input prompt.
+       - num_iterations: the number of iterations to generate
+       - vocab_size: the size of the vocabulary
+       returns:
+       - BeamSearchTestOutput: a named tuple containing the expected outputs and cache indirection
+           - expected_outputs: the expected outputs for the given start token, number of iterations, vocabulary size
+           - expected_cache_indirection: the expected cache indirection for the given start token, number of iterations, vocabulary size
+    """
+    expected_outputs = []
+    expected_cache_indirection = []
+
+    # These scores are deterministically set to the 4 tokens following the current input token (see model forward pass)
+    base_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
+    # extend the base scores to the full vocabulary size to calculate the correct softmax scores
+    full_scores = torch.zeros(vocab_size)
+    full_scores[:base_scores.shape[0]] = base_scores
+
+    # calculate the softmax scores for the first token
+    softmax_score = torch.log_softmax(full_scores * start_token, dim=-1)
+    # get the top 2 offsets => these will become beam 0 and beam 1
+    # The base scores are at the start of the full scores. So we can use their index as offset.
+    top_offset, second_best_offset = torch.topk(softmax_score, k=2,
+                                                dim=-1).indices
+
+    # First iteration
+    expected_outputs = [[start_token + top_offset],
+                        [start_token + second_best_offset]]
+    expected_cache_indirection = [[0], [1]]
+    beam_scores = [softmax_score[top_offset], softmax_score[second_best_offset]]
+
+    for i in range(1, num_iterations):
+        # calculate the softmax scores for the next token
+        softmax_score_0 = torch.log_softmax(full_scores *
+                                            expected_outputs[0][-1],
+                                            dim=-1)
+        softmax_score_1 = torch.log_softmax(full_scores *
+                                            expected_outputs[1][-1],
+                                            dim=-1)
+
+        # For the given setup: Beam 0 will always select the highest scoring token, which is at offset 3.
+        # naming: score_<beam_id><offset>
+        score_03 = softmax_score_0[top_offset] + beam_scores[0]
+
+        # beam 1 will either select the highest scoring token of beam 1, or the second highest scoring token of beam 0.
+        score_02 = softmax_score_0[second_best_offset] + beam_scores[0]
+        score_13 = softmax_score_1[top_offset] + beam_scores[1]
+
+        # This should always be true
+        assert score_03 >= score_13
+        # If beam 1 selects the highest scoring token of beam 1, we update the beam scores and cache indirection
+        if score_13 >= score_02:
+            expected_outputs[1].append(expected_outputs[1][-1] + top_offset)
+            beam_scores[1] = score_13
+        else:
+            # Beam 1 drops its old beam and changes to beam 0 and selects the second highest scoring token of beam 0.
+            for j in range(i):
+                expected_outputs[1][j] = expected_outputs[0][j]
+                if i < num_iterations - 1:
+                    # Avoid swapping in the last iteration, as the cache indirection provided by the model is returned before this change.
+                    expected_cache_indirection[1][
+                        j] = expected_cache_indirection[0][j]
+            expected_outputs[1].append(expected_outputs[0][-1] +
+                                       second_best_offset)
+            beam_scores[1] = score_02
+
+        # Update Beam 0
+        beam_scores[0] = score_03
+        expected_outputs[0].append(expected_outputs[0][-1] + top_offset)
+
+        # Update cache indirection if necessary
+        if i < num_iterations - 1:
+            expected_cache_indirection[0].append(0)
+            expected_cache_indirection[1].append(1)
+
+    return BeamSearchTestOutput(
+        outputs=torch.tensor(expected_outputs),
+        cache_indirection=torch.tensor(expected_cache_indirection))

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -83,9 +83,11 @@ class TestStrategySelection:
 
     class MockLlmRequest:
         sampling_config: SamplingConfig
-        is_context_init_state: bool  # Not used in this test
+        is_context_init_state: bool  # Torch sampler accesses this, but it does not affect this test
 
-        def get_beam_width_by_iter(self, for_next_iteration: bool) -> int:
+        def get_beam_width_by_iter(
+            self, for_next_iteration: bool
+        ) -> int:  # Torch sampler accesses this, but it does not affect this test
             return self.sampling_config.beam_width
 
     def _check_params(self, params: SamplingParams):

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1468,7 +1468,7 @@ class TestBatchedSampling:
                 group_logit_indices: Optional[torch.Tensor] = None,
                 generator: Optional[torch.Generator] = None,
                 return_probs: bool,
-                        group_metadata: StrategyMetadata | None = None,
+                group_metadata: StrategyMetadata | None = None,
             ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
                 assert issubclass(group_key, sampling_utils_flashinfer._StrategyImpls.StrategyImpl)
                 assert generator is sampler.get_generator(logits.device)

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -51,7 +51,6 @@ from tensorrt_llm._torch.pyexecutor.sampler import (
 )
 from tensorrt_llm._torch.pyexecutor.sampling_utils import (
     BeamSearch,
-    BeamSearchForPrefill,
     Greedy,
     Strategy,
     TemperatureOnly,
@@ -85,6 +84,9 @@ class TestStrategySelection:
     class MockLlmRequest:
         sampling_config: SamplingConfig
         is_context_init_state: bool  # Not used in this test
+
+        def get_beam_width_by_iter(self, for_next_iteration: bool) -> int:
+            return self.sampling_config.beam_width
 
     def _check_params(self, params: SamplingParams):
         # cf. description of 'top_p' in doc-string of SamplingParams and
@@ -790,7 +792,7 @@ class TestBatchedSampling:
         # Check that all relevant strategies are covered
         # Beam search is tested in test_beam_search.py instead of here.
         # It's added here to pass the assert statement, without testing it.
-        assert Union[*BASE_CASES.keys(), BeamSearch, BeamSearchForPrefill] == Strategy
+        assert Union[*BASE_CASES.keys(), BeamSearch] == Strategy
 
         test_cases = []
 

--- a/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
@@ -47,8 +47,8 @@ def run_test(eagle_model_dir, max_seq_len, beam_width, use_dynamic_tree,
         ))
     # fill with NOT_FINISHED to ensure that all finish reasons are NOT_FINISHED
     torch_sampler.store.finish_reasons.fill_(FinishReason.NOT_FINISHED.value)
-    finish_reasons_list = torch_sampler.store.finish_reasons[..., 0].to(
-        device="cpu").T.tolist()
+    finish_reasons_list = torch_sampler.store.finish_reasons.to(
+        device="cpu").permute(1, 0, 2).tolist()
     input_new_tokens_list = input_new_tokens.tolist()
     num_accepted_draft_tokens = torch_sampler._process_draft_tokens_tree(
         request=input_request,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added beam search support for improved text generation quality with multiple hypotheses exploration.
  * Introduced configuration option to disable overlap scheduler for performance tuning.
  * Enhanced sampling strategy system with expanded metadata support and multi-beam handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Added Beam search to Torch Sampler
- Performance needs to be improved
- Streaming and logprobs are supported
- Early finished beams are supported
- Top-K logprobs are not supported
- Beam search is not fully async yet

## Test Coverage

- test_beam_search.py is updated to test the newly introduced features and end to end tests
- test time for test_beam_search.py   1min05sec
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
