### PR TITLE
[None] [refactor] Include Python attributions in wheel packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ from typing import List
 from setuptools import find_packages, setup
 from setuptools.dist import Distribution
 
+from tensorrt_llm._packaging_utils import get_license_files
+
 
 def parse_requirements(filename: os.PathLike):
     with open(filename) as f:
@@ -73,17 +75,6 @@ def get_version():
         raise RuntimeError(f"Could not set version from {version_file}")
 
     return version
-
-
-def get_license():
-    import sysconfig
-    platform_tag = sysconfig.get_platform()
-    if "x86_64" in platform_tag:
-        return ["LICENSE", "ATTRIBUTIONS-CPP-x86_64.md"]
-    elif "arm64" in platform_tag or "aarch64" in platform_tag:
-        return ["LICENSE", "ATTRIBUTIONS-CPP-aarch64.md"]
-    else:
-        raise RuntimeError(f"Unrecognized CPU architecture: {platform_tag}")
 
 
 class BinaryDistribution(Distribution):
@@ -255,7 +246,7 @@ setup(
     package_data={
         'tensorrt_llm': package_data,
     },
-    license_files=get_license(),
+    license_files=get_license_files(),
     entry_points={
         'console_scripts': [
             'trtllm-build=tensorrt_llm.commands.build:main',

--- a/tensorrt_llm/_packaging_utils.py
+++ b/tensorrt_llm/_packaging_utils.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared utilities for packaging and distribution."""
+
+
+def get_license_files():
+    """Get the list of license files to include in the package based on platform.
+
+    Returns:
+        List[str]: Platform-specific license files.
+    """
+    import sysconfig
+    platform_tag = sysconfig.get_platform()
+    if "x86_64" in platform_tag:
+        return [
+            "LICENSE", "ATTRIBUTIONS-CPP-x86_64.md", "ATTRIBUTIONS-Python.md"
+        ]
+    elif "arm64" in platform_tag or "aarch64" in platform_tag:
+        return [
+            "LICENSE", "ATTRIBUTIONS-CPP-aarch64.md", "ATTRIBUTIONS-Python.md"
+        ]
+    else:
+        raise RuntimeError(f"Unrecognized CPU architecture: {platform_tag}")

--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -2,25 +2,15 @@ import argparse
 import os
 import subprocess
 import sys
-import sysconfig
 
 import requests
 
 
-def get_expected_license_files():
-    """Get expected license files based on platform architecture."""
-    platform_tag = sysconfig.get_platform()
-    if "x86_64" in platform_tag:
-        return ["LICENSE", "ATTRIBUTIONS-CPP-x86_64.md"]
-    elif "arm64" in platform_tag or "aarch64" in platform_tag:
-        return ["LICENSE", "ATTRIBUTIONS-CPP-aarch64.md"]
-    else:
-        raise RuntimeError(f"Unrecognized CPU architecture: {platform_tag}")
-
-
 def verify_license_files():
     """Verify that the correct platform-specific license files are packaged."""
-    expected_files = get_expected_license_files()
+    # Import after package is installed to ensure we're testing the installed version
+    from tensorrt_llm._packaging_utils import get_license_files
+    expected_files = get_license_files()
 
     result = subprocess.run(
         'python3 -c "from importlib.metadata import distribution; '


### PR DESCRIPTION
## Summary by Author
* Initially, the guidance was to avoid including the ATTRIBUTIONS-Python.md in the wheel, as it is not "shipped" along with the wheel. But updated guidance recommends to include it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated platform-specific license file handling into a centralized utility, ensuring correct attribution files are bundled for x86_64 and ARM64 architectures during package installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
