### PR TITLE
[None][chore] Print device info in trtllm-bench report

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -227,7 +227,8 @@ class ReportUtility:
             try:
                 props = torch.cuda.get_device_properties(idx)
                 gpu_info["name"] = getattr(props, "name", "Unknown")
-                gpu_info["memory.total"] = float(getattr(props, "total_memory", 0.0)) / (1024.0**3)  # GB
+                gpu_info["memory.total"] = float(
+                    getattr(props, "total_memory", 0.0)) / (1024.0**3)  # GB
                 if pynvml:
                     # For memory clock, we must use pynvml
                     handle = pynvml.nvmlDeviceGetHandleByIndex(idx)
@@ -588,8 +589,10 @@ class ReportUtility:
             for gpu in gpus:
                 name = gpu.get("name", "Unknown")
                 idx = gpu.get("index", 0)
-                mem_total_str = f"{gpu["memory.total"]:.2f} GB" if gpu.get("memory.total") is not None else "N/A"
-                mem_clock_str = f"{gpu.get("clocks.mem"):.2f} GHz" if gpu.get("clocks.mem") is not None else "N/A"
+                mem_total_str = f"{gpu['memory.total']:.2f} GB" if gpu.get(
+                    "memory.total") is not None else "N/A"
+                mem_clock_str = f"{gpu['clocks.mem']:.2f} GHz" if gpu.get(
+                    'clocks.mem') is not None else "N/A"
 
                 machine_info += (
                     f"GPU {idx}: {name}, memory {mem_total_str}, {mem_clock_str}\n"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now include MACHINE DETAILS with primary GPU info (index, name, total memory, memory clock when available).
  * Console/log output embeds machine details before other statistics for clearer diagnostics.
  * Automatic, graceful fallback: reports still generate and explicitly indicate when GPU details cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Add printing of devices' information in trtllm-bench report.
Prints GPU name, memory size (GB), memory clock (GHz).
Assumes homogeneous only setup, queries the first device only.
e.g.
```
===========================================================
= MACHINE DETAILS 
===========================================================
NVIDIA H100 80GB HBM3, memory 79.11 GB, 2.62 GHz
```
