### PR TITLE
Add wrapper class of tensor

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -124,14 +124,20 @@ class FlashInferAttentionMetadata(AttentionMetadata):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self._post_init_with_buffers(self.cuda_graph_buffers)
+
+    def _post_init_with_buffers(self, buffers) -> None:
+        torch.cuda.is_current_stream_capturing()
 
         if self.workspace_buffer is None:
             # Note: even though flashinfer only recommends 128 MB, we have to push it
             # a bit higher to cover all possible CUDA graph cases. If it's too small,
             # warmup will crash.
-            self.workspace_buffer = torch.empty(320 * 1024 * 1024,
-                                                dtype=torch.uint8,
-                                                device="cuda")
+            self.workspace_buffer = self.get_empty(
+                buffers,
+                320 * 1024 * 1024,
+                dtype=torch.uint8,
+                cache_name="workspace_buffer")
 
         self.paged_kv_indptr_decode = torch.empty((self.max_num_requests + 1, ),
                                                   device='cuda',
@@ -163,9 +169,10 @@ class FlashInferAttentionMetadata(AttentionMetadata):
 
         if self.kv_cache_manager is not None:
             max_num_pages = self.kv_cache_manager.blocks_in_primary_pool
-            self._paged_kv_indices = torch.empty((max_num_pages, ),
-                                                 device='cuda',
-                                                 dtype=torch.int)
+            self._paged_kv_indices = self.get_empty(
+                buffers, (max_num_pages, ),
+                dtype=torch.int,
+                cache_name="_paged_kv_indices")
 
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -35,14 +35,16 @@ class RocketTrtllmAttentionMetadata(TrtllmAttentionMetadata):
         if self.sparse_attention_config is None:
             raise ValueError("Sparse attention config is not set")
         self.prompt_budget = self.sparse_attention_config.prompt_budget
-        self.kt_cache_block_offsets = torch.empty(
-            [
+
+        self.kt_cache_block_offsets = self.get_empty(
+            self.cuda_graph_buffers, [
                 self.max_num_sequences,
                 self.kv_cache_manager.max_kt_blocks_per_seq
             ],
             dtype=torch.int32,
             device='cuda',
-        )
+            cache_name="kt_cache_block_offsets")
+
         self.host_kt_cache_block_offsets = torch.zeros_like(
             self.kt_cache_block_offsets,
             device='cpu',

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -1,11 +1,52 @@
 import contextlib
 import math
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
 
 from tensorrt_llm.logger import logger
+
+
+def get_smallest_key_greater_than(ordered_dict, target_value):
+    """
+    Finds the key-value pair where the key is the smallest key
+    in the dictionary that is strictly greater than target_value.
+    """
+    # 1. Filter keys: Create a generator of all keys k where k >= target_value
+    candidate_keys = (k for k in ordered_dict.keys() if k >= target_value)
+
+    if candidate_keys is None or len(candidate_keys) == 0:
+        return (None, None)
+
+    # 2. Find the minimum of the filtered keys
+    min_key = min(candidate_keys)
+    # 3. Use the key to get the value
+    min_value = ordered_dict[min_key]
+    return (min_key, min_value)
+
+
+def get_biggest_key_smaller_than(ordered_dict, target_value):
+    """
+    Finds the key-value pair where the key is the smallest key
+    in the dictionary that is strictly greater than target_value.
+    """
+    # 1. Filter keys: Create a generator of all keys k where k < target_value
+    candidate_keys = (k for k in ordered_dict.keys() if k < target_value)
+
+    if candidate_keys is None or len(candidate_keys) == 0:
+        return (None, None)
+
+    # 2. Find the maximum of the filtered keys
+    max_key = max(candidate_keys)
+    # 3. Use the key to get the value
+    max_value = ordered_dict[max_key]
+    return (max_key, max_value)
+
+
+def get_size_in_byte(target_shape: list[int], target_dtype: torch.dtype):
+    return math.prod(target_shape) * target_dtype.itemsize
 
 
 @dataclass
@@ -30,26 +71,65 @@ class Buffers:
 
     def __init__(self):
         self.buffers: dict[str, list[BufferBlock]] = {}
+        self.managed_buffers = OrderedDict()
+        self.max_buffer_concurrency = 0
 
     @staticmethod
     def _view_as(buffer: torch.Tensor, target_shape: list[int],
                  target_dtype: torch.dtype) -> torch.Tensor:
         """Safely creates a view of a raw byte buffer with the desired shape and dtype."""
         # The buffer is stored as uint8, so its numel is its size in bytes.
-        required_size_in_bytes = math.prod(target_shape) * target_dtype.itemsize
-        if buffer.numel() < required_size_in_bytes:
+        required_memory_size = get_size_in_byte(target_shape, target_dtype)
+        if buffer.numel() < required_memory_size:
             raise ValueError(
                 "Buffer is too small for the requested shape and dtype.")
 
         # Slice the buffer to the exact required size, then view it with the correct type and shape.
-        return buffer[:required_size_in_bytes].view(target_dtype).view(
+        return buffer[:required_memory_size].view(target_dtype).view(
             target_shape)
+
+    def _get_managed_buffer(self, required_memory_size: int):
+        size, buffer = get_smallest_key_greater_than(self.managed_buffers,
+                                                     required_memory_size)
+
+        if size is not None and buffer is not None:
+            return buffer
+
+        size_1, buffer_1 = get_biggest_key_smaller_than(self.managed_buffers,
+                                                        required_memory_size)
+        if size_1 is not None and buffer is not None:
+            del self.managed_buffers[size_1]
+
+        new_buffer_tensor = None
+        try:
+            with torch.cuda.memory.use_mem_pool(get_shared_pool()):
+                new_buffer_tensor = torch.zeros((required_memory_size, ),
+                                                device='cuda',
+                                                dtype=torch.uint8)
+        except Exception as ex:
+            # Need to check if this is an OOM exception
+            logger.debug(
+                f"Exception happened to create tensor from given memory pool: {str(ex)}"
+            )
+            # if exception happens during allocating memory from shared pool, retry
+            # to allocate from default pool
+            new_buffer_tensor = torch.zeros((required_memory_size, ),
+                                            device='cuda',
+                                            dtype=torch.uint8)
+
+        self.managed_buffers[required_memory_size] = new_buffer_tensor
+
+        return new_buffer_tensor
 
     def get_buffer(self, tensor_shape: list[int], dtype: torch.dtype,
                    buffer_name: str, reserve_buffer: bool):
 
         # all buffers are allocated with 1 byte element size
         required_memory_size = math.prod(tensor_shape) * dtype.itemsize
+
+        if buffer_name is None or len(buffer_name) == 0:
+            return _get_managed_buffer(required_memory_size)
+
         candidate_blocks = self.buffers.get(buffer_name, [])
 
         # Find the best-fit available buffer.
@@ -106,6 +186,43 @@ class Buffers:
         # Add the new buffer to the pool for this name.
         self.buffers.setdefault(buffer_name, []).append(new_block)
         return self._view_as(new_block.buffer, tensor_shape, dtype)
+
+    def release_buffer(self, buffer):
+        buffer_size_in_bytes = self.get_size_in_byte(buffer.shape, buffer.dtype)
+        self.managed_buffers[buffer_size_in_bytes] = buffer
+
+
+class WrapperTensor(torch.Tensor):
+    # Must implement the __new__ method to correctly initialize the Tensor data and metadata
+    # The official documentation recommends implementing this method when using Tensor subclasses.
+    @staticmethod
+    def __new__(cls, *args, **kwargs):
+        # Create the underlying torch.Tensor instance
+        # Must pass cls (i.e., WrapperTensor) as the factory function
+        # so that torch.Tensor's factory methods (like empty, zeros, etc.)
+        # know that a WrapperTensor instance should be created.
+        return super().__new__(cls, *args, **kwargs)
+
+    # __init__ is used to initialize properties specific to the subclass,
+    # but for Tensor subclasses, this is usually not necessary.
+    # The Tensor's data and metadata are handled in __new__.
+    def __init__(self, pool, *args, **kwargs):
+        # Note: If a torch.Tensor instance is passed directly to create a WrapperTensor,
+        # for example, WrapperTensor(torch.rand(2, 3)),
+        # then __init__ might be called. However, the more common and recommended way is
+        # through factory methods like WrapperTensor.new_empty(size) or .as_subclass(cls)
+        # or by directly using the internal ._make_subclass method.
+        # For this simple requirement, we don't need to override __init__.
+        self.pool = pool
+
+    # Called when the object is garbage collected
+    def __del__(self):
+        # Try to get the shape. If the Tensor has been partially cleaned up (e.g., its internal state has been freed),
+        # accessing .shape might fail.
+        self.pool.release_tensor(self)
+        print(
+            f"WrapperTensor object is being destructed. Shape is: {current_shape}"
+        )
 
 
 _buffer = Buffers()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
