### PR TITLE
[None][feat] Enable nvfp4 cuda core for sm120

### DIFF
--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.cu
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cutlass/numeric_conversion.h"
+#include "tensorrt_llm/common/cudaFp8Utils.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h"
+#include <cub/cub.cuh>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+namespace cuda_core_gemm_nvfp4
+{
+template <typename InputType, typename OutputType, typename ScaleType, SizeType32 TILE_M, SizeType32 TILE_N,
+    SizeType32 BLOCK_SIZE>
+__device__ void cudaCoreGemmImpl(InputType const* __restrict__ act, InputType const* __restrict__ weight,
+    ScaleType const* __restrict__ scale_a, ScaleType const* __restrict__ scale_w, float const alpha,
+    OutputType* __restrict__ output, SizeType32 m, SizeType32 n, SizeType32 k)
+{
+    using VecType = int4;
+
+    using ScaleVecType = __nv_fp8x2_e4m3;
+    using CvtInputType = typename tensorrt_llm::kernels::cutlass_kernels::TllmToCutlassTypeAdapter<InputType>::type;
+    static constexpr SizeType32 step_k = static_cast<SizeType32>(128 / cutlass::sizeof_bits<CvtInputType>::value);
+    static constexpr SizeType32 nvfp4_scale_granularity = 16;
+    static constexpr SizeType32 step_k_scale = step_k / nvfp4_scale_granularity;
+    static constexpr SizeType32 tile_k = step_k * BLOCK_SIZE;
+    auto tile_id_m = static_cast<SizeType32>(blockIdx.x * TILE_M);
+    auto tile_id_n = static_cast<SizeType32>(blockIdx.y * TILE_N);
+    auto tid = static_cast<SizeType32>(threadIdx.x);
+    float tile_a[step_k];
+    float tile_w[TILE_N * step_k];
+    float tile_a_scale[step_k_scale];
+    float tile_w_scale[TILE_N * step_k_scale];
+    float acc[TILE_M * TILE_N];
+
+    static_assert(step_k % 4 == 0);
+    using Converter = cutlass::NumericArrayConverter<float, CvtInputType, 8>;
+    using CvtSrcType = typename Converter::source_type;
+    using CvtResType = typename Converter::result_type;
+    static constexpr SizeType32 k_cvt_count = static_cast<SizeType32>(sizeof(VecType) / sizeof(CvtSrcType));
+
+#pragma unroll
+    for (SizeType32 i = 0; i < TILE_M * TILE_N; ++i)
+    {
+        acc[i] = 0;
+    }
+    act += tile_id_m * k / 2;
+    weight += tile_id_n * k / 2;
+    output += tile_id_m * n + tile_id_n;
+
+    scale_a += tile_id_m * k / nvfp4_scale_granularity;
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaGridDependencySynchronize();
+#endif
+
+    int const num_cols_sf = k / nvfp4_scale_granularity;
+    int const num_sf_tiles_k = (num_cols_sf + 4 - 1) / 4;
+    for (SizeType32 idx_k = tid * step_k; idx_k < k; idx_k += tile_k)
+    {
+        for (SizeType32 j = 0; j < TILE_N; ++j)
+        {
+            auto tile_w_quantized = reinterpret_cast<VecType const*>(weight + (j * k + idx_k) / 2)[0];
+#pragma unroll
+            for (SizeType32 cvt_idx = 0; cvt_idx < k_cvt_count; ++cvt_idx)
+            {
+                reinterpret_cast<CvtResType*>(tile_w)[j * k_cvt_count + cvt_idx]
+                    = Converter::convert(reinterpret_cast<CvtSrcType*>(&tile_w_quantized)[cvt_idx]);
+            }
+        }
+        for (SizeType32 j = 0; j < TILE_N; ++j)
+        {
+            int const row_idx = tile_id_n + j;
+            int const col_idx = idx_k / nvfp4_scale_granularity;
+            int const tile_offset = ((row_idx / 128) * num_sf_tiles_k + col_idx / 4) * 512;
+            int const dst_idx = tile_offset + (row_idx % 32) * 16 + ((row_idx % 128) / 32) * 4 + col_idx % 4;
+            auto tile_w_scale_fp8x2 = reinterpret_cast<ScaleVecType const*>(scale_w + dst_idx)[0];
+            const char2 tmp = reinterpret_cast<char2 const&>(tile_w_scale_fp8x2);
+            tile_w_scale[j * step_k_scale + 0] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.x));
+            tile_w_scale[j * step_k_scale + 1] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.y));
+        }
+#pragma unroll
+        for (SizeType32 i = 0; i < TILE_M; ++i)
+        {
+            auto tile_a_quantized = reinterpret_cast<VecType const*>(act + (i * k + idx_k) / 2)[0];
+#pragma unroll
+            for (SizeType32 cvt_idx = 0; cvt_idx < k_cvt_count; ++cvt_idx)
+            {
+                reinterpret_cast<CvtResType*>(tile_a)[cvt_idx]
+                    = Converter::convert(reinterpret_cast<CvtSrcType*>(&tile_a_quantized)[cvt_idx]);
+            }
+            auto tile_a_scale_fp8x2
+                = reinterpret_cast<ScaleVecType const*>(scale_a + (i * k + idx_k) / nvfp4_scale_granularity)[0];
+            const char2 tmp = reinterpret_cast<char2 const&>(tile_a_scale_fp8x2);
+            tile_a_scale[0] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.x));
+            tile_a_scale[1] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.y));
+#pragma unroll
+            for (SizeType32 j = 0; j < TILE_N; ++j)
+            {
+#pragma unroll
+                for (SizeType32 l = 0; l < step_k; ++l)
+                {
+                    acc[i * TILE_N + j] = fma(alpha * tile_a[l] * tile_a_scale[l / nvfp4_scale_granularity],
+                        tile_w[j * step_k + l] * tile_w_scale[j * step_k_scale + l / nvfp4_scale_granularity],
+                        acc[i * TILE_N + j]);
+                }
+            }
+        }
+    }
+
+    typedef cub::WarpReduce<float> WarpReduce;
+
+    static constexpr SizeType32 warp_size = 32;
+    static constexpr SizeType32 warp_num = BLOCK_SIZE / warp_size;
+    SizeType32 warp_id = tid / warp_size, lane_id = tid % warp_size;
+    __shared__ float shmem[TILE_M * TILE_N * warp_num];
+    __shared__ typename WarpReduce::TempStorage temp_storage[warp_num];
+#pragma unroll
+    for (SizeType32 mi = 0; mi < TILE_M; ++mi)
+    {
+#pragma unroll
+        for (SizeType32 ni = 0; ni < TILE_N; ++ni)
+        {
+            float val = WarpReduce(temp_storage[warp_id]).Sum(acc[mi * TILE_N + ni]);
+            if (lane_id == 0)
+            {
+                shmem[mi * TILE_N + ni + warp_id * TILE_M * TILE_N] = val;
+            }
+        }
+    }
+    __syncthreads();
+    for (SizeType32 ii = tid; ii < TILE_M * TILE_N; ii += BLOCK_SIZE)
+    {
+        SizeType32 mid = ii / TILE_N, nid = ii % TILE_N;
+        float val = 0;
+#pragma unroll
+        for (SizeType32 jj = 0; jj < warp_num; ++jj)
+        {
+            val += shmem[jj * TILE_M * TILE_N + ii];
+        }
+        output[mid * n + nid] = static_cast<OutputType>(val);
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+template <typename InputType, typename OutputType, typename ScaleType, SizeType32 TILE_M, SizeType32 TILE_N,
+    SizeType32 BLOCK_SIZE>
+__global__ void cudaCoreGemmFp4(InputType const* __restrict__ act, InputType const* __restrict__ weight,
+    ScaleType const* __restrict__ scale_a, ScaleType const* __restrict__ scale_w, float const* alpha_ptr,
+    OutputType* __restrict__ output, SizeType32 m, SizeType32 n, SizeType32 k)
+{
+    float alpha = alpha_ptr[0];
+    cudaCoreGemmImpl<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE>(
+        reinterpret_cast<InputType const*>(act), reinterpret_cast<InputType const*>(weight),
+        reinterpret_cast<ScaleType const*>(scale_a), reinterpret_cast<ScaleType const*>(scale_w), alpha,
+        reinterpret_cast<OutputType*>(output), m, n, k);
+}
+
+template <typename InputType, typename OutputType, typename ScaleType, SizeType32 TILE_M, SizeType32 TILE_N,
+    SizeType32 BLOCK_SIZE>
+void cudaCoreGemmKernel(Params const& params, cudaStream_t stream)
+{
+    dim3 block(BLOCK_SIZE);
+    dim3 grid(params.m / TILE_M, params.n / TILE_N);
+
+    if (tensorrt_llm::common::getEnvEnablePDL())
+    {
+        TLLM_LOG_DEBUG("Enable PDL in fp8_gemm_plugin");
+        cudaLaunchConfig_t kernelConfig = {0};
+        kernelConfig.gridDim = grid;
+        kernelConfig.blockDim = block;
+        kernelConfig.dynamicSmemBytes = 0;
+        kernelConfig.stream = stream;
+
+        cudaLaunchAttribute attribute[1];
+        attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attribute[0].val.programmaticStreamSerializationAllowed = 1;
+        kernelConfig.attrs = attribute;
+        kernelConfig.numAttrs = 1;
+
+        if (params.scale_a && params.scale_b && params.alpha_ptr)
+        {
+            TLLM_CUDA_CHECK(cudaLaunchKernelEx(&kernelConfig,
+                cudaCoreGemmFp4<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE>,
+                reinterpret_cast<InputType const*>(params.act), reinterpret_cast<InputType const*>(params.weight),
+                reinterpret_cast<ScaleType const*>(params.scale_a), reinterpret_cast<ScaleType const*>(params.scale_b),
+                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k));
+        }
+    }
+    else
+    {
+        if (params.scale_a && params.scale_b && params.alpha_ptr)
+        {
+            cudaCoreGemmFp4<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+                reinterpret_cast<InputType const*>(params.act), reinterpret_cast<InputType const*>(params.weight),
+                reinterpret_cast<ScaleType const*>(params.scale_a), reinterpret_cast<ScaleType const*>(params.scale_b),
+                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k);
+        }
+    }
+}
+
+template <typename InputType, typename OutputType, typename ScaleType, int TILE_M, int TILE_N, int BLOCK_SIZE>
+bool cudaCoreGemmTemplateCaller(Params const& params, cudaStream_t stream)
+{
+    constexpr int cudaCoreGemmTemplateMaxM = 16;
+    if (params.m == TILE_M)
+    {
+        cudaCoreGemmKernel<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE>(params, stream);
+        return true;
+    }
+    if constexpr (TILE_M < cudaCoreGemmTemplateMaxM)
+    {
+        return cudaCoreGemmTemplateCaller<InputType, OutputType, ScaleType, TILE_M + 1, TILE_N, BLOCK_SIZE>(
+            params, stream);
+    }
+    return false;
+}
+
+template <typename InputType, typename OutputType, typename ScaleType = float>
+bool cudaCoreGemmLauncher(Params const& params, cudaStream_t stream)
+{
+    return cudaCoreGemmTemplateCaller<InputType, OutputType, ScaleType, 1, 2, 128>(params, stream);
+}
+
+bool cudaCoreGemmDispatcher(Params const& params, cudaStream_t stream)
+{
+    bool dispatched = true;
+    if (params.n % 2 != 0)
+    {
+        dispatched = false;
+    }
+    else if (params.inputType == CUDA_R_8U)
+    {
+        if (params.k % 16 != 0)
+        {
+            // Expect k % 16 == 0 for nvfp4 scaling granularity
+            dispatched = false;
+        }
+        else if (params.outputType == CUDA_R_16F)
+        {
+            dispatched = cudaCoreGemmLauncher<__nv_fp4_e2m1, half, __nv_fp8_e4m3>(params, stream);
+        }
+        else if (params.outputType == CUDA_R_16BF)
+        {
+            dispatched = cudaCoreGemmLauncher<__nv_fp4_e2m1, __nv_bfloat16, __nv_fp8_e4m3>(params, stream);
+        }
+        else if (params.outputType == CUDA_R_32F)
+        {
+            dispatched = cudaCoreGemmLauncher<__nv_fp4_e2m1, float, __nv_fp8_e4m3>(params, stream);
+        }
+        else
+        {
+            dispatched = false;
+        }
+    }
+    else
+    {
+        dispatched = false;
+    }
+
+    if (!dispatched)
+    {
+        TLLM_LOG_WARNING(
+            "tensorrt_llm::kernels::cuda_core_gemm_nvfp4::cudaCoreGemmDispatcher [NOT DISPATCHED], inputType=%d, "
+            "outputType=%d, "
+            "m=%d, "
+            "n=%d, k=%d",
+            params.inputType, params.outputType, params.m, params.n, params.k);
+    }
+    return dispatched;
+}
+
+} // namespace cuda_core_gemm_nvfp4
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/common/quantization.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h"
+#include "tensorrt_llm/runtime/common.h"
+
+#include <NvInferRuntime.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+namespace cuda_core_gemm_nvfp4
+{
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+struct Params
+{
+    void const* act;
+    void const* weight;
+    void* output;
+    SizeType32 m, n, k;
+    cudaDataType_t inputType;
+    cudaDataType_t outputType;
+    // torch flow
+    __nv_fp8_e4m3 const* scale_a;
+    __nv_fp8_e4m3 const* scale_b;
+    float const* alpha_ptr;
+
+    // used by torch flow
+    Params(void const* _act, void const* _weight, void* _output, SizeType32 _m, SizeType32 _n, SizeType32 _k,
+        __nv_fp8_e4m3 const* _scale_a, __nv_fp8_e4m3 const* _scale_b, cudaDataType_t _inputType,
+        cudaDataType_t _outputType, float const* _alpha_ptr)
+        : act(_act)
+        , weight(_weight)
+        , output(_output)
+        , m(_m)
+        , n(_n)
+        , k(_k)
+        , inputType(_inputType)
+        , outputType(_outputType)
+        , scale_a(_scale_a)
+        , scale_b(_scale_b)
+        , alpha_ptr(_alpha_ptr)
+    {
+    }
+};
+
+bool cudaCoreGemmDispatcher(Params const& params, cudaStream_t stream);
+} // namespace cuda_core_gemm_nvfp4
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   cutlassScaledMM.cpp
   cublasScaledMM.cpp
   cublasFp4ScaledMM.cpp
+  cudaNvfp4MM.cpp
   cudaScaledMM.cpp
   dynamicDecodeOp.cpp
   fmhaPackMaskOp.cpp

--- a/cpp/tensorrt_llm/thop/cudaNvfp4MM.cpp
+++ b/cpp/tensorrt_llm/thop/cudaNvfp4MM.cpp
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (out) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+#include "tensorrt_llm/thop/thUtils.h"
+#include "userbuffersTensor.h"
+#include <torch/extension.h>
+
+using torch::Tensor;
+
+namespace torch_ext
+{
+
+namespace
+{
+
+using tensorrt_llm::common::check;
+
+void cuda_core_nvfp4_gemm_caller(Tensor& out, Tensor const& a, Tensor const& b, Tensor const& scale_a,
+    Tensor const& scale_b, Tensor const& alpha, bool fast_acc = false)
+{
+    int32_t m = a.sizes()[0];
+    int32_t n = b.sizes()[0];
+    int32_t k = a.sizes()[1] * 2;
+    TORCH_CHECK(a.sizes()[1] == b.sizes()[1]);
+
+    auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+    auto* a_ptr = static_cast<void*>(a.data_ptr());
+    auto* b_ptr = static_cast<void*>(b.data_ptr());
+    auto* out_ptr = static_cast<void*>(out.data_ptr());
+    void* a_scale = static_cast<void*>(scale_a.data_ptr());
+    void* b_scale = static_cast<void*>(scale_b.data_ptr());
+    void* alpha_ptr = static_cast<void*>(alpha.data_ptr());
+
+    TORCH_CHECK(a_scale != nullptr);
+    TORCH_CHECK(b_scale != nullptr);
+    TORCH_CHECK(alpha_ptr != nullptr);
+
+    cudaDataType_t aType = convert_torch_dtype(a.scalar_type());
+    cudaDataType_t bType = convert_torch_dtype(b.scalar_type());
+    cudaDataType_t outType = convert_torch_dtype(out.scalar_type());
+    TORCH_CHECK(aType == bType);
+    cudaDataType_t scaleAType = convert_torch_dtype(scale_a.scalar_type());
+    cudaDataType_t scaleBType = convert_torch_dtype(scale_b.scalar_type());
+    TORCH_CHECK(scaleAType == CUDA_R_8U);
+    TORCH_CHECK(scaleBType == CUDA_R_8U);
+    cudaDataType_t alphaType = convert_torch_dtype(alpha.scalar_type());
+    TORCH_CHECK(alphaType == CUDA_R_32F);
+
+    tensorrt_llm::kernels::cuda_core_gemm_nvfp4::Params params(a_ptr, b_ptr, out_ptr, m, n, k,
+        reinterpret_cast<__nv_fp8_e4m3 const*>(a_scale), reinterpret_cast<__nv_fp8_e4m3 const*>(b_scale), aType,
+        outType, reinterpret_cast<float const*>(alpha_ptr));
+    bool dispatched = tensorrt_llm::kernels::cuda_core_gemm_nvfp4::cudaCoreGemmDispatcher(params, stream);
+    TORCH_CHECK(dispatched, "Failed to dispatch cudaCoreGemmLauncher");
+}
+
+} // namespace
+
+Tensor& cuda_core_nvfp4_gemm_out(Tensor const& mat_a, Tensor const& mat_b, Tensor const& scale_a, Tensor const& scale_b,
+    Tensor const& alpha, std::optional<at::Tensor> const& bias, Tensor& out)
+{
+    CHECK_TH_CUDA(mat_a);
+    CHECK_TH_CUDA(mat_b);
+    CHECK_TH_CUDA(scale_a);
+    CHECK_TH_CUDA(scale_b);
+    CHECK_TH_CUDA(alpha);
+    CHECK_TH_CUDA(out);
+
+    CHECK_INPUT(mat_a, FLOAT4_E2M1X2);
+    CHECK_INPUT(mat_b, FLOAT4_E2M1X2);
+
+    TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2 && out.dim() == 2);
+    TORCH_CHECK(mat_a.sizes()[0] == out.sizes()[0]);
+    TORCH_CHECK(mat_a.sizes()[1] == mat_b.sizes()[1]);
+    TORCH_CHECK(mat_b.sizes()[0] == out.sizes()[1]);
+
+    TORCH_CHECK(!bias.has_value(), "bias is not support yet");
+
+    TORCH_CHECK(scale_a.dtype() == SF_DTYPE);
+    TORCH_CHECK(scale_b.dtype() == SF_DTYPE);
+
+    cuda_core_nvfp4_gemm_caller(out, mat_a, mat_b, scale_a, scale_b, alpha, true);
+    return out;
+}
+
+// mat_a: [M, K / 2], FLOAT4_E2M1X2
+// mat_b: [N, K / 2], FLOAT4_E2M1X2
+// out: [M, N], fp16/bf16/fp32
+// scale_a: ceil(M / 128) * 128 * ceil(K / sfVecSize / 4) * 4, SF_DTYPE (UE4M3 or UE8M0)
+// scale_b: ceil(N / 128) * 128 * ceil(K / sfVecSize / 4) * 4, SF_DTYPE (UE4M3 or UE8M0)
+// bias: fp16/bf16/fp32
+// out_dtype: fp16/bf16/fp32
+Tensor cuda_core_nvfp4_gemm(Tensor const& mat_a, Tensor const& mat_b, Tensor const& scale_a, Tensor const& scale_b,
+    Tensor const& alpha, std::optional<at::Tensor> const& bias, std::optional<c10::ScalarType> out_dtype,
+    bool to_userbuffers = false)
+{
+    TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2);
+    auto const out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
+
+    std::vector<int64_t> output_size = {mat_a.sizes()[0], mat_b.sizes()[0]};
+
+    Tensor out;
+    if (to_userbuffers)
+    {
+        out = torch_ext::create_userbuffers_tensor(output_size, out_dtype_).first;
+    }
+    else
+    {
+        out = at::empty(output_size, mat_a.options().dtype(out_dtype_));
+    }
+
+    return cuda_core_nvfp4_gemm_out(mat_a, mat_b, scale_a, scale_b, alpha, bias, out);
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "cuda_core_nvfp4_gemm(Tensor mat_a, Tensor mat_b, Tensor scale_a, Tensor scale_b, Tensor alpha, Tensor? bias,"
+        " ScalarType? out_dtype, bool to_userbuffers=False) -> (Tensor out)");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("cuda_core_nvfp4_gemm", &torch_ext::cuda_core_nvfp4_gemm);
+}

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -567,3 +567,18 @@ def _register_fake():
         m = input.shape[0]
         n = weight.shape[0]
         return input.new_empty((m, n), dtype=input.dtype)
+
+    @torch.library.register_fake("trtllm::cuda_core_nvfp4_gemm")
+    def _(mat_a: torch.Tensor,
+          mat_b: torch.Tensor,
+          scale_a: torch.Tensor,
+          scale_b: torch.Tensor,
+          alpha: torch.Tensor,
+          bias: Optional[torch.Tensor],
+          out_dtype: Optional[torch.dtype],
+          to_userbuffers: bool = False):
+        # mat_a: [M, K/2], mat_b: [N, K/2]
+        # Output should be [M, N] with dtype=out_dtype
+        m = mat_a.shape[0]
+        n = mat_b.shape[0]
+        return mat_a.new_empty((m, n), dtype=out_dtype)

--- a/tests/unittest/_torch/thop/parallel/test_fp4_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp4_linear.py
@@ -19,15 +19,16 @@ scaling_vector_size = 16
 @pytest.mark.parametrize(
     "dtype", [torch.float16, torch.bfloat16]
 )  # TODO: Do we need float32 test case? fp4_quantize only supports fp16, bf16, fp8_e4m3
-def test_fp4_linear(dtype):
-    SEQ_LEN = 10
-    HIDDEN_SIZE = 128
+@pytest.mark.parametrize("mnk", [(1, 192, 128), (4, 192, 128), (8, 7168, 16384),
+                                 (128, 7168, 16384)])
+def test_fp4_linear(dtype, mnk):
+    SEQ_LEN, OUTPUT_SIZE, HIDDEN_SIZE = mnk
     torch.manual_seed(0)
 
     x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype).cuda()
     x_sf_global = (448 * 6) / x.abs().max().float()
 
-    w = torch.randn((HIDDEN_SIZE, HIDDEN_SIZE), dtype=dtype).cuda()
+    w = torch.randn((OUTPUT_SIZE, HIDDEN_SIZE), dtype=dtype).cuda()
     w_sf_global = (448 * 6) / w.abs().max().float()
     w_fp4, w_sf_block = torch.ops.trtllm.fp4_quantize(w, w_sf_global,
                                                       scaling_vector_size,
@@ -35,7 +36,7 @@ def test_fp4_linear(dtype):
 
     qc = QuantConfig(quant_algo=QuantAlgo.NVFP4)
     l_fp4 = Linear(in_features=HIDDEN_SIZE,
-                   out_features=HIDDEN_SIZE,
+                   out_features=OUTPUT_SIZE,
                    bias=False,
                    dtype=dtype,
                    quant_config=qc)
@@ -44,7 +45,7 @@ def test_fp4_linear(dtype):
     assert l_fp4.weight_scale.dtype == fp4_utils.float4_sf_dtype
 
     w_sf_block_unswizzled = (torch.ops.trtllm.block_scale_interleave_reverse(
-        w_sf_block.cpu().view(HIDDEN_SIZE, -1)))
+        w_sf_block.cpu().view(pad_up(OUTPUT_SIZE, 128), -1)))
 
     l_fp4.load_weights([{
         'input_scale':
@@ -68,7 +69,7 @@ def test_fp4_linear(dtype):
     with torch.inference_mode(), autotune():
         output = l_fp4.forward(x)
 
-    output_ref = l_fp4.forward(x)
+    output = l_fp4.forward(x)
 
     # ref linear
     with torch.inference_mode():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NVFP4 matrix multiplication acceleration for weight-only GEMM operations
  * Extended CUDA core optimization support to SM89 and SM120 GPU architectures

* **Chores**
  * Updated build system with new NVFP4 kernel implementation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
