### PR TITLE
[https://nvbugs/5593199][test] Enhance beam search tests deterministic dummy model

### DIFF
--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -1,43 +1,278 @@
-import os
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib as _pl
+from typing import Any
 
 import pytest
-from utils.llm_data import llm_models_root
-from utils.util import force_ampere, similar
+import torch
+from transformers.configuration_utils import PretrainedConfig
 
 from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
+from tensorrt_llm._torch.models.checkpoints import HfCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import (
+    ModelConfig, register_auto_model, register_checkpoint_weight_loader,
+    register_config_loader)
+from tensorrt_llm.executor.result import CompletionOutput, GenerationResult
 from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig
+
+
+# Define a dummy model to create deterministic outputs for the test
+class DummyConfig(PretrainedConfig):
+
+    def __init__(self):
+        self.architectures: list[str] = ["DummyModel"]
+        self.torch_dtype: torch.dtype = torch.float16
+        self.num_key_value_heads: int = 16
+        self.num_attention_heads: int = 16
+        self.hidden_size: int = 256
+        self.vocab_size: int = 1000
+        self.num_hidden_layers: int = 1
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+
+@register_auto_model("DummyModel")
+class DummyModel(torch.nn.Module):
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__()
+        self.dtype = model_config.pretrained_config.torch_dtype
+        self.model_config = model_config
+
+    def infer_max_seq_len(self):
+        return 2048
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(self,
+                *args,
+                input_ids: torch.Tensor,
+                position_ids: torch.Tensor,
+                attn_metadata: AttentionMetadata,
+                return_context_logits: bool = False,
+                **kwargs) -> torch.Tensor:
+        num_batch_tokens = input_ids.size(0)
+
+        vocab_size = self.config.vocab_size
+        last_tokens = torch.cumsum(
+            attn_metadata.seq_lens_cuda,
+            dim=0,
+            dtype=torch.long,
+        ) - 1
+
+        # Logits: fixed values for testing
+        logits = torch.zeros((num_batch_tokens, vocab_size), device='cuda')
+        indices = torch.arange(num_batch_tokens, device='cuda')
+
+        # multiply the scores with input_ids to prevent paths like AB and BA to have the same score.
+        # Score the next 4 tokens starting from the current input token.
+        logits[indices, input_ids % vocab_size] += 0.1 * input_ids
+        logits[indices, (input_ids + 1) % vocab_size] += 0.2 * input_ids
+        logits[indices, (input_ids + 2) % vocab_size] += 0.3 * input_ids
+        logits[indices, (input_ids + 3) % vocab_size] += 0.4 * input_ids
+
+        # Logits shape depends on return_context_logits flag
+        if not return_context_logits:
+            # For context logits, return logits for all positions
+            logits = logits[last_tokens]
+
+        num_context_requests = attn_metadata.num_contexts
+        # each beam has its own attn_metadata.seq_lens_cuda entry
+        num_generation_requests = (last_tokens.shape[0] - num_context_requests
+                                   ) // attn_metadata.beam_width
+        num_requests = num_generation_requests + num_context_requests
+        num_generation_beams = num_generation_requests * attn_metadata.beam_width
+
+        # return cache indirection, as additional model output.
+        # each sequence should only return a 1D cache indirection tensor
+        context_cache_indirection = attn_metadata.cache_indirection[:
+                                                                    num_context_requests,
+                                                                    0]
+        generation_cache_indirection = attn_metadata.cache_indirection[
+            num_context_requests:num_requests].view(
+                num_generation_requests * attn_metadata.beam_width,
+                attn_metadata.cache_indirection.shape[-1]
+            )[:num_generation_beams]
+        return {
+            "logits":
+            logits,
+            "cache_indirection":
+            torch.cat([context_cache_indirection, generation_cache_indirection],
+                      dim=0),
+        }
+
+    def load_weights(self,
+                     weights: dict,
+                     weight_mapper: BaseWeightMapper | None = None,
+                     skip_modules: list[str] = []):
+        pass
+
+
+@register_checkpoint_weight_loader("DUMMY_FORMAT")
+class DummyWeightLoader(BaseWeightLoader):
+
+    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
+        """Load weights from your dummy format.
+        Args:
+            checkpoint_dir: Directory containing checkpoint files
+            **kwargs: Additional loading parameters
+        Returns:
+            Dictionary mapping parameter names to tensors
+        """
+        weights = {}
+
+        return weights
+
+
+@register_config_loader("DUMMY_FORMAT")
+class DummyConfigLoader(BaseConfigLoader):
+
+    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        """Load and parse configuration from your dummy format.
+        Args:
+            checkpoint_dir: Directory containing configuration files
+            **kwargs: Additional loading parameters
+        Returns:
+            ModelConfig object containing parsed configuration
+        """
+        return ModelConfig(pretrained_config=DummyConfig())
 
 
 @pytest.fixture(scope="module")
 def input_prompts():
-    return [
-        "Born in north-east France, Soyer trained as a",
-        "The future of AI is",
-    ]
+    return [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
 
-@pytest.fixture(scope="module")
-def expected_outputs():
-    return {
-        "Born in north-east France, Soyer trained as a": [
-            "painter in Paris before moving to London in",
-            "painter and sculptor in Paris before moving"
-        ],
-        "The future of AI is":
-        ["bright, but it's not without", "bright, but it's not going"],
-    }
+class BeamSearchTestOutput:
+
+    def __init__(self, outputs: torch.Tensor, cache_indirection: torch.Tensor):
+        self.outputs = outputs
+        self.cache_indirection = cache_indirection
+
+
+def get_expected_outputs(
+        start_token: int,
+        num_iterations: int = 4,
+        vocab_size: int = 1000,
+        use_overlap_scheduler: bool = False) -> list[list[int]]:
+    """Get the expected outputs for the given start token, number of iterations, vocabulary size
+       This function only works for a beam width of 2.
+
+       arguments:
+       - start_token: the token to start the generation from. This is the last token of the input prompt.
+       - num_iterations: the number of iterations to generate
+       - vocab_size: the size of the vocabulary
+       - use_overlap_scheduler: whether to use the overlap scheduler
+       returns:
+       - BeamSearchTestOutput: a named tuple containing the expected outputs and cache indirection
+           - expected_outputs: the expected outputs for the given start token, number of iterations, vocabulary size
+           - expected_cache_indirection: the expected cache indirection for the given start token, number of iterations, vocabulary size
+    """
+    expected_outputs = []
+    expected_cache_indirection = []
+
+    # These scores are deterministically set to the 4 tokens following the current input token (see model forward pass)
+    base_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
+    # extend the base scores to the full vocabulary size to calculate the correct softmax scores
+    full_scores = torch.zeros(vocab_size)
+    full_scores[:base_scores.shape[0]] = base_scores
+
+    # calculate the softmax scores for the first token
+    softmax_score = torch.log_softmax(full_scores * start_token, dim=-1)
+    # get the top 2 offsets => these will become beam 0 and beam 1
+    # The base scores are at the start of the full scores. So we can use their index as offset.
+    top_offset, second_best_offset = torch.topk(softmax_score, k=2,
+                                                dim=-1).indices
+
+    # iteration 1
+    expected_outputs = [[start_token + top_offset],
+                        [start_token + second_best_offset]]
+    expected_cache_indirection = [[0], [1]]
+    beam_scores = [softmax_score[top_offset], softmax_score[second_best_offset]]
+
+    for i in range(1, num_iterations):
+        # calculate the softmax scores for the next token
+        softmax_score_0 = torch.log_softmax(full_scores *
+                                            expected_outputs[0][-1],
+                                            dim=-1)
+        softmax_score_1 = torch.log_softmax(full_scores *
+                                            expected_outputs[1][-1],
+                                            dim=-1)
+
+        # For the given setup: Beam 0 will always select the highest scoring token, which is at offset 3.
+        # naming: score_<beam_id><offset>
+        score_03 = softmax_score_0[top_offset] + beam_scores[0]
+
+        # beam 1 will either select the highest scoring token of beam 1, or the second highest scoring token of beam 0.
+        score_02 = softmax_score_0[second_best_offset] + beam_scores[0]
+        score_13 = softmax_score_1[top_offset] + beam_scores[1]
+
+        # This should always be true
+        assert score_03 >= score_13
+        # If beam 1 selects the highest scoring token of beam 1, we update the beam scores and cache indirection
+        if score_13 >= score_02:
+            expected_outputs[1].append(expected_outputs[1][-1] + top_offset)
+            expected_outputs[0].append(expected_outputs[0][-1] + top_offset)
+            beam_scores[0] = score_03
+            beam_scores[1] = score_13
+            expected_cache_indirection[1].append(1)
+            expected_cache_indirection[0].append(0)
+        else:
+            # Beam 1 drops its old beam and changes to beam 0 and selects the second highest scoring token of beam 0.
+            for j in range(i):
+                expected_outputs[1][j] = expected_outputs[0][j]
+                if use_overlap_scheduler or i < num_iterations - 1:
+                    # Avoid swapping in the last iteration, as the cache indirection provided by the model does not reflect this change
+                    # in case of overlap scheduler one additional model forward is performed, so we do not need to skip the last swap
+                    expected_cache_indirection[1][
+                        j] = expected_cache_indirection[0][j]
+            expected_outputs[1].append(expected_outputs[0][-1] +
+                                       second_best_offset)
+            expected_outputs[0].append(expected_outputs[0][-1] + top_offset)
+            beam_scores[0] = score_03
+            beam_scores[1] = score_02
+            expected_cache_indirection[1].append(1)
+            expected_cache_indirection[0].append(0)
+
+    return BeamSearchTestOutput(
+        outputs=torch.tensor(expected_outputs),
+        cache_indirection=torch.tensor(expected_cache_indirection))
 
 
 @pytest.fixture(scope="module")
 def fixed_params():
-    return {"max_tokens": 8, "max_beam_width": 2}
+    return {"max_tokens": 4, "max_beam_width": 2}
 
 
 @pytest.fixture(scope="module")
 def llm(fixed_params, input_prompts):
+    assert fixed_params[
+        "max_beam_width"] == 2, "This test only works for a beam width of 2"
     return LLM(
-        model=os.path.join(llm_models_root(), "llama-models-v2",
-                           "TinyLlama-1.1B-Chat-v1.0"),
+        model=_pl.Path("dummy_path"),
         kv_cache_config=KvCacheConfig(max_tokens=10000),
         max_batch_size=fixed_params["max_beam_width"] * len(
             input_prompts
@@ -46,14 +281,16 @@ def llm(fixed_params, input_prompts):
         max_beam_width=fixed_params["max_beam_width"],
         disable_overlap_scheduler=True,
         cuda_graph_config=None,
-    )
+        checkpoint_loader=HfCheckpointLoader(weight_loader=DummyWeightLoader(),
+                                             config_loader=DummyConfigLoader()))
 
 
 @pytest.fixture(scope="module")
 def llm_cuda_graph(fixed_params, input_prompts):
+    assert fixed_params[
+        "max_beam_width"] == 2, "This test only works for a beam width of 2"
     return LLM(
-        model=os.path.join(llm_models_root(), "llama-models-v2",
-                           "TinyLlama-1.1B-Chat-v1.0"),
+        model=_pl.Path("dummy_path"),
         kv_cache_config=KvCacheConfig(max_tokens=10000),
         max_batch_size=fixed_params["max_beam_width"] * len(
             input_prompts
@@ -63,10 +300,128 @@ def llm_cuda_graph(fixed_params, input_prompts):
         disable_overlap_scheduler=False,
         cuda_graph_config=CudaGraphConfig(batch_sizes=[1, 2, 4, 8],
                                           enable_padding=True),
-    )
+        checkpoint_loader=HfCheckpointLoader(weight_loader=DummyWeightLoader(),
+                                             config_loader=DummyConfigLoader()))
 
 
-@force_ampere  # Save H100 resource
+def check_generation_logits(beam: CompletionOutput,
+                            sampling_params: SamplingParams) -> None:
+    """Check if the generation logits have the correct shape"""
+    if sampling_params.return_generation_logits:
+        gen_logits = beam.generation_logits
+        assert gen_logits is not None, "generation logits should not be None"
+        assert gen_logits.ndim == 2, f"generation logits should have 2 dimensions, but got {gen_logits.ndim}"
+        assert gen_logits.shape[
+            0] == sampling_params.max_tokens, f"expected {sampling_params.max_tokens} generation logits, but got {gen_logits.shape[0]}"
+    else:
+        assert beam.generation_logits is None, "generation logits should be None"
+
+
+def check_logprobs(beam: CompletionOutput,
+                   sampling_params: SamplingParams) -> None:
+    """Check if the logprobs have the correct shape"""
+    if sampling_params.logprobs:
+        assert len(
+            beam.logprobs
+        ) == sampling_params.max_tokens, f"expected {sampling_params.max_tokens} logprobs, but got {len(beam.logprobs)}"
+    else:
+        assert len(beam.logprobs) == 0, "logprobs should be empty"
+
+
+def check_cache_indirection(beam: CompletionOutput,
+                            sampling_params: SamplingParams,
+                            reference_cache_indirection: torch.Tensor,
+                            prompt_length: int, beam_idx: int) -> None:
+    """Check if the cache indirection seen by the model is the same as the expected cache indirection"""
+    cache_indirection = beam.additional_generation_outputs["cache_indirection"]
+    assert cache_indirection is not None, "cache indirection should not be None"
+    assert cache_indirection.shape[
+        1] == sampling_params.best_of, f"expected {sampling_params.best_of} entries in dim 1 of cache indirection, but got {cache_indirection.shape[1]}"
+    # check if the cache indirection is correct for the given deterministic input prompt
+    # Check only the last cache indirection
+    last_cache_indirection = cache_indirection[-1, beam_idx]
+
+    num_generated_tokens = sampling_params.max_tokens
+    # We return the cache indirection before the sampling step, therefore cache indirection does not reflect changes during the sampling of the last token
+    num_valid_cache_indirection = num_generated_tokens - 1
+
+    assert all(last_cache_indirection[:prompt_length] ==
+               0), "prompt tokens should have a cache indirection of 0"
+    # remove the prompt tokens from the cache indirection and check if the remaining cache indirection is correct
+    valid_cache_indirection = last_cache_indirection[
+        prompt_length:prompt_length + num_valid_cache_indirection]
+    assert all(
+        valid_cache_indirection == reference_cache_indirection[
+            beam_idx, :num_valid_cache_indirection]
+    ), f"expected {reference_cache_indirection[beam_idx, :num_valid_cache_indirection].tolist()} cache indirection, but got {valid_cache_indirection.tolist()}"
+
+
+def validate_output_beam(beam: CompletionOutput,
+                         expected_outputs: BeamSearchTestOutput,
+                         sampling_params: SamplingParams, prompt_length: int,
+                         beam_idx: int) -> None:
+    """Perform several checks on the output of a single beam"""
+    check_generation_logits(beam, sampling_params)
+    check_logprobs(beam, sampling_params)
+    check_cache_indirection(beam, sampling_params,
+                            expected_outputs.cache_indirection, prompt_length,
+                            beam_idx)
+    # Check output similarity
+    assert beam.token_ids == expected_outputs.outputs[beam_idx].tolist(
+    ), f"expected {expected_outputs.outputs[beam_idx].tolist()} token ids, but got {beam.token_ids}"
+
+
+def check_context_logits(output: GenerationResult,
+                         sampling_params: SamplingParams):
+    """Check if the context logits have the correct shape"""
+    if sampling_params.return_context_logits:
+        assert output.context_logits is not None, "context logits should not be None"
+        assert len(output.prompt_token_ids) == output.context_logits.shape[
+            0], f"expected {len(output.prompt_token_ids)} context logits, but got {output.context_logits.shape[0]}"
+    else:
+        assert output.context_logits is None, "context logits should be None"
+
+
+def validate_output(output: GenerationResult,
+                    input_prompt: list[int],
+                    sampling_params: SamplingParams,
+                    use_overlap_scheduler: bool = False) -> None:
+    """Perform several checks on the output of a single prompt"""
+    check_context_logits(output, sampling_params)
+
+    # validate number of outputs equals beam width
+    num_output_beams = sampling_params.n
+    assert len(
+        output.outputs
+    ) == num_output_beams, f"expected {num_output_beams} outputs, but got {len(output.outputs)}"
+    # check each beam
+    expected_outputs = get_expected_outputs(
+        input_prompt[-1],
+        num_iterations=sampling_params.max_tokens,
+        use_overlap_scheduler=use_overlap_scheduler)
+    for beam_idx, beam in enumerate(output.outputs):
+        validate_output_beam(beam, expected_outputs, sampling_params,
+                             len(input_prompt), beam_idx)
+
+
+def validate_outputs(llm: LLM,
+                     input_prompts: list[list[int]],
+                     sampling_params: SamplingParams,
+                     use_overlap_scheduler: bool = False) -> None:
+    """Generate outputs for a list of prompts and validate the outputs"""
+    outputs = llm.generate(input_prompts, sampling_params=sampling_params)
+    num_prompts = len(input_prompts)
+
+    assert len(
+        outputs
+    ) == num_prompts, f"expected {num_prompts} outputs, but got {len(outputs)}"
+    for output_idx, output in enumerate(outputs):
+        validate_output(output,
+                        input_prompts[output_idx],
+                        sampling_params,
+                        use_overlap_scheduler=use_overlap_scheduler)
+
+
 @pytest.mark.parametrize("return_log_probs", [True, False])
 @pytest.mark.parametrize("gather_generation_logits", [True, False])
 @pytest.mark.parametrize("gather_context_logits", [True, False])
@@ -77,12 +432,14 @@ def test_beam_search_output_shapes(gather_context_logits: bool,
                                    gather_generation_logits: bool,
                                    return_log_probs: bool,
                                    num_output_beams: int, num_prompts: int, llm,
-                                   fixed_params, input_prompts,
-                                   expected_outputs):
+                                   fixed_params, input_prompts) -> None:
     if return_log_probs and num_prompts > 1:
         pytest.skip(
             "Beam search currently does not support return_log_probs with multiple prompts"
         )
+
+    # create sampling parameters
+    # additional_model_outputs is used to gather the cache indirection from the model.
     sampling_params = SamplingParams(
         max_tokens=fixed_params["max_tokens"],
         n=num_output_beams,
@@ -91,38 +448,12 @@ def test_beam_search_output_shapes(gather_context_logits: bool,
         return_context_logits=gather_context_logits,
         return_generation_logits=gather_generation_logits,
         logprobs=return_log_probs,
+        end_id=-1,
+        additional_model_outputs=["cache_indirection"],
     )
-    outputs = llm.generate(input_prompts[:num_prompts],
-                           sampling_params=sampling_params)
-    assert len(outputs) == num_prompts
-    for output_idx, output in enumerate(outputs):
-        if gather_context_logits:
-            assert output.context_logits is not None
-            assert len(
-                output.prompt_token_ids) == output.context_logits.shape[0]
-        else:
-            assert output.context_logits is None
-        assert len(output.outputs) == num_output_beams
-        for beam_idx, beam in enumerate(output.outputs):
-            if gather_generation_logits:
-                gen_logits = beam.generation_logits
-                assert gen_logits is not None
-                assert gen_logits.ndim == 2
-                assert gen_logits.shape[0] == sampling_params.max_tokens
-            else:
-                assert beam.generation_logits is None
-
-            if return_log_probs:
-                assert len(beam.logprobs) == sampling_params.max_tokens
-            else:
-                assert len(beam.logprobs) == 0
-            # Check output similarity
-            assert similar(
-                beam.text,
-                expected_outputs[input_prompts[output_idx]][beam_idx])
+    validate_outputs(llm, input_prompts[:num_prompts], sampling_params)
 
 
-@force_ampere  # Save H100 resource
 @pytest.mark.parametrize("return_log_probs", [True, False])
 @pytest.mark.parametrize("gather_generation_logits", [True, False])
 @pytest.mark.parametrize("gather_context_logits", [True, False])
@@ -132,11 +463,13 @@ def test_beam_search_output_shapes(gather_context_logits: bool,
 def test_beam_search_output_shapes_cuda_graph_and_overlap(
         gather_context_logits: bool, gather_generation_logits: bool,
         return_log_probs: bool, num_output_beams: int, num_prompts: int,
-        llm_cuda_graph, fixed_params, input_prompts, expected_outputs):
+        llm_cuda_graph, fixed_params, input_prompts) -> None:
     if return_log_probs and num_prompts > 1:
         pytest.skip(
             "Beam search currently does not support return_log_probs with multiple prompts"
         )
+    # create sampling parameters
+    # additional_model_outputs is used to gather the cache indirection from the model.
     sampling_params = SamplingParams(
         max_tokens=fixed_params["max_tokens"],
         n=num_output_beams,
@@ -145,36 +478,15 @@ def test_beam_search_output_shapes_cuda_graph_and_overlap(
         return_context_logits=gather_context_logits,
         return_generation_logits=gather_generation_logits,
         logprobs=return_log_probs,
+        end_id=-1,
+        additional_model_outputs=["cache_indirection"],
     )
-    # test padding of cuda graph with 3 prompts
-    # replicate the prompts to have more than 2 prompts available
-    if (num_prompts == 3 and len(input_prompts) == 2):
-        input_prompts = [input_prompts[0]] * 3
-    outputs = llm_cuda_graph.generate(input_prompts[:num_prompts],
-                                      sampling_params=sampling_params)
-    assert len(outputs) == num_prompts
-    for output_idx, output in enumerate(outputs):
-        if gather_context_logits:
-            assert output.context_logits is not None
-            assert len(
-                output.prompt_token_ids) == output.context_logits.shape[0]
-        else:
-            assert output.context_logits is None
-        assert len(output.outputs) == num_output_beams
-        for beam_idx, beam in enumerate(output.outputs):
-            if gather_generation_logits:
-                gen_logits = beam.generation_logits
-                assert gen_logits is not None
-                assert gen_logits.ndim == 2
-                assert gen_logits.shape[0] == sampling_params.max_tokens
-            else:
-                assert beam.generation_logits is None
+    # use_overlap_scheduler=True is used to adjust the expected cache indirection for the test
+    validate_outputs(llm_cuda_graph,
+                     input_prompts[:num_prompts],
+                     sampling_params,
+                     use_overlap_scheduler=True)
 
-            if return_log_probs:
-                assert len(beam.logprobs) == sampling_params.max_tokens
-            else:
-                assert len(beam.logprobs) == 0
-            # Check output similarity
-            assert similar(
-                beam.text,
-                expected_outputs[input_prompts[output_idx]][beam_idx])
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- added copyright header
- Introduced a DummyModel and associated configurations to facilitate deterministic outputs for beam search tests.
- Updated test cases to validate generation logits, logprobs, and cache indirection.
- Refactored input prompts and expected outputs to align with the new model structure.
- Added checks for context logits and overall output validation to ensure correctness in beam search functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced beam search test infrastructure with improved scaffolding and deterministic utilities for more robust and comprehensive test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Updated beam search tests to provide deterministic output, to prevent the choice of hardware to affect the results

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
