### PR TITLE
[TRTLLM-8832][feat] fully async _select_generated_logits with tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -15,6 +15,8 @@ l0_a10:
   tests:
   # ------------- PyTorch tests ---------------
   - unittest/_torch/sampler/test_torch_sampler.py
+  - unittest/_torch/sampler/test_torch_multi_arange.py
+  - unittest/utils/test_util.py
   - unittest/_torch/modeling/test_modeling_mistral.py
   - unittest/_torch/modeling/test_modeling_pixtral.py
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no

--- a/tests/unittest/_torch/sampler/test_torch_multi_arange.py
+++ b/tests/unittest/_torch/sampler/test_torch_multi_arange.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from itertools import product
+from typing import Iterable, Optional
+
+import numpy as np
+import pytest
+import torch
+from utils.util import assert_no_cuda_sync, force_ampere
+
+from tensorrt_llm._torch.pyexecutor.sampling_utils import (ACCEPT_SYNC_COMPUTE,
+                                                           torch_multi_arange)
+
+BASE_CASES = [
+    (None, [], None, []),
+    ([], [], None, []),
+    (None, [], [], []),
+    ([], [], [], []),
+    (None, [1], None, [0]),
+    (None, [-1], None, []),
+    (None, [3], None, [0, 1, 2]),
+    (None, [-3], None, []),
+    ([-5], [-3], None, [-5, -4]),
+    ([-5], [-2], [2], [-5, -3]),
+    ([-5], [-1], [2], [-5, -3]),
+    ([-5], [-3], [3], [-5]),
+    ([-3], [-5], None, []),
+    ([-3], [-5], [-1], [-3, -4]),
+    ([-3], [-5], [-3], [-3]),
+    ([-3], [-5], [1], []),
+    ([-5], [-3], [-2], []),
+    ([-3], [2], None, [-3, -2, -1, 0, 1]),
+    ([-3], [2], [2], [-3, -1, 1]),
+    ([-3], [3], [2], [-3, -1, 1]),
+    ([2], [5], None, [2, 3, 4]),
+    ([2], [5], [2], [2, 4]),
+    ([2], [6], [2], [2, 4]),
+]
+
+
+def _build_multi_arange_case() -> tuple[Iterable, Iterable, Iterable, Iterable]:
+    gen = np.random.default_rng(seed=42)
+    cases = [
+        BASE_CASES[i] for i in gen.choice(len(BASE_CASES), 128)
+        if len(BASE_CASES[i][3]) > 0
+    ]
+    starts = [
+        val for case in cases
+        for val in (case[0] if case[0] is not None else [0] * len(case[1]))
+    ]
+    ends = [val for case in cases for val in case[1]]
+    steps = [
+        val for case in cases
+        for val in (case[2] if case[2] is not None else [1] * len(case[1]))
+    ]
+    expected = [val for case in cases for val in case[3]]
+    return starts, ends, steps, expected
+
+
+@force_ampere
+@pytest.mark.parametrize(
+    "device, allow_sync, dtype, starts, ends, steps, expected",
+    [
+        pytest.param(device, allow_sync, dtype, starts, ends, steps, expected)
+        for (dtype,
+             (starts, ends, steps, expected), device, allow_sync) in product(
+                 [
+                     torch.int32,
+                     torch.int64,
+                 ],
+                 BASE_CASES + [_build_multi_arange_case()],
+                 [
+                     "cpu",
+                     "cuda",
+                 ],
+                 [False, True],
+             ) if device == "cuda" or allow_sync
+    ],
+)
+def test_torch_multi_arange(
+    device: str,
+    allow_sync: bool,
+    dtype: torch.dtype,
+    starts: Optional[Iterable],
+    ends: Iterable,
+    steps: Optional[Iterable],
+    expected: Iterable,
+):
+    torch_device = torch.device(device)
+
+    def _make_tensor(data: Iterable) -> torch.Tensor:
+        return torch.tensor(data, device=torch_device, dtype=dtype)
+
+    def _maybe_make_tensor(data: Optional[Iterable]) -> Optional[torch.Tensor]:
+        if data is None:
+            return None
+        return _make_tensor(data)
+
+    starts_tensor = _maybe_make_tensor(starts)
+    ends_tensor = _make_tensor(ends)
+    steps_tensor = _maybe_make_tensor(steps)
+    expected_tensor = _make_tensor(expected)
+
+    extra_args = {}
+    extra_args["output_length"] = ACCEPT_SYNC_COMPUTE
+    if device != "cpu":
+        # Pre-allocates a large chunk of memory, because PyTorch caching memory allocator
+        # can sync otherwise.
+        buf = torch.ones((2**30, ), device=device)
+        del buf
+        if not allow_sync:
+            extra_args["output_length"] = expected_tensor.numel()
+        # Warmup to avoid syncs due to lazy loading of kernels
+        _ = torch_multi_arange(
+            ends_tensor,
+            starts=starts_tensor,
+            steps=steps_tensor,
+            **extra_args,
+        )
+
+    with torch.cuda.Stream():
+        with assert_no_cuda_sync() if not allow_sync else nullcontext():
+            result = torch_multi_arange(
+                ends_tensor,
+                starts=starts_tensor,
+                steps=steps_tensor,
+                **extra_args,
+            )
+
+    torch.testing.assert_close(result, expected_tensor)

--- a/tests/unittest/utils/test_util.py
+++ b/tests/unittest/utils/test_util.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+from .util import (DeviceSleepCtl, assert_no_cuda_sync, device_sleep,
+                   force_ampere)
+
+
+@force_ampere
+@pytest.mark.parametrize(
+    "cancel",
+    [False, True],
+)
+def test_device_sleep(cancel: bool):
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    sleep_ctl = DeviceSleepCtl()
+    sleep_time = 0.3
+
+    start_event.record()
+    device_sleep(sleep_time, ctl=sleep_ctl, spin_s=0.01)
+    end_event.record()
+
+    if cancel:
+        sleep_ctl.cancel()
+    end_event.synchronize()
+    # NB: torch.cuda.Event.elapsed_time returns millis
+    elapsed_time = start_event.elapsed_time(end_event) / 1000
+    if cancel:
+        assert elapsed_time < sleep_time
+    else:
+        assert elapsed_time >= sleep_time
+
+
+@force_ampere
+@pytest.mark.parametrize(
+    "uut_syncs",
+    [False, True],
+)
+def test_assert_no_cuda_sync(uut_syncs: bool):
+
+    def _uut():
+        if uut_syncs:
+            torch.cuda.synchronize()
+
+    ctx = pytest.raises(AssertionError, match="sync code should return quickly"
+                        ) if uut_syncs else nullcontext()
+    with ctx:
+        with assert_no_cuda_sync(sync_timeout_s=0.2):
+            _uut()

--- a/tests/unittest/utils/util.py
+++ b/tests/unittest/utils/util.py
@@ -1,6 +1,23 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
 import os
+import time
 import unittest
 from contextlib import contextmanager
+from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Generator
@@ -19,6 +36,7 @@ except ImportError:
 from parameterized import parameterized
 
 import tensorrt_llm
+from tensorrt_llm._torch.hostfunc import hostfunc
 from tensorrt_llm._utils import (mpi_disabled, torch_dtype_to_trt,
                                  trt_dtype_to_torch)
 from tensorrt_llm.llmapi.utils import get_total_gpu_memory
@@ -451,3 +469,49 @@ def check_accuracy(a, b, atol, rtol, percent):
 
 skip_ray = pytest.mark.skipif(
     mpi_disabled(), reason="This test is skipped for Ray orchestrator.")
+
+
+@dataclass
+class DeviceSleepCtl:
+    _cancellation_requested: bool = False
+
+    @property
+    def cancellation_requested(self):
+        return self._cancellation_requested
+
+    def cancel(self):
+        self._cancellation_requested = True
+
+
+@hostfunc
+def device_sleep(duration_s: float,
+                 *,
+                 ctl: DeviceSleepCtl,
+                 spin_s: float = 0.1):
+    spin_iters = math.ceil(duration_s / spin_s)
+    for _ in range(spin_iters):
+        if ctl.cancellation_requested:
+            break
+        time.sleep(spin_s)
+
+
+@contextmanager
+def assert_no_cuda_sync(
+        sync_timeout_s: float = 5) -> Generator[None, None, None]:
+    """Check that the function does not stream synchronize."""
+
+    sleep_finished_event = torch.cuda.Event()
+    scope_finished_event = torch.cuda.Event()
+
+    torch.cuda.synchronize()
+    sleep_ctl = DeviceSleepCtl()
+    device_sleep(sync_timeout_s, ctl=sleep_ctl)
+    sleep_finished_event.record()
+    yield None
+    scope_finished_event.record()
+
+    assert not sleep_finished_event.query(
+    ), """sync code should return quickly"""
+
+    sleep_ctl.cancel()
+    scope_finished_event.synchronize()


### PR DESCRIPTION
## Description

* add test utility `test_assert_no_cuda_sync`, incl. unit tests
* implement test for `torch_multi_arange`
* implement test for `TorchSampler._select_generated_logits`
* make `torch_multi_arange` fully async
* make `TorchSampler._select_generated_logits` fully async

## Test Coverage

Tests included with PR.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sampling logic to limit logits considered, reduce blocking tensor ops, and handle edge cases more robustly (device-aware and more consistent).
  * Strengthened multi-range generation to support device tensors, explicit output length, and stricter input validation.

* **Tests**
  * Added extensive unit and integration tests covering multi-range generation, sampling selection, CUDA sync assertions, and cancellable sleep utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->