### PR TITLE
[https://nvbugs/5552836][fix] Add flag `TLLM_SPAWN_EXTRA_MAIN_PROCESS` to disable spawning main process

### DIFF
--- a/examples/llm-api/llm_mgmn_llm_distributed.sh
+++ b/examples/llm-api/llm_mgmn_llm_distributed.sh
@@ -35,6 +35,10 @@
 #      not supported in Slurm mode, you need to download the model and put it in
 #      the LOCAL_MODEL directory.
 
+# Optionally, set TLLM_SPAWN_EXTRA_MAIN_PROCESS to 0 to disable spawning extra
+# processes to offload the LLM frontend to a separate process. This is more
+# stable, but is not recommended for high-throughput streaming generation.
+
 # Adjust the paths to run
 export script=$SOURCE_ROOT/examples/llm-api/quickstart_advanced.py
 

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -28,6 +28,22 @@ class LlmLauncherEnvs(StrEnum):
     # Whether to use periodical responses handler in await_responses
     TLLM_EXECUTOR_PERIODICAL_RESP_IN_AWAIT = "TLLM_EXECUTOR_PERIODICAL_RESP_IN_AWAIT"
 
+    # Whether to spawn a additional process for the main process, it will optimize
+    # the performance of the main process. Default is 1.
+    TLLM_SPAWN_EXTRA_MAIN_PROCESS = "TLLM_SPAWN_EXTRA_MAIN_PROCESS"
+
+    # TODO: Add other helpers
+
+    @staticmethod
+    def should_spawn_extra_main_process() -> bool:
+        return os.environ.get(LlmLauncherEnvs.TLLM_SPAWN_EXTRA_MAIN_PROCESS,
+                              '1') == '1'
+
+    @staticmethod
+    def set_spawn_extra_main_process(value: bool = True):
+        os.environ[LlmLauncherEnvs.
+                   TLLM_SPAWN_EXTRA_MAIN_PROCESS] = '1' if value else '0'
+
 
 def get_spawn_proxy_process_ipc_addr_env() -> str | None:
     ''' Get the IPC address for the spawn proxy process dynamically. '''
@@ -49,7 +65,7 @@ def create_mpi_comm_session(
         n_workers: int) -> RemoteMpiCommSessionClient | MpiPoolSession:
     assert mpi_rank(
     ) == 0, f"create_mpi_comm_session must be called by rank 0, but it was called by rank {mpi_rank()}"
-    if get_spawn_proxy_process_env():
+    if LlmLauncherEnvs.should_spawn_extra_main_process():
         assert get_spawn_proxy_process_ipc_addr_env(
         ), f"{LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR} is not set."
         logger_debug(

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -7,24 +7,45 @@ task_with_command=("$@")
 # the performance of the main process.
 spawn_extra_main_process=${TLLM_SPAWN_EXTRA_MAIN_PROCESS:-1}
 
-native_mpi_rank=$OMPI_COMM_WORLD_RANK
-mpi_rank=${SLURM_PROCID:-${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMI_ID:-0}}}}
+function get_mpi_rank {
+    # Try different environment variables in order of preference
+    if [ -n "$SLURM_PROCID" ]; then
+        echo "$SLURM_PROCID"
+    elif [ -n "$OMPI_COMM_WORLD_RANK" ]; then
+        echo "$OMPI_COMM_WORLD_RANK"
+    elif [ -n "$PMIX_RANK" ]; then
+        echo "$PMIX_RANK"
+    elif [ -n "$PMI_RANK" ]; then
+        echo "$PMI_RANK"
+    elif [ -n "$PMI_ID" ]; then
+        echo "$PMI_ID"
+    elif [ -n "$RANK" ]; then
+        echo "$RANK"
+    else
+        echo "0"
+    fi
+}
 
-log_stderr() { echo -e "\033[33m$@\033[0m" >&2; }
-log_stderr "mpi_rank: $mpi_rank"
 
-# Tell TRTLLM to use the MPI Comm Session.
-export TLLM_SPAWN_PROXY_PROCESS=1
-
-function mpi_world_size {
+function get_mpi_world_size {
+    # Try different environment variables in order of preference
     if [ -n "$SLURM_NTASKS" ]; then
         echo "$SLURM_NTASKS"
     elif [ -n "$OMPI_COMM_WORLD_SIZE" ]; then
         echo "$OMPI_COMM_WORLD_SIZE"
+    elif [ -n "$OMPI_APP_CTX_NUM_PROCS" ]; then
+        echo "$OMPI_APP_CTX_NUM_PROCS"
+    elif [ -n "$WORLD_SIZE" ]; then
+        echo "$WORLD_SIZE"
     else
         echo "1"
     fi
 }
+
+readonly mpi_rank=$(get_mpi_rank)
+readonly mpi_world_size=$(get_mpi_world_size)
+log_stderr() { echo -e "\033[33m$@\033[0m" >&2; }
+log_stderr "mpi_rank [$mpi_rank] of world_size [$mpi_world_size]"
 
 function export_free_tcp_addr_for_spawn_proxy_process {
     # find free port starting from 10012
@@ -48,6 +69,9 @@ print(port); s.close()')
 # This will optimize the LLM frontend performance, which is critical for the
 # streaming generation performance when throughput is high.
 function run_with_spawn_extra_main_process {
+    # Tell TRTLLM to use the MPI Comm Session when spawning extra main process.
+    export TLLM_SPAWN_PROXY_PROCESS=1
+
     log_stderr "Rank${mpi_rank} run with spawn extra main process"
 
     if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
@@ -104,7 +128,7 @@ function run_with_spawn_extra_main_process {
         subshell_pid=$!
         log_stderr "Rank${mpi_rank} Subshell PID: $subshell_pid"
 
-        log_stderr "Rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_world_size) ..."
+        log_stderr "Rank${mpi_rank} run mgmn leader node with mpi_world_size: $mpi_world_size ..."
         log_stderr "Rank0 host: $HOSTNAME"
         python3 -m tensorrt_llm.llmapi.mgmn_leader_node
         mgmn_leader_node_exit_code=$?
@@ -126,7 +150,7 @@ function run_with_spawn_extra_main_process {
         # Turn off "exit on error" so the following lines always run
         set +e
 
-        log_stderr "Rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_world_size) ..."
+        log_stderr "Rank${mpi_rank} run mgmn worker node with mpi_world_size: $mpi_world_size ..."
         python3 -m tensorrt_llm.llmapi.mgmn_worker_node
         mgmn_worker_node_exit_code=$?
         log_stderr "Rank${mpi_rank} MGMN worker node exit code: $mgmn_worker_node_exit_code"
@@ -138,6 +162,10 @@ function run_with_spawn_extra_main_process {
 # Run both the LLM frontend and Worker0 task in the main process.
 # NOTE, this method is not recommended for high-throughput streaming generation.
 function run_without_spawn_extra_main_process {
+    # Do NOT use MPI Comm Session when not spawning extra main process.
+    # This allows the Python code to use MpiPoolSession instead.
+    export TLLM_SPAWN_PROXY_PROCESS=0
+
     log_stderr "Rank${mpi_rank} run without spawn extra main process"
 
     if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
@@ -153,8 +181,6 @@ function run_without_spawn_extra_main_process {
 
 
 # main logic ==
-export tllm_mpi_size=$(mpi_world_size)
-log_stderr "tllm_mpi_size: $tllm_mpi_size"
 
 if [ "$spawn_extra_main_process" -eq 1 ]; then
     run_with_spawn_extra_main_process

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -2,15 +2,18 @@
 set -Eeo pipefail
 
 task_with_command=("$@")
+
+# Whether to spawn a additional process for the main process, it will optimize
+# the performance of the main process.
+spawn_extra_main_process=${TLLM_SPAWN_EXTRA_MAIN_PROCESS:-1}
+
 native_mpi_rank=$OMPI_COMM_WORLD_RANK
 mpi_rank=${SLURM_PROCID:-${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMI_ID:-0}}}}
 
 log_stderr() { echo -e "\033[33m$@\033[0m" >&2; }
 log_stderr "mpi_rank: $mpi_rank"
 
-pid=$(ps -o pid= -p $$ | tr -d ' ')
-
-# Tell TRTLLM to spawn a additional process for the Proxy
+# Tell TRTLLM to use the MPI Comm Session.
 export TLLM_SPAWN_PROXY_PROCESS=1
 
 function mpi_world_size {
@@ -40,90 +43,121 @@ print(port); s.close()')
     export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY=$(openssl rand -hex 32)
 }
 
+# Invoke the RemoteCommSession Server/Client to run the LLM frontend in a
+# separate process, and the main process (MPI rank0) will run the Worker0 task.
+# This will optimize the LLM frontend performance, which is critical for the
+# streaming generation performance when throughput is high.
+function run_with_spawn_extra_main_process {
+    log_stderr "Rank${mpi_rank} run with spawn extra main process"
 
-export tllm_mpi_size=$(mpi_world_size)
-log_stderr "tllm_mpi_size: $tllm_mpi_size"
+    if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
+        log_stderr "Rank${mpi_rank} run ${task_with_command[@]} in background"
 
-export_free_tcp_addr_for_spawn_proxy_process
+        export_free_tcp_addr_for_spawn_proxy_process
 
-if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
-    log_stderr "Rank${mpi_rank} run ${task_with_command[@]} in background"
+        # MPI doesn't allow spawn a process sharing the MPI environment in a MPI
+        # process, or duplicate MPI_Init in the child process will cause undefined
+        # behavior. Thus we need to clean the MPI environment in the parent process
+        # before spawning the child process, and restore the MPI environment later
+        # before running MPI operations in the parent process.
+        mpi_blacklist=(
+            OMPI_ PMIX_ PMI_ SLURM_ MPI_ UCX_
+            I_MPI_ HYDRA_ KMP_ MPICH_ MV2_ CRAY_
+        )
 
-    # MPI doesn't allow spawn a process sharing the MPI environment in a MPI
-    # process, or duplicate MPI_Init in the child process will cause undefined
-    # behavior. Thus we need to clean the MPI environment in the parent process
-    # before spawning the child process, and restore the MPI environment later
-    # before running MPI operations in the parent process.
-    mpi_blacklist=(
-        OMPI_ PMIX_ PMI_ SLURM_ MPI_ UCX_
-        I_MPI_ HYDRA_ KMP_ MPICH_ MV2_ CRAY_
-    )
-
-    (
-        # Remove MPI-related variables only in the subshell context
-        for var in $(compgen -e); do
-            for prefix in "${mpi_blacklist[@]}"; do
-                if [[ "$var" == "$prefix"* ]]; then
-                    unset "$var"
-                    break
-                fi
+        (
+            # Remove MPI-related variables only in the subshell context
+            for var in $(compgen -e); do
+                for prefix in "${mpi_blacklist[@]}"; do
+                    if [[ "$var" == "$prefix"* ]]; then
+                        unset "$var"
+                        break
+                    fi
+                done
             done
-        done
+
+            # Turn off "exit on error" so the following lines always run
+            set +e
+
+            # Execute the task with cleaned environment
+            "${task_with_command[@]}"
+            task_exit_code=$?
+            log_stderr "Rank${mpi_rank} Task exit code: $task_exit_code"
+
+            # Stop the MPI Comm server
+            python3 -m tensorrt_llm.llmapi.mgmn_leader_node --action stop
+            mpi_exit_code=$?
+            log_stderr "Rank${mpi_rank} MPI Comm server exit code: $mpi_exit_code"
+
+            # Propagate task exit status
+            if [ $task_exit_code -ne 0 ]; then
+                exit $task_exit_code
+            else
+                exit $mpi_exit_code
+            fi
+        ) &
 
         # Turn off "exit on error" so the following lines always run
         set +e
 
-        # Execute the task with cleaned environment
-        "${task_with_command[@]}"
-        task_exit_code=$?
-        log_stderr "Rank${mpi_rank} Task exit code: $task_exit_code"
+        # Capture subshell PID
+        subshell_pid=$!
+        log_stderr "Rank${mpi_rank} Subshell PID: $subshell_pid"
 
-        # Stop the MPI Comm server
-        python3 -m tensorrt_llm.llmapi.mgmn_leader_node --action stop
-        mpi_exit_code=$?
-        log_stderr "Rank${mpi_rank} MPI Comm server exit code: $mpi_exit_code"
+        log_stderr "Rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_world_size) ..."
+        log_stderr "Rank0 host: $HOSTNAME"
+        python3 -m tensorrt_llm.llmapi.mgmn_leader_node
+        mgmn_leader_node_exit_code=$?
+        log_stderr "Rank${mpi_rank} MGMN leader node exit code: $mgmn_leader_node_exit_code"
 
-        # Propagate task exit status
-        if [ $task_exit_code -ne 0 ]; then
-            exit $task_exit_code
+        # Wait for subshell
+        wait $subshell_pid
+        # This is subshell's exit code
+        subshell_exit_code=$?
+        log_stderr "Rank${mpi_rank} Subshell exit code: $subshell_exit_code"
+
+        # Propagate subshell exit status
+        if [ $subshell_exit_code -ne 0 ]; then
+            exit $subshell_exit_code
         else
-            exit $mpi_exit_code
+            exit $mgmn_leader_node_exit_code
         fi
-    ) &
-
-    # Turn off "exit on error" so the following lines always run
-    set +e
-
-    # Capture subshell PID
-    subshell_pid=$!
-    log_stderr "Rank${mpi_rank} Subshell PID: $subshell_pid"
-
-    log_stderr "Rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_world_size) ..."
-    log_stderr "Rank0 host: $HOSTNAME"
-    python3 -m tensorrt_llm.llmapi.mgmn_leader_node
-    mgmn_leader_node_exit_code=$?
-    log_stderr "Rank${mpi_rank} MGMN leader node exit code: $mgmn_leader_node_exit_code"
-
-    # Wait for subshell
-    wait $subshell_pid
-    # This is subshell's exit code
-    subshell_exit_code=$?
-    log_stderr "Rank${mpi_rank} Subshell exit code: $subshell_exit_code"
-
-    # Propagate subshell exit status
-    if [ $subshell_exit_code -ne 0 ]; then
-        exit $subshell_exit_code
     else
-        exit $mgmn_leader_node_exit_code
+        # Turn off "exit on error" so the following lines always run
+        set +e
+
+        log_stderr "Rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_world_size) ..."
+        python3 -m tensorrt_llm.llmapi.mgmn_worker_node
+        mgmn_worker_node_exit_code=$?
+        log_stderr "Rank${mpi_rank} MGMN worker node exit code: $mgmn_worker_node_exit_code"
+
+        exit $mgmn_worker_node_exit_code
     fi
+}
+
+# Run both the LLM frontend and Worker0 task in the main process.
+# NOTE, this method is not recommended for high-throughput streaming generation.
+function run_without_spawn_extra_main_process {
+    log_stderr "Rank${mpi_rank} run without spawn extra main process"
+
+    if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
+        "${task_with_command[@]}"
+    else
+        python3 -m tensorrt_llm.llmapi.mgmn_worker_node
+        mgmn_worker_node_exit_code=$?
+        log_stderr "Rank${mpi_rank} MGMN worker node exit code: $mgmn_worker_node_exit_code"
+
+        exit $mgmn_worker_node_exit_code
+    fi
+}
+
+
+# main logic ==
+export tllm_mpi_size=$(mpi_world_size)
+log_stderr "tllm_mpi_size: $tllm_mpi_size"
+
+if [ "$spawn_extra_main_process" -eq 1 ]; then
+    run_with_spawn_extra_main_process
 else
-    # Turn off "exit on error" so the following lines always run
-    set +e
-
-    log_stderr "Rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_world_size) ..."
-    python3 -m tensorrt_llm.llmapi.mgmn_worker_node
-    mgmn_worker_node_exit_code=$?
-    log_stderr "Rank${mpi_rank} MGMN worker node exit code: $mgmn_worker_node_exit_code"
-
-    exit $mgmn_worker_node_exit_code
+    run_without_spawn_extra_main_process
 fi

--- a/tests/integration/test_lists/test-db/l0_dgx_h200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h200.yml
@@ -169,6 +169,8 @@ l0_dgx_h200:
   - test_e2e.py::test_trtllm_bench_llmapi_launch[trt_backend-llama-v3-llama3-8b]
   - examples/test_nemotron_nas.py::test_nemotron_nas_summary_2gpu[DeciLM-7B]
   - llmapi/test_llm_examples.py::test_llmapi_example_distributed_tp2
+  - llmapi/test_llm_examples.py::test_llmapi_example_launch_distributed_tp2[spawn_extra_main_process]
+  - llmapi/test_llm_examples.py::test_llmapi_example_launch_distributed_tp2[no_spawn_extra_main_process]
   - unittest/trt/functional/test_allreduce_norm.py
   - examples/test_multimodal.py::test_llm_multimodal_general[Llama-3.2-11B-Vision-pp:1-tp:2-bfloat16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[llava-v1.6-mistral-7b-hf-vision-trtllm-pp:1-tp:2-float16-bs:1-cpp_e2e:False-nb:1]

--- a/tests/unittest/llmapi/_run_remote_mpi_session.sh
+++ b/tests/unittest/llmapi/_run_remote_mpi_session.sh
@@ -4,7 +4,8 @@ set -ex
 task=$1
 
 echo "Starting remote MPI session test with task: $task"
-echo "MPI processes: 2"
+
+echo "TLLM_SPAWN_EXTRA_MAIN_PROCESS: $TLLM_SPAWN_EXTRA_MAIN_PROCESS"
 
 # Add timeout to prevent infinite hanging
 timeout 60 mpirun --allow-run-as-root -np 2 trtllm-llmapi-launch python3 _run_mpi_comm_task.py --task_type $task

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -55,16 +55,23 @@ def run_client(server_addr, values_to_process):
 
 
 @pytest.mark.parametrize("task_type", ["submit", "submit_sync"])
-def test_remote_mpi_session(task_type: Literal["submit", "submit_sync"]):
+@pytest.mark.parametrize(
+    "spawn_extra_main_process", [True, False],
+    ids=["spawn_extra_main_process", "no_spawn_extra_main_process"])
+def test_remote_mpi_session(task_type: Literal["submit", "submit_sync"],
+                            spawn_extra_main_process: bool):
     """Test RemoteMpiPoolSessionClient and RemoteMpiPoolSessionServer interaction"""
     cur_dir = os.path.dirname(os.path.abspath(__file__))
-    test_file = os.path.join(cur_dir, "_test_remote_mpi_session.sh")
+    test_file = os.path.join(cur_dir, "_run_remote_mpi_session.sh")
     assert os.path.exists(test_file), f"Test file {test_file} does not exist"
     command = ["bash", test_file, task_type]
     print(' '.join(command))
 
+    envs = os.environ.copy()
+    envs[
+        'TLLM_SPAWN_EXTRA_MAIN_PROCESS'] = "1" if spawn_extra_main_process else "0"
     with Popen(command,
-               env=os.environ,
+               env=envs,
                stdout=PIPE,
                stderr=PIPE,
                bufsize=1,

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -8,6 +8,7 @@ from typing import Literal
 import pytest
 
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
+from tensorrt_llm.executor.utils import LlmLauncherEnvs
 from tensorrt_llm.llmapi.mpi_session import (MPINodeState, MpiPoolSession,
                                              RemoteMpiCommSessionClient,
                                              split_mpi_env)
@@ -68,8 +69,9 @@ def test_remote_mpi_session(task_type: Literal["submit", "submit_sync"],
     print(' '.join(command))
 
     envs = os.environ.copy()
-    envs[
-        'TLLM_SPAWN_EXTRA_MAIN_PROCESS'] = "1" if spawn_extra_main_process else "0"
+    LlmLauncherEnvs.set_spawn_extra_main_process(spawn_extra_main_process)
+    envs[LlmLauncherEnvs.TLLM_SPAWN_EXTRA_MAIN_PROCESS] = os.environ[
+        LlmLauncherEnvs.TLLM_SPAWN_EXTRA_MAIN_PROCESS]
     with Popen(command,
                env=envs,
                stdout=PIPE,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control LLM frontend process spawning behavior, enabling users to choose between separate process execution (more stable) or inline execution (higher throughput).

* **Documentation**
  * Added environment variable documentation describing process spawning configuration and its trade-offs.

* **Tests**
  * Extended test coverage to validate both process spawning modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
