### PR TITLE
[None][autodeploy] minor refactor to rmsnorm transforms

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -124,7 +124,7 @@ transforms:
   # TODO (lucaslie): add backend selection as part of configurable inference optimizers
   fuse_rmsnorm:
     stage: post_load_fusion
-    rmsnorm_backend: flashinfer
+    rmsnorm_backend: triton
     gated_rmsnorm_backend: triton
     requires_shape_prop: true
 

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -122,15 +122,11 @@ transforms:
   fuse_allreduce_residual_rmsnorm:
     stage: post_load_fusion
   # TODO (lucaslie): add backend selection as part of configurable inference optimizers
-  # check if we can fuse rmsnorm
   fuse_rmsnorm:
-    # TODO (lucaslie): add backend selection as part of configurable inference optimizers
-    # check if we can fuse rmsnorm
     stage: post_load_fusion
-    backend: triton
+    rmsnorm_backend: flashinfer
+    gated_rmsnorm_backend: triton
     requires_shape_prop: true
-  fuse_gated_rmsnorm:
-    stage: post_load_fusion
 
   ############################################################################################
   # VISUALIZE GRAPH

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rms_norm.py
@@ -83,8 +83,8 @@ def _(input: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
     return torch.empty_like(input)
 
 
-@torch.library.custom_op("auto_deploy::torch_rmsnorm_gated", mutates_args=())
-def torch_rmsnorm_gated(
+@torch.library.custom_op("auto_deploy::triton_rmsnorm_gated", mutates_args=())
+def triton_rmsnorm_gated(
     x: torch.Tensor,
     weight: torch.Tensor,
     gate: torch.Tensor | None,
@@ -140,8 +140,8 @@ def torch_rmsnorm_gated(
     return out2.reshape(x_shape)
 
 
-@torch_rmsnorm_gated.register_fake
-def _torch_rmsnorm_gated_meta(
+@triton_rmsnorm_gated.register_fake
+def _triton_rmsnorm_gated_meta(
     x,
     weight,
     gate,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
@@ -90,23 +90,28 @@ def _rms_norm_replacement(
 class FuseRMSNormConfig(TransformConfig):
     """Configuration for the RMSNorm fusion transform."""
 
-    backend: str = Field(
+    rmsnorm_backend: str = Field(
         default="flashinfer",
-        description="Backend to use for RMSNorm computation ('flashinfer' or 'triton').",
+        description="Backend to use for RMSNorm computation ('flashinfer', 'triton', or 'torch').",
+    )
+    gated_rmsnorm_backend: str = Field(
+        default="triton",
+        description="Backend to use for gated RMSNorm computation (currently only 'triton').",
     )
 
 
 @TransformRegistry.register("fuse_rmsnorm")
 class FuseRMSNorm(BaseTransform):
-    """Matches and replaces RMSNorm patterns in the graph with FlashInfer or Triton implementation.
+    """Matches and replaces RMSNorm patterns (regular and gated) in the graph with optimized implementations.
 
-    This function sets up pattern matching to identify RMSNorm operations in the graph
+    This function sets up pattern matching to identify both regular and gated RMSNorm operations in the graph
     and replaces them with optimized implementations. It uses dummy tensors to register
     the pattern matching rules.
 
     Args:
         gm: Input graph module to transform.
-        backend: Backend to use for RMSNorm computation ("flashinfer" or "triton").
+        rmsnorm_backend: Backend to use for regular RMSNorm computation ("flashinfer", "triton", or "torch").
+        gated_rmsnorm_backend: Backend to use for gated RMSNorm computation (currently only "triton").
 
     Returns:
         Transformed graph module with optimized RMSNorm operations.
@@ -125,15 +130,23 @@ class FuseRMSNorm(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        if self.config.backend.lower() not in _BACKEND_OPS:
+        # Validate rmsnorm_backend
+        if self.config.rmsnorm_backend.lower() not in _BACKEND_OPS:
             raise ValueError(
-                f"Invalid backend, must be one of {list(_BACKEND_OPS)}, got {self.config.backend}"
+                f"Invalid rmsnorm_backend, must be one of {list(_BACKEND_OPS)}, got {self.config.rmsnorm_backend}"
+            )
+
+        # Validate gated_rmsnorm_backend (currently only triton is supported)
+        if self.config.gated_rmsnorm_backend.lower() != "triton":
+            raise ValueError(
+                f"""Invalid gated_rmsnorm_backend, currently only 'triton' is supported,
+                got {self.config.gated_rmsnorm_backend}"""
             )
 
         graph = gm.graph
         patterns = ADPatternMatcherPass()
 
-        # Create dummy tensors for pattern matching
+        # Pattern matching for regular RMSNorm
         bs = 2
         hidden_size = 512
 
@@ -160,12 +173,41 @@ class FuseRMSNorm(BaseTransform):
             for input_dtype, weight_dtype in configs:
                 register_ad_pattern(
                     search_fn=search_fn,
-                    replace_fn=partial(_rms_norm_replacement, backend=self.config.backend),
+                    replace_fn=partial(_rms_norm_replacement, backend=self.config.rmsnorm_backend),
                     patterns=patterns,
                     dummy_args=dummy_args(input_dtype, weight_dtype),
                     op_ignore_types={},
                     scalar_workaround={"eps": 1e-6},
                 )
+
+        # Pattern matching for gated RMSNorm
+        B, S, H = 2, 3, 4096
+        group_size = 512
+        eps = 1e-5
+
+        def make_dummy_args_gated(group_size: int, eps: float) -> list:
+            x = torch.randn(B, S, H, dtype=torch.float32)
+            w = torch.randn(H, dtype=torch.float32)
+            g = torch.randn(B, S, H, dtype=torch.float32)
+            return [x, w, g, eps, group_size]
+
+        op_ignore_types = {
+            torch.ops.aten.reshape.default: (int, list, tuple),
+            torch.ops.aten.view.default: (int, list, tuple),
+            torch.ops.aten.mean.dim: (list, tuple),
+            torch.ops.aten.to.dtype: (torch.dtype,),
+        }
+
+        # Register pattern for gated RMSNorm
+        register_ad_pattern(
+            search_fn=_gated_rmsnorm_pattern_ref,
+            replace_fn=partial(_gated_rmsnorm_replacement),
+            patterns=patterns,
+            dummy_args=make_dummy_args_gated(group_size, eps),
+            op_ignore_types=op_ignore_types,
+            scalar_workaround={"eps": eps, "group_size": group_size},
+            skip_duplicates=True,
+        )
 
         cnt = patterns.apply(graph)
 
@@ -204,61 +246,6 @@ def _gated_rmsnorm_replacement(
     eps: float,
     group_size: int,
 ) -> torch.Tensor:
-    return torch.ops.auto_deploy.torch_rmsnorm_gated(
+    return torch.ops.auto_deploy.triton_rmsnorm_gated(
         x, weight, gate, float(eps), int(group_size), False
     )
-
-
-@TransformRegistry.register("fuse_gated_rmsnorm")
-class FuseGatedRMSNorm(BaseTransform):
-    """
-    Fuse the NemotronH-style gated RMSNorm subgraph into a single custom op:
-        auto_deploy::torch_rmsnorm_gated(x, weight, gate, eps, group_size, norm_before_gate=False)
-    """
-
-    def _apply(
-        self,
-        gm: GraphModule,
-        cm: CachedSequenceInterface,
-        factory: ModelFactory,
-        shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
-        graph = gm.graph
-        patterns = ADPatternMatcherPass()
-
-        B, S, H = 2, 3, 4096
-        group_size = 512
-        eps = 1e-5
-
-        def make_dummy_args(group_size: int, eps: float) -> list:
-            x = torch.randn(B, S, H, dtype=torch.float32)
-            w = torch.randn(H, dtype=torch.float32)
-            g = torch.randn(B, S, H, dtype=torch.float32)
-            return [x, w, g, eps, group_size]
-
-        op_ignore_types = {
-            torch.ops.aten.reshape.default: (int, list, tuple),
-            torch.ops.aten.view.default: (int, list, tuple),
-            torch.ops.aten.mean.dim: (list, tuple),
-            torch.ops.aten.to.dtype: (torch.dtype,),
-        }
-
-        register_ad_pattern(
-            search_fn=_gated_rmsnorm_pattern_ref,
-            replace_fn=partial(_gated_rmsnorm_replacement),
-            patterns=patterns,
-            dummy_args=make_dummy_args(group_size, eps),
-            op_ignore_types=op_ignore_types,
-            scalar_workaround={"eps": eps, "group_size": group_size},
-            skip_duplicates=True,
-        )
-
-        num = patterns.apply(graph)
-
-        info = TransformInfo(
-            skipped=False,
-            num_matches=num,
-            is_clean=num == 0,
-            has_valid_shapes=num == 0,
-        )
-        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
@@ -201,7 +201,7 @@ class FuseRMSNorm(BaseTransform):
         # Register pattern for gated RMSNorm
         register_ad_pattern(
             search_fn=_gated_rmsnorm_pattern_ref,
-            replace_fn=partial(_gated_rmsnorm_replacement),
+            replace_fn=_gated_rmsnorm_replacement,
             patterns=patterns,
             dummy_args=make_dummy_args_gated(group_size, eps),
             op_ignore_types=op_ignore_types,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_mamba_rms_norm.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_mamba_rms_norm.py
@@ -24,7 +24,7 @@ def test_custom_op_matches_ref(B, T, H, group, use_gate, dtype):
     )
 
     # Custom op (currently returns fp32). Cast it back to x.dtype for apples-to-apples with ref.
-    y_op_fp32 = torch.ops.auto_deploy.torch_rmsnorm_gated(x, w, z, 1e-5, group, False)
+    y_op_fp32 = torch.ops.auto_deploy.triton_rmsnorm_gated(x, w, z, 1e-5, group, False)
     y_op = y_op_fp32.to(x.dtype)
 
     assert y_ref.dtype == x.dtype and y_op.dtype == x.dtype

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fuse_rmsnorm.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fuse_rmsnorm.py
@@ -66,7 +66,8 @@ def _run_test(model, op, variant):
         {
             "fuse_rmsnorm": {
                 "stage": "post_load_fusion",
-                "backend": variant,
+                "gated_rmsnorm_backend": "triton",
+                "rmsnorm_backend": variant,
             },
         },
     )(None, gm)
@@ -102,4 +103,4 @@ def test_rmsnorm_fusion(eps, variant, op):
 def test_rmsnorm_fusion_nemotron_h():
     # Only the triton backend supports the nemotron h rmsnorm
     model = TestModel(eps=1e-6, use_nemotron_h=True)
-    _run_test(model, torch.ops.auto_deploy.triton_rms_norm, "triton")
+    _run_test(model, torch.ops.auto_deploy.triton_rms_norm, variant="triton")


### PR DESCRIPTION
This PR merge two transforms: fuse_rmsnorm and fuse_gated_rmsnorm to simplify the pipeline.

Tested with Llama3 and NemotronH model E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated RMSNorm transform configuration structure with explicit backend selection for standard and gated normalization variants
  * Consolidated gated RMSNorm handling into the unified RMSNorm transform, improving configuration consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
