### PR TITLE
[None][feat] Autotuner can iterate through all tactics for test purposes

### DIFF
--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h"
+#include "tensorrt_llm/thop/thUtils.h"
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
@@ -310,12 +311,6 @@ at::Tensor run_fp8_block_scale_moe(at::optional<at::Tensor> const& routing_logit
     auto const& moe_stream = at::cuda::getCurrentCUDAStream(hidden_states.get_device());
     moe_runner.run(args, workspace, hidden_states.get_device(), moe_stream, moeConfigIndex);
     return output;
-}
-
-inline int32_t nextPowerOfTwo(float val)
-{
-    int32_t const intVal = static_cast<int32_t>(std::ceil(val));
-    return intVal <= 1 ? 1 : 1 << static_cast<int32_t>(std::ceil(std::log2(intVal)));
 }
 
 // Wrapped the TRTLLM-Gen kernel runner in a Torch custom class to allow

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -557,7 +557,6 @@ class AutoTuner:
         """
 
         def __init__(self, autotuner):
-            self.autotuner = autotuner
             # State for captured contexts
             self._captured_contexts: List[Dict[str, Any]] = []
             self._configurations = None

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -402,7 +402,6 @@ class FP8BlockScaleMoERunner(TunableRunner):
         local_num_experts: int,
         routed_scaling_factor: Optional[float],
         routing_method_type: int,
-        tile_tokens_dim: int,
     ):
 
         self.num_experts = num_experts
@@ -414,7 +413,6 @@ class FP8BlockScaleMoERunner(TunableRunner):
         self.local_num_experts = local_num_experts
         self.routed_scaling_factor = routed_scaling_factor
         self.routing_method_type = routing_method_type
-        self.tile_tokens_dim = tile_tokens_dim
 
         FP8BlockScaleMoERunner.tuning_config = FP8BlockScaleMoERunner.get_tuning_config(
         )
@@ -439,17 +437,16 @@ class FP8BlockScaleMoERunner(TunableRunner):
                 and self.local_num_experts == other.local_num_experts)
 
     def get_runner(self):
-        instance_key = (self.tile_tokens_dim, )
+        instance_key = ()
         if instance_key not in FP8BlockScaleMoERunner.runner_dict:
             FP8BlockScaleMoERunner.runner_dict[
-                instance_key] = torch.classes.trtllm.FP8BlockScaleMoERunner(
-                    self.tile_tokens_dim)
+                instance_key] = torch.classes.trtllm.FP8BlockScaleMoERunner()
         return FP8BlockScaleMoERunner.runner_dict[instance_key]
 
     def forward(
         self,
         inputs: List[torch.Tensor],
-        tactic: int = -1,
+        tactic: List[int] = [-1, -1],
     ) -> torch.Tensor:
 
         args = FP8BlockScaleMoEInputs(*inputs)
@@ -467,7 +464,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
             args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
-                          profile: OptimizationProfile, **kwargs) -> List[int]:
+                          profile: OptimizationProfile,
+                          **kwargs) -> List[List[int]]:
 
         args = FP8BlockScaleMoEInputs(*inputs)
 
@@ -530,6 +528,14 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
         return constraint_specs_tuple
 
+    @staticmethod
+    def inputs_pre_hook(inputs: List[torch.Tensor]):
+        args = FP8BlockScaleMoEInputs(*inputs)
+        args.hidden_states = args.hidden_states / torch.max(
+            args.hidden_states) * 448
+        # turn dataclass object to list
+        return list(args)
+
     @classmethod
     @lru_cache(maxsize=None)
     def get_tuning_config(cls) -> TuningConfig:
@@ -566,12 +572,6 @@ def fp8_block_scale_moe_runner(
         topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
-    # FIXME: temporarily disable tuning multiple runners due to kernel failure in test:
-    # python3 -m pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm]
-    tile_tokens_dim = calculate_tile_tokens_dim(hidden_states.shape[0],
-                                                num_experts,
-                                                top_k,
-                                                max_tile_tokens_dim=64)
     kernel_runners = [
         FP8BlockScaleMoERunner(
             num_experts,
@@ -583,7 +583,6 @@ def fp8_block_scale_moe_runner(
             local_num_experts,
             routed_scaling_factor,
             routing_method_type,
-            tile_tokens_dim,
         )
     ]
 
@@ -617,7 +616,8 @@ def fp8_block_scale_moe_runner(
     input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
     input_tensors[
         0] = routing_logits  # replace dummy routing logits with actual routing logits
-    return kernel_runner(input_tensors, tactic=best_tactic)
+    return kernel_runner(input_tensors,
+                         tactic=[-1, -1] if best_tactic == -1 else best_tactic)
 
 
 @fp8_block_scale_moe_runner.register_fake

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -528,14 +528,6 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
         return constraint_specs_tuple
 
-    @staticmethod
-    def inputs_pre_hook(inputs: List[torch.Tensor]):
-        args = FP8BlockScaleMoEInputs(*inputs)
-        args.hidden_states = args.hidden_states / torch.max(
-            args.hidden_states) * 448
-        # turn dataclass object to list
-        return list(args)
-
     @classmethod
     @lru_cache(maxsize=None)
     def get_tuning_config(cls) -> TuningConfig:

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -38,7 +38,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_triton import \
     IS_TRITON_KERNELS_AVAILABLE
 from tensorrt_llm._torch.modules.gated_mlp import GatedMLP
-from tensorrt_llm._utils import mpi_rank
+from tensorrt_llm._utils import get_sm_version, mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
@@ -579,10 +579,6 @@ def test_fused_moe_fp8(moe_backend, dtype, routing_cls, bias):
         fused_moe.cuda()
         fused_moe.load_weights([weights])
 
-        AutoTuner.get().clear_cache()
-        with torch.inference_mode(), autotune():
-            fused_moe.forward(x, router_logits)
-
         ref_fused_moe = RefGatedMLPFusedMoE(
             num_experts=NUM_EXPERTS,
             routing_method=routing_method,
@@ -593,13 +589,28 @@ def test_fused_moe_fp8(moe_backend, dtype, routing_cls, bias):
             bias=bias)
         ref_fused_moe.load_weights([weights])
         ref_fused_moe.cuda()
+
+        AutoTuner.get().clear_cache()
         with torch.inference_mode():
-            output = fused_moe.forward(x, router_logits)
             ref_output = ref_fused_moe.forward(x, router_logits)
 
-        # compare
-        torch.cuda.synchronize()
-        check_accuracy(output, ref_output, rtol=0.04, atol=0.1, percent=0.99)
+        with torch.inference_mode(), autotune():
+            fused_moe.forward(x, router_logits)
+
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
+            output = fused_moe.forward(x, router_logits)
+
+        # Test all kernel tactics
+        with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+        ) as iterator:
+            for _ in iterator:
+                output = fused_moe.forward(x, router_logits)
+                check_accuracy(output,
+                               ref_output,
+                               rtol=0.04,
+                               atol=0.1,
+                               percent=0.99)
 
 
 def set_tensor_value_2(x, num_row, num_cols):
@@ -1321,6 +1332,11 @@ def test_fused_moe_nvfp4(dtype, moe_backend):
     if moe_backend == "TRTLLM" and dtype == torch.float16:
         pytest.skip("TRTLLM NVFP4 MoE backend does not support float16 yet")
 
+    test_all_kernels = True
+    if get_sm_version() == 120:
+        # Disable; got "Assertion failed: Failed to initialize cutlass TMA WS grouped gemm. Error: Error Internal"
+        test_all_kernels = False
+
     mapping = Mapping()
     mapping.rank = mpi_rank()
 
@@ -1426,16 +1442,31 @@ def test_fused_moe_nvfp4(dtype, moe_backend):
         ref_fused_moe.cuda()
 
         AutoTuner.get().clear_cache()
+        with torch.inference_mode():
+            ref_output = ref_fused_moe.forward(x, router_logits)
+
         with torch.inference_mode(), autotune():
             fused_moe.forward(x, router_logits)
 
-        with torch.inference_mode():
-            output = fused_moe.forward(x, router_logits)
-            ref_output = ref_fused_moe.forward(x, router_logits)
-
-        # compare
-        torch.cuda.synchronize()
+        output = fused_moe.forward(x, router_logits)
         torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=0.15)
+
+        if not test_all_kernels:
+            return
+
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
+            output = fused_moe.forward(x, router_logits)
+
+        # Test all kernel tactics
+        with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+        ) as iterator:
+            for _ in iterator:
+                output = fused_moe.forward(x, router_logits)
+                torch.testing.assert_close(output,
+                                           ref_output,
+                                           rtol=1e-2,
+                                           atol=0.15)
 
 
 @skip_pre_blackwell
@@ -1555,16 +1586,25 @@ def test_fused_moe_w4a8_nvfp4_fp8(moe_backend):
         ref_fused_moe.cuda()
 
         AutoTuner.get().clear_cache()
+        with torch.inference_mode():
+            ref_output = ref_fused_moe.forward(x, router_logits)
+
         with torch.inference_mode(), autotune():
             fused_moe.forward(x, router_logits)
 
-        with torch.inference_mode():
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
             output = fused_moe.forward(x, router_logits)
-            ref_output = ref_fused_moe.forward(x, router_logits)
 
-        # compare
-        torch.cuda.synchronize()
-        torch.testing.assert_close(output, ref_output, rtol=1e-1, atol=0.5)
+        # Test all kernel tactics
+        with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+        ) as iterator:
+            for _ in iterator:
+                output = fused_moe.forward(x, router_logits)
+                torch.testing.assert_close(output,
+                                           ref_output,
+                                           rtol=1e-1,
+                                           atol=0.5)
 
 
 @skip_neither_ada_nor_hopper_unittest
@@ -1811,21 +1851,35 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
             return results
 
         AutoTuner.get().clear_cache()
+        with torch.inference_mode():
+            ref_output = ref()
+
         with torch.inference_mode(), autotune():
             fused_moe.forward(x, router_logits)
 
-        torch.cuda.synchronize()
-        with torch.inference_mode():
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
             output = fused_moe.forward(x, router_logits)
-            ref_output = ref()
+
+        # Test all kernel tactics
+        with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+        ) as iterator:
+            for _ in iterator:
+                output = fused_moe.forward(x, router_logits)
+                # assert that result does not contain NaN or is all 0s
+                assert not torch.isnan(output).any(), "output contains NaN"
+                assert torch.nonzero(output).numel() > 0, "output is empty"
+                torch.testing.assert_close(output,
+                                           ref_output,
+                                           rtol=1e-2,
+                                           atol=0.1)
 
         torch.cuda.synchronize()
-        # assert that result does not contain NaN or is all 0s
         assert not torch.isnan(ref_output).any(), "ref_output contains NaN"
         assert not torch.isnan(output).any(), "output contains NaN"
         assert torch.nonzero(output).numel() > 0, "output is empty"
         assert torch.nonzero(ref_output).numel() > 0, "ref_output is empty"
-        # compare
+        # Final comparison
         torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=0.1)
 
 
@@ -1920,16 +1974,23 @@ def test_fused_moe_mxfp4_mxfp8(moe_backend, bias):
     ref_fused_moe.load_weights([weights])
 
     AutoTuner.get().clear_cache()
+    with torch.inference_mode():
+        ref_output = ref_fused_moe.forward(x, router_logits)
+
     with torch.inference_mode(), autotune():
         fused_moe.forward(x, router_logits)
 
-    with torch.inference_mode():
+    # Captures fused_moe underlying runners as autotuner context
+    with torch.inference_mode(), AutoTuner.get().capture_exec_context():
         output = fused_moe.forward(x, router_logits)
-        ref_output = ref_fused_moe.forward(x, router_logits)
 
-    # compare
-    torch.cuda.synchronize()
-    torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=0.15)
+    # Test different tactics using last captured context
+    with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+    ) as iterator:
+        # Iterate runner/tactic in internal autotuner context
+        for _ in enumerate(iterator):
+            output = fused_moe.forward(x, router_logits)
+            torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=0.15)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -2061,13 +2122,15 @@ def test_fused_moe_wfp4a16(dtype, hidden_size, moe_backend):
             return results
 
         AutoTuner.get().clear_cache()
+        with torch.inference_mode():
+            ref_output = ref()
+
         with torch.inference_mode(), autotune():
             fused_moe.forward(x, router_logits)
 
-        torch.cuda.synchronize()
-        with torch.inference_mode():
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
             output = fused_moe.forward(x, router_logits)
-            ref_output = ref()
 
         # compare
         torch.cuda.synchronize()
@@ -2324,18 +2387,26 @@ def test_fused_moe_int8_woq_per_channel(dtype, weight_dtype):
             return results
 
         AutoTuner.get().clear_cache()
+        with torch.inference_mode():
+            ref_output = ref()
+
         with torch.inference_mode(), autotune():
             fused_moe.forward(x, router_logits)
 
-        torch.cuda.synchronize()
-        with torch.inference_mode():
+        # Explicitly capture context for kernel testing
+        with AutoTuner.get().capture_exec_context(), torch.inference_mode():
             output = fused_moe.forward(x, router_logits)
-            ref_output = ref()
 
-        # compare
-        torch.cuda.synchronize()
+        # Test all kernel tactics
         atol = calc_woq_tolerence(ref_output, weight_dtype)
-        torch.testing.assert_close(output, ref_output, rtol=1e-7, atol=atol)
+        with torch.inference_mode(), AutoTuner.get().get_tactics_iterator(
+        ) as iterator:
+            for _ in iterator:
+                output = fused_moe.forward(x, router_logits)
+                torch.testing.assert_close(output,
+                                           ref_output,
+                                           rtol=1e-7,
+                                           atol=atol)
 
 
 class RefGatedMLPFusedMoE(nn.Module):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced multi-tile architecture for MOE operations with enhanced configuration flexibility

* **Improvements**
  * Expanded kernel configuration support for optimized matrix operations

* **Tests**
  * Added comprehensive autotuner testing framework with execution context capture and exhaustive kernel-tactic replay
  * Enhanced kernel testing to validate outputs across multiple optimization strategies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- re-enable autotune for trtllm fp8 blockscale moe
- autotuner can iterate through all tactics for testing

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

```
tests/unittest/_torch/misc/test_autotuner.py
tests/unittest/_torch/modules/test_fused_moe.py
```
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
