### PR TITLE
[TRTLLM-8933][chore] remove unused update_executor_config function

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -3,11 +3,8 @@ from typing import Dict, List, Optional, Union
 
 from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import \
     BaseCheckpointLoader
-from tensorrt_llm.bindings.executor import ExecutorConfig
 
 from ...llmapi.llm_args import LoadFormat, SamplerType
-from ...logger import logger
-from ...mapping import Mapping
 from ..model_config import MoeLoadBalancerConfig
 from .resource_manager import BaseResourceManager
 
@@ -115,57 +112,6 @@ class PyTorchConfig:
     # total GPU memory minus the statically allocated engine memory.
     # If false, set the PyTorch CUDA memory fraction to 1.0.
     _limit_torch_cuda_mem_fraction: bool = True
-
-
-EXETENDED_EXECUTOR_CONFIG_FIELDS = [
-    'backend',
-    'pytorch_backend_config',
-    'max_seq_len',
-    'mapping',
-    'hf_model_dir',
-    'mm_encoder_only',
-]
-
-
-def update_executor_config(
-        executor_config: ExecutorConfig,
-        backend: Optional[str] = None,
-        pytorch_backend_config: Optional[PyTorchConfig] = None,
-        mapping: Optional[Mapping] = None,
-        speculative_config: Optional["DecodingBaseConfig"] = None,
-        hf_model_dir: Optional[str] = None,
-        max_input_len: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
-        checkpoint_format: Optional[str] = None,
-        checkpoint_loader: Optional[BaseCheckpointLoader] = None,
-        mm_encoder_only: bool = False):
-    if backend is None:
-        return
-
-    for field_name in EXETENDED_EXECUTOR_CONFIG_FIELDS:
-        if hasattr(executor_config, field_name):
-            raise AttributeError(
-                f"{field_name} should be dynamically assigned.")
-        setattr(executor_config, field_name, None)
-
-    executor_config.backend = backend
-    executor_config.pytorch_backend_config = pytorch_backend_config
-    executor_config.mapping = mapping
-    executor_config.speculative_config = speculative_config
-    executor_config.mm_encoder_only = mm_encoder_only
-
-    logger.info(f"{executor_config.pytorch_backend_config}")
-
-    executor_config.hf_model_dir = hf_model_dir
-
-    if max_input_len is not None:
-        executor_config.max_input_len = max_input_len
-
-    if max_seq_len is not None:
-        executor_config.max_seq_len = max_seq_len
-
-    executor_config.checkpoint_loader = _construct_checkpoint_loader(
-        backend, checkpoint_loader, checkpoint_format)
 
 
 def _construct_checkpoint_loader(

--- a/tests/unittest/executor/test_base_worker.py
+++ b/tests/unittest/executor/test_base_worker.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 
 from tensorrt_llm._utils import mpi_comm, mpi_rank, mpi_world_size
-from tensorrt_llm.bindings import executor as tllm
 from tensorrt_llm.llmapi.mpi_session import MpiPoolSession
 
 # isort: off
@@ -15,7 +14,6 @@ from utils.llm_data import llm_models_root
 from utils.util import skip_single_gpu
 # isort: on
 
-from tensorrt_llm._torch.pyexecutor.config import update_executor_config
 from tensorrt_llm.executor.base_worker import BaseWorker
 from tensorrt_llm.executor.request import GenerationRequest
 from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
@@ -28,12 +26,16 @@ model_path = llm_models_root() / default_model_name
 class FakeWorker(BaseWorker):
 
     def __init__(self, engine: str, tp_size: int = 1):
-        llm_args, executor_config = create_fake_executor_config(engine, tp_size)
+        llm_args = TorchLlmArgs(
+            model=model_path,
+            tensor_parallel_size=tp_size,
+            backend='pytorch',
+            enable_iter_perf_stats=True,
+        )
         super().__init__(
             engine=engine,
             llm_args=llm_args,
             hf_model_dir=engine,
-            executor_config=executor_config,
         )
         # Note: BaseWorker doesn't call setup_engine() automatically,
         # unlike GenerationExecutorWorker, so we need to call it manually
@@ -114,34 +116,6 @@ class TestWorkerBase:
             elapsed = time.time() - start_time
             print(f"await_responses latency: {elapsed:.3f} seconds")
             assert timeout / 2 <= elapsed <= timeout * 2, f"Latency out of expected range: {elapsed}"
-
-
-def create_fake_executor_config(model_path, tp_size=1):
-    # Use TorchLlmArgs for PyTorch backend tests
-    llm_args = TorchLlmArgs(
-        model=model_path,
-        tensor_parallel_size=tp_size,
-        backend='pytorch',
-        enable_iter_perf_stats=True,
-    )
-
-    executor_config = tllm.ExecutorConfig(1)
-    executor_config.max_batch_size = 1
-    executor_config.model_world_size = tp_size
-
-    update_executor_config(
-        executor_config,
-        pytorch_backend_config=llm_args.get_pytorch_backend_config(),
-        mapping=llm_args.parallel_config.to_mapping(),
-        speculative_config=llm_args.speculative_config,
-        hf_model_dir=model_path,
-        max_input_len=20,
-        max_seq_len=40,
-        checkpoint_format=llm_args.checkpoint_format,
-        checkpoint_loader=llm_args.checkpoint_loader,
-    )
-
-    return llm_args, executor_config
 
 
 class TestRpcWorkerBaseTP2:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed executor configuration update function and associated configuration constant from the public API.

* **Tests**
  * Updated test infrastructure to streamline configuration initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
