### PR TITLE
[https://nvbugs/5570599][fix] Only use cuda_graph_warmup_block when cuda graph is enabled

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -209,12 +209,14 @@ class KvCacheCreator:
                                  1) // self._tokens_per_block
 
         # Max cuda graph warmup required tokens
-        max_cuda_graph_bs = min(self._model_engine.batch_size,
-                                self._model_engine._max_cuda_graph_batch_size)
-        cuda_graph_warmup_block = (
-            self._model_engine.max_seq_len +
-            1) // self._tokens_per_block + max_cuda_graph_bs - 1
-        num_cache_blocks = max(cuda_graph_warmup_block, num_cache_blocks)
+        if self._pytorch_backend_config.use_cuda_graph:
+            max_cuda_graph_bs = min(
+                self._model_engine.batch_size,
+                self._model_engine._max_cuda_graph_batch_size)
+            cuda_graph_warmup_block = (
+                self._model_engine.max_seq_len +
+                1) // self._tokens_per_block + max_cuda_graph_bs - 1
+            num_cache_blocks = max(cuda_graph_warmup_block, num_cache_blocks)
 
         # This is the minimal blocks required to run with max bs
         # If not able to allocate self._model_engine.batch_size blocks, the max batch size should be adjusted.


### PR DESCRIPTION
Only use cuda_graph_warmup_block when cuda graph is enabled
