### PR TITLE
[TRTLLM-8690][feat] add more tensors to share buffers

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -124,14 +124,20 @@ class FlashInferAttentionMetadata(AttentionMetadata):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self._post_init_with_buffers(self.cuda_graph_buffers)
+
+    def _post_init_with_buffers(self, buffers) -> None:
+        capture_graph = torch.cuda.is_current_stream_capturing()
 
         if self.workspace_buffer is None:
             # Note: even though flashinfer only recommends 128 MB, we have to push it
             # a bit higher to cover all possible CUDA graph cases. If it's too small,
             # warmup will crash.
-            self.workspace_buffer = torch.empty(320 * 1024 * 1024,
-                                                dtype=torch.uint8,
-                                                device="cuda")
+            self.workspace_buffer = self.get_empty(
+                buffers, (320 * 1024 * 1024, ),
+                dtype=torch.uint8,
+                cache_name="workspace_buffer",
+                capture_graph=capture_graph)
 
         self.paged_kv_indptr_decode = torch.empty((self.max_num_requests + 1, ),
                                                   device='cuda',
@@ -163,9 +169,11 @@ class FlashInferAttentionMetadata(AttentionMetadata):
 
         if self.kv_cache_manager is not None:
             max_num_pages = self.kv_cache_manager.blocks_in_primary_pool
-            self._paged_kv_indices = torch.empty((max_num_pages, ),
-                                                 device='cuda',
-                                                 dtype=torch.int)
+            self._paged_kv_indices = self.get_empty(
+                buffers, (max_num_pages, ),
+                dtype=torch.int,
+                cache_name="_paged_kv_indices",
+                capture_graph=capture_graph)
 
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,

--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -134,10 +134,12 @@ class FlashInferAttentionMetadata(AttentionMetadata):
             # a bit higher to cover all possible CUDA graph cases. If it's too small,
             # warmup will crash.
             self.workspace_buffer = self.get_empty(
-                buffers, (320 * 1024 * 1024, ),
+                buffers,
+                (320 * 1024 * 1024, ),
                 dtype=torch.uint8,
                 cache_name="workspace_buffer",
-                capture_graph=capture_graph)
+                capture_graph=capture_graph,
+            )
 
         self.paged_kv_indptr_decode = torch.empty((self.max_num_requests + 1, ),
                                                   device='cuda',
@@ -170,10 +172,12 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         if self.kv_cache_manager is not None:
             max_num_pages = self.kv_cache_manager.blocks_in_primary_pool
             self._paged_kv_indices = self.get_empty(
-                buffers, (max_num_pages, ),
+                buffers,
+                (max_num_pages, ),
                 dtype=torch.int,
                 cache_name="_paged_kv_indices",
-                capture_graph=capture_graph)
+                capture_graph=capture_graph,
+            )
 
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -384,11 +384,13 @@ class AttentionMetadata:
                        like_tensor: torch.Tensor,
                        cache_name: str,
                        capture_graph: bool = False) -> torch.Tensor:
-        return AttentionMetadata.get_empty(buffers,
-                                           like_tensor.shape,
-                                           dtype=like_tensor.dtype,
-                                           cache_name=cache_name,
-                                           capture_graph=capture_graph)
+        return AttentionMetadata.get_empty(
+            buffers,
+            like_tensor.shape,
+            dtype=like_tensor.dtype,
+            cache_name=cache_name,
+            capture_graph=capture_graph,
+        )
 
 
 class PositionalEmbedder(Protocol):

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -17,6 +17,7 @@ from tensorrt_llm.functional import (PositionEmbeddingType, RopeEmbeddingUtils,
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
+from ..memory_buffer_utils import Buffers
 from ..metadata import KVCacheParams
 from ..pyexecutor.resource_manager import KVCacheManager
 from ..utils import get_model_extra_attrs
@@ -350,7 +351,7 @@ class AttentionMetadata:
         """
 
     @staticmethod
-    def get_empty(buffers,
+    def get_empty(buffers: Buffers,
                   tensor_shape: list[int],
                   dtype: torch.dtype,
                   cache_name: str,

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -349,6 +349,47 @@ class AttentionMetadata:
         Hook to be called during forward when using spec-dec one-model mode.
         """
 
+    @staticmethod
+    def get_empty(buffers,
+                  tensor_shape: list[int],
+                  dtype: torch.dtype,
+                  cache_name: str,
+                  capture_graph: bool = False) -> torch.Tensor:
+        """
+        Finds a compatible, reusable buffer from a cache or creates a new one.
+
+        This function searches for a pre-allocated tensor (buffer) that can be
+        reused for an operation involving a tensor with the shape of `tensor_shape`.
+
+        The compatibility rules are: The buffer's total elements must be >= tensor_shape's.
+
+        If a compatible buffer is found, it's returned immediately. Otherwise, a new
+        buffer is allocated on the 'cuda' device with the give properties of 'tensor_shape' and 'dtype'.
+
+        Args:
+            tensor_shape: The required shape.
+            dtype: The required dtype.
+            cache_name: The key for the specific list of buffers to search in.
+        Returns:
+            An existing compatible buffer or a newly created one.
+        """
+        if buffers is None:
+            return torch.zeros(tensor_shape, device='cuda', dtype=dtype)
+
+        return buffers.get_buffer(tensor_shape, dtype, cache_name,
+                                  capture_graph)
+
+    @staticmethod
+    def get_empty_like(buffers,
+                       like_tensor: torch.Tensor,
+                       cache_name: str,
+                       capture_graph: bool = False) -> torch.Tensor:
+        return AttentionMetadata.get_empty(buffers,
+                                           like_tensor.shape,
+                                           dtype=like_tensor.dtype,
+                                           cache_name=cache_name,
+                                           capture_graph=capture_graph)
+
 
 class PositionalEmbedder(Protocol):
     """

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -305,6 +305,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         capture_graph = torch.cuda.is_current_stream_capturing()
 
         self.indexer_k_cache_block_offsets = self.get_empty(
+            self.cuda_graph_buffers,
             [self.max_num_sequences, self.kv_cache_manager.max_blocks_per_seq],
             cache_name="indexer_k_cache_block_offsets",
             dtype=torch.int32,
@@ -318,7 +319,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # For mla_rope_append_paged_kv_assign_q
         if not self.enable_context_mla_with_cached_kv:
             self.ctx_cached_token_indptr = self.get_empty(
-                (self.max_num_requests + 1, ),
+                self.cuda_graph_buffers, (self.max_num_requests + 1, ),
                 cache_name="ctx_cached_token_indptr",
                 dtype=torch.int64,
                 capture_graph=capture_graph)
@@ -327,7 +328,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                 device='cpu',
                 pin_memory=True,
             )
-            self.ctx_kv_indptr = self.get_empty((self.max_num_requests + 1, ),
+            self.ctx_kv_indptr = self.get_empty(self.cuda_graph_buffers,
+                                                (self.max_num_requests + 1, ),
                                                 cache_name="ctx_kv_indptr",
                                                 dtype=torch.int64,
                                                 capture_graph=capture_graph)
@@ -338,7 +340,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             )
         # New generation buffers for dsa
         self.gen_cached_token_indptr = self.get_empty(
-            (self.max_num_requests + 1, ),
+            self.cuda_graph_buffers, (self.max_num_requests + 1, ),
             cache_name="gen_cached_token_indptr",
             dtype=torch.int64,
             capture_graph=capture_graph)
@@ -347,7 +349,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             device='cpu',
             pin_memory=True,
         )
-        self.gen_kv_indptr = self.get_empty((self.max_num_requests + 1, ),
+        self.gen_kv_indptr = self.get_empty(self.cuda_graph_buffers,
+                                            (self.max_num_requests + 1, ),
                                             cache_name="gen_kv_indptr",
                                             dtype=torch.int64,
                                             capture_graph=capture_graph)
@@ -358,7 +361,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         )
         # Indexer metadata
         # Separate slot mappings for non-interleaved layout (flat byte indices)
-        self.slot_mapping_fp8 = self.get_empty((self.max_num_tokens, ),
+        self.slot_mapping_fp8 = self.get_empty(self.cuda_graph_buffers,
+                                               (self.max_num_tokens, ),
                                                cache_name="slot_mapping_fp8",
                                                dtype=torch.int64,
                                                capture_graph=capture_graph)
@@ -368,7 +372,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             pin_memory=True,
         )
         self.slot_mapping_scale = self.get_empty(
-            (self.max_num_tokens, ),
+            self.cuda_graph_buffers, (self.max_num_tokens, ),
             cache_name="slot_mapping_scale",
             dtype=torch.int64,
             capture_graph=capture_graph)
@@ -378,26 +382,30 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             pin_memory=True,
         )
         # Per-token request index buffer for topk_indices conversion
-        self.req_idx_per_token = self.get_empty((self.max_num_tokens, ),
+        self.req_idx_per_token = self.get_empty(self.cuda_graph_buffers,
+                                                (self.max_num_tokens, ),
                                                 cache_name="req_idx_per_token",
                                                 dtype=torch.int32,
                                                 capture_graph=capture_graph)
         # Block table for topk_indices conversion (shared for context and generation)
         self.block_table = self.get_empty(
+            self.cuda_graph_buffers,
             (self.max_num_requests, self.kv_cache_manager.max_blocks_per_seq),
             cache_name="block_table",
             dtype=torch.int32,
             capture_graph=capture_graph)
         self.scheduler_metadata_buffer = self.get_empty(
-            (self.num_sms + 1, 2),
+            self.cuda_graph_buffers, (self.num_sms + 1, 2),
             cache_name="scheduler_metadata_buffer",
             dtype=torch.int32,
             capture_graph=capture_graph)
-        self.cu_seqlen_ks = self.get_empty((self.max_num_tokens, ),
+        self.cu_seqlen_ks = self.get_empty(self.cuda_graph_buffers,
+                                           (self.max_num_tokens, ),
                                            cache_name="cu_seqlen_ks",
                                            dtype=torch.int32,
                                            capture_graph=capture_graph)
-        self.cu_seqlen_ke = self.get_empty((self.max_num_tokens, ),
+        self.cu_seqlen_ke = self.get_empty(self.cuda_graph_buffers,
+                                           (self.max_num_tokens, ),
                                            cache_name="cu_seqlen_ke",
                                            dtype=torch.int32,
                                            capture_graph=capture_graph)

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -304,7 +304,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
 
         capture_graph = torch.cuda.is_current_stream_capturing()
 
-        self.indexer_k_cache_block_offsets = get_empty(
+        self.indexer_k_cache_block_offsets = self.get_empty(
             [self.max_num_sequences, self.kv_cache_manager.max_blocks_per_seq],
             cache_name="indexer_k_cache_block_offsets",
             dtype=torch.int32,
@@ -317,7 +317,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
 
         # For mla_rope_append_paged_kv_assign_q
         if not self.enable_context_mla_with_cached_kv:
-            self.ctx_cached_token_indptr = get_empty(
+            self.ctx_cached_token_indptr = self.get_empty(
                 (self.max_num_requests + 1, ),
                 cache_name="ctx_cached_token_indptr",
                 dtype=torch.int64,
@@ -327,17 +327,17 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                 device='cpu',
                 pin_memory=True,
             )
-            self.ctx_kv_indptr = get_empty((self.max_num_requests + 1, ),
-                                           cache_name="ctx_kv_indptr",
-                                           dtype=torch.int64,
-                                           capture_graph=capture_graph)
+            self.ctx_kv_indptr = self.get_empty((self.max_num_requests + 1, ),
+                                                cache_name="ctx_kv_indptr",
+                                                dtype=torch.int64,
+                                                capture_graph=capture_graph)
             self.host_ctx_kv_indptr = torch.zeros_like(
                 self.ctx_kv_indptr,
                 device='cpu',
                 pin_memory=True,
             )
         # New generation buffers for dsa
-        self.gen_cached_token_indptr = get_empty(
+        self.gen_cached_token_indptr = self.get_empty(
             (self.max_num_requests + 1, ),
             cache_name="gen_cached_token_indptr",
             dtype=torch.int64,
@@ -347,10 +347,10 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             device='cpu',
             pin_memory=True,
         )
-        self.gen_kv_indptr = get_empty((self.max_num_requests + 1, ),
-                                       cache_name="gen_kv_indptr",
-                                       dtype=torch.int64,
-                                       capture_graph=capture_graph)
+        self.gen_kv_indptr = self.get_empty((self.max_num_requests + 1, ),
+                                            cache_name="gen_kv_indptr",
+                                            dtype=torch.int64,
+                                            capture_graph=capture_graph)
         self.host_gen_kv_indptr = torch.zeros_like(
             self.gen_kv_indptr,
             device='cpu',
@@ -358,48 +358,49 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         )
         # Indexer metadata
         # Separate slot mappings for non-interleaved layout (flat byte indices)
-        self.slot_mapping_fp8 = get_empty((self.max_num_tokens, ),
-                                          cache_name="slot_mapping_fp8",
-                                          dtype=torch.int64,
-                                          capture_graph=capture_graph)
+        self.slot_mapping_fp8 = self.get_empty((self.max_num_tokens, ),
+                                               cache_name="slot_mapping_fp8",
+                                               dtype=torch.int64,
+                                               capture_graph=capture_graph)
         self.host_slot_mapping_fp8 = torch.zeros_like(
             self.slot_mapping_fp8,
             device='cpu',
             pin_memory=True,
         )
-        self.slot_mapping_scale = get_empty((self.max_num_tokens, ),
-                                            cache_name="slot_mapping_scale",
-                                            dtype=torch.int64,
-                                            capture_graph=capture_graph)
+        self.slot_mapping_scale = self.get_empty(
+            (self.max_num_tokens, ),
+            cache_name="slot_mapping_scale",
+            dtype=torch.int64,
+            capture_graph=capture_graph)
         self.host_slot_mapping_scale = torch.zeros_like(
             self.slot_mapping_scale,
             device='cpu',
             pin_memory=True,
         )
         # Per-token request index buffer for topk_indices conversion
-        self.req_idx_per_token = get_empty((self.max_num_tokens, ),
-                                           cache_name="req_idx_per_token",
-                                           dtype=torch.int32,
-                                           capture_graph=capture_graph)
+        self.req_idx_per_token = self.get_empty((self.max_num_tokens, ),
+                                                cache_name="req_idx_per_token",
+                                                dtype=torch.int32,
+                                                capture_graph=capture_graph)
         # Block table for topk_indices conversion (shared for context and generation)
-        self.block_table = get_empty(
+        self.block_table = self.get_empty(
             (self.max_num_requests, self.kv_cache_manager.max_blocks_per_seq),
             cache_name="block_table",
             dtype=torch.int32,
             capture_graph=capture_graph)
-        self.scheduler_metadata_buffer = get_empty(
+        self.scheduler_metadata_buffer = self.get_empty(
             (self.num_sms + 1, 2),
             cache_name="scheduler_metadata_buffer",
             dtype=torch.int32,
             capture_graph=capture_graph)
-        self.cu_seqlen_ks = get_empty((self.max_num_tokens, ),
-                                      cache_name="cu_seqlen_ks",
-                                      dtype=torch.int32,
-                                      capture_graph=capture_graph)
-        self.cu_seqlen_ke = get_empty((self.max_num_tokens, ),
-                                      cache_name="cu_seqlen_ke",
-                                      dtype=torch.int32,
-                                      capture_graph=capture_graph)
+        self.cu_seqlen_ks = self.get_empty((self.max_num_tokens, ),
+                                           cache_name="cu_seqlen_ks",
+                                           dtype=torch.int32,
+                                           capture_graph=capture_graph)
+        self.cu_seqlen_ke = self.get_empty((self.max_num_tokens, ),
+                                           cache_name="cu_seqlen_ke",
+                                           dtype=torch.int32,
+                                           capture_graph=capture_graph)
 
     def prepare(self):
         super().prepare()

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -309,7 +309,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             [self.max_num_sequences, self.kv_cache_manager.max_blocks_per_seq],
             cache_name="indexer_k_cache_block_offsets",
             dtype=torch.int32,
-            capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
         self.host_indexer_k_cache_block_offsets = torch.zeros_like(
             self.indexer_k_cache_block_offsets,
             device='cpu',
@@ -319,20 +320,24 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # For mla_rope_append_paged_kv_assign_q
         if not self.enable_context_mla_with_cached_kv:
             self.ctx_cached_token_indptr = self.get_empty(
-                self.cuda_graph_buffers, (self.max_num_requests + 1, ),
+                self.cuda_graph_buffers,
+                (self.max_num_requests + 1, ),
                 cache_name="ctx_cached_token_indptr",
                 dtype=torch.int64,
-                capture_graph=capture_graph)
+                capture_graph=capture_graph,
+            )
             self.host_ctx_cached_token_indptr = torch.zeros_like(
                 self.ctx_cached_token_indptr,
                 device='cpu',
                 pin_memory=True,
             )
-            self.ctx_kv_indptr = self.get_empty(self.cuda_graph_buffers,
-                                                (self.max_num_requests + 1, ),
-                                                cache_name="ctx_kv_indptr",
-                                                dtype=torch.int64,
-                                                capture_graph=capture_graph)
+            self.ctx_kv_indptr = self.get_empty(
+                self.cuda_graph_buffers,
+                (self.max_num_requests + 1, ),
+                cache_name="ctx_kv_indptr",
+                dtype=torch.int64,
+                capture_graph=capture_graph,
+            )
             self.host_ctx_kv_indptr = torch.zeros_like(
                 self.ctx_kv_indptr,
                 device='cpu',
@@ -340,20 +345,24 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             )
         # New generation buffers for dsa
         self.gen_cached_token_indptr = self.get_empty(
-            self.cuda_graph_buffers, (self.max_num_requests + 1, ),
+            self.cuda_graph_buffers,
+            (self.max_num_requests + 1, ),
             cache_name="gen_cached_token_indptr",
             dtype=torch.int64,
-            capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
         self.host_gen_cached_token_indptr = torch.zeros_like(
             self.gen_cached_token_indptr,
             device='cpu',
             pin_memory=True,
         )
-        self.gen_kv_indptr = self.get_empty(self.cuda_graph_buffers,
-                                            (self.max_num_requests + 1, ),
-                                            cache_name="gen_kv_indptr",
-                                            dtype=torch.int64,
-                                            capture_graph=capture_graph)
+        self.gen_kv_indptr = self.get_empty(
+            self.cuda_graph_buffers,
+            (self.max_num_requests + 1, ),
+            cache_name="gen_kv_indptr",
+            dtype=torch.int64,
+            capture_graph=capture_graph,
+        )
         self.host_gen_kv_indptr = torch.zeros_like(
             self.gen_kv_indptr,
             device='cpu',
@@ -361,54 +370,67 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         )
         # Indexer metadata
         # Separate slot mappings for non-interleaved layout (flat byte indices)
-        self.slot_mapping_fp8 = self.get_empty(self.cuda_graph_buffers,
-                                               (self.max_num_tokens, ),
-                                               cache_name="slot_mapping_fp8",
-                                               dtype=torch.int64,
-                                               capture_graph=capture_graph)
+        self.slot_mapping_fp8 = self.get_empty(
+            self.cuda_graph_buffers,
+            (self.max_num_tokens, ),
+            cache_name="slot_mapping_fp8",
+            dtype=torch.int64,
+            capture_graph=capture_graph,
+        )
         self.host_slot_mapping_fp8 = torch.zeros_like(
             self.slot_mapping_fp8,
             device='cpu',
             pin_memory=True,
         )
         self.slot_mapping_scale = self.get_empty(
-            self.cuda_graph_buffers, (self.max_num_tokens, ),
+            self.cuda_graph_buffers,
+            (self.max_num_tokens, ),
             cache_name="slot_mapping_scale",
             dtype=torch.int64,
-            capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
         self.host_slot_mapping_scale = torch.zeros_like(
             self.slot_mapping_scale,
             device='cpu',
             pin_memory=True,
         )
         # Per-token request index buffer for topk_indices conversion
-        self.req_idx_per_token = self.get_empty(self.cuda_graph_buffers,
-                                                (self.max_num_tokens, ),
-                                                cache_name="req_idx_per_token",
-                                                dtype=torch.int32,
-                                                capture_graph=capture_graph)
+        self.req_idx_per_token = self.get_empty(
+            self.cuda_graph_buffers,
+            (self.max_num_tokens, ),
+            cache_name="req_idx_per_token",
+            dtype=torch.int32,
+            capture_graph=capture_graph,
+        )
         # Block table for topk_indices conversion (shared for context and generation)
         self.block_table = self.get_empty(
             self.cuda_graph_buffers,
             (self.max_num_requests, self.kv_cache_manager.max_blocks_per_seq),
             cache_name="block_table",
             dtype=torch.int32,
-            capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
         self.scheduler_metadata_buffer = self.get_empty(
-            self.cuda_graph_buffers, (self.num_sms + 1, 2),
+            self.cuda_graph_buffers,
+            (self.num_sms + 1, 2),
             cache_name="scheduler_metadata_buffer",
             dtype=torch.int32,
-            capture_graph=capture_graph)
-        self.cu_seqlen_ks = self.get_empty(self.cuda_graph_buffers,
-                                           (self.max_num_tokens, ),
-                                           cache_name="cu_seqlen_ks",
-                                           dtype=torch.int32,
-                                           capture_graph=capture_graph)
-        self.cu_seqlen_ke = self.get_empty(self.cuda_graph_buffers,
-                                           (self.max_num_tokens, ),
-                                           cache_name="cu_seqlen_ke",
-                                           dtype=torch.int32,
-                                           capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
+        self.cu_seqlen_ks = self.get_empty(
+            self.cuda_graph_buffers,
+            (self.max_num_tokens, ),
+            cache_name="cu_seqlen_ks",
+            dtype=torch.int32,
+            capture_graph=capture_graph,
+        )
+        self.cu_seqlen_ke = self.get_empty(
+            self.cuda_graph_buffers,
+            (self.max_num_tokens, ),
+            cache_name="cu_seqlen_ke",
+            dtype=torch.int32,
+            capture_graph=capture_graph,
+        )
 
     def prepare(self):
         super().prepare()

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -38,13 +38,15 @@ class RocketTrtllmAttentionMetadata(TrtllmAttentionMetadata):
 
         capture_graph = torch.cuda.is_current_stream_capturing()
         self.kt_cache_block_offsets = self.get_empty(
-            self.cuda_graph_buffers, [
+            self.cuda_graph_buffers,
+            [
                 self.max_num_sequences,
                 self.kv_cache_manager.max_kt_blocks_per_seq
             ],
             dtype=torch.int32,
             cache_name="kt_cache_block_offsets",
-            capture_graph=capture_graph)
+            capture_graph=capture_graph,
+        )
 
         self.host_kt_cache_block_offsets = torch.zeros_like(
             self.kt_cache_block_offsets,

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -35,14 +35,17 @@ class RocketTrtllmAttentionMetadata(TrtllmAttentionMetadata):
         if self.sparse_attention_config is None:
             raise ValueError("Sparse attention config is not set")
         self.prompt_budget = self.sparse_attention_config.prompt_budget
-        self.kt_cache_block_offsets = torch.empty(
-            [
+
+        capture_graph = torch.cuda.is_current_stream_capturing()
+        self.kt_cache_block_offsets = self.get_empty(
+            self.cuda_graph_buffers, [
                 self.max_num_sequences,
                 self.kv_cache_manager.max_kt_blocks_per_seq
             ],
             dtype=torch.int32,
-            device='cuda',
-        )
+            cache_name="kt_cache_block_offsets",
+            capture_graph=capture_graph)
+
         self.host_kt_cache_block_offsets = torch.zeros_like(
             self.kt_cache_block_offsets,
             device='cpu',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -649,50 +649,20 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
         capture_graph = torch.cuda.is_current_stream_capturing()
 
-        def get_empty(tensor_shape: list[int], dtype: torch.dtype,
-                      cache_name: str) -> torch.Tensor:
-            """
-            Finds a compatible, reusable buffer from a cache or creates a new one.
-
-            This function searches for a pre-allocated tensor (buffer) that can be
-            reused for an operation involving a tensor with the shape of `tensor_shape`.
-
-            The compatibility rules are: The buffer's total elements must be >= tensor_shape's.
-
-            If a compatible buffer is found, it's returned immediately. Otherwise, a new
-            buffer is allocated on the 'cuda' device with the give properties of 'tensor_shape' and 'dtype'.
-
-            Args:
-                tensor_shape: The required shape.
-                dtype: The required dtype.
-                cache_name: The key for the specific list of buffers to search in.
-            Returns:
-                An existing compatible buffer or a newly created one.
-            """
-            if buffers is None:
-                return torch.zeros(tensor_shape, device='cuda', dtype=dtype)
-
-            return buffers.get_buffer(tensor_shape, dtype, cache_name,
-                                      capture_graph)
-
-        def get_empty_like(like_tensor: torch.Tensor,
-                           cache_name: str) -> torch.Tensor:
-            return get_empty(like_tensor.shape,
-                             cache_name=cache_name,
-                             dtype=like_tensor.dtype)
-
-        self.prompt_lens_cuda = get_empty(
-            (self.max_num_sequences, ),
-            cache_name="prompt_lens_cuda",
-            dtype=torch.int,
-        )
+        self.prompt_lens_cuda = self.get_empty(buffers,
+                                               (self.max_num_sequences, ),
+                                               cache_name="prompt_lens_cuda",
+                                               dtype=torch.int,
+                                               capture_graph=capture_graph)
         self.prompt_lens_cpu = torch.empty_like(
             self.prompt_lens_cuda,
             device='cpu',
             pin_memory=True,
         )
-        self.kv_lens_cuda = get_empty_like(self.prompt_lens_cuda,
-                                           cache_name="kv_lens_cuda")
+        self.kv_lens_cuda = self.get_empty_like(buffers,
+                                                self.prompt_lens_cuda,
+                                                cache_name="kv_lens_cuda",
+                                                capture_graph=capture_graph)
         self.kv_lens = torch.empty_like(self.kv_lens_cuda,
                                         device='cpu',
                                         pin_memory=True)
@@ -707,14 +677,14 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 dtype=torch.int8,
             )
         if self.kv_cache_manager is not None:
-            self.kv_cache_block_offsets = get_empty(
-                [
+            self.kv_cache_block_offsets = self.get_empty(
+                buffers, [
                     self.kv_cache_manager.num_pools, self.max_num_sequences, 2,
                     self.kv_cache_manager.max_blocks_per_seq
                 ],
                 cache_name="kv_cache_block_offsets",
                 dtype=torch.int32,
-            )
+                capture_graph=capture_graph)
             self.host_kv_cache_block_offsets = torch.empty_like(
                 self.kv_cache_block_offsets,
                 device='cpu',
@@ -723,50 +693,50 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             self.block_ids_per_seq = None
             self.kv_block_ids_per_seq = None
             if self.enable_flash_mla:
-                self.block_ids_per_seq = get_empty(
-                    [
+                self.block_ids_per_seq = self.get_empty(
+                    buffers, [
                         self.kv_cache_manager.max_batch_size,
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="block_ids_per_seq",
                     dtype=torch.int32,
-                )
-                self.kv_block_ids_per_seq = get_empty(
-                    [
+                    capture_graph=capture_graph)
+                self.kv_block_ids_per_seq = self.get_empty(
+                    buffers, [
                         self.kv_cache_manager.max_batch_size,
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="kv_block_ids_per_seq",
                     dtype=torch.int32,
-                )
+                    capture_graph=capture_graph)
             if self.enable_context_mla_with_cached_kv:
                 # for kv cache reuse/chunked context in MLA
-                self.ctx_cached_token_indptr = get_empty(
-                    (self.max_num_requests + 1, ),
+                self.ctx_cached_token_indptr = self.get_empty(
+                    buffers, (self.max_num_requests + 1, ),
                     cache_name="ctx_cached_token_indptr",
                     dtype=torch.int64,
-                )
+                    capture_graph=capture_graph)
                 self.host_ctx_cached_token_indptr = torch.zeros_like(
                     self.ctx_cached_token_indptr,
                     device='cpu',
                     pin_memory=True,
                 )
-                self.ctx_uncached_token_indptr = get_empty(
-                    (self.max_num_requests + 1, ),
+                self.ctx_uncached_token_indptr = self.get_empty(
+                    buffers, (self.max_num_requests + 1, ),
                     cache_name="ctx_uncached_token_indptr",
                     dtype=torch.int64,
-                )
+                    capture_graph=capture_graph)
                 self.host_ctx_uncached_token_indptr = torch.zeros_like(
                     self.ctx_uncached_token_indptr,
                     device='cpu',
                     pin_memory=True,
                 )
                 # context full seqlens include cached tokens and uncached tokens
-                self.ctx_kv_indptr = get_empty(
-                    (self.max_num_requests + 1, ),
+                self.ctx_kv_indptr = self.get_empty(
+                    buffers, (self.max_num_requests + 1, ),
                     cache_name="ctx_kv_indptr",
                     dtype=torch.int64,
-                )
+                    capture_graph=capture_graph)
                 self.host_ctx_kv_indptr = torch.zeros_like(
                     self.ctx_kv_indptr,
                     device='cpu',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -649,20 +649,24 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
         capture_graph = torch.cuda.is_current_stream_capturing()
 
-        self.prompt_lens_cuda = self.get_empty(buffers,
-                                               (self.max_num_sequences, ),
-                                               cache_name="prompt_lens_cuda",
-                                               dtype=torch.int,
-                                               capture_graph=capture_graph)
+        self.prompt_lens_cuda = self.get_empty(
+            buffers,
+            (self.max_num_sequences, ),
+            cache_name="prompt_lens_cuda",
+            dtype=torch.int,
+            capture_graph=capture_graph,
+        )
         self.prompt_lens_cpu = torch.empty_like(
             self.prompt_lens_cuda,
             device='cpu',
             pin_memory=True,
         )
-        self.kv_lens_cuda = self.get_empty_like(buffers,
-                                                self.prompt_lens_cuda,
-                                                cache_name="kv_lens_cuda",
-                                                capture_graph=capture_graph)
+        self.kv_lens_cuda = self.get_empty_like(
+            buffers,
+            self.prompt_lens_cuda,
+            cache_name="kv_lens_cuda",
+            capture_graph=capture_graph,
+        )
         self.kv_lens = torch.empty_like(self.kv_lens_cuda,
                                         device='cpu',
                                         pin_memory=True)
@@ -678,13 +682,15 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             )
         if self.kv_cache_manager is not None:
             self.kv_cache_block_offsets = self.get_empty(
-                buffers, [
+                buffers,
+                [
                     self.kv_cache_manager.num_pools, self.max_num_sequences, 2,
                     self.kv_cache_manager.max_blocks_per_seq
                 ],
                 cache_name="kv_cache_block_offsets",
                 dtype=torch.int32,
-                capture_graph=capture_graph)
+                capture_graph=capture_graph,
+            )
             self.host_kv_cache_block_offsets = torch.empty_like(
                 self.kv_cache_block_offsets,
                 device='cpu',
@@ -694,38 +700,46 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             self.kv_block_ids_per_seq = None
             if self.enable_flash_mla:
                 self.block_ids_per_seq = self.get_empty(
-                    buffers, [
+                    buffers,
+                    [
                         self.kv_cache_manager.max_batch_size,
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="block_ids_per_seq",
                     dtype=torch.int32,
-                    capture_graph=capture_graph)
+                    capture_graph=capture_graph,
+                )
                 self.kv_block_ids_per_seq = self.get_empty(
-                    buffers, [
+                    buffers,
+                    [
                         self.kv_cache_manager.max_batch_size,
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="kv_block_ids_per_seq",
                     dtype=torch.int32,
-                    capture_graph=capture_graph)
+                    capture_graph=capture_graph,
+                )
             if self.enable_context_mla_with_cached_kv:
                 # for kv cache reuse/chunked context in MLA
                 self.ctx_cached_token_indptr = self.get_empty(
-                    buffers, (self.max_num_requests + 1, ),
+                    buffers,
+                    (self.max_num_requests + 1, ),
                     cache_name="ctx_cached_token_indptr",
                     dtype=torch.int64,
-                    capture_graph=capture_graph)
+                    capture_graph=capture_graph,
+                )
                 self.host_ctx_cached_token_indptr = torch.zeros_like(
                     self.ctx_cached_token_indptr,
                     device='cpu',
                     pin_memory=True,
                 )
                 self.ctx_uncached_token_indptr = self.get_empty(
-                    buffers, (self.max_num_requests + 1, ),
+                    buffers,
+                    (self.max_num_requests + 1, ),
                     cache_name="ctx_uncached_token_indptr",
                     dtype=torch.int64,
-                    capture_graph=capture_graph)
+                    capture_graph=capture_graph,
+                )
                 self.host_ctx_uncached_token_indptr = torch.zeros_like(
                     self.ctx_uncached_token_indptr,
                     device='cpu',
@@ -733,10 +747,12 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 )
                 # context full seqlens include cached tokens and uncached tokens
                 self.ctx_kv_indptr = self.get_empty(
-                    buffers, (self.max_num_requests + 1, ),
+                    buffers,
+                    (self.max_num_requests + 1, ),
                     cache_name="ctx_kv_indptr",
                     dtype=torch.int64,
-                    capture_graph=capture_graph)
+                    capture_graph=capture_graph,
+                )
                 self.host_ctx_kv_indptr = torch.zeros_like(
                     self.ctx_kv_indptr,
                     device='cpu',

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -1,11 +1,16 @@
 import contextlib
 import math
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
 
 from tensorrt_llm.logger import logger
+
+
+def get_size_in_byte(target_shape: list[int], target_dtype: torch.dtype):
+    return math.prod(target_shape) * target_dtype.itemsize
 
 
 @dataclass
@@ -30,26 +35,65 @@ class Buffers:
 
     def __init__(self):
         self.buffers: dict[str, list[BufferBlock]] = {}
+        self.managed_buffers = OrderedDict()
+        self.max_buffer_concurrency = 0
 
     @staticmethod
     def _view_as(buffer: torch.Tensor, target_shape: list[int],
                  target_dtype: torch.dtype) -> torch.Tensor:
         """Safely creates a view of a raw byte buffer with the desired shape and dtype."""
         # The buffer is stored as uint8, so its numel is its size in bytes.
-        required_size_in_bytes = math.prod(target_shape) * target_dtype.itemsize
-        if buffer.numel() < required_size_in_bytes:
+        required_memory_size = get_size_in_byte(target_shape, target_dtype)
+        if buffer.numel() < required_memory_size:
             raise ValueError(
                 "Buffer is too small for the requested shape and dtype.")
 
         # Slice the buffer to the exact required size, then view it with the correct type and shape.
-        return buffer[:required_size_in_bytes].view(target_dtype).view(
+        return buffer[:required_memory_size].view(target_dtype).view(
             target_shape)
+
+    def _get_managed_buffer(self, required_memory_size: int):
+        size, buffer = get_smallest_key_greater_than(self.managed_buffers,
+                                                     required_memory_size)
+
+        if size is not None and buffer is not None:
+            return buffer
+
+        size_1, buffer_1 = get_biggest_key_smaller_than(self.managed_buffers,
+                                                        required_memory_size)
+        if size_1 is not None and buffer is not None:
+            del self.managed_buffers[size_1]
+
+        new_buffer_tensor = None
+        try:
+            with torch.cuda.memory.use_mem_pool(get_shared_pool()):
+                new_buffer_tensor = torch.zeros((required_memory_size, ),
+                                                device='cuda',
+                                                dtype=torch.uint8)
+        except Exception as ex:
+            # Need to check if this is an OOM exception
+            logger.debug(
+                f"Exception happened to create tensor from given memory pool: {str(ex)}"
+            )
+            # if exception happens during allocating memory from shared pool, retry
+            # to allocate from default pool
+            new_buffer_tensor = torch.zeros((required_memory_size, ),
+                                            device='cuda',
+                                            dtype=torch.uint8)
+
+        self.managed_buffers[required_memory_size] = new_buffer_tensor
+
+        return new_buffer_tensor
 
     def get_buffer(self, tensor_shape: list[int], dtype: torch.dtype,
                    buffer_name: str, reserve_buffer: bool):
 
         # all buffers are allocated with 1 byte element size
         required_memory_size = math.prod(tensor_shape) * dtype.itemsize
+
+        if buffer_name is None or len(buffer_name) == 0:
+            return _get_managed_buffer(required_memory_size)
+
         candidate_blocks = self.buffers.get(buffer_name, [])
 
         # Find the best-fit available buffer.

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -9,6 +9,28 @@ import torch
 from tensorrt_llm.logger import logger
 
 
+def get_smallest_key_greater_than(ordered_dict, target_value):
+    """
+    Return (k, ordered_dict[k]) where k is the smallest key with k >= target_value,
+    or (None, None) if not found.
+    """
+    min_key = min((k for k in ordered_dict.keys() if k >= target_value),
+                  default=None)
+    return (min_key, ordered_dict[min_key]) if min_key is not None else (None,
+                                                                         None)
+
+
+def get_biggest_key_smaller_than(ordered_dict, target_value):
+    """
+    Return (k, ordered_dict[k]) where k is the largest key with k < target_value,
+    or (None, None) if not found.
+    """
+    max_key = max((k for k in ordered_dict.keys() if k < target_value),
+                  default=None)
+    return (max_key, ordered_dict[max_key]) if max_key is not None else (None,
+                                                                         None)
+
+
 def get_size_in_byte(target_shape: list[int], target_dtype: torch.dtype):
     return math.prod(target_shape) * target_dtype.itemsize
 

--- a/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_deepgemm.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import torch
 
+from ....memory_buffer_utils import get_memory_buffers
 from .moe_op import MoEOp
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
 class DeepGemmMoEOp(MoEOp):
     """DeepGemm-based MoE op for GB200 block FP8."""
+    buffers = get_memory_buffers()
 
     def __init__(self):
         """Initialize DeepGemm op."""
@@ -85,23 +87,27 @@ class DeepGemmMoEOp(MoEOp):
         workspace = {}
 
         # Workspace for FP8 activations
-        workspace["workspace_0"] = torch.empty(
+        capture_graph = torch.cuda.is_current_stream_capturing()
+        workspace["workspace_0"] = DeepGemmMoEOp.buffers.get_buffer(
             (expert_size_per_partition * m_max * fp8_dim),
             dtype=torch.float8_e4m3fn,
-            device='cuda')
+            buffer_name='workspace_0',
+            reserve_buffer=capture_graph)
 
         # Workspace for intermediate results
-        workspace["workspace_1"] = torch.empty(
+        workspace["workspace_1"] = DeepGemmMoEOp.buffers.get_buffer(
             (expert_size_per_partition * m_max *
              max(intermediate_size * 2, hidden_size)),
             dtype=torch.bfloat16,
-            device='cuda')
+            buffer_name='workspace_1',
+            reserve_buffer=capture_graph)
 
         # Workspace for scaling factors
-        workspace["workspace_sf"] = torch.empty(
+        workspace["workspace_sf"] = DeepGemmMoEOp.buffers.get_buffer(
             expert_size_per_partition * (scale_k_padded // 4) * m_padded,
             dtype=torch.int32,
-            device='cuda')
+            buffer_name='workspace_sf',
+            reserve_buffer=capture_graph)
 
         return workspace
 


### PR DESCRIPTION
Support to share more buffers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced memory allocation infrastructure with CUDA graph support across attention backends.
  * Improved buffer management and reuse strategies for optimized resource utilization during inference operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
