### PR TITLE
[OMNIML-2932] [feat] nvfp4 awq support

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -422,7 +422,10 @@ class Attention(nn.Module):
         # and keeps attention output in BF16 for better precision when applying pre_quant_scale
         if self.has_quant_scale and not self.attn_output_gate and not has_awq_pre_quant_scale:
             out_scale = self.o_proj.inv_input_scale
-        if has_awq_pre_quant_scale:
+        if has_awq_pre_quant_scale and enable_attn_nvfp4_output:
+            logger.warning_once(
+                "Disable attn nvfp4 output because o_proj has pre_quant_scale for AWQ."
+            )
             enable_attn_nvfp4_output = False
         if self.o_proj.has_nvfp4 and self.support_nvfp4_output and enable_attn_nvfp4_output and not self.attn_output_gate:
             out_scale_sf = self.o_proj.input_scale

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -383,7 +383,9 @@ class Attention(nn.Module):
 
         if self.attn_backend == "TRTLLM":
             # Don't use FP8 output if o_proj has pre_quant_scale - keep BF16 for better precision
-            if self.has_quant_scale and self.o_proj.pre_quant_scale is None and (
+            has_pre_quant_scale = getattr(self.o_proj, 'pre_quant_scale',
+                                          None) is not None
+            if self.has_quant_scale and not has_pre_quant_scale and (
                     self.attn.has_fp8_kv_cache or self.attn.has_fp4_kv_cache):
                 out_dtype = torch.float8_e4m3fn
         output = q.new_empty([num_tokens, hidden_size], dtype=out_dtype)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -424,8 +424,8 @@ class Attention(nn.Module):
             out_scale = self.o_proj.inv_input_scale
         if has_awq_pre_quant_scale and enable_attn_nvfp4_output:
             logger.warning_once(
-                "Disable attn nvfp4 output because o_proj has pre_quant_scale for AWQ."
-            )
+                "Disable attn nvfp4 output because o_proj has pre_quant_scale for AWQ.",
+                key="disable_attn_nvfp4_output_for_awq")
             enable_attn_nvfp4_output = False
         if self.o_proj.has_nvfp4 and self.support_nvfp4_output and enable_attn_nvfp4_output and not self.attn_output_gate:
             out_scale_sf = self.o_proj.input_scale

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -419,7 +419,9 @@ class Attention(nn.Module):
         # and keeps attention output in BF16 for better precision when applying pre_quant_scale
         if self.has_quant_scale and not self.attn_output_gate and self.o_proj.pre_quant_scale is None:
             out_scale = self.o_proj.inv_input_scale
-        if self.o_proj.pre_quant_scale is not None:
+        if hasattr(
+                self.o_proj,
+                'pre_quant_scale') and self.o_proj.pre_quant_scale is not None:
             enable_attn_nvfp4_output = False
         if self.o_proj.has_nvfp4 and self.support_nvfp4_output and enable_attn_nvfp4_output and not self.attn_output_gate:
             out_scale_sf = self.o_proj.input_scale

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -415,13 +415,14 @@ class Attention(nn.Module):
 
         out_scale = None
         out_scale_sf = None
+        has_awq_pre_quant_scale = hasattr(
+            self.o_proj,
+            'pre_quant_scale') and self.o_proj.pre_quant_scale is not None
         # Don't set out_scale if o_proj has pre_quant_scale - this prevents FP8/FP4 output
         # and keeps attention output in BF16 for better precision when applying pre_quant_scale
-        if self.has_quant_scale and not self.attn_output_gate and self.o_proj.pre_quant_scale is None:
+        if self.has_quant_scale and not self.attn_output_gate and not has_awq_pre_quant_scale:
             out_scale = self.o_proj.inv_input_scale
-        if hasattr(
-                self.o_proj,
-                'pre_quant_scale') and self.o_proj.pre_quant_scale is not None:
+        if has_awq_pre_quant_scale:
             enable_attn_nvfp4_output = False
         if self.o_proj.has_nvfp4 and self.support_nvfp4_output and enable_attn_nvfp4_output and not self.attn_output_gate:
             out_scale_sf = self.o_proj.input_scale

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -426,6 +426,14 @@ class CutlassFusedMoE(MoE):
             elif self.has_int8_woq_per_channel:
                 use_int8_woq_per_channel = True
             elif self.has_nvfp4:
+                # Apply pre_quant_scale if it exists (for NVFP4_AWQ)
+                if hasattr(
+                        self,
+                        'fc31_act_scale') and self.fc31_act_scale is not None:
+                    assert not isinstance(
+                        x, Fp4QuantizedTensor
+                    ), "Fp4QuantizedTensor is not expected for AWQ quantization."
+                    x = x * self.fc31_act_scale
                 if run_post_quant_allgather or self.enable_alltoall:
                     if isinstance(x, Fp4QuantizedTensor):
                         assert not x.is_sf_swizzled, "Fp4QuantizedTensor should not be swizzled before communication"

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -310,6 +310,12 @@ class TRTLLMGenFusedMoE(MoE):
                 x_row = x.shape[0]
                 x, x_sf = x.fp4_tensor, x.scaling_factor
             else:
+                # Apply pre_quant_scale if it exists (for NVFP4_AWQ)
+                # fc31_act_scale shape: (1, hidden_size)
+                # x shape: (num_tokens, hidden_size)
+                if hasattr(self, 'fc31_act_scale'
+                            ) and self.fc31_act_scale is not None:
+                    x = x * self.fc31_act_scale
                 x_row = x.shape[0]
                 x, x_sf = torch.ops.trtllm.fp4_quantize(
                     x, self.fc31_input_scale, self.scaling_vector_size, False,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -313,8 +313,9 @@ class TRTLLMGenFusedMoE(MoE):
                 # Apply pre_quant_scale if it exists (for NVFP4_AWQ)
                 # fc31_act_scale shape: (1, hidden_size)
                 # x shape: (num_tokens, hidden_size)
-                if hasattr(self, 'fc31_act_scale'
-                            ) and self.fc31_act_scale is not None:
+                if hasattr(
+                        self,
+                        'fc31_act_scale') and self.fc31_act_scale is not None:
                     x = x * self.fc31_act_scale
                 x_row = x.shape[0]
                 x, x_sf = torch.ops.trtllm.fp4_quantize(

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1851,8 +1851,6 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
         # If pre_quant_scale exists, we need a per-channel act scale for fc31
         # All experts share the same input, so pre_quant_scale should be identical across experts
         if has_pre_quant_scale:
-            from ..linear import TensorParallelMode, load_weight_shard
-
             # Create fc31_act_scale parameter (for gate_up_proj / w3_w1)
             # Shape: (1, hidden_size) - single vector for all experts (they share the same input)
             fc31_act_scale = nn.Parameter(torch.empty(1,

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1888,7 +1888,7 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
         module.fc2_input_scale.data.copy_(
             tmp_fc2_input_scale.max().reciprocal())
 
-        # Step1.5: Load pre_quant_scale if it exists (for NVFP4_AWQ)
+        # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         if has_pre_quant_scale:
             from ..linear import TensorParallelMode, load_weight_shard
 

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1892,6 +1892,7 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
         if has_pre_quant_scale:
             from ..linear import TensorParallelMode, load_weight_shard
 
+            device = module.fc31_act_scale.device
             # Load fc31 (w3/w1) pre_quant_scales
             # All experts should have identical pre_quant_scale since they share the same input
             all_w3_pre_quant_scales = []
@@ -1902,13 +1903,13 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                     module.tp_size,
                     module.tp_rank,
                     TensorParallelMode.ROW,
-                    device='cuda')
+                    device=device)
                 w1_pre_quant_scale = load_weight_shard(
                     weights[f"{expert_id}.w1.pre_quant_scale"],
                     module.tp_size,
                     module.tp_rank,
                     TensorParallelMode.ROW,
-                    device='cuda')
+                    device=device)
                 all_w3_pre_quant_scales.append(w3_pre_quant_scale)
                 all_w1_pre_quant_scales.append(w1_pre_quant_scale)
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1117,7 +1117,7 @@ class NVFP4LinearMethod(LinearMethodBase):
         copy_weight(module.weight_scale, weight_scale)
         copy_weight(module.alpha, alpha)
         module.scalar_alpha = alpha.item()
-        
+
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         # NOTE: pre_quant_scale is the same for gate and up since modelopt checks which layer shared the same input
         if "pre_quant_scale" in weights[0]:

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -900,6 +900,10 @@ class NVFP4LinearMethod(LinearMethodBase):
         module.inv_kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
                                          requires_grad=False)
 
+        # NOTE: Not in all linear we have this tensor - pre_quant_scale is computed as an average and merged with the
+        # LayerNorm for QKV and Gate/Up projection layers when possible. we can see the tensor only for o_proj and down_proj
+        module.pre_quant_scale = None
+
         if bias:
             module.bias = Parameter(torch.empty((out_features), dtype=dtype),
                                     requires_grad=False)
@@ -909,10 +913,28 @@ class NVFP4LinearMethod(LinearMethodBase):
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
         if isinstance(input, Fp4QuantizedTensor):
+            # Input is already quantized - this should not happen if pre_quant_scale exists
+            # because we disable FP4 output for attention output when pre_quant_scale is present
+            if module.pre_quant_scale is not None:
+                raise RuntimeError(
+                    "Received FP4 quantized input but pre_quant_scale exists. "
+                    "This indicates FP4 output was not properly disabled for the previous layer."
+                )
             act_fp4, act_sf = input.fp4_tensor, input.scaling_factor
         elif isinstance(input, tuple):
+            # Input is a tuple of (fp4_tensor, scaling_factor)
+            if module.pre_quant_scale is not None:
+                raise RuntimeError(
+                    "Received FP4 quantized tuple input but pre_quant_scale exists. "
+                    "This indicates FP4 output was not properly disabled for the previous layer."
+                )
             act_fp4, act_sf = input
         else:
+            # Input is a regular tensor () - apply pre_quant_scale if it exists (for NVFP4_AWQ)
+            if module.pre_quant_scale is not None:
+                assert input.dtype == module.pre_quant_scale.dtype, "Input dtype and pre_quant_scale dtype must match"
+                input = input * module.pre_quant_scale
+
             act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(
                 input, module.input_scale, module.scaling_vector_size, False)
 
@@ -1022,6 +1044,24 @@ class NVFP4LinearMethod(LinearMethodBase):
         copy_weight(module.alpha, alpha)
         module.scalar_alpha = alpha.item()
 
+        # Load pre_quant_scale if it exists (for NVFP4_AWQ)
+        if "pre_quant_scale" in weights[0]:
+            device = module.weight.device
+            pre_quant_scale = load_weight_shard(
+                weights[0]["pre_quant_scale"],
+                module.tp_size,
+                module.tp_rank,
+                # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
+                TensorParallelMode.flip(module.tp_mode),
+                device,
+            )
+
+            module.pre_quant_scale = Parameter(
+                torch.ones((module.in_features, ), dtype=pre_quant_scale.dtype),
+                requires_grad=False).to(device=device)
+
+            copy_weight(module.pre_quant_scale, pre_quant_scale)
+
     def load_weights_fused_qkv_linear(self, module: Linear,
                                       weights: List[Dict]) -> None:
         q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
@@ -1077,6 +1117,25 @@ class NVFP4LinearMethod(LinearMethodBase):
         copy_weight(module.weight_scale, weight_scale)
         copy_weight(module.alpha, alpha)
         module.scalar_alpha = alpha.item()
+        
+        # Load pre_quant_scale if it exists (for NVFP4_AWQ)
+        # NOTE: pre_quant_scale is the same for gate and up since modelopt checks which layer shared the same input
+        if "pre_quant_scale" in weights[0]:
+            device = module.weight.device
+            pre_quant_scale = load_weight_shard(
+                weights[0]["pre_quant_scale"],
+                module.tp_size,
+                module.tp_rank,
+                # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
+                TensorParallelMode.flip(module.tp_mode),
+                device,
+            )
+
+            module.pre_quant_scale = Parameter(
+                torch.ones((module.in_features, ), dtype=pre_quant_scale.dtype),
+                requires_grad=False).to(device=device)
+
+            copy_weight(module.pre_quant_scale, pre_quant_scale)
 
     def post_load_weights(self, module: Linear):
         super().post_load_weights(module)

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -44,6 +44,7 @@ class QuantAlgo(StrEnum, metaclass=BaseEnumMeta):
     W4A8_MXFP4_FP8 = auto()
     W4A8_MXFP4_MXFP8 = auto()
     W4A16_MXFP4 = auto()
+    NVFP4_AWQ = auto()
     NO_QUANT = auto()
 
 
@@ -409,6 +410,9 @@ class QuantMode(IntFlag):
         elif quant_algo == QuantAlgo.FP8_BLOCK_SCALES:
             quant_mode = QuantMode.from_description(use_fp8_block_scales=True)
         elif quant_algo == QuantAlgo.NVFP4:
+            quant_mode = QuantMode.from_description(use_nvfp4=True)
+        elif quant_algo == QuantAlgo.NVFP4_AWQ:
+            # NVFP4_AWQ uses the same QuantMode as NVFP4, distinction is at QuantAlgo level
             quant_mode = QuantMode.from_description(use_nvfp4=True)
         elif quant_algo == QuantAlgo.W4A8_NVFP4_FP8:
             quant_mode = QuantMode.from_description(use_w4a8_nvfp4_fp8=True)

--- a/tensorrt_llm/quantization/quantize.py
+++ b/tensorrt_llm/quantization/quantize.py
@@ -72,6 +72,14 @@ def quantize_layers(
                 else:
                     quant_mode = quant_config.quant_mode
                 init_params["quant_mode"] = quant_mode
+
+                # Auto-detect pre_quant_scale based on quant_algo
+                # For AWQ-based quantization methods that use pre_quant_scale
+                if quant_config.quant_algo in [
+                        QuantAlgo.W4A16_AWQ, QuantAlgo.NVFP4_AWQ,
+                        QuantAlgo.W4A8_AWQ
+                ]:
+                    init_params["pre_quant_scale"] = True
             if "bias" in init_params and not isinstance(module,
                                                         MixtureOfExperts):
                 init_params["bias"] = init_params["bias"] is not None

--- a/tests/unittest/_torch/modules/test_awq_quantization.py
+++ b/tests/unittest/_torch/modules/test_awq_quantization.py
@@ -1,0 +1,181 @@
+from unittest.mock import patch
+
+import pytest
+import torch
+from utils.util import skip_pre_blackwell
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.modules.fused_moe import DefaultMoeRoutingMethod, create_moe
+from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+@skip_pre_blackwell  # NVFP4 AWQ features require Blackwell (SM100) or later
+@pytest.mark.parametrize("has_scale", [True, False])
+def test_linear_nvfp4_awq_pre_quant_scale(has_scale):
+    """
+    Test that Linear (NVFP4 mode) applies pre_quant_scale to input before quantization.
+
+    This tests the logic in NVFP4LinearMethod.apply (around line 824-827):
+        if module.pre_quant_scale is not None:
+            assert input.dtype == module.pre_quant_scale.dtype
+            input = input * module.pre_quant_scale
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    # Create a Linear module with NVFP4 quantization using actual initialization
+    mapping = Mapping(world_size=1, rank=0, tp_size=1)
+    quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+
+    in_features = 128
+    out_features = 256
+
+    # Create actual Linear module
+    linear = Linear(
+        in_features=in_features,
+        out_features=out_features,
+        dtype=torch.bfloat16,
+        mapping=mapping,
+        quant_config=quant_config,
+    ).cuda()
+
+    # Set pre_quant_scale based on test parameter (skip weight init as it's quantized)
+    if has_scale:
+        scale = torch.full((in_features,), 0.5, dtype=torch.bfloat16, device="cuda")
+        linear.pre_quant_scale = torch.nn.Parameter(scale, requires_grad=False)
+
+    # Prepare input
+    x = torch.ones(2, in_features, dtype=torch.bfloat16, device="cuda")
+
+    # Mock torch.ops.trtllm.fp4_quantize to capture the input after scaling
+    captured_input = None
+
+    def mock_fp4_quantize(input_tensor, *args, **kwargs):
+        nonlocal captured_input
+        captured_input = input_tensor
+        # Return dummy quantized output
+        return (
+            torch.zeros(
+                input_tensor.shape[0], input_tensor.shape[1] // 2, dtype=torch.uint8, device="cuda"
+            ),
+            torch.ones(
+                input_tensor.shape[0],
+                input_tensor.shape[1] // 16,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+        )
+
+    # Also mock the GEMM to avoid execution errors
+    # just return a dummy output since we are capturing the input before input quantization
+    def mock_gemm(act_fp4, *args, **kwargs):
+        batch_size = act_fp4.shape[0]
+        return torch.zeros(batch_size, out_features, dtype=torch.bfloat16, device="cuda")
+
+    with patch("torch.ops.trtllm.fp4_quantize", side_effect=mock_fp4_quantize, create=True):
+        with patch("torch.ops.trtllm.nvfp4_gemm", side_effect=mock_gemm, create=True):
+            linear(x)
+
+    assert captured_input is not None, "fp4_quantize was not called"
+
+    if has_scale:
+        # Should be scaled
+        expected = x * scale
+        assert torch.allclose(captured_input, expected, rtol=1e-5, atol=1e-5), (
+            "Expected scaled input"
+        )
+    else:
+        # Should be original
+        assert torch.equal(captured_input, x), "Expected original input"
+
+
+@skip_pre_blackwell  # TRTLLMGenFusedMoE requires Blackwell (SM100) or later
+@pytest.mark.parametrize("has_scale", [True, False])
+def test_fused_moe_trtllm_gen_input_scaling(has_scale):
+    """
+    Test that TRTLLMGenFusedMoE applies fc31_act_scale to input x if present.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    # Setup
+    mapping = Mapping(world_size=1, rank=0, tp_size=1)
+    quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    model_config = ModelConfig(mapping=mapping, quant_config=quant_config, moe_backend="TRTLLM")
+
+    num_experts = 8
+    hidden_size = 128
+    intermediate_size = 256
+    top_k = 2
+    seq_len = 4
+
+    routing_method = DefaultMoeRoutingMethod(top_k=top_k)
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    # Create actual MoE module
+    moe = create_moe(
+        num_experts=num_experts,
+        routing_method=routing_method,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        dtype=torch.bfloat16,
+        reduce_results=False,
+        model_config=model_config,
+    ).cuda()
+
+    # Set fc31_act_scale directly (simulating AWQ pre_quant_scale)
+    if has_scale:
+        scale = torch.full((hidden_size,), 0.5, dtype=torch.bfloat16, device="cuda")
+        moe.fc31_act_scale = torch.nn.Parameter(scale, requires_grad=False)
+
+    # Prepare input
+    x = torch.ones(seq_len, hidden_size, dtype=torch.bfloat16, device="cuda")
+    router_logits = torch.randn(seq_len, num_experts, dtype=torch.bfloat16, device="cuda")
+
+    # Mock torch.ops.trtllm.fp4_quantize to capture the input after scaling
+    captured_input = None
+
+    def mock_fp4_quantize(input_tensor, *args, **kwargs):
+        nonlocal captured_input
+        captured_input = input_tensor
+        # Return dummy quantized output
+        return (
+            torch.zeros(
+                input_tensor.shape[0], input_tensor.shape[1] // 2, dtype=torch.uint8, device="cuda"
+            ),
+            torch.ones(
+                input_tensor.shape[0],
+                input_tensor.shape[1] // 16,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+        )
+
+    # Also mock the MoE runner to avoid execution errors
+    # just return a dummy output since we are capturing the input before input quantization
+    def mock_moe_runner(*args, **kwargs):
+        return [torch.zeros(seq_len, hidden_size, dtype=torch.bfloat16, device="cuda")]
+
+    with patch("torch.ops.trtllm.fp4_quantize", side_effect=mock_fp4_quantize, create=True):
+        with patch(
+            "torch.ops.trtllm.fp4_block_scale_moe_runner", side_effect=mock_moe_runner, create=True
+        ):
+            with torch.inference_mode():
+                moe.forward(x, router_logits)
+
+    assert captured_input is not None, "fp4_quantize was not called"
+
+    if has_scale:
+        # Should be scaled by fc31_act_scale (which is loaded from pre_quant_scale)
+        # The scale is 0.5, so x_passed should be x * 0.5
+        expected = x * 0.5
+        assert torch.allclose(captured_input, expected, rtol=1e-5, atol=1e-5), (
+            "Expected scaled input"
+        )
+    else:
+        # Should be original
+        assert torch.equal(captured_input, x), "Expected original input"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4_AWQ quantization algorithm support for Mixture-of-Experts models with enhanced activation scaling.

* **Improvements**
  * Implemented pre-quantization scaling to improve accuracy for AWQ-based quantization across attention and fused components.
  * Added guards to prevent incompatible FP4/FP8 output configurations when pre-quantization scaling is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:


**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Add NVFP4 AWQ support. Counterpart in ModelOpt: https://github.com/NVIDIA/TensorRT-Model-Optimizer/pull/421.

Adding an optional pre_quant_scale parameter for AWQ. 

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Tested Qwen3-8B and 30B Moe with TP/EP.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
