### PR TITLE
[None][perf] Use fp8 quant kernel in DS3.2 indexer module

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.cu
@@ -185,10 +185,10 @@ void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::strideBatchGe
 }
 
 template <typename ElementA, typename ElementB, typename ElementD>
-void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::fp8CS1x128(
-    __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream)
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::fp8CS1x128(__nv_fp8_e4m3* mat_quant, float* scales,
+    __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream, bool use_ue8m0)
 {
-    fp8_1x128_cs(mat_quant, scales, mat, shape_x, shape_y, stream);
+    fp8_1x128_cs(mat_quant, scales, mat, shape_x, shape_y, stream, use_ue8m0);
 }
 
 template <typename ElementA, typename ElementB, typename ElementD>

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h
@@ -55,8 +55,12 @@ public:
         int shape_k, cudaStream_t stream, float* scales_a, int stride_scales_a, float* scales_b)
         = 0;
 
+    // Backward compatibility to support old signature
     virtual void fp8CS1x128(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y,
         cudaStream_t stream)
+        = 0;
+    virtual void fp8CS1x128(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y,
+        cudaStream_t stream, bool use_ue8m0)
         = 0;
     virtual void fp8CS1x128Reshape(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x,
         int shape_h, int shape_y, int stride_x, cudaStream_t stream)
@@ -113,7 +117,13 @@ public:
         cudaStream_t stream, float* scales_a, int stride_scales_a, float* scales_b) override;
 
     void fp8CS1x128(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y,
-        cudaStream_t stream) override;
+        cudaStream_t stream) override
+    {
+        fp8CS1x128(mat_quant, scales, mat, shape_x, shape_y, stream, false);
+    }
+
+    void fp8CS1x128(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y,
+        cudaStream_t stream, bool use_ue8m0) override;
     void fp8CS1x128Reshape(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_h,
         int shape_y, int stride_x, cudaStream_t stream) override;
     void fp8CS128x128(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y,

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -26,7 +26,7 @@ namespace torch_ext
 using Fp8BlockScaleGemmRunnerPtr
     = std::unique_ptr<tensorrt_llm::kernels::fp8_blockscale_gemm::CutlassFp8BlockScaleGemmRunnerInterface>;
 
-std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
+std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self, bool use_ue8m0)
 {
     CHECK_TH_CUDA(self);
     CHECK_CONTIGUOUS(self);
@@ -64,7 +64,7 @@ std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
     auto stream = at::cuda::getCurrentCUDAStream(self.get_device());
 
     mGemmRunner.fp8CS1x128(
-        act_buffer, act_scale_buffer, reinterpret_cast<__nv_bfloat16 const*>(self.data_ptr()), n, m, stream);
+        act_buffer, act_scale_buffer, reinterpret_cast<__nv_bfloat16 const*>(self.data_ptr()), n, m, stream, use_ue8m0);
 
     // Post-process the scale tensor for sm100 gemm/moe kernel
     if (tensorrt_llm::common::isSM100Family())
@@ -137,7 +137,7 @@ std::tuple<at::Tensor, at::Tensor> fp8_batched_quantize_1x128_permute102(at::Ten
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
-    m.def("fp8_quantize_1x128(Tensor input) -> (Tensor, Tensor)");
+    m.def("fp8_quantize_1x128(Tensor input, bool use_ue8m0=False) -> (Tensor, Tensor)");
     m.def("fp8_batched_quantize_1x128_permute102(Tensor input) -> (Tensor, Tensor)");
 }
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 
 import tensorrt_llm
 import tensorrt_llm.bindings
-import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
 from tensorrt_llm._torch.attention_backend.interface import (
     MLAParams, PositionalEmbeddingParams)
 from tensorrt_llm._torch.attention_backend.trtllm import (
@@ -28,6 +27,7 @@ from tensorrt_llm.bindings.internal.batch_manager import \
     CacheType as CacheTypeCpp
 from tensorrt_llm.deep_gemm import (fp8_mqa_logits, fp8_paged_mqa_logits,
                                     get_paged_mqa_logits_metadata)
+from tensorrt_llm.quantization.utils import fp8_utils
 from tensorrt_llm.llmapi.llm_args import SparseAttentionConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
@@ -1060,7 +1060,8 @@ class Indexer(nn.Module):
     def forward(self, qr: torch.Tensor, hidden_states: torch.Tensor,
                 metadata: DSAtrtllmAttentionMetadata,
                 position_ids: torch.Tensor):
-        metadata.kv_cache_manager.quant_block_size
+        quant_block_size = metadata.kv_cache_manager.quant_block_size
+        assert quant_block_size == 128, "Only support quant_block_size = 128 for now"
 
         q, k = maybe_execute_in_parallel(
             lambda: self.wq_b(qr),

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -361,7 +361,7 @@ def _register_fake():
                                     (batch_size, ), dtype=torch.int32)
 
     @torch.library.register_fake("trtllm::fp8_quantize_1x128")
-    def _(input: torch.Tensor):
+    def _(input: torch.Tensor, use_ue8m0: bool = False):
         pad_m = fp4_utils.pad_up(input.shape[0], 4)
         blocked_n = (input.shape[1] + 127) // 128
         if get_sm_version() >= 100:

--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -521,8 +521,9 @@ def per_token_quant_and_transform(
 
 
 def fp8_quantize_1x128_sf_transpose(
-        x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    x_fp8, x_scale = torch.ops.trtllm.fp8_quantize_1x128(x)
+        x: torch.Tensor,
+        use_ue8m0: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_fp8, x_scale = torch.ops.trtllm.fp8_quantize_1x128(x, use_ue8m0=use_ue8m0)
     if x_scale.ndim == 1:  # Handle SM version differences (SM90: 1D padded, SM100+: 2D)
         x_padded = (x.shape[0] + 3) // 4 * 4
         num_blocks = (x.shape[1] + 127) // 128

--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -518,3 +518,15 @@ def per_token_quant_and_transform(
         tma_stride_check=True,
     )
     return output, output_scale
+
+
+def fp8_quantize_1x128_sf_transpose(
+        x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_fp8, x_scale = torch.ops.trtllm.fp8_quantize_1x128(x)
+    if x_scale.ndim == 1:  # Handle SM version differences (SM90: 1D padded, SM100+: 2D)
+        x_padded = (x.shape[0] + 3) // 4 * 4
+        num_blocks = (x.shape[1] + 127) // 128
+        x_scale = x_scale[:x_padded * num_blocks].view(num_blocks,
+                                                       x_padded)[:, :x.shape[0]]
+    x_scale = x_scale.contiguous().transpose(0, 1)
+    return x_fp8, x_scale

--- a/tests/unittest/_torch/attention/sparse/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/test_dsa_indexer.py
@@ -27,6 +27,7 @@ from tensorrt_llm.bindings.internal.batch_manager import \
 from tensorrt_llm.deep_gemm import fp8_paged_mqa_logits
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.quantization.utils import fp8_utils
 
 
 def has_deep_gemm():
@@ -519,14 +520,7 @@ def test_fp8_k_cache_roundtrip():
     k_original = torch.randn((total_tokens, head_dim),
                              device="cuda",
                              dtype=torch.bfloat16)
-    k_fp8, k_scale = torch.ops.trtllm.fp8_quantize_1x128(k_original)
-    # Handle SM version differences (SM90: 1D padded, SM100+: 2D)
-    if k_scale.ndim == 1:
-        num_blocks = (k_original.shape[1] + 127) // 128
-        m_padded = (k_original.shape[0] + 3) // 4 * 4
-        k_scale = k_scale[:num_blocks * m_padded].view(
-            num_blocks, m_padded)[:, :k_original.shape[0]]
-    k_scale = k_scale.transpose(0, 1).contiguous()
+    k_fp8, k_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(k_original)
 
     # Write to cache
     indexer._update_k_cache(k_fp8, k_scale, metadata)
@@ -658,14 +652,9 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n):
     )
     Indexer.prepare(metadata_context)
 
-    k_context_fp8, k_context_scale = torch.ops.trtllm.fp8_quantize_1x128(
+    k_context_fp8, k_context_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(
         k_context_bf16)
-    if k_context_scale.ndim == 1:
-        num_blocks = (k_context_bf16.shape[1] + 127) // 128
-        m_padded = (k_context_bf16.shape[0] + 3) // 4 * 4
-        k_context_scale = k_context_scale[:num_blocks * m_padded].view(
-            num_blocks, m_padded)[:, :k_context_bf16.shape[0]]
-    k_context_scale = k_context_scale.transpose(0, 1).contiguous()
+
     indexer._update_k_cache(k_context_fp8, k_context_scale, metadata_context)
     print(f"✓ Wrote {total_context_tokens} FP8 context tokens to cache")
 
@@ -688,13 +677,8 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n):
     )
     Indexer.prepare(metadata_gen)
 
-    k_gen_fp8, k_gen_scale = torch.ops.trtllm.fp8_quantize_1x128(k_gen_bf16)
-    if k_gen_scale.ndim == 1:
-        num_blocks = (k_gen_bf16.shape[1] + 127) // 128
-        m_padded = (k_gen_bf16.shape[0] + 3) // 4 * 4
-        k_gen_scale = k_gen_scale[:num_blocks * m_padded].view(
-            num_blocks, m_padded)[:, :k_gen_bf16.shape[0]]
-    k_gen_scale = k_gen_scale.transpose(0, 1).contiguous()
+    k_gen_fp8, k_gen_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(
+        k_gen_bf16)
     indexer._update_k_cache(k_gen_fp8, k_gen_scale, metadata_gen)
     print(
         f"✓ Wrote {batch_size * num_gen_tokens} FP8 generation tokens to cache")
@@ -981,17 +965,7 @@ def test_indexer_chunked_prefill(chunk_size, seq_lens_list, chunking_type):
 
     # Quantize inputs
     q_fp8 = q.to(torch.float8_e4m3fn)
-    k_fp8, k_scale = torch.ops.trtllm.fp8_quantize_1x128(k)
-    # Handle SM90/SM100 differences
-    if k_scale.ndim == 1:
-        head_dim = k.shape[1]
-        num_blocks = (head_dim + 127) // 128
-        num_tokens = k.shape[0]
-        m_padded = (num_tokens + 3) // 4 * 4
-        k_scale = (k_scale[:num_blocks * m_padded].view(
-            num_blocks, m_padded)[:, :num_tokens].transpose(0, 1).contiguous())
-    else:
-        k_scale = k_scale.transpose(0, 1).contiguous()
+    k_fp8, k_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(k)
 
     # ========== Test Path 1: Chunked Prefill ==========
     print(f"\n=== Chunked Path ===")
@@ -1025,8 +999,8 @@ def test_indexer_chunked_prefill(chunk_size, seq_lens_list, chunking_type):
             f"K[{chunk.k_token_start}:{chunk.k_token_end}] ({num_k} tokens)")
 
     topk_indices_chunked = indexer.sparse_attn_indexer(metadata_chunked,
-                                                       hidden_states, q_fp8, k,
-                                                       weights)
+                                                       hidden_states, q_fp8,
+                                                       k_fp8, k_scale, weights)
 
     print(f"✓ Chunked execution completed, shape: {topk_indices_chunked.shape}")
 
@@ -1056,8 +1030,8 @@ def test_indexer_chunked_prefill(chunk_size, seq_lens_list, chunking_type):
         )
 
     topk_indices_baseline = indexer.sparse_attn_indexer(metadata_baseline,
-                                                        hidden_states, q_fp8, k,
-                                                        weights)
+                                                        hidden_states, q_fp8,
+                                                        k_fp8, k_scale, weights)
 
     print(
         f"✓ Non-chunked execution completed, shape: {topk_indices_baseline.shape}"

--- a/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
@@ -20,6 +20,9 @@ from parameterized import parameterized
 from utils.util import (getSMVersion, skip_pre_blackwell_unittest,
                         unittest_name_func)
 
+from tensorrt_llm.quantization.utils.fp8_utils import \
+    per_token_quant_and_transform
+
 
 def _dequant_fp8(input, scale, transpose_scale, block_m, block_n):
     input = input.to(torch.float)
@@ -196,3 +199,79 @@ def test_mxfp8_quantize_alignment_torch_device(m, k, dtype,
 
     mxfp8_quantize_check_accuracy(a_pt[:, :k].cpu().to(torch.float32),
                                   a.cpu().to(torch.float32), 8, 0, 0.999)
+
+
+@pytest.mark.skipif(
+    getSMVersion() != 100 and getSMVersion() != 90,
+    reason="Only test on Blackwell and Hopper",
+)
+@pytest.mark.parametrize("k", [128, 256, 512])
+@pytest.mark.parametrize("m", [4, 16, 64])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_fp8_quantize_ue8m0_vs_triton(dtype, m, k):
+    """Test fp8_quantize_1x128 with use_ue8m0=True against Triton reference."""
+    torch.random.manual_seed(42)
+
+    # Ensure alignment requirements
+    assert m % 4 == 0, "m must be divisible by 4"
+    assert k % 128 == 0, "k must be divisible by 128"
+
+    # Create input tensor
+    input_tensor = torch.randn((m, k), device='cuda', dtype=dtype)
+
+    # CUDA version with UE8M0
+    cuda_fp8, cuda_scale_float = torch.ops.trtllm.fp8_quantize_1x128(
+        input_tensor, use_ue8m0=True)
+
+    # Triton reference with UE8M0
+    triton_fp8, triton_scale_int32 = per_token_quant_and_transform(
+        input_tensor.clone(), quant_group_size=128, scale_ue8m0=True)
+
+    # Convert CUDA float32 scale to int32 packed format for comparison
+    from tensorrt_llm.deep_gemm import transform_sf_into_required_layout
+
+    # CUDA output is [num_blocks, m], need to transpose to [m, num_blocks]
+    cuda_scale_int32 = transform_sf_into_required_layout(
+        sf=cuda_scale_float.t().contiguous(),
+        mn=m,
+        k=k,
+        recipe=(1, 1, 128),
+        num_groups=None,
+        is_sfa=False)
+
+    # Compare quantized FP8 values (should match within FP8 precision)
+    torch.testing.assert_close(
+        cuda_fp8.to(torch.float32),
+        triton_fp8.to(torch.float32),
+        atol=1.0,
+        rtol=0.01,
+        msg=f"FP8 quantized values mismatch for shape ({m}, {k})")
+
+    # Compare packed int32 scales by decoding to float
+    def decode_ue8m0_int32_to_float(int32_tensor):
+        """Decode int32 packed UE8M0 scales to float32. Formula: value = 2^(exponent - 127)
+        """
+        # Extract 4 bytes from each int32
+        b0 = (int32_tensor >> 0) & 0xFF
+        b1 = (int32_tensor >> 8) & 0xFF
+        b2 = (int32_tensor >> 16) & 0xFF
+        b3 = (int32_tensor >> 24) & 0xFF
+
+        # Decode: value = 2^(exponent - 127)
+        s0 = torch.pow(2.0, b0.float() - 127.0)
+        s1 = torch.pow(2.0, b1.float() - 127.0)
+        s2 = torch.pow(2.0, b2.float() - 127.0)
+        s3 = torch.pow(2.0, b3.float() - 127.0)
+
+        return torch.stack([s0, s1, s2, s3], dim=-1)
+
+    cuda_scales_decoded = decode_ue8m0_int32_to_float(cuda_scale_int32)
+    triton_scales_decoded = decode_ue8m0_int32_to_float(triton_scale_int32)
+
+    # Compare: values should match, or both be tiny (< 1e-10 means zero-block)
+    torch.testing.assert_close(
+        cuda_scales_decoded,
+        triton_scales_decoded,
+        atol=1e-10,
+        rtol=0.01,
+        msg=f"UE8M0 decoded scales mismatch for shape ({m}, {k})")

--- a/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
@@ -228,10 +228,8 @@ def test_fp8_quantize_ue8m0_vs_triton(dtype, m, k):
         input_tensor.clone(), quant_group_size=128, scale_ue8m0=True)
 
     # Convert CUDA float32 scale to int32 packed format for comparison
-    from tensorrt_llm.deep_gemm import transform_sf_into_required_layout
-
-    # CUDA output is [num_blocks, m], need to transpose to [m, num_blocks]
-    cuda_scale_int32 = transform_sf_into_required_layout(
+    from tensorrt_llm.quantization.utils import fp8_utils
+    cuda_scale_int32 = fp8_utils.transform_sf_into_required_layout(
         sf=cuda_scale_float.t().contiguous(),
         mn=m,
         k=k,


### PR DESCRIPTION
Improved perf of FP8 quantization on indexer q  — average quantization time reduced from 70 µs → 6 µs (64 heads × 64 tokens).
For batch size = 16 with 16 gen tokens, the E2E iteration time improved from ~37.7 ms → 36.5 ms (≈ 1.03X).

Accuracy implications (w/ NVFP4 ckpt):

Using E4M3 (`self.scale_fmt=None`) to dynamically quant indexer q, k:

```
           Tasks            |Version|   Filter   |n-shot|  Metric   |   | Value |   |Stderr|
|----------------------------|------:|------------|-----:|-----------|---|------:|---|-----:|
|gpqa_diamond_cot_zeroshot_aa|      1|strict-match|     0|exact_match|↑  |78.7879|±  |2.9127|

[TRT-LLM] [I] lm-eval gpqa_diamond_cot_zeroshot_aa average accuracy: 78.79
```

Using UE8M0 (`self.scale_fmt=ue8m0`) to dynamically quant indexer q, k:
```
|           Tasks            |Version|   Filter   |n-shot|  Metric   |   |Value |   |Stderr|
|----------------------------|------:|------------|-----:|-----------|---|-----:|---|-----:|
|gpqa_diamond_cot_zeroshot_aa|      1|strict-match|     0|exact_match|↑  |80.303|±  |2.8336|

[TRT-LLM] [I] lm-eval gpqa_diamond_cot_zeroshot_aa average accuracy: 80.30
```
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized sparse attention quantization by consolidating per-token quantization operations into a unified fused approach with cached quantized values, reducing computational overhead and improving efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
