### PR TITLE
[TRTLLM-8136][feat] Dynamic draft length in spec decode (stage 2).

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -62,7 +62,6 @@ class CUDAGraphRunnerConfig:
     max_num_tokens: int
     spec_config: Optional[DecodingBaseConfig]
     cuda_graph_mem_pool: Any
-    dynamic_draft_len_mapping: Optional[Dict[int, int]]
     use_mrope: bool
     original_max_draft_len: int
     original_max_total_draft_tokens: int
@@ -72,6 +71,7 @@ class CUDAGraphRunnerConfig:
     mapping: Optional[Mapping]
     dist: Optional[MPIDist]
     kv_cache_manager_key: Any
+    dynamic_draft_len_mapping: Optional[Dict[int, int]]
 
 
 class CUDAGraphRunner:
@@ -452,7 +452,7 @@ class CUDAGraphRunner:
         self.graphs.clear()
         self.graph_outputs.clear()
         self.graph_metadata.clear()
-        self.padding_dummy_requests = None
+        self.padding_dummy_requests = {}
         del self.memory_pool
         self.memory_pool = None
         torch.cuda.empty_cache()

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -562,8 +562,8 @@ class PyTorchModelEngine(ModelEngine):
             return
 
         # The lifetime of model engine and kv cache manager can be different.
-        # Reset the global cuda graph dummy request to None in warmup.
-        self.cuda_graph_runner.padding_dummy_request = None
+        # Reset the global cuda graph dummy requests in warmup.
+        self.cuda_graph_runner.padding_dummy_requests = {}
 
         # TODO: current warmup_request is not suitable for context parallelism.
         cp_type = self.mapping.cp_config.get('cp_type', None)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1062,7 +1062,7 @@ class PyExecutor:
 
                 self.drafter.update_max_total_draft_tokens(
                     self.max_total_draft_tokens)
-
+                self.model_engine.max_total_draft_tokens = self.max_total_draft_tokens
             # Check if draft_len=0 → immediately disable
             # self.max_total_draft_tokens==0 is only possible when draft_len_schedule is provided
             # for example, draft_len_schedule = {1:4, 4:2, 8:0}, batch_size >= 8 will set self.max_draft_len = 0

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -172,7 +172,7 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
             batch.context_requests = []
             batch.generation_requests = requests
             pages_before = kv_cache_manager.get_num_free_blocks()
-            new_dummy_block = 1 if model_engine.cuda_graph_runner.padding_dummy_request is None else 0
+            new_dummy_block = 1 if not model_engine.cuda_graph_runner.padding_dummy_requests else 0
             with model_engine.cuda_graph_runner.pad_batch(
                     batch, resource_manager) as padded_batch:
                 if batch_size < 8 and max_seq_len < 25:

--- a/tests/unittest/_torch/speculative/test_draft_len_schedule.py
+++ b/tests/unittest/_torch/speculative/test_draft_len_schedule.py
@@ -269,8 +269,8 @@ def test_draft_len_schedule_functionality(drafter_type: str, draft_schedule: dic
     # This matches what the authentic code does: len(executor.active_requests)
     expected_mapping = {
         1: 5,
-        2: 5,
-        3: 5,
+        2: 4,
+        3: 4,
         4: 4,
         5: 3,
         6: 2,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
This PR updates the LLM API design from the dynamic draft length [Stage 1 PR](https://github.com/NVIDIA/TensorRT-LLM/pull/8194) to improve CUDA graph compatibility. Aslo, this PR implements the CUDA graph capture logic and runtime Selection/Padding logic for dynamic draft length.

1. LLM API Design
Users can specify a new field draft_len_schedule in spec_config.
Example: {4:4, 8:2, 32:1, 64:0}.
Logic:
Batch Size 1-4 --> Draft Length 4
Batch Size 5-8 --> Draft Length 2
Batch Size 9-32 --> Draft Length 1
Batch Size 33-64 --> Draft Length 0
Constraint: All keys in draft_len_schedule must be present in cuda_graph_config.batch_sizes to align CUDA graph capturing behavior with the legacy (static) behavior.

2. CUDA Graph Capture
We will only capture the specific (batch_size, draft_len) pairs defined by the schedule, rather than the full Cartesian product.
Example: cuda_graph_config.batch_sizes = [1,2,3,4,5,6,7,8,16,24,32,64], max_draft_len = 4.
New Behavior: with draft_len_schedule={4:4, 8:2, 32:1, 64:0}. Captures [(1,4),(2,4),(3,4),(4,4),(5,2),(6,2),(7,2),(8,2),(16,1),(24,1),(32,1),(64,0)].
Legacy Behavior: Captures (BS, 4) for all batch sizes (plus extra graphs with draft len = 0 for disabled spec decode).
This feature produces equal or lower graph capture overhead compared to the legacy behavior.

3. Runtime Selection/Padding Logic
We use the pre-scheduling active batch size to determine the draft length.
Example: If pre-scheduling BS = 10 --> Runtime DL = 1. We pad to the nearest round-up graph: (16, 1).
Edge Case (Batch Size Decrease): Active batch size may drop after scheduling. We treat the determined runtime draft length as the source of truth and pad the batch size up to the nearest existing graph for that draft length.
Scenario: Pre-schedule BS = 6 --> DL = 2. Post-schedule BS drops to 4.
Resolution: We stick to DL = 2. Since (4, 2) was not captured (BS 4 maps to DL 4 in the schedule), we pad up to the nearest graph with DL 2, which is (5, 2).

Planned Timeline
Stage 1 (merged): LLM API design and drafter changes (ngram/model drafter). [[PR]](https://github.com/NVIDIA/TensorRT-LLM/pull/8194) (Note: API in this stage1 PR is stale; updated in Stage 2).
Stage 2 (current): Target side changes (CUDA graph capture and selection/padding logic). Also update the llm api design.
Stage 3 (future): Perf study and extend to Chain Drafter.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
