### PR TITLE
[TRTLLM-8540][feat] Add support for disagg in DSv3.2

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -269,7 +269,8 @@ private:
     std::unique_ptr<executor::kv_cache::CacheState> mCacheState;
     std::unique_ptr<executor::kv_cache::ConnectionManager> mManager;
     std::optional<executor::CacheTransceiverConfig> mCacheTransceiverConfig;
-    std::unique_ptr<kv_cache_manager::CacheTransBufferManager> mCacheTransBufferManager;
+    std::vector<std::unique_ptr<kv_cache_manager::CacheTransBufferManager>> mCacheTransBufferManagers;
+    std::vector<kv_cache_manager::CacheTransBufferManager*> mCacheTransBufferManagerPtrs;
     // library handle to the communicator related features,
     // this is used to defer dependency resolution until needed.
     static std::mutex mDllMutex;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -595,6 +595,21 @@ public:
 
     ~WindowBlockManager();
 
+    [[nodiscard]] bool isEnableIndexerKCache() const
+    {
+        return mEnableIndexerKCache;
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheQuantBlockSize() const
+    {
+        return mIndexerKCacheQuantBlockSize;
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheIndexHeadDim() const
+    {
+        return mIndexerKCacheIndexHeadDim;
+    }
+
     void allocatePools(bool useUvm);
 
     void releasePools();
@@ -1020,6 +1035,21 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, bool enableIndexerKCache = false,
         SizeType32 indexerKCacheQuantBlockSize = 128, SizeType32 indexerKCacheIndexHeadDim = 0);
+
+    [[nodiscard]] bool isEnableIndexerKCache() const
+    {
+        return mWindowBlockManagers.begin()->second.isEnableIndexerKCache();
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheQuantBlockSize() const
+    {
+        return mWindowBlockManagers.begin()->second.getIndexerKCacheQuantBlockSize();
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheIndexHeadDim() const
+    {
+        return mWindowBlockManagers.begin()->second.getIndexerKCacheIndexHeadDim();
+    }
 
     BlockManager(BlockManager const&) = delete;
     BlockManager& operator=(BlockManager const&) = delete;
@@ -1500,6 +1530,10 @@ public:
 
     [[nodiscard]] virtual bool isEnableBlockReuse() const = 0;
 
+    [[nodiscard]] virtual bool isEnableIndexerKCache() const = 0;
+    [[nodiscard]] virtual SizeType32 getIndexerKCacheIndexHeadDim() const = 0;
+    [[nodiscard]] virtual SizeType32 getIndexerKCacheQuantBlockSize() const = 0;
+
     // void removeToken(SizeType32 seqSlotIdx);
     virtual void rewindKVCache(LlmRequest::RequestIdType requestId, SizeType32 rewindLengths) = 0;
 
@@ -1832,6 +1866,21 @@ public:
     [[nodiscard]] bool isEnableBlockReuse() const override
     {
         return mEnableBlockReuse;
+    }
+
+    [[nodiscard]] bool isEnableIndexerKCache() const override
+    {
+        return mBlockManager.isEnableIndexerKCache();
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheIndexHeadDim() const override
+    {
+        return mBlockManager.getIndexerKCacheIndexHeadDim();
+    }
+
+    [[nodiscard]] SizeType32 getIndexerKCacheQuantBlockSize() const override
+    {
+        return mBlockManager.getIndexerKCacheQuantBlockSize();
     }
 
     void removeToken(LlmRequest::RequestIdType requestId);

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1038,17 +1038,17 @@ public:
 
     [[nodiscard]] bool isEnableIndexerKCache() const
     {
-        return mWindowBlockManagers.begin()->second.isEnableIndexerKCache();
+        return mIsEnableIndexerKCache;
     }
 
     [[nodiscard]] SizeType32 getIndexerKCacheQuantBlockSize() const
     {
-        return mWindowBlockManagers.begin()->second.getIndexerKCacheQuantBlockSize();
+        return mIndexerKCacheQuantBlockSize;
     }
 
     [[nodiscard]] SizeType32 getIndexerKCacheIndexHeadDim() const
     {
-        return mWindowBlockManagers.begin()->second.getIndexerKCacheIndexHeadDim();
+        return mIndexerKCacheIndexHeadDim;
     }
 
     BlockManager(BlockManager const&) = delete;
@@ -1428,6 +1428,10 @@ private:
     std::vector<SizeType32> mAbsolutePoolToRelativePoolIndex;
     // Record what sequences are currently managed by the block manager
     std::set<LlmRequest::RequestIdType> mManagedSequences;
+
+    bool mIsEnableIndexerKCache{false};
+    SizeType32 mIndexerKCacheQuantBlockSize{0};
+    SizeType32 mIndexerKCacheIndexHeadDim{0};
 };
 
 struct OffsetTableDimensions

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -45,9 +45,8 @@ namespace tensorrt_llm::batch_manager::kv_cache_manager
 BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest const& llmRequest,
     BlockKey const& lastBlockKey, int32_t indexFromEnd, bool recvSideHasCP)
 {
-    auto poolNum = cacheManager->getBlockManager().getNumPools();
-    // Note: When recv side has CP, the requested seqLen is lesser than seqLen on the sender side as seqLen is
-    // distributed among CP ranks. So, we transfer all blocks from send side.
+    auto poolNum = cacheManager->getBlockManager().getNumPools(
+        /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     if (poolNum > 1 || !cacheManager->isEnableBlockReuse() || lastBlockKey.uniqueTokens.size() == 0 || recvSideHasCP)
     {
         // disable reuse path, and vwsa don't support reuse.
@@ -88,8 +87,9 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
 BlockRange getBlockRangeForReceiving(
     BaseKVCacheManager* cacheManager, LlmRequest const& llmRequest, bool srcEnableBlockReuse, bool recvSideHasCP)
 {
-    auto poolNum = cacheManager->getBlockManager().getNumPools();
     // Note: When recv side has CP, we request all blocks from send side right now.
+    auto poolNum = cacheManager->getBlockManager().getNumPools(
+        /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     if (poolNum == 1 && srcEnableBlockReuse && !recvSideHasCP)
     {
         // Build from all block ids, then slice off the reused blocks so we only transfer newly allocated ones.
@@ -171,7 +171,8 @@ void checkAlternateWindow(BaseKVCacheManager* cacheManager, BaseCacheFormatter::
     // if gen PP and context PP are different, cache formatter only support alternative window like gpt-oss.
     // which is one layer is WSA, and another layer is Full attention.
 
-    auto numPools = cacheManager->getBlockManager().getNumPools();
+    auto numPools = cacheManager->getBlockManager().getNumPools(
+        /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     auto layerNum = cacheManager->getBlockManager().getNumLayers();
 
     auto selfPPNum = selfConfig.getParallelConfig().mPipelineParallelism;
@@ -248,7 +249,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
     auto& blockManager = mCacheManager->getBlockManager();
     auto const& lastBlockKey = session.getLastBlockKey();
     auto blockRange = getBlockRangeForSending(mCacheManager, llmRequest, lastBlockKey, indexFromEnd);
-    auto const numPools = blockManager.getNumPools();
+    auto const numPools
+        = blockManager.getNumPools(/*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     // TODO(oargov): are we sure the other side has the same number of pools? this might not hold for pp_size>1...
 
     bool layerWise = common::getEnvDisaggLayerwise() && numPools == 1;
@@ -556,7 +558,8 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
     TLLM_LOG_DEBUG("pickUpConnections size: %d connections size: %d", pickUpConnections.size(), connections.size());
     std::vector<runtime::ITensor::SharedPtr> recvBufferTmps;
     std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> outputBuffersPerWindow;
-    auto const numPools = mCacheManager->getBlockManager().getNumPools();
+    auto const numPools = mCacheManager->getBlockManager().getNumPools(
+        /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     // TODO(oargov): are we sure the other side has the same number of pools? this might not hold for pp_size>1...
     size_t blockNum = 0;
     size_t cacheBlockSizeSum = 0;
@@ -970,7 +973,13 @@ std::unique_ptr<BaseCacheFormatter> createCacheFormatter(
 {
     if (isMLA)
     {
-        return std::make_unique<MLACacheFormatter>(cacheManager, cacheTransBufferManager);
+        std::vector<CacheTransBufferManager*> cacheTransBufferManagers = {cacheTransBufferManager};
+        auto maxNumTokens = cacheTransBufferManager->getMaxNumTokens();
+        if (cacheManager->isEnableIndexerKCache())
+        {
+            cacheTransBufferManagers.push_back(new CacheTransBufferManager(cacheManager, maxNumTokens, true));
+        }
+        return std::make_unique<MLACacheFormatter>(cacheManager, cacheTransBufferManagers);
     }
     return std::make_unique<CacheFormatter>(cacheManager, cacheTransBufferManager);
 }

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -972,19 +972,14 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
 }
 
 std::unique_ptr<BaseCacheFormatter> createCacheFormatter(
-    BaseKVCacheManager* cacheManager, CacheTransBufferManager* cacheTransBufferManager, bool isMLA)
+    BaseKVCacheManager* cacheManager, std::vector<CacheTransBufferManager*> const& cacheTransBufferManagers, bool isMLA)
 {
+    TLLM_CHECK(!cacheTransBufferManagers.empty());
     if (isMLA)
     {
-        std::vector<CacheTransBufferManager*> cacheTransBufferManagers = {cacheTransBufferManager};
-        auto maxNumTokens = cacheTransBufferManager->getMaxNumTokens();
-        if (cacheManager->isEnableIndexerKCache())
-        {
-            cacheTransBufferManagers.push_back(new CacheTransBufferManager(cacheManager, maxNumTokens, true));
-        }
         return std::make_unique<MLACacheFormatter>(cacheManager, cacheTransBufferManagers);
     }
-    return std::make_unique<CacheFormatter>(cacheManager, cacheTransBufferManager);
+    return std::make_unique<CacheFormatter>(cacheManager, cacheTransBufferManagers[0]);
 }
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -47,6 +47,9 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
 {
     auto poolNum = cacheManager->getBlockManager().getNumPools(
         /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
+
+    // Note: When recv side has CP, the requested seqLen is lesser than seqLen on the sender side as seqLen is
+    // distributed among CP ranks. So, we transfer all blocks from send side.
     if (poolNum > 1 || !cacheManager->isEnableBlockReuse() || lastBlockKey.uniqueTokens.size() == 0 || recvSideHasCP)
     {
         // disable reuse path, and vwsa don't support reuse.

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
@@ -133,7 +133,7 @@ private:
     CacheTransBufferManager* mCacheTransBufferManager;
 };
 
-std::unique_ptr<BaseCacheFormatter> createCacheFormatter(
-    BaseKVCacheManager* cacheManager, CacheTransBufferManager* cacheTransBufferManager, bool isMLA = false);
+std::unique_ptr<BaseCacheFormatter> createCacheFormatter(BaseKVCacheManager* cacheManager,
+    std::vector<CacheTransBufferManager*> const& cacheTransBufferManagers, bool isMLA = false);
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -189,14 +189,22 @@ bool FabricMemory::supportFbaricMemory()
 }
 
 CacheTransBufferManager::CacheTransBufferManager(
-    KVCacheManager::BaseKVCacheManager* cacheManager, std::optional<size_t> maxNumTokens)
+    KVCacheManager::BaseKVCacheManager* cacheManager, std::optional<size_t> maxNumTokens, bool transferIndexerKCache)
     : mCacheManager{cacheManager}
     , mBufferManager{std::make_shared<runtime::CudaStream>()}
+    , mTransferIndexerKCache{transferIndexerKCache}
+    , mMaxNumTokens{maxNumTokens}
 {
-
     // TODO: FP4 dataSize
     TLLM_CHECK(mCacheManager);
-    mDataType = mCacheManager->getPrimaryPool(0)->getDataType();
+    if (transferIndexerKCache)
+    {
+        mDataType = mCacheManager->getIndexerKCachePool()->getDataType();
+    }
+    else
+    {
+        mDataType = mCacheManager->getPrimaryPool(0)->getDataType();
+    }
 
     auto tokensPerBlock = mCacheManager->getBlockManager().getTokensPerBlock();
     size_t bufferSizeFromMaxNumToken = 0;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -222,7 +222,7 @@ CacheTransBufferManager::CacheTransBufferManager(
             auto poolIdx = mCacheManager->getBlockManager().getLayerPoolIdx(layerId);
             auto windowSize = static_cast<size_t>(mCacheManager->getBlockManager().getPoolWindowSize(poolIdx));
             auto alignedWindowSize = (windowSize + tokensPerBlock - 1) / tokensPerBlock * tokensPerBlock;
-            auto validTokenNum = (alignedWindowSize > maxNumTokens.value() ? alignedWindowSize : maxNumTokens.value());
+            auto validTokenNum = (alignedWindowSize < maxNumTokens.value() ? alignedWindowSize : maxNumTokens.value());
             if (common::getEnvKVCacheTransferAllBlocksForWindow())
             {
                 validTokenNum = maxNumTokens.value();

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -192,7 +192,6 @@ CacheTransBufferManager::CacheTransBufferManager(
     KVCacheManager::BaseKVCacheManager* cacheManager, std::optional<size_t> maxNumTokens, bool transferIndexerKCache)
     : mCacheManager{cacheManager}
     , mBufferManager{std::make_shared<runtime::CudaStream>()}
-    , mTransferIndexerKCache{transferIndexerKCache}
     , mMaxNumTokens{maxNumTokens}
 {
     // TODO: FP4 dataSize

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
@@ -57,8 +57,8 @@ private:
 class CacheTransBufferManager
 {
 public:
-    CacheTransBufferManager(
-        KVCacheManager::BaseKVCacheManager* cacheManager, std::optional<size_t> maxNumTokens = std::nullopt);
+    CacheTransBufferManager(KVCacheManager::BaseKVCacheManager* cacheManager,
+        std::optional<size_t> maxNumTokens = std::nullopt, bool transferIndexerKCache = false);
 
     static size_t preAllocBufferSize(std::map<SizeType32, SizeType32> const& cacheSizeBytesPerTokenPerWindow,
         SizeType32 tokensPerBlock,
@@ -81,6 +81,11 @@ public:
     runtime::ITensor::SharedPtr getRecvBuffer(std::optional<int> bufferId);
     size_t getRecvBufferCount();
     size_t getSendBufferCount();
+
+    std::optional<size_t> getMaxNumTokens()
+    {
+        return mMaxNumTokens;
+    }
 
 private:
     struct ConcurrenceResource
@@ -114,6 +119,8 @@ private:
     KVCacheManager::BaseKVCacheManager* mCacheManager;
     runtime::BufferManager mBufferManager;
     std::vector<std::unique_ptr<FabricMemory>> mFabricMemory;
+    bool mTransferIndexerKCache;
+    std::optional<size_t> mMaxNumTokens;
 };
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
@@ -119,7 +119,6 @@ private:
     KVCacheManager::BaseKVCacheManager* mCacheManager;
     runtime::BufferManager mBufferManager;
     std::vector<std::unique_ptr<FabricMemory>> mFabricMemory;
-    bool mTransferIndexerKCache;
     std::optional<size_t> mMaxNumTokens;
 };
 

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
@@ -70,11 +70,11 @@ public:
     void freeBufferIndexForRecv(std::optional<int> bufferId);
 
     std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> getOrAllocateSendBuffers(
-        std::optional<int> bufferId, int targetNum, std::vector<size_t> const& targetBufferEleSizes,
+        std::optional<int> bufferId, int targetNum, std::vector<size_t> const& requestedNumberOfElements,
         runtime::BufferManager const& bufferManagerToUse);
 
     std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> getOrAllocateRecvBuffers(
-        std::optional<int> bufferId, int targetNum, std::vector<size_t> const& targetBufferEleSizes,
+        std::optional<int> bufferId, int targetNum, std::vector<size_t> const& requestedNumberOfElements,
         runtime::BufferManager const& bufferManagerToUse);
 
     runtime::ITensor::SharedPtr getSendBuffer(std::optional<int> bufferId);
@@ -98,7 +98,7 @@ private:
     };
 
     std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> getOrAllocateBuffers(std::optional<int> bufferId,
-        int targetNum, std::vector<size_t> const& targetBufferEleSizes,
+        int targetNum, std::vector<size_t> const& requestedNumberOfElements,
         runtime::BufferManager const& bufferManagerToUse, ConcurrenceResource& concurrenceResource);
 
     void allocateBuffer();
@@ -112,7 +112,7 @@ private:
     size_t mTransferBufferSize;
     bool mOnlyUseDynamicBuffer;
     bool mUseFabricMemory;
-    size_t mBufferEleSize;
+    size_t mNumberOfElements;
     nvinfer1::DataType mDataType;
     ConcurrenceResource mConcurrenceSendResource;
     ConcurrenceResource mConcurrenceRecvResource;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -137,7 +137,9 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
         kvFactor = 1;
     }
     mCacheState = std::make_unique<executor::kv_cache::CacheState>(cacheStateModelCfg, worldConfig,
-        attentionLayerNumPerPP, dataType, attentionType, kvFactor, cacheManager->isEnableBlockReuse());
+        attentionLayerNumPerPP, dataType, attentionType, kvFactor, cacheManager->isEnableBlockReuse(),
+        cacheManager->isEnableIndexerKCache(), cacheManager->getIndexerKCacheIndexHeadDim(),
+        cacheManager->getIndexerKCacheQuantBlockSize());
 
     if (mCacheState->getParallelConfig().mEnableAttentionDP)
     {

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -551,6 +551,9 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     , mEventManager{std::move(eventManager)}
     , mStream{stream}
     , mCacheType{cacheType}
+    , mIsEnableIndexerKCache{enableIndexerKCache}
+    , mIndexerKCacheQuantBlockSize{indexerKCacheQuantBlockSize}
+    , mIndexerKCacheIndexHeadDim{indexerKCacheIndexHeadDim}
 {
     if (agentConfig.has_value())
         mLoopbackAgent = makeLoopbackAgent("nixl", &agentConfig.value());

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -147,8 +147,6 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         }
         else
         {
-            std::cout << "transferIndexerKCache" << std::endl;
-
             auto blockRangeForWindow = blockRange.getBlockRangeForWindow(windowSizes.at(0), true);
             for (auto it = blockRangeForWindow.begin(); it != blockRangeForWindow.end(); ++it)
             {

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -147,6 +147,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         }
         else
         {
+            std::cout << "transferIndexerKCache" << std::endl;
+
             auto blockRangeForWindow = blockRange.getBlockRangeForWindow(windowSizes.at(0), true);
             for (auto it = blockRangeForWindow.begin(); it != blockRangeForWindow.end(); ++it)
             {

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -252,7 +252,6 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             }
             else
             {
-
                 // If cacheIdx< bufferCoverTargetNum, the ouputSplitCaches.at(cacheIdx) is allocated by cudaMallocAsync,
                 // which is unable to be transferred by UCX GPU-direct RDMA. We need copy the data to pre-allocated
                 // cudaMalloc buffer,and then start send.

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.h
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.h
@@ -27,12 +27,11 @@ namespace tensorrt_llm::batch_manager::kv_cache_manager
 class MLACacheFormatter final : public BaseCacheFormatter
 {
 public:
-    MLACacheFormatter(BaseKVCacheManager* cacheManager, CacheTransBufferManager* cacheTransBufferManager)
+    MLACacheFormatter(BaseKVCacheManager* cacheManager, std::vector<CacheTransBufferManager*> cacheTransBufferManagers)
         : mCacheManager{cacheManager}
-        , mCacheTransBufferManager{cacheTransBufferManager}
+        , mCacheTransBufferManagers{cacheTransBufferManagers}
     {
         TLLM_CHECK(mCacheManager);
-        TLLM_CHECK(mCacheTransBufferManager);
     }
 
     void format(tensorrt_llm::batch_manager::TransferSession& session) override;
@@ -58,7 +57,7 @@ public:
 
 private:
     BaseKVCacheManager* mCacheManager;
-    CacheTransBufferManager* mCacheTransBufferManager;
+    std::vector<CacheTransBufferManager*> mCacheTransBufferManagers;
 };
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -20,6 +20,7 @@
 #include "tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h"
 #include <string>
 #include <unistd.h>
+#include <utility>
 
 namespace tensorrt_llm::executor::kv_cache
 {
@@ -35,25 +36,26 @@ std::string genUniqueAgentName()
     return std::string(hostname) + "_" + std::to_string(pid) + "_" + std::to_string(counter++);
 }
 
-// NIXL connection is specific ,and different from the UCX and mpi connection, since NIXL only support one-sided
-// communication. gen send buffer metaData to context when it sending requestInfo, but don't send buffer offset, since
-// unformmatter has not called yet, it didn't know the cacheSize and offset. We assume the recv_size is the same as the
-// send_size. and compute the buffer offset according to  the layer num of the selfPPrank ,and previous PP rank's layer
-// num, since the buffer size is ratio is equal to the layer num ratio except the VSWA case.
+// NIXL connection is specific, and different from the UCX and mpi connection,
+// since NIXL only support one-sided communication. gen send buffer metaData to
+// context when it sending requestInfo, but don't send buffer offset, since
+// unformmatter has not called yet, it didn't know the cacheSize and offset. We
+// assume the recv_size is the same as the send_size. and compute the buffer
+// offset according to  the layer num of the selfPPrank ,and previous PP rank's
+// layer num, since the buffer size is ratio is equal to the layer num ratio
+// except the VSWA case.
 
 auto computeSendOffsetRatio(
-    CacheState const& peerCacheState, int peerIdx, CacheState const& selfCacheState, int validConnectionIdx)
+    CacheState const& peerCacheState, int peerIdx, CacheState const& selfCacheState, int connectionIdx)
 {
     auto peerTargetInfo = targetIRanks(selfCacheState, peerCacheState, peerIdx);
-    // int ppRank = valideConnectionIdx % peerTargetInfo.mDomainPPSize;
     size_t offsetLayer = 0;
-    for (int i = 0; i < validConnectionIdx; i++)
+    for (int i = 0; i < connectionIdx; i++)
     {
         offsetLayer += peerTargetInfo.getPeerPPDomainLayerNum(i);
     }
 
-    size_t selfSendLayer = peerTargetInfo.getPeerPPDomainLayerNum(validConnectionIdx);
-
+    size_t selfSendLayer = peerTargetInfo.getPeerPPDomainLayerNum(connectionIdx);
     return std::make_pair(offsetLayer, selfSendLayer);
 }
 
@@ -62,16 +64,40 @@ AgentConnection::AgentConnection(
     : mAgentName(mAgentName)
     , mRemoteAgentName(mRemoteAgentName)
     , mAgentConnectionManager(mAgentConnectionManager)
-    , mCacheTransBufferManager(mAgentConnectionManager->getCacheTransBufferManager())
+    , mCacheTransBufferManagers(mAgentConnectionManager->getCacheTransBufferManagers())
     , mNeedSendMetadata(true)
 {
     TLLM_CHECK(mAgentConnectionManager != nullptr);
-    TLLM_CHECK(mCacheTransBufferManager != nullptr);
+    TLLM_CHECK(!mCacheTransBufferManagers.empty());
 }
 
-std::optional<size_t> AgentConnection::getCacheBufferId() const
+std::optional<size_t> AgentConnection::getCacheBufferId(size_t bufferIdx) const
 {
-    return mCacheBufferId;
+    TLLM_CHECK(bufferIdx < mCacheBufferIds.size());
+    return mCacheBufferIds[bufferIdx];
+}
+
+size_t AgentConnection::getSenderBufferCount() const
+{
+    return mSenderState.mCacheReceiverBufferDescs.size();
+}
+
+void AgentConnection::setActiveSenderBufferIdx(size_t bufferIdx)
+{
+    mSenderState.setActiveBufferIdx(bufferIdx);
+}
+
+MemoryDesc const& AgentConnection::SenderState::activeBufferDesc() const
+{
+    TLLM_CHECK(!mCacheReceiverBufferDescs.empty());
+    TLLM_CHECK(mActiveBufferIdx < mCacheReceiverBufferDescs.size());
+    return mCacheReceiverBufferDescs[mActiveBufferIdx];
+}
+
+void AgentConnection::SenderState::setActiveBufferIdx(size_t bufferIdx)
+{
+    TLLM_CHECK(bufferIdx < mCacheReceiverBufferDescs.size());
+    mActiveBufferIdx = bufferIdx;
 }
 
 void MemoryDesc::serialize(MemoryDesc const& memoryDesc, std::ostream& os)
@@ -100,11 +126,10 @@ size_t MemoryDesc::serializedSize(MemoryDesc const& memoryDesc)
 
 void AgentConnection::send(DataContext const& ctx, void const* data, size_t size) const
 {
-
     MemoryDesc srcDesc{
         reinterpret_cast<uintptr_t>(data), size, static_cast<uint32_t>(mAgentConnectionManager->getDeviceId())};
     MemoryDescs srcDescs{MemoryType::kVRAM, {srcDesc}};
-    auto dstBaseDesc = mSenderState.mCacheReceiverBufferDesc;
+    auto const& dstBaseDesc = mSenderState.activeBufferDesc();
     auto offset = size / mSenderState.mOffsetRatio.second * mSenderState.mOffsetRatio.first;
     MemoryDesc dstDesc{dstBaseDesc.getAddr() + offset, size, dstBaseDesc.getDeviceId()};
     TLLM_LOG_DEBUG(
@@ -128,22 +153,34 @@ void AgentConnection::recv(DataContext const& ctx, void* data, size_t size) cons
     mAgentConnectionManager->waitForSyncInfo(mRemoteAgentName, syncInfo);
 }
 
-void AgentConnection::sendRequestAndBufferInfo(
-    batch_manager::RequestInfo& requestInfo, std::optional<size_t> cacheBufferId, int validConnectionIdx)
+void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
+    std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx)
 {
     TLLM_CHECK(!common::getEnvTryZCopyForKVCacheTransfer());
 
-    TLLM_CHECK(cacheBufferId.has_value());
-    auto preAllocateBuffer = mCacheTransBufferManager->getRecvBuffer(cacheBufferId.value());
-    // memory Desp , validSegmentIdx send
-    mCacheBufferId = cacheBufferId;
-    // TODO: deviceID;
+    TLLM_CHECK(!cacheBufferIds.empty());
+    TLLM_CHECK(cacheBufferIds.size() == mCacheTransBufferManagers.size());
+    auto preAllocateBuffers = std::vector<runtime::ITensor::SharedPtr>();
+    preAllocateBuffers.reserve(cacheBufferIds.size());
+    std::vector<MemoryDesc> bufferDescs;
+    bufferDescs.reserve(cacheBufferIds.size());
+    for (size_t i = 0; i < cacheBufferIds.size(); i++)
+    {
+        TLLM_CHECK(cacheBufferIds[i].has_value());
+        auto preAllocateBuffer = mCacheTransBufferManagers[i]->getRecvBuffer(cacheBufferIds[i].value());
+        preAllocateBuffers.push_back(preAllocateBuffer);
+        TLLM_CHECK(preAllocateBuffer != nullptr);
+    }
+    mCacheBufferIds = cacheBufferIds;
     int deviceId = -1;
     TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
     TLLM_CHECK(deviceId != -1);
     TLLM_CHECK(deviceId == mAgentConnectionManager->getDeviceId());
-    MemoryDesc bufferDesc(
-        reinterpret_cast<uintptr_t>(preAllocateBuffer->data()), preAllocateBuffer->getSize(), deviceId);
+    for (size_t i = 0; i < preAllocateBuffers.size(); i++)
+    {
+        bufferDescs.emplace_back(
+            reinterpret_cast<uintptr_t>(preAllocateBuffers[i]->data()), preAllocateBuffers[i]->getSize(), deviceId);
+    }
     std::string address = mAgentConnectionManager->getAgent()->getLocalConnectionInfo();
     std::optional<std::string> metadataOpt = std::nullopt;
     if (mNeedSendMetadata)
@@ -154,7 +191,7 @@ void AgentConnection::sendRequestAndBufferInfo(
     }
 
     RequestAndBufferInfo requestAndBufferInfo{
-        mAgentName, address, requestInfo, bufferDesc, metadataOpt, validConnectionIdx};
+        mAgentName, address, requestInfo, bufferDescs, metadataOpt, connectionIdx};
     std::stringstream ss;
     NotificationInfo notificationInfo{requestAndBufferInfo};
     NotificationInfo::serialize(notificationInfo, ss);
@@ -162,16 +199,17 @@ void AgentConnection::sendRequestAndBufferInfo(
 }
 
 void AgentConnection::setSenderState(
-    MemoryDesc mCacheReceiverBufferDesc, int validSegmentIdx, std::pair<size_t, size_t> offsetRatio)
+    std::vector<MemoryDesc> cacheReceiverBufferDescs, int validSegmentIdx, std::pair<size_t, size_t> offsetRatio)
 {
-    mSenderState.mCacheReceiverBufferDesc = mCacheReceiverBufferDesc;
+    TLLM_CHECK(!cacheReceiverBufferDescs.empty());
+    mSenderState.mCacheReceiverBufferDescs = std::move(cacheReceiverBufferDescs);
     mSenderState.validSegmentIdx = validSegmentIdx;
     mSenderState.mOffsetRatio = offsetRatio;
+    mSenderState.setActiveBufferIdx(0);
 }
 
 void AgentConnection::setHasLoadRemoteAgent(bool hasLoadRemoteAgent)
 {
-
     mHasLoadRemoteAgent = hasLoadRemoteAgent;
 }
 
@@ -197,8 +235,10 @@ bool AgentConnection::recvReadySignal(DataContext const& ctx) const
 }
 
 AgentConnectionManager::AgentConnectionManager(
-    batch_manager::kv_cache_manager::CacheTransBufferManager* cacheTransBufferManager, CacheState cacheState)
+    std::vector<batch_manager::kv_cache_manager::CacheTransBufferManager*> cacheTransBufferManagers,
+    CacheState cacheState)
     : mCacheState(std::move(cacheState))
+    , mCacheTransBufferManagers(std::move(cacheTransBufferManagers))
     , mRegMemDescs(MemoryType::kVRAM, {})
 {
     TLLM_CUDA_CHECK(cudaGetDevice(&mDeviceId));
@@ -208,21 +248,25 @@ AgentConnectionManager::AgentConnectionManager(
     // Create Agent
     BaseAgentConfig config{mAgentName, true};
     m_Agent = makeTransferAgent("nixl", &config);
-    mCacheTransBufferManager = cacheTransBufferManager;
-    auto recvBufferCount = mCacheTransBufferManager->getRecvBufferCount();
-    auto sendBufferCount = mCacheTransBufferManager->getSendBufferCount();
-    std::vector<MemoryDesc> MemDescs;
-    for (size_t i = 0; i < recvBufferCount; i++)
+    TLLM_CHECK(!mCacheTransBufferManagers.empty());
+    std::vector<MemoryDesc> memDescs;
+    for (auto* cacheTransBufferManager : mCacheTransBufferManagers)
     {
-        auto recvBuffer = mCacheTransBufferManager->getRecvBuffer(i);
-        MemDescs.emplace_back(recvBuffer->data(), recvBuffer->getSizeInBytes(), mDeviceId);
+        TLLM_CHECK(cacheTransBufferManager != nullptr);
+        auto recvBufferCount = cacheTransBufferManager->getRecvBufferCount();
+        auto sendBufferCount = cacheTransBufferManager->getSendBufferCount();
+        for (size_t i = 0; i < recvBufferCount; i++)
+        {
+            auto recvBuffer = cacheTransBufferManager->getRecvBuffer(i);
+            memDescs.emplace_back(recvBuffer->data(), recvBuffer->getSizeInBytes(), mDeviceId);
+        }
+        for (size_t i = 0; i < sendBufferCount; i++)
+        {
+            auto sendBuffer = cacheTransBufferManager->getSendBuffer(i);
+            memDescs.emplace_back(sendBuffer->data(), sendBuffer->getSizeInBytes(), mDeviceId);
+        }
     }
-    for (size_t i = 0; i < sendBufferCount; i++)
-    {
-        auto sendBuffer = mCacheTransBufferManager->getSendBuffer(i);
-        MemDescs.emplace_back(sendBuffer->data(), sendBuffer->getSizeInBytes(), mDeviceId);
-    }
-    mRegMemDescs = MemoryDescs{MemoryType::kVRAM, MemDescs};
+    mRegMemDescs = MemoryDescs{MemoryType::kVRAM, memDescs};
     m_Agent->registerMemory(mRegMemDescs);
 
     AgentState localAgentState{mAgentName, m_Agent->getLocalConnectionInfo()};
@@ -273,8 +317,6 @@ AgentConnectionManager::AgentConnectionManager(
 
 AgentConnection const* AgentConnectionManager::recvConnectionAndRequestInfo(batch_manager::RequestInfo& requestInfo)
 {
-    // recv remoteAgentDesc, and bufferDesc , and validSegmentIdx ,
-
     while (true)
     {
         updateUnhandledNotifications();
@@ -296,16 +338,16 @@ AgentConnection const* AgentConnectionManager::recvConnectionAndRequestInfo(batc
                     erase = true;
                     requestInfo = requestAndBufferInfo.mRequestInfo;
                     auto address = requestAndBufferInfo.mAddress;
-                    auto bufferDesc = requestAndBufferInfo.mBufferDesc;
+                    auto bufferDescs = std::move(requestAndBufferInfo.mBufferDescs);
                     auto metadataOpt = requestAndBufferInfo.mMetadata;
-                    auto validConnectionIdx = requestAndBufferInfo.mValidConnectionIdx;
+                    auto connectionIdx = requestAndBufferInfo.mValidConnectionIdx;
                     auto remoteAgentName = requestAndBufferInfo.mAgentName;
                     TLLM_LOG_DEBUG(" recv Address:%s", address.c_str());
                     auto connection = connect(remoteAgentName, address, metadataOpt, true);
                     // to compute the offset.
                     auto offsetRatio = computeSendOffsetRatio(requestInfo.getTransState().getCacheState().value(),
-                        requestInfo.getTransState().getCommState()->getSelfIdx(), mCacheState, validConnectionIdx);
-                    connection->setSenderState(bufferDesc, validConnectionIdx, offsetRatio);
+                        requestInfo.getTransState().getCommState()->getSelfIdx(), mCacheState, connectionIdx);
+                    connection->setSenderState(std::move(bufferDescs), connectionIdx, offsetRatio);
                     notifIt = notifs.erase(notifIt);
                     if (notifs.empty())
                     {
@@ -334,25 +376,21 @@ AgentConnection const* AgentConnectionManager::recvConnectionAndRequestInfo(batc
 
 void AgentConnectionManager::updateUnhandledNotifications()
 {
-
-    auto notif_map = m_Agent->getNotifiedSyncMessages();
+    auto notifiedSyncMessages = m_Agent->getNotifiedSyncMessages();
     std::lock_guard<std::mutex> lock(mNotificationMutex);
 
     // Merge new notifications with existing ones
-    for (auto const& [agent, notifs] : notif_map)
+    for (auto const& [agent, notifs] : notifiedSyncMessages)
     {
-        auto& existing_notifs = mUnhandledNotifications[agent];
-        existing_notifs.insert(
-            existing_notifs.end(), std::make_move_iterator(notifs.begin()), std::make_move_iterator(notifs.end()));
+        auto& existingNotifications = mUnhandledNotifications[agent];
+        existingNotifications.insert(existingNotifications.end(), std::make_move_iterator(notifs.begin()),
+            std::make_move_iterator(notifs.end()));
     }
 }
 
 [[nodiscard]] std::vector<Connection const*> AgentConnectionManager::getConnections(CommState const& state)
 {
-    //  agentDesc +ip
-    // get metaData from ip;
     TLLM_CHECK(state.isAgentState());
-    // TODO:  AgentCommState
     auto ret = std::vector<Connection const*>();
     for (auto&& agentState : state.getAgentState())
     {
@@ -368,9 +406,10 @@ BaseTransferAgent* AgentConnectionManager::getAgent() const
     return m_Agent.get();
 }
 
-batch_manager::kv_cache_manager::CacheTransBufferManager* AgentConnectionManager::getCacheTransBufferManager()
+std::vector<batch_manager::kv_cache_manager::CacheTransBufferManager*> const&
+AgentConnectionManager::getCacheTransBufferManagers() const
 {
-    return mCacheTransBufferManager;
+    return mCacheTransBufferManagers;
 }
 
 AgentConnection* AgentConnectionManager::connect(std::string const& remoteAgentName, std::string const& connectionInfo,
@@ -548,7 +587,6 @@ std::string const& AgentConnectionManager::getAgentName() const
 
 AgentConnectionManager::~AgentConnectionManager()
 {
-    // TODO: invalideRemoteAgent
     m_Agent->deregisterMemory(mRegMemDescs);
 }
 } // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
@@ -1093,7 +1093,8 @@ __global__ void concatKVCacheForWindowKernel(T const** __restrict__ inputCaches,
 template <typename T>
 void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> const& kVCacheBlocksPerWindow,
     std::vector<runtime::ITensor::SharedPtr>& outputSplitBlocks, kv_cache::CacheState const& destCacheState,
-    kv_cache::CacheState const& selfCacheState, int selfIdx, runtime::BufferManager const& bufferManager)
+    kv_cache::CacheState const& selfCacheState, int selfIdx, runtime::BufferManager const& bufferManager,
+    bool isIndexerKCache = false)
 {
 
     size_t inputBlockNumSum = 0;
@@ -1124,7 +1125,15 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     std::vector<SizeType32> layersInWindow;
     size_t cacheBlockSizeSum = 0;
     size_t inputBlockLayerNumSum = 0;
-    auto cacheDataType = kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
+    nvinfer1::DataType cacheDataType = nvinfer1::DataType::kINT64;
+    if (isIndexerKCache)
+    {
+        cacheDataType = nvinfer1::DataType::kUINT8;
+    }
+    else
+    {
+        cacheDataType = kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
+    }
 
     for (auto const& [window, blocks] : kVCacheBlocksPerWindow)
     {
@@ -1148,7 +1157,9 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
 
     for (auto&& outputSplitBlock : outputSplitBlocks)
     {
-        TLLM_CHECK(outputSplitBlock->getDataType() == cacheDataType);
+        TLLM_CHECK_WITH_INFO(outputSplitBlock->getDataType() == cacheDataType,
+            "outputSplitBlock data type mismatch expected: %d, actual: %d", static_cast<int>(cacheDataType),
+            static_cast<int>(outputSplitBlock->getDataType()));
         cachePtrs.push_back(reinterpret_cast<uint64_t>(outputSplitBlock->data()));
     }
     std::vector<uint64_t> prefixLayerNum(targetRankInfo.mDomainPPSize + 1, 0);
@@ -1224,7 +1235,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
 
     dim3 gridDim{gridDimx, gridDimy};
 
-    int const sizePerHead = selfModelConfig.mSizePerHead;
+    int sizePerHead = selfModelConfig.mSizePerHead;
     T const** inputBlockPtrsDev = static_cast<T const**>(PtrsDeviceBuffer->data());
     T** outputCachePtrsDev = static_cast<T**>(PtrsDeviceBuffer->data()) + inputBlockNumSum;
     uint64_t* prefixLayerNumDevPtr
@@ -1236,7 +1247,14 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     int const selfPPRank = selfIdx / (selfParallelConfig.mTensorParallelism * selfParallelConfig.mContextParallelism);
     int const numLayers = selfParallelConfig.mAttentionLayerNumPerPP.at(selfPPRank);
     int const headNum = selfModelConfig.mNbKvHeadsPerLayer[0];
-    int const dimsPerHead = selfModelConfig.mSizePerHead;
+
+    int dimsPerHead = selfModelConfig.mSizePerHead;
+    if (isIndexerKCache)
+    {
+        dimsPerHead = selfCacheState.getIndexerDimPerHead()
+            + selfCacheState.getIndexerDimPerHead() / selfCacheState.getIndexerKCacheQuantBlockSize() * 4;
+        sizePerHead = dimsPerHead;
+    }
     int const domainPPSize = targetRankInfo.mDomainPPSize;
     int const domainTPSize = targetRankInfo.mDomainTPSize;
     int const domainCPSize = targetRankInfo.mDomainCPSize;
@@ -1404,35 +1422,44 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
 }
 
 void splitKVCacheDispatch(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> const& kVCacheBlocksPerWindow,
-    std::vector<runtime::ITensor::SharedPtr>& ouputSplitBlocks, kv_cache::CacheState const& iCacheState,
-    kv_cache::CacheState const& oCacheState, int selfIdx, runtime::BufferManager const& bufferManager)
+    std::vector<runtime::ITensor::SharedPtr>& outputSplitBlocks, kv_cache::CacheState const& iCacheState,
+    kv_cache::CacheState const& oCacheState, int selfIdx, runtime::BufferManager const& bufferManager,
+    bool isIndexerKCache)
 {
-    auto dataType = kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
+    auto dataType = nvinfer1::DataType::kINT64;
+    if (isIndexerKCache)
+    {
+        dataType = nvinfer1::DataType::kUINT8;
+    }
+    else
+    {
+        dataType = kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
+    }
     auto dataSize = tensorrt_llm::common::getDTypeSize(dataType);
     switch (dataSize)
     {
     case 8:
     {
-        splitKVCache<int64_t>(
-            kVCacheBlocksPerWindow, ouputSplitBlocks, iCacheState, oCacheState, selfIdx, bufferManager);
+        splitKVCache<int64_t>(kVCacheBlocksPerWindow, outputSplitBlocks, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 4:
     {
-        splitKVCache<int32_t>(
-            kVCacheBlocksPerWindow, ouputSplitBlocks, iCacheState, oCacheState, selfIdx, bufferManager);
+        splitKVCache<int32_t>(kVCacheBlocksPerWindow, outputSplitBlocks, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 2:
     {
-        splitKVCache<int16_t>(
-            kVCacheBlocksPerWindow, ouputSplitBlocks, iCacheState, oCacheState, selfIdx, bufferManager);
+        splitKVCache<int16_t>(kVCacheBlocksPerWindow, outputSplitBlocks, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 1:
     {
-        splitKVCache<int8_t>(
-            kVCacheBlocksPerWindow, ouputSplitBlocks, iCacheState, oCacheState, selfIdx, bufferManager);
+        splitKVCache<int8_t>(kVCacheBlocksPerWindow, outputSplitBlocks, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     default:
@@ -1446,7 +1473,7 @@ template <typename T>
 void concatKVCache(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlocks,
     std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>& outputKvCacheBlocksPerWindow,
     kv_cache::CacheState const& destCacheState, kv_cache::CacheState const& selfCacheState, int selfIdx,
-    runtime::BufferManager const& bufferManager)
+    runtime::BufferManager const& bufferManager, bool isIndexerKCache)
 {
 
     size_t outputBlockNumSum = 0;
@@ -1554,7 +1581,7 @@ void concatKVCache(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlo
         layersPerWindowDevPtr = static_cast<int const*>(windowInfoDeviceBuffer->data()) + windowSizes.size();
     }
     dim3 gridDim{gridDimx, gridDimy};
-    int const sizePerHead = selfModelConfig.mSizePerHead;
+    int sizePerHead = selfModelConfig.mSizePerHead;
     int const endLayerId = selfModelConfig.mNbKvHeadsPerLayer.size() / oPPNum;
     T** ouptutBlockPtrsDev = static_cast<T**>(PtrsDeviceBuffer->data());
     T const** inputSplitBlockPtrsDev = static_cast<T const**>(PtrsDeviceBuffer->data()) + outputBlockNumSum;
@@ -1565,7 +1592,14 @@ void concatKVCache(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlo
     int const numLayers = selfParallelConfig.mAttentionLayerNumPerPP.at(selfPPRank);
     TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "concatKVCache numLayers:%d", numLayers);
     int const headNum = selfModelConfig.mNbKvHeadsPerLayer[0];
-    int const dimsPerHead = selfModelConfig.mSizePerHead;
+    int dimsPerHead = selfModelConfig.mSizePerHead;
+    if (isIndexerKCache)
+    {
+        dimsPerHead = selfCacheState.getIndexerDimPerHead()
+            + selfCacheState.getIndexerDimPerHead() / selfCacheState.getIndexerKCacheQuantBlockSize() * 4;
+        sizePerHead = dimsPerHead;
+    }
+
     int const domainPPSize = targetRankInfo.mDomainPPSize;
     int const domainTPSize = targetRankInfo.mDomainTPSize;
 
@@ -1735,7 +1769,7 @@ void concatKVCache(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlo
 void concatKvCacheV2Dispatch(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlocks,
     std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>& outputKvCacheBlocksPerWindow,
     kv_cache::CacheState const& iCacheState, kv_cache::CacheState const& oCacheState, int selfIdx,
-    runtime::BufferManager const& bufferManager)
+    runtime::BufferManager const& bufferManager, bool isIndexerKCache)
 {
 
     auto dataType = outputKvCacheBlocksPerWindow.begin()->second.front()->getDataType();
@@ -1744,26 +1778,26 @@ void concatKvCacheV2Dispatch(std::vector<runtime::ITensor::SharedPtr> const& inp
     {
     case 8:
     {
-        concatKVCache<int64_t>(
-            inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx, bufferManager);
+        concatKVCache<int64_t>(inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 4:
     {
-        concatKVCache<int32_t>(
-            inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx, bufferManager);
+        concatKVCache<int32_t>(inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 2:
     {
-        concatKVCache<int16_t>(
-            inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx, bufferManager);
+        concatKVCache<int16_t>(inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     case 1:
     {
-        concatKVCache<int8_t>(
-            inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx, bufferManager);
+        concatKVCache<int8_t>(inputSplitBlocks, outputKvCacheBlocksPerWindow, iCacheState, oCacheState, selfIdx,
+            bufferManager, isIndexerKCache);
         break;
     }
     default:

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
@@ -1136,15 +1136,8 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     std::vector<SizeType32> layersInWindow;
     size_t cacheBlockSizeSum = 0;
     size_t inputBlockLayerNumSum = 0;
-    nvinfer1::DataType cacheDataType = nvinfer1::DataType::kINT64;
-    if (isIndexerKCache)
-    {
-        cacheDataType = nvinfer1::DataType::kUINT8;
-    }
-    else
-    {
-        cacheDataType = kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
-    }
+    auto cacheDataType
+        = isIndexerKCache ? nvinfer1::DataType::kUINT8 : kVCacheBlocksPerWindow.begin()->second.front()->getDataType();
 
     for (auto const& [window, blocks] : kVCacheBlocksPerWindow)
     {

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h
@@ -97,11 +97,12 @@ nvinfer1::Dims makeShapeFromCacheState(kv_cache::CacheState const& cacheState);
 
 void splitKVCacheDispatch(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> const& kVCacheBlocksPerWindow,
     std::vector<runtime::ITensor::SharedPtr>& ouputSplitBlocks, kv_cache::CacheState const& peerCacheState,
-    kv_cache::CacheState const& selfCacheState, int selfIdx, runtime::BufferManager const& bufferManager);
+    kv_cache::CacheState const& selfCacheState, int selfIdx, runtime::BufferManager const& bufferManager,
+    bool isIndexerKCache = false);
 
 void concatKvCacheV2Dispatch(std::vector<runtime::ITensor::SharedPtr> const& inputSplitBlocksPerWindow,
     std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>& outputKvCacheBlocksPerWindow,
     kv_cache::CacheState const& peerCacheState, kv_cache::CacheState const& selfCacheState, int selfIdx,
-    runtime::BufferManager const& bufferManager);
+    runtime::BufferManager const& bufferManager, bool isIndexerKCache = false);
 
 } // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -544,9 +544,12 @@ kv_cache::CacheState Serialization::deserializeCacheState(std::istream& is)
     auto attentionType = su::deserialize<decltype(CacheState::AttentionConfig::mAttentionType)>(is);
     auto kvFactor = su::deserialize<decltype(CacheState::AttentionConfig::mKvFactor)>(is);
     auto enableBlockReuse = su::deserialize<bool>(is);
+    auto hasIndexerKCache = su::deserialize<bool>(is);
+    auto indexerDimPerHead = su::deserialize<decltype(CacheState::ModelConfig::mSizePerHead)>(is);
+    auto indexerKCacheQuantBlockSize = su::deserialize<decltype(CacheState::ModelConfig::mTokensPerBlock)>(is);
     return CacheState{nbKvHeadsPerLayer, sizePerHead, tokensPerBlock, tensorParallelism, pipelineParallelism,
         contextParallelism, attentionLayerNumPerPP, dataType, attentionType, kvFactor, enableAttentionDP, DPrank,
-        DPsize, enableBlockReuse};
+        DPsize, enableBlockReuse, hasIndexerKCache, indexerDimPerHead, indexerKCacheQuantBlockSize};
 }
 
 void Serialization::serialize(kv_cache::CacheState const& state, std::ostream& os)
@@ -565,6 +568,9 @@ void Serialization::serialize(kv_cache::CacheState const& state, std::ostream& o
     su::serialize(state.mAttentionConfig.mAttentionType, os);
     su::serialize(state.mAttentionConfig.mKvFactor, os);
     su::serialize(state.mEnableBlockReuse, os);
+    su::serialize(state.getHasIndexerKCache(), os);
+    su::serialize(state.getIndexerDimPerHead(), os);
+    su::serialize(state.getIndexerKCacheQuantBlockSize(), os);
 }
 
 size_t Serialization::serializedSize(kv_cache::CacheState const& state)
@@ -584,6 +590,9 @@ size_t Serialization::serializedSize(kv_cache::CacheState const& state)
     totalSize += su::serializedSize(state.mAttentionConfig.mAttentionType);
     totalSize += su::serializedSize(state.mAttentionConfig.mKvFactor);
     totalSize += su::serializedSize(state.mEnableBlockReuse);
+    totalSize += su::serializedSize(state.getHasIndexerKCache());
+    totalSize += su::serializedSize(state.getIndexerDimPerHead());
+    totalSize += su::serializedSize(state.getIndexerKCacheQuantBlockSize());
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -506,7 +506,8 @@ private:
                 }
                 // The keepsMmaAbForGeneration sparseMla kernels only support numHeadsQPerKv = 128.
                 TLLM_CHECK_WITH_INFO(!params.mSparseMla || params.mNumHeadsQPerKv == 128,
-                    "The keepsMmaAbForGeneration sparseMla kernels only support numHeadsQPerKv = 128");
+                    "The keepsMmaAbForGeneration sparseMla kernels only support numHeadsQPerKv = 128, got %d",
+                    params.mNumHeadsQPerKv);
                 // The 2CTA keepsMmaAbForGeneration kernel is used when the numHeadsQPerKv is 128.
                 if (params.mNumHeadsQPerKv == 128)
                 {

--- a/cpp/tests/unit_tests/executor/agentCommTest.cpp
+++ b/cpp/tests/unit_tests/executor/agentCommTest.cpp
@@ -108,9 +108,11 @@ protected:
 
 TEST_F(AgentCommTest, AgentConnectionManagerBasic)
 {
-    auto connectionManager = std::make_unique<AgentConnectionManager>(mTransBufferManager.get(), *mCacheState);
+    std::vector<CacheTransBufferManager*> bufferManagers{mTransBufferManager.get()};
+    auto connectionManager = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState);
     ASSERT_TRUE(connectionManager != nullptr);
-    ASSERT_TRUE(connectionManager->getCacheTransBufferManager() != nullptr);
+    ASSERT_EQ(connectionManager->getCacheTransBufferManagers().size(), bufferManagers.size());
+    ASSERT_TRUE(connectionManager->getCacheTransBufferManagers().front() != nullptr);
     ASSERT_EQ(connectionManager->getDeviceId(), 0);
     ASSERT_TRUE(!connectionManager->getAgentName().empty());
     ASSERT_TRUE(connectionManager->getAgent() != nullptr);
@@ -121,8 +123,9 @@ TEST_F(AgentCommTest, AgentConnectionManagerBasic)
 
 TEST_F(AgentCommTest, AgentConnectionManagerConnect)
 {
-    auto connectionManager0 = std::make_unique<AgentConnectionManager>(mTransBufferManager.get(), *mCacheState);
-    auto connectionManager1 = std::make_unique<AgentConnectionManager>(mTransBufferManager.get(), *mCacheState);
+    std::vector<CacheTransBufferManager*> bufferManagers{mTransBufferManager.get()};
+    auto connectionManager0 = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState);
+    auto connectionManager1 = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState);
     auto agentName0 = connectionManager0->getAgentName();
     auto agentName1 = connectionManager1->getAgentName();
     ASSERT_TRUE(!agentName0.empty());
@@ -144,18 +147,18 @@ TEST_F(AgentCommTest, AgentConnectionManagerConnect)
     tensorrt_llm::executor::DataTransceiverState dataTransceiverState0{cacheState0, commState0};
     tensorrt_llm::executor::DataTransceiverState dataTransceiverState1{cacheState1, commState1};
     tensorrt_llm::batch_manager::RequestInfo sendRequestInfo{requestId, dataTransceiverState0};
-    size_t cacheBufferId = 0;
+    std::vector<std::optional<size_t>> cacheBufferIds{std::optional<size_t>{0}};
     int validConnectionIdx = 0;
     // convert to AgentConnection
     auto agentConnection0 = const_cast<tensorrt_llm::executor::kv_cache::AgentConnection*>(
         dynamic_cast<tensorrt_llm::executor::kv_cache::AgentConnection const*>(connection0));
-    agentConnection0->sendRequestAndBufferInfo(sendRequestInfo, cacheBufferId, validConnectionIdx);
+    agentConnection0->sendRequestAndBufferInfo(sendRequestInfo, cacheBufferIds, validConnectionIdx);
 
     tensorrt_llm::batch_manager::RequestInfo recvRequestInfo;
     auto connection1 = connectionManager1->recvConnectionAndRequestInfo(recvRequestInfo);
     ASSERT_EQ(recvRequestInfo.getRequestId(), requestId);
 
-    auto sendBuffer = mTransBufferManager->getSendBuffer(cacheBufferId);
+    auto sendBuffer = mTransBufferManager->getSendBuffer(cacheBufferIds[0].value());
     auto sendSize = 1024;
     std::vector<char> sendData(sendSize);
     std::fill(sendData.begin(), sendData.end(), 'a');
@@ -172,7 +175,7 @@ TEST_F(AgentCommTest, AgentConnectionManagerConnect)
 
     future.wait();
 
-    auto recvBuffer = mTransBufferManager->getRecvBuffer(cacheBufferId);
+    auto recvBuffer = mTransBufferManager->getRecvBuffer(cacheBufferIds[0].value());
     std::vector<char> recvData(sendSize);
     TLLM_CUDA_CHECK(cudaMemcpy(recvData.data(), recvBuffer->data(), sendSize, cudaMemcpyDeviceToHost));
     for (size_t i = 0; i < sendSize; i++)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1087,7 +1087,8 @@ TEST(SerializeUtilsTest, RequestAndBufferInfo)
     // Test with all fields populated
     {
         kv_cache::RequestAndBufferInfo original{"testAgent", "127.0.0.1:8080",
-            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 1024, 0},
+            tensorrt_llm::batch_manager::RequestInfo{},
+            std::vector<kv_cache::MemoryDesc>{kv_cache::MemoryDesc{nullptr, 1024, 0}},
             std::make_optional<std::string>("metadata"), 1};
 
         auto deserialized = serializeDeserializeNotification(original);
@@ -1095,9 +1096,10 @@ TEST(SerializeUtilsTest, RequestAndBufferInfo)
         EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
         EXPECT_EQ(original.mAddress, deserialized.mAddress);
         EXPECT_EQ(original.mRequestInfo.getRequestId(), deserialized.mRequestInfo.getRequestId());
-        EXPECT_EQ(original.mBufferDesc.getAddr(), deserialized.mBufferDesc.getAddr());
-        EXPECT_EQ(original.mBufferDesc.getLen(), deserialized.mBufferDesc.getLen());
-        EXPECT_EQ(original.mBufferDesc.getDeviceId(), deserialized.mBufferDesc.getDeviceId());
+        ASSERT_EQ(original.mBufferDescs.size(), deserialized.mBufferDescs.size());
+        EXPECT_EQ(original.mBufferDescs[0].getAddr(), deserialized.mBufferDescs[0].getAddr());
+        EXPECT_EQ(original.mBufferDescs[0].getLen(), deserialized.mBufferDescs[0].getLen());
+        EXPECT_EQ(original.mBufferDescs[0].getDeviceId(), deserialized.mBufferDescs[0].getDeviceId());
         EXPECT_EQ(original.mMetadata, deserialized.mMetadata);
         EXPECT_EQ(original.mValidConnectionIdx, deserialized.mValidConnectionIdx);
     }
@@ -1105,16 +1107,18 @@ TEST(SerializeUtilsTest, RequestAndBufferInfo)
     // Test with nullopt metadata
     {
         kv_cache::RequestAndBufferInfo original{"testAgent2", "192.168.1.1:9090",
-            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 512, 0}, std::nullopt, 2};
+            tensorrt_llm::batch_manager::RequestInfo{},
+            std::vector<kv_cache::MemoryDesc>{kv_cache::MemoryDesc{nullptr, 512, 0}}, std::nullopt, 2};
 
         auto deserialized = serializeDeserializeNotification(original);
 
         EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
         EXPECT_EQ(original.mAddress, deserialized.mAddress);
         EXPECT_EQ(original.mRequestInfo.getRequestId(), deserialized.mRequestInfo.getRequestId());
-        EXPECT_EQ(original.mBufferDesc.getAddr(), deserialized.mBufferDesc.getAddr());
-        EXPECT_EQ(original.mBufferDesc.getLen(), deserialized.mBufferDesc.getLen());
-        EXPECT_EQ(original.mBufferDesc.getDeviceId(), deserialized.mBufferDesc.getDeviceId());
+        ASSERT_EQ(original.mBufferDescs.size(), deserialized.mBufferDescs.size());
+        EXPECT_EQ(original.mBufferDescs[0].getAddr(), deserialized.mBufferDescs[0].getAddr());
+        EXPECT_EQ(original.mBufferDescs[0].getLen(), deserialized.mBufferDescs[0].getLen());
+        EXPECT_EQ(original.mBufferDescs[0].getDeviceId(), deserialized.mBufferDescs[0].getDeviceId());
         EXPECT_EQ(original.mMetadata, deserialized.mMetadata);
         EXPECT_EQ(original.mValidConnectionIdx, deserialized.mValidConnectionIdx);
     }
@@ -1194,7 +1198,8 @@ TEST(SerializeUtilsTest, NotificationInfo)
     // Test with RequestAndBufferInfo variant
     {
         kv_cache::RequestAndBufferInfo requestInfo{"testAgent", "127.0.0.1:8080",
-            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 1024, 0},
+            tensorrt_llm::batch_manager::RequestInfo{},
+            std::vector<kv_cache::MemoryDesc>{kv_cache::MemoryDesc{nullptr, 1024, 0}},
             std::make_optional<std::string>("test_metadata"), 1};
 
         kv_cache::NotificationInfo original{requestInfo};

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -986,7 +986,7 @@ protected:
             blockIdx = 0;
             for (auto it = indexerKCacheBlockRange.begin(); it != indexerKCacheBlockRange.end(); ++it)
             {
-                verifyBlockData(*it, blockIdx, llmRequest->getPromptLen(), windowSizes[0], true);
+                verifyBlockData(*it, llmRequest->getPromptLen(), blockIdx, windowSizes[0], true);
                 blockIdx++;
             }
         }
@@ -1089,7 +1089,7 @@ protected:
         bufferManager.getStream().synchronize();
     }
 
-    void verifyBlockData(tensorrt_llm::runtime::ITensor& blockData, int blockId, size_t initial, int windowSize = 0,
+    void verifyBlockData(tensorrt_llm::runtime::ITensor& blockData, size_t initial, int blockId, int windowSize = 0,
         bool isIndexerKCache = false)
     {
         auto const& blockManager = mManager->getBlockManager();

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -193,7 +193,7 @@ protected:
         auto constexpr sizePerHead = 64;
         auto constexpr hiddenSize = numHeads * sizePerHead;
         auto constexpr tokensPerBlock = 8;
-        auto constexpr maxBlocksPerSeq = 10;
+        auto constexpr maxBlocksPerSeq = 100;
         auto constexpr maxBeamWidth = 4;
         auto constexpr sinkTokenLength = 0;
         mMaxNumSequences = 8;

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -1022,7 +1022,8 @@ protected:
         }
         int kvFactor = mCacheState->getAttentionConfig().mKvFactor;
         int tokensPerBlock = mCacheState->getModelConfig().mTokensPerBlock;
-        int startTokenId = (blockId * mCpSize + mCpRank) * tokensPerBlock;
+        // We don't account for CP here because contextCP is always 1 currently.
+        int startTokenId = blockId * tokensPerBlock;
         int sizePerHead;
         if (isIndexerKCache)
         {
@@ -1117,7 +1118,8 @@ protected:
         }
         int kvFactor = mCacheState->getAttentionConfig().mKvFactor;
         int tokensPerBlock = mCacheState->getModelConfig().mTokensPerBlock;
-        int startTokenId = (blockId * mCpSize + mCpRank) * tokensPerBlock;
+        // We don't account for CP here because contextCP is always 1 currently.
+        int startTokenId = blockId * tokensPerBlock;
         int sizePerHead;
         if (isIndexerKCache)
         {

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -99,6 +99,8 @@ def launch_disaggregated_llm(
 
     args = LlmArgs.from_kwargs(model=model_name,
                                tensor_parallel_size=tensor_parallel_size)
+    if "FP4" in model_name:
+        args.quant_config.quant_algo = "NVFP4"
 
     trtllm_serve_path = "trtllm-serve"
     # Common arguments for both servers

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -45,7 +45,7 @@ class Result(GenerationResultBase):
 DuckLLM = namedtuple('DuckLLM', ['args', 'tokenizer', 'generate_async'])
 
 DEFAULT_TEST_TIMEOUT = 1800
-DEFAULT_SERVER_WAITING_TIMEOUT = 1200
+DEFAULT_SERVER_WAITING_TIMEOUT = 3600
 
 
 class MyThreadPoolExecutor(ThreadPoolExecutor):

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -108,6 +108,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[baseline_mtp1] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_mtp1] TIMEOUT (180)
+  - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (360)
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Indexer KCache support for optimized key-value cache management
  * Enabled configurable indexer KCache block size and dimension settings
  * Enhanced multi-GPU cache transfer capabilities with indexer KCache option
  * Improved MLA (Multi-Head Latent Attention) cache handling with new transfer paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

gsm8k accuracy for disagg:

|Tasks|Version|     Filter     |n-shot|  Metric   |   | Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|------:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|_  |95.7544|_  |0.5554|
|     |       |strict-match    |     5|exact_match|_  |95.6785|_  |0.5601|

[10/30/2025-21:00:20] [TRT-LLM] [I] lm-eval gsm8k average accuracy: 95.72
[10/30/2025-21:00:20] [TRT-LLM] [I] Hypothesis testing report:


|           Tasks            |Version|   Filter   |n-shot|  Metric   |   |Value |   |Stderr|
|----------------------------|------:|------------|-----:|-----------|---|-----:|---|-----:|
|gpqa_diamond_cot_zeroshot_aa|      1|strict-match|     0|exact_match|↑  |79.798|±  |2.8606|

[11/04/2025-23:53:54] [TRT-LLM] [I] lm-eval gpqa_diamond_cot_zeroshot_aa average accuracy: 79.80
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
