### PR TITLE
[https://nvbugs/5617275][fix] Extract py files from prebuilt wheel for editable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,11 @@ else:
         'libs/libdecoder_attention_1.so', 'libs/nvshmem/License.txt',
         'libs/nvshmem/nvshmem_bootstrap_uid.so.3',
         'libs/nvshmem/nvshmem_transport_ibgda.so.103', 'bindings.*.so',
-        'deep_ep/LICENSE', 'deep_ep_cpp_tllm.*.so', "include/**/*",
-        'deep_gemm/LICENSE', 'deep_gemm/include/**/*',
-        'deep_gemm_cpp_tllm.*.so', 'scripts/install_tensorrt.sh',
-        'flash_mla/LICENSE', 'flash_mla_cpp_tllm.*.so'
+        'deep_ep/LICENSE', 'deep_ep/*.py', 'deep_ep_cpp_tllm.*.so',
+        "include/**/*", 'deep_gemm/LICENSE', 'deep_gemm/include/**/*',
+        'deep_gemm/*.py', 'deep_gemm_cpp_tllm.*.so',
+        'scripts/install_tensorrt.sh', 'flash_mla/LICENSE', 'flash_mla/*.py',
+        'flash_mla_cpp_tllm.*.so'
     ]
 
 package_data += [
@@ -203,8 +204,19 @@ def extract_from_precompiled(precompiled_location: str, package_data: List[str],
 
     with zipfile.ZipFile(wheel_path) as wheel:
         for file in wheel.filelist:
-            if file.filename.endswith((".py", ".yaml")):
+            # Skip yaml files
+            if file.filename.endswith(".yaml"):
                 continue
+
+            # Skip .py files EXCEPT for generated C++ extension wrappers
+            # (deep_gemm, deep_ep, flash_mla Python files are generated during build)
+            if file.filename.endswith(".py"):
+                allowed_dirs = ("tensorrt_llm/deep_gemm/",
+                                "tensorrt_llm/deep_ep/",
+                                "tensorrt_llm/flash_mla/")
+                if not any(file.filename.startswith(d) for d in allowed_dirs):
+                    continue
+
             for filename_pattern in package_data:
                 if fnmatch.fnmatchcase(file.filename,
                                        f"tensorrt_llm/{filename_pattern}"):

--- a/tests/unittest/utils/test_prebuilt_whl_cpp_extensions.py
+++ b/tests/unittest/utils/test_prebuilt_whl_cpp_extensions.py
@@ -1,0 +1,67 @@
+"""
+Test that prebuilt wheel extraction includes all necessary Python files.
+
+"""
+from pathlib import Path
+
+
+def test_cpp_extension_wrapper_files_exist():
+    """Verify that C++ extension wrapper Python files were extracted from prebuilt wheel."""
+    import tensorrt_llm
+
+    trtllm_root = Path(tensorrt_llm.__file__).parent
+
+    # C++ extensions that have Python wrapper files generated during build
+    required_files = {
+        'deep_gemm':
+        ['__init__.py', 'testing/__init__.py', 'utils/__init__.py'],
+        'deep_ep': ['__init__.py', 'buffer.py', 'utils.py'],
+        'flash_mla': ['__init__.py', 'flash_mla_interface.py'],
+    }
+
+    missing_files = []
+    for ext_dir, files in required_files.items():
+        for file in files:
+            file_path = trtllm_root / ext_dir / file
+            if not file_path.exists():
+                missing_files.append(str(file_path.relative_to(trtllm_root)))
+
+    assert not missing_files, (
+        f"Missing Python wrapper files for C++ extensions: {missing_files}\n"
+        f"This indicates setup.py may not be extracting Python files from prebuilt wheels.\n"
+        f"Check setup.py extract_from_precompiled() function.")
+
+
+def test_cpp_extensions_importable():
+    """Verify that C++ extension wrappers can be imported successfully."""
+    import_tests = [
+        ('tensorrt_llm.deep_gemm', 'fp8_mqa_logits'),
+        ('tensorrt_llm.deep_ep', 'Buffer'),
+        ('tensorrt_llm.flash_mla', 'flash_mla_interface'),
+    ]
+
+    failed_imports = []
+    for module_name, attr_name in import_tests:
+        try:
+            module = __import__(module_name, fromlist=[attr_name])
+            if not hasattr(module, attr_name):
+                failed_imports.append(
+                    f"{module_name}.{attr_name} (attribute not found)")
+        except ImportError as e:
+            failed_imports.append(f"{module_name} (ImportError: {e})")
+
+    assert not failed_imports, (
+        f"Failed to import C++ extension wrappers: {failed_imports}\n"
+        f"This may indicate missing Python files or circular import issues.")
+
+
+if __name__ == '__main__':
+    print("Testing C++ extension wrapper files...")
+    test_cpp_extension_wrapper_files_exist()
+    print("✅ All required Python files exist")
+
+    print("\nTesting C++ extension imports...")
+    test_cpp_extensions_importable()
+    print("✅ All imports successful")
+
+    print("\n✅ All tests passed!")


### PR DESCRIPTION
This PR fixes an import issue that only occurs when using editable installs with prebuilt wheels. Regular pip install <wheel> or source builds are unaffected.

The problem lies in the `setup.py` extraction logic, which skips .py files during editable installs when using prebuilt wheels.
This went unnoticed because:
	1.	Source builds: submodule __init__.py files are generated at build time, so they’re always present.
	2.	Normal pip installs: the wheel is unpacked directly into site-packages, ensuring all .py files exist.
Only the editable install + prebuilt wheel combination triggers the missing imports (e.g. tensorrt_llm.deep_gemm, deep_ep, flashMLA).

To repro (under a clean TensorRT-LLM code dir without build cache, e.g., no `./tensorrt_llm/deep_gemm` dir):
```
pip uninstall -y tensorrt-llm
TRTLLM_PRECOMPILED_LOCATION=https://urm.nvidia.com/artifactory/sw-tensorrt-generic/llm-artifacts/LLM/main/L0_PostMerge/2356/x86_64-linux-gnu/cuda13/tensorrt_llm-1.2.0rc2-cp312-cp312-linux_x86_64.whl pip install -e .["devel"]
python -c 'from tensorrt_llm.deep_gemm import fp8_mqa_logits' or python -c 'from tensorrt_llm.deep_ep import Buffer'
// Error
```
but with this PR, `TRTLLM_PRECOMPILED_LOCATION=... pip install ...` should install it properly and have no more import errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved packaging and extraction of C++ extension modules within distribution wheels with refined logic for handling extension wrapper files.

* **Tests**
  * Added verification tests to ensure C++ extension wrappers are properly available and importable in packaged distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
