### PR TITLE
[None][chore] Design diagram review process change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -186,6 +186,9 @@ docs/source/performance/perf-benchmarking.md @NVIDIA/trtllm-bench-reviewers
 ## These scripts install and pin dependency versions
 /docker/common/** @NVIDIA/trt-llm-setup-infra-devs @NVIDIA/trt-llm-infra-devs @NVIDIA/trt-llm-oss-compliance
 
+### TAVA Architecture Diagram
+/.github/tava_architecture_diagram.md @NVIDIA/trt-llm-TAVA-design-change
+
 ### CODEOWNERS file itself
 /.github/CODEOWNERS @NVIDIA/trt-llm-gh-workflows-infra-devs @NVIDIA/trt-llm-infra-devs @NVIDIA/trt-llm-oss-compliance
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,6 +49,7 @@ Please review the following before submitting your PR:
 - Any new dependencies have been scanned for license and vulnerabilities
 - [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
 - Documentation updated as needed
+- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
 - The reviewers assigned automatically/manually are appropriate for the PR.
 
 

--- a/.github/tava_architecture_diagram.md
+++ b/.github/tava_architecture_diagram.md
@@ -16,6 +16,7 @@ graph TB
     subgraph "TensorRT_Flow"
         trtllmExecutor[trtllm.Executor]
         Engine[TensorRT Engine]
+        TRTGraph[TensorRT Graph]
         Plugins[TensorRT Plugins]
         LLMAPI --> trtllmExecutor
         trtllmExecutor --> |build|Engine
@@ -65,73 +66,19 @@ graph TB
     CustomOps --> cudaKernel
     Plugins --> cudaKernel
 
-
-    %% TensorRT_Flow --> |Generate| Tokens
-    %% TensorRT_Flow --> |Report| Stats
-    %% TensorRT_Flow --> |Evaluate| Metrics
-    %% PyTorch_Flow --> |Generate| Tokens
-    %% PyTorch_Flow --> |Report| Stats
-    %% PyTorch_Flow --> |Evaluate| Metrics
-
-    %% Add descriptions for CLI tools
+    %% CLI tools format
     classDef cli fill:#f9f,stroke:#333,stroke-width:2px;
     class CLI cli;
     
-    %% Add descriptions for components
+    %% TRT flow format
     classDef component fill:#bbf,stroke:#333,stroke-width:2px;
     class TRTGraph,Plugins,Engine,Executor,Decoder,Scheduler,BatchManager,KVCache component;
     
-    %% Add descriptions for APIs
+    %% APIs format
     classDef api fill:#bfb,stroke:#333,stroke-width:2px;
     class PythonAPI,CppAPI,LLMAPI api;
 
-    %% Add descriptions for results
+    %% Results format
     classDef result fill:#fbb,stroke:#333,stroke-width:2px;
     class Tokens,Stats,Metrics result;
 ```
-
-## CLI Tools Description
-
-1. **trtllm-build**: Builds TensorRT engines from TensorRT-LLM checkpoints
-2. **trtllm-bench**: Benchmarks the performance of TensorRT-LLM models
-3. **trtllm-eval**: Evaluates model accuracy and performance
-4. **trtllm-llmapi-launch**: Launches the LLM API server
-5. **trtllm-prune**: Prunes model weights for optimization
-6. **trtllm-refit**: Updates weights in a TensorRT engine
-7. **trtllm-serve**: Serves models through various interfaces
-
-## Key Components
-
-1. **Model Definition & Conversion**:
-   - Converts models from various sources (HuggingFace, NeMo, JAX, etc.)
-   - Creates TensorRT-LLM checkpoints
-   - Supports different model formats and architectures
-
-2. **TensorRT Flow**:
-   - TensorRT Engine: Optimized inference engine
-   - Runtime: Core execution engine
-   - C++ Runtime: High-performance implementation
-   - Executor: Manages model execution
-   - Scheduler: Handles request scheduling and batching
-   - Batch Manager: Manages in-flight batching
-   - KV Cache Manager: Handles KV cache memory
-   - Decoder: Generates output tokens
-   - TensorRT Plugins: Custom operations
-   - Custom Kernels: Optimized CUDA implementations
-
-3. **PyTorch Flow**:
-   - PyTorch Runtime: Python-based implementation
-   - PyExecutor: Manages PyTorch model execution
-   - PyScheduler: Handles PyTorch request scheduling
-   - PyDecoder: PyTorch token generation
-   - PyModelEngine: PyTorch model engine
-
-4. **API Layer**:
-   - Python API: High-level Python interface
-   - C++ API: Low-level C++ interface
-   - LLM API: Interface for model interaction (generate, chat, stream, batch, embed, tokenize)
-
-5. **Output Results**:
-   - Generated Tokens: Output text from the model
-   - Performance Stats: Throughput, latency, memory usage
-   - Accuracy Metrics: Model evaluation metrics

--- a/.github/tava_architecture_diagram.md
+++ b/.github/tava_architecture_diagram.md
@@ -1,0 +1,137 @@
+```mermaid
+graph TB
+    subgraph "User API & CLI Tools"
+        CLI[CLI Tools]
+        LLMAPI[LLM API]
+        CLI --> LLMAPI
+    end
+
+    subgraph "Model Checkpoint"
+        Checkpoint[Huggingface Models]
+        Checkpoint --> CLI
+        Checkpoint --> LLMAPI
+
+    end
+
+    subgraph "TensorRT_Flow"
+        trtllmExecutor[trtllm.Executor]
+        Engine[TensorRT Engine]
+        Plugins[TensorRT Plugins]
+        LLMAPI --> trtllmExecutor
+        trtllmExecutor --> |build|Engine
+        trtllmExecutor --> |compile|TRTGraph
+        trtllmExecutor --> |compile|Plugins
+        Engine --> Executor
+        Plugins --> Executor
+        TRTGraph --> Executor
+        Executor --> Decoder[Decoder]
+        Decoder --> Sampling[Sampling]
+        Executor --> Scheduler[Scheduler]
+        Scheduler --> |In-flight Batching| BatchManager[Batch Manager]
+        BatchManager --> KVCache[KV Cache Manager]
+    end
+
+    subgraph "PyTorch_Flow"
+        PyExecutor[PyExecutor]
+        PyEngine[PyTorch Engine]
+        CustomOps[Custom Ops]
+        PyTorchOps[Pytorch Ops]
+        KernelLibs[Kernel Libs]
+        LLMAPI --> PyExecutor
+        PyExecutor --> PyEngine[PyTorch Engine]
+        PyEngine --> CustomOps
+        PyEngine --> PyTorchOps
+        PyEngine --> KernelLibs
+        PyEngine --> PyScheduler[Scheduler]
+        PyEngine --> PyDecoder[Decoder]
+        PyScheduler --> |Pybind|Scheduler
+        PyDecoder --> |Pybind|Decoder
+        
+    end
+
+    subgraph "TensorRT-LLM Kernel Libs"
+        cudaKernel[CUDA Kernels]
+    end
+
+    subgraph "Output_Results"
+        Tokens[Generated Tokens]
+        Stats[Performance Stats]
+        Metrics[Accuracy Metrics]
+    end
+
+    TensorRT_Flow --> Output_Results
+    PyTorch_Flow --> Output_Results
+
+    CustomOps --> cudaKernel
+    Plugins --> cudaKernel
+
+
+    %% TensorRT_Flow --> |Generate| Tokens
+    %% TensorRT_Flow --> |Report| Stats
+    %% TensorRT_Flow --> |Evaluate| Metrics
+    %% PyTorch_Flow --> |Generate| Tokens
+    %% PyTorch_Flow --> |Report| Stats
+    %% PyTorch_Flow --> |Evaluate| Metrics
+
+    %% Add descriptions for CLI tools
+    classDef cli fill:#f9f,stroke:#333,stroke-width:2px;
+    class CLI cli;
+    
+    %% Add descriptions for components
+    classDef component fill:#bbf,stroke:#333,stroke-width:2px;
+    class TRTGraph,Plugins,Engine,Executor,Decoder,Scheduler,BatchManager,KVCache component;
+    
+    %% Add descriptions for APIs
+    classDef api fill:#bfb,stroke:#333,stroke-width:2px;
+    class PythonAPI,CppAPI,LLMAPI api;
+
+    %% Add descriptions for results
+    classDef result fill:#fbb,stroke:#333,stroke-width:2px;
+    class Tokens,Stats,Metrics result;
+```
+
+## CLI Tools Description
+
+1. **trtllm-build**: Builds TensorRT engines from TensorRT-LLM checkpoints
+2. **trtllm-bench**: Benchmarks the performance of TensorRT-LLM models
+3. **trtllm-eval**: Evaluates model accuracy and performance
+4. **trtllm-llmapi-launch**: Launches the LLM API server
+5. **trtllm-prune**: Prunes model weights for optimization
+6. **trtllm-refit**: Updates weights in a TensorRT engine
+7. **trtllm-serve**: Serves models through various interfaces
+
+## Key Components
+
+1. **Model Definition & Conversion**:
+   - Converts models from various sources (HuggingFace, NeMo, JAX, etc.)
+   - Creates TensorRT-LLM checkpoints
+   - Supports different model formats and architectures
+
+2. **TensorRT Flow**:
+   - TensorRT Engine: Optimized inference engine
+   - Runtime: Core execution engine
+   - C++ Runtime: High-performance implementation
+   - Executor: Manages model execution
+   - Scheduler: Handles request scheduling and batching
+   - Batch Manager: Manages in-flight batching
+   - KV Cache Manager: Handles KV cache memory
+   - Decoder: Generates output tokens
+   - TensorRT Plugins: Custom operations
+   - Custom Kernels: Optimized CUDA implementations
+
+3. **PyTorch Flow**:
+   - PyTorch Runtime: Python-based implementation
+   - PyExecutor: Manages PyTorch model execution
+   - PyScheduler: Handles PyTorch request scheduling
+   - PyDecoder: PyTorch token generation
+   - PyModelEngine: PyTorch model engine
+
+4. **API Layer**:
+   - Python API: High-level Python interface
+   - C++ API: Low-level C++ interface
+   - LLM API: Interface for model interaction (generate, chat, stream, batch, embed, tokenize)
+
+5. **Output Results**:
+   - Generated Tokens: Output text from the model
+   - Performance Stats: Throughput, latency, memory usage
+   - Accuracy Metrics: Model evaluation metrics


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architectural documentation with system component diagrams, data flow visualization, component descriptions, and CLI tool reference for the TensorRT-LLM platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
