### PR TITLE
[TRTLLM-8988][feat] Unify MPI & Ray's req/response handling with RPC Client/Server

### DIFF
--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -524,6 +524,13 @@ def mpi_disabled() -> bool:
     return os.environ.get("TLLM_DISABLE_MPI") == "1"
 
 
+def ray_use_rpc() -> bool:
+    """True if TLLM_RAY_USE_RPC is set to "1", False otherwise.
+    # TODO: deprecate this once Ray is fully moved to use RPC client/server.
+    """
+    return os.environ.get("TLLM_RAY_USE_RPC") == "1"
+
+
 def mpi_rank():
     if mpi_disabled():
         try:

--- a/tensorrt_llm/executor/ray_executor.py
+++ b/tensorrt_llm/executor/ray_executor.py
@@ -1,4 +1,7 @@
+import asyncio
+import atexit
 import os
+import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 try:
@@ -17,11 +20,16 @@ from tensorrt_llm._utils import get_free_port
 from tensorrt_llm.logger import logger
 
 from .._utils import nvtx_range_debug
+from ..llmapi.tracer import global_tracer
+from ..llmapi.utils import _SyncQueue, logger_debug
 from .executor import GenerationExecutor
 from .postproc_worker import PostprocWorkerConfig
 from .ray_gpu_worker import RayGPUWorker, RayWorkerWrapper
 from .request import GenerationRequest
-from .result import GenerationResult, RayAsyncQueue, RaySyncQueue
+from .result import GenerationResult
+from .rpc import RPCClient
+from .rpc.rpc_common import get_unique_ipc_addr
+from .utils import ErrorResponse, is_llm_response
 
 __all__ = [
     "RayExecutor",
@@ -76,28 +84,24 @@ class RayExecutor(GenerationExecutor):
             self.master_address = ray.util.get_node_ip_address()
             self.master_port = get_free_port()
 
-            self.response_queue = RayAsyncQueue.options(runtime_env={
-                "env_vars": {
-                    "TLLM_DISABLE_MPI": "1"
-                }
-            }).remote()
-            self.response_sync_queue = RaySyncQueue.options(runtime_env={
-                "env_vars": {
-                    "TLLM_DISABLE_MPI": "1"
-                }
-            }).remote()
-            self.async_response_queue_weakref = self.create_actor_weak_ref(
-                self.response_queue)
-            self.sync_response_queue_weakref = self.create_actor_weak_ref(
-                self.response_sync_queue)
-            self.response_queue.warmup.remote()
-            self.response_sync_queue.warmup.remote()
+            self.rpc_addr = get_unique_ipc_addr()
+            self.rpc_client = RPCClient(self.rpc_addr)
+
+            self._results = {}
+            self._shutdown_event = threading.Event()
+            self.main_loop_task_obj = None
+            self.main_loop = None
 
             worker_kwargs = dict(**worker_kwargs,
                                  postproc_worker_config=postproc_worker_config,
-                                 is_llm_executor=is_llm_executor)
+                                 is_llm_executor=is_llm_executor,
+                                 rpc_addr=self.rpc_addr)
 
             self.create_workers(RayGPUWorker, worker_kwargs)
+
+            logger.info("Setting up engine via RPC")
+            self.setup_engine_remote()
+            self.setup_mainloop()
         except Exception as e:
             # Clean up the Ray resources early during exception
             self.shutdown()
@@ -110,8 +114,103 @@ class RayExecutor(GenerationExecutor):
         return ray.actor.ActorHandle._deserialization_helper(state,
                                                              weak_ref=True)
 
-    def use_ray_queue(self) -> bool:
-        return True
+    async def _generic_fetch_loop_async(self, fetch_method_name: str,
+                                        handler_method, method_name: str):
+        # TODO copied from GenerationExecutorRpcProxy, need refactoring.
+        """Generic method for fetching data in a loop from RPC worker.
+
+        Args:
+            fetch_method_name: Name of the RPC client method to call
+            handler_method: The handler method to call with the fetched data
+            method_name: Name of the method for logging
+        """
+        try:
+            fetch_method = getattr(self.rpc_client, fetch_method_name)
+            async for data in fetch_method().remote_streaming():
+                if self._shutdown_event.is_set():
+                    return
+                handler_method(data)
+        except asyncio.CancelledError:
+            logger.debug(f"{method_name} task cancelled")
+        except Exception as e:
+            logger.error(f"Error in {method_name}: {e}")
+            raise
+
+    async def _fetch_responses_loop_async(self):
+        # TODO copied from GenerationExecutorRpcProxy, need refactoring.
+        await self._generic_fetch_loop_async(
+            fetch_method_name="fetch_responses_loop_async",
+            handler_method=self.handle_responses,
+            method_name="_fetch_responses_loop_async")
+
+    def setup_mainloop(self):
+        # TODO copied from GenerationExecutorRpcProxy, need refactoring.
+        async def main_loop_task():
+            await self._fetch_responses_loop_async()
+
+        def _run_main_loop_task():
+            """Local method to run the main loop task."""
+            self.main_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.main_loop)
+
+            self.main_loop_task_obj = self.main_loop.create_task(
+                main_loop_task())
+            try:
+                self.main_loop.run_until_complete(self.main_loop_task_obj)
+            except asyncio.CancelledError:
+                pass  # Task cancellation is expected during shutdown
+            finally:
+                self.main_loop.close()
+
+        self.main_loop_thread = threading.Thread(target=_run_main_loop_task,
+                                                 daemon=True,
+                                                 name="ray_executor_main_loop")
+        self.main_loop_thread.start()
+        atexit.register(self.shutdown)
+
+    def setup_engine_remote(self):
+        return self.collective_rpc("setup_engine", non_block=False)
+
+    def handle_responses(self, responses: list[GenerationResult]) -> bool:
+        # TODO copied from GenerationExecutorRpcProxy, need refactoring.
+        async_queues = []
+        event_loop = None
+
+        def process_res(res: list):
+            for r in res:
+                client_id = r.client_id
+                nonlocal event_loop
+                nonlocal async_queues
+
+                if client_id not in self._results:
+                    logger.warning(
+                        f"Received response for unknown client_id: {client_id}")
+                    continue
+
+                queue = self._results[client_id].queue
+                if isinstance(queue, _SyncQueue):
+                    queue.put_nowait(r)
+                    async_queues.append(queue)
+                    # all the loops are identical
+                    event_loop = event_loop or queue.loop
+                else:
+                    queue.put(r)
+
+                if (is_llm_response(r) and r.result.is_final) or isinstance(
+                        r, ErrorResponse):
+                    self._results.pop(client_id)
+
+        # Handle the case where responses might not be a list of lists
+        if responses and not isinstance(responses[0], list):
+            # If responses is a flat list, wrap it
+            responses = [responses]
+
+        for res in responses:
+            global_tracer().log_instant("RPC.get")
+            process_res(res)
+
+        if async_queues:
+            _SyncQueue.notify_many(event_loop, async_queues)
 
     def create_workers(self, worker_cls, worker_kwargs):
         # When set to be a fraction, it allows Ray to schedule
@@ -192,10 +291,13 @@ class RayExecutor(GenerationExecutor):
         """
             Low-level API to the executor. Return a "future" GenerationResult
             which can be waited.
-            Forwards the request to the workers through the request queue.
+            Forwards the request to the workers through RPC.
         """
         request.set_id(self._get_next_client_id())
         logprob_params = self._get_logprob_params(request)
+
+        with nvtx_range_debug("rpc_submit"):
+            self.rpc_client.submit(request).remote(need_response=False)
 
         result = GenerationResult(
             request,
@@ -203,15 +305,12 @@ class RayExecutor(GenerationExecutor):
             executor=self,
             disaggregated_params=request.disaggregated_params,
             logprob_params=logprob_params)
-
-        with nvtx_range_debug("request_queue.put"):
-            self.call_all_ray_workers("enqueue_request",
-                                      leader_only=True,
-                                      request=request,
-                                      async_call=True,
-                                      result_wait_queue=result.queue)
+        self._results[request.id] = result
 
         return result
+
+    def start(self):
+        pass
 
     def report_device_ids(self) -> list[str]:
         gpu_ids = self.call_all_ray_workers("report_device_id",
@@ -225,12 +324,44 @@ class RayExecutor(GenerationExecutor):
                                   async_call=False,
                                   request_id=request_id)
 
+    # TODO: Use Ray RPC to shutdown RPC server, and then close client
     def shutdown(self):
-        # Release actors
-        self.response_queue = None
-        self.response_sync_queue = None
-        self.async_response_queue_weakref = None
-        self.sync_response_queue_weakref = None
+        if self._shutdown_event.is_set():
+            return
+        self._shutdown_event.set()
+        logger_debug(f"Shutting down RayExecutor (RPC mode)", color="yellow")
+
+        # First, cancel the main loop to stop fetching responses
+        if hasattr(self, 'main_loop') and self.main_loop and hasattr(
+                self, 'main_loop_task_obj') and self.main_loop_task_obj:
+            logger_debug("Cancelling main loop task.", color="yellow")
+            try:
+                self.main_loop.call_soon_threadsafe(
+                    self.main_loop_task_obj.cancel)
+            except Exception as e:
+                logger_debug(f"Error cancelling main loop task: {e}",
+                             color="yellow")
+
+            if hasattr(self, 'main_loop_thread'):
+                self.main_loop_thread.join()
+
+        # Then, shutdown the workers
+        if hasattr(self, 'workers') and self.workers is not None:
+            try:
+                logger_debug("Shutting down RPC remote", color="yellow")
+                shutdown_refs = [
+                    worker.shutdown.remote() for worker in self.workers
+                ]
+                # Add timeout to prevent indefinite hanging
+                ray.get(shutdown_refs, timeout=30.0)
+            except ray.exceptions.GetTimeoutError:
+                logger.warning(
+                    "Timeout waiting for workers to shutdown after 30 seconds")
+            except Exception as e:
+                logger.warning(f"Error shutting down RPC remote: {e}")
+
+        if hasattr(self, 'rpc_client') and self.rpc_client is not None:
+            self.rpc_client.close()
 
         self.workers = None
         if hasattr(self,

--- a/tensorrt_llm/executor/ray_executor.py
+++ b/tensorrt_llm/executor/ray_executor.py
@@ -13,13 +13,15 @@ from ray.util.placement_group import (PlacementGroup,
                                       placement_group)
 
 from tensorrt_llm._ray_utils import unwrap_ray_errors
-from tensorrt_llm._utils import get_free_port
+from tensorrt_llm._utils import get_free_port, nvtx_range_debug, ray_use_rpc
 from tensorrt_llm.logger import logger
 
 from ..llmapi.utils import logger_debug
 from .executor import GenerationExecutor
 from .postproc_worker import PostprocWorkerConfig
 from .ray_gpu_worker import RayGPUWorker, RayWorkerWrapper
+from .request import GenerationRequest
+from .result import GenerationResult, RayAsyncQueue, RaySyncQueue
 from .rpc_proxy import RpcExecutorMixin
 
 __all__ = [
@@ -74,18 +76,40 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
             self.tp_size = tp_size
             self.master_address = ray.util.get_node_ip_address()
             self.master_port = get_free_port()
-            self.init_rpc_executor()
+            self.use_rpc = ray_use_rpc()
 
             worker_kwargs = dict(**worker_kwargs,
                                  postproc_worker_config=postproc_worker_config,
-                                 is_llm_executor=is_llm_executor,
-                                 rpc_addr=self.rpc_addr)
-            self.create_workers(RayGPUWorker, worker_kwargs)
-            self.setup_engine_remote()
-            self.setup_mainloop(tasks=[self._fetch_responses_loop_async],
-                                thread_name="ray_executor_main_loop")
+                                 is_llm_executor=is_llm_executor)
+
+            if self.use_rpc:
+                self.init_rpc_executor()
+                worker_kwargs['rpc_addr'] = self.rpc_addr
+                self.create_workers(RayGPUWorker, worker_kwargs)
+                self.setup_engine_remote()
+                self.setup_mainloop(tasks=[self._fetch_responses_loop_async],
+                                    thread_name="ray_executor_main_loop")
+                logger.info(f"Connecting to RPC server at {self.rpc_addr}")
+            else:
+                self.response_queue = RayAsyncQueue.options(runtime_env={
+                    "env_vars": {
+                        "TLLM_DISABLE_MPI": "1"
+                    }
+                }).remote()
+                self.response_sync_queue = RaySyncQueue.options(runtime_env={
+                    "env_vars": {
+                        "TLLM_DISABLE_MPI": "1"
+                    }
+                }).remote()
+                self.async_response_queue_weakref = self.create_actor_weak_ref(
+                    self.response_queue)
+                self.sync_response_queue_weakref = self.create_actor_weak_ref(
+                    self.response_sync_queue)
+                self.response_queue.warmup.remote()
+                self.response_sync_queue.warmup.remote()
+                self.create_workers(RayGPUWorker, worker_kwargs)
+
         except Exception as e:
-            # Clean up the Ray resources early during exception
             self.shutdown()
             logger.error(f"Failed to initialize RayExecutor: {e}")
             raise e
@@ -165,6 +189,43 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
                                                         **kwargs))
         return refs if non_block else ray.get(refs)
 
+    def submit(self, request: "GenerationRequest") -> "GenerationResult":
+        """
+        Low-level API to the executor. Return a "future" GenerationResult
+        which can be waited.
+        Forwards the request to the workers through RPC or Ray queues depending on mode.
+        """
+        request.set_id(self._get_next_client_id())
+        logprob_params = self._get_logprob_params(request)
+
+        if self.use_rpc:
+            with nvtx_range_debug("rpc_submit"):
+                self.rpc_client.submit(request).remote(need_response=False)
+
+            result = GenerationResult(
+                request,
+                background_error_handler=self._handle_background_error,
+                executor=self,
+                disaggregated_params=request.disaggregated_params,
+                logprob_params=logprob_params)
+            self._results[request.id] = result
+        else:
+            result = GenerationResult(
+                request,
+                background_error_handler=self._handle_background_error,
+                executor=self,
+                disaggregated_params=request.disaggregated_params,
+                logprob_params=logprob_params)
+
+            with nvtx_range_debug("request_queue.put"):
+                self.call_all_ray_workers("enqueue_request",
+                                          leader_only=True,
+                                          request=request,
+                                          async_call=True,
+                                          result_wait_queue=result.queue)
+
+        return result
+
     def start(self):
         pass
 
@@ -177,50 +238,69 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
                                             async_call=False)
         return sorted(gpu_ids)
 
+    def use_ray_queue(self) -> bool:
+        return not self.use_rpc
+
     def abort_request(self, request_id: int) -> None:
         self.call_all_ray_workers("abort_request",
                                   leader_only=True,
                                   async_call=False,
                                   request_id=request_id)
 
-    # TODO: Use Ray RPC to shutdown RPC server, and then close client
     def shutdown(self):
-        if self._shutdown_event.is_set():
+        if hasattr(self, '_shutdown_event') and self._shutdown_event.is_set():
             return
-        self._shutdown_event.set()
-        logger_debug(f"Shutting down RayExecutor (RPC mode)", color="yellow")
+        if hasattr(self, '_shutdown_event'):
+            self._shutdown_event.set()
 
-        # First, cancel the main loop to stop fetching responses
-        if hasattr(self, 'main_loop') and self.main_loop and hasattr(
-                self, 'main_loop_task_obj') and self.main_loop_task_obj:
-            logger_debug("Cancelling main loop task.", color="yellow")
-            try:
-                self.main_loop.call_soon_threadsafe(
-                    self.main_loop_task_obj.cancel)
-            except Exception as e:
-                logger_debug(f"Error cancelling main loop task: {e}",
-                             color="yellow")
+        mode_str = "RPC mode" if self.use_rpc else "Ray queue mode"
+        logger_debug(f"Shutting down RayExecutor ({mode_str})", color="yellow")
 
-            if hasattr(self, 'main_loop_thread'):
-                self.main_loop_thread.join()
+        if self.use_rpc:
+            if hasattr(self, 'main_loop') and self.main_loop and hasattr(
+                    self, 'main_loop_task_obj') and self.main_loop_task_obj:
+                logger_debug("Cancelling main loop task.", color="yellow")
+                try:
+                    self.main_loop.call_soon_threadsafe(
+                        self.main_loop_task_obj.cancel)
+                except Exception as e:
+                    logger_debug(f"Error cancelling main loop task: {e}",
+                                 color="yellow")
 
-        # Then, shutdown the workers
-        if hasattr(self, 'workers') and self.workers is not None:
-            try:
-                logger_debug("Shutting down RPC remote", color="yellow")
-                shutdown_refs = [
-                    worker.shutdown.remote() for worker in self.workers
-                ]
-                # Add timeout to prevent indefinite hanging
-                ray.get(shutdown_refs, timeout=30.0)
-            except ray.exceptions.GetTimeoutError:
-                logger.warning(
-                    "Timeout waiting for workers to shutdown after 30 seconds")
-            except Exception as e:
-                logger.warning(f"Error shutting down RPC remote: {e}")
+                if hasattr(self, 'main_loop_thread'):
+                    self.main_loop_thread.join()
 
-        if hasattr(self, 'rpc_client') and self.rpc_client is not None:
-            self.rpc_client.close()
+            # Then, shutdown the workers
+            if hasattr(self, 'workers') and self.workers is not None:
+                try:
+                    logger_debug("Shutting down RPC remote", color="yellow")
+                    shutdown_refs = [
+                        worker.shutdown.remote() for worker in self.workers
+                    ]
+                    # Add timeout to prevent indefinite hanging
+                    ray.get(shutdown_refs, timeout=30.0)
+                except ray.exceptions.GetTimeoutError:
+                    logger.warning(
+                        "Timeout waiting for workers to shutdown after 30 seconds"
+                    )
+                except Exception as e:
+                    logger.warning(f"Error shutting down RPC remote: {e}")
+
+            if hasattr(self, 'rpc_client') and self.rpc_client is not None:
+                try:
+                    self.rpc_client.close()
+                except Exception as e:
+                    # Suppress errors during RPC client shutdown
+                    # These can occur if the client is already closed or if there are
+                    # pending operations that get cancelled during cleanup
+                    logger_debug(
+                        f"Suppressed error during RPC client close: {e}")
+        else:
+            # Release actors
+            self.response_queue = None
+            self.response_sync_queue = None
+            self.async_response_queue_weakref = None
+            self.sync_response_queue_weakref = None
 
         self.workers = None
         if hasattr(self,
@@ -235,12 +315,6 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
         if self.has_start_local_cluser and ray.is_initialized():
             logger.debug("Shutting down Ray cluster")
             ray.shutdown()
-
-    @property
-    def enable_postprocess_parallel(self) -> bool:
-        ret = super().enable_postprocess_parallel
-        assert ret == False, "Postprocess parallel is not supported in RayExecutor"
-        return ret
 
     def _get_placement_group(self,
                              tp_size: int) -> Tuple[PlacementGroup, List[int]]:
@@ -307,3 +381,15 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
         pg = placement_group(bundles, strategy=strategy)
 
         return pg, bundle_indices
+
+    @property
+    def enable_postprocess_parallel(self) -> bool:
+        ret = super().enable_postprocess_parallel
+        assert ret == False, "Postprocess parallel is not supported in RayExecutor"
+        return ret
+
+    @staticmethod
+    def create_actor_weak_ref(actor_handle: ray.actor.ActorHandle):
+        state, _, _ = actor_handle._serialization_helper()
+        return ray.actor.ActorHandle._deserialization_helper(state,
+                                                             weak_ref=True)

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 import weakref
 from dataclasses import dataclass, field
@@ -13,7 +14,13 @@ import torch.nn.functional as F
 
 from tensorrt_llm.llmapi import tracing
 
-from .._utils import nvtx_range_debug
+try:
+    import ray
+except ModuleNotFoundError:
+    from tensorrt_llm import ray_stub as ray
+
+from .._ray_utils import unwrap_ray_errors
+from .._utils import mpi_disabled, nvtx_range_debug, ray_use_rpc
 from ..bindings import executor as tllm
 from ..disaggregated_params import DisaggregatedParams
 from ..llmapi.tracer import global_tracer
@@ -153,12 +160,104 @@ class CompletionOutput:
         return self.logprobs[self._last_logprobs_len:]
 
 
+def warmup_tensorrt_llm():
+    import tensorrt_llm
+    print("Warmup by importing tensorrt_llm with version",
+          tensorrt_llm.version.__version__)
+
+
+@ray.remote(max_concurrency=1000000, num_cpus=2)
+class RayAsyncQueue:
+    """Ray actor for async response handling."""
+
+    def __init__(self):
+        self.data = {}
+        self.event_map = {}
+        self.warmup_done = False
+
+    def register(self, key: int):
+        assert key not in self.event_map, f"Key {key} already registered"
+        self.event_map[key] = asyncio.Event()
+
+    def unregister(self, key: int):
+        if key in self.event_map:
+            del self.event_map[key]
+
+        if key in self.data:
+            del self.data[key]
+
+    def warmup(self):
+        if self.warmup_done:
+            return
+        warmup_tensorrt_llm()
+        self.warmup_done = True
+
+    def put_response(self, key: int, item: Any):
+        assert key in self.event_map, f"Key {key} not registered"
+        self.data[key] = item
+        self.event_map[key].set()
+
+    async def get_async(self, key: int):
+        assert key in self.event_map, f"Key {key} not registered"
+        await self.event_map[key].wait()
+        self.event_map[key].clear()
+        ret = self.data[key]
+        del self.data[key]
+        return ret
+
+
+SYNC_QUEUE_MAX_CONCURRENCY = 2
+
+
+@ray.remote(max_concurrency=SYNC_QUEUE_MAX_CONCURRENCY,
+            num_cpus=SYNC_QUEUE_MAX_CONCURRENCY)
+class RaySyncQueue:
+    """Ray actor for sync response handling."""
+
+    def __init__(self):
+        self.data = {}
+        self.event_map = {}
+        self.semaphore = threading.Semaphore(SYNC_QUEUE_MAX_CONCURRENCY - 1)
+        self.warmup_done = False
+
+    def register(self, key: int):
+        assert key not in self.event_map, f"Key {key} already registered"
+        self.event_map[key] = threading.Event()
+        self.event_map[key]
+
+    def unregister(self, key: int):
+        if key in self.event_map:
+            del self.event_map[key]
+
+        if key in self.data:
+            del self.data[key]
+
+    def warmup(self):
+        if self.warmup_done:
+            return
+        warmup_tensorrt_llm()
+        self.warmup_done = True
+
+    def put_response(self, key: int, item: Any):
+        self.data[key] = item
+        self.event_map[key].set()
+
+    def get(self, key: int):
+        with self.semaphore:
+            self.event_map[key].wait()
+            self.event_map[key].clear()
+            ret = self.data[key]
+            del self.data[key]
+            return ret
+
+
 class GenerationResultBase:
     ''' This holds the core logic of the GenerationResult class. '''
 
     def __init__(self,
                  id: int,
                  sampling_params: SamplingParams,
+                 ray_queue: Optional[RayAsyncQueue] = None,
                  background_error_handler: Optional[Callable] = None,
                  postproc_params: "Optional[PostprocParams]" = None):
         self.id = id
@@ -176,12 +275,22 @@ class GenerationResultBase:
         # torch backend will use trtllm sampler in beam search mode, but it does not support return logprobs incrementally
         self.use_trtllm_sampler = sampling_params.use_beam_search and sampling_params.best_of > 1
 
-        if has_event_loop():
-            self.aqueue = AsyncQueue()
-            self.queue = self.aqueue.sync_q
+        if ray_queue is not None and not ray_use_rpc():
+            if has_event_loop():
+                self.aqueue = ray_queue
+                self.queue = self.aqueue
+            else:
+                self.queue = ray_queue
+                self.aqueue = None
+            with unwrap_ray_errors():
+                ray.get(self.queue.register.remote(id))
         else:
-            self.queue = Queue()
-            self.aqueue = None
+            if has_event_loop():
+                self.aqueue = AsyncQueue()
+                self.queue = self.aqueue.sync_q
+            else:
+                self.queue = Queue()
+                self.aqueue = None
 
         # In Sampling mode, the Executor runtime will return best_of sequences
         # in total, which the LLM API will select the n-best sequences among
@@ -448,6 +557,12 @@ class GenerationResultBase:
         else:
             raise ValueError(f"Unknown response type: {response}")
 
+        if self._done and mpi_disabled() and not ray_use_rpc():
+            assert hasattr(
+                self.queue, "unregister"
+            ), "Ray path should be activated for unregistering the Ray queue."
+            self.queue.unregister.remote(self.id)
+
     def record_stats(self,
                      output: CompletionOutput,
                      stats: Optional[dict[str, float]] = None) -> None:
@@ -673,9 +788,15 @@ class GenerationResult(GenerationResultBase):
         disaggregated_params: Optional[DisaggregatedParams] = None,
         logprob_params: Optional[LogprobParams] = None,
     ) -> None:
+        use_async_queue = has_event_loop()
+        shared_queue = None
+        if executor and executor.use_ray_queue() and not ray_use_rpc():
+            shared_queue = executor.async_response_queue_weakref if use_async_queue else executor.sync_response_queue_weakref
+
         super().__init__(
             generation_request.id,
             generation_request.sampling_params,
+            shared_queue,
             background_error_handler,
             postproc_params=generation_request.postproc_params,
         )
@@ -730,13 +851,26 @@ class GenerationResult(GenerationResultBase):
         if hasattr(self, "_logprob_params"):
             del self._logprob_params
 
+    def _handle_ray_response(self, response: Any):
+        return response
+
     def _result_step(self, timeout: Optional[float] = None):
-        response = self.queue.get()
+        if mpi_disabled() and not ray_use_rpc():
+            with unwrap_ray_errors():
+                response = ray.get(self.queue.get.remote(self.request_id))
+            response = self._handle_ray_response(response)
+        else:
+            response = self.queue.get()
+
         self._handle_response(response)
 
     async def _aresult_step(self):
         assert self.aqueue is not None, "The asyncio event loop was not present during initialization, so async operations are not available."
-        response = await self.aqueue.get()
+        if mpi_disabled() and not ray_use_rpc():
+            response = await self.aqueue.get_async.remote(self.request_id)
+            response = self._handle_ray_response(response)
+        else:
+            response = await self.aqueue.get()
         global_tracer().log_instant("result_step.get")
         self._handle_response(response)
 

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import threading
+import time
 import uuid
 from typing import Any, AsyncIterator, Dict, Optional
 
@@ -406,6 +407,26 @@ class RPCClient:
         if self._loop is None or not self._loop.is_running():
             self._loop = asyncio.new_event_loop()
 
+            # TODO: WAR. Need to fix Ray+RPC shutdown.
+            def custom_exception_handler(loop, context):
+                exception = context.get('exception')
+                message = context.get('message', '')
+
+                if isinstance(exception, asyncio.CancelledError):
+                    if '_chain' in message or 'zmq' in message.lower(
+                    ) or '_AsyncSocket' in message:
+                        print(
+                            f"Suppressed zmq error during shutdown: {message}")
+                        return
+
+                if 'pending' in message:
+                    print(f"Suppressed error during shutdown: {message}")
+                    return
+
+                loop.default_exception_handler(context)
+
+            self._loop.set_exception_handler(custom_exception_handler)
+
             def run_loop():
                 asyncio.set_event_loop(self._loop)
                 self._loop.run_forever()
@@ -416,7 +437,6 @@ class RPCClient:
             self._loop_thread.start()
 
             # Give the loop a moment to start
-            import time
             time.sleep(0.1)
 
     def _call_sync(self, method_name, *args, **kwargs):

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -412,7 +412,8 @@ class RPCClient:
                 exception = context.get('exception')
                 message = context.get('message', '')
 
-                if isinstance(exception, asyncio.CancelledError) or "pending" in message:
+                if isinstance(exception,
+                              asyncio.CancelledError) or "pending" in message:
                     logger.debug(f"Suppressed error during shutdown: {message}")
                     return
 

--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -407,20 +407,13 @@ class RPCClient:
         if self._loop is None or not self._loop.is_running():
             self._loop = asyncio.new_event_loop()
 
-            # TODO: WAR. Need to fix Ray+RPC shutdown.
+            # TODO: WAR. Remove after RPC shutdown is fixed.
             def custom_exception_handler(loop, context):
                 exception = context.get('exception')
                 message = context.get('message', '')
 
-                if isinstance(exception, asyncio.CancelledError):
-                    if '_chain' in message or 'zmq' in message.lower(
-                    ) or '_AsyncSocket' in message:
-                        print(
-                            f"Suppressed zmq error during shutdown: {message}")
-                        return
-
-                if 'pending' in message:
-                    print(f"Suppressed error during shutdown: {message}")
+                if isinstance(exception, asyncio.CancelledError) or "pending" in message:
+                    logger.debug(f"Suppressed error during shutdown: {message}")
                     return
 
                 loop.default_exception_handler(context)

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -2,7 +2,7 @@ import asyncio
 import atexit
 import json
 import threading
-from typing import Optional
+from typing import Callable, List, Optional
 
 from .._utils import nvtx_range_debug
 from ..llmapi.mpi_session import MpiPoolSession, MpiSession
@@ -20,120 +20,48 @@ from .utils import (ErrorResponse, create_mpi_comm_session,
                     get_spawn_proxy_process_env, is_llm_response)
 
 
-class GenerationExecutorRpcProxy(GenerationExecutor):
-    # NOTE: this is a global counter for the number of instances of this class
-    INSTANCE_COUNTER = 0
+class RpcExecutorMixin:
+    """Mixin for executors that use RPC client for hot path communication.
 
-    def __init__(
-        self,
-        worker_kwargs: dict,
-        model_world_size: int = 1,
-        mpi_session: Optional[MpiSession] = None,
-        *,
-        postproc_worker_config: Optional[PostprocWorkerConfig] = None,
-        is_llm_executor: Optional[bool] = None,
-    ):
-        """
-        Args:
-            worker_kwargs: kwargs for the rpc worker
-            model_world_size: the world size of the model
-            mpi_session: the mpi session to use
-            postproc_worker_config: the postproc worker config
-            is_llm_executor: whether this is an llm executor
-        """
-        GenerationExecutorRpcProxy.INSTANCE_COUNTER += 1
+    Provides:
+    - RPC client initialization
+    - Response handling loop
+    - Main loop thread management
+    - Shutdown logic for RPC components
+
+    The inheriting class should call init_rpc_executor() to set up RPC client.
+    """
+
+    def init_rpc_executor(self):
         self.rpc_addr = get_unique_ipc_addr()
         self.rpc_client = RPCClient(self.rpc_addr)
 
-        postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
-        )
-
-        super().__init__(
-            num_postprocess_workers=postproc_worker_config.
-            num_postprocess_workers,
-            postprocess_tokenizer_dir=postproc_worker_config.
-            postprocess_tokenizer_dir,
-            is_llm_executor=is_llm_executor,
-        )
-
         self._results = {}
-
-        self._create_mpi_session(model_world_size, mpi_session)
-
         self._shutdown_event = threading.Event()
-        self.worker_kwargs = worker_kwargs
-
         self.main_loop_task_obj = None
         self.main_loop = None
         self.main_loop_thread = None
 
-        self.launch_workers()
-
-        # Invoke model creation on the remote
-        # TBD: Move model creation to the mpi task, or left in RPC?
-        self.setup_engine_remote()
-
-        # Setup main loop after engine is ready
-        self.setup_mainloop()
-
-    def launch_workers(self):
-        logger.debug(f"Launching workers")
-        assert self.mpi_session is not None
-        self.mpi_session.submit(RpcWorker.main_task,
-                                rpc_addr=self.rpc_addr,
-                                **self.worker_kwargs)
-
-    async def _generic_fetch_loop_async(self, fetch_method_name: str,
-                                        handler_method, method_name: str):
-        """Generic method for fetching data in a loop from RPC worker.
+    def setup_mainloop(self,
+                       tasks: Optional[List[Callable]] = None,
+                       thread_name: str = "rpc_proxy_main_loop"):
+        """Setup main loop thread with custom async tasks.
 
         Args:
-            fetch_method_name: Name of the RPC client method to call
-            handler_method: The handler method to call with the fetched data
-            method_name: Name of the method for logging
+            tasks: List of async coroutine functions to run.
+            thread_name: Name for the main loop thread
         """
-        try:
-            fetch_method = getattr(self.rpc_client, fetch_method_name)
-            async for data in fetch_method().remote_streaming():
-                if self._shutdown_event.is_set():
-                    return
-                handler_method(data)
-        except asyncio.CancelledError:
-            logger.debug(f"{method_name} task cancelled")
-        except Exception as e:
-            logger.error(f"Error in {method_name}: {e}")
-            raise
-
-    async def _fetch_responses_loop_async(self):
-        await self._generic_fetch_loop_async(
-            fetch_method_name="fetch_responses_loop_async",
-            handler_method=self.handle_responses,
-            method_name="_fetch_responses_loop_async")
-
-    async def _fetch_stats_loop_async(self):
-        await self._generic_fetch_loop_async(
-            fetch_method_name="fetch_stats_loop_async",
-            handler_method=self.handle_stats,
-            method_name="_fetch_stats_loop_async")
-
-    async def _fetch_kv_cache_events_loop_async(self):
-        await self._generic_fetch_loop_async(
-            fetch_method_name="fetch_kv_cache_events_loop_async",
-            handler_method=self.handle_kv_cache_events,
-            method_name="_fetch_kv_cache_events_loop_async")
-
-    def setup_mainloop(self):
-
-        async def main_loop_task():
+        if tasks is None:
             tasks = [
-                self._fetch_responses_loop_async(),
-                self._fetch_stats_loop_async(),
-                self._fetch_kv_cache_events_loop_async(),
+                self._fetch_responses_loop_async,
+                self._fetch_stats_loop_async,
             ]
             # Only add kv_cache_events loop if it's enabled
             if self._iter_kv_events_result:
-                tasks.append(self._fetch_kv_cache_events_loop_async())
-            await asyncio.gather(*tasks)
+                tasks.append(self._fetch_kv_cache_events_loop_async)
+
+        async def main_loop_task():
+            await asyncio.gather(*[task() for task in tasks])
 
         def _run_main_loop_task():
             """Local method to run the main loop task."""
@@ -151,9 +79,29 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
 
         self.main_loop_thread = threading.Thread(target=_run_main_loop_task,
                                                  daemon=True,
-                                                 name="rpc_proxy_main_loop")
+                                                 name=thread_name)
         self.main_loop_thread.start()
         atexit.register(self.shutdown)
+
+    def submit(self, request: GenerationRequest) -> GenerationResult:
+        request.set_id(self._get_next_client_id())
+        logprob_params = self._get_logprob_params(request)
+
+        # submit is a fire-and-forget operation, don't need to wait for response
+        with nvtx_range_debug("RPCExecutor.submit",
+                              color="green",
+                              category="Proxy"):
+            self.rpc_client.submit(request).remote(need_response=False)
+
+        result = GenerationResult(
+            request,
+            background_error_handler=self._handle_background_error,
+            executor=self,
+            disaggregated_params=request.disaggregated_params,
+            logprob_params=logprob_params)
+        self._results[request.id] = result
+
+        return result
 
     def handle_responses(self, responses: list[GenerationResult]) -> bool:
         async_queues = []
@@ -194,6 +142,63 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
 
         if async_queues:
             _SyncQueue.notify_many(event_loop, async_queues)
+
+    def handle_stats(self, stats):
+        """Handle stats received from RPC worker and put them into the stats result queue.
+
+        Args:
+            stats: Statistics data from the RPC worker (can be dict, str, or list)
+        """
+        self._handle_iteration_data(stats, self._iter_stats_result, "stats")
+
+    def handle_kv_cache_events(self, events):
+        """Handle KV cache events received from RPC worker and put them into the events result queue.
+
+        Args:
+            events: KV cache events data from the RPC worker (can be dict, str, or list)
+        """
+        self._handle_iteration_data(events, self._iter_kv_events_result,
+                                    "kv_cache_events")
+
+    async def _generic_fetch_loop_async(self, fetch_method_name: str,
+                                        handler_method: Callable,
+                                        method_name: str):
+        """Generic method for fetching data in a loop from RPC worker.
+
+        Args:
+            fetch_method_name: Name of the RPC client method to call
+            handler_method: The handler method to call with the fetched data
+            method_name: Name of the method for logging
+        """
+        try:
+            fetch_method = getattr(self.rpc_client, fetch_method_name)
+            async for data in fetch_method().remote_streaming():
+                if self._shutdown_event.is_set():
+                    return
+                handler_method(data)
+        except asyncio.CancelledError:
+            logger.debug(f"{method_name} task cancelled")
+        except Exception as e:
+            logger.error(f"Error in {method_name}: {e}")
+            raise
+
+    async def _fetch_responses_loop_async(self):
+        await self._generic_fetch_loop_async(
+            fetch_method_name="fetch_responses_loop_async",
+            handler_method=self.handle_responses,
+            method_name="_fetch_responses_loop_async")
+
+    async def _fetch_stats_loop_async(self):
+        await self._generic_fetch_loop_async(
+            fetch_method_name="fetch_stats_loop_async",
+            handler_method=self.handle_stats,
+            method_name="_fetch_stats_loop_async")
+
+    async def _fetch_kv_cache_events_loop_async(self):
+        await self._generic_fetch_loop_async(
+            fetch_method_name="fetch_kv_cache_events_loop_async",
+            handler_method=self.handle_kv_cache_events,
+            method_name="_fetch_kv_cache_events_loop_async")
 
     def _handle_iteration_data(self, data, result_singleton, data_type: str):
         """Generic method to handle iteration data received from RPC worker.
@@ -268,42 +273,74 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
             logger.error(f"rpc_proxy.py: Error in handle_{data_type}: {e}")
             raise e
 
-    def handle_stats(self, stats):
-        """Handle stats received from RPC worker and put them into the stats result queue.
 
-        Args:
-            stats: Statistics data from the RPC worker (can be dict, str, or list)
+class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
+    # NOTE: this is a global counter for the number of instances of this class
+    INSTANCE_COUNTER = 0
+
+    def __init__(
+        self,
+        worker_kwargs: dict,
+        model_world_size: int = 1,
+        mpi_session: Optional[MpiSession] = None,
+        *,
+        postproc_worker_config: Optional[PostprocWorkerConfig] = None,
+        is_llm_executor: Optional[bool] = None,
+    ):
         """
-        self._handle_iteration_data(stats, self._iter_stats_result, "stats")
-
-    def handle_kv_cache_events(self, events):
-        """Handle KV cache events received from RPC worker and put them into the events result queue.
-
         Args:
-            events: KV cache events data from the RPC worker (can be dict, str, or list)
+            worker_kwargs: kwargs for the rpc worker
+            model_world_size: the world size of the model
+            mpi_session: the mpi session to use
+            postproc_worker_config: the postproc worker config
+            is_llm_executor: whether this is an llm executor
         """
-        self._handle_iteration_data(events, self._iter_kv_events_result,
-                                    "kv_cache_events")
+        GenerationExecutorRpcProxy.INSTANCE_COUNTER += 1
+        self.init_rpc_executor()
 
-    def submit(self, request: GenerationRequest) -> GenerationResult:
-        request.set_id(self._get_next_client_id())
-        logprob_params = self._get_logprob_params(request)
+        postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
+        )
 
-        # submit is a fire-and-forget operation, don't need to wait for response
-        with nvtx_range_debug("GenerationExecutorRpcProxy.submit",
-                              color="green",
-                              category="Proxy"):
-            self.rpc_client.submit(request).remote(need_response=False)
+        super().__init__(
+            num_postprocess_workers=postproc_worker_config.
+            num_postprocess_workers,
+            postprocess_tokenizer_dir=postproc_worker_config.
+            postprocess_tokenizer_dir,
+            is_llm_executor=is_llm_executor,
+        )
 
-        result = GenerationResult(
-            request,
-            background_error_handler=self._handle_background_error,
-            executor=self,
-            disaggregated_params=request.disaggregated_params,
-            logprob_params=logprob_params)
-        self._results[request.id] = result
+        self._create_mpi_session(model_world_size, mpi_session)
 
-        return result
+        self.worker_kwargs = worker_kwargs
+
+        self.launch_workers()
+
+        # Invoke model creation on the remote
+        # TBD: Move model creation to the mpi task, or left in RPC?
+        self.setup_engine_remote()
+
+        # Setup main loop after engine is ready
+        self._setup_mainloop_with_tasks()
+
+    def launch_workers(self):
+        logger.debug(f"Launching workers")
+        assert self.mpi_session is not None
+        self.mpi_session.submit(RpcWorker.main_task,
+                                rpc_addr=self.rpc_addr,
+                                **self.worker_kwargs)
+
+    def _setup_mainloop_with_tasks(self):
+        """Setup mainloop with all tasks needed for RpcProxy."""
+        tasks = [
+            self._fetch_responses_loop_async,
+            self._fetch_stats_loop_async,
+        ]
+        # Only add kv_cache_events loop if it's enabled
+        if self._iter_kv_events_result:
+            tasks.append(self._fetch_kv_cache_events_loop_async)
+
+        # Call mixin's setup_mainloop with custom tasks
+        self.setup_mainloop(tasks=tasks, thread_name="rpc_proxy_main_loop")
 
     def fetch_stats_remote(self):
         return self.rpc_client.fetch_stats().remote()

--- a/tensorrt_llm/executor/rpc_worker.py
+++ b/tensorrt_llm/executor/rpc_worker.py
@@ -22,7 +22,151 @@ from .request import GenerationRequest
 from .rpc import RPCServer
 
 
-class RpcWorker(BaseWorker):
+class RpcWorkerMixin:
+    """Mixin for workers that serve RPC requests.
+
+    Provides:
+    - RPC server initialization
+    - Response queue management
+    - Async response fetching methods
+    - Shutdown logic for RPC components
+
+    The inheriting class should call init_rpc_worker() in its __init__.
+    """
+
+    # Number of RPC server workers
+    NUM_WORKERS = 6
+
+    def init_rpc_worker(self, rank: int, rpc_addr: Optional[str]):
+        if rpc_addr is None:
+            raise RuntimeError(
+                "RPC mode enabled but no rpc_addr provided to worker")
+
+        self.rank = rank
+        self.shutdown_event = Event()
+        self._response_queue = Queue()
+        self.set_result_queue(self._response_queue)
+
+        self.rpc_server = None
+        self.rpc_addr = rpc_addr
+
+    def start_rpc_server(self):
+        if self.rank == 0:
+            self.rpc_server = RPCServer(self,
+                                        num_workers=RpcWorkerMixin.NUM_WORKERS)
+            self.rpc_server.bind(self.rpc_addr)
+            self.rpc_server.start()
+
+    def submit(self, request: GenerationRequest):
+        """ Submits a request to the worker. """
+        with nvtx_range_debug("RpcWorker.submit",
+                              color="blue",
+                              category="Worker"):
+            super().submit(request)
+
+    def fetch_responses(self, timeout: Optional[float] = None) -> list:
+        """Fetch responses from the response queue (blocking)."""
+        logger_debug(f"RpcWorker {self.rank} is fetching responses",
+                     color="yellow")
+        with nvtx_range_debug("RpcWorker.fetch_responses",
+                              color="orange",
+                              category="Worker"):
+            # NOTE: This is a blocking call, it will wait for the responses to be available.
+            responses = super().await_responses(timeout)
+            self._await_response_helper.responses_handler(responses)
+
+        qsize = self._response_queue.qsize()
+        logger_debug(f"RpcWorker returning {qsize} responses", color="yellow")
+
+        all_responses = []
+        for _ in range(qsize):
+            # The queue contains batches of responses, so extend the list
+            all_responses.extend(self._response_queue.get())
+        return all_responses
+
+    async def fetch_responses_async(self,
+                                    timeout: Optional[float] = None) -> list:
+        """Async version of fetch_responses using asyncio.to_thread."""
+        # A really async version of fetch_responses
+        logger_debug(f"RpcWorker {self.rank} is fetching responses async",
+                     color="yellow")
+
+        # First, await any pending responses without blocking the event loop
+        responses = await asyncio.to_thread(self.fetch_responses,
+                                            timeout=timeout)
+        return responses
+
+    async def fetch_responses_loop_async(self) -> AsyncGenerator[list, None]:
+        while not self.shutdown_event.is_set():
+            responses = await self.fetch_responses_async()
+            if responses:  # Only yield if there are actual responses
+                logger_debug(
+                    f"RpcWorker {self.rank} is yielding responses: {responses}",
+                    color="yellow")
+                yield responses  # batching the responses to opt IPC performance
+            else:
+                # Small delay to prevent busy waiting when no responses
+                await asyncio.sleep(0)
+        logger_debug(
+            f"RpcWorker {self.rank} quitting fetch_responses_loop_async",
+            color="yellow")
+
+    async def fetch_stats_async(self, timeout: Optional[float] = None) -> list:
+        """Async version of fetch_stats using asyncio.to_thread."""
+        return await asyncio.to_thread(self.fetch_stats)
+
+    async def fetch_kv_cache_events_async(self,
+                                          timeout: Optional[float] = None
+                                          ) -> list:
+        """Async version of fetch_kv_cache_events using asyncio.to_thread."""
+        return await asyncio.to_thread(self.fetch_kv_cache_events)
+
+    async def fetch_stats_loop_async(
+            self,
+            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
+        async for data in self._generic_fetch_loop_async(
+                fetch_method=self.fetch_stats_async,
+                serializer=self._stats_serializer,
+                method_name="fetch_stats_loop_async",
+                timeout=timeout):
+            yield data
+
+    async def fetch_kv_cache_events_loop_async(
+            self,
+            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
+        async for data in self._generic_fetch_loop_async(
+                fetch_method=self.fetch_kv_cache_events_async,
+                serializer=self._kv_cache_events_serializer,
+                method_name="fetch_kv_cache_events_loop_async",
+                timeout=timeout):
+            yield data
+
+    async def _generic_fetch_loop_async(
+            self,
+            fetch_method,
+            serializer,
+            method_name: str,
+            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
+        """Generic method for fetching data in a loop.
+
+        Args:
+            fetch_method: The async method to call for fetching data
+            serializer: The serializer function to apply to each item
+            method_name: Name of the method for logging
+            timeout: Optional timeout between fetches
+        """
+        while not self.shutdown_event.is_set():
+            timeout = timeout or 0.1
+            await asyncio.sleep(timeout)
+            data = await fetch_method()
+            # Always yield data, even if empty, to prevent the client looks like hanging
+            # TODO: Remove the empty data to reduce the IPC overhead
+            yield [serializer(item) for item in data]
+        logger_debug(f"RpcWorker {self.rank} quitting {method_name}",
+                     color="yellow")
+
+
+class RpcWorker(RpcWorkerMixin, BaseWorker):
     """
     A RPC wrapper for the BaseWorker class.
 
@@ -34,9 +178,6 @@ class RpcWorker(BaseWorker):
         - `fetch_kv_cache_events`: Fetch the latest kv cache events from engine.
         - `shutdown`: Shutdown the worker.
     """
-
-    # Number of RPC server workers
-    NUM_WORKERS = 6
 
     def __init__(
         self,
@@ -70,111 +211,6 @@ class RpcWorker(BaseWorker):
         self._response_queue = Queue()
         self.set_result_queue(self._response_queue)
 
-    def submit(self, request: GenerationRequest):
-        """ Submits a request to the worker. """
-        with nvtx_range_debug("RpcWorker.submit",
-                              color="blue",
-                              category="Worker"):
-            super().submit(request)
-
-    def fetch_responses(self, timeout: Optional[float] = None) -> list:
-        logger_debug(f"RpcWorker {mpi_rank()} is fetching responses",
-                     color="yellow")
-        with nvtx_range_debug("RpcWorker.fetch_responses",
-                              color="orange",
-                              category="Worker"):
-            # NOTE: This is a blocking call, it will wait for the responses to be available.
-            responses = super().await_responses(timeout)
-            self._await_response_helper.responses_handler(responses)
-
-        qsize = self._response_queue.qsize()
-        logger_debug(f"RpcWorker returning {qsize} responses", color="yellow")
-
-        all_responses = []
-        for _ in range(qsize):
-            # The queue contains batches of responses, so extend the list
-            all_responses.extend(self._response_queue.get())
-        return all_responses
-
-    async def fetch_responses_async(self,
-                                    timeout: Optional[float] = None) -> list:
-        # A really async version of fetch_responses
-        logger_debug(f"RpcWorker {mpi_rank()} is fetching responses async",
-                     color="yellow")
-
-        # First, await any pending responses without blocking the event loop
-        responses = await asyncio.to_thread(self.fetch_responses,
-                                            timeout=timeout)
-        return responses
-
-    async def fetch_stats_async(self, timeout: Optional[float] = None) -> list:
-        return await asyncio.to_thread(self.fetch_stats)
-
-    async def fetch_kv_cache_events_async(self,
-                                          timeout: Optional[float] = None
-                                          ) -> list:
-        return await asyncio.to_thread(self.fetch_kv_cache_events)
-
-    # for streaming performance
-    async def fetch_responses_loop_async(self) -> AsyncGenerator[list, None]:
-        while not self.shutdown_event.is_set():
-            responses = await self.fetch_responses_async()
-            if responses:  # Only yield if there are actual responses
-                logger_debug(
-                    f"RpcWorker {mpi_rank()} is yielding responses: {responses}",
-                    color="yellow")
-                yield responses  # batching the responses to opt IPC performance
-            else:
-                # Small delay to prevent busy waiting when no responses
-                await asyncio.sleep(0)
-        logger_debug(
-            f"RpcWorker {mpi_rank()} quitting fetch_responses_loop_async",
-            color="yellow")
-
-    async def _generic_fetch_loop_async(
-            self,
-            fetch_method,
-            serializer,
-            method_name: str,
-            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
-        """Generic method for fetching data in a loop.
-
-        Args:
-            fetch_method: The async method to call for fetching data
-            serializer: The serializer function to apply to each item
-            method_name: Name of the method for logging
-            timeout: Optional timeout between fetches
-        """
-        while not self.shutdown_event.is_set():
-            timeout = timeout or 0.1
-            await asyncio.sleep(timeout)
-            data = await fetch_method()
-            # Always yield data, even if empty, to prevent the client looks like hanging
-            # TODO: Remove the empty data to reduce the IPC overhead
-            yield [serializer(item) for item in data]
-        logger_debug(f"RpcWorker {mpi_rank()} quitting {method_name}",
-                     color="yellow")
-
-    async def fetch_stats_loop_async(
-            self,
-            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
-        async for data in self._generic_fetch_loop_async(
-                fetch_method=self.fetch_stats_async,
-                serializer=self._stats_serializer,
-                method_name="fetch_stats_loop_async",
-                timeout=timeout):
-            yield data
-
-    async def fetch_kv_cache_events_loop_async(
-            self,
-            timeout: Optional[float] = None) -> AsyncGenerator[list, None]:
-        async for data in self._generic_fetch_loop_async(
-                fetch_method=self.fetch_kv_cache_events_async,
-                serializer=self._kv_cache_events_serializer,
-                method_name="fetch_kv_cache_events_loop_async",
-                timeout=timeout):
-            yield data
-
     def setup_engine(self):
         # Force all the ranks to wait here, and start creating the executor simultaneously.
         # Only call barrier if we have multiple ranks to avoid hanging in single-process tests
@@ -182,13 +218,6 @@ class RpcWorker(BaseWorker):
             mpi_comm().barrier()
 
         super().setup_engine()
-
-    def shutdown(self):
-        logger_debug(f"RPC worker {mpi_rank()} is shutting down",
-                     color="yellow")
-        self.shutdown_event.set()
-        super().shutdown()
-        logger_debug(f"RPC worker {mpi_rank()} is shutdown", color="yellow")
 
     def start(self):
         pass
@@ -246,6 +275,13 @@ class RpcWorker(BaseWorker):
                 f"Worker {mpi_rank()} is waiting for the worker to shutdown")
             worker.shutdown_event.wait()
             rpc_server.shutdown()
+
+    def shutdown(self):
+        logger_debug(f"RPC worker {mpi_rank()} is shutting down",
+                     color="yellow")
+        self.shutdown_event.set()
+        super().shutdown()
+        logger_debug(f"RPC worker {mpi_rank()} is shutdown", color="yellow")
 
     def __enter__(self):
         return self

--- a/tests/integration/defs/examples/test_ray.py
+++ b/tests/integration/defs/examples/test_ray.py
@@ -12,7 +12,11 @@ def ray_example_root(llm_root):
     return example_root
 
 
-def test_llm_inference_async_ray(ray_example_root, llm_venv):
+@pytest.mark.parametrize("use_rpc", [True, False], ids=["rpc", "no_rpc"])
+def test_llm_inference_async_ray(ray_example_root, llm_venv, monkeypatch,
+                                 use_rpc):
+    if use_rpc:
+        monkeypatch.setenv("TLLM_RAY_USE_RPC", "1")
     script_path = os.path.join(ray_example_root, "llm_inference_async_ray.py")
     model_path = f"{llm_models_root()}/llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
     venv_check_call(llm_venv, [script_path, "--model", model_path])

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -131,7 +131,7 @@ l0_h100:
     - unittest/_torch/executor
     - unittest/_torch/ray_orchestrator/single_gpu
     - unittest/llmapi/test_llm_pytorch.py
-    - examples/test_ray.py::test_llm_inference_async_ray
+    - examples/test_ray.py::test_llm_inference_async_ray[no_rpc]
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RPC-based execution support in Ray executor as an alternative to queue-based submission. Enable via `TLLM_RAY_USE_RPC=1` environment variable for enhanced execution flexibility.

* **Improvements**
  * Enhanced conditional execution path handling for better response management and lifecycle control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
