### PR TITLE
[TRTLLM-8768][chore] Fuse QK down_proj with indexer K + weight_proj for FP4 ckpt

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1120,10 +1120,9 @@ class Indexer(nn.Module):
 
     @torch.inference_mode()
     def forward(self, qr: torch.Tensor, hidden_states: torch.Tensor,
-                indexer_k: Optional[torch.Tensor],
-                indexer_weights: Optional[torch.Tensor],
                 metadata: DSAtrtllmAttentionMetadata,
-                position_ids: torch.Tensor):
+                position_ids: torch.Tensor, indexer_k: Optional[torch.Tensor],
+                indexer_weights: Optional[torch.Tensor]):
         quant_block_size = metadata.kv_cache_manager.quant_block_size
         assert quant_block_size == 128, "Only support quant_block_size = 128 for now"
 
@@ -1144,6 +1143,7 @@ class Indexer(nn.Module):
                 self.ln_events[1],
                 self.aux_stream,
             )
+            k = self.k_norm(k)
 
         # q/k rope + possible fast_hadamard_transform
         q = q.view(-1, self.n_heads, self.head_dim)

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -600,7 +600,23 @@ class Indexer(nn.Module):
             quant_config=quant_config,
             skip_create_weights_in_init=skip_create_weights_in_init,
             use_custom_cublas_mm=True)
+        self.wk = Linear(
+            self.hidden_size,
+            self.head_dim,
+            bias=False,
+            dtype=dtype,
+            quant_config=quant_config,
+            skip_create_weights_in_init=skip_create_weights_in_init,
+            use_custom_cublas_mm=True)
         self.k_norm = LayerNorm(hidden_size=self.head_dim, eps=1e-6)
+        self.weights_proj = Linear(
+            self.hidden_size,
+            self.n_heads,
+            bias=False,
+            dtype=dtype,
+            quant_config=None,
+            skip_create_weights_in_init=skip_create_weights_in_init,
+            use_custom_cublas_mm=True)
 
         self.rotary_emb = RotaryEmbedding(
             pos_embd_params.rope,
@@ -613,6 +629,19 @@ class Indexer(nn.Module):
         self.scale_fmt = "ue8m0"
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+
+    @staticmethod
+    def load_weights_to_kv_a(fused_a: torch.Tensor, weights: dict,
+                             names: list) -> torch.Tensor:
+        prefix = '.'.join(names[:-1])
+        indexer_wk = weights[f"{prefix}.indexer.wk.weight"][:]
+        indexer_weights_proj = weights[
+            f"{prefix}.indexer.weights_proj.weight"][:]
+
+        assert fused_a.dtype == indexer_wk.dtype == indexer_weights_proj.dtype, \
+            "all weights in kv_a_proj_with_mqa module must have matching dtype"
+
+        return torch.cat([fused_a, indexer_wk, indexer_weights_proj], dim=0)
 
     @staticmethod
     def prepare_one_prefill_chunk(
@@ -1091,14 +1120,30 @@ class Indexer(nn.Module):
 
     @torch.inference_mode()
     def forward(self, qr: torch.Tensor, hidden_states: torch.Tensor,
-                indexer_k: torch.Tensor, indexer_weights: torch.Tensor,
+                indexer_k: Optional[torch.Tensor],
+                indexer_weights: Optional[torch.Tensor],
                 metadata: DSAtrtllmAttentionMetadata,
                 position_ids: torch.Tensor):
         quant_block_size = metadata.kv_cache_manager.quant_block_size
         assert quant_block_size == 128, "Only support quant_block_size = 128 for now"
-        k = indexer_k
-        q = self.wq_b(
-            qr)  # TODO: fuse wq_b and move this outside of the indexer
+
+        if indexer_k is not None:
+            q, k = maybe_execute_in_parallel(
+                lambda: self.wq_b(
+                    qr),  # TODO: fuse wq_b and move this outside of the indexer
+                lambda: self.k_norm(indexer_k),
+                self.ln_events[0],
+                self.ln_events[1],
+                self.aux_stream,
+            )
+        else:
+            q, k = maybe_execute_in_parallel(
+                lambda: self.wq_b(qr),
+                lambda: self.wk(hidden_states),
+                self.ln_events[0],
+                self.ln_events[1],
+                self.aux_stream,
+            )
 
         # q/k rope + possible fast_hadamard_transform
         q = q.view(-1, self.n_heads, self.head_dim)
@@ -1134,7 +1179,8 @@ class Indexer(nn.Module):
         q_scale = q_scale.view(-1, self.n_heads, 1)
 
         # indexer weight scaling
-        weights = indexer_weights  #self.weights_proj(hidden_states)
+        weights = indexer_weights if indexer_weights is not None else self.weights_proj(
+            hidden_states)
         weights = weights.unsqueeze(
             -1) * q_scale * self.softmax_scale * self.n_heads**-0.5
         weights = weights.squeeze(-1)

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -600,23 +600,23 @@ class Indexer(nn.Module):
             quant_config=quant_config,
             skip_create_weights_in_init=skip_create_weights_in_init,
             use_custom_cublas_mm=True)
-        self.wk = Linear(
-            self.hidden_size,
-            self.head_dim,
-            bias=False,
-            dtype=dtype,
-            quant_config=quant_config,
-            skip_create_weights_in_init=skip_create_weights_in_init,
-            use_custom_cublas_mm=True)
+        # self.wk = Linear(
+        #     self.hidden_size,
+        #     self.head_dim,
+        #     bias=False,
+        #     dtype=dtype,
+        #     quant_config=quant_config,
+        #     skip_create_weights_in_init=skip_create_weights_in_init,
+        #     use_custom_cublas_mm=True)
         self.k_norm = LayerNorm(hidden_size=self.head_dim, eps=1e-6)
-        self.weights_proj = Linear(
-            self.hidden_size,
-            self.n_heads,
-            bias=False,
-            dtype=dtype,
-            quant_config=None,
-            skip_create_weights_in_init=skip_create_weights_in_init,
-            use_custom_cublas_mm=True)
+        # self.weights_proj = Linear(
+        #     self.hidden_size,
+        #     self.n_heads,
+        #     bias=False,
+        #     dtype=dtype,
+        #     quant_config=None,
+        #     skip_create_weights_in_init=skip_create_weights_in_init,
+        #     use_custom_cublas_mm=True)
 
         self.rotary_emb = RotaryEmbedding(
             pos_embd_params.rope,
@@ -1107,29 +1107,23 @@ class Indexer(nn.Module):
 
     @torch.inference_mode()
     def forward(self, qr: torch.Tensor, hidden_states: torch.Tensor,
+                indexer_k: torch.Tensor, indexer_weights: torch.Tensor,
                 metadata: DSAtrtllmAttentionMetadata,
                 position_ids: torch.Tensor):
         quant_block_size = metadata.kv_cache_manager.quant_block_size
         assert quant_block_size == 128, "Only support quant_block_size = 128 for now"
+        k = indexer_k
+        q = self.wq_b(
+            qr)  # TODO: fuse wq_b and move this outside of the indexer
 
-        q, k = maybe_execute_in_parallel(
-            lambda: self.wq_b(qr),
-            lambda: self.wk(hidden_states),
-            self.ln_events[0],
-            self.ln_events[1],
-            self.aux_stream,
-        )
+        # q/k rope + possible fast_hadamard_transform
         q = q.view(-1, self.n_heads, self.head_dim)
         q_pe, q_nope = torch.split(
             q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1)
-        k = self.k_norm(k)
         k_pe, k_nope = torch.split(
             k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1)
-
-        # k_pe needs unsqueeze to match n_heads
         q_pe, k_pe = self.rotary_emb(position_ids, [q_pe, k_pe.unsqueeze(1)])
         q = torch.cat([q_pe, q_nope], dim=-1)
-        # Remove head dimension (size 1) for MQA k
         k = torch.cat([k_pe[:, 0, :], k_nope], dim=-1)
 
         q, k = maybe_execute_in_parallel(
@@ -1139,9 +1133,8 @@ class Indexer(nn.Module):
             self.ln_events[1],
             self.aux_stream,
         )
-        # we only quant q here since k quant is fused with cache insertion
+        # dyn q/k quant
         q = q.view(-1, self.head_dim)
-
         q, k = maybe_execute_in_parallel(
             lambda: fp8_utils.fp8_quantize_1x128_sf_transpose(
                 q, use_ue8m0=self.scale_fmt == "ue8m0"),
@@ -1156,7 +1149,8 @@ class Indexer(nn.Module):
         q_fp8 = q_fp8.view(-1, self.n_heads, self.head_dim)
         q_scale = q_scale.view(-1, self.n_heads, 1)
 
-        weights = self.weights_proj(hidden_states)
+        # indexer weight scaling
+        weights = indexer_weights  #self.weights_proj(hidden_states)
         weights = weights.unsqueeze(
             -1) * q_scale * self.softmax_scale * self.n_heads**-0.5
         weights = weights.squeeze(-1)

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -600,23 +600,7 @@ class Indexer(nn.Module):
             quant_config=quant_config,
             skip_create_weights_in_init=skip_create_weights_in_init,
             use_custom_cublas_mm=True)
-        # self.wk = Linear(
-        #     self.hidden_size,
-        #     self.head_dim,
-        #     bias=False,
-        #     dtype=dtype,
-        #     quant_config=quant_config,
-        #     skip_create_weights_in_init=skip_create_weights_in_init,
-        #     use_custom_cublas_mm=True)
         self.k_norm = LayerNorm(hidden_size=self.head_dim, eps=1e-6)
-        # self.weights_proj = Linear(
-        #     self.hidden_size,
-        #     self.n_heads,
-        #     bias=False,
-        #     dtype=dtype,
-        #     quant_config=None,
-        #     skip_create_weights_in_init=skip_create_weights_in_init,
-        #     use_custom_cublas_mm=True)
 
         self.rotary_emb = RotaryEmbedding(
             pos_embd_params.rope,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -358,15 +358,11 @@ class DeepseekV3WeightLoader:
                     has_indexer = hasattr(
                         attn_module,
                         'indexer') and attn_module.indexer is not None
-                    if has_indexer:
-                        indexer_wk = weights[
-                            f"{'.'.join(names[:-1])}.indexer.wk.weight"][:]
-                        indexer_weights_proj = weights[
-                            f"{'.'.join(names[:-1])}.indexer.weights_proj.weight"][:]
-                        # validate all weights have matching dtype
-                        assert fused_a.dtype == indexer_wk.dtype == indexer_weights_proj.dtype, "all weights in kv_a_proj_with_mqa module must have matching dtype"
-                        fused_a = torch.cat(
-                            [fused_a, indexer_wk, indexer_weights_proj], dim=0)
+                    if has_indexer and attn_module.fuse_a_indexer_k_weight:
+                        from tensorrt_llm._torch.attention_backend.sparse.dsa import \
+                            Indexer
+                        fused_a = Indexer.load_weights_to_kv_a(
+                            fused_a, weights, names)
 
                     if f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight_scale_inv" in weights:
                         fused_a_scale = weights[
@@ -569,6 +565,14 @@ class DeepseekV32Attention(MLA):
     ):
         config = model_config.pretrained_config
         predicted_tokens_per_seq = model_config.spec_config.max_total_draft_tokens + 1 if model_config.spec_config is not None else 1
+
+        # DSV3.2 nvfp4 ckpt has kv_a_proj_with_mqa module in bfloat16
+        # TODO: check it more directly/robustly, e.g., indexer_weight_quant == fuseA_quant == indexer_quant
+        if model_config.get_quant_config().quant_algo == QuantAlgo.NVFP4:
+            self.fuse_a_indexer_k_weight = True
+        else:
+            self.fuse_a_indexer_k_weight = False
+
         super().__init__(hidden_size=config.hidden_size,
                          num_attention_heads=config.num_attention_heads,
                          num_key_value_heads=config.num_key_value_heads,
@@ -590,12 +594,18 @@ class DeepseekV32Attention(MLA):
                          config=model_config,
                          aux_stream=aux_stream)
 
+        if self.fuse_a_indexer_k_weight:
+            # avoid loading indexer.wk and indexer.weights_proj twice
+            self.indexer.wk = None
+            self.indexer.weights_proj = None
+
         # For DeepseekV32, the kv_a_proj_with_mqa includes:
         # q_a_proj + kv_a_proj_with_mqa + indexer.wk + indexer.weights_proj
         self.kv_a_proj_with_mqa = DeepseekV3Linear(
             config.hidden_size,
             self.kv_lora_rank + self.qk_rope_head_dim + self.q_lora_rank +
-            self.indexer.head_dim + self.indexer.n_heads,
+            (self.indexer.head_dim +
+             self.indexer.n_heads if self.fuse_a_indexer_k_weight else 0),
             bias=False,
             dtype=config.torch_dtype,
             quant_config=model_config.get_quant_config(),

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -363,7 +363,8 @@ class DeepseekV3WeightLoader:
                                 [q_a_proj_scale, fused_a_scale], dim=0)
 
                         module.weight_scale.data.copy_(fused_a_scale)
-
+                    # For DeepseekV32 with fuse_a_indexer_k_weight=True: kv_a_proj_with_mqa is oversized
+                    # to include indexer weights, which is filled in post_load_weights.
                     module.weight.data[0:fused_a.shape[0]].copy_(fused_a)
                 elif names[-1] in params_map:
                     module_weights = []
@@ -383,10 +384,6 @@ class DeepseekV3WeightLoader:
                 elif names[-1] == "self_attn":
                     continue
                 elif names[-1] == "next_layer_layernorm":
-                    continue
-                elif names[-1] == "kv_a_proj_with_mqa_fused":
-                    # For DeepseekV32: skip loading for the fused module (kv_a_proj_with_mqa + indexer k/weights_proj)
-                    # it will be populated in post_load_weights instead
                     continue
                 else:
                     module_weights = filter_weights(name, weights)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -364,7 +364,7 @@ class DeepseekV3WeightLoader:
 
                         module.weight_scale.data.copy_(fused_a_scale)
 
-                    module.weight.data.copy_(fused_a)
+                    module.weight.data[0:fused_a.shape[0]].copy_(fused_a)
                 elif names[-1] in params_map:
                     module_weights = []
                     for new_name in params_map[names[-1]]:
@@ -589,18 +589,12 @@ class DeepseekV32Attention(MLA):
 
         self.indexer = self.mqa.indexer
 
-        # Create fused version if needed (will be populated in post_load_weights)
         if self.fuse_a_indexer_k_weight:
-            if model_config.quant_config.exclude_modules is None:
-                model_config.quant_config.exclude_modules = []
-            model_config.quant_config.exclude_modules.append(
-                "*kv_a_proj_with_mqa_fused*")
-
-            # Note: Creating extra kv_a_proj_with_mqa_fused could duplicate storage until post_load_weights,
-            # It's around ~2GB (~60 × 33MB). Might be acceptable.
-            self.kv_a_proj_with_mqa_fused = DeepseekV3Linear(
+            # For DeepseekV32, the kv_a_proj_with_mqa includes:
+            # q_a_proj + kv_a_proj_with_mqa + indexer.wk + indexer.weights_proj
+            self.kv_a_proj_with_mqa = DeepseekV3Linear(
                 config.hidden_size,
-                self.q_lora_rank + self.kv_lora_rank + self.qk_rope_head_dim +
+                self.kv_lora_rank + self.qk_rope_head_dim + self.q_lora_rank +
                 self.indexer.head_dim + self.indexer.n_heads,
                 bias=False,
                 dtype=config.torch_dtype,
@@ -612,18 +606,17 @@ class DeepseekV32Attention(MLA):
     def post_load_weights(self):
         if self.fuse_a_indexer_k_weight:
             assert self.kv_a_proj_with_mqa.weight.data.dtype == self.indexer.wk.weight.data.dtype == self.indexer.weights_proj.weight.data.dtype, "all weights in kv_a_proj_with_mqa module must have matching dtype"
-            # Concatenate weights: kv_a_proj_with_mqa + indexer.wk + indexer.weights_proj
-            fused_weight = torch.cat([
-                self.kv_a_proj_with_mqa.weight.data,
-                self.indexer.wk.weight.data,
-                self.indexer.weights_proj.weight.data
-            ],
-                                     dim=0)
-
-            self.kv_a_proj_with_mqa_fused.weight.data.copy_(fused_weight)
-            self.kv_a_proj_with_mqa = self.kv_a_proj_with_mqa_fused
-            # Clean up references to avoid redundant storage
-            self.kv_a_proj_with_mqa_fused = None
+            # Copy indexer weights into the fused kv_a_proj_with_mqa module
+            indexer_wk_weight = self.indexer.wk.weight.data
+            offset = self.kv_lora_rank + self.qk_rope_head_dim + self.q_lora_rank
+            self.kv_a_proj_with_mqa.weight.data[offset:offset +
+                                                self.indexer.head_dim].copy_(
+                                                    indexer_wk_weight)
+            offset += self.indexer.head_dim
+            indexer_weights_proj_weight = self.indexer.weights_proj.weight.data
+            self.kv_a_proj_with_mqa.weight.data[offset:offset +
+                                                self.indexer.n_heads].copy_(
+                                                    indexer_weights_proj_weight)
             self.indexer.wk = None
             self.indexer.weights_proj = None
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1262,9 +1262,14 @@ class MLA(nn.Module):
         # TODO: fuse wq_b + (indexer) wlq here
         q = self.q_b_proj(q)
         # Indexer
-        topk_indices = self.indexer(qr, hidden_states, indexer_k,
-                                    indexer_weights, attn_metadata,
-                                    position_ids)
+        topk_indices = self.indexer(
+            qr,
+            hidden_states,
+            attn_metadata,
+            position_ids,
+            indexer_k=indexer_k,  # indexer K proj
+            indexer_weights=indexer_weights,  # indexer weights proj
+        )
 
         assert q.shape[
             0] == num_tokens, f"Expect q.shape[0] to be {num_tokens}, but got {q.shape[0]}"

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1234,9 +1234,14 @@ class MLA(nn.Module):
         if position_ids is not None:
             position_ids = position_ids[..., :num_tokens]
 
-        q, compressed_kv, k_pe = self.kv_a_proj_with_mqa(hidden_states).split(
-            [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], -1)
+        q, compressed_kv, k_pe, indexer_k, indexer_weights = self.kv_a_proj_with_mqa(
+            hidden_states).split([
+                self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim,
+                self.indexer.head_dim, self.indexer.n_heads
+            ], -1)
 
+        latent_cache = torch.concat([compressed_kv, k_pe], dim=-1)
+        # TODO: possibly fuse q_a_rmsnorm + kv_a_rmsnorm + indexer.k_layernorm?
         q, compressed_kv = maybe_execute_in_parallel(
             lambda: self.q_a_layernorm(q),
             lambda: self.kv_a_layernorm(compressed_kv),
@@ -1244,23 +1249,19 @@ class MLA(nn.Module):
             self.ln_events[1],
             self.aux_stream,
         )
+        indexer_k = self.indexer.k_norm(indexer_k)
         qr = q
-        q, latent_cache = maybe_execute_in_parallel(
-            lambda: self.q_b_proj(q),
-            lambda: torch.concat([compressed_kv, k_pe], dim=-1),
-            self.ln_events[0],
-            self.ln_events[1],
-            self.aux_stream,
-        )
+        # TODO: fuse wq_b + (indexer) wlq here
+        q = self.q_b_proj(q)
+        # Indexer
+        topk_indices = self.indexer(qr, hidden_states, indexer_k,
+                                    indexer_weights, attn_metadata,
+                                    position_ids)
 
         assert q.shape[
             0] == num_tokens, f"Expect q.shape[0] to be {num_tokens}, but got {q.shape[0]}"
 
         assert output is not None, "output must be provided"
-
-        # Indexer
-        topk_indices = self.indexer(qr, hidden_states, attn_metadata,
-                                    position_ids)
 
         if num_contexts > 0:
             q_ctx = q[:num_ctx_tokens, ...]

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -963,8 +963,6 @@ class MLA(nn.Module):
         if not config.skip_create_weights_in_init:
             self.create_weights()
 
-        self.indexer = self.mqa.indexer if self.is_dsa else None
-
     def create_weights(self):
         # self.mha/mqa has no weights but has states that are related to quant_config,
         # which could be modified after __init__

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1234,13 +1234,21 @@ class MLA(nn.Module):
         if position_ids is not None:
             position_ids = position_ids[..., :num_tokens]
 
-        q, compressed_kv, k_pe, indexer_k, indexer_weights = self.kv_a_proj_with_mqa(
-            hidden_states).split([
-                self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim,
-                self.indexer.head_dim, self.indexer.n_heads
-            ], -1)
+        if self.fuse_a_indexer_k_weight:
+            q, compressed_kv, k_pe, indexer_k, indexer_weights = self.kv_a_proj_with_mqa(
+                hidden_states).split([
+                    self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim,
+                    self.indexer.head_dim, self.indexer.n_heads
+                ], -1)
+        else:
+            q, compressed_kv, k_pe = self.kv_a_proj_with_mqa(
+                hidden_states).split([
+                    self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim
+                ], -1)
+            indexer_k = None
+            indexer_weights = None
 
-        # TODO: possibly fuse q_a_rmsnorm + kv_a_rmsnorm + indexer.k_layernorm?
+        # TODO: possibly overlap/fuse q_a_rmsnorm + kv_a_rmsnorm + indexer.k_layernorm?
         q, compressed_kv = maybe_execute_in_parallel(
             lambda: self.q_a_layernorm(q),
             lambda: self.kv_a_layernorm(compressed_kv),
@@ -1248,14 +1256,9 @@ class MLA(nn.Module):
             self.ln_events[1],
             self.aux_stream,
         )
-        indexer_k, latent_cache = maybe_execute_in_parallel(
-            lambda: self.indexer.k_norm(indexer_k),
-            lambda: torch.concat([compressed_kv, k_pe], dim=-1),
-            self.ln_events[0],
-            self.ln_events[1],
-            self.aux_stream,
-        )
         qr = q
+        latent_cache = torch.concat([compressed_kv, k_pe], dim=-1)
+
         # TODO: fuse wq_b + (indexer) wlq here
         q = self.q_b_proj(q)
         # Indexer

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -675,59 +675,19 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str):
         sum(batch_query_lens[:i + 1]) for i in range(len(batch_order))
     ]
     num_ctx_tokens = sum(query_lens[i] for i in ctx_indices)
-
-    def create_causal_indices(req_indices, cache_offset_start=0):
-        """Helper to create causal attention indices with padding."""
-        indices = []
-        kv_offset = cache_offset_start
-        for req_idx in req_indices:
-            for local_pos in range(query_lens[req_idx]):
-                num_attend = min(cached_lens[req_idx] + local_pos + 1,
-                                 topk_tokens)
-                attend_indices = torch.arange(
-                    num_attend, dtype=torch.int32, device=device) + kv_offset
-                if num_attend < topk_tokens:
-                    padding = torch.full((topk_tokens - num_attend, ),
-                                         -1,
-                                         dtype=torch.int32,
-                                         device=device)
-                    attend_indices = torch.cat([attend_indices, padding])
-                indices.append(attend_indices)
-            kv_offset += seq_lens[req_idx]
-        return torch.stack(indices, dim=0)
-
-    def local_to_global_indices(local_indices,
-                                req_indices,
-                                cache_offset_start=0):
-        """
-        Transform indexer's local indices to global indices.
-        """
-        global_indices = local_indices.clone()
-        kv_offset = cache_offset_start
-        token_idx = 0
-
-        for req_idx in req_indices:
-            num_tokens = query_lens[req_idx]
-            # Add offset for this request's cache position
-            for local_pos in range(num_tokens):
-                # Only transform non-padding indices (>= 0)
-                mask = global_indices[token_idx] >= 0
-                global_indices[token_idx][mask] += kv_offset
-                token_idx += 1
-            kv_offset += seq_lens[req_idx]
-        return global_indices
-
-    topk_indices_local = mla.mqa.indexer(qr, hidden_states, attn_metadata,
-                                         position_ids)
+    topk_indices_local = mla.mqa.indexer(
+        qr,
+        hidden_states,
+        attn_metadata,
+        position_ids,
+        None,  # indexer_k
+        None,  # indexer_weights
+    )
 
     # Validate indexer output against expected causal indices (since seq_len < topk=2048)
     if num_contexts > 0:
         # Transform context indices from local to global
         ctx_topk_local = topk_indices_local[:num_ctx_tokens]
-
-        # Create expected global indices (sorted) for validation (not used but can be used for validation)
-        expected_ctx_indices = create_causal_indices(ctx_indices,
-                                                     cache_offset_start=0)
 
         mla.forward_context_dsa(
             q=q[:num_ctx_tokens],
@@ -747,11 +707,6 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str):
         num_gen_tokens = sum(query_lens[i] for i in gen_indices)
         gen_topk_local = topk_indices_local[num_ctx_tokens:num_ctx_tokens +
                                             num_gen_tokens]
-
-        # Create expected global indices (sorted) for validation (not used but can be used for validation)
-        expected_gen_indices = create_causal_indices(gen_indices,
-                                                     cache_offset_start=0)
-
         mla.forward_generation_dsa(
             q=q[num_ctx_tokens:],
             compressed_kv=compressed_kv[num_ctx_tokens:],

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -443,6 +443,7 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str):
             dtype=dtype,
             config=model_config,
         ).to(device)
+        mla.indexer = mla.mqa.indexer.to(device)
         mla_layers.append(mla)
 
     # Use the test layer


### PR DESCRIPTION
Perf implication:

Without this PR:
concurrency=64;  ISL/OSL=1K/2K;  DEP=8:
```
Request Throughput (req/sec):                     0.9469
Total Output Throughput (tokens/sec):             1939.3511
Total Token Throughput (tokens/sec):              2926.8559
Total Latency (ms):                               67585.4940
Average request latency (ms):                     67518.0704
Per User Output Throughput [w/ ctx] (tps/user):   30.3326
Per GPU Output Throughput (tps/gpu):              242.4189
```

With this PR (~1.02X):
concurrency=64;  ISL/OSL=1K/2K;  DEP=8:
```
Request Throughput (req/sec):                     0.9670
Total Output Throughput (tokens/sec):             1980.3425
Total Token Throughput (tokens/sec):              2988.7198
Total Latency (ms):                               66186.5319
Average request latency (ms):                     66121.9604
Per User Output Throughput [w/ ctx] (tps/user):   30.9731
Per GPU Output Throughput (tps/gpu):              247.5428
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for DeepseekV3.2 attention variant.

* **Refactor**
  * Optimized sparse attention backend with improved indexer-based attention pathway for enhanced performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
