### PR TITLE
[None][fix] Layer-wise benchmarks: use local models, lint

### DIFF
--- a/examples/layer_wise_benchmarks/README.md
+++ b/examples/layer_wise_benchmarks/README.md
@@ -42,7 +42,7 @@ NP=4 ./mpi_launch.sh ./run_single.sh config_gen.yaml --batch-size 32 --seq-len-q
 NP=4 ./mpi_launch.sh ./run_single.sh config_ctx.yaml --layer-indices 5,6,7,8
 NP=4 ./mpi_launch.sh ./run_single.sh config_gen.yaml --layer-indices 5,6,7,8
 
-# Scale DEP=16 MNNVL to 4 GPUs: reduce the number of experts, uses MNNVL A2A if applicable
+# Scale DEP=16 to 4 GPUs: reduce the number of experts, uses MNNVL A2A if applicable
 NP=4 ./mpi_launch.sh ./run_single.sh config_gen.yaml --scaled-from 16 --moe-backend WIDEEP
 
 # Scale TEP=16 to 4 GPUs: reduce the number of attention heads and experts

--- a/examples/layer_wise_benchmarks/slurm_init_containers.sh
+++ b/examples/layer_wise_benchmarks/slurm_init_containers.sh
@@ -22,6 +22,7 @@ if [ "${CONTAINER_IMAGE:-}" == "" ]; then
         DOCKER_IMAGE=$LLM_SBSA_DOCKER_IMAGE
     else
         echo "Unsupported machine hardware name \"$MACHINE\""
+        exit 1
     fi
 
     # Change "urm.nvidia.com/sw-tensorrt-docker/..." to "urm.nvidia.com#sw-tensorrt-docker/..." to bypass credentials

--- a/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
@@ -292,11 +292,11 @@ class DeepSeekV3Runner:
             max_num_requests=kv_cache_manager.max_batch_size,
             num_contexts={
                 "CTX": batch_size,
-                "GEN": 0
+                "GEN": 0,
             }[run_type],
             prompt_lens=[{
                 "CTX": seq_len_q,
-                "GEN": seq_len_kv_cache
+                "GEN": seq_len_kv_cache,
             }[run_type]] * batch_size,
             max_num_tokens=batch_size * seq_len_q,
             kv_cache_manager=kv_cache_manager,
@@ -380,7 +380,7 @@ class DeepSeekV3Runner:
             mapping=mapping,
             dtype=torch_dtype_to_binding({
                 None: torch.bfloat16,
-                "FP8": torch.float8_e4m3fn
+                "FP8": torch.float8_e4m3fn,
             }[model_config.quant_config.kv_cache_quant_algo]),
             sparse_attn_config=model_config.sparse_attention_config,
         )

--- a/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
@@ -48,7 +48,7 @@ class RoutingMethod(DeepseekV3Gate):
         super().__init__(*args, **kwargs)
         self.world_size = mpi_world_size()
         self.rank = mpi_rank()
-        self.balance_method = None
+        self.balance_method = BalanceMethod.NotModified
         self.balance_ratio = None
 
     def apply(self, router_logits) -> (torch.Tensor, torch.Tensor):
@@ -276,7 +276,7 @@ class DeepSeekV3Runner:
                         batch_size: int,
                         seq_len_q: int,
                         seq_len_kv_cache: int,
-                        kv_cache_manager: Optional[KVCacheManager] = None,
+                        kv_cache_manager: KVCacheManager,
                         attn_workspace: Optional[torch.Tensor] = None):
         if self.model_config.moe_backend == "TRTLLM" and os.getenv(
                 "TRTLLM_ENABLE_PDL") != "1":

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -626,9 +626,23 @@ def deepseek_v3_model_root(request):
     elif request.param == "DeepSeek-V3-Lite-nvfp4_moe_only":
         deepseek_v3_model_root = os.path.join(models_root, "DeepSeek-V3-Lite",
                                               "nvfp4_moe_only")
+    elif request.param == "DeepSeek-V3.2-Exp":
+        deepseek_v3_model_root = os.path.join(models_root,
+                                              "DeepSeek-V3.2-Exp-hf")
     assert exists(
         deepseek_v3_model_root), f"{deepseek_v3_model_root} does not exist!"
     return deepseek_v3_model_root
+
+
+@pytest.fixture(scope="function")
+def deepseek_r1_model_root(request):
+    models_root = llm_models_root()
+    if request.param == "DeepSeek-R1-0528-FP4-v2":
+        deepseek_r1_model_root = os.path.join(models_root, "DeepSeek-R1",
+                                              "DeepSeek-R1-0528-FP4-v2")
+    assert exists(
+        deepseek_r1_model_root), f"{deepseek_r1_model_root} does not exist!"
+    return deepseek_r1_model_root
 
 
 @pytest.fixture(scope="session")

--- a/tests/unittest/tools/test_layer_wise_benchmarks.py
+++ b/tests/unittest/tools/test_layer_wise_benchmarks.py
@@ -2,17 +2,22 @@ import os
 
 import pytest
 import torch
+from defs.conftest import deepseek_r1_model_root  # noqa: F401
+from defs.conftest import deepseek_v3_model_root  # noqa: F401
 from defs.trt_test_alternative import check_call
 from utils.cpp_paths import llm_root  # noqa: F401
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 4,
                     reason="needs 4 GPUs to run this test")
-def test_deepseek_r1_ctx_tep(llm_root):
+@pytest.mark.parametrize("deepseek_r1_model_root", ["DeepSeek-R1-0528-FP4-v2"],
+                         indirect=True)
+def test_deepseek_r1_ctx_tep(llm_root, deepseek_r1_model_root):
     check_call([
         "./mpi_launch.sh",
         "./run_single.sh",
         "config_ctx.yaml",
+        "--model=" + deepseek_r1_model_root,
         "--no-enable-attention-dp",
         "--moe-backend=TRTLLM",
     ],
@@ -26,12 +31,14 @@ def test_deepseek_r1_ctx_tep(llm_root):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 4,
                     reason="needs 4 GPUs to run this test")
-def test_deepseek_v32_ctx_dep(llm_root):
+@pytest.mark.parametrize("deepseek_v3_model_root", ["DeepSeek-V3.2-Exp"],
+                         indirect=True)
+def test_deepseek_v32_ctx_dep(llm_root, deepseek_v3_model_root):
     check_call([
         "./mpi_launch.sh",
         "./run_single.sh",
         "config_ctx.yaml",
-        "--model=deepseek-ai/DeepSeek-V3.2-Exp",
+        "--model=" + deepseek_v3_model_root,
         "--tokens-per-block=64",
         "--moe-backend=DEEPGEMM",
     ],
@@ -44,14 +51,17 @@ def test_deepseek_v32_ctx_dep(llm_root):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 4,
                     reason="needs 4 GPUs to run this test")
-def test_deepseek_r1_gen_scaled_from_16_dep(llm_root):
+@pytest.mark.parametrize("deepseek_r1_model_root", ["DeepSeek-R1-0528-FP4-v2"],
+                         indirect=True)
+def test_deepseek_r1_gen_scaled_from_16_dep(llm_root, deepseek_r1_model_root):
     check_call([
         "./mpi_launch.sh",
         "./run_single.sh",
         "config_gen.yaml",
+        "--model=" + deepseek_r1_model_root,
+        "--layer-indices=5,6",
         "--scaled-from=16",
         "--moe-backend=WIDEEP",
-        "--layer-indices=5,6",
     ],
                cwd=llm_root / "examples" / "layer_wise_benchmarks",
                env={

--- a/tests/unittest/tools/test_layer_wise_benchmarks.py
+++ b/tests/unittest/tools/test_layer_wise_benchmarks.py
@@ -1,17 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 import os
 
 import pytest


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use local DeepSeek-V3.2-Exp and DeepSeek-R1-0528-FP4-v2 models in layer-wise benchmarking tests.

* **Bug Fixes**
  * Improved error handling in initialization scripts by enforcing early exit for unsupported hardware architectures.

* **Documentation**
  * Updated benchmark documentation comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
