### PR TITLE
[None][fixes] Add tool call parsing fixes and Qwen3 coder parser

### DIFF
--- a/tensorrt_llm/serve/chat_utils.py
+++ b/tensorrt_llm/serve/chat_utils.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from functools import partial
 from typing import (Any, Callable, Coroutine, Dict, Iterable, List, Literal,
@@ -185,6 +186,36 @@ def parse_chat_message_content(
         content,
         mm_data_tracker,
     )
+    if role == "assistant":
+        result.update(_parse_assistant_message_content(message))
+    elif role == "tool":
+        result.update(_parse_tool_message_content(message))
+    return result
+
+
+# Adapted from: https://github.com/vllm-project/vllm/blob/4574d48bab9c4e38b7c0a830eeefc8f0980e8c58/vllm/entrypoints/chat_utils.py#L1406
+def _parse_assistant_message_content(message: Dict[str, Any]) -> Dict[str, Any]:
+    result = {}
+    tool_calls = message.get("tool_calls")
+    if tool_calls is not None:
+        result["tool_calls"] = []
+        for item in tool_calls:
+            if content := item["function"].get("arguments"):
+                if isinstance(content, str):
+                    item["function"]["arguments"] = json.loads(content)
+                else:
+                    item["function"]["arguments"] = content
+            else:
+                item["function"]["arguments"] = {}
+            result["tool_calls"].append(item)
+
+    return result
+
+
+def _parse_tool_message_content(message: Dict[str, Any]) -> Dict[str, Any]:
+    result = {}
+    if "tool_call_id" in message:
+        result["tool_call_id"] = message["tool_call_id"]
     return result
 
 

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -396,6 +396,12 @@ ChatCompletionContentPartParam = Union[OpenAIChatCompletionContentPartParam,
 
 class CustomChatCompletionMessageParam(TypedDict, total=False):
     """Enables custom roles in the Chat Completion API."""
+
+    # This is so custom fields not in any of the `ChatCompletionMessage<XYZ>Param` defined by OpenAI
+    # are still allowed.
+    # Examples include: assistant messages with `reasoning` / `reasoning_content`.
+    __pydantic_config__ = ConfigDict(extra="allow")  # type: ignore
+
     role: Required[str]
     """The role of the message's author."""
 

--- a/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
@@ -1,0 +1,344 @@
+# Adapted from: https://raw.githubusercontent.com/sgl-project/sglang/d8fcbaa38da95201914a1277971044ee66837b26/python/sglang/srt/function_call/qwen3_coder_detector.py
+
+import ast
+import html
+import json
+import re
+from typing import Any, Dict, List, Tuple
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.serve.openai_protocol import ChatCompletionToolsParam as Tool
+from tensorrt_llm.serve.tool_parser.base_tool_parser import BaseToolParser
+from tensorrt_llm.serve.tool_parser.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+
+
+def _safe_val(raw: str) -> Any:
+    raw = html.unescape(raw.strip())
+    try:
+        return json.loads(raw)
+    except Exception:
+        try:
+            return ast.literal_eval(raw)
+        except Exception:
+            return raw
+
+
+class Qwen3CoderToolParser(BaseToolParser):
+    """Tool parser for Qwen 3 models.
+
+    Assumes function call format:
+        <tool_call>
+        <function=execute_bash>
+        <parameter=command>
+        pwd && ls
+        </parameter>
+        </function>
+        </tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.tool_call_start_token: str = "<tool_call>"
+        self.tool_call_end_token: str = "</tool_call>"
+        self.tool_call_prefix: str = "<function="
+        self.tool_call_regex = re.compile(
+            r"<tool_call>(.*?)</tool_call>|<tool_call>(.*?)$", re.DOTALL
+        )
+        self.tool_call_function_regex = re.compile(
+            r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
+        )
+        self.tool_call_parameter_regex = re.compile(
+            r"<parameter=(.*?)</parameter>|<parameter=(.*?)$", re.DOTALL
+        )
+        self._buf: str = ""
+
+        # Streaming state variables
+        self._current_function_name: str = ""
+        self._current_parameters: Dict[str, Any] = {}
+        self._streamed_parameters: Dict[
+            str, str
+        ] = {}  # Track what parameter content we've streamed
+        self._in_tool_call: bool = False
+        self._function_name_sent: bool = False
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.tool_call_start_token in text
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        normal, calls = self._extract(text, tools)
+        return StreamingParseResult(normal_text=normal, calls=calls)
+
+    def parse_streaming_increment(self, new_text: str, tools: List[Tool]) -> StreamingParseResult:
+        self._buf += new_text
+        normal = ""
+        calls: List[ToolCallItem] = []
+
+        # Build tool indices for validation
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
+        while True:
+            # If we're not in a tool call and don't see a start token, return normal text
+            if not self._in_tool_call and self.tool_call_start_token not in self._buf:
+                normal += self._buf
+                self._buf = ""
+                break
+
+            # Look for tool call start
+            if not self._in_tool_call:
+                s = self._buf.find(self.tool_call_start_token)
+                if s == -1:
+                    normal += self._buf
+                    self._buf = ""
+                    break
+
+                normal += self._buf[:s]
+                self._buf = self._buf[s:]
+
+                self._in_tool_call = True
+                self._function_name_sent = False
+                self._current_function_name = ""
+                self._current_parameters = {}
+                self._streamed_parameters = {}
+
+                # Remove the start token
+                self._buf = self._buf[len(self.tool_call_start_token) :]
+                continue
+
+            # We're in a tool call, try to parse function name if not sent yet
+            if not self._function_name_sent:
+                # Look for function name pattern: <function=name>
+                function_match = re.search(r"<function=([^>]+)>", self._buf)
+                if function_match:
+                    function_name = function_match.group(1).strip()
+
+                    # Validate function name
+                    if function_name in self._tool_indices:
+                        self._current_function_name = function_name
+                        self._function_name_sent = True
+
+                        # Initialize tool call tracking
+                        if self.current_tool_id == -1:
+                            self.current_tool_id = 0
+
+                        # Ensure tracking arrays are large enough
+                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                            self.prev_tool_call_arr.append({})
+                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                            self.streamed_args_for_tool.append("")
+
+                        # Store tool call info
+                        self.prev_tool_call_arr[self.current_tool_id] = {
+                            "name": function_name,
+                            "arguments": {},
+                        }
+
+                        # Send tool name with empty parameters
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=function_name,
+                                parameters="",
+                            )
+                        )
+
+                        # Remove the processed function declaration
+                        self._buf = self._buf[function_match.end() :]
+                        continue
+                    else:
+                        # Invalid function name, reset state
+                        logger.warning(f"Invalid function name: {function_name}")
+                        self._reset_streaming_state()
+                        normal += self._buf
+                        self._buf = ""
+                        break
+                else:
+                    # Function name not complete yet, wait for more text
+                    break
+
+            # Parse parameters incrementally
+            if self._function_name_sent:
+                # Process parameters and get any calls to emit
+                parameter_calls = self._parse_and_stream_parameters(self._buf)
+                calls.extend(parameter_calls)
+
+                # Check if tool call is complete
+                if self.tool_call_end_token in self._buf:
+                    end_pos = self._buf.find(self.tool_call_end_token)
+
+                    # Add closing brace to complete the JSON object
+                    current_streamed = self.streamed_args_for_tool[self.current_tool_id]
+                    if current_streamed:
+                        # Count opening and closing braces to check if JSON is complete
+                        open_braces = current_streamed.count("{")
+                        close_braces = current_streamed.count("}")
+                        if open_braces > close_braces:
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters="}",
+                                )
+                            )
+                            self.streamed_args_for_tool[self.current_tool_id] = (
+                                current_streamed + "}"
+                            )
+
+                    # Complete the tool call
+                    self._buf = self._buf[end_pos + len(self.tool_call_end_token) :]
+                    self._reset_streaming_state()
+                    self.current_tool_id += 1
+                    continue
+                else:
+                    # Tool call not complete yet, wait for more text
+                    break
+
+        return StreamingParseResult(normal_text=normal, calls=calls)
+
+    def _parse_and_stream_parameters(self, text_to_parse: str) -> List[ToolCallItem]:
+        """Parse complete parameter blocks from text and return any tool call items to emit.
+
+        This method:
+        1. Finds all complete <parameter> blocks
+        2. Parses them into a dictionary
+        3. Compares with current parameters and generates diff if needed
+        4. Updates internal state
+
+        Args:
+            text_to_parse: The text to search for parameter blocks
+
+        Returns:
+            List of ToolCallItem objects to emit (may be empty)
+        """
+        calls: List[ToolCallItem] = []
+
+        # Find all complete parameter patterns
+        param_matches = list(
+            re.finditer(r"<parameter=([^>]+)>(.*?)</parameter>", text_to_parse, re.DOTALL)
+        )
+
+        # Build new parameters dictionary
+        new_params = {}
+        for match in param_matches:
+            param_name = match.group(1).strip()
+            param_value = match.group(2)
+            new_params[param_name] = _safe_val(param_value)
+
+        # Calculate parameter diff to stream with proper incremental JSON building
+        if new_params != self._current_parameters:
+            previous_args_json = self.streamed_args_for_tool[self.current_tool_id]
+
+            # Build incremental JSON properly
+            if not self._current_parameters:
+                # First parameter(s) - start JSON object but don't close it yet
+                items = []
+                for key, value in new_params.items():
+                    items.append(
+                        f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
+                    )
+                json_fragment = "{" + ", ".join(items)
+
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None,
+                        parameters=json_fragment,
+                    )
+                )
+                self.streamed_args_for_tool[self.current_tool_id] = json_fragment
+
+            else:
+                # Additional parameters - add them incrementally
+                new_keys = set(new_params.keys()) - set(self._current_parameters.keys())
+                if new_keys:
+                    # Build the continuation part (no closing brace yet)
+                    continuation_parts = []
+                    for key in new_keys:
+                        value = new_params[key]
+                        continuation_parts.append(
+                            f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
+                        )
+
+                    json_fragment = ", " + ", ".join(continuation_parts)
+
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=json_fragment,
+                        )
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] = (
+                        previous_args_json + json_fragment
+                    )
+
+            # Update current state
+            self._current_parameters = new_params
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = new_params
+
+        return calls
+
+    def _reset_streaming_state(self):
+        """Reset streaming state for the next tool call."""
+        self._in_tool_call = False
+        self._function_name_sent = False
+        self._current_function_name = ""
+        self._current_parameters = {}
+        self._streamed_parameters = {}
+        self.current_tool_name_sent = False
+
+    def _extract(self, text: str, tools: List[Tool]) -> Tuple[str, List[ToolCallItem]]:
+        normal_parts: List[str] = []
+        calls: List[ToolCallItem] = []
+        cursor = 0
+        while True:
+            s = text.find(self.tool_call_start_token, cursor)
+            if s == -1:
+                normal_parts.append(text[cursor:])
+                break
+            normal_parts.append(text[cursor:s])
+            e = text.find(self.tool_call_end_token, s)
+            if e == -1:
+                normal_parts.append(text[s:])
+                break
+            block = text[s : e + len(self.tool_call_end_token)]
+            cursor = e + len(self.tool_call_end_token)
+            calls.extend(self._parse_block(block, tools))
+        return "".join(normal_parts), calls
+
+    def _parse_block(self, block: str, tools: List[Tool]) -> List[ToolCallItem]:
+        res: List[ToolCallItem] = []
+        for m in self.tool_call_function_regex.findall(block):
+            txt = m[0] if m[0] else m[1]
+            if ">" not in txt:
+                continue
+            idx = txt.index(">")
+            fname = txt[:idx].strip()
+            body = txt[idx + 1 :]
+            params: Dict[str, Any] = {}
+            for pm in self.tool_call_parameter_regex.findall(body):
+                ptxt = pm[0] if pm[0] else pm[1]
+                if ">" not in ptxt:
+                    continue
+                pidx = ptxt.index(">")
+                pname = ptxt[:pidx].strip()
+                pval = ptxt[pidx + 1 :].lstrip("\n").rstrip("\n")
+                params[pname] = _safe_val(pval)
+            raw = {"name": fname, "arguments": params}
+            try:
+                # TODO: fix idx in function call, the index for a function
+                # call will always be -1 in parse_base_json
+                res.extend(self.parse_base_json(raw, tools))
+            except Exception:
+                logger.warning("invalid tool call for %s dropped", fname)
+        return res
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError

--- a/tensorrt_llm/serve/tool_parser/tool_parser_factory.py
+++ b/tensorrt_llm/serve/tool_parser/tool_parser_factory.py
@@ -1,12 +1,14 @@
 from typing import Type
 
 from .base_tool_parser import BaseToolParser
+from .qwen3_coder_parser import Qwen3CoderToolParser
 from .qwen3_tool_parser import Qwen3ToolParser
 
 
 class ToolParserFactory:
     parsers: dict[str, Type[BaseToolParser]] = {
         "qwen3": Qwen3ToolParser,
+        "qwen3_coder": Qwen3CoderToolParser,
     }
 
     @staticmethod

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -73,6 +73,7 @@ l0_a10:
   # executor
   - unittest/executor/test_rpc.py
   # trtllm-serve CPU-only
+  - unittest/llmapi/apps/test_chat_utils.py
   - unittest/llmapi/apps/test_tool_parsers.py
   - unittest/llmapi/apps/test_harmony_channel_validation.py
 - condition:

--- a/tests/unittest/llmapi/apps/test_chat_utils.py
+++ b/tests/unittest/llmapi/apps/test_chat_utils.py
@@ -1,0 +1,179 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm.serve.chat_utils import parse_chat_message_content
+
+
+@pytest.fixture
+def mock_mm_data_tracker():
+    """Create a mock MultimodalDataTracker for testing."""
+    return MagicMock()
+
+
+class TestParseAssistantMessages:
+    """Test suite for assistant role messages."""
+
+    @pytest.mark.parametrize("content", [None, "Hello, how can I help you?"])
+    def test_assistant_message_no_tool_calls(
+        self,
+        mock_mm_data_tracker,
+        content,
+    ):
+        """Test parsing an assistant message with simple string content."""
+        message = {"role": "assistant", "content": content}
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        assert result["role"] == "assistant"
+        assert result["content"] == (content or "")
+        assert result["media"] == []
+        assert "tool_calls" not in result
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            # JSON string.
+            '{"location": "San Francisco", "unit": "celsius"}',
+            # Python dict.
+            {"location": "San Francisco", "unit": "celsius"},
+        ],
+    )
+    def test_assistant_message_with_tool_calls_string_arguments(
+        self, mock_mm_data_tracker, arguments
+    ):
+        """Test parsing an assistant message with tool calls where arguments are JSON strings."""
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        }
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        assert result == {
+            "role": "assistant",
+            "content": "",
+            "media": [],
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"location": "San Francisco", "unit": "celsius"},
+                    },
+                }
+            ],
+        }
+
+    def test_assistant_message_with_empty_tool_arguments(self, mock_mm_data_tracker):
+        """Test parsing an assistant message with tool calls that have no arguments."""
+        message = {
+            "role": "assistant",
+            "content": "Foobar",
+            "tool_calls": [
+                {
+                    "id": "call_789",
+                    "type": "function",
+                    "function": {"name": "get_current_time", "arguments": None},
+                }
+            ],
+        }
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        expected = {
+            "role": "assistant",
+            "content": "Foobar",
+            "media": [],
+            "tool_calls": [
+                {
+                    "id": "call_789",
+                    "type": "function",
+                    "function": {"name": "get_current_time", "arguments": {}},
+                }
+            ],
+        }
+        assert result == expected
+
+    def test_assistant_message_with_multiple_tool_calls(self, mock_mm_data_tracker):
+        """Test parsing an assistant message with multiple tool calls."""
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"location": "New York"}'},
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "get_time", "arguments": {"timezone": "EST"}},
+                },
+                {"id": "call_3", "type": "function", "function": {"name": "no_args_function"}},
+            ],
+        }
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        expected = {
+            "role": "assistant",
+            "content": "",
+            "media": [],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": {"location": "New York"}},
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "get_time", "arguments": {"timezone": "EST"}},
+                },
+                {
+                    "id": "call_3",
+                    "type": "function",
+                    "function": {"name": "no_args_function", "arguments": {}},
+                },
+            ],
+        }
+        assert result == expected
+
+
+class TestParseToolMessages:
+    """Test suite for tool role messages."""
+
+    @pytest.mark.parametrize("content", ["The weather in San Francisco is 72°F and sunny.", None])
+    def test_tool_message_with_tool_call_id(self, mock_mm_data_tracker, content):
+        """Test parsing a tool message with tool_call_id."""
+        message = {"role": "tool", "content": (content or ""), "tool_call_id": "call_123"}
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        expected = {**message, "media": []}
+        assert result == expected
+
+    def test_tool_message_without_tool_call_id(self, mock_mm_data_tracker):
+        """Test parsing a tool message without tool_call_id."""
+        message = {
+            "role": "tool",
+            "content": "Database query completed successfully.",
+        }
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        expected = {**message, "media": []}
+        assert result == expected

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import json
+from typing import NamedTuple
 
 import pytest
 
@@ -21,6 +23,8 @@ from tensorrt_llm.serve.openai_protocol import (ChatCompletionToolsParam,
                                                 FunctionDefinition)
 from tensorrt_llm.serve.tool_parser.base_tool_parser import BaseToolParser
 from tensorrt_llm.serve.tool_parser.core_types import StructureInfo
+from tensorrt_llm.serve.tool_parser.qwen3_coder_parser import \
+    Qwen3CoderToolParser
 from tensorrt_llm.serve.tool_parser.qwen3_tool_parser import Qwen3ToolParser
 
 
@@ -66,7 +70,7 @@ def sample_tools():
                                                 }
                                             },
                                             "required": ["query"]
-                                        }))
+                                        })),
     ]
 
 
@@ -115,7 +119,7 @@ class TestBaseToolParser:
         parser = ConcreteToolParser()
         indices = parser._get_tool_indices(sample_tools)
 
-        assert len(indices) == 2
+        assert len(indices) == len(sample_tools)
         assert indices["get_weather"] == 0
         assert indices["search_web"] == 1
 
@@ -320,113 +324,215 @@ class TestBaseToolParser:
 # ============================================================================
 
 
-class TestQwen3ToolParser:
+class ToolParserTestCases(NamedTuple):
+    has_tool_call_true: str
+    detect_and_parse_single_tool: tuple[
+        # Input text.
+        str,
+        # Expected `normal_text`.
+        str,
+        # Expected `name`.
+        str,
+        # Expected `parameters`.
+        dict,
+    ]
+    detect_and_parse_multiple_tools: tuple[
+        # Input text.
+        str,
+        # Expected names.
+        tuple[str],
+    ]
+    detect_and_parse_malformed_tool: str
+    detect_and_parse_with_parameters_key: tuple[
+        # Input text.
+        str,
+        # Expected `name`.
+        str,
+        # Expected `parameters`.
+        dict,
+    ]
+    parse_streaming_increment_partial_bot_token: str
+    undefined_tool: str
+
+
+class BaseToolParserTestClass:
+    """Base class from which tests for actual implementations can be extended.
+
+    NOTE: the name deliberately ends with `Class` so that `pytest` does not pick it up for execution
+    automatically.
+    """
+
+    @abc.abstractmethod
+    def make_parser(self):
+        ...
+
+    @property
+    def make_tool_parser_test_cases(self) -> ToolParserTestCases:
+        ...
+
+    @pytest.fixture
+    def parser(self):
+        return self.make_parser()
+
+    @pytest.fixture(scope="class")
+    def tool_parser_test_cases(self) -> ToolParserTestCases:
+        return self.make_tool_parser_test_cases()
+
+    def test_has_tool_call_false(self, parser):
+        """Test has_tool_call returns False when no tool call present."""
+        text = "Just some regular text without tool calls"
+
+        assert parser.has_tool_call(text) is False
+
+    def test_has_tool_call_true(self, parser, tool_parser_test_cases):
+        """Test has_tool_call returns True when tool call is present."""
+        text = tool_parser_test_cases.has_tool_call_true
+
+        assert parser.has_tool_call(text) is True
+
+    def test_detect_and_parse_no_tool_call(self, sample_tools, parser):
+        """Test detect_and_parse with text containing no tool calls."""
+        text = "This is just a regular response."
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == text
+        assert len(result.calls) == 0
+
+    def test_detect_and_parse_single_tool(self, sample_tools, parser,
+                                          tool_parser_test_cases):
+        """Test detect_and_parse with a single tool call."""
+        text, normal_text, name, parameters = tool_parser_test_cases.detect_and_parse_single_tool
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == normal_text
+        assert len(result.calls) == 1
+        assert result.calls[0].name == name
+        assert json.loads(result.calls[0].parameters) == parameters
+
+    def test_detect_and_parse_multiple_tools(self, sample_tools, parser,
+                                             tool_parser_test_cases):
+        """Test detect_and_parse with multiple tool calls."""
+        text, call_names = tool_parser_test_cases.detect_and_parse_multiple_tools
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert tuple(call.name for call in result.calls) == call_names
+
+    def test_detect_and_parse_malformed_tool(self, sample_tools, parser,
+                                             tool_parser_test_cases):
+        """Test detect_and_parse handles malformed tool call output from the model gracefully."""
+        text = tool_parser_test_cases.detect_and_parse_malformed_tool
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 0
+
+    def test_detect_and_parse_with_parameters_key(self, sample_tools, parser,
+                                                  tool_parser_test_cases):
+        """Test detect_and_parse handles 'parameters' key."""
+        text, name, parameters = tool_parser_test_cases.detect_and_parse_with_parameters_key
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == name
+        assert json.loads(result.calls[0].parameters) == parameters
+
+    def test_parse_streaming_increment_normal_text(self, sample_tools, parser):
+        """Test streaming parser handles normal text without tool calls."""
+        text = "Hello, how can I help?"
+
+        result = parser.parse_streaming_increment(text, sample_tools)
+
+        assert result.normal_text == text
+        assert len(result.calls) == 0
+
+    def test_parse_streaming_increment_partial_bot_token(
+            self, sample_tools, parser, tool_parser_test_cases):
+        """Test streaming parser buffers partial bot token."""
+        text = tool_parser_test_cases.parse_streaming_increment_partial_bot_token
+
+        result = parser.parse_streaming_increment(text, sample_tools)
+
+        assert result.normal_text == ""
+        assert len(result.calls) == 0
+
+    def test_undefined_tool(self, sample_tools, parser, tool_parser_test_cases):
+        """Test the parser handles undefined tool gracefully."""
+        text = tool_parser_test_cases.undefined_tool
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        # Should not return any calls for undefined function
+        assert len(result.calls) == 0
+
+
+class TestQwen3ToolParser(BaseToolParserTestClass):
     """Test suite for Qwen3ToolParser class."""
 
-    def test_initialization(self):
-        """Test that Qwen3ToolParser initializes correctly."""
-        parser = Qwen3ToolParser()
+    def make_parser(self):
+        return Qwen3ToolParser()
 
+    def make_tool_parser_test_cases(self):
+        return ToolParserTestCases(
+            has_tool_call_true=
+            'Some text <tool_call>\n{"name":"get_weather"}\n</tool_call>',
+            detect_and_parse_single_tool=(
+                # Input text.
+                ('Normal text\n'
+                 '<tool_call>\n'
+                 '{"name":"get_weather","arguments":{"location":"NYC"}}\n'
+                 '</tool_call>'),
+                # Expected `normal_text`.
+                "Normal text",
+                # Expected `name`.
+                "get_weather",
+                # Expected `parameters`.
+                {
+                    "location": "NYC"
+                },
+            ),
+            detect_and_parse_multiple_tools=(
+                # Input text.
+                ('<tool_call>\n{"name":"get_weather","arguments":{"location":"LA"}}\n</tool_call>\n'
+                 '<tool_call>\n{"name":"search_web","arguments":{"query":"AI"}}\n</tool_call>'
+                 ),
+                # Expected names.
+                ("get_weather", "search_web"),
+            ),
+            detect_and_parse_malformed_tool=
+            ('<tool_call>\n{"name":"get_weather","arguments":MALFORMED}\n</tool_call>'
+             ),
+            detect_and_parse_with_parameters_key=(
+                # Input text.
+                ('<tool_call>\n{"name":"search_web","parameters":{"query":"test"}}\n</tool_call>'
+                 ),
+                # Expected `name`.
+                "search_web",
+                # Expected `parameters`.
+                {
+                    "query": "test"
+                },
+            ),
+            parse_streaming_increment_partial_bot_token="<tool",
+            undefined_tool=
+            '<tool_call>\n{"name":"undefined_func","arguments":{}}\n</tool_call>',
+        )
+
+    def test_initialization(self, parser):
+        """Test that Qwen3ToolParser initializes correctly."""
         assert parser.bot_token == "<tool_call>\n"
         assert parser.eot_token == "\n</tool_call>"
         assert parser.tool_call_separator == "\n"
         assert parser._normal_text_buffer == ""
 
-    def test_has_tool_call_true(self):
-        """Test has_tool_call returns True when tool call is present."""
-        parser = Qwen3ToolParser()
-        text = 'Some text <tool_call>\n{"name":"get_weather"}\n</tool_call>'
-
-        assert parser.has_tool_call(text) is True
-
-    def test_has_tool_call_false(self):
-        """Test has_tool_call returns False when no tool call present."""
-        parser = Qwen3ToolParser()
-        text = "Just some regular text without tool calls"
-
-        assert parser.has_tool_call(text) is False
-
-    def test_detect_and_parse_no_tool_call(self, sample_tools):
-        """Test detect_and_parse with text containing no tool calls."""
-        parser = Qwen3ToolParser()
-        text = "This is just a regular response."
-
-        result = parser.detect_and_parse(text, sample_tools)
-
-        assert result.normal_text == "This is just a regular response."
-        assert len(result.calls) == 0
-
-    def test_detect_and_parse_single_tool(self, sample_tools):
-        """Test detect_and_parse with a single tool call."""
-        parser = Qwen3ToolParser()
-        text = 'Normal text\n<tool_call>\n{"name":"get_weather","arguments":{"location":"NYC"}}\n</tool_call>'
-
-        result = parser.detect_and_parse(text, sample_tools)
-
-        assert result.normal_text == "Normal text"
-        assert len(result.calls) == 1
-        assert result.calls[0].name == "get_weather"
-        assert json.loads(result.calls[0].parameters) == {"location": "NYC"}
-
-    def test_detect_and_parse_multiple_tools(self, sample_tools):
-        """Test detect_and_parse with multiple tool calls."""
-        parser = Qwen3ToolParser()
-        text = (
-            '<tool_call>\n{"name":"get_weather","arguments":{"location":"LA"}}\n</tool_call>\n'
-            '<tool_call>\n{"name":"search_web","arguments":{"query":"AI"}}\n</tool_call>'
-        )
-
-        result = parser.detect_and_parse(text, sample_tools)
-
-        assert len(result.calls) == 2
-        assert result.calls[0].name == "get_weather"
-        assert result.calls[1].name == "search_web"
-
-    def test_detect_and_parse_malformed_json(self, sample_tools):
-        """Test detect_and_parse handles malformed JSON gracefully."""
-        parser = Qwen3ToolParser()
-        text = '<tool_call>\n{"name":"get_weather","arguments":MALFORMED}\n</tool_call>'
-
-        result = parser.detect_and_parse(text, sample_tools)
-
-        # Should return empty calls due to JSON parsing error
-        assert len(result.calls) == 0
-
-    def test_detect_and_parse_with_parameters_key(self, sample_tools):
-        """Test detect_and_parse handles 'parameters' key."""
-        parser = Qwen3ToolParser()
-        text = '<tool_call>\n{"name":"search_web","parameters":{"query":"test"}}\n</tool_call>'
-
-        result = parser.detect_and_parse(text, sample_tools)
-
-        assert len(result.calls) == 1
-        assert result.calls[0].name == "search_web"
-        assert json.loads(result.calls[0].parameters) == {"query": "test"}
-
-    def test_parse_streaming_increment_normal_text(self, sample_tools):
-        """Test streaming parser handles normal text without tool calls."""
-        parser = Qwen3ToolParser()
-
-        result = parser.parse_streaming_increment("Hello, how can I help?",
-                                                  sample_tools)
-
-        assert result.normal_text == "Hello, how can I help?"
-        assert len(result.calls) == 0
-
-    def test_parse_streaming_increment_partial_bot_token(self, sample_tools):
-        """Test streaming parser buffers partial bot token."""
-        parser = Qwen3ToolParser()
-
-        # Send partial bot token
-        result = parser.parse_streaming_increment("<tool", sample_tools)
-
-        # Should buffer
-        assert result.normal_text == ""
-        assert len(result.calls) == 0
-
-    def test_parse_streaming_increment_complete_tool_call(self, sample_tools):
+    # NOTE: this is not put in the base class. Even though it could be made generic, the added logic
+    # to do so loses the clarity of this more direct approach.
+    def test_parse_streaming_increment_complete_tool_call(
+            self, sample_tools, parser):
         """Test streaming parser with complete tool call in chunks."""
-        parser = Qwen3ToolParser()
 
         # Send bot token
         parser.parse_streaming_increment("<tool_call>\n", sample_tools)
@@ -448,9 +554,9 @@ class TestQwen3ToolParser:
         assert len(result.calls) == 1
         assert json.loads(result.calls[0].parameters) == {"location": "SF"}
 
-    def test_parse_streaming_increment_end_token_handling(self, sample_tools):
+    def test_parse_streaming_increment_end_token_handling(
+            self, sample_tools, parser):
         """Test streaming parser handles end token correctly."""
-        parser = Qwen3ToolParser()
 
         # Send complete tool call
         parser.parse_streaming_increment(
@@ -462,9 +568,8 @@ class TestQwen3ToolParser:
         assert parser._normal_text_buffer == ""
 
     def test_parse_streaming_increment_multiple_tools_streaming(
-            self, sample_tools):
+            self, sample_tools, parser):
         """Test streaming parser handles multiple tool calls."""
-        parser = Qwen3ToolParser()
 
         # First tool
         parser.parse_streaming_increment('<tool_call>\n', sample_tools)
@@ -506,9 +611,8 @@ class TestQwen3ToolParser:
         assert "search_web" in info2.begin
         assert info1.end == info2.end == "}\n</tool_call>"
 
-    def test_qwen3_format_compliance(self, sample_tools):
+    def test_qwen3_format_compliance(self, sample_tools, parser):
         """Test that Qwen3ToolParser follows the documented format structure."""
-        parser = Qwen3ToolParser()
 
         # Test the exact format from the docstring
         text = '<tool_call>\n{"name":"get_weather", "arguments":{"location":"Tokyo"}}\n</tool_call>'
@@ -519,15 +623,238 @@ class TestQwen3ToolParser:
         assert result.calls[0].name == "get_weather"
         assert json.loads(result.calls[0].parameters) == {"location": "Tokyo"}
 
-    def test_undefined_tool_in_qwen3_format(self, sample_tools):
-        """Test Qwen3ToolParser handles undefined tool gracefully."""
-        parser = Qwen3ToolParser()
-        text = '<tool_call>\n{"name":"undefined_func","arguments":{}}\n</tool_call>'
 
-        result = parser.detect_and_parse(text, sample_tools)
+class TestQwen3CoderToolParser(BaseToolParserTestClass):
+    """Test suite for Qwen3CoderToolParser class."""
 
-        # Should not return any calls for undefined function
+    def make_parser(self):
+        return Qwen3CoderToolParser()
+
+    def make_tool_parser_test_cases(self):
+        return ToolParserTestCases(
+            has_tool_call_true=("Some text <tool_call>\n"
+                                "<function=get_weather>\n"
+                                "<parameter=location>NYC</parameter>\n"
+                                "</function>\n"
+                                "</tool_call>"),
+            detect_and_parse_single_tool=(
+                # Input text.
+                ("Normal text\n"
+                 "<tool_call>\n"
+                 "<function=get_weather>\n"
+                 "<parameter=location>NYC</parameter>\n"
+                 "</function>\n"
+                 "</tool_call>"),
+                # Expected `normal_text`.
+                "Normal text\n",
+                # Expected `name`.
+                "get_weather",
+                # Expected `parameters`.
+                {
+                    "location": "NYC"
+                },
+            ),
+            detect_and_parse_multiple_tools=(
+                # Input text.
+                ("<tool_call>\n"
+                 "<function=get_weather>\n"
+                 "<parameter=location>LA</parameter>\n"
+                 "</function>\n"
+                 "</tool_call>\n"
+                 "<tool_call>\n"
+                 "<function=search_web>\n"
+                 "<parameter=query>AI</parameter>\n"
+                 "</function>\n"
+                 "</tool_call>"),
+                # Expected names.
+                ("get_weather", "search_web"),
+            ),
+            detect_and_parse_malformed_tool=(
+                # Typo.
+                # NOTE: the regexes + logic in `Qwen3CoderToolParser` seems deliberately forgiving.
+                # For example, forgetting the closing `</function>` is fine, as is the closing
+                # `</parameter>`. However, the values returned in the function call information
+                # might be dubious as a result.
+                "<too_call>\n"
+                "<function=get_weather>\n"
+                "<parameter=location>San Francisco, CA</parameter>\n"
+                "</function>\n"
+                "</tool_call>"),
+            detect_and_parse_with_parameters_key=(
+                # Input text (Qwen3Coder uses "parameter", not "parameters").
+                ("<tool_call>\n"
+                 "<function=search_web>\n"
+                 "<parameter=query>test</parameter>\n"
+                 "</function>\n"
+                 "</tool_call>"),
+                # Expected `name`.
+                "search_web",
+                # Expected `parameters`.
+                {
+                    "query": "test"
+                },
+            ),
+            parse_streaming_increment_partial_bot_token="<tool_call>",
+            undefined_tool=("<tool_call>\n"
+                            "<function=undefined_func>\n"
+                            "<parameter=arg>value</parameter>\n"
+                            "</function>\n"
+                            "</tool_call>"),
+        )
+
+    def test_parse_streaming_increment_complete_tool_call(
+            self, sample_tools, parser):
+        """Test streaming parser with complete tool call in chunks."""
+
+        # Send tool call start token
+        result = parser.parse_streaming_increment("<tool_call>\n", sample_tools)
         assert len(result.calls) == 0
+
+        # Send function declaration
+        result = parser.parse_streaming_increment("<function=get_weather>\n",
+                                                  sample_tools)
+
+        # Should send tool name with empty parameters
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert result.calls[0].parameters == ""
+
+        # Send parameter block
+        result = parser.parse_streaming_increment(
+            '<parameter=location>SF</parameter>\n</function>\n</tool_call>',
+            sample_tools)
+
+        # Should stream parameters
+        assert len(result.calls) >= 1
+        # Check that parameters were sent (could be in multiple chunks)
+        all_params = "".join(call.parameters for call in result.calls
+                             if call.parameters)
+        assert "location" in all_params
+        assert "SF" in all_params
+
+    def test_parse_streaming_increment_end_token_handling(
+            self, sample_tools, parser):
+        """Test streaming parser handles end token correctly."""
+
+        # Send complete tool call
+        parser.parse_streaming_increment(
+            "<tool_call>\n"
+            "<function=get_weather>\n"
+            "<parameter=location>NYC</parameter>\n"
+            "</function>\n"
+            "</tool_call>", sample_tools)
+
+        # Check buffer state - should be cleared after complete tool call
+        assert parser._buf == ""
+        assert parser._in_tool_call is False
+
+    def test_parse_streaming_increment_multiple_tools_streaming(
+            self, sample_tools, parser):
+        """Test streaming parser handles multiple tool calls."""
+
+        # First tool.
+        parser.parse_streaming_increment("<tool_call>\n", sample_tools)
+        parser.parse_streaming_increment("<function=get_weather>\n",
+                                         sample_tools)
+        parser.parse_streaming_increment(
+            "<parameter=location>NYC</parameter>\n</function>\n</tool_call>\n",
+            sample_tools)
+
+        # Second tool.
+        parser.parse_streaming_increment("<tool_call>\n", sample_tools)
+        result = parser.parse_streaming_increment("<function=search_web>\n",
+                                                  sample_tools)
+
+        # Should have started second tool.
+        assert result.calls[0].name == "search_web"
+        assert result.calls[0].parameters == ""
+        assert result.calls[0].tool_index == 1
+
+    def test_parse_streaming_increment_multiple_parameters(
+            self, sample_tools, parser):
+        """Test parser handles multiple parameters in a single function call."""
+
+        tool_def = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="multi_param_func",
+                description="Function with multiple parameters",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "param1": {
+                            "type": "string"
+                        },
+                        "param2": {
+                            "type": "string"
+                        },
+                        "param3": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["param1", "param2", "param3"]
+                }))
+
+        text = ("<tool_call>\n"
+                "<function=multi_param_func>\n"
+                "<parameter=param1>value1</parameter>\n"
+                "<parameter=param2>value2</parameter>\n"
+                "<parameter=param3>42</parameter>\n"
+                "</function>\n"
+                "</tool_call>")
+
+        result = parser.detect_and_parse(text, [tool_def])
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "multi_param_func"
+        assert json.loads(result.calls[0].parameters) == {
+            "param1": "value1",
+            "param2": "value2",
+            "param3": 42
+        }
+
+    def test_qwen3_coder_format_compliance(
+        self,
+        parser,
+    ):
+        """Test that Qwen3CoderToolParser follows the documented format structure."""
+
+        # Test the exact format from the docstring
+        text = ("<tool_call>\n"
+                "<function=execute_bash>\n"
+                "<parameter=command>\n"
+                "pwd && ls\n"
+                "</parameter>\n"
+                "</function>\n"
+                "</tool_call>")
+
+        tool_def = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="execute_bash",
+                description="Execute a bash command.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The command to execute.",
+                        },
+                        "unit": {
+                            "type": "string",
+                        }
+                    },
+                    "required": ["command"],
+                },
+            ))
+
+        result = parser.detect_and_parse(text, [tool_def])
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "execute_bash"
+        assert json.loads(result.calls[0].parameters) == {
+            "command": "pwd && ls"
+        }
 
 
 # ============================================================================


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added support for Qwen 3 Coder model tool calling with streaming and incremental parameter processing
* Enabled custom message fields (e.g., reasoning_content) in chat completion messages

## Tests
* Added comprehensive test coverage for chat message parsing with multiple tool call scenarios
* Expanded test infrastructure for tool parsers across different model implementations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## [None][fixes] Add tool call parsing fixes and Qwen3 coder parser

This commit:
* fixes a couple of issues in messages not being included in the conversation when users send the result of a tool call back in a subsequent request
* forks the Qwen3 coder tool call parser from SGLang and adds it to TRTLLM

**TODO**:

- [x] Add unit tests

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
