### PR TITLE
[TRTLLM-8119][feat] Update doc/tests/chat_template for nano-v2-vlm

### DIFF
--- a/examples/models/core/nemotron/README_nano-v2-vl.md
+++ b/examples/models/core/nemotron/README_nano-v2-vl.md
@@ -1,0 +1,84 @@
+# Nemotron-nano-v2-VL
+
+## Model series
+ * https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+ * https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8
+ * https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD
+
+## Support Matrix
+  * BF16 / FP8 / FP4
+  * Tensor Parallel / Pipeline Parallel
+  * Inflight Batching
+  * PAGED_KV_CACHE
+  * checkpoint type: Huggingface (HF)
+  * Image / video multimodal input
+
+
+## Offline batch inference example CMDs
+ * Taking BF16 model as an example below, you can change to FP8 / FP4 ckpt.
+
+ * Image modality input:
+
+```bash
+python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code
+```
+
+ * Image modality input with chunked_prefill:
+
+```bash
+python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code --enable_chunked_prefill --max_num_tokens=256
+```
+
+ * Video modality input:
+
+```bash
+python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code --modality video --max_num_tokens 131072
+```
+
+ * Video modality input with Efficient video sampling (EVS):
+
+```bash
+TLLM_VIDEO_PRUNING_RATIO=0.9 python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code --modality video --max_num_tokens 131072
+```
+
+## Online serving example CMDs
+
+ * Taking BF16 model as an example below, you can change to FP8 / FP4 ckpt.
+
+```bash
+# Create extra config file.
+cat > ./extra-llm-api-config.yml << EOF
+kv_cache_config:
+  enable_block_reuse: false
+  mamba_ssm_cache_dtype: float32
+EOF
+
+# CMD to launch serve without EVS.
+trtllm-serve  \
+nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16\
+--host 0.0.0.0 \
+--port 8000 \
+--backend pytorch \
+--max_batch_size 16 \
+--max_num_tokens 131072 \
+--trust_remote_code \
+--media_io_kwargs "{\"video\": {\"fps\": 2, \"num_frames\": 128} }" \
+--extra_llm_api_options extra-llm-api-config.yml
+
+# CMD to launch serve with EVS (video_pruning_ratio=0.9).
+TLLM_VIDEO_PRUNING_RATIO=0.9 trtllm-serve  \
+nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16\
+--host 0.0.0.0 \
+--port 8000 \
+--backend pytorch \
+--max_batch_size 16 \
+--max_num_tokens 131072 \
+--trust_remote_code \
+--media_io_kwargs "{\"video\": {\"fps\": 2, \"num_frames\": 128} }" \
+--extra_llm_api_options extra-llm-api-config.yml
+```
+
+# Known issue:
+ * Don't set too large batch size, otherwise the Mamba cache might raise OOM error.
+ * Video modality cannot support chunked prefill yet.
+ * Prefix-caching is not supported for Nemotron-nano-v2-VL yet .

--- a/examples/models/core/nemotron/README_nemotron-3.md
+++ b/examples/models/core/nemotron/README_nemotron-3.md
@@ -1,4 +1,4 @@
-# Nemotron
+# Nemotron-3
 
 This document demonstrates how to build the Nemotron models using TensorRT LLM and run on a single GPU or multiple GPUs.
 

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -15,9 +15,9 @@ from .modeling_llama import LlamaForCausalLM
 from .modeling_llava_next import LlavaNextModel
 from .modeling_mistral import Mistral3VLM, MistralForCausalLM
 from .modeling_mixtral import MixtralForCausalLM
-from .modeling_nanov2vlm import NemotronH_Nano_VL_V2
 from .modeling_nemotron import NemotronForCausalLM
 from .modeling_nemotron_h import NemotronHForCausalLM
+from .modeling_nemotron_nano import NemotronH_Nano_VL_V2
 from .modeling_nemotron_nas import NemotronNASForCausalLM
 from .modeling_phi3 import Phi3ForCausalLM
 from .modeling_phi4mm import Phi4MMForCausalLM

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -11,19 +11,27 @@ from PIL import Image
 from tensorrt_llm._torch.models.checkpoints import NemotronHHfWeightMapper
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
-from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
-                       MultimodalPlaceholderPlacement, TextPrompt,
-                       compute_retained_tokens_count, compute_retention_mask,
-                       register_input_processor)
+from ...inputs import (
+    BaseMultimodalDummyInputsBuilder,
+    BaseMultimodalInputProcessor,
+    ExtraProcessedInputs,
+    MultimodalPlaceholderMetadata,
+    MultimodalPlaceholderPlacement,
+    TextPrompt,
+    compute_retained_tokens_count,
+    compute_retention_mask,
+    register_input_processor,
+)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..model_config import ModelConfig
 from .modeling_auto import AutoModelForCausalLM
-from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
-                                        get_multimodal_embeddings)
+from .modeling_multimodal_utils import (
+    find_input_mm_embeds,
+    fuse_input_embeds,
+    get_multimodal_embeddings,
+)
 from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
 
@@ -38,22 +46,20 @@ def _is_disagg() -> bool:
 
 
 class SquaredReLU(nn.Module):
-
     def forward(self, x):
         return torch.pow(torch.nn.functional.relu(x), 2)
 
 
 # Source codes are from NemotronH_Nano_VL_V2 modeling.py.
 class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
-
-    def __init__(self,
-                 model_config: ModelConfig[transformers.PretrainedConfig]):
+    def __init__(self, model_config: ModelConfig[transformers.PretrainedConfig]):
         config = model_config.pretrained_config
         super().__init__(config)
         self.image_size = config.force_image_size
         self.patch_size = config.patch_size
-        self.num_image_token = int((self.image_size // self.patch_size)**2 *
-                                   (config.downsample_ratio**2))
+        self.num_image_token = int(
+            (self.image_size // self.patch_size) ** 2 * (config.downsample_ratio**2)
+        )
         self.downsample_ratio = config.downsample_ratio
         self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.ps_version = config.ps_version  # Pixel shuffle version.
@@ -64,36 +70,43 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         self.vision_projection_hidden_size = config.projector_hidden_size
         self.llm_hidden_size = config.llm_config.hidden_size
         self.mlp1 = nn.Sequential(
-            nn.RMSNorm(self.vit_hidden_size * int(1 / self.downsample_ratio)**2,
-                       eps=config.llm_config.rms_norm_eps,
-                       dtype=config.torch_dtype),
-            nn.Linear(self.vit_hidden_size * int(1 / self.downsample_ratio)**2,
-                      self.vision_projection_hidden_size,
-                      bias=False,
-                      dtype=config.torch_dtype), SquaredReLU(),
-            nn.Linear(self.vision_projection_hidden_size,
-                      self.llm_hidden_size,
-                      bias=False,
-                      dtype=config.torch_dtype))
+            nn.RMSNorm(
+                self.vit_hidden_size * int(1 / self.downsample_ratio) ** 2,
+                eps=config.llm_config.rms_norm_eps,
+                dtype=config.torch_dtype,
+            ),
+            nn.Linear(
+                self.vit_hidden_size * int(1 / self.downsample_ratio) ** 2,
+                self.vision_projection_hidden_size,
+                bias=False,
+                dtype=config.torch_dtype,
+            ),
+            SquaredReLU(),
+            nn.Linear(
+                self.vision_projection_hidden_size,
+                self.llm_hidden_size,
+                bias=False,
+                dtype=config.torch_dtype,
+            ),
+        )
 
         # Construct the vision encoder.
         vision_model_config = copy.deepcopy(model_config)
         vision_model_config.pretrained_config = vision_model_config.pretrained_config.vision_config
-        self.vision_model = RADIOVisionModel(vision_model_config,
-                                             disable_quantization=True)
+        self.vision_model = RADIOVisionModel(vision_model_config, disable_quantization=True)
 
     def load_weights(self, weights):
         # Load mlp1 weights.
         mlp1_weights = {
-            k.replace('mlp1.', ''): v
-            for k, v in weights.items() if k.startswith('mlp1.')
+            k.replace("mlp1.", ""): v for k, v in weights.items() if k.startswith("mlp1.")
         }
         self.mlp1.load_state_dict(mlp1_weights, strict=True)
 
         # Load vision encoder weights.
         vision_encoder_weights = {
-            k.replace('vision_model.', ''): v
-            for k, v in weights.items() if k.startswith('vision_model.')
+            k.replace("vision_model.", ""): v
+            for k, v in weights.items()
+            if k.startswith("vision_model.")
         }
         self.vision_model.load_weights(vision_encoder_weights)
 
@@ -105,12 +118,14 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         # N, W, H * scale, C // scale --> N, H * scale, W, C // scale
         x = x.permute(0, 2, 1, 3).contiguous()
         # N, H * scale, W, C // scale --> N, H * scale, W * scale, C // (scale ** 2)
-        x = x.view(n, int(h * scale_factor), int(w * scale_factor),
-                   int(c / (scale_factor * scale_factor)))
-        if self.ps_version == 'v1':
+        x = x.view(
+            n, int(h * scale_factor), int(w * scale_factor), int(c / (scale_factor * scale_factor))
+        )
+        if self.ps_version == "v1":
             logger.warning(
                 "In ps_version 'v1', the height and width have not been swapped back, "
-                'which results in a transposed image.')
+                "which results in a transposed image."
+            )
         else:
             x = x.permute(0, 2, 1, 3).contiguous()
         return x
@@ -121,35 +136,34 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         n = pixel_values.shape[0]
         vit_embeds_lst = []
         for i in range(0, n, micro_batch_size):
-            micro_batch_pixel_values = pixel_values[i:i + micro_batch_size]
+            micro_batch_pixel_values = pixel_values[i : i + micro_batch_size]
             vit_embeds = self.vision_model(micro_batch_pixel_values)
             # Down-sampling and projection.
-            h = w = int(vit_embeds.shape[1]**0.5)
+            h = w = int(vit_embeds.shape[1] ** 0.5)
             vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
-            vit_embeds = self.pixel_shuffle(vit_embeds,
-                                            scale_factor=self.downsample_ratio)
-            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1,
-                                            vit_embeds.shape[-1])
+            vit_embeds = self.pixel_shuffle(vit_embeds, scale_factor=self.downsample_ratio)
+            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
             vit_embeds = self.mlp1(vit_embeds)
             vit_embeds_lst.append(vit_embeds)
         vit_embeds = torch.cat(vit_embeds_lst, dim=0)
         return vit_embeds
 
     def apply_evs_per_video(
-            self, mm_embed: torch.Tensor,
-            video_sizes: List[Tuple]) -> Tuple[torch.Tensor, List[int]]:
+        self, mm_embed: torch.Tensor, video_sizes: List[Tuple]
+    ) -> Tuple[torch.Tensor, List[int]]:
         """Apply EVS to the multimodal embedding for a single video."""
         start_idx, mm_embed_list, num_tokens_per_video = 0, [], []
         for video_size in video_sizes:
             # Fetch mm_embed correctly for the flattened temporal/patches dimension.
             t, p, ih, iw = video_size
-            partial_mm_embed = mm_embed[start_idx:start_idx + t * p]
+            partial_mm_embed = mm_embed[start_idx : start_idx + t * p]
             # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
 
             # Need to expose temporal dimension for EVS.
             _, wh, hidden_size = partial_mm_embed.shape
-            reshaped_partial_mm_embed = partial_mm_embed.reshape(
-                t, p, wh, hidden_size).reshape(t, p * wh, hidden_size)
+            reshaped_partial_mm_embed = partial_mm_embed.reshape(t, p, wh, hidden_size).reshape(
+                t, p * wh, hidden_size
+            )
             # -> [num_frames, num_patches_per_frame*h*w, hidden_size]
 
             original_retention_mask = compute_retention_mask(
@@ -161,8 +175,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             ).flatten(start_dim=1)
             # -> [num_frames, num_patches_per_frame*h*w]
             num_tokens_per_frame = original_retention_mask.sum(dim=1)
-            retention_mask = original_retention_mask.reshape(t, p, wh).reshape(
-                t * p, wh)
+            retention_mask = original_retention_mask.reshape(t, p, wh).reshape(t * p, wh)
             # -> [num_frames * num_patches_per_frame, h*w]
 
             # Skip by temporal/patch dimension.
@@ -176,8 +189,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         return mm_embed, num_tokens_in_video
 
     def apply_evs(
-        self, mm_embedding: List[torch.Tensor],
-        multimodal_data_lst: List[Dict[str, Any]]
+        self, mm_embedding: List[torch.Tensor], multimodal_data_lst: List[Dict[str, Any]]
     ) -> Tuple[List[torch.Tensor], Optional[List[List[int] | None]]]:
         """Apply EVS to the multimodal embedding."""
         # Skip EVS if pruning ratio is 0.
@@ -185,31 +197,29 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             return mm_embedding, None
 
         modality_types = [
-            multimodal_data['modality_type']
-            for multimodal_data in multimodal_data_lst
+            multimodal_data["modality_type"] for multimodal_data in multimodal_data_lst
         ]
         # Skip EVS if there is no video modality.
         if "video" not in modality_types:
             return mm_embedding, None
 
         video_size_list = [
-            multimodal_data[modality_type]["video_size"] for modality_type,
-            multimodal_data in zip(modality_types, multimodal_data_lst)
+            multimodal_data[modality_type]["video_size"]
+            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         mm_embedding_evs = []
         num_tokens_in_videos = []
         # Iterate over batch.
-        for modality_type, mm_embed, video_sizes in zip(modality_types,
-                                                        mm_embedding,
-                                                        video_size_list):
+        for modality_type, mm_embed, video_sizes in zip(
+            modality_types, mm_embedding, video_size_list
+        ):
             # Skip EVS if modality type is not video.
             if modality_type != "video":
                 mm_embedding_evs.append(mm_embed)
                 num_tokens_in_videos.append(None)
             else:
                 # Iterate over each video in the batch.
-                mm_embed, num_tokens_per_frames = self.apply_evs_per_video(
-                    mm_embed, video_sizes)
+                mm_embed, num_tokens_per_frames = self.apply_evs_per_video(mm_embed, video_sizes)
                 mm_embedding_evs.append(mm_embed)
                 num_tokens_in_videos.append(num_tokens_per_frames)
         return mm_embedding_evs, num_tokens_in_videos
@@ -219,83 +229,81 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
         mm_embedding = []
         multimodal_data_lst = [
-            multimodal_param.multimodal_data
-            for multimodal_param in multimodal_params
+            multimodal_param.multimodal_data for multimodal_param in multimodal_params
         ]
         modality_types = [
-            multimodal_data['modality_type']
-            for multimodal_data in multimodal_data_lst
+            multimodal_data["modality_type"] for multimodal_data in multimodal_data_lst
         ]
         # Batch data.
         pixel_values = [
-            multimodal_data[modality_type]["pixel_values"] for modality_type,
-            multimodal_data in zip(modality_types, multimodal_data_lst)
+            multimodal_data[modality_type]["pixel_values"]
+            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         batched_pixel_values = torch.cat(pixel_values, dim=0)
         # -> [num_patches, channel, height, width]
         patch_list = [
-            multimodal_data[modality_type]["num_patches"] for modality_type,
-            multimodal_data in zip(modality_types, multimodal_data_lst)
+            multimodal_data[modality_type]["num_patches"]
+            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         batched_num_patches = torch.cat(patch_list, dim=0).tolist()
         # -> list of[num_patches1, num_patches2, ...]
         batched_image_embeds = self.extract_feature(batched_pixel_values)
         # -> [num_patches, num_image_token, hidden_size]
-        mm_embedding = torch.split(batched_image_embeds,
-                                   batched_num_patches,
-                                   dim=0)
+        mm_embedding = torch.split(batched_image_embeds, batched_num_patches, dim=0)
 
-        mm_embedding, num_tokens_in_videos = self.apply_evs(
-            mm_embedding, multimodal_data_lst)
+        mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_lst)
 
-        mm_embedding = [
-            m.reshape(-1, self.llm_hidden_size) for m in mm_embedding
-        ]
+        mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
         # -> list of [num_patches*num_image_token, hidden_size]
         return mm_embedding, num_tokens_in_videos
 
 
-class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
-                             BaseMultimodalDummyInputsBuilder):
-
-    def __init__(self,
-                 model_path: str,
-                 config: transformers.PretrainedConfig,
-                 tokenizer: transformers.AutoTokenizer,
-                 trust_remote_code: bool = True):
+class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder):
+    def __init__(
+        self,
+        model_path: str,
+        config: transformers.PretrainedConfig,
+        tokenizer: transformers.AutoTokenizer,
+        trust_remote_code: bool = True,
+    ):
         super().__init__()
         if not trust_remote_code:
             raise ValueError("trust_remote_code must be True for Phi4MM")
 
         self._config = config
-        self._tokenizer = tokenizer if tokenizer is not None else transformers.AutoTokenizer.from_pretrained(
-            model_path,
-            trust_remote_code=trust_remote_code,
-            use_fast=self.use_fast)
-        self._processor = transformers.AutoProcessor.from_pretrained(
-            model_path,
-            trust_remote_code=trust_remote_code,
-            use_fast=self.use_fast)
+        self._tokenizer = (
+            tokenizer
+            if tokenizer is not None
+            else transformers.AutoTokenizer.from_pretrained(
+                model_path, trust_remote_code=trust_remote_code, use_fast=self.use_fast
+            )
+        )
+        self._processor = transformers.AutoImageProcessor.from_pretrained(
+            model_path, trust_remote_code=trust_remote_code, use_fast=self.use_fast
+        )
         self._model_path = model_path
         self._dtype = self.config.torch_dtype
-        self.device = 'cpu'
+        self.device = "cpu"
 
         self.image_size = self.config.force_image_size
         self.patch_size = self.config.patch_size
         self.downsample_ratio = self.config.downsample_ratio
         self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.img_context_token_id = self.config.img_context_token_id
-        self.num_image_token = int((self.image_size // self.patch_size)**2 *
-                                   (self.downsample_ratio**2))
+        self.num_image_token = int(
+            (self.image_size // self.patch_size) ** 2 * (self.downsample_ratio**2)
+        )
         self.video_pruning_ratio = VIDEO_PRUNING_RATIO
         self.img_context_token = self.config.img_context_token
         self.video_context_token = self.config.video_context_token
         self.img_start_token = self.config.img_start_token
         self.img_end_token = self.config.img_end_token
         self.image_start_token_id = self.tokenizer.encode(
-            self.img_start_token, add_special_tokens=False)[0]
+            self.img_start_token, add_special_tokens=False
+        )[0]
         self.image_end_token_id = self.tokenizer.encode(
-            self.img_end_token, add_special_tokens=False)[0]
+            self.img_end_token, add_special_tokens=False
+        )[0]
 
     @property
     def config(self) -> transformers.PretrainedConfig:
@@ -321,9 +329,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
         return self.config.llm_config.vocab_size
 
     def get_mm_special_token_ids(self) -> torch.Tensor:
-        " Return multimodal special token ids for NanoV2VL. "
-        return torch.tensor(
-            [self.image_start_token_id, self.image_end_token_id])
+        "Return multimodal special token ids for NanoV2VL."
+        return torch.tensor([self.image_start_token_id, self.image_end_token_id])
 
     def get_mm_token_ids(self):
         return torch.tensor([self.img_context_token_id], dtype=torch.int32)
@@ -340,15 +347,16 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
             min_num: int,
             max_num: int,
         ) -> list[tuple[int, int]]:
-            target_ratios = {(i, j)
-                             for n in range(min_num, max_num + 1)
-                             for i in range(1, n + 1)
-                             for j in range(1, n + 1)
-                             if min_num <= i * j <= max_num}
+            target_ratios = {
+                (i, j)
+                for n in range(min_num, max_num + 1)
+                for i in range(1, n + 1)
+                for j in range(1, n + 1)
+                if min_num <= i * j <= max_num
+            }
             return sorted(target_ratios, key=lambda x: x[0] * x[1])
 
-        def _find_closest_aspect_ratio(aspect_ratio, target_ratios, width,
-                                       height, image_size):
+        def _find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
             best_ratio_diff = float("inf")
             best_ratio = (1, 1)
             area = width * height
@@ -387,13 +395,12 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
 
         image_height = image.height
         image_width = image.width
-        if 'max_num_tiles' in kwargs:
-            max_num_tiles = kwargs['max_num_tiles']
+        if "max_num_tiles" in kwargs:
+            max_num_tiles = kwargs["max_num_tiles"]
         else:
             max_num_tiles = self.processor.max_num_tiles
         target_ratios = _get_internvl_target_ratios(1, max_num_tiles)
-        blocks = _calculate_targets(image_width, image_height, target_ratios,
-                                    self.image_size)
+        blocks = _calculate_targets(image_width, image_height, target_ratios, self.image_size)
         if self.processor.use_thumbnail and blocks != 1:
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
@@ -419,8 +426,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                 max_num_tiles=VIDEO_MAX_NUM_TILES,
                 **kwargs,
             )
-            num_image_tokens_per_frame = num_tokens_per_frame - len(
-                self.get_mm_special_token_ids())
+            num_image_tokens_per_frame = num_tokens_per_frame - len(self.get_mm_special_token_ids())
             blocks = num_image_tokens_per_frame // self.num_image_token
             video_size = (num_frames, blocks * self.image_size, self.image_size)
             num_total_tokens = compute_retained_tokens_count(
@@ -429,8 +435,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                 pruning_ratio=video_pruning_ratio,
             )
             # Add special tokens for each frame.
-            num_total_tokens += num_frames * len(
-                self.get_mm_special_token_ids())
+            num_total_tokens += num_frames * len(self.get_mm_special_token_ids())
         else:
             # No pruning - sum tokens for all frames
             num_total_tokens = sum(
@@ -439,37 +444,40 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                     video_pruning_ratio=None,
                     max_num_tiles=VIDEO_MAX_NUM_TILES,
                     **kwargs,
-                ) for frame in video)
+                )
+                for frame in video
+            )
         return num_total_tokens
 
     def _process_images(
-            self, images: List[Image.Image | torch.Tensor],
-            text_prompt: str) -> Tuple[Dict[str, Any], torch.Tensor]:
+        self, images: List[Image.Image | torch.Tensor], text_prompt: str
+    ) -> Tuple[Dict[str, Any], torch.Tensor]:
         # Multiple images can be processed in one call.
-        processed_images = self.processor(images=images,
-                                          return_tensors='pt').to(self.device)
+        processed_images = self.processor(images=images, return_tensors="pt").to(self.device)
 
         # Prepare text prompt for image modality.
         parts = text_prompt.split(self.img_context_token)
-        if len(parts) - 1 != len(processed_images['num_patches']):
+        if len(parts) - 1 != len(processed_images["num_patches"]):
             raise ValueError(
-                f"Number of {self.img_context_token} tokens ({len(parts) - 1}) doesn't match num_patches_list length ({len(processed_images['num_patches'])})"
+                f"Number of {self.img_context_token} tokens ({len(parts) - 1}) doesn't match "
+                f"num_patches_list length ({len(processed_images['num_patches'])})"
             )
         processed_query = parts[0]
-        for num_patches, part in zip(processed_images['num_patches'],
-                                     parts[1:]):
+        for num_patches, part in zip(processed_images["num_patches"], parts[1:]):
             feature_size = num_patches * self.num_image_token
-            image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
+            image_repl = (
+                self.img_start_token + self.img_context_token * feature_size + self.img_end_token
+            )
             processed_query += image_repl + part
 
-        input_ids = self.tokenizer.encode(processed_query,
-                                          add_special_tokens=False,
-                                          return_tensors="pt")
+        input_ids = self.tokenizer.encode(
+            processed_query, add_special_tokens=False, return_tensors="pt"
+        )
         return processed_images, input_ids
 
     def _process_videos_frames(
-            self,
-            videos: List[List[Image.Image | torch.Tensor]]) -> Dict[str, Any]:
+        self, videos: List[List[Image.Image | torch.Tensor]]
+    ) -> Dict[str, Any]:
         num_patches_list = []
         pixel_values_list = []
         video_size_list = []
@@ -479,25 +487,24 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
             # Use VIDEO_MAX_NUM_TILES for video modality to match the training behaviors.
             orig_max_num_tiles = self.processor.max_num_tiles
             self.processor.max_num_tiles = VIDEO_MAX_NUM_TILES
-            processed_images = self.processor(
-                images=video, return_tensors='pt').to(self.device)
+            processed_images = self.processor(images=video, return_tensors="pt").to(self.device)
             self.processor.max_num_tiles = orig_max_num_tiles
 
-            t, _, h, w = processed_images['pixel_values'].shape
-            num_patches_list.append(processed_images['num_patches'])
-            pixel_values_list.append(processed_images['pixel_values'])
+            t, _, h, w = processed_images["pixel_values"].shape
+            num_patches_list.append(processed_images["num_patches"])
+            pixel_values_list.append(processed_images["pixel_values"])
             video_size_list.append([num_frames, t // num_frames, h, w])
 
-        processed_images['num_patches'] = torch.tensor(
-            [sum(num_patches) for num_patches in num_patches_list])
-        processed_images['pixel_values'] = torch.cat(pixel_values_list, dim=0)
-        processed_images['video_size'] = video_size_list
+        processed_images["num_patches"] = torch.tensor(
+            [sum(num_patches) for num_patches in num_patches_list]
+        )
+        processed_images["pixel_values"] = torch.cat(pixel_values_list, dim=0)
+        processed_images["video_size"] = video_size_list
         return processed_images
 
     def _get_frame_separators(
-            self, video_size_lst: List[Tuple],
-            video_metadatas: List[Dict[str, Any] | None]) -> List[List[str]]:
-
+        self, video_size_lst: List[Tuple], video_metadatas: List[Dict[str, Any] | None]
+    ) -> List[List[str]]:
         # Process videos one by one to get correct processed_query.
         frame_separators_lst = []
         for metadata, video_size in zip(video_metadatas, video_size_lst):
@@ -509,51 +516,52 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                 frame_duration_ms = int(1000.0 / metedata_fps)
                 frames_indices = metadata["frames_indices"]
                 timestamps = [
-                    int(frame_index) * frame_duration_ms / 1000.0
-                    for frame_index in frames_indices
+                    int(frame_index) * frame_duration_ms / 1000.0 for frame_index in frames_indices
                 ]
                 frame_separators = [
                     f"Frame {i + 1} sampled at {timestamp:.2f} seconds: "
                     for i, timestamp in enumerate(timestamps)
                 ]
             else:
-                frame_separators = [
-                    f"Frame {i + 1}: " for i in range(num_frames)
-                ]
+                frame_separators = [f"Frame {i + 1}: " for i in range(num_frames)]
             frame_separators_lst.append(frame_separators)
 
         return frame_separators_lst
 
     def _process_video_prompts(
-        self, split_text_prompt: List[str],
+        self,
+        split_text_prompt: List[str],
         num_tokens_per_frame_lst: List[List[int] | None],
-        frame_separators_lst: List[List[str]]
+        frame_separators_lst: List[List[str]],
     ) -> Tuple[torch.Tensor, Optional[List[torch.Tensor]]]:
         # Process videos one by one to get correct processed_query.
         processed_query = []
         evs_query = []
         for video_index, (num_tokens_per_frame, frame_separators) in enumerate(
-                zip(num_tokens_per_frame_lst, frame_separators_lst)):
-
+            zip(num_tokens_per_frame_lst, frame_separators_lst)
+        ):
             # Prepare video and EVS query.
             processed_query.append(split_text_prompt[video_index])
             processed_query.append("This is a video:\n")
-            for frame_sep, num_tokens in zip(frame_separators,
-                                             num_tokens_per_frame):
+            for frame_sep, num_tokens in zip(frame_separators, num_tokens_per_frame):
                 frame_prompts = [
-                    frame_sep, self.img_start_token,
-                    self.img_context_token * num_tokens, self.img_end_token,
-                    "\n"
+                    frame_sep,
+                    self.img_start_token,
+                    self.img_context_token * num_tokens,
+                    self.img_end_token,
                 ]
                 processed_query.extend(frame_prompts)
-            # Video_context_token as placeholder, and it will be combined with the real image_tokens_per_frames during model forward.
+            # Video_context_token as placeholder,
+            # it will be replaced with the real image_tokens_per_frames during model forward.
             if self.video_pruning_ratio > 0:
                 evs_query.append(split_text_prompt[video_index])
                 evs_query.append("This is a video:\n")
                 for frame_sep in frame_separators:
                     frame_prompts = [
-                        frame_sep, self.img_start_token,
-                        self.video_context_token, self.img_end_token, "\n"
+                        frame_sep,
+                        self.img_start_token,
+                        self.video_context_token,
+                        self.img_end_token,
                     ]
                     evs_query.extend(frame_prompts)
         # Append the last part of the text prompt.
@@ -565,7 +573,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                 query,
                 add_special_tokens=False,
                 return_tensors="pt",
-            ) for query in processed_query
+            )
+            for query in processed_query
         ]
         input_ids = torch.cat(input_ids_lst, dim=1)
 
@@ -576,15 +585,15 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
                     query,
                     add_special_tokens=False,
                     return_tensors="pt",
-                )[0] for query in evs_query
+                )[0]
+                for query in evs_query
             ]
         else:
             evs_ids = None
 
         return input_ids, evs_ids
 
-    def _compute_token_numbers_per_video(
-            self, video_size_lst: List[Tuple]) -> List[List[int]]:
+    def _compute_token_numbers_per_video(self, video_size_lst: List[Tuple]) -> List[List[int]]:
         num_tokens_per_frame_lst = []
         for video_size in video_size_lst:
             num_frames = video_size[0]
@@ -594,19 +603,16 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
 
             if self.video_pruning_ratio > 0:
                 desired_num_tokens = compute_retained_tokens_count(
-                    video_size=(num_frames, num_patches_per_frame * img_height,
-                                img_width),
+                    video_size=(num_frames, num_patches_per_frame * img_height, img_width),
                     spatial_merge_size=self.spatial_merge_size,
                     pruning_ratio=self.video_pruning_ratio,
                 )
                 # It is dummy tokens and will be adjusted in VisionEncoder after applied EVS.
-                # We need to know the length of the full input ids ahead, to make Mamba-mixer and inflight-batching work.
-                num_tokens_per_frame = [desired_num_tokens
-                                        ] + [0] * (num_frames - 1)
+                # Need to know the length of the full input ids ahead,
+                # to make Mamba-mixer and inflight-batching work.
+                num_tokens_per_frame = [desired_num_tokens] + [0] * (num_frames - 1)
             else:
-                num_tokens_per_frame = [
-                    num_patches_per_frame * self.num_image_token
-                ] * num_frames
+                num_tokens_per_frame = [num_patches_per_frame * self.num_image_token] * num_frames
 
             num_tokens_per_frame_lst.append(num_tokens_per_frame)
         return num_tokens_per_frame_lst
@@ -615,8 +621,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
     def __call__(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        text_prompt, mm_data = inputs.get("prompt"), inputs.get(
-            "multi_modal_data", {})
+        text_prompt, mm_data = inputs.get("prompt"), inputs.get("multi_modal_data", {})
         images = mm_data.get("image", None)
         videos = mm_data.get("video", None)
         if images is not None and videos is not None:
@@ -625,9 +630,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
             )
 
         if images is None and videos is None:
-            input_ids = self.tokenizer.encode(text_prompt,
-                                              add_special_tokens=False,
-                                              return_tensors="pt")
+            input_ids = self.tokenizer.encode(
+                text_prompt, add_special_tokens=False, return_tensors="pt"
+            )
             return input_ids[0].to(torch.int32).tolist(), {}
 
         modality_type = None
@@ -635,51 +640,52 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
         input_ids = None
         if images is not None:
             modality_type = "image"
-            processed_images, input_ids = self._process_images(
-                images, text_prompt)
+            processed_images, input_ids = self._process_images(images, text_prompt)
             evs_ids = None
-            modality_data["pixel_values"] = processed_images["pixel_values"].to(
-                self.dtype)
-            modality_data["num_patches"] = processed_images["num_patches"].sum(
-                dim=0, keepdim=True)
+            modality_data["pixel_values"] = processed_images["pixel_values"].to(self.dtype)
+            modality_data["num_patches"] = processed_images["num_patches"].sum(dim=0, keepdim=True)
             modality_data["video_size"] = None
             # During model inference, the image/video modality data can be mixed during inflight-batching.
-            # Store input_ids for image modality here when EVS is enabled, which will be used in merge_evs_mm_embeds later.
-            modality_data["evs_ids"] = input_ids[0].to(
-                torch.int32) if self.video_pruning_ratio > 0 else None
+            # Store input_ids for image modality here when EVS is enabled,
+            # which will be used in merge_evs_mm_embeds later.
+            modality_data["evs_ids"] = (
+                input_ids[0].to(torch.int32) if self.video_pruning_ratio > 0 else None
+            )
         elif videos is not None:
             modality_type = "video"
-            video_frames, video_metadatas = [
-                video_data.frames for video_data in videos
-            ], [video_data.metadata for video_data in videos]
+            video_frames, video_metadatas = (
+                [video_data.frames for video_data in videos],
+                [video_data.metadata for video_data in videos],
+            )
             num_videos = len(video_frames)
             processed_images = self._process_videos_frames(video_frames)
 
             # Num_tokens_per_frame_lst is a dummy one when EVS is enabled.
             num_tokens_per_frame_lst = self._compute_token_numbers_per_video(
-                processed_images['video_size'])
+                processed_images["video_size"]
+            )
             # Special video tokens will be added to match training behaviors.
             frame_separators_lst = self._get_frame_separators(
-                processed_images['video_size'], video_metadatas)
+                processed_images["video_size"], video_metadatas
+            )
 
             split_text_prompt = text_prompt.split(self.video_context_token)
             if len(split_text_prompt) - 1 != num_videos:
                 raise ValueError(
-                    f"Number of {self.video_context_token} tokens ({len(split_text_prompt) - 1}) doesn't match number of videos ({num_videos})"
+                    f"Number of {self.video_context_token} tokens ({len(split_text_prompt) - 1})"
+                    f"doesn't match the number of videos ({num_videos})"
                 )
             input_ids, evs_ids = self._process_video_prompts(
-                split_text_prompt, num_tokens_per_frame_lst,
-                frame_separators_lst)
-            modality_data["pixel_values"] = processed_images["pixel_values"].to(
-                self.dtype)
-            modality_data["num_patches"] = processed_images["num_patches"].sum(
-                dim=0, keepdim=True)
+                split_text_prompt, num_tokens_per_frame_lst, frame_separators_lst
+            )
+            modality_data["pixel_values"] = processed_images["pixel_values"].to(self.dtype)
+            modality_data["num_patches"] = processed_images["num_patches"].sum(dim=0, keepdim=True)
             modality_data["video_size"] = processed_images["video_size"]
             modality_data["evs_ids"] = evs_ids
 
         # Will package inputs for language model forward in AGGREGATE mode.
         multimodal_data = {}
-        multimodal_data['modality_type'] = modality_type
+        multimodal_data["modality_type"] = modality_type
         multimodal_data[modality_type] = modality_data
         return input_ids[0].to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data,
@@ -697,15 +703,14 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor,
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
         placeholders_separator="",
-    ))
+    ),
+)
 class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
-
     _supports_flash_attn_2 = True
 
     def __init__(self, model_config: ModelConfig):
         if _is_disagg():
-            raise ValueError(
-                "NanoV2VL does not support disaggregated inference yet.")
+            raise ValueError("NanoV2VL does not support disaggregated inference yet.")
 
         config = model_config.pretrained_config
         super().__init__(config)
@@ -735,8 +740,9 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         # Load language model weights.
         filtered_weights = {
-            k.replace('language_model.', ''): v
-            for k, v in weights.items() if k.startswith('language_model.')
+            k.replace("language_model.", ""): v
+            for k, v in weights.items()
+            if k.startswith("language_model.")
         }
         weight_mapper = NemotronHHfWeightMapper()
         weight_mapper.init_model_and_config(self.llm, self.model_config)
@@ -750,9 +756,12 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.config = self.llm.config
         self.model_config.pretrained_config = self.llm.config
 
-    def merge_evs_mm_embeds(self, num_tokens_in_videos: List[int],
-                            multimodal_params: List[MultimodalParams],
-                            input_ids: torch.Tensor) -> torch.Tensor:
+    def merge_evs_mm_embeds(
+        self,
+        num_tokens_in_videos: List[int],
+        multimodal_params: List[MultimodalParams],
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
         """Merge EVS and MM embeds into input_ids.
 
         Args:
@@ -765,25 +774,22 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             Input ids with EVS and MM embeds merged.
         """
         multimodal_data_lst = [
-            multimodal_param.multimodal_data
-            for multimodal_param in multimodal_params
+            multimodal_param.multimodal_data for multimodal_param in multimodal_params
         ]
-        modalities = [
-            multimodal_data['modality_type']
-            for multimodal_data in multimodal_data_lst
-        ]
+        modalities = [multimodal_data["modality_type"] for multimodal_data in multimodal_data_lst]
         # Skip EVS if there is no video modality.
         if "video" not in modalities:
             return input_ids
 
         evs_ids_lst = [
-            multimodal_data[modality]['evs_ids'] for modality, multimodal_data
-            in zip(modalities, multimodal_data_lst)
+            multimodal_data[modality]["evs_ids"]
+            for modality, multimodal_data in zip(modalities, multimodal_data_lst)
         ]
         # Iterate over batch.
         context_ids = []
         for evs_ids, modality, num_tokens_in_video in zip(
-                evs_ids_lst, modalities, num_tokens_in_videos):
+            evs_ids_lst, modalities, num_tokens_in_videos
+        ):
             # Special handling for image modality when mixing image and video modalities during inflight-batching.
             if modality == "image":
                 context_ids.append(evs_ids)
@@ -791,10 +797,9 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
             image_idx = 0
             for evs_id in evs_ids:
-                if len(evs_id
-                       ) == 1 and evs_id[0] == self.video_context_token_id:
+                if len(evs_id) == 1 and evs_id[0] == self.video_context_token_id:
                     image_mm = torch.full(
-                        (num_tokens_in_video[image_idx], ),
+                        (num_tokens_in_video[image_idx],),
                         fill_value=self.img_context_token_id,
                         dtype=evs_id.dtype,
                         device=evs_id.device,
@@ -809,7 +814,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         # Special handling for inflight-batching.
         # Assume input ids format is [context_ids, generation_ids].
-        input_ids[:context_ids.shape[0]] = context_ids
+        input_ids[: context_ids.shape[0]] = context_ids
         del context_ids
 
         return input_ids
@@ -827,7 +832,10 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         """
         VLM forward logic with inflight batching support.
         """
-        num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
+        num_context_requests, num_generation_requests = (
+            attn_metadata.num_contexts,
+            attn_metadata.num_generations,
+        )
         logger.debug(
             f"num_context_requests: {num_context_requests}, num_generation_requests: {num_generation_requests}"
         )
@@ -838,11 +846,12 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             if not _is_disagg():
                 mm_embedding, num_tokens_in_videos = get_multimodal_embeddings(
                     encoder_forward_fn=self.vision_encoder.forward,
-                    multimodal_params=multimodal_params[:num_context_requests])
+                    multimodal_params=multimodal_params[:num_context_requests],
+                )
             else:
                 raise NotImplementedError(
                     "Nano-V2-VLM does not support disaggregated inference yet. Please unset "
-                    f"the TLLM_MULTIMODAL_DISAGGREGATED environment variable, or set it to '0'."
+                    "the TLLM_MULTIMODAL_DISAGGREGATED environment variable, or set it to '0'."
                 )
             # Adjust input_ids in videos if EVS is applied.
             if self.video_pruning_ratio > 0:
@@ -853,13 +862,13 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 )
 
             mm_embedding = find_input_mm_embeds(
-                mm_embedding, multimodal_params[:num_context_requests])
+                mm_embedding, multimodal_params[:num_context_requests]
+            )
         input_ids, input_embeds = fuse_input_embeds(
             self.llm.model.embed_tokens,
             input_ids,
             mm_embedding,
-            mm_token_ids=torch.tensor([self.img_context_token_id],
-                                      dtype=torch.int32),
+            mm_token_ids=torch.tensor([self.img_context_token_id], dtype=torch.int32),
         )
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
@@ -870,5 +879,5 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             lora_params=kwargs.get("lora_params", None),
         )
 
-        logger.debug(f'output shape: {output_prob.shape}')
+        logger.debug(f"output shape: {output_prob.shape}")
         return output_prob

--- a/tensorrt_llm/evaluate/lm_eval.py
+++ b/tensorrt_llm/evaluate/lm_eval.py
@@ -219,7 +219,8 @@ class MultimodalLmEvalWrapper(LmEvalWrapper):
             else:
                 text = text.replace(LM_EVAL_DEFAULT_IMAGE_PLACEHOLDER, "")
 
-            conv = ConversationMessage(role="user", content=text)
+            conv = ConversationMessage(role=content.get("role", "user"),
+                                       content=text)
             mm_data_tracker = MultimodalDataTracker(self.model_type)
 
             # NOTE: Since we already have loaded images, for the placeholder purpose, we add data here.

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -374,7 +374,7 @@ NOTE:
 """
 
 HF_CHAT_TEMPLATE_EXCEPTIONS = ["llava_llama"]
-PLACEHOLDER_EXCEPTIONS = ["llava_next"]
+PLACEHOLDER_EXCEPTIONS = ["llava_next", "NemotronH_Nano_VL_V2"]
 
 
 # Helpers to always get the latest supported multimodal model types from the registry
@@ -533,6 +533,29 @@ def handle_placeholder_exceptions(model_type: str,
                                               mm_placeholder_counts):
             conv["content"] = [{"type": "text", "text": conv["content"]}, \
                 *[{"type": "image"} for _ in range(mm_placeholder_count['<image>'])]]
+    elif model_type == "NemotronH_Nano_VL_V2":
+        # There are divergences between trtllm and vllm on how to handle the placeholders.
+        # For now, we will use this exception to handle with the divergences in TRTLLM.
+        # In the near future, we will remove this placeholder exception and use dict format as vllm does.
+        for conv, mm_placeholder_count in zip(conversation,
+                                              mm_placeholder_counts):
+            if '<image>' not in mm_placeholder_count and '<video>' not in mm_placeholder_count:
+                # Skip if no image or video placeholders.
+                continue
+
+            # Contents from all kinds of roles will be handled.
+            content = []
+            content.append({"type": "text", "text": conv["content"]})
+            # Extend image/video placeholders so that the chat_template can be applied correctly.
+            if '<image>' in mm_placeholder_count:
+                content.extend([{
+                    "type": "image"
+                } for _ in range(mm_placeholder_count['<image>'])])
+            if '<video>' in mm_placeholder_count:
+                content.extend([{
+                    "type": "video"
+                } for _ in range(mm_placeholder_count['<video>'])])
+            conv["content"] = content
     else:
         raise ValueError(f"This path should not be reached for: {model_type}")
     return conversation

--- a/tests/integration/defs/accuracy/references/mmmu.yaml
+++ b/tests/integration/defs/accuracy/references/mmmu.yaml
@@ -10,3 +10,8 @@ Efficient-Large-Model/NVILA-8B:
   - accuracy: 47.77
 Efficient-Large-Model/VILA1.5-3b:
   - accuracy: 32.33
+# MMMU for Nemotron-Nano-12B-v2-VL-BF16 requires reasoning on.
+# While enabling reasoning for current test harness is not supported,
+# the metric here is for model sanity checking.
+nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16:
+  - accuracy: 26.67

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -157,3 +157,38 @@ class TestVILA1_5_3B(LlmapiAccuracyTestHarness):
         ) as llm:
             task = MMMU(self.MODEL_NAME)
             task.evaluate(llm, sampling_params=self.sampling_params)
+
+
+class TestNemotron_Nano_12B_V2_VL(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+    MODEL_PATH = f"{llm_models_root()}/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+    MAX_NUM_TOKENS = 25600
+    EXTRA_EVALUATOR_KWARGS = dict(
+        apply_chat_template=True,
+        system_prompt="/no_think",
+    )
+
+    # NOTE: MMMU adds <|endoftext|> to the stop token.
+    sampling_params = SamplingParams(
+        max_tokens=MAX_NUM_TOKENS,
+        truncate_prompt_tokens=MMMU.MAX_INPUT_LEN,
+        temperature=0.0,
+        top_k=1,
+        stop="<|endoftext|>",
+    )
+
+    kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8, enable_block_reuse=False)
+
+    def test_auto_dtype(self):
+        with LLM(
+            self.MODEL_PATH,
+            max_batch_size=128,
+            max_num_tokens=self.MAX_NUM_TOKENS,
+            kv_cache_config=self.kv_cache_config,
+        ) as llm:
+            task = MMMU(self.MODEL_NAME)
+            task.evaluate(
+                llm,
+                sampling_params=self.sampling_params,
+                extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
+            )

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -2455,10 +2455,6 @@ def test_ptp_quickstart_advanced_mixed_precision(llm_root, llm_venv):
                  "gemma/gemma-3-27b-it",
                  marks=(pytest.mark.skip_less_device_memory(80000),
                         skip_post_blackwell)),
-    pytest.param(
-        "Nano-v2-VLM",
-        "Nano-v2-VLM",
-        marks=pytest.mark.skip(reason="Nano V2 VLM ckpt is not released yet.")),
 ])
 def test_ptp_quickstart_multimodal(llm_root, llm_venv, model_name, model_path,
                                    modality, use_cuda_graph):
@@ -2505,23 +2501,6 @@ def test_ptp_quickstart_multimodal(llm_root, llm_venv, model_name, model_path,
     }
 
     expected_keywords = {
-        "Nano-v2-VLM": {
-            "image": [
-                ["natural", "ocean", "waves", "stormy", "overcast", "sea"],
-                ["mountain", "rock", "large", "clear", "blue", "sky"],
-                ["road", "lane", "vehicle", "bus", "cars", "traffic"],
-            ],
-            "video": [
-                [
-                    "person", "red", "dress", "walking", "street", "black",
-                    "leather", "jacket"
-                ],
-                ["space", "earth", "black", "frame", "city", "lights", "dark"],
-            ],
-            "mixture_text_image":
-            [["invented", "internet", "person", "people", "computers"],
-             ["large", "rock", "mountain", "center", "sky", "clear", "trees"]]
-        },
         "mistral-small-3.1-24b-instruct": {
             "image": [
                 ["dramatic", "seascape", "ocean", "turbulent", "waves", "dark"],
@@ -2568,13 +2547,6 @@ def test_ptp_quickstart_multimodal(llm_root, llm_venv, model_name, model_path,
         cmd.append("--disable_kv_cache_reuse")
         cmd.append("--kv_cache_fraction=0.5")
         cmd.append("--max_seq_len=1024")
-    # Nano V2 VLM needs smaller max_batch_size to save memory.
-    # Also need to disable kv cache reuse for Nemotron-H architecture.
-    if model_name == "Nano-v2-VLM":
-        cmd.append("--max_batch_size=128")
-        cmd.append("--disable_kv_cache_reuse")
-        if modality == "video":
-            cmd.append("--max_num_tokens=20480")
 
     output = llm_venv.run_cmd(cmd, caller=check_output)
 

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -629,6 +629,7 @@ accuracy/test_llm_api_pytorch_multimodal.py::TestNano_V2_VLM::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestLlava_V1_6_Mistral_7B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestNVILA_8B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestVILA1_5_3B::test_auto_dtype
+accuracy/test_llm_api_pytorch_multimodal.py::TestNemotron_Nano_12B_V2_VL::test_auto_dtype
 
 test_e2e.py::test_llama_e2e[use_cpp_session-remove_input_padding-]
 test_e2e.py::test_llama_e2e[use_py_session-remove_input_padding-]

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -17,6 +17,7 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_mllama"
   - unittest/_torch/modeling -k "modeling_siglip"
   - unittest/_torch/modeling -k "modeling_vila"
+  - unittest/_torch/modeling -k "modeling_nemotron_nano_v2_vl"
   - unittest/_torch/modeling/test_modeling_llava_next.py::TestLlavaNext::test_all
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all
   - test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -1,0 +1,206 @@
+import os
+from pathlib import Path
+
+import pytest
+import torch
+import transformers
+from test_modeling_multimodal import llm_models_root
+from test_modeling_nemotron_h import extract_decode_logprobs
+
+from tensorrt_llm import LLM
+from tensorrt_llm.inputs import (
+    create_input_processor,
+    create_input_processor_with_hash,
+    default_multimodal_input_loader,
+    prompt_inputs,
+)
+from tensorrt_llm.llmapi import KvCacheConfig
+from tensorrt_llm.llmapi.llm_args import CudaGraphConfig
+from tensorrt_llm.sampling_params import SamplingParams
+
+MODEL_PATH = str(os.path.join(llm_models_root(), "NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"))
+
+
+@pytest.fixture(scope="function")
+def data_dict_fixture():
+    test_data_root = Path(os.path.join(llm_models_root(), "multimodals", "test_data"))
+    data_dict = {
+        "image": {
+            "single": {
+                "prompts": ["Describe the natural environment in the image."],
+                "media": [str(test_data_root / "seashore.png")],
+            },
+            "multiple": {
+                "prompts": ["Describe the difference between the two images."],
+                "media": [
+                    str(test_data_root / "seashore.png"),
+                    str(test_data_root / "seashore.png"),
+                ],
+            },
+        },
+        "video": {
+            "single": {
+                "prompts": ["Describe the natural environment in the video."],
+                "media": [str(test_data_root / "world.mp4")],
+            },
+            "multiple": {
+                "prompts": ["Describe the difference between the two videos."],
+                "media": [str(test_data_root / "world.mp4"), str(test_data_root / "world.mp4")],
+            },
+        },
+    }
+    return data_dict
+
+
+@pytest.fixture(scope="function")
+def nano_llm_model():
+    """Fixture to create and cleanup the Nemotron nano VL model."""
+    # Since nemotron-h series models are with both attention and mamba cache,
+    # we use the top-level LLM to create the engine to make things simpler.
+    nano_llm = LLM(
+        model=MODEL_PATH,
+        tensor_parallel_size=1,
+        max_batch_size=2,
+        cuda_graph_config=CudaGraphConfig(),
+        kv_cache_config=KvCacheConfig(enable_block_reuse=False, mamba_ssm_cache_dtype="float32"),
+    )
+    yield nano_llm
+
+    # Cleanup.
+    nano_llm.shutdown()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+@pytest.mark.parametrize("condition", ["single", "multiple"])
+@pytest.mark.parametrize("modality", ["image", "video"])
+def test_nemotron_nano_v2_vl_input_processor(data_dict_fixture, condition, modality):
+    # Create input processor for NemotronH_Nano_VL_V2.
+    tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    input_processor = create_input_processor(MODEL_PATH, tokenizer=tokenizer)
+    input_processor_with_hash = create_input_processor_with_hash(input_processor)
+
+    # Reference results.
+    reference_results = {
+        "image": {
+            "single": {
+                "prompt_pattern": "<image>",
+                "prompt_token_ids_length": 282,
+                "pixel_values_shape": (1, 3, 512, 512),
+                "num_patches": torch.tensor([1]),
+            },
+            "multiple": {
+                "prompt_pattern": "<image 1><image> <image 2><image>",
+                "prompt_token_ids_length": 550,
+                "pixel_values_shape": (2, 3, 512, 512),
+                "num_patches": torch.tensor([2]),
+            },
+        },
+        "video": {
+            "single": {
+                "prompt_pattern": "<video>",
+                "prompt_token_ids_length": 2202,
+                "pixel_values_shape": (8, 3, 512, 512),
+                "num_patches": torch.tensor([8]),
+            },
+            "multiple": {
+                "prompt_pattern": "<video>\n<video>\n",
+                "prompt_token_ids_length": 4381,
+                "pixel_values_shape": (16, 3, 512, 512),
+                "num_patches": torch.tensor([16]),
+            },
+        },
+    }
+
+    prompts = data_dict_fixture[modality][condition]["prompts"]
+    media = data_dict_fixture[modality][condition]["media"]
+    inputs = default_multimodal_input_loader(
+        tokenizer=input_processor.tokenizer,
+        model_dir=MODEL_PATH,
+        model_type="NemotronH_Nano_VL_V2",
+        modality=modality,
+        prompts=prompts,
+        media=media,
+        image_data_format="pt",
+        num_frames=8,
+        device="cpu",
+    )
+    inputs = [prompt_inputs(i) for i in inputs]
+
+    # Check special tokens in the prompt.
+    final_prompt = inputs[0]["prompt"]
+    prompt_pattern = reference_results[modality][condition]["prompt_pattern"]
+    assert prompt_pattern in final_prompt, f"{final_prompt=} is not expected."
+
+    prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
+        inputs[0], sampling_params=None
+    )
+
+    # Check the output of the input processor.
+    prompt_token_ids_length = len(prompt_token_ids)
+    pixel_values_shape = extra_processed_inputs["multimodal_data"][modality]["pixel_values"].shape
+    num_patches = extra_processed_inputs["multimodal_data"][modality]["num_patches"]
+    ref_prompt_token_ids_length = reference_results[modality][condition]["prompt_token_ids_length"]
+    ref_pixel_values_shape = reference_results[modality][condition]["pixel_values_shape"]
+    ref_num_patches = reference_results[modality][condition]["num_patches"]
+    assert prompt_token_ids_length == ref_prompt_token_ids_length, (
+        f"{prompt_token_ids_length=} is not expected."
+    )
+    assert pixel_values_shape == ref_pixel_values_shape, f"{pixel_values_shape=} is not expected."
+    assert num_patches == ref_num_patches, f"{num_patches=} is not expected."
+
+
+@pytest.mark.threadleak(enabled=False)
+@pytest.mark.parametrize("condition", ["single", "multiple"])
+@pytest.mark.parametrize("modality", ["image", "video"])
+def test_nemotron_nano_v2_vl_model_sanity_check(
+    data_dict_fixture, nano_llm_model, condition, modality
+):
+    nano_llm = nano_llm_model
+    sampling_params = SamplingParams(
+        max_tokens=5,
+        temperature=0.0,
+        add_special_tokens=False,
+        return_generation_logits=True,
+    )
+
+    # The reference data is generated by running the model with the same prompts and media.
+    reference_data_dict = {
+        "image": {
+            "single": torch.tensor(
+                [-8.5795e-01, -1.5373e-01, -7.2846e-04, -6.3667e-01, -3.1307e-02]
+            ),
+            "multiple": torch.tensor([-0.5846, -0.6330, -0.0124, -0.1146, -0.0172]),
+        },
+        "video": {
+            "single": torch.tensor([-0.5612, -0.0334, -0.8856, -0.4056, -0.6041]),
+            "multiple": torch.tensor([-0.4943, -0.9333, -0.0096, -1.2496, -0.9441]),
+        },
+    }
+    prompts = data_dict_fixture[modality][condition]["prompts"]
+    media = data_dict_fixture[modality][condition]["media"]
+    inputs = default_multimodal_input_loader(
+        tokenizer=nano_llm.tokenizer,
+        model_dir=MODEL_PATH,
+        model_type="NemotronH_Nano_VL_V2",
+        modality=modality,
+        prompts=prompts,
+        media=media,
+        image_data_format="pt",
+        num_frames=8,
+        device="cpu",
+    )
+    outputs = nano_llm.generate(
+        inputs,
+        sampling_params,
+    )
+    decode_logprobs = extract_decode_logprobs(outputs[0])
+    ref_decode_logprobs = reference_data_dict[modality][condition]
+
+    diff = torch.abs(decode_logprobs - ref_decode_logprobs)
+    if diff.max() > 0.3:
+        raise ValueError(
+            f"Max difference is too large: {decode_logprobs=} | {ref_decode_logprobs=}"
+        )
+    else:
+        print("Passed! Max difference is within tolerance")


### PR DESCRIPTION
Feature:
* Update doc for nano-v2-vl.
* Update chat_template util for nano-v2-vl.
* Enable e2e and metrics sanity tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVIDIA-Nemotron-Nano-12B-v2-VL model with BF16 and FP8 variants, including multimodal capabilities for images and videos.
  * Enhanced multimodal placeholder handling for improved image and video processing.
  * Added comprehensive documentation for Nemotron-Nano-v2-VL model series with inference examples.

* **Bug Fixes**
  * Fixed prompt formatting for video and image frame sequences.
  * Improved chat template role assignment for better conversation handling.

* **Tests**
  * Expanded test coverage for new Nemotron Nano model variants across multiple modalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
