### PR TITLE
[https://nvbugs/5478158][fix] Disable paged context FMHA for INT4/AWQ + FP8 KV-cache in torch flow

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1294,7 +1294,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             # Context MLA uses separate qkv instead of paged_context_fmha
             use_paged_context_fmha = False
 
-        if self.quant_config.layer_quant_mode.has_fp8_kv_cache(
+        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_kv_cache(
         ) and self.quant_config.quant_algo == QuantAlgo.W4A16_AWQ and use_paged_context_fmha:
             logger.warning(
                 "Disabling Paged context FMHA, as it is not supported with FP8 KV cache, for W4A16 AWQ quantization"

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1296,10 +1296,9 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
 
         if self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_kv_cache(
         ) and self.quant_config.quant_algo == QuantAlgo.W4A16_AWQ and use_paged_context_fmha:
-            logger.warning(
-                "Disabling Paged context FMHA, as it is not supported with FP8 KV cache, for W4A16 AWQ quantization"
+            raise ValueError(
+                "Paged context FMHA is not supported with FP8 KV cache, for W4A16 AWQ quantization - disable chunked perfill and kv cache reuse"
             )
-            use_paged_context_fmha = False
 
         use_nvfp4_output = False
         if enable_attn_nvfp4_output and self.has_nvfp4 and self.support_nvfp4_output(


### PR DESCRIPTION
INT4/AWQ (FP16/BF16 compute) + FP8 KV-cache + paged context FMHA requests a fused kernel meta that isn’t precompiled -> “FMHA kernels are not found” at context prefill, despite scales/KV-cache being correct.

root cause:
Fused context FMHA key: D=128, causal, Layout=Q_PAGED_KV (ragged), Q=FP16/BF16, KV=FP8.

disabling aged context FMHA make it works.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of incompatible quantization configurations. When FP8 KV cache is used with W4A16 AWQ quantization and paged context FMHA, the system now logs a warning and automatically disables paged context FMHA to ensure stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->