### PR TITLE
[https://nvbugs/5575920][fix] Fix cublas/cublasLt handle creation memory not sufficient error

### DIFF
--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -290,13 +290,10 @@ std::shared_ptr<cublasHandle_t> getCublasHandle()
             logMemoryAndHandleError("Creating cublas handle", ctx);
 
             auto handle = std::make_unique<cublasHandle_t>();
-
             cublasStatus_t status = cublasCreate(handle.get());
 
-            if (status != CUBLAS_STATUS_SUCCESS)
-            {
-                logMemoryAndHandleError("cublas handle", ctx, status);
-            }
+            // This will log memory state and throw if status != SUCCESS
+            logMemoryAndHandleError("cublas handle", ctx, status);
 
             return handle;
         },
@@ -322,13 +319,10 @@ std::shared_ptr<cublasLtHandle_t> getCublasLtHandle()
             logMemoryAndHandleError("Creating cublasLt handle", ctx);
 
             auto handle = std::make_unique<cublasLtHandle_t>();
-
             cublasStatus_t status = cublasLtCreate(handle.get());
 
-            if (status != CUBLAS_STATUS_SUCCESS)
-            {
-                logMemoryAndHandleError("cublasLt handle", ctx, status);
-            }
+            // This will log memory state and throw if status != SUCCESS
+            logMemoryAndHandleError("cublasLt handle", ctx, status);
 
             return handle;
         },

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -284,9 +284,6 @@ inline void logMemoryUsage(char const* operation, CUcontext ctx)
 // Helper function to throw
 inline void throwCublasErrorWithMemInfo(char const* operation, CUcontext ctx, cublasStatus_t status)
 {
-
-    logMemoryUsage(operation, ctx);
-
     auto const mem = getMemoryInfo();
     TLLM_THROW(
         "Failed to create %s. "

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -264,6 +264,21 @@ static std::pair<size_t, size_t> logMemoryUsage(char const* operation, CUcontext
     return {free_mem, total_mem};
 }
 
+// Helper function to handle memory-related errors for cublas handle creation.
+static void throwCublasMemoryError(char const* handleType, cublasStatus_t status, CUcontext ctx)
+{
+    // Re-fetch and log current memory state for debugging
+    auto [free_mem, total_mem] = logMemoryUsage(
+        (std::string("Failed to create ") + handleType + " - logging current memory state").c_str(), ctx);
+
+    TLLM_THROW(
+        "Failed to create %s. "
+        "Status: %d, Context: %p, Free Memory: %zu MB (%.1f%%), Total: %zu MB. "
+        "Consider reducing kv_cache_config.free_gpu_memory_fraction.",
+        handleType, status, ctx, free_mem / (1024 * 1024), (float) free_mem / total_mem * 100.0,
+        total_mem / (1024 * 1024));
+}
+
 } // namespace
 
 std::shared_ptr<cublasHandle_t> getCublasHandle()
@@ -280,14 +295,7 @@ std::shared_ptr<cublasHandle_t> getCublasHandle()
 
             if (status != CUBLAS_STATUS_SUCCESS)
             {
-                // Re-fetch memory info for error message (memory state might have changed)
-                cudaMemGetInfo(&free_mem, &total_mem);
-                TLLM_THROW(
-                    "Failed to create cublas handle. "
-                    "Status: %d, Context: %p, Free Memory: %zu MB (%.1f%%), Total: %zu MB. "
-                    "Consider reducing kv_cache_config.max_tokens or free_gpu_memory_fraction.",
-                    status, ctx, free_mem / (1024 * 1024), (float) free_mem / total_mem * 100.0,
-                    total_mem / (1024 * 1024));
+                throwCublasMemoryError("cublas handle", status, ctx);
             }
 
             return handle;
@@ -319,14 +327,7 @@ std::shared_ptr<cublasLtHandle_t> getCublasLtHandle()
 
             if (status != CUBLAS_STATUS_SUCCESS)
             {
-                // Re-fetch memory info for error message (memory state might have changed)
-                cudaMemGetInfo(&free_mem, &total_mem);
-                TLLM_THROW(
-                    "Failed to create cublasLt handle. "
-                    "Status: %d, Context: %p, Free Memory: %zu MB (%.1f%%), Total: %zu MB. "
-                    "Consider reducing kv_cache_config.max_tokens or free_gpu_memory_fraction.",
-                    status, ctx, free_mem / (1024 * 1024), (float) free_mem / total_mem * 100.0,
-                    total_mem / (1024 * 1024));
+                throwCublasMemoryError("cublasLt handle", status, ctx);
             }
 
             return handle;

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -261,20 +261,20 @@ struct MemoryInfo
 };
 
 // Helper function to get current memory information
-inline MemoryInfo getMemoryInfo()
+MemoryInfo getMemoryInfo()
 {
     size_t free_mem = 0, total_mem = 0;
     TLLM_CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem));
 
-    const size_t free_mb = free_mem / (1024 * 1024);
-    const size_t total_mb = total_mem / (1024 * 1024);
+    size_t const free_mb = free_mem / (1024 * 1024);
+    size_t const total_mb = total_mem / (1024 * 1024);
     float const free_percent = (total_mem > 0) ? (static_cast<float>(free_mem) / total_mem * 100.0f) : 0.0f;
 
     return {free_mb, total_mb, free_percent};
 }
 
 // Helper function to log current memory usage
-inline void logMemoryUsage(char const* operation, CUcontext ctx)
+void logMemoryUsage(char const* operation, CUcontext ctx)
 {
     auto const mem = getMemoryInfo();
     TLLM_LOG_DEBUG("%s: Context=%p, Free Memory=%zu MB (%.1f%%), Total=%zu MB", operation, ctx, mem.free_mb,
@@ -282,7 +282,7 @@ inline void logMemoryUsage(char const* operation, CUcontext ctx)
 }
 
 // Helper function to throw
-inline void throwCublasErrorWithMemInfo(char const* operation, CUcontext ctx, cublasStatus_t status)
+void throwCublasErrorWithMemInfo(char const* operation, CUcontext ctx, cublasStatus_t status)
 {
     auto const mem = getMemoryInfo();
     TLLM_THROW(

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -252,31 +252,47 @@ private:
     std::unordered_map<CacheKey, std::weak_ptr<T>, hash<CacheKey>>* mObservers;
 };
 
-// Unified helper function for memory logging and error handling
-// If status is CUBLAS_STATUS_SUCCESS, it just logs memory usage
-// Otherwise, it logs and throws an error with memory diagnostics
-static void logMemoryAndHandleError(char const* operation, CUcontext ctx, cublasStatus_t status = CUBLAS_STATUS_SUCCESS)
+// Structure to hold memory information
+struct MemoryInfo
+{
+    size_t free_mb;
+    size_t total_mb;
+    float free_percent;
+};
+
+// Helper function to get current memory information
+inline MemoryInfo getMemoryInfo()
 {
     size_t free_mem = 0, total_mem = 0;
     TLLM_CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem));
 
-    size_t free_mb = free_mem / (1024 * 1024);
-    size_t total_mb = total_mem / (1024 * 1024);
-    float free_percent = (total_mem > 0) ? ((float) free_mem / total_mem * 100.0f) : 0.0f;
+    const size_t free_mb = free_mem / (1024 * 1024);
+    const size_t total_mb = total_mem / (1024 * 1024);
+    float const free_percent = (total_mem > 0) ? (static_cast<float>(free_mem) / total_mem * 100.0f) : 0.0f;
 
-    // Always log the memory state
-    TLLM_LOG_DEBUG(
-        "%s: Context=%p, Free Memory=%zu MB (%.1f%%), Total=%zu MB", operation, ctx, free_mb, free_percent, total_mb);
+    return {free_mb, total_mb, free_percent};
+}
 
-    // If there's an error, throw with details
-    if (status != CUBLAS_STATUS_SUCCESS)
-    {
-        TLLM_THROW(
-            "Failed to create %s. "
-            "Status: %d, Context: %p, Free Memory: %zu MB (%.1f%%), Total: %zu MB. "
-            "Consider reducing kv_cache_config.free_gpu_memory_fraction.",
-            operation, status, ctx, free_mb, free_percent, total_mb);
-    }
+// Helper function to log current memory usage
+inline void logMemoryUsage(char const* operation, CUcontext ctx)
+{
+    auto const mem = getMemoryInfo();
+    TLLM_LOG_DEBUG("%s: Context=%p, Free Memory=%zu MB (%.1f%%), Total=%zu MB", operation, ctx, mem.free_mb,
+        mem.free_percent, mem.total_mb);
+}
+
+// Helper function to throw
+inline void throwCublasErrorWithMemInfo(char const* operation, CUcontext ctx, cublasStatus_t status)
+{
+
+    logMemoryUsage(operation, ctx);
+
+    auto const mem = getMemoryInfo();
+    TLLM_THROW(
+        "Failed to create %s. "
+        "Status: %d, Context: %p, Free Memory: %zu MB (%.1f%%), Total: %zu MB. "
+        "Consider reducing kv_cache_config.free_gpu_memory_fraction.",
+        operation, status, ctx, mem.free_mb, mem.free_percent, mem.total_mb);
 }
 
 } // namespace
@@ -287,13 +303,15 @@ std::shared_ptr<cublasHandle_t> getCublasHandle()
         []() -> auto
         {
             CUcontext ctx = getCurrentCudaCtx();
-            logMemoryAndHandleError("Creating cublas handle", ctx);
+            logMemoryUsage("Creating cublas handle", ctx);
 
             auto handle = std::make_unique<cublasHandle_t>();
             cublasStatus_t status = cublasCreate(handle.get());
 
-            // This will log memory state and throw if status != SUCCESS
-            logMemoryAndHandleError("cublas handle", ctx, status);
+            if (status != CUBLAS_STATUS_SUCCESS)
+            {
+                throwCublasErrorWithMemInfo("cublas handle", ctx, status);
+            }
 
             return handle;
         },
@@ -316,13 +334,15 @@ std::shared_ptr<cublasLtHandle_t> getCublasLtHandle()
         []() -> auto
         {
             CUcontext ctx = getCurrentCudaCtx();
-            logMemoryAndHandleError("Creating cublasLt handle", ctx);
+            logMemoryUsage("Creating cublasLt handle", ctx);
 
             auto handle = std::make_unique<cublasLtHandle_t>();
             cublasStatus_t status = cublasLtCreate(handle.get());
 
-            // This will log memory state and throw if status != SUCCESS
-            logMemoryAndHandleError("cublasLt handle", ctx, status);
+            if (status != CUBLAS_STATUS_SUCCESS)
+            {
+                throwCublasErrorWithMemInfo("cublasLt handle", ctx, status);
+            }
 
             return handle;
         },

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -121,7 +121,7 @@ endef
 	@echo "Pulling docker image: $(IMAGE_WITH_TAG)"
 	docker pull $(IMAGE_WITH_TAG)
 
-DOCKER_RUN_OPTS ?= --rm -it --ipc=host --ulimit stack=67108864 $(if $(filter 0,$(IS_ROOTLESS)),--ulimit memlock=-1)
+DOCKER_RUN_OPTS ?= --rm -it --ipc=host --ulimit stack=67108864 $(if $(filter 0,$(IS_ROOTLESS)),--ulimit memlock=-1) --privileged
 DOCKER_RUN_ARGS   ?=
 # Check if NVIDIA_VISIBLE_DEVICES is set and not empty
 NVIDIA_VISIBLE_DEVICES_VAL = $(shell echo $$NVIDIA_VISIBLE_DEVICES)
@@ -156,6 +156,7 @@ endif
 	docker run $(DOCKER_RUN_OPTS) $(DOCKER_RUN_ARGS) \
     		$(GPU_OPTS) \
     		--volume $(SOURCE_DIR):$(CODE_DIR) \
+			--volume /home/scratch.trt_llm_data/:/scratch.trt_llm_data/ \
     		$(EXTRA_VOLUMES) \
     		$(if $(and $(filter 1,$(LOCAL_USER)),$(shell [ -w "$(USER_CACHE_DIR)" ] && echo 1)),--volume $(USER_CACHE_DIR):/home/$(USER_NAME)/.cache:rw) \
     		--env "CCACHE_DIR=$(CCACHE_DIR)" \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -121,7 +121,7 @@ endef
 	@echo "Pulling docker image: $(IMAGE_WITH_TAG)"
 	docker pull $(IMAGE_WITH_TAG)
 
-DOCKER_RUN_OPTS ?= --rm -it --ipc=host --ulimit stack=67108864 $(if $(filter 0,$(IS_ROOTLESS)),--ulimit memlock=-1) --privileged
+DOCKER_RUN_OPTS ?= --rm -it --ipc=host --ulimit stack=67108864 $(if $(filter 0,$(IS_ROOTLESS)),--ulimit memlock=-1)
 DOCKER_RUN_ARGS   ?=
 # Check if NVIDIA_VISIBLE_DEVICES is set and not empty
 NVIDIA_VISIBLE_DEVICES_VAL = $(shell echo $$NVIDIA_VISIBLE_DEVICES)
@@ -156,7 +156,6 @@ endif
 	docker run $(DOCKER_RUN_OPTS) $(DOCKER_RUN_ARGS) \
     		$(GPU_OPTS) \
     		--volume $(SOURCE_DIR):$(CODE_DIR) \
-			--volume /home/scratch.trt_llm_data/:/scratch.trt_llm_data/ \
     		$(EXTRA_VOLUMES) \
     		$(if $(and $(filter 1,$(LOCAL_USER)),$(shell [ -w "$(USER_CACHE_DIR)" ] && echo 1)),--volume $(USER_CACHE_DIR):/home/$(USER_NAME)/.cache:rw) \
     		--env "CCACHE_DIR=$(CCACHE_DIR)" \

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -155,7 +155,10 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             disable_overlap_scheduler=torch_compile,
         )
         if fp8kv:
-            pytorch_config["kv_cache_config"] = KvCacheConfig(dtype="fp8")
+            pytorch_config["kv_cache_config"] = KvCacheConfig(
+                dtype="fp8",
+                # max_tokens=100000,  # Limit tokens to prevent no room for CUBLAS handles
+            )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",
                 **pytorch_config) as llm:
@@ -189,7 +192,10 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             disable_overlap_scheduler=torch_compile,
         )
         if fp8kv:
-            pytorch_config["kv_cache_config"] = KvCacheConfig(dtype="fp8")
+            pytorch_config["kv_cache_config"] = KvCacheConfig(
+                dtype="fp8",
+                # max_tokens=100000,  # Limit tokens to prevent no room for CUBLAS handles
+            )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",
                 tensor_parallel_size=tp_size,

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -157,7 +157,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         if fp8kv:
             pytorch_config["kv_cache_config"] = KvCacheConfig(
                 dtype="fp8",
-                # max_tokens=100000,  # Limit tokens to prevent no room for CUBLAS handles
+                max_tokens=
+                100000,  # Limit tokens to prevent no room for cublas/cublasLt handles
             )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",
@@ -194,7 +195,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         if fp8kv:
             pytorch_config["kv_cache_config"] = KvCacheConfig(
                 dtype="fp8",
-                # max_tokens=100000,  # Limit tokens to prevent no room for CUBLAS handles
+                max_tokens=
+                100000,  # Limit tokens to prevent no room for cublas/cublasLt handles
             )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -157,8 +157,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         if fp8kv:
             pytorch_config["kv_cache_config"] = KvCacheConfig(
                 dtype="fp8",
-                max_tokens=
-                100000,  # Limit tokens to prevent no room for cublas/cublasLt handles
+                free_gpu_memory_fraction=
+                0.8,  # Prevent cublas/cublasLt handle allocation memory insufficient errors
             )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",
@@ -195,8 +195,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         if fp8kv:
             pytorch_config["kv_cache_config"] = KvCacheConfig(
                 dtype="fp8",
-                max_tokens=
-                100000,  # Limit tokens to prevent no room for cublas/cublasLt handles
+                free_gpu_memory_fraction=
+                0.8,  # Prevent cublas/cublasLt handle allocation memory insufficient errors
             )
         with LLM(
                 f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory management instrumentation and error handling for GPU operations, providing better diagnostic information when issues occur.
  * Improved stability during FP8 KV cache operations by optimizing memory allocation parameters in test scenarios.

* **Tests**
  * Updated test configurations to improve reliability and reduce memory-related issues during accuracy testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
