### PR TITLE
[TRTLLM-8948][test] Add long bench case

### DIFF
--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -433,6 +433,142 @@ class PassKeyRetrieval128k(AccuracyTask):
     MAX_OUTPUT_LEN = 50
 
 
+class LongBenchV2(AccuracyTask):
+    DATASET = "longbench_v2"
+
+    # Hypothesis testing parameters
+    # Using similar parameters as MMLU/GSM8K for consistency
+    ALPHA = 0.05
+    BETA = 0.2
+    SIGMA = 50.0
+    NUM_SAMPLES = 215
+
+    # Input and output sizes
+    MAX_BATCH_SIZE = 32
+    MAX_INPUT_LEN = 1280000
+    MAX_OUTPUT_LEN = 32000
+
+    # Evaluator class
+    EVALUATOR_CLS = tensorrt_llm.evaluate.LongBenchV2
+
+    def __init__(self,
+                 model_name: str,
+                 dataset_path: str = None,
+                 length: str = "medium",
+                 max_len: int = 1280000,
+                 max_input_length: int = 1280000,
+                 max_output_length: int = 32000):
+        """
+        Initialize LongBenchV2 task.
+
+        Args:
+            model_name: Name of the model being evaluated
+            dataset_path: Path to LongBench-v2 dataset
+            length: Length setting (short/medium/long)
+            max_len: Maximum sequence length for prompt truncation
+            max_input_length: Maximum input length for sampling params
+            max_output_length: Maximum output length for sampling params
+        """
+        super().__init__(model_name)
+        self.dataset_path = dataset_path or f"{llm_models_root()}/zai-org/LongBench-v2"
+        self.length = length
+        self.max_len = max_len
+        self.max_input_length = max_input_length
+        self.max_output_length = max_output_length
+
+        # Update evaluator kwargs with instance-specific parameters
+        self.EVALUATOR_KWARGS = dict(
+            dataset_path=self.dataset_path,
+            length=self.length,
+            max_len=self.max_len,
+            apply_chat_template=True,
+            random_seed=0,
+        )
+
+        # Override max input/output lengths
+        self.MAX_INPUT_LEN = max_input_length
+        self.MAX_OUTPUT_LEN = max_output_length
+
+    @staticmethod
+    def create_modified_model_dir(original_model_dir: str,
+                                  max_position_embeddings: int = 1280000,
+                                  model_max_length: int = 1280000) -> str:
+        """
+        Create temporary directory with modified config files for long context evaluation.
+
+        This method creates a temporary directory with symlinks to all model files except
+        config files, which are copied and modified to support longer context lengths.
+        This is useful for evaluating models on long context tasks that exceed the
+        original model's max_position_embeddings.
+
+        Args:
+            original_model_dir: Path to the original model directory
+            max_position_embeddings: New value for max_position_embeddings in config.json
+            model_max_length: New value for model_max_length in tokenizer_config.json
+
+        Returns:
+            Path to the temporary modified model directory
+
+        Note:
+            The caller is responsible for cleaning up the temporary directory after use.
+        """
+        import tempfile
+
+        # Create temporary model directory with symlinks
+        temp_dir = tempfile.mkdtemp(prefix="longbench_v2_modified_model_")
+        logger.info(f"Created temporary model directory: {temp_dir}")
+
+        # Create symlinks for all files except config files
+        for item in os.listdir(original_model_dir):
+            src = os.path.join(original_model_dir, item)
+            dst = os.path.join(temp_dir, item)
+
+            # Skip config files - will handle them separately
+            if item in ["config.json", "tokenizer_config.json"]:
+                continue
+
+            # Create symlink for other files/directories
+            os.symlink(src, dst)
+            logger.info(f"  Symlinked: {item}")
+
+        # Modify and copy config.json
+        config_src = os.path.join(original_model_dir, "config.json")
+        config_dst = os.path.join(temp_dir, "config.json")
+        if os.path.exists(config_src):
+            with open(config_src, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+
+            # Modify max_position_embeddings
+            original_max_pos = config.get('max_position_embeddings')
+            config['max_position_embeddings'] = max_position_embeddings
+            logger.info(
+                f"  Modified config.json: max_position_embeddings {original_max_pos} -> {max_position_embeddings}"
+            )
+
+            with open(config_dst, 'w', encoding='utf-8') as f:
+                json.dump(config, f, indent=2, ensure_ascii=False)
+
+        # Modify and copy tokenizer_config.json
+        tokenizer_config_src = os.path.join(original_model_dir,
+                                            "tokenizer_config.json")
+        tokenizer_config_dst = os.path.join(temp_dir, "tokenizer_config.json")
+        if os.path.exists(tokenizer_config_src):
+            with open(tokenizer_config_src, 'r', encoding='utf-8') as f:
+                tokenizer_config = json.load(f)
+
+            # Modify model_max_length
+            original_max_len = tokenizer_config.get('model_max_length')
+            tokenizer_config['model_max_length'] = model_max_length
+            logger.info(
+                f"  Modified tokenizer_config.json: model_max_length {original_max_len} -> {model_max_length}"
+            )
+
+            with open(tokenizer_config_dst, 'w', encoding='utf-8') as f:
+                json.dump(tokenizer_config, f, indent=2, ensure_ascii=False)
+
+        return temp_dir
+
+
 class CliFlowAccuracyTestHarness:
     # Model
     MODEL_NAME = None

--- a/tests/integration/defs/accuracy/references/longbench_v2.yaml
+++ b/tests/integration/defs/accuracy/references/longbench_v2.yaml
@@ -1,0 +1,10 @@
+DeepSeek-R1-0528:
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    spec_dec_algo: MTP
+    accuracy: 45.0
+
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    spec_dec_algo: MTP
+    accuracy: 45.0

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -3501,7 +3501,7 @@ def test_llmapi_generation_logits(llm_venv, model_path,
 
 
 @skip_pre_blackwell
-@pytest.mark.skip_less_device_memory(189000)
+@pytest.mark.skip_less_device_memory(183000)
 @pytest.mark.timeout(28800)
 @pytest.mark.parametrize("model_name,model_path,gpu_count", [
     ("DeepSeek-R1-0528", "DeepSeek-R1/DeepSeek-R1-0528", 8),
@@ -3616,6 +3616,7 @@ def test_longbench_v2_multigpus(llm_venv, model_name, model_path, gpu_count):
             "--kv_cache_free_gpu_memory_fraction=0.8",
             f"--extra_llm_api_options={extra_config_file.name}",
             "longbench_v2",
+            f"--dataset_path={llm_models_root()}/zai-org/LongBench-v2",
             "--length=medium",
             "--max_len=1280000",
             "--max_input_length=1280000",

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -3501,10 +3501,10 @@ def test_llmapi_generation_logits(llm_venv, model_path,
 
 
 @skip_pre_blackwell
-@pytest.mark.skip_less_device_memory(192000)
+@pytest.mark.skip_less_device_memory(189000)
 @pytest.mark.parametrize("model_name,model_path,gpu_count", [
-    ("DeepSeek-R1-0528", "DeepSeek-R1/DeepSeek-R1-0528", "8"),
-    ("DeepSeek-R1-0528-FP4", "DeepSeek-R1/DeepSeek-R1-0528-FP4", "4"),
+    ("DeepSeek-R1-0528", "DeepSeek-R1/DeepSeek-R1-0528", 8),
+    ("DeepSeek-R1-0528-FP4", "DeepSeek-R1/DeepSeek-R1-0528-FP4", 4),
 ])
 def test_longbench_v2_multigpus(llm_venv, model_name, model_path, gpu_count):
     original_model_dir = Path(llm_models_root()) / model_path
@@ -3619,6 +3619,8 @@ def test_longbench_v2_multigpus(llm_venv, model_name, model_path, gpu_count):
             "--max_len=1280000",
             "--max_input_length=1280000",
             "--max_output_length=32000",
+            "--check_accuracy",
+            "--accuracy_threshold=45.0",
         ]
 
         print(f"\nRunning command:")

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -3502,6 +3502,7 @@ def test_llmapi_generation_logits(llm_venv, model_path,
 
 @skip_pre_blackwell
 @pytest.mark.skip_less_device_memory(189000)
+@pytest.mark.timeout(28800)
 @pytest.mark.parametrize("model_name,model_path,gpu_count", [
     ("DeepSeek-R1-0528", "DeepSeek-R1/DeepSeek-R1-0528", 8),
     ("DeepSeek-R1-0528-FP4", "DeepSeek-R1/DeepSeek-R1-0528-FP4", 4),

--- a/tests/integration/test_lists/qa/llm_function_long_bench.txt
+++ b/tests/integration/test_lists/qa/llm_function_long_bench.txt
@@ -1,0 +1,2 @@
+test_e2e.py::test_longbench_v2_multigpus[DeepSeek-R1-0528-DeepSeek-R1/DeepSeek-R1-0528-8]
+test_e2e.py::test_longbench_v2_multigpus[DeepSeek-R1-0528-FP4-DeepSeek-R1/DeepSeek-R1-0528-FP4-4]


### PR DESCRIPTION
This PR only run once to get the accuracy number, the accuracy threshold is 45.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LongBench v2 evaluation CLI adds optional accuracy checking with a configurable threshold; runs will emit a warning and fail if measured accuracy falls below the threshold.

* **Tests**
  * Added end-to-end multi-GPU tests covering long-context model evaluation with the new accuracy-checking workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
