### PR TITLE
[https://nvbugs/5625972][fix] Patch llama4 export for bug in torch2.9

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/patches/llama4_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/llama4_rope.py
@@ -1,0 +1,69 @@
+"""Patch for Llama4 Rotary Embedding to use custom polar op."""
+# TODO(fridah): remove this patch once the issue introduced in https://github.com/pytorch/pytorch/pull/160894 is solved
+
+import torch
+from transformers.models.llama4.modeling_llama4 import Llama4TextRotaryEmbedding
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+@torch.library.custom_op("auto_deploy::polar", mutates_args=())
+def polar_custom(abs: torch.Tensor, angle: torch.Tensor) -> torch.Tensor:
+    """Custom wrapper for torch.polar."""
+    real = abs * torch.cos(angle)
+    imag = abs * torch.sin(angle)
+    return torch.complex(real, imag)
+
+
+@polar_custom.register_fake
+def polar_custom_fake(abs: torch.Tensor, angle: torch.Tensor) -> torch.Tensor:
+    """Fake implementation for export."""
+    out_dtype = torch.complex64 if abs.dtype == torch.float32 else torch.complex128
+    return torch.empty_like(abs, dtype=out_dtype)
+
+
+def _forward_rope(self: Llama4TextRotaryEmbedding, x, position_ids):
+    inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    position_ids_expanded = position_ids[:, None, :].float()
+
+    device_type = (
+        x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+    )
+    with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+        freqs = (inv_freq_expanded.to(x.device) @ position_ids_expanded).transpose(1, 2)
+
+        # Use custom polar op instead of torch.polar
+        freqs_cis = torch.ops.auto_deploy.polar(torch.ones_like(freqs), freqs)
+        freqs_cis = freqs_cis * self.attention_scaling
+
+    return freqs_cis
+
+
+@ExportPatchRegistry.register("hf_llama4_rope")
+class Llama4RopePatch(BaseExportPatch):
+    """
+    Patch for Llama4 Rotary Embedding to make it compatible with torch.export.
+
+    This patch replaces torch.polar with our custom polar op in the
+    Llama4TextRotaryEmbedding forward method to avoid shape prop issues
+    with aten::polar Meta kernel during export/tracing.
+    """
+
+    def _apply_patch(self):
+        """Apply the Llama4 RoPE patch."""
+        self.original_values["Llama4TextRotaryEmbedding.forward"] = (
+            Llama4TextRotaryEmbedding.forward
+        )
+
+        Llama4TextRotaryEmbedding._original_forward = Llama4TextRotaryEmbedding.forward
+
+        Llama4TextRotaryEmbedding.forward = _forward_rope
+
+    def _revert_patch(self):
+        """Revert the Llama4 RoPE patch."""
+        Llama4TextRotaryEmbedding.forward = self.original_values[
+            "Llama4TextRotaryEmbedding.forward"
+        ]
+
+        if hasattr(Llama4TextRotaryEmbedding, "_original_forward"):
+            delattr(Llama4TextRotaryEmbedding, "_original_forward")

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -114,7 +114,7 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
                 },
             },
         ),
-        pytest.param(
+        (
             "meta-llama/Llama-4-Scout-17B-16E-Instruct",
             {
                 "transforms": {
@@ -122,7 +122,6 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
                     "compile_model": {"backend": "torch-opt"},
                 },
             },
-            marks=pytest.mark.skip(reason="https://nvbugs/5625972"),
         ),
         (
             "meta-llama/Llama-4-Scout-17B-16E-Instruct",


### PR DESCRIPTION
patch torch.polar for llama4 for bug in torch2.9
closes https://github.com/NVIDIA/TensorRT-LLM/issues/8924
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom operator support for complex number handling in model export and compilation workflows.

* **Tests**
  * Enabled testing for an additional model configuration to ensure broader compatibility coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
