### PR TITLE
[TRTLLM-9179][feat] add pp_partition to customize each rank's layer number

### DIFF
--- a/docs/source/developer-guide/api-change.md
+++ b/docs/source/developer-guide/api-change.md
@@ -45,14 +45,17 @@ All API schemas are:
 Argument names should describe what the argument represents, not how it is used internally.
 
 ✅ **Good**: `max_new_tokens` (clear meaning)
+
 ❌ **Bad**: `num` (ambiguous)
 
 **Reflect Argument Type and Granularity**
 
 - For **boolean** knobs, prefix with verbs like `enable_` and so on.
+
   Examples: `enable_cache`, `enable_flash_attention`
 
 - For **numerical threshold** knobs, suffix with `_limit`, `_size`, `_count`, `_len_` or `_ratio`
+
   Examples: `max_seq_len`, `prefill_batch_size`
 
 **Avoid Redundant Prefixes**
@@ -60,6 +63,7 @@ Argument names should describe what the argument represents, not how it is used 
 Example (in `MoeConfig`):
 
 ✅ **Good**: `backend`
+
 ❌ **Bad**: `moe_backend` (redundant since it's already in `MoeConfig`)
 
 **Use Specific Names for Narrow Scenarios**
@@ -69,6 +73,7 @@ When adding knobs for specific use cases, make the name convey the restriction c
 Example (argument to the LLM class):
 
 ✅ **Good**: `rope_scaling_factor` → clearly indicates it's for RoPE
+
 ❌ **Bad**: `scaling_factor` → too generic and prone to misuse
 
 ### 2. Hierarchical Configuration
@@ -78,12 +83,15 @@ Organize complex or hierarchical arguments into **dedicated configuration datacl
 **Guidelines**
 
 - Use the `XxxConfig` suffix consistently
+
   Examples: `ModelConfig`, `ParallelConfig`, `MoeConfig`
 
 - **Reflect conceptual hierarchy**
+
   The dataclass name should represent a coherent functional unit, not an arbitrary grouping
 
 - **Avoid over-nesting**
+
   Use only one level of configuration hierarchy whenever possible (e.g., `LlmArgs → ParallelConfig`) to balance readability and modularity
 
 ### 3. Prefer `LlmArgs` Over Environment Variables

--- a/docs/source/developer-guide/api-change.md
+++ b/docs/source/developer-guide/api-change.md
@@ -34,7 +34,7 @@ TensorRT LLM classifies APIs into two categories:
 All API schemas are:
 - Stored as YAML files in the codebase
 - Protected by unit tests in `tests/unittest/api_stability/`
-- Automatically validated to ensure consistency 
+- Automatically validated to ensure consistency
 
 ## API Change Principles
 
@@ -44,7 +44,7 @@ All API schemas are:
 
 Argument names should describe what the argument represents, not how it is used internally.
 
-✅ **Good**: `max_new_tokens` (clear meaning)  
+✅ **Good**: `max_new_tokens` (clear meaning)
 ❌ **Bad**: `num` (ambiguous)
 
 **Reflect Argument Type and Granularity**
@@ -52,14 +52,14 @@ Argument names should describe what the argument represents, not how it is used 
 - For **boolean** knobs, prefix with verbs like `enable_` and so on.
   Examples: `enable_cache`, `enable_flash_attention`
 
-- For **numerical threshold** knobs, suffix with `_limit`, `_size`, `_count`, `_len_` or `_ratio`  
+- For **numerical threshold** knobs, suffix with `_limit`, `_size`, `_count`, `_len_` or `_ratio`
   Examples: `max_seq_len`, `prefill_batch_size`
 
 **Avoid Redundant Prefixes**
 
 Example (in `MoeConfig`):
 
-✅ **Good**: `backend`  
+✅ **Good**: `backend`
 ❌ **Bad**: `moe_backend` (redundant since it's already in `MoeConfig`)
 
 **Use Specific Names for Narrow Scenarios**
@@ -68,7 +68,7 @@ When adding knobs for specific use cases, make the name convey the restriction c
 
 Example (argument to the LLM class):
 
-✅ **Good**: `rope_scaling_factor` → clearly indicates it's for RoPE  
+✅ **Good**: `rope_scaling_factor` → clearly indicates it's for RoPE
 ❌ **Bad**: `scaling_factor` → too generic and prone to misuse
 
 ### 2. Hierarchical Configuration
@@ -77,13 +77,13 @@ Organize complex or hierarchical arguments into **dedicated configuration datacl
 
 **Guidelines**
 
-- Use the `XxxConfig` suffix consistently  
+- Use the `XxxConfig` suffix consistently
   Examples: `ModelConfig`, `ParallelConfig`, `MoeConfig`
-  
-- **Reflect conceptual hierarchy**  
+
+- **Reflect conceptual hierarchy**
   The dataclass name should represent a coherent functional unit, not an arbitrary grouping
-  
-- **Avoid over-nesting**  
+
+- **Avoid over-nesting**
   Use only one level of configuration hierarchy whenever possible (e.g., `LlmArgs → ParallelConfig`) to balance readability and modularity
 
 ### 3. Prefer `LlmArgs` Over Environment Variables
@@ -154,7 +154,7 @@ garbage_collection_gen0_threshold: int = Field(
 
 Add the field to the appropriate schema file:
 
-- **Non-committed arguments**: `tests/unittest/api_stability/references/llm_args.yaml`
+- **Non-committed arguments**: `tests/unittest/api_stability/references/llm.yaml`
   ```yaml
   garbage_collection_gen0_threshold:
     type: int
@@ -162,7 +162,7 @@ Add the field to the appropriate schema file:
     status: beta  # Must match the status in code
   ```
 
-- **Committed arguments**: `tests/unittest/api_stability/references_committed/llm_args.yaml`
+- **Committed arguments**: `tests/unittest/api_stability/references_committed/llm.yaml`
   ```yaml
   garbage_collection_gen0_threshold:
     type: int
@@ -196,16 +196,16 @@ For non-committed APIs, use the `@set_api_status` decorator:
 ```python
 @set_api_status("beta")
 def generate_with_streaming(
-    self, 
-    prompts: List[str], 
+    self,
+    prompts: List[str],
     **kwargs
 ) -> Iterator[GenerationOutput]:
     """Generate text with streaming output.
-    
+
     Args:
         prompts: Input prompts for generation
         **kwargs: Additional generation parameters
-        
+
     Returns:
         Iterator of generation outputs
     """

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -326,6 +326,7 @@ class _ParallelConfig(StrictBaseModel):
     moe_tp_size: int = -1
     moe_ep_size: int = -1
     cp_config: dict = Field(default_factory=dict)
+    pp_partition: Optional[List[int]] = Field(default=None)
     enable_attention_dp: bool = False
     enable_lm_head_tp_in_adp: bool = False
 
@@ -372,6 +373,7 @@ class _ParallelConfig(StrictBaseModel):
                        gpus_per_node=self.gpus_per_node,
                        tp_size=self.tp_size,
                        pp_size=self.pp_size,
+                       pp_partition=self.pp_partition,
                        cp_size=self.cp_size,
                        cp_config=self.cp_config,
                        enable_attention_dp=self.enable_attention_dp,
@@ -1587,6 +1589,12 @@ class BaseLlmArgs(StrictBaseModel):
         description="Enable LM head TP in attention dp.",
         status="prototype")
 
+    pp_partition: Optional[List[int]] = Field(
+        default=None,
+        description=
+        "Pipeline parallel partition, a list of each rank's layer number.",
+        status="prototype")
+
     cp_config: Optional[dict] = Field(default_factory=dict,
                                       description="Context parallel config.",
                                       status="prototype")
@@ -1843,6 +1851,7 @@ class BaseLlmArgs(StrictBaseModel):
             moe_ep_size=self.moe_expert_parallel_size,
             enable_attention_dp=self.enable_attention_dp,
             enable_lm_head_tp_in_adp=self.enable_lm_head_tp_in_adp,
+            pp_partition=self.pp_partition,
             cp_config=self.cp_config)
         return self
 

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -18,6 +18,10 @@ methods:
         annotation: Optional[dict]
         default: null
         status: prototype
+      pp_partition:
+        annotation: Optional[List[int]]
+        default: null
+        status: prototype
       # Stats
       iter_stats_max_iterations:
         annotation: Optional[int]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pp_partition` parameter to the LLM API enabling custom pipeline parallelism configuration. Users can now specify precise layer distribution strategies across pipeline stages for optimized performance in distributed LLM inference deployments.

* **Documentation**
  * Minor formatting and styling corrections applied to the API Change Guide documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

bs1, [16, 16, 15, 14+MTP3]:
- rank0: 96ms
- rank1: 95ms
- rank2: 95ms
- rank3: 106ms
 
bs1, [16, 15, 15, 15+MTP3]:
- rank0: 103ms
- rank1: 103ms
- rank2: 104ms
- rank3: 122ms
 
bs1, [16, 16, 16, 13+MTP3]:
- rank0: 94ms
- rank1: 100ms
- rank2: 104~108ms
- rank3: 95~100ms

Can improve from 122ms -> ~106ms

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

add test to existed PP tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
