### PR TITLE
[None][chore] Lock onnx version <1.20.0 and remove WAR for TRT 10.13

### DIFF
--- a/docs/source/installation/linux.md
+++ b/docs/source/installation/linux.md
@@ -57,14 +57,14 @@ There are some known limitations when you pip install pre-built TensorRT LLM whe
     to discover a SLURM installation in the usual places.
     ```
 
- 2. Prevent `pip` from replacing existing PyTorch installation
+2. Prevent `pip` from replacing existing PyTorch installation
 
-    On certain systems, particularly Ubuntu 22.04, users installing TensorRT LLM would find that their existing, CUDA 13.0 compatible PyTorch installation (e.g., `torch==2.9.0+cu130`) was being uninstalled by `pip`. It was then replaced by a CUDA 12.8 version (`torch==2.9.0`), causing the TensorRT LLM installation to be unusable and leading to runtime errors.
-   
-    The solution is to create a `pip` constraints file, locking `torch` to the currently installed version. Here is an example of how this can be done manually:
+   On certain systems, particularly Ubuntu 22.04, users installing TensorRT LLM would find that their existing, CUDA 13.0 compatible PyTorch installation (e.g., `torch==2.9.0+cu130`) was being uninstalled by `pip`. It was then replaced by a CUDA 12.8 version (`torch==2.9.0`), causing the TensorRT LLM installation to be unusable and leading to runtime errors.
 
-    ```bash
-    CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
-    echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
-    pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
-    ```
+   The solution is to create a `pip` constraints file, locking `torch` to the currently installed version. Here is an example of how this can be done manually:
+
+   ```bash
+   CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
+   echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
+   pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
+   ```

--- a/docs/source/installation/linux.md
+++ b/docs/source/installation/linux.md
@@ -56,3 +56,15 @@ There are some known limitations when you pip install pre-built TensorRT LLM whe
     when OMPI was not configured --with-slurm and we weren't able
     to discover a SLURM installation in the usual places.
     ```
+
+ 2. Prevent `pip` from replacing existing PyTorch installation
+
+   On certain systems, particularly Ubuntu 22.04, users installing TensorRT LLM would find that their existing, CUDA 13.0 compatible PyTorch installation (e.g., `torch==2.9.0+cu130`) was being uninstalled by `pip`. It was then replaced by a CUDA 12.8 version (`torch==2.9.0`), causing the TensorRT LLM installation to be unusable and leading to runtime errors.
+   
+   The solution is to create a `pip` constraints file, locking `torch` to the currently installed version. Here is an example of how this can be done manually:
+
+   ```bash
+   CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
+   echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
+   pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
+   ```

--- a/docs/source/installation/linux.md
+++ b/docs/source/installation/linux.md
@@ -59,12 +59,12 @@ There are some known limitations when you pip install pre-built TensorRT LLM whe
 
  2. Prevent `pip` from replacing existing PyTorch installation
 
-   On certain systems, particularly Ubuntu 22.04, users installing TensorRT LLM would find that their existing, CUDA 13.0 compatible PyTorch installation (e.g., `torch==2.9.0+cu130`) was being uninstalled by `pip`. It was then replaced by a CUDA 12.8 version (`torch==2.9.0`), causing the TensorRT LLM installation to be unusable and leading to runtime errors.
+    On certain systems, particularly Ubuntu 22.04, users installing TensorRT LLM would find that their existing, CUDA 13.0 compatible PyTorch installation (e.g., `torch==2.9.0+cu130`) was being uninstalled by `pip`. It was then replaced by a CUDA 12.8 version (`torch==2.9.0`), causing the TensorRT LLM installation to be unusable and leading to runtime errors.
    
-   The solution is to create a `pip` constraints file, locking `torch` to the currently installed version. Here is an example of how this can be done manually:
+    The solution is to create a `pip` constraints file, locking `torch` to the currently installed version. Here is an example of how this can be done manually:
 
-   ```bash
-   CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
-   echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
-   pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
-   ```
+    ```bash
+    CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
+    echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
+    pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
+    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ diffusers>=0.27.0
 lark
 mpi4py
 numpy<2
-onnx>=1.18.0
+onnx>=1.18.0,<1.20.0
 onnx_graphsurgeon>=0.5.2
 openai
 polygraphy

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,6 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
-# WAR for tensorrt depending on the archived nvidia-cuda-runtime-cu13 package
-nvidia-cuda-runtime-cu13==0.0.0a0
 tensorrt~=10.13.0
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-10.html#rel-25-10 uses 2.9.0a0.
 torch>=2.9.0a0,<=2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,7 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
-# WAR for tensorrt depending on the archived nvidia-cuda-runtime-cu13 package
-nvidia-cuda-runtime-cu13==0.0.0a0
-tensorrt==10.13.3.9
+tensorrt~=10.13.0
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-10.html#rel-25-10 uses 2.9.0a0.
 torch>=2.9.0a0,<=2.9.0
 torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
+# WAR for tensorrt depending on the archived nvidia-cuda-runtime-cu13 package
+nvidia-cuda-runtime-cu13==0.0.0a0
 tensorrt==10.13.3.9
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-10.html#rel-25-10 uses 2.9.0a0.
 torch>=2.9.0a0,<=2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
-tensorrt~=10.13.0
+tensorrt==10.13.3
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-10.html#rel-25-10 uses 2.9.0a0.
 torch>=2.9.0a0,<=2.9.0
 torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
-tensorrt==10.13.3
+tensorrt==10.13.3.9
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-10.html#rel-25-10 uses 2.9.0a0.
 torch>=2.9.0a0,<=2.9.0
 torchvision

--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -42,6 +42,51 @@ def download_wheel(args):
                           shell=True)
 
 
+def install_tensorrt_llm():
+    """
+    Installs the tensorrt_llm wheel, dynamically creating a torch constraint
+    if torch is already installed to prevent it from being replaced.
+    """
+    print("##########  Install tensorrt_llm package  ##########")
+
+    install_command = "pip3 install tensorrt_llm-*.whl"
+
+    # Always check for an existing torch installation, regardless of OS.
+    try:
+        print("Checking for existing torch installation...")
+        torch_version_result = subprocess.run(
+            ['python3', '-c', 'import torch; print(torch.__version__)'],
+            capture_output=True,
+            text=True,
+            check=True)
+        torch_version = torch_version_result.stdout.strip()
+
+        if torch_version:
+            print(f"Found installed torch version: {torch_version}")
+            constraint_filename = "torch-constraint.txt"
+            with open(constraint_filename, "w") as f:
+                f.write(f"torch=={torch_version}\n")
+            print(
+                f"Created {constraint_filename} to constrain torch to version {torch_version}."
+            )
+
+            # Modify install command to use the constraint
+            install_command += f" -c {constraint_filename}"
+        else:
+            # This case is unlikely if the subprocess call succeeds
+            print(
+                "Could not determine installed torch version. Installing without constraint."
+            )
+
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # This handles cases where python3 fails or 'import torch' raises an error.
+        print("Torch is not installed. Proceeding without constraint.")
+
+    # Execute the final installation command
+    print(f"Executing command: {install_command}")
+    subprocess.check_call(install_command, shell=True)
+
+
 def test_pip_install():
     parser = argparse.ArgumentParser(description="Check Pip Install")
     parser.add_argument("--wheel_path",
@@ -62,8 +107,8 @@ def test_pip_install():
                           shell=True)
 
     download_wheel(args)
-    print("##########  Install tensorrt_llm package  ##########")
-    subprocess.check_call("pip3 install tensorrt_llm-*.whl", shell=True)
+    install_tensorrt_llm()
+
     print("##########  Test import tensorrt_llm  ##########")
     subprocess.check_call(
         'python3 -c "import tensorrt_llm; print(tensorrt_llm.__version__)"',


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version constraints for a core dependency to ensure improved compatibility and system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
