### PR TITLE
[TRTLLM-8377][test] unit tests for TorchSampler batched sampling

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -673,15 +673,17 @@ class TorchSampler(Sampler):
         assert self._generator.device == device
         return self._generator
 
-    def get_spec_tree_manager(self, resource_manager: ResourceManager) -> Optional[SpecTreeManager]:
+    def get_spec_tree_manager(
+        self, resource_manager: Optional[ResourceManager]
+    ) -> Optional[SpecTreeManager]:
         if resource_manager is None:
             return None
         spec_resource_manager = resource_manager.get_resource_manager(
-            ResourceManagerType.SPEC_RESOURCE_MANAGER
+            ResourceManagerType.SPEC_RESOURCE_MANAGER.value
         )
         if spec_resource_manager is None or not hasattr(spec_resource_manager, "spec_tree_manager"):
             return None
-        return spec_resource_manager.spec_tree_manager
+        return spec_resource_manager.spec_tree_manager  # type: ignore
 
     @staticmethod
     def _meet_max_token_stop_criteria(request: LlmRequest, max_seq_len: int):

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -679,7 +679,7 @@ class TorchSampler(Sampler):
         if resource_manager is None:
             return None
         spec_resource_manager = resource_manager.get_resource_manager(
-            ResourceManagerType.SPEC_RESOURCE_MANAGER.value
+            ResourceManagerType.SPEC_RESOURCE_MANAGER
         )
         if spec_resource_manager is None or not hasattr(spec_resource_manager, "spec_tree_manager"):
             return None

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1063,7 +1063,7 @@ class TestBatchedSampling:
         new_tokens_tensors = []
         for sample_state in sample_states:
             assert sample_state.sampler_event is not None
-            sample_state.sampler_event.wait()
+            sample_state.sampler_event.synchronize()
             assert sample_state.host is not None
             new_tokens_tensors.append(sample_state.host.new_tokens.unsqueeze(-1))
         new_tokens = torch.cat(new_tokens_tensors, dim=-1)

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -15,19 +15,40 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import product
-from typing import Callable, Generator, Optional, cast
+from random import shuffle as shuffle_inplace
+from typing import Callable, Final, Generator, Optional, Type, Union, cast
 
+import flashinfer.sampling
+import numpy as np
 import pytest
 import torch
+from scipy.stats import power_divergence
 from utils.util import assert_no_cuda_sync, force_ampere
 
+from tensorrt_llm._torch.pyexecutor import sampling_utils_flashinfer
 from tensorrt_llm._torch.pyexecutor.llm_request import convert_wordlist
 from tensorrt_llm._torch.pyexecutor.sampler import (
     GREEDY,
     LlmRequest,
     ScheduledRequests,
+    SimpleGroupedStrategySampler,
     TorchSampler,
+    _BatchedSamplingResult,
+    _request_get_sampling_params,
     _request_strategy,
+    get_draft_token_length,
+)
+from tensorrt_llm._torch.pyexecutor.sampling_utils import (
+    Greedy,
+    Strategy,
+    TemperatureOnly,
+    TopK,
+    TopKTopP,
+    TopP,
+    UtilsSamplingParams,
+)
+from tensorrt_llm._torch.pyexecutor.sampling_utils_flashinfer import (
+    FlashInferGroupedStrategySampler,
 )
 from tensorrt_llm.bindings import SamplingConfig
 from tensorrt_llm.bindings.executor import FinishReason
@@ -511,8 +532,8 @@ class RequestCase:
         new_tokens: list[int],
         finish_reasons: list[FinishReason],
         max_new_tokens: int = MAX_NEW_TOKENS,
-        end_id: int = None,
-        stop_words_list: list[list[int]] = None,
+        end_id: Optional[int] = None,
+        stop_words_list: Optional[list[list[int]]] = None,
     ):
         seq_slot = self.seq_slots.pop()  # random seq slot in MAX_NUM_SEQUENCES
         self.prompt = prompt
@@ -680,3 +701,1286 @@ def test_are_stop_words_isnt_called_when_no_stop_words():
     )
     sampler._are_stop_words = stop_words_that_raises
     _ = run_without_stop_words()
+
+
+class TestBatchedSampling:
+    """Validate batched/mixed sampling."""
+
+    VOCAB_SIZE = 123
+
+    @staticmethod
+    def _build_test_cases(
+        *,
+        vocab_size: int,
+        allow_greedy: bool = True,
+        include_all: bool = True,
+        include_uniform: bool = False,  # include_all takes precedence
+        include_mixed: bool = False,  # include_all takes precedence
+    ) -> list[tuple[list[SamplingParams], str]]:
+        """Return sampling params and a human-readable name."""
+
+        BASE_CASES = {  # one entry per sampling strategy
+            Greedy: SamplingParams(),
+            TemperatureOnly: SamplingParams(temperature=0.7),
+            TopP: SamplingParams(top_p=0.42, temperature=0.2),
+            TopK: SamplingParams(top_k=27, temperature=0.5),
+            TopKTopP: SamplingParams(top_k=27, top_p=0.6, temperature=0.5),
+        }
+
+        # Check that all relevant strategies are covered
+        assert Union[*BASE_CASES.keys()] == Strategy
+
+        test_cases = []
+
+        def _get_strategy_name(strategy_type: Type[Strategy]) -> str:
+            return strategy_type.__args__[0].__args__[0]  # type: ignore
+
+        if include_all or include_uniform:
+            # base cases
+            for strategy_type, params in BASE_CASES.items():
+                if strategy_type == Greedy and not allow_greedy:
+                    continue
+                strategy_name = _get_strategy_name(strategy_type)
+                test_cases.append(
+                    (
+                        [params],
+                        f"single_{strategy_name}",
+                    )
+                )
+
+        rng = np.random.default_rng(seed=42)
+
+        if include_all or include_uniform:
+            # homogeneous batches
+            max_batch_size: Final = 24
+            for strategy_type, params in BASE_CASES.items():
+                batch_size = rng.integers(low=1, high=max_batch_size)
+                if strategy_type == Greedy and not allow_greedy:
+                    continue
+                strategy_name = _get_strategy_name(strategy_type)
+                test_cases.append(
+                    (
+                        [params] * batch_size,
+                        f"uniform_batch_{strategy_name}",
+                    )
+                )
+
+        if include_all or include_mixed:
+
+            class OneContinguous:
+                pass
+
+            class Shuffle:
+                pass
+
+            class VaryParams:
+                pass
+
+            # mixed contiguous batches
+            max_sub_batch_size: Final = 6
+            type_to_constrain = TopK
+            mixed_params_list = None
+            for constraint_value in [
+                None,  # all sub-batches have a least two requests
+                0,  # one sub-batch omitted
+                1,  # one size-1 sub-batch
+                OneContinguous(),  # one contiguous sub-batch, rest shuffled
+                Shuffle(),  # random ordering
+                VaryParams(),  # random ordering + randomized request parameter values
+            ]:
+                mixed_params_list = []
+                constrained_indices = None
+                for strategy_type, params in BASE_CASES.items():
+                    sub_batch_size = rng.integers(low=2, high=max_sub_batch_size)
+                    if strategy_type == Greedy and not allow_greedy:
+                        continue
+                    if strategy_type == type_to_constrain and constraint_value is not None:
+                        if isinstance(constraint_value, int):
+                            sub_batch_size = constraint_value
+                        else:
+                            constrained_indices = (
+                                len(mixed_params_list),
+                                len(mixed_params_list) + sub_batch_size,
+                            )
+                    strategy_name = _get_strategy_name(strategy_type)
+                    mixed_params_list += [params] * sub_batch_size
+                label = "mixed_batch"
+                if isinstance(constraint_value, OneContinguous):
+                    assert constrained_indices is not None
+                    no_shuffle_start_idx, no_shuffle_end_idx = constrained_indices
+                    head_shuffled = mixed_params_list[:no_shuffle_start_idx]
+                    shuffle_inplace(head_shuffled)
+                    tail_shuffled = mixed_params_list[no_shuffle_end_idx:]
+                    shuffle_inplace(tail_shuffled)
+                    mixed_params_list = (
+                        head_shuffled
+                        + mixed_params_list[no_shuffle_start_idx:no_shuffle_end_idx]
+                        + tail_shuffled
+                    )
+                    label += "_oneContiguous"
+                elif isinstance(constraint_value, Shuffle):
+                    shuffle_inplace(mixed_params_list)
+                    label += "_shuffled"
+                elif isinstance(constraint_value, VaryParams):
+                    shuffle_inplace(mixed_params_list)
+
+                    def _perturb_params(param: SamplingParams):
+                        top_k = param.top_k
+                        if top_k is not None:
+                            top_k = rng.integers(vocab_size // 3)
+                        top_p = param.top_p
+                        if top_p is not None:
+                            top_p *= rng.random()
+                        temperature = param.temperature
+                        if temperature is not None:
+                            temperature *= rng.random()
+                        return SamplingParams(
+                            top_p=top_p,
+                            top_k=top_k,
+                            temperature=temperature,
+                        )
+
+                    mixed_params_list = [_perturb_params(params) for params in mixed_params_list]
+                    label += "_randomized"
+                else:
+                    label += f"_one{constraint_value}" if constraint_value is not None else ""
+                test_cases.append((mixed_params_list, label))
+
+        return test_cases
+
+    @pytest.fixture(scope="function")
+    def draft_lens(
+        self,
+        max_draft_len: int,
+        sampling_params_list: list[SamplingParams],
+        allow_zero_draft_len: bool,
+    ) -> list[int]:
+        draft_len = list(
+            np.random.default_rng(seed=42).integers(
+                1 if (max_draft_len > 0 and not allow_zero_draft_len) else 0,
+                max_draft_len + 1,
+                size=(
+                    len(
+                        sampling_params_list,
+                    )
+                ),
+            )
+        )
+        return draft_len
+
+    @pytest.fixture(scope="function")
+    def seq_slot_assignment(
+        self, sampling_params_list: list[SamplingParams]
+    ) -> tuple[list[int], int]:
+        # Returns list of seq slots associated with each request and
+        # total number of seq slots.
+        #
+        # Assumes a dense packing of requests in the sample state buffer.
+        #
+        # This choice only affects _unbatch_sampling_results, which is tested in
+        # test_unbatch_sampling_results, overriding 'seq_slot_assignment' via test
+        # parametrization.
+        seq_slots = list(range(len(sampling_params_list)))
+        return seq_slots, len(seq_slots)
+
+    @pytest.fixture(scope="function")
+    def mock_requests(
+        self,
+        sampling_params_list: list[SamplingParams],
+        with_draft_logits: bool,
+        vocab_size: int,
+        seq_slot_assignment: tuple[list[int], int],
+        draft_lens: list[int],
+    ) -> ScheduledRequests:
+        return self._build_mock_requests(
+            sampling_params_list=sampling_params_list,
+            with_draft_logits=with_draft_logits,
+            vocab_size=vocab_size,
+            seq_slot_assignment=seq_slot_assignment,
+            draft_lens=draft_lens,
+        )
+
+    def _build_mock_requests(
+        self,
+        sampling_params_list: list[SamplingParams],
+        *,
+        with_draft_logits: bool,
+        vocab_size: int,
+        seq_slot_assignment: tuple[list[int], int],
+        draft_lens: list[int],
+    ) -> ScheduledRequests:
+        seq_slots, num_seq_slots = seq_slot_assignment
+
+        class ScheduledRequestsMock:
+            def __init__(
+                self,
+                sampling_params_list: list[SamplingParams],
+                *,
+                with_draft_logits: bool,
+                draft_lens: list[int],
+            ):
+                self._sampling_params_list = sampling_params_list
+                self._with_draft_logits = with_draft_logits
+
+                def _attach_draft_logits(req: LlmRequest) -> LlmRequest:
+                    draft_len = len(req.py_draft_tokens)
+                    if draft_len and with_draft_logits:
+                        req.py_draft_logits = torch.testing.make_tensor(  # type: ignore
+                            (draft_len, vocab_size),
+                            dtype=torch.float32,
+                            device="cuda",
+                        )
+                    return req
+
+                # NB:
+                #   -  stop words are tested in test_write_finish_reasons
+                #   -  'end_id' is tested in test_write_finish_reasons
+                #   -  embedding bias is tested elsewhere
+                #   -  py_min_length is tested elsewhere
+                #   -  py_return_log_probs is tested elsewhere
+                #   -  code paths gated by py_return_context_logits tested in test_select_generated_logits
+                self._gen_requests = [
+                    _attach_draft_logits(
+                        LlmRequest(
+                            request_id=seq_slot,
+                            max_new_tokens=(2 * draft_len),  # not used by tested code
+                            input_tokens=[12],  # not used by tested code
+                            sampling_config=SamplingConfig(sampling_params._get_sampling_config()),
+                            seq_slot=seq_slot,
+                            is_streaming=False,  # not relevant for tested code
+                            draft_tokens=(  # 'len(.py_draft_tokens)' is inspected by get_draft_token_length
+                                torch.testing.make_tensor(
+                                    (draft_len,),
+                                    dtype=torch.int32,
+                                    device="cpu",
+                                ).tolist()
+                                if draft_len
+                                else None
+                            ),
+                        )
+                    )
+                    for sampling_params, seq_slot, draft_len in zip(
+                        sampling_params_list, seq_slots, draft_lens
+                    )
+                ]
+
+            @property
+            def context_requests(self) -> list[LlmRequest]:
+                # Code paths excluded by this choice are addressed by test_select_generated_logits
+                return []
+
+            @property
+            def generation_requests(self) -> list[LlmRequest]:
+                # The batched sampling code in sample_async only checks that this is not empty
+                return self._gen_requests
+
+            def all_requests(self) -> list[LlmRequest]:
+                # The sampling code relies on this ordering assumption
+                return self.context_requests + self.generation_requests
+
+        with torch.inference_mode(True):
+            return cast(
+                ScheduledRequests,
+                ScheduledRequestsMock(
+                    sampling_params_list, with_draft_logits=with_draft_logits, draft_lens=draft_lens
+                ),
+            )
+
+    @pytest.fixture(scope="function")
+    def model_outputs(
+        self,
+        mock_requests: ScheduledRequests,
+        vocab_size: int,
+    ) -> Generator[dict[str, torch.Tensor], None, None]:
+        total_steps = sum(get_draft_token_length(req) + 1 for req in mock_requests.all_requests())
+        logits = torch.testing.make_tensor(
+            (total_steps, vocab_size),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        logits_orig = logits.clone()
+        try:
+            yield {
+                # No 'd2t': Non-greedy sampling with 'd2t' is currently not
+                #           supported and greedy case is tested elsewhere
+                "logits": logits,
+            }
+        finally:
+            torch.testing.assert_close(logits, logits_orig)
+
+    @pytest.fixture(scope="function")
+    def sampler(
+        self,
+        use_flashinfer: bool,
+        max_draft_len: int,
+        seq_slot_assignment: tuple[list[int], int],
+    ) -> TorchSampler:
+        return self._build_sampler(
+            use_flashinfer=use_flashinfer,
+            max_draft_len=max_draft_len,
+            seq_slot_assignment=seq_slot_assignment,
+        )
+
+    def _build_sampler(
+        self,
+        *,
+        use_flashinfer: bool,
+        max_draft_len: int,
+        seq_slot_assignment: tuple[list[int], int],
+    ) -> TorchSampler:
+        _, num_seq_slots = seq_slot_assignment
+        return TorchSampler(
+            TorchSampler.Args(
+                max_seq_len=321,  # only used for stop criteria, tested separately
+                max_draft_len=42,  # not used by TorchSampler
+                max_beam_width=1,  # currently the only supported value
+                max_num_sequences=num_seq_slots,
+                max_total_draft_tokens=max_draft_len,
+                disable_flash_infer_sampling=(not use_flashinfer),
+            )
+        )
+
+    def _sample(
+        self,
+        sampler: TorchSampler,
+        scheduled_requests: ScheduledRequests,
+        model_outputs: dict[str, torch.Tensor],
+        *,
+        num_repeats: Optional[int] = None,
+    ) -> torch.Tensor:
+        assert not scheduled_requests.context_requests
+        # FIXME: Currently, sample_async is not fully async (TRTLLM-9175)
+        #   with assert_no_cuda_sync(sync_timeout_s=(0.01 * (num_repeats or 1) + 0.25)):
+        sample_states = [
+            sampler.sample_async(
+                scheduled_requests,
+                model_outputs=model_outputs,
+                num_context_logits_prefix_sum=[0],
+                resource_manager=None,  #  only used for tree sampling, which is not tested here
+            )
+            for _ in range(num_repeats if num_repeats is not None else 1)
+        ]
+        new_tokens_tensors = []
+        for sample_state in sample_states:
+            assert sample_state.sampler_event is not None
+            sample_state.sampler_event.wait()
+            assert sample_state.host is not None
+            new_tokens_tensors.append(sample_state.host.new_tokens.unsqueeze(-1))
+        new_tokens = torch.cat(new_tokens_tensors, dim=-1)
+        if num_repeats is None:
+            new_tokens = new_tokens.squeeze(-1)
+        return new_tokens
+
+    @pytest.mark.parametrize(
+        "use_flashinfer, max_draft_len, sampling_params_list",
+        [
+            pytest.param(use_flashinfer, max_draft_len, [])
+            for (use_flashinfer, max_draft_len) in product(
+                [False, True],
+                [0, 3],
+            )
+        ],
+    )
+    def test_backend_selection(
+        self,
+        sampler: TorchSampler,
+        use_flashinfer: bool,
+    ):
+        """Check that TorchSampler uses the correct sampling backend."""
+        expected_cls = (
+            FlashInferGroupedStrategySampler if use_flashinfer else SimpleGroupedStrategySampler
+        )
+        assert sampler._grouped_sampler_cls == expected_cls
+
+    @pytest.mark.parametrize(
+        (
+            "use_flashinfer",
+            "max_draft_len",
+            "draft_lens",
+            "sampling_params_list",
+            "with_draft_logits",
+            "params_label",
+            "allow_zero_draft_len",
+            "vocab_size",
+        ),
+        [
+            # NB: with_draft_logits=True and non-zero draft len ensures that
+            #     LlmRequest.py_target_probs is set.
+            pytest.param(
+                use_flashinfer,
+                3,
+                [3] * len(sampling_params_list),
+                sampling_params_list,
+                True,
+                params_label,
+                False,
+                vocab_size,
+                id=f"{'FlashInfer' if use_flashinfer else 'Torch'}-{params_label}",
+            )
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (use_flashinfer, (sampling_params_list, params_label), vocab_size) in product(
+                [False, True],
+                _build_test_cases(
+                    vocab_size=VOCAB_SIZE,
+                    allow_greedy=False,  # Greedy does not return probs
+                ),
+                [VOCAB_SIZE],
+            )
+        ],
+    )
+    def test_probs(
+        self,
+        sampler: TorchSampler,
+        mock_requests: ScheduledRequests,
+        model_outputs: dict[str, torch.Tensor],
+        draft_lens: list[int],
+        vocab_size: int,
+        params_label: str,
+        allow_zero_draft_len: bool,  # used by fixtures
+    ):
+        with torch.cuda.Stream():
+            torch.manual_seed(42)  # torch.testing.make_tensor does not accept Generator
+
+            strategy_tags = {
+                strategy_type: strategy_type.__args__[0].__args__[0]  # type: ignore
+                for strategy_type in [
+                    TemperatureOnly,
+                    TopP,
+                    TopK,
+                    TopKTopP,
+                ]
+            }
+
+            _ = self._sample(
+                sampler,
+                scheduled_requests=mock_requests,
+                model_outputs=model_outputs,
+            )
+
+            logit_offset = 0
+            for req, draft_len in zip(mock_requests.all_requests(), draft_lens):
+                assert req.py_target_probs is not None
+                probs = req.py_target_probs.cpu()
+                assert probs.shape == (draft_len + 1, vocab_size)
+                # NB: _request_strategy tested in TestStrategySelection
+                strategy = _request_strategy(req, vocab_size=vocab_size)
+
+                steps = draft_len + 1
+
+                assert strategy is not GREEDY
+                temperature = strategy[-1]
+                assert temperature is not None
+                req_logits = model_outputs["logits"][logit_offset : (logit_offset + steps), :].cpu()
+                expected_probs_after_temperature = torch.softmax(req_logits / temperature, dim=-1)
+
+                # check normalization
+                torch.testing.assert_close(
+                    probs.sum(dim=-1), torch.tensor(1.0).broadcast_to(probs.shape[:-1])
+                )
+
+                # Do not compare tiny probs (ignore floating point accuracy differences)
+                prob_threshold = 1e-10
+                expected_probs_after_temperature = torch.where(
+                    expected_probs_after_temperature >= prob_threshold,
+                    expected_probs_after_temperature,
+                    0,
+                )
+                probs = torch.where(probs >= prob_threshold, probs, 0)
+                expected_probs_after_temperature /= expected_probs_after_temperature.sum(
+                    dim=-1, keepdim=True
+                )
+                probs /= probs.sum(dim=-1, keepdim=True)
+
+                if strategy[0] == strategy_tags[TemperatureOnly]:
+                    torch.testing.assert_close(probs, expected_probs_after_temperature)
+                else:
+                    if strategy[0] not in [
+                        strategy_tags[strategy_type] for strategy_type in [TopP, TopK, TopKTopP]
+                    ]:
+                        raise ValueError(f"Unknown strategy: {strategy}")
+
+                    top_k = None
+                    if strategy[0] in [
+                        strategy_tags[strategy_type] for strategy_type in [TopK, TopKTopP]
+                    ]:
+                        # Validate top-k
+                        top_k = strategy[1]
+                        assert top_k is not None
+
+                        # Correct for possible zero probs in input
+                        input_nnz = torch.count_nonzero(expected_probs_after_temperature, dim=-1)
+                        top_k = torch.where(input_nnz < top_k, input_nnz, top_k)
+
+                        nnz = torch.count_nonzero(probs, dim=-1)
+                        if strategy[0] == strategy_tags[TopKTopP]:
+                            # when top-k is followed by top-p, the result set is smaller
+                            assert torch.le(nnz, top_k).all()
+                        else:
+                            torch.testing.assert_close(nnz, top_k)
+
+                    if strategy[0] in [
+                        strategy_tags[strategy_type] for strategy_type in [TopP, TopKTopP]
+                    ]:
+                        # Validate top-p
+                        top_p = strategy[-2]
+                        assert top_p is not None
+
+                        if top_k is not None:
+                            expected_probs_before_top_p, indices = (
+                                expected_probs_after_temperature.topk(
+                                    cast(int, top_k.amax().item()), dim=-1
+                                )
+                            )
+                            expected_probs_before_top_p /= expected_probs_before_top_p.sum(
+                                dim=-1, keepdim=True
+                            )
+                            probs_sorted = probs.gather(-1, indices)
+                        else:
+                            expected_probs_before_top_p = expected_probs_after_temperature
+                            probs_sorted = probs
+
+                            if params_label.startswith("single_"):
+                                # top_p is chosen to cover possible edge cases
+                                assert 1 in probs.count_nonzero(dim=-1)
+                                assert len(set(probs.count_nonzero(dim=-1))) > 1
+
+                        # Check that probs make top-p and that no index can be omitted without missing top-p
+                        probs_sorted_pre_norm = torch.where(
+                            probs_sorted != 0, expected_probs_before_top_p, 0.0
+                        )
+                        probs_sorted_pre_norm_nz = torch.where(
+                            probs_sorted_pre_norm != 0, probs_sorted_pre_norm, float("inf")
+                        )
+                        assert torch.ge(
+                            probs_sorted_pre_norm.sum(dim=-1),
+                            cast(float, top_p),
+                        ).all()
+                        assert torch.lt(
+                            probs_sorted_pre_norm.sum(dim=-1)
+                            - probs_sorted_pre_norm_nz.amin(dim=-1),
+                            cast(float, top_p),
+                        ).all()
+
+                    # All indices not selected must have logits less or equal
+                    # to the smallest selected logit.
+                    probs_selected_min = torch.where(
+                        probs == 0.0, float("inf"), expected_probs_after_temperature
+                    ).amin(dim=-1)
+                    probs_other_max = torch.where(
+                        probs == 0.0, expected_probs_after_temperature, 0.0
+                    )
+                    assert torch.le(probs_other_max.amax(dim=-1), probs_selected_min).all()
+
+                    # Check selected probs agree up to normalization
+                    expected_probs = torch.where(
+                        probs != 0.0, expected_probs_after_temperature, 0.0
+                    )
+                    expected_probs /= expected_probs.sum(keepdim=True, dim=-1)
+                    torch.testing.assert_close(probs, expected_probs)
+
+                logit_offset += steps
+
+    @pytest.mark.parametrize(
+        (
+            "use_flashinfer",
+            "max_draft_len",
+            "sampling_params_list",
+            "with_draft_logits",
+            "allow_zero_draft_len",
+            "bypass_sampling",
+            "vocab_size",
+        ),
+        [
+            pytest.param(
+                use_flashinfer,
+                max_draft_len,
+                sampling_params_list,
+                with_draft_logits,
+                allow_zero_draft_len,
+                # Run full sampling test only for uniform batches, with/without probs, but skip
+                # sampling statistics when varying draft lens etc. to validate batch handling:
+                not (
+                    (not is_mixed) and (not allow_zero_draft_len) and max_draft_len > 0
+                ),  # bypass_sampling
+                vocab_size,
+                id=(
+                    f"{'FlashInfer' if use_flashinfer else 'Torch'}"
+                    f"-draft_len={0 if allow_zero_draft_len else 1}..{max_draft_len}"
+                    f"-return_probs={with_draft_logits}-{params_label}"
+                ),
+            )
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (
+                use_flashinfer,
+                is_mixed,
+                with_draft_logits,
+                max_draft_len,
+                allow_zero_draft_len,
+                _build_test_cases,
+                vocab_size,
+            ) in product(
+                [False, True],
+                [False, True],
+                [True, False],
+                [0, 3],
+                [False, True],
+                [_build_test_cases],
+                [VOCAB_SIZE],
+            )
+            for (sampling_params_list, params_label) in _build_test_cases(
+                vocab_size=vocab_size,
+                include_all=False,
+                include_uniform=(not is_mixed),
+                include_mixed=is_mixed,
+            )
+            if (allow_zero_draft_len or max_draft_len > 0)
+            and (not with_draft_logits or max_draft_len > 0)
+        ],
+    )
+    def test_samples(
+        self,
+        sampler: TorchSampler,
+        mock_requests: ScheduledRequests,
+        model_outputs: dict[str, torch.Tensor],
+        draft_lens: list[int],
+        vocab_size: int,
+        sampling_params_list: list[SamplingParams],
+        seq_slot_assignment: tuple[list[int], int],
+        with_draft_logits: bool,
+        max_draft_len: int,
+        use_flashinfer: bool,
+        allow_zero_draft_len: bool,  # used by fixtures
+        bypass_sampling: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        with torch.cuda.Stream():
+            torch.manual_seed(42)  # torch.testing.make_tensor does not accept Generator
+
+            # Because max_draft_len can be zero and probs are not computed in this case,
+            # a separate sampler instance (with larger max_draft_len) is needed to
+            # compute probs in general.
+            draft_len_with_probs = max(3, max_draft_len)
+            sampler_with_probs = self._build_sampler(
+                use_flashinfer=use_flashinfer,
+                max_draft_len=draft_len_with_probs,
+                seq_slot_assignment=seq_slot_assignment,
+            )
+            mock_requests_with_probs = self._build_mock_requests(
+                sampling_params_list=sampling_params_list,
+                vocab_size=vocab_size,
+                seq_slot_assignment=seq_slot_assignment,
+                # NB: with_draft_logits=True and non-zero draft len ensures that
+                #     LlmRequest.py_target_probs is set.
+                with_draft_logits=True,
+                draft_lens=([draft_len_with_probs] * len(sampling_params_list)),
+            )
+            # zero-pad logits to draft_len_with_probs
+            logits = model_outputs["logits"]
+            logits_offset = 0
+            steps_with_probs = draft_len_with_probs + 1
+            logits_with_probs = torch.zeros(
+                (steps_with_probs * len(mock_requests_with_probs.all_requests()), vocab_size),
+                dtype=logits.dtype,
+                device=logits.device,
+            )
+            for req_idx, draft_len in enumerate(draft_lens):
+                steps = draft_len + 1
+                logits_with_probs[
+                    (req_idx * steps_with_probs) : (req_idx * steps_with_probs + steps)
+                ] = logits[logits_offset : (logits_offset + steps)]
+                logits_offset += steps
+            model_outputs_with_probs = model_outputs.copy()
+            model_outputs_with_probs["logits"] = logits_with_probs
+            _ = self._sample(
+                sampler_with_probs,
+                scheduled_requests=mock_requests_with_probs,
+                model_outputs=model_outputs_with_probs,
+            )
+
+            num_samples = 5000 if not bypass_sampling else 1
+
+            @dataclass(frozen=True, kw_only=True)
+            class MockSamplingLogEntry:
+                probs: torch.Tensor
+                sampling_params: UtilsSamplingParams
+
+            # filled when bypass_sampling=True
+            mock_sampling_log: list[MockSamplingLogEntry] = []
+
+            with monkeypatch.context() as patch_ctx:
+                # FlashInfer sampling batches requests of the same kind (e.g. top-p)
+                # together even if they have different parameter values (e.g. probability thresholds).
+                # This variable tracks which request types have been encountered.
+                flashinfer_keys_seen = set()
+
+                if use_flashinfer:
+                    sample_grouped_strategies_orig = (
+                        sampler._grouped_sampler_cls.sample_grouped_strategies
+                    )
+
+                    def _sample_grouped_strategies(
+                        group_key: FlashInferGroupedStrategySampler.STRATEGY_KEY_TYPE,
+                        strategies: list[Strategy],
+                        logits: torch.Tensor,
+                        *,
+                        group_logit_indices: Optional[torch.Tensor] = None,
+                        generator: Optional[torch.Generator] = None,
+                        return_probs: bool,
+                    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+                        assert issubclass(
+                            group_key, sampling_utils_flashinfer._StrategyImpls.StrategyImpl
+                        )
+                        assert generator is sampler.get_generator(logits.device)
+                        nonlocal flashinfer_keys_seen
+                        assert group_key not in flashinfer_keys_seen
+                        flashinfer_keys_seen.add(group_key)
+                        return sample_grouped_strategies_orig(
+                            group_key,
+                            strategies,
+                            logits,
+                            group_logit_indices=group_logit_indices,
+                            generator=generator,
+                            return_probs=return_probs,
+                        )
+
+                    patch_ctx.setattr(
+                        sampler._grouped_sampler_cls,
+                        "sample_grouped_strategies",
+                        _sample_grouped_strategies,
+                    )
+
+                    sample_async_orig = sampler.sample_async
+
+                    def _sample_async(
+                        scheduled_requests: ScheduledRequests,
+                        model_outputs: dict[str, torch.Tensor],
+                        num_context_logits_prefix_sum: list[int],
+                        resource_manager=None,
+                    ):
+                        nonlocal flashinfer_keys_seen
+                        flashinfer_keys_seen.clear()
+                        res = sample_async_orig(
+                            scheduled_requests,
+                            model_outputs,
+                            num_context_logits_prefix_sum,
+                            resource_manager,
+                        )
+                        assert flashinfer_keys_seen
+                        return res
+
+                    patch_ctx.setattr(sampler, "sample_async", _sample_async)
+
+                if bypass_sampling:
+
+                    def _mock_flashinfer_top_k_top_p(
+                        logits: torch.Tensor,
+                        *,
+                        top_k: torch.Tensor,
+                        top_p: torch.Tensor,
+                        filter_apply_order: str,
+                        deterministic: bool,
+                        check_nan: bool,
+                        generator: torch.Generator,
+                    ) -> torch.Tensor:
+                        assert filter_apply_order == "top_k_first"
+                        assert deterministic
+                        assert not check_nan, "check_nan syncs"
+                        assert generator is sampler.get_generator(logits.device)
+                        nonlocal mock_sampling_log
+                        new_entries = [
+                            MockSamplingLogEntry(
+                                probs=torch.softmax(logits[row_idx], dim=-1),
+                                sampling_params=UtilsSamplingParams(
+                                    top_k=cast(int, top_k[row_idx].item()),
+                                    top_p=top_p[row_idx].item(),
+                                    temperature=None,
+                                ),
+                            )
+                            for row_idx in range(logits.size(0))
+                        ]
+                        mock_tokens = torch.arange(
+                            len(mock_sampling_log), len(mock_sampling_log) + len(new_entries)
+                        )
+                        mock_sampling_log += new_entries
+                        return mock_tokens
+
+                    patch_ctx.setattr(
+                        flashinfer.sampling,
+                        "top_k_top_p_sampling_from_logits",
+                        _mock_flashinfer_top_k_top_p,
+                    )
+
+                    def _mock_flashinfer_from_logits(
+                        logits: torch.Tensor,
+                        *,
+                        deterministic: bool,
+                        check_nan: bool,
+                        generator: torch.Generator,
+                    ) -> torch.Tensor:
+                        assert deterministic
+                        assert not check_nan, "check_nan syncs"
+                        assert generator is sampler.get_generator(logits.device)
+                        nonlocal mock_sampling_log
+                        new_entries = [
+                            MockSamplingLogEntry(
+                                probs=torch.softmax(logits[row_idx], dim=-1),
+                                sampling_params=UtilsSamplingParams(
+                                    top_k=None,
+                                    top_p=None,
+                                    temperature=None,
+                                ),
+                            )
+                            for row_idx in range(logits.size(0))
+                        ]
+                        mock_tokens = torch.arange(
+                            len(mock_sampling_log), len(mock_sampling_log) + len(new_entries)
+                        )
+                        mock_sampling_log += new_entries
+                        return mock_tokens
+
+                    patch_ctx.setattr(
+                        flashinfer.sampling, "sampling_from_logits", _mock_flashinfer_from_logits
+                    )
+
+                    def _mock_flashinfer_top_p(
+                        probs: torch.Tensor,
+                        *,
+                        top_p: torch.Tensor,
+                        deterministic: bool,
+                        check_nan: bool,
+                        generator: torch.Generator,
+                    ) -> torch.Tensor:
+                        assert deterministic
+                        assert not check_nan, "check_nan syncs"
+                        assert generator is sampler.get_generator(probs.device)
+                        nonlocal mock_sampling_log
+                        new_entries = [
+                            MockSamplingLogEntry(
+                                probs=probs[row_idx],
+                                sampling_params=UtilsSamplingParams(
+                                    top_k=None,
+                                    top_p=top_p[row_idx].item(),
+                                    temperature=None,
+                                ),
+                            )
+                            for row_idx in range(probs.size(0))
+                        ]
+                        mock_tokens = torch.arange(
+                            len(mock_sampling_log), len(mock_sampling_log) + len(new_entries)
+                        )
+                        mock_sampling_log += new_entries
+                        return mock_tokens
+
+                    patch_ctx.setattr(
+                        flashinfer.sampling, "top_p_sampling_from_probs", _mock_flashinfer_top_p
+                    )
+
+                    def _mock_flashinfer_from_probs(
+                        probs: torch.Tensor,
+                        *,
+                        deterministic: bool,
+                        check_nan: bool,
+                        generator: torch.Generator,
+                    ) -> torch.Tensor:
+                        assert deterministic
+                        assert not check_nan, "check_nan syncs"
+                        assert generator is sampler.get_generator(probs.device)
+                        nonlocal mock_sampling_log
+                        new_entries = [
+                            MockSamplingLogEntry(
+                                probs=probs[row_idx],
+                                sampling_params=UtilsSamplingParams(
+                                    top_k=None,
+                                    top_p=None,
+                                    temperature=None,
+                                ),
+                            )
+                            for row_idx in range(probs.size(0))
+                        ]
+                        mock_tokens = torch.arange(
+                            len(mock_sampling_log), len(mock_sampling_log) + len(new_entries)
+                        )
+                        mock_sampling_log += new_entries
+                        return mock_tokens
+
+                    patch_ctx.setattr(
+                        flashinfer.sampling, "sampling_from_probs", _mock_flashinfer_from_probs
+                    )
+
+                    def _mock_torch_multinomial(
+                        probs: torch.Tensor,
+                        num_samples: int,
+                        generator: torch.Generator,
+                    ) -> torch.Tensor:
+                        assert generator is sampler.get_generator(probs.device)
+                        assert num_samples == 1
+                        nonlocal mock_sampling_log
+                        new_entries = [
+                            MockSamplingLogEntry(
+                                probs=probs[row_idx],
+                                sampling_params=UtilsSamplingParams(
+                                    top_k=None,
+                                    top_p=None,
+                                    temperature=None,
+                                ),
+                            )
+                            for row_idx in range(probs.size(0))
+                        ]
+                        mock_tokens = torch.arange(
+                            len(mock_sampling_log), len(mock_sampling_log) + len(new_entries)
+                        )
+                        mock_sampling_log += new_entries
+                        return mock_tokens.unsqueeze(-1)
+
+                    patch_ctx.setattr(torch, "multinomial", _mock_torch_multinomial)
+
+                new_tokens_repeats = self._sample(
+                    sampler,
+                    scheduled_requests=mock_requests,
+                    model_outputs=model_outputs,
+                    num_repeats=num_samples,
+                )
+
+            # remove 'beam' dimension
+            assert new_tokens_repeats.size(-2) == 1
+            new_tokens_repeats = new_tokens_repeats.squeeze(-2)
+
+            # compute token frequencies
+            new_tokens_repeats_safe = new_tokens_repeats.clamp(
+                min=0, max=vocab_size - 1
+            )  # tame uninitialized memory
+            token_counts = torch.zeros(
+                (*new_tokens_repeats_safe.shape[:-1], vocab_size),
+                device=new_tokens_repeats_safe.device,
+                dtype=torch.int32,
+            )
+            token_counts = (
+                token_counts.view((-1, vocab_size))
+                .scatter_add_(
+                    dim=1,
+                    index=new_tokens_repeats_safe.view((-1, new_tokens_repeats_safe.size(-1))),
+                    src=torch.ones_like(
+                        new_tokens_repeats_safe.view((-1, new_tokens_repeats_safe.size(-1)))
+                    ),
+                )
+                .view(token_counts.shape)
+            )
+            token_counts = token_counts.to(dtype=torch.float32)
+            assert (token_counts.sum(-1, keepdim=True) == num_samples).all()
+
+            for req_idx, (req, req_with_probs, draft_len) in enumerate(
+                zip(
+                    mock_requests.all_requests(),
+                    mock_requests_with_probs.all_requests(),
+                    draft_lens,
+                )
+            ):
+                strategy = _request_strategy(req, vocab_size=vocab_size)
+                assert strategy == _request_strategy(req_with_probs, vocab_size=vocab_size)
+                if strategy is GREEDY:  # handle Greedy case explicitly
+                    # greedy never returns probs
+                    assert getattr(req_with_probs, "py_target_probs", None) is None
+                    assert getattr(req, "py_target_probs", None) is None
+                    req_logit_offset = sum(draft_len + 1 for draft_len in draft_lens[:req_idx])
+                    req_logits = logits[req_logit_offset : (req_logit_offset + draft_len + 1)]
+                    tokens_expected = torch.argmax(req_logits, dim=-1, keepdim=True)
+                    tokens_sampled = new_tokens_repeats[: (draft_len + 1), req.py_seq_slot, :]
+                    assert torch.all(tokens_expected.cpu() == tokens_sampled)
+                    continue  # nothing else to check
+
+                assert req_with_probs.py_target_probs is not None
+                probs = req_with_probs.py_target_probs.cpu()
+                assert probs.size(0) >= draft_len + 1
+                probs = probs[: (draft_len + 1)]
+
+                # check probs are returned only when needed
+                should_return_probs = draft_len and with_draft_logits
+                assert (
+                    hasattr(req, "py_target_probs") and req.py_target_probs is not None
+                ) == should_return_probs
+                # check probs
+                if should_return_probs:
+                    assert req.py_target_probs is not None
+                    torch.testing.assert_close(req.py_target_probs.cpu(), probs)
+
+                if bypass_sampling:  # fast path (mock sampling)
+                    for step_idx in range(draft_len + 1):
+                        log_idx = new_tokens_repeats[step_idx, req.py_seq_slot, 0]
+                        log_entry = mock_sampling_log[log_idx]
+                        req_params = _request_get_sampling_params(req)
+
+                        # Tests rely on UUT handling temperature outside the sampling routines
+                        assert log_entry.sampling_params.temperature is None
+
+                        req_has_top_p = (
+                            log_entry.sampling_params.top_p is not None
+                            and log_entry.sampling_params.top_p != 1
+                        )
+                        req_has_top_k = (
+                            log_entry.sampling_params.top_k is not None
+                            and log_entry.sampling_params.top_k != vocab_size
+                        )
+                        if req_has_top_k:
+                            assert req_params.top_k is not None
+                            assert req_params.top_k == log_entry.sampling_params.top_k
+                        if req_has_top_p:
+                            assert req_params.top_p is not None
+                            assert log_entry.sampling_params.top_p is not None
+                            assert np.allclose(req_params.top_p, log_entry.sampling_params.top_p)
+                        if req_has_top_k or req_has_top_p:
+                            # for top-k and/or top-p _sampling_, probs contains only the top probs,
+                            # whereas log_entry.probs contains all probs passed to the sampling code.
+
+                            # validate selection in 'probs' is consistent with log_entry.probs
+                            log_entry_probs_selected = torch.where(
+                                probs[step_idx] != 0, log_entry.probs.cpu(), 1
+                            )
+                            log_entry_probs_masked = torch.where(
+                                probs[step_idx] == 0, log_entry.probs.cpu(), 0
+                            )
+                            assert torch.all(
+                                log_entry_probs_masked.amax(dim=-1)
+                                <= log_entry_probs_selected.amin(dim=-1)
+                            )
+
+                            # validate non-zero probs
+                            log_entry_probs_selected = torch.where(
+                                probs[step_idx] != 0, log_entry.probs.cpu(), 0
+                            )
+                            log_entry_probs_selected /= log_entry_probs_selected.sum(-1)
+                            torch.testing.assert_close(log_entry_probs_selected, probs[step_idx])
+                        else:
+                            torch.testing.assert_close(log_entry.probs.cpu(), probs[step_idx])
+
+                    continue  # no real samples to run tests below
+
+                test_token_counts = token_counts[: (draft_len + 1), req.py_seq_slot]
+                test_expected_counts = num_samples * probs.cpu()
+
+                # NB: G-test yields NaN if expected count is 0
+                #     -> check those entries separately and mask them
+                #     (https://stats.stackexchange.com/a/668064)
+                #
+                test_token_counts_for_zero_prob = torch.where(
+                    test_expected_counts != 0, 0, test_token_counts
+                )
+                assert (test_token_counts_for_zero_prob == 0).all()
+                test_expected_counts_ma = np.ma.masked_array(
+                    test_expected_counts.numpy(),
+                    mask=(test_expected_counts.numpy() == 0),
+                )
+                test_token_counts_ma = np.ma.masked_array(
+                    test_token_counts.numpy(),
+                    mask=test_expected_counts_ma.mask,
+                )
+
+                # FlashInfer normalization is numerically inaccurate enough to
+                # yield a tiny p-value in the test below, despite passing the
+                # test's normalization check. Most likely, this mainly
+                # affects the 'delta' distributions handled explicitly below.
+                assert np.allclose(test_expected_counts_ma.sum(axis=-1), num_samples)
+                test_expected_counts_ma /= test_expected_counts_ma.sum(axis=-1, keepdims=True)
+                test_expected_counts_ma *= num_samples
+
+                # Skip entries with exact agreement. Needed, because
+                # 'power_divergence' generates NaN p-values otherwise.
+                mask = ~(
+                    np.round(test_expected_counts_ma).astype(np.int64)
+                    == test_token_counts_ma.astype(np.int64)
+                ).all(axis=-1)
+                test_expected_counts_ma = test_expected_counts_ma[mask]
+                test_token_counts_ma = test_token_counts_ma[mask]
+
+                # Perform G-test (asymptotically approximated by Pearson's chi-square test) to
+                # check that sampled tokens are consistent with the expected probs.
+                test_result = power_divergence(
+                    f_obs=test_token_counts_ma,
+                    f_exp=test_expected_counts_ma,
+                    axis=-1,
+                    lambda_="log-likelihood",  # = KL divergence
+                )
+                if hasattr(test_result.pvalue, "mask"):
+                    assert test_result.pvalue.mask
+                    pvalue = test_result.pvalue.data
+                else:
+                    pvalue = test_result.pvalue
+                if not np.all(pvalue > 0.1):  # This can happen by "chance" (many test instances)
+                    # Fail test if sampled data are highly unlikely
+                    assert np.all(pvalue > 0.001)
+                    prob_delta = (
+                        np.abs(test_token_counts_ma - test_expected_counts_ma) / num_samples
+                    )
+                    # accept small prob differences
+                    prob_delta = np.where(
+                        prob_delta > 5e-2, prob_delta, 0
+                    )  # NB: this is rather liberal
+                    # bound relative differences on remaining probs
+                    prob_delta_rel = (
+                        np.ma.masked_array(
+                            num_samples * prob_delta, mask=test_expected_counts_ma.mask
+                        )
+                        / test_expected_counts_ma.data
+                    )
+                    assert prob_delta_rel.max() < 0.05
+
+    @staticmethod
+    def _build_seq_slot_assignments() -> list[tuple[list[int], int, str]]:
+        rng = np.random.default_rng(seed=42)
+
+        max_seq_slots: Final = 2048
+        margin: Final = 12
+
+        seq_slot_assignments = []
+        for include_first, include_last in product([False, True], [False, True]):
+            total_seq_slots = rng.integers(max_seq_slots // 2, max_seq_slots)
+            start = 0 if include_first else rng.integers(margin)
+            end = total_seq_slots - (0 if include_last else rng.integers(margin))
+            for dense in [False, True]:
+                if dense:
+                    seq_slots = range(start, end)
+                else:
+                    allowed_slots = np.arange(start, end)
+                    num_seq_slots = rng.integers(len(allowed_slots) // 2, len(allowed_slots))
+                    seq_slots = list(rng.choice(allowed_slots, num_seq_slots, replace=False))
+                seq_slot_assignments.append(
+                    (
+                        seq_slots,
+                        total_seq_slots,
+                        (
+                            f"lo_{'in' if include_first else 'out'}"
+                            f"_hi_{'in' if include_last else 'out'}"
+                            f"_{'dense' if dense else 'sparse'}"
+                        ),
+                    )
+                )
+
+        return seq_slot_assignments
+
+    @pytest.mark.parametrize(
+        (
+            "use_flashinfer",
+            "max_draft_len",
+            "allow_zero_draft_len",
+            "vocab_size",
+            "seq_slot_assignment",
+            "ordered",
+        ),
+        [
+            pytest.param(
+                False,  # NB: _unbatch_sampling_results does not depend on backend
+                max_draft_len,
+                allow_zero_draft_len,
+                vocab_size,
+                (seq_slots, total_seq_slots),
+                ordered,
+                id=(
+                    f"draft_len={0 if allow_zero_draft_len else 1}..{max_draft_len}"
+                    f"-{label}-{'ordered' if ordered else 'permuted'}"
+                ),
+            )
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (
+                is_mixed,
+                max_draft_len,
+                allow_zero_draft_len,
+                _build_seq_slot_assignments,
+                vocab_size,
+                ordered,
+            ) in product(
+                [False, True],
+                [0, 3],
+                [False, True],
+                [_build_seq_slot_assignments],
+                [VOCAB_SIZE],
+                [False, True],
+            )
+            for (seq_slots, total_seq_slots, label) in _build_seq_slot_assignments()
+        ],
+    )
+    def test_unbatch_sampling_results(
+        self,
+        sampler: TorchSampler,
+        vocab_size: int,  # used by fixtures
+        seq_slot_assignment: tuple[list[int], int],
+        max_draft_len: int,
+        use_flashinfer: bool,  # used by fixtures
+        allow_zero_draft_len: bool,  # used by fixtures
+        ordered: bool,
+    ):
+        with torch.cuda.Stream():
+            seq_slots, total_seq_slots = seq_slot_assignment
+            seq_slots_tensor = torch.tensor(seq_slots, dtype=torch.int32)
+
+            torch.manual_seed(42)  # torch.testing.make_tensor does not accept Generator
+            rng = np.random.default_rng(seed=42)
+
+            draft_lens = list(
+                rng.integers(
+                    1 if (max_draft_len > 0 and not allow_zero_draft_len) else 0,
+                    max_draft_len + 1,
+                    size=(
+                        len(
+                            seq_slots,
+                        )
+                    ),
+                )
+            )
+
+            req_num_steps = torch.tensor(draft_lens, dtype=torch.int32) + 1
+            total_steps = cast(int, req_num_steps.sum())
+
+            new_tokens_cuda = torch.testing.make_tensor(
+                (max_draft_len + 1, total_seq_slots, 1),
+                device="cuda",
+                dtype=torch.int32,
+            )
+            new_tokens_cuda_snapshot = new_tokens_cuda.clone()
+
+            batch_req_indices = torch.arange(0, len(seq_slots), dtype=torch.int32)
+            if not ordered:
+                batch_req_indices = batch_req_indices[torch.randperm(batch_req_indices.numel())]
+
+            first_token = rng.integers(123456)
+            batch_next_tokens_cuda_int = torch.arange(
+                first_token, first_token + total_steps, dtype=torch.int32, device="cuda"
+            )
+
+            batched_sampling_result = _BatchedSamplingResult(
+                batch_req_indices=batch_req_indices.clone(),
+                batch_next_tokens_cuda_int=batch_next_tokens_cuda_int.clone(),
+            )
+            seq_slots_tensor_snapshot = seq_slots_tensor.clone()
+
+            # FIXME: Currently, _unbatch_sampling_results is not fully async (TRTLLM-9175)
+            # with assert_no_cuda_sync(sync_timeout_s=0.2):
+            new_tokens_host = sampler._unbatch_sampling_results(
+                batched_sampling_result=batched_sampling_result,
+                new_tokens_cuda=new_tokens_cuda,
+                req_num_steps=req_num_steps,
+                seq_slots=seq_slots_tensor,
+            )
+            torch.cuda.synchronize()
+            assert new_tokens_host.device == torch.device("cpu")
+
+            # check for unwanted side effects
+            for slot in range(total_seq_slots):
+                if slot in seq_slots:
+                    continue
+                torch.testing.assert_close(
+                    new_tokens_cuda_snapshot[:, slot], new_tokens_cuda[:, slot]
+                )
+            torch.testing.assert_close(
+                batch_next_tokens_cuda_int, batched_sampling_result.batch_next_tokens_cuda_int
+            )
+            torch.testing.assert_close(batch_req_indices, batched_sampling_result.batch_req_indices)
+            torch.testing.assert_close(seq_slots_tensor, seq_slots_tensor_snapshot)
+
+            # validate tokens returned
+            input_offset = 0
+            for req_idx in batch_req_indices.tolist():
+                steps = draft_lens[req_idx] + 1
+                seq_slot = seq_slots[req_idx]
+                req_tokens = batch_next_tokens_cuda_int[input_offset : (input_offset + steps)]
+                torch.testing.assert_close(new_tokens_cuda[:steps, seq_slot, 0], req_tokens)
+                torch.testing.assert_close(new_tokens_host[:steps, seq_slot, 0], req_tokens.cpu())
+                input_offset += steps

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -781,7 +781,7 @@ class TestBatchedSampling:
             type_to_constrain = TopK
             mixed_params_list = None
             for constraint_value in [
-                None,  # all sub-batches have a least two requests
+                None,  # all sub-batches have at least two requests
                 0,  # one sub-batch omitted
                 1,  # one size-1 sub-batch
                 OneContinguous(),  # one contiguous sub-batch, rest shuffled


### PR DESCRIPTION
## Description

This PR provides extended test coverage for the code introduced by #7294, #8398, and #8581, as well as for some pre-existing code. With these changes, `test_torch_sampler.py` runs 436 test cases in slightly less than 4' total.

## Test Coverage

Provided by this PR.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional FlashInfer-based sampling optimization for improved performance during text generation
  * Added configuration option to control FlashInfer sampling usage

* **Tests**
  * Expanded test coverage for batched sampling with multiple backend configurations and sampling strategy combinations

* **Refactor**
  * Enhanced sampling strategy implementation with improved type safety and modular architecture for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->