### PR TITLE
[None][feat] Add SM-level disaggregation support

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -327,9 +327,8 @@ class ExecutorRequestQueue:
         self.waiting_queue.extend(new_requests)
 
         new_requests = self._get_from_waiting_queue(
-            self.waiting_queue,
-            remaining_capacity,
-            enable_attention_dp, all_ranks_num_active_requests)
+            self.waiting_queue, remaining_capacity, enable_attention_dp,
+            all_ranks_num_active_requests)
 
         # Update performance metrics
         if self.enable_iter_perf_stats and self.dist.rank == 0:
@@ -347,17 +346,18 @@ class ExecutorRequestQueue:
         else:
             num_active_requests = num_active_requests_on_engine if self.is_sm_disagg else len(
                 activate_requests)
-            remaining_capacity = self.max_num_active_requests - len(activate_requests)
-            return self._fetch_new_requests_attention_tp(num_active_requests, remaining_capacity)
+            remaining_capacity = self.max_num_active_requests - len(
+                activate_requests)
+            return self._fetch_new_requests_attention_tp(
+                num_active_requests, remaining_capacity)
 
     def _fetch_new_requests_attention_tp(
-            self, num_active_requests: int, remaining_capacity: int) -> List[LlmRequest]:
+            self, num_active_requests: int,
+            remaining_capacity: int) -> List[LlmRequest]:
         """Handle standard (non-attention DP) request fetching."""
         # fetch and process requests into waiting queue
         new_requests = self._fetch_and_process_requests(
-            num_active_requests,
-            remaining_capacity,
-            enable_attention_dp=False)
+            num_active_requests, remaining_capacity, enable_attention_dp=False)
 
         # Merge requests and add to active list
         merged_requests = self._merge_requests(new_requests)

--- a/tensorrt_llm/_torch/pyexecutor/green_ctx.py
+++ b/tensorrt_llm/_torch/pyexecutor/green_ctx.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from cuda.bindings import driver
+
+from tensorrt_llm.runtime.generation import CUASSERT
+
+
+def green_ctx_create_streams(res_list, device):
+    streams = []
+    for res in res_list:
+        desc = CUASSERT(driver.cuDevResourceGenerateDesc([res], 1))[0]
+        green_ctx = CUASSERT(
+            driver.cuGreenCtxCreate(
+                desc, device, driver.CUgreenCtxCreate_flags.CU_GREEN_CTX_DEFAULT_STREAM
+            )
+        )[0]
+        stream = CUASSERT(
+            driver.cuGreenCtxStreamCreate(
+                green_ctx, driver.CUstream_flags.CU_STREAM_NON_BLOCKING, 0
+            )
+        )[0]
+        stream = torch.cuda.get_stream_from_external(stream, device)
+        streams.append(stream)
+    return streams
+
+
+def green_ctx_split_percent(sm_percent: float, device_id: int = 0):
+    device = CUASSERT(driver.cuDeviceGet(device_id))[0]
+
+    res = CUASSERT(
+        driver.cuDeviceGetDevResource(device, driver.CUdevResourceType.CU_DEV_RESOURCE_TYPE_SM)
+    )[0]
+    sm_count = res.sm.smCount
+
+    major = CUASSERT(
+        driver.cuDeviceGetAttribute(
+            driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device
+        )
+    )[0]
+    if major >= 9:
+        sm_min = 8
+        sm_align = 8
+    else:
+        sm_min = 4 if major == 8 else 2
+        sm_align = 2
+
+    def green_ctx_split_aligned(sm_g1):
+        sm_g1 = round(sm_g1 / sm_align) * sm_align
+        sm_g1 = min(max(sm_g1, sm_min), sm_count - sm_min)
+        result = CUASSERT(
+            driver.cuDevSmResourceSplitByCount(
+                1,  # nbGroups
+                res,
+                0,  # useFlags
+                sm_g1,
+            )
+        )
+        res_split = (result[0][0], result[2])
+        streams = green_ctx_create_streams(res_split, device)
+        return streams, res_split
+
+    sm_g1 = round(sm_count * sm_percent)
+    sm_g2 = sm_count - sm_g1
+    # Choose the split closer to sm_percent when sm_count is not divisible by sm_align
+    sm_g1_dist = min(sm_g1 % sm_align, sm_align - (sm_g1 % sm_align))
+    sm_g2_dist = min(sm_g2 % sm_align, sm_align - (sm_g2 % sm_align))
+    if sm_g1_dist <= sm_g2_dist:
+        (stream_g1, stream_g2), (res_g1, res_g2) = green_ctx_split_aligned(sm_g1)
+    else:
+        (stream_g2, stream_g1), (res_g2, res_g1) = green_ctx_split_aligned(sm_g2)
+    return (stream_g1, stream_g2), (res_g1, res_g2)

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -816,3 +816,11 @@ def get_draft_token_length(request: LlmRequest) -> int:
     if request.py_draft_tokens is not None:
         return len(request.py_draft_tokens)
     return 0
+
+
+def get_context_requests(requests: List[LlmRequest]):
+    return [req for req in requests if req.is_context_init_state]
+
+
+def get_generation_requests(requests: List[LlmRequest]):
+    return [req for req in requests if not req.is_context_init_state]

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -825,5 +825,9 @@ def get_context_requests(requests: List[LlmRequest]):
 def get_generation_requests(requests: List[LlmRequest]):
     return [req for req in requests if not req.is_context_init_state]
 
+
 def get_generation_to_complete_requests(requests: List[LlmRequest]):
-    return [req for req in requests if req.state == LlmRequestState.GENERATION_TO_COMPLETE]
+    return [
+        req for req in requests
+        if req.state == LlmRequestState.GENERATION_TO_COMPLETE
+    ]

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -824,3 +824,6 @@ def get_context_requests(requests: List[LlmRequest]):
 
 def get_generation_requests(requests: List[LlmRequest]):
     return [req for req in requests if not req.is_context_init_state]
+
+def get_generation_to_complete_requests(requests: List[LlmRequest]):
+    return [req for req in requests if req.state == LlmRequestState.GENERATION_TO_COMPLETE]

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -149,10 +149,8 @@ class PyTorchModelEngine(ModelEngine):
             max_num_tokens,
             max_seq_len,
             max_batch_size,
-        ) = llm_args.get_runtime_sizes()
-        if is_sm_disagg_ctx_phase:
-            max_num_tokens = llm_args.sm_disagg_config.context_max_num_tokens
-            max_batch_size = llm_args.sm_disagg_config.context_max_batch_size
+        ) = llm_args.get_runtime_sizes(
+            sm_disagg_mode='ctx' if is_sm_disagg_ctx_phase else 'gen')
 
         self.batch_size = max_batch_size
         self.max_num_tokens = max_num_tokens

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1418,7 +1418,8 @@ class PyTorchModelEngine(ModelEngine):
                 request.py_multimodal_data = multimodal_params.multimodal_data
                 multimodal_params_list.append(multimodal_params)
 
-            request.py_batch_idx = request.py_seq_slot
+            if not self.sm_disagg_enabled:
+                request.py_batch_idx = request.py_seq_slot
 
         if len(multimodal_params_list) > 0:
             # discard the text token indices as it only includes context tokens at this moment
@@ -1460,10 +1461,8 @@ class PyTorchModelEngine(ModelEngine):
             # the request has no previous tensor:
             # (1) next_draft_tokens_device is None, which means overlap scheduler is disabled; or
             # (2) a dummy request; or
-            # (3) the first step in the generation server of disaggregated serving; or
-            # (4) the first step in the generation phase of SM-level disaggregation
-            if next_draft_tokens_device is None or request.is_dummy or request.py_batch_idx is None \
-                    or self.sm_disagg_enabled and request.max_num_generated_tokens == 0:
+            # (3) the first step in the generation server of disaggregated serving
+            if next_draft_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
                 # get token ids, including input token ids and draft token ids. For these dummy requests,
                 # no need to copy the token ids.
                 if not (request.is_attention_dp_dummy
@@ -1587,10 +1586,8 @@ class PyTorchModelEngine(ModelEngine):
                 # the request has no previous tensor:
                 # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
                 # (2) a dummy request; or
-                # (3) the first step in the generation server of disaggregated serving; or
-                # (4) the first step in the generation phase of SM-level disaggregation
-                if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None \
-                        or self.sm_disagg_enabled and request.max_num_generated_tokens == 0:
+                # (3) the first step in the generation server of disaggregated serving
+                if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
                     # skip adding input_ids of CUDA graph dummy requests so that new_tokens_device
                     # can be aligned to the correct positions.
                     if not request.is_cuda_graph_dummy:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1199,7 +1199,8 @@ class PyExecutor:
                 f'scheduled {len(scheduled_batch.generation_requests)} generation requests'
             )
 
-            if scheduled_batch.batch_size == 0 and not get_generation_to_complete_requests(self.active_requests):
+            if scheduled_batch.batch_size == 0 and not get_generation_to_complete_requests(
+                    self.active_requests):
                 self.sm_disagg_ctx_cv.wait()
 
         return scheduled_batch, iter_stats

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -255,7 +255,7 @@ def create_py_executor(
         max_num_tokens,
         max_seq_len,
         max_batch_size,
-    ) = llm_args.get_runtime_sizes()
+    ) = llm_args.get_runtime_sizes(sm_disagg_mode='sum')
 
     tokens_per_block = kv_cache_config.tokens_per_block
     if llm_args.attn_backend == "VANILLA":
@@ -451,6 +451,8 @@ def create_py_executor(
 
     max_seq_len = model_engine_max_seq_len
     max_num_tokens = model_engine.max_num_tokens
+    if ctx_model_engine is not None:
+        max_num_tokens += ctx_model_engine.max_num_tokens
     sparse_attention_config = model_engine.sparse_attention_config
 
     config = model_engine.model.model_config.pretrained_config

--- a/tensorrt_llm/_torch/pyexecutor/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler.py
@@ -79,6 +79,9 @@ class BindCapacityScheduler(CapacityScheduler):
         scheduler_policy: CapacitySchedulerPolicy = CapacitySchedulerPolicy.
         GUARANTEED_NO_EVICT,
         two_step_lookahead: bool = False,
+        no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
+        no_schedule_after_state: LlmRequestState = LlmRequestState.
+        GENERATION_COMPLETE,
     ):
         super(BindCapacityScheduler, self).__init__()
         self.kv_cache_manager = kv_cache_manager
@@ -89,8 +92,8 @@ class BindCapacityScheduler(CapacityScheduler):
             capacity_scheduler_policy=scheduler_policy._to_pybind(),
             has_kv_cache_manager=kv_cache_manager is not None,
             two_step_lookahead=two_step_lookahead,
-            no_schedule_until_state=LlmRequestState.CONTEXT_INIT,
-            no_schedule_after_state=LlmRequestState.GENERATION_COMPLETE)
+            no_schedule_until_state=no_schedule_until_state,
+            no_schedule_after_state=no_schedule_after_state)
 
     def schedule_request(
         self, active_requests: RequestList
@@ -175,6 +178,9 @@ class BindMicroBatchScheduler(MicroBatchScheduler):
         max_batch_size: int,
         max_num_tokens: int = None,
         ctx_chunk_config: Optional[Tuple[StrEnum, int]] = None,
+        no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
+        no_schedule_after_state: LlmRequestState = LlmRequestState.
+        GENERATION_COMPLETE,
     ) -> None:
         super(BindMicroBatchScheduler, self).__init__()
         self.max_batch_size = max_batch_size
@@ -186,7 +192,8 @@ class BindMicroBatchScheduler(MicroBatchScheduler):
                 ctx_chunk_config[0]._to_pybind(), ctx_chunk_config[1])
 
         self.impl = tb_internal.algorithms.MicroBatchScheduler(
-            ctx_chunk_config_cpp, max_num_tokens)
+            ctx_chunk_config_cpp, max_num_tokens, no_schedule_until_state,
+            no_schedule_after_state)
 
     def schedule(
         self, active_requests: RequestList, inflight_request_ids: set[int]

--- a/tensorrt_llm/_torch/pyexecutor/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler.py
@@ -180,7 +180,7 @@ class BindMicroBatchScheduler(MicroBatchScheduler):
         ctx_chunk_config: Optional[Tuple[StrEnum, int]] = None,
         no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
         no_schedule_after_state: LlmRequestState = LlmRequestState.
-        GENERATION_COMPLETE,
+        GENERATION_TO_COMPLETE,
     ) -> None:
         super(BindMicroBatchScheduler, self).__init__()
         self.max_batch_size = max_batch_size

--- a/tensorrt_llm/_torch/virtual_memory.py
+++ b/tensorrt_llm/_torch/virtual_memory.py
@@ -78,6 +78,7 @@ class ExecutorMemoryType(StrEnum):
     EXTRA_RESOURCES = "executor_extra"
     KV_CACHE = "kv_cache"
     MODEL_ENGINE_MAIN = "model"
+    MODEL_ENGINE_CTX = "ctx_model"
     MODEL_ENGINE_DRAFT = "draft_model"
 
 

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -14,8 +14,8 @@ from .llm_args import (AttentionDpConfig, AutoDecodingConfig, BatchingType,
                        MedusaDecodingConfig, MoeConfig, MTPDecodingConfig,
                        NGramDecodingConfig, RocketSparseAttentionConfig,
                        SaveHiddenStatesDecodingConfig, SchedulerConfig,
-                       TorchCompileConfig, TorchLlmArgs, TrtLlmArgs,
-                       UserProvidedDecodingConfig)
+                       SmDisaggConfig, TorchCompileConfig, TorchLlmArgs,
+                       TrtLlmArgs, UserProvidedDecodingConfig)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
 from .mm_encoder import MultimodalEncoder
@@ -62,6 +62,7 @@ __all__ = [
     'AttentionDpConfig',
     'LoRARequest',
     'SaveHiddenStatesDecodingConfig',
+    'SmDisaggConfig',
     'RocketSparseAttentionConfig',
     'DeepSeekSparseAttentionConfig',
 ]

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -424,6 +424,29 @@ class AttentionDpConfig(StrictBaseModel):
         return cls(**data)
 
 
+class SmDisaggConfig(StrictBaseModel):
+    """
+    Configuration for SM-level disaggregation.
+    """
+    context_sm_percent: float = Field(
+        default=0.5,
+        description="Percentage of SMs allocated to context phase.")
+    context_max_num_tokens: int = Field(
+        default=0,
+        description=
+        "The maximum number of tokens for context phase. If less than or equal to 0, the same value as generation phase is used."
+    )
+    context_max_batch_size: int = Field(
+        default=0,
+        description=
+        "The maximum batch size for context phase. If less than or equal to 0, the same value as generation phase is used."
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+
 class _ParallelConfig(StrictBaseModel):
     """The model distribution configs for LLM."""
     tp_size: int = 1
@@ -2619,6 +2642,11 @@ class TorchLlmArgs(BaseLlmArgs):
         description="Disable the overlap scheduler.",
         status="beta")
 
+    sm_disagg_config: Optional[SmDisaggConfig] = Field(
+        default=None,
+        description="SM-level disaggregation config.",
+        status="prototype")
+
     moe_config: MoeConfig = Field(default_factory=MoeConfig,
                                   description="MoE config.",
                                   status="beta")
@@ -2976,6 +3004,23 @@ class TorchLlmArgs(BaseLlmArgs):
                 raise ValueError(
                     "attention_dp_config.timeout_iters must be greater or equal to 0 when enable_balance is true"
                 )
+        return self
+
+    @model_validator(mode='after')
+    def validate_and_sync_sm_disagg_config(self) -> 'TorchLlmArgs':
+        """Validate SM-level disaggregation configuration."""
+        if self.sm_disagg_config is None:
+            return self
+
+        config = self.sm_disagg_config
+        if not 0 < config.context_sm_percent < 1:
+            raise ValueError(
+                "sm_disagg_config.context_sm_percent must be in the range (0, 1)"
+            )
+        if config.context_max_num_tokens <= 0:
+            config.context_max_num_tokens = self.max_num_tokens
+        if config.context_max_batch_size <= 0:
+            config.context_max_batch_size = self.max_batch_size
         return self
 
     @model_validator(mode='after')

--- a/tests/unittest/_torch/misc/test_green_ctx.py
+++ b/tests/unittest/_torch/misc/test_green_ctx.py
@@ -1,0 +1,17 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.pyexecutor.green_ctx import green_ctx_split_percent
+
+
+@pytest.mark.parametrize("sm_percent", [0.2, 0.4, 0.6, 0.8])
+def test_green_ctx_split_percent(sm_percent):
+    sm_count = torch.cuda.get_device_properties(device=0).multi_processor_count
+    sm_major = torch.cuda.get_device_capability()[0]
+    sm_align = 8 if sm_major >= 9 else (4 if sm_major == 8 else 2)
+
+    _, (res_g1, res_g2) = green_ctx_split_percent(sm_percent)
+
+    sm_g1, sm_g2 = res_g1.sm.smCount, res_g2.sm.smCount
+    assert sm_g1 + sm_g2 == sm_count
+    assert abs(sm_g1 - round(sm_count * sm_percent)) <= sm_align

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -107,6 +107,10 @@ methods:
         annotation: bool
         default: False
         status: beta
+      sm_disagg_config:
+        annotation: Optional[tensorrt_llm.llmapi.llm_args.SmDisaggConfig]
+        status: prototype
+        default: null
       moe_config:
         annotation: tensorrt_llm.llmapi.llm_args.MoeConfig
         status: beta


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for SM-level disaggregation mode to optimize context execution with configurable parameters including context execution percentage, token limits, and batch size settings.
  * Enabled context-disaggregated execution capabilities for improved performance optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

### Background and overview

The SOTA request scheduling scheme - chunked prefill - piggybacks chunked context requests with generation requests to achieve stable TPOT and improved GPU utilization. However, the TPOT latency is bloated as the generation requests now often need to be processed together with many more context tokens.

Alternatively, disaggregated serving processes context and generation requests on different nodes to achieve low TOPT. However, the generation nodes can be underutilized, especially when using smaller batch sizes to meet the TPOT target. Besides, there are deployment scenarios where disaggregated serving is not suitable, e.g., lack of high speed interconnect.

This PR aims to achieve better throghput@latency by implementing a new feature called SM-level disaggregation. The feature achieves low TPOT latency by decoupling context and generation requests (as in desegregated serving), but still runs the decoupled requests on the same GPU for better GPU utilization (as in chunked prefill). To achieve that, we partition the GPU (using [Green Contexts](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GREEN__CONTEXTS.html)) and allocate SMs to context and generation phases, and the context and generation requests are asynchronously scheduled onto two different streams on the same GPU.

<img width="922" height="222" alt="image" src="https://github.com/user-attachments/assets/9dd00403-b9bf-49b6-9024-01f90ebfd36d" />

This is the first PR that implements the core functionality of SM-level disaggregation. Follow-up PRs are planned to address doc and examples, persistent kernel perf issues, and parallelism support.

### Design

<img width="963" height="363" alt="image" src="https://github.com/user-attachments/assets/aed763c6-86d2-4ae9-9106-4a22604d4891" />

- The Python executor starts two executor loops if the feature is enabled, one for context phase and one for generation phase
- Two model engines are instantiated (but model weights are still shared) as they are non-reentrant
- Handing of shared variables/resources (active_requests and KV cache) is lock protected

### Performance results

- GPT-OSS-120B, ISL/OSL = 10k/600 on 1x B200: Up to 26.2% improvement on user throughput or up to 8.9% improvement on GPU throughput over chunked prefill. Disaggregated serving has the same perf as chunked prefill in this case.

<img width="1866" height="1116" alt="image" src="https://github.com/user-attachments/assets/1cc92b0a-cd6c-4563-898d-5d8849f5e587" />

- Llama 2 70B, OpenOrca (avg ISL/OSL = 221/276) on 1x B200: Up to 29.0% improvement on user throughput or up to 14.1% improvement on GPU throughput over chunked prefill.

<img width="1646" height="982" alt="image" src="https://github.com/user-attachments/assets/70563114-8d4b-4af5-ae79-cca4d4ec71ab" />

Limitation: Note that the context and generation workloads are relatively balanced in above cases (in terms of compute time). This feature (as well as any other disaggregation schemes) won't show much benefit if the workload is dominated by context or generation.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Please suggest appropriate test cases to guard the feature.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
