### PR TITLE
[TRTLLM-9159][doc] Add KV Connector docs

### DIFF
--- a/examples/llm-api/llm_kv_cache_connector.py
+++ b/examples/llm-api/llm_kv_cache_connector.py
@@ -1,6 +1,84 @@
 ### :title KV Cache Connector
 ### :order 6
 ### :section Customization
+'''
+This script demonstrates the KV cache connector feature in TensorRT-LLM, which enables
+custom persistence and reuse of KV cache blocks across different LLM instances.
+
+**Scenario:**
+The script implements a persistent KV cache connector that saves computed KV cache blocks
+to disk and loads them back in subsequent runs, eliminating redundant computation for
+recurring prompts.
+
+**What is a KV Cache Connector?**
+
+A KV cache connector is a customizable interface that allows you to:
+1.  **Save KV Cache:** Persist computed KV cache blocks to an external storage
+    (disk, database, distributed cache, etc.)
+2.  **Load KV Cache:** Retrieve previously computed cache blocks instead of recomputing them
+3.  **Share Cache Across Instances:** Reuse cache blocks across different LLM instances
+    or sessions, unlike regular block reuse which is limited to a single instance
+
+**How It Works:**
+
+This example implements a `PersistentKvCacheConnector` with two key components:
+
+* **PersistentKvCacheConnectorLeader (Scheduler):**
+    - Hashes token sequences to create unique identifiers for each cache block
+    - Checks if cached blocks exist on disk for incoming requests
+    - Schedules load operations for cache hits
+    - Schedules save operations for newly computed blocks
+
+* **PersistentKvCacheConnectorWorker:**
+    - Executes the actual load/save operations between GPU and disk
+    - Loads cached blocks from disk files into GPU memory
+    - Saves newly computed blocks from GPU to disk files
+
+**Demonstration:**
+
+The script processes the same prompt twice using two separate LLM instances:
+
+1.  **First Run (Instance 1):**
+    - The LLM computes the KV cache for the input prompt
+    - The connector saves the computed cache blocks to disk (as .pt files)
+    - The generation completes and the LLM instance is destroyed
+
+2.  **Second Run (Instance 2):**
+    - A new LLM instance is created with the same connector configuration
+    - When processing the same prompt, the connector finds matching cache blocks on disk
+    - The cache is loaded from disk instead of being recomputed
+    - **Expected Outcome:** Faster prefill as cache blocks are loaded rather than computed
+    - Both outputs should be identical, demonstrating deterministic cache reuse
+
+**Key Benefits:**
+
+- **Cross-Instance Cache Sharing:** Share computed caches across multiple LLM instances
+- **Persistent Storage:** Cache survives beyond the lifetime of a single LLM instance
+- **Custom Storage Backends:** Implement any storage mechanism (shown here: disk files)
+- **Reduced Computation:** Eliminate redundant KV cache computation for repeated prompts
+
+**How to Run:**
+
+```bash
+python llm_kv_cache_connector.py <model_path>
+```
+
+Example:
+```bash
+python llm_kv_cache_connector.py meta-llama/Llama-3.1-8B-Instruct
+```
+
+**Implementation Notes:**
+
+- This example uses content-based hashing to identify cache blocks
+- Cache files are stored in a temporary directory (cleaned up after the demo)
+- The implementation is simplified and not optimized for production use
+- Does not support chunked prefill in this example
+- See `tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py` for the full connector interface
+
+**NOTE:** This example connector implementation is designed for demonstration purposes
+and is NOT suitable for production use without additional optimizations and error handling.
+'''
 
 import os
 import sys
@@ -16,11 +94,6 @@ from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
     KvCacheConnectorScheduler, KvCacheConnectorWorker, SchedulerOutput)
 from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
 from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig, TorchLlmArgs
-
-# This is a simple example of the use of the KV cache connector.
-# It persists KV cache contents into a folder, and can load them back on subsequent runs.
-# See tensorrt_llm/_torch/pyexecutor/connector.py for details about the KV cache connector interface.
-# NOTE: This example connector implementation is NOT suitable for production use.
 
 CONNECTOR_CACHE_FOLDER_KEY = "CONNECTOR_CACHE_FOLDER"
 
@@ -198,6 +271,7 @@ def main(model: str):
 
     this_module = __file__[__file__.rfind("/") + 1:__file__.rfind(".py")]
 
+    # --- KV Cache Connector Config ---
     kv_connector_config = KvCacheConnectorConfig(
         connector_module=this_module,
         connector_scheduler_class="PersistentKvCacheConnectorLeader",
@@ -207,6 +281,7 @@ def main(model: str):
     connector_cache_dir = TemporaryDirectory()
     os.environ[CONNECTOR_CACHE_FOLDER_KEY] = connector_cache_dir.name
 
+    # Create LLM instance with KV Cache Connector
     llm = LLM(model=model,
               backend="pytorch",
               cuda_graph_config=None,
@@ -220,6 +295,7 @@ def main(model: str):
 
     sampling_params = SamplingParams(max_tokens=32)
 
+    # Generate text with the first LLM instance and save the kv cache blocks by the connector.
     output = llm.generate([test_text], sampling_params)
     text0 = output[0].outputs[0].text
 
@@ -228,16 +304,19 @@ def main(model: str):
 
     del llm
 
+    # Create a new LLM instance with the same connector configuration
     llm = LLM(model=model,
               backend="pytorch",
               cuda_graph_config=None,
               kv_connector_config=kv_connector_config)
 
+    # Generate text with the second LLM instance and it should reuse the kv cache blocks from the connector.
     output = llm.generate([test_text], sampling_params)
     text1 = output[0].outputs[0].text
 
     print("Second output (using connector cache): ", text1)
 
+    # Verify that the two outputs are identical
     assert text0 == text1
 
     connector_cache_dir.cleanup()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent KV cache connector for TensorRT-LLM that enables caching and reusing model computation blocks across multiple instances
  * Implemented disk-backed caching to optimize GPU memory usage by storing and retrieving cached data
  * Supports cache reuse across separate model runs, producing identical outputs while reducing memory overhead
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
