### PR TITLE
[None][infra] Lock generation pipeline update

### DIFF
--- a/jenkins/GenerateLock.groovy
+++ b/jenkins/GenerateLock.groovy
@@ -111,6 +111,12 @@ pipeline {
         timestamps()
     }
 
+    triggers {
+        parameterizedCron('''
+            H 2 * * * %branchName=release/1.1.0rc3;repoUrlKey=tensorrt_llm_github
+        ''')
+    }
+
     stages {
         stage("Generating Poetry Locks"){
             agent {

--- a/jenkins/GenerateLock.groovy
+++ b/jenkins/GenerateLock.groovy
@@ -81,7 +81,7 @@ def generate()
             echo "No update that needs to be checked in"
         } else {
             sh "git status"
-            sh "git add \$(find . -type f \\( -name 'poetry.lock' -o -name 'pyproject.toml' \\))"
+            sh "git add \$(find . -type f \\( -name 'poetry.lock' -o -name 'pyproject.toml' -o -name 'metadata.json' \\))"
             sh "git commit -s -m \"[None][infra] Check in most recent lock file from nightly pipeline\""
             withCredentials([string(credentialsId: CREDENTIAL_ID, variable: 'API_TOKEN')]) {
                 def authedUrl = LLM_REPO.replaceFirst('https://', "https://svc_tensorrt:${API_TOKEN}@")
@@ -113,7 +113,7 @@ pipeline {
 
     triggers {
         parameterizedCron('''
-            H 2 * * * %branchName=release/1.1.0rc3;repoUrlKey=tensorrt_llm_github
+            H 2 * * * %branchName=main;repoUrlKey=tensorrt_llm_github
         ''')
     }
 

--- a/scripts/generate_lock_file.py
+++ b/scripts/generate_lock_file.py
@@ -33,7 +33,7 @@ import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, os.getcwd())
@@ -77,13 +77,20 @@ def get_project_info(path: str):
 
 
 def generate_metadata_json():
-    commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                          text=True).strip()
+    try:
+        commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                              text=True).strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error retrieving git commit hash: {e}")
+        raise
+
     data = {
         "commit_hash": commit_hash,
-        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     }
-    with open(f"{FOLDER_SECURITY_SCANNING}/metadata.json", "w") as f:
+    with open(f"{FOLDER_SECURITY_SCANNING}/metadata.json",
+              "w",
+              encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
 

--- a/scripts/generate_lock_file.py
+++ b/scripts/generate_lock_file.py
@@ -27,11 +27,13 @@ python3 scripts/generate_lock_files.py --path <path>/requirements.txt
 """
 
 import argparse
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, os.getcwd())
@@ -74,6 +76,17 @@ def get_project_info(path: str):
     return {"name": name, "version": version}
 
 
+def generate_metadata_json():
+    commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                          text=True).strip()
+    data = {
+        "commit_hash": commit_hash,
+        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    }
+    with open(f"{FOLDER_SECURITY_SCANNING}/metadata.json", "w") as f:
+        json.dump(data, f, indent=2)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Lock files generator",
@@ -93,6 +106,7 @@ if __name__ == "__main__":
     if os.path.exists(FOLDER_SECURITY_SCANNING):
         shutil.rmtree(FOLDER_SECURITY_SCANNING)
     os.mkdir(FOLDER_SECURITY_SCANNING)
+    generate_metadata_json()
 
     # generate pyproject.toml and poetry.lock files in the same location
     for path in paths:


### PR DESCRIPTION
## Description

1. add nightly schedule to run lock file generation for main branch
2. record the commit hash that run lock file generation

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata now captures git commit information and UTC timestamps
  * Automated nightly process scheduled to run daily at 2:00 AM

<!-- end of auto-generated comment: release notes by coderabbit.ai -->