### PR TITLE
[None][fix] AutoDeploy: Use tmp folder for the load_moe_align

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/load_moe_align.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/load_moe_align.py
@@ -4,6 +4,7 @@ Build moe_align CUDA extension eagerly with a persistent build directory
 """
 
 import os
+import tempfile
 
 import torch
 from torch.utils.cpp_extension import load
@@ -12,21 +13,10 @@ from torch.utils.cpp_extension import load
 os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "8.0;8.6;8.9;9.0")
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-CACHE_ROOT = os.environ.get("AD_CACHE_DIR") or os.path.join(
-    os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")),
-    "ad_cache",
-)
-BUILD_DIR = os.path.join(CACHE_ROOT, "auto_deploy", "fused_moe", "moe_align")
-try:
-    os.makedirs(BUILD_DIR, exist_ok=True)
-except PermissionError:
-    import tempfile
 
-    # Fallback to the system temp dir while maintaining a stable subfolder layout
-    BUILD_DIR = os.path.join(
-        tempfile.gettempdir(), "ad_cache", "auto_deploy", "fused_moe", "moe_align"
-    )
-    os.makedirs(BUILD_DIR, exist_ok=True)
+# Use system temp directory to avoid environment variable dependency
+BUILD_DIR = os.path.join(tempfile.gettempdir(), "ad_cache", "auto_deploy", "fused_moe", "moe_align")
+os.makedirs(BUILD_DIR, exist_ok=True)
 
 moe_align_ext = load(
     name="moe_align_ext",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build directory resolution to use system temporary directories, improving portability and reducing environment variable dependencies for the MOE custom operations build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

