### PR TITLE
[#9102][feat] AutoDeploy: Support fp8 kv cache

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
@@ -283,7 +283,7 @@ class CudaBackendCausalConv(AttentionDescriptor):
                 in_channels,
                 max(1, kernel_size - 1),
                 device=si.device,
-                dtype=cache_config.dtype or inp_fake.dtype,
+                dtype=inp_fake.dtype,
             )
 
         return {"conv_state_cache": _get_conv_cache}

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
@@ -341,7 +341,7 @@ class TorchBackendCausalConv(AttentionDescriptor):
                 in_channels,
                 kernel_size,
                 device=si.device,
-                dtype=cache_config.dtype or inp_fake.dtype,
+                dtype=inp_fake.dtype,
             )
 
         return {"conv_state_cache": _get_conv_cache}


### PR DESCRIPTION
If the model has both linear attention and kv cache attention, the datatype for causal conv may have different datatype vs. the kv cache dtype. 

We may consider changing the cache_config.dtype to cache_config.kv_dtype and then add a new field cache_config.causal_conv_dtype

fixes #9102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache tensor data type handling in Mamba convolution operations to consistently follow input tensor dtype across CUDA and PyTorch backends, ensuring improved type compatibility and removing fallback configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

