### PR TITLE
[None][fix] Make the sliced nvfp4 output contiguous

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -824,9 +824,9 @@ class NVFP4LinearMethod(LinearMethodBase):
                                                      act_sf,
                                                      module.weight_scale,
                                                      module.alpha, module.dtype)
-        # Take the dim of out_features if padded.
+        # Take the dim of out_features if padded. Make sure the output is contiguous
         if output.shape[-1] > module.out_features:
-            output = output[..., :module.out_features]
+            output = output[..., :module.out_features].contiguous()
 
         if bias is not None:
             output = output + bias


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tensor memory layout handling in NVFP4-accelerated linear operations for enhanced performance and stability during inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[None][fix] Make the sliced nvfp4 output contiguous

1. Add torch.tensor.contiguous() to linear output in nvfp4 situation. In case the following function needs it.
2. minor change