### PR TITLE
[TRTLLM-9050][test] add llama4 disagg case to cover kv cache overflow error

### DIFF
--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
@@ -1,20 +1,4 @@
-# Configuration for reproducing KV cache buffer overflow bug
-# RCCA: https://nvbugspro.nvidia.com/bug/5555681
-#
-# This config uses Llama-4-Scout-17B-16E-Instruct model (16 experts MoE)
-# and intentionally sets max_tokens_in_buffer to a small value (2048)
-# to trigger illegal memory access when transferring large KV cache (~16k tokens)
-# between disaggregated context and generation workers.
-# 这个配置使用Llama-4-Scout-17B-16E-Instruct模型（16专家MoE）
-# 并故意将max_tokens_in_buffer设置为较小值(2048)
-# 以触发在disaggregated context和generation workers之间传输大KV cache(~16k tokens)时的非法内存访问
-#
-# Scout model is smaller than Maverick (16E vs 128E) so should have less memory pressure
-# Scout模型比Maverick更小（16E vs 128E），所以内存压力会小得多
-
-# NOTE: This will be replaced with absolute path in the test
-# 注意：这个路径会在测试中被替换为绝对路径
-model: PLACEHOLDER_MODEL_PATH
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 hostname: localhost
 port: 8000
 backend: pytorch
@@ -26,20 +10,19 @@ context_servers:
   moe_expert_parallel_size: 1
   enable_attention_dp: false
   max_num_tokens: 8192
-  max_seq_len: 257000  # Reduced from 257000 to fit in GPU memory
-  max_input_len: 256000  # Reduced from 256000
+  max_seq_len: 257000
+  max_input_len: 256000
   max_batch_size: 1
   trust_remote_code: true
   enable_chunked_prefill: true
   kv_cache_config:
-    enable_block_reuse: false  # Disable block reuse to save memory
-    free_gpu_memory_fraction: 0.3  # Increase memory allocation significantly
+    enable_block_reuse: false
+    free_gpu_memory_fraction: 0.3
   disable_overlap_scheduler: true
-  cuda_graph_config: null  # Disable CUDA graph to reduce memory usage
+  cuda_graph_config: null
   cache_transceiver_config:
     backend: UCX
     # Intentionally small to reproduce buffer overflow bug
-    # 故意设置为小值以复现缓冲区溢出bug
     max_tokens_in_buffer: 2048
   urls:
     - "localhost:8001"
@@ -51,20 +34,19 @@ generation_servers:
   moe_expert_parallel_size: 1
   enable_attention_dp: false
   max_num_tokens: 8192
-  max_seq_len: 257000  # Reduced from 257000 to fit in GPU memory
-  max_input_len: 256000  # Reduced from 256000
+  max_seq_len: 257000
+  max_input_len: 256000
   max_batch_size: 1
   trust_remote_code: true
   enable_chunked_prefill: true
   kv_cache_config:
-    enable_block_reuse: false  # Disable block reuse to save memory
-    free_gpu_memory_fraction: 0.3  # Increase memory allocation significantly
+    enable_block_reuse: false
+    free_gpu_memory_fraction: 0.3
   disable_overlap_scheduler: true
-  cuda_graph_config: null  # Disable CUDA graph to reduce memory usage
+  cuda_graph_config: null
   cache_transceiver_config:
     backend: UCX
     # Intentionally small to reproduce buffer overflow bug
-    # 故意设置为小值以复现缓冲区溢出bug
     max_tokens_in_buffer: 2048
   urls:
     - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
@@ -1,0 +1,70 @@
+# Configuration for reproducing KV cache buffer overflow bug
+# RCCA: https://nvbugspro.nvidia.com/bug/5555681
+#
+# This config uses Llama-4-Scout-17B-16E-Instruct model (16 experts MoE)
+# and intentionally sets max_tokens_in_buffer to a small value (2048)
+# to trigger illegal memory access when transferring large KV cache (~16k tokens)
+# between disaggregated context and generation workers.
+# 这个配置使用Llama-4-Scout-17B-16E-Instruct模型（16专家MoE）
+# 并故意将max_tokens_in_buffer设置为较小值(2048)
+# 以触发在disaggregated context和generation workers之间传输大KV cache(~16k tokens)时的非法内存访问
+#
+# Scout model is smaller than Maverick (16E vs 128E) so should have less memory pressure
+# Scout模型比Maverick更小（16E vs 128E），所以内存压力会小得多
+
+# NOTE: This will be replaced with absolute path in the test
+# 注意：这个路径会在测试中被替换为绝对路径
+model: PLACEHOLDER_MODEL_PATH
+hostname: localhost
+port: 8000
+backend: pytorch
+
+context_servers:
+  num_instances: 1
+  tensor_parallel_size: 4
+  pipeline_parallel_size: 1
+  moe_expert_parallel_size: 1
+  enable_attention_dp: false
+  max_num_tokens: 8192
+  max_seq_len: 257000  # Reduced from 257000 to fit in GPU memory
+  max_input_len: 256000  # Reduced from 256000
+  max_batch_size: 1
+  trust_remote_code: true
+  enable_chunked_prefill: true
+  kv_cache_config:
+    enable_block_reuse: false  # Disable block reuse to save memory
+    free_gpu_memory_fraction: 0.3  # Increase memory allocation significantly
+  disable_overlap_scheduler: true
+  cuda_graph_config: null  # Disable CUDA graph to reduce memory usage
+  cache_transceiver_config:
+    backend: UCX
+    # Intentionally small to reproduce buffer overflow bug
+    # 故意设置为小值以复现缓冲区溢出bug
+    max_tokens_in_buffer: 2048
+  urls:
+    - "localhost:8001"
+
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 4
+  pipeline_parallel_size: 1
+  moe_expert_parallel_size: 1
+  enable_attention_dp: false
+  max_num_tokens: 8192
+  max_seq_len: 257000  # Reduced from 257000 to fit in GPU memory
+  max_input_len: 256000  # Reduced from 256000
+  max_batch_size: 1
+  trust_remote_code: true
+  enable_chunked_prefill: true
+  kv_cache_config:
+    enable_block_reuse: false  # Disable block reuse to save memory
+    free_gpu_memory_fraction: 0.3  # Increase memory allocation significantly
+  disable_overlap_scheduler: true
+  cuda_graph_config: null  # Disable CUDA graph to reduce memory usage
+  cache_transceiver_config:
+    backend: UCX
+    # Intentionally small to reproduce buffer overflow bug
+    # 故意设置为小值以复现缓冲区溢出bug
+    max_tokens_in_buffer: 2048
+  urls:
+    - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_llama4_kv_cache_overflow.yaml
@@ -1,4 +1,4 @@
-model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+model: llama4-models/nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8
 hostname: localhost
 port: 8000
 backend: pytorch

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from typing import Callable
 
 import pytest
@@ -267,6 +268,8 @@ def get_test_config(test_desc, example_dir, test_root):
         (3,
          f"{test_configs_root}/disagg_config_deepseek_v3_lite_empty_batch.yaml"
          ),
+        "llama4_kv_cache_overflow":
+        (8, f"{test_configs_root}/disagg_config_llama4_kv_cache_overflow.yaml"),
     }
 
     if test_desc not in config_map:
@@ -1687,6 +1690,126 @@ def get_config_for_benchmark(model_root, backend):
     return serve_config
 
 
+def run_disaggregated_genai_perf(config_file,
+                                 model_path,
+                                 num_ranks,
+                                 server_start_timeout=1200,
+                                 input_tokens=128000,
+                                 output_tokens=100,
+                                 env=None,
+                                 cwd=None):
+    """Run disaggregated test with genai-perf for performance/stress testing."""
+    cleanup_output_files()
+    run_env = env.copy()
+    run_env["UCX_TLS"] = "^ib"
+
+    workers_cmd = [
+        'mpirun', '--allow-run-as-root', '--oversubscribe', '-n',
+        str(num_ranks), 'trtllm-serve', 'disaggregated_mpi_worker', '-c',
+        config_file
+    ]
+
+    server_cmd = [
+        'trtllm-serve', 'disaggregated', '--server_start_timeout',
+        str(server_start_timeout), '-c', config_file
+    ]
+
+    artifact_dir = os.path.join(cwd or ".", "benchmark-results")
+
+    try:
+        with (open('output_workers.log', 'w') as output_workers,
+              popen(workers_cmd,
+                    stdout=output_workers,
+                    stderr=subprocess.STDOUT,
+                    env=run_env,
+                    cwd=cwd) as workers_proc, open('output_disagg.log', 'w') as
+              output_disagg,
+              popen(server_cmd,
+                    stdout=output_disagg,
+                    stderr=subprocess.STDOUT,
+                    env=run_env,
+                    cwd=cwd) as server_proc):
+
+            # Wait for server to be ready
+            server_url = "http://localhost:8000"
+            start_wait = time.time()
+            server_ready = False
+
+            logger.info(
+                f"Waiting for server to be ready (timeout: {server_start_timeout}s)..."
+            )
+            while time.time() - start_wait < server_start_timeout:
+                try:
+                    response = requests.get(f"{server_url}/health", timeout=5)
+                    if response.status_code == 200:
+                        logger.info("✓ Server is ready!")
+                        server_ready = True
+                        break
+                except Exception as e:
+                    logger.debug(f"Server not ready yet: {e}")
+                time.sleep(5)
+
+            if not server_ready:
+                raise RuntimeError(
+                    f"Server did not become ready within {server_start_timeout} seconds"
+                )
+
+            logger.info("Waiting 10 seconds for full initialization...")
+            time.sleep(10)
+
+            # Run genai-perf
+            logger.info(
+                f"Running genai-perf with {input_tokens} input tokens...")
+            genai_perf_cmd = [
+                'genai-perf', 'profile', '--model', model_path, '--tokenizer',
+                model_path, '--endpoint-type', 'chat', '--endpoint',
+                '/v1/chat/completions', '--streaming', '--url',
+                'localhost:8000', '--synthetic-input-tokens-mean',
+                str(input_tokens), '--synthetic-input-tokens-stddev', '0',
+                '--output-tokens-mean',
+                str(output_tokens), '--output-tokens-stddev', '0',
+                '--extra-inputs', f'max_tokens:{output_tokens}',
+                '--extra-inputs', f'min_tokens:{output_tokens}',
+                '--extra-inputs', 'ignore_eos:true', '--concurrency', '1',
+                '--warmup-request-count', '8', '--num-dataset-entries', '64',
+                '--random-seed', '100', '--artifact-dir', artifact_dir, '--',
+                '-v', '-H', 'Authorization: Bearer NOT USED', '-H',
+                'Accept: text/event-stream', '-p', '200000'
+            ]
+
+            check_call(genai_perf_cmd,
+                       env=env,
+                       poll_procs=[workers_proc, server_proc])
+
+    except Exception:
+        # Print outputs on error
+        logger.error("-------- Workers output (last 30 lines) --------")
+        try:
+            with open('output_workers.log', 'r') as f:
+                lines = f.read().split('\n')
+                for line in lines[-30:]:
+                    if line.strip():
+                        logger.error(line)
+        except FileNotFoundError:
+            pass
+
+        logger.error("-------- Disagg server output (last 30 lines) --------")
+        try:
+            with open('output_disagg.log', 'r') as f:
+                lines = f.read().split('\n')
+                for line in lines[-30:]:
+                    if line.strip():
+                        logger.error(line)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        server_proc.terminate()
+        workers_proc.terminate()
+        server_proc.wait()
+        workers_proc.wait()
+
+
 @pytest.mark.parametrize("benchmark_model_root", [
     'DeepSeek-V3-Lite-fp8', 'DeepSeek-V3-Lite-bf16', 'llama-v3-8b-hf',
     'llama-3.1-8b-instruct-hf-fp8'
@@ -1773,176 +1896,29 @@ def test_disaggregated_deepseek_v3_lite_bf16_empty_batch(
 
 
 @pytest.mark.skip_less_device(8)
-@pytest.mark.skip_less_device_memory(80000)
+@pytest.mark.skip_less_device_memory(140000)
+@pytest.mark.parametrize(
+    "model_path",
+    ['llama4-models/nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8'])
 def test_llama4_long_context_kv_cache_overflow(disaggregated_test_root,
                                                disaggregated_example_root,
-                                               llm_venv):
+                                               llm_venv, model_path):
     """
     RCCA: https://nvbugspro.nvidia.com/bug/5555681
+    Test to reproduce KV cache buffer overflow bug with long context.
     """
-    import tempfile
-    import time
-
-    import requests
-
-    # Get model path directly without using fixture
     models_root = llm_models_root()
-    llama_model_path = os.path.join(models_root, "llama4-models", "nvidia",
-                                    "Llama-4-Maverick-17B-128E-Instruct-FP8")
+    llama4_model_root = os.path.join(models_root, model_path)
 
-    # Update config file with actual model path
-    test_configs_root = os.path.join(os.path.dirname(__file__), "test_configs")
-    config_template = os.path.join(
-        test_configs_root, "disagg_config_llama4_kv_cache_overflow.yaml")
+    num_ranks, config_file = get_test_config("llama4_kv_cache_overflow",
+                                             disaggregated_example_root,
+                                             os.path.dirname(__file__))
 
-    # Create a temporary config file with the actual model path
-    with open(config_template, 'r') as f:
-        config_content = f.read()
-
-    # Replace placeholder with actual model path
-    config_content = config_content.replace("PLACEHOLDER_MODEL_PATH",
-                                            llama_model_path)
-
-    # Write to temporary file
-    # 写入临时文件
-    temp_config = tempfile.NamedTemporaryFile(
-        mode='w',
-        suffix='.yaml',
-        delete=False,
-        dir=llm_venv.get_working_directory())
-    temp_config.write(config_content)
-    temp_config.close()
-
-    # We'll use genai-perf to generate synthetic long inputs
-    # This is more realistic and can generate 128k tokens
-    artifact_dir = os.path.join(llm_venv.get_working_directory(),
-                                "benchmark-results")
-
-    # Set environment variables for debugging
-    env = llm_venv._new_env.copy()
-    # Get num_ranks from config
-    num_ranks = 8  # 4 for context + 4 for generation
-
-    cleanup_output_files()
-    run_env = env.copy()
-
-    workers_cmd = [
-        'mpirun', '--allow-run-as-root', '--oversubscribe', '-n',
-        str(num_ranks), 'trtllm-serve', 'disaggregated_mpi_worker', '-c',
-        temp_config.name
-    ]
-
-    server_start_timeout = 900
-    server_cmd = [
-        'trtllm-serve', 'disaggregated', '--server_start_timeout',
-        str(server_start_timeout), '-c', temp_config.name
-    ]
-
-    try:
-        with (  # Start workers
-                open('output_workers.log', 'w') as output_workers,
-                popen(workers_cmd,
-                      stdout=output_workers,
-                      stderr=subprocess.STDOUT,
-                      env=run_env,
-                      cwd=llm_venv.get_working_directory()) as workers_proc,
-                # Start server
-                open('output_disagg.log', 'w') as output_disagg,
-                popen(server_cmd,
-                      stdout=output_disagg,
-                      stderr=subprocess.STDOUT,
-                      env=run_env,
-                      cwd=llm_venv.get_working_directory()) as server_proc):
-
-            # Wait for disaggregated server to be ready
-            # 等待 disaggregated 服务器就绪
-            server_url = "http://localhost:8000"
-            max_wait = 600  # 20 minutes - increased timeout for large model initialization
-            start_wait = time.time()
-            server_ready = False
-
-            logger.info(f"Waiting for server at {server_url} to be ready...")
-            while time.time() - start_wait < max_wait:
-                try:
-                    response = requests.get(f"{server_url}/health", timeout=5)
-                    if response.status_code == 200:
-                        logger.info("✓ Server is ready!")
-                        server_ready = True
-                        break
-                except Exception as e:
-                    logger.debug(f"Server not ready yet: {e}")
-                time.sleep(5)
-
-            if not server_ready:
-                raise RuntimeError(
-                    f"Server did not become ready within {max_wait} seconds")
-
-            # Give it a few more seconds to fully initialize
-            logger.info("Waiting 10 more seconds for full initialization...")
-            time.sleep(10)
-
-            # Use genai-perf to generate load with 128k token inputs
-            # This better reproduces the KV cache overflow bug
-            logger.info(
-                "Running genai-perf with 128k token synthetic inputs...")
-
-            genai_perf_cmd = [
-                'genai-perf',
-                'profile',
-                '--model',
-                llama_model_path,
-                '--tokenizer',
-                llama_model_path,
-                '--endpoint-type',
-                'chat',
-                '--endpoint',
-                '/v1/chat/completions',
-                '--streaming',
-                '--url',
-                'localhost:8000',
-                '--synthetic-input-tokens-mean',
-                '128000',  # 128k tokens to exceed buffer
-                '--synthetic-input-tokens-stddev',
-                '0',
-                '--output-tokens-mean',
-                '100',
-                '--output-tokens-stddev',
-                '0',
-                '--extra-inputs',
-                'max_tokens:100',
-                '--extra-inputs',
-                'min_tokens:100',
-                '--extra-inputs',
-                'ignore_eos:true',
-                '--concurrency',
-                '1',
-                '--warmup-request-count',
-                '8',
-                '--num-dataset-entries',
-                '64',
-                '--random-seed',
-                '100',
-                '--artifact-dir',
-                artifact_dir,
-                '--',
-                '-v',
-                '-H',
-                'Authorization: Bearer NOT USED',
-                '-H',
-                'Accept: text/event-stream',
-                '-p',
-                '200000'
-            ]
-
-            logger.info(f"Running command: {' '.join(genai_perf_cmd[:10])}...")
-            check_call(genai_perf_cmd,
-                       env=env,
-                       poll_procs=[workers_proc, server_proc])
-    finally:
-        # Cleanup temporary config file
-        if os.path.exists(temp_config.name):
-            os.unlink(temp_config.name)
-        server_proc.terminate()
-        workers_proc.terminate()
-        server_proc.wait()
-        workers_proc.wait()
+    run_disaggregated_genai_perf(config_file=config_file,
+                                 model_path=llama4_model_root,
+                                 num_ranks=num_ranks,
+                                 server_start_timeout=1200,
+                                 input_tokens=128000,
+                                 output_tokens=100,
+                                 env=llm_venv._new_env,
+                                 cwd=llm_venv.get_working_directory())

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -3481,211 +3481,124 @@ def test_llama4_long_context_kv_cache_split_4gpus(llm_root, llm_venv):
     """
     RCCA: https://nvbugspro.nvidia.com/bug/5555681
 
-    Reproduces KV cache split overflow issue in disaggregated serving scenario.
-    Uses separate prefill and decode workers to reproduce the bug.
-    Matches genai-perf reproduction with 128k input tokens.
+    Reproduces KV cache split overflow issue.
+
+    This test can reproduce the bug in two ways:
+    1. Using pipeline parallelism (PP=2) where KV cache is transferred between PP stages
+    2. Using disaggregated serving with separate prefill and decode workers
+
+    Method 1 (Pipeline Parallelism) is simpler and is used by default.
+    KV cache transfer happens between PP stages, and when max_tokens_in_buffer
+    is too small, it will trigger illegal memory access.
+
+    本测试可以通过两种方式复现bug：
+    1. 使用pipeline并行(PP=2)，KV cache在PP stages之间传输
+    2. 使用disaggregated serving，分离的prefill和decode workers
+
+    默认使用方法1（Pipeline并行），更简单。
+    KV cache在PP stages之间传输时，如果max_tokens_in_buffer太小会触发非法内存访问。
     """
     import os
-    import subprocess
     import tempfile
-    import time
 
-    import requests
-    import yaml
+    from tensorrt_llm import LLM, SamplingParams
 
     # Set environment variable for DEBUG log level to reproduce detailed plugin logs
     # 设置环境变量以启用DEBUG日志级别，复现详细的plugin注册日志
     os.environ['TLLM_LOG_LEVEL'] = 'debug'
 
+    # Enable CUDA error checking to get more detailed error messages
+    # 启用CUDA错误检查以获得更详细的错误信息
+    os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
+    os.environ['NCCL_DEBUG'] = 'INFO'
+    os.environ['TRTLLM_ENABLE_KVCACHE_DEBUG'] = '1'
+
     # Use Llama-4-Scout model as shown in the reproduction log
     # 使用日志中显示的Llama-4-Scout模型
-    model_path = f"{llm_models_root()}/llama4-models/nvidia/Llama-4-Scout-17B-16E-Instruct"
+    model_path = f"{llm_models_root()}/llama4-models/nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8"
 
-    temp_dir = tempfile.mkdtemp()
+    with tempfile.NamedTemporaryFile(mode='w+t',
+                                     suffix=".llama4_long_context.log",
+                                     dir="./",
+                                     delete=True,
+                                     delete_on_close=True) as running_log:
+        # Method 1: Use Pipeline Parallelism (PP=2) to reproduce the bug
+        # Pipeline parallelism causes KV cache to be transferred between PP stages
+        # When max_tokens_in_buffer is too small, it will trigger illegal memory access
+        #
+        # 方法1：使用Pipeline并行(PP=2)复现bug
+        # Pipeline并行会在PP stages之间传输KV cache
+        # 当max_tokens_in_buffer太小时会触发非法内存访问
+        with LLM(
+                model_path,
+                tensor_parallel_size=2,  # TP=2 on first 2 GPUs
+                pipeline_parallel_size=
+                2,  # PP=2: critical for KV cache transfer between stages
+                moe_expert_parallel_size=1,
+                max_seq_len=257000,
+                max_input_len=256000,
+                max_num_tokens=8192,
+                max_batch_size=1,
+                enable_chunked_prefill=True,
+                trust_remote_code=True,
+                backend="pytorch",
+                kv_cache_config={
+                    "enable_block_reuse": True,
+                    "free_gpu_memory_fraction": 0.3
+                },
+                disable_overlap_scheduler=True,
+                cache_transceiver_config=
+            {
+                "backend": "UCX",
+                # Intentionally set to small value (2048) to reproduce buffer overflow bug
+                # This is much smaller than the 128k tokens input, which will trigger
+                # illegal memory access when transferring KV cache between PP stages
+                # 故意设置为较小值(2048)以复现缓冲区溢出bug
+                # 这比128k tokens的输入小得多，在PP stages之间传输KV cache时会触发非法内存访问
+                "max_tokens_in_buffer": 2048
+            }) as llm:
 
-    # Configuration for context (prefill) worker with 2 GPUs
-    # 配置prefill worker使用2个GPU
-    ctx_config = {
-        "tensor_parallel_size": 2,
-        "pipeline_parallel_size": 1,
-        "disable_overlap_scheduler": True,
-        "max_seq_len": 257000,
-        "max_input_len": 256000,
-        "max_num_tokens": 8192,
-        "max_batch_size": 1,
-        "enable_chunked_prefill": True,
-        "kv_cache_config": {
-            "enable_block_reuse": True,
-            "free_gpu_memory_fraction": 0.3
-        },
-        "cache_transceiver_config": {
-            "backend": "UCX",
-            # Intentionally set to small value to reproduce buffer overflow
-            # 故意设置为小值以复现缓冲区溢出
-            "max_tokens_in_buffer": 2048
-        }
-    }
+            # Create a long prompt that exceeds max_tokens_in_buffer to trigger the bug
+            # 创建超过max_tokens_in_buffer的长提示以触发bug
+            # Each repetition is ~10 tokens, so 12800 repetitions ≈ 128k tokens
+            base_text = "Machine learning is a fascinating field of study. " * 12800
+            long_prompt = "Summarize the following text: " + base_text
 
-    # Configuration for generation (decode) worker with 2 GPUs
-    # 配置decode worker使用2个GPU
-    gen_config = {
-        "tensor_parallel_size": 2,
-        "pipeline_parallel_size": 1,
-        "max_seq_len": 257000,
-        "max_input_len": 256000,
-        "max_num_tokens": 8192,
-        "max_batch_size": 1,
-        "kv_cache_config": {
-            "enable_block_reuse": False,
-            "free_gpu_memory_fraction": 0.3
-        },
-        "cache_transceiver_config": {
-            "backend": "UCX",
-            # Intentionally set to small value to reproduce buffer overflow
-            # 故意设置为小值以复现缓冲区溢出
-            "max_tokens_in_buffer": 2048
-        }
-    }
+            print(f"Prompt length: {len(long_prompt)} characters")
+            print("Generating with pipeline parallelism...")
 
-    # Disaggregated server configuration
-    # Disaggregated服务器配置
-    disagg_config = {
-        "hostname": "localhost",
-        "port": 8000,
-        "backend": "pytorch",
-        "context_servers": {
-            "num_instances": 1,
-            "urls": ["localhost:8001"]
-        },
-        "generation_servers": {
-            "num_instances": 1,
-            "urls": ["localhost:8002"]
-        }
-    }
+            sampling_params = SamplingParams(
+                max_tokens=100,
+                min_tokens=100,
+                temperature=0.0,
+                ignore_eos=True,
+            )
 
-    # Write config files
-    # 写入配置文件
-    ctx_config_path = os.path.join(temp_dir, "ctx_config.yaml")
-    gen_config_path = os.path.join(temp_dir, "gen_config.yaml")
-    disagg_config_path = os.path.join(temp_dir, "disagg_config.yaml")
+            # Test generation with long context
+            # KV cache will be transferred between PP stage 0 and stage 1
+            # If buffer is too small, illegal memory access will occur
+            # 测试长上下文生成
+            # KV cache会在PP stage 0和stage 1之间传输
+            # 如果缓冲区太小会发生非法内存访问
+            result = llm.generate(long_prompt, sampling_params=sampling_params)
 
-    with open(ctx_config_path, 'w') as f:
-        yaml.dump(ctx_config, f)
-    with open(gen_config_path, 'w') as f:
-        yaml.dump(gen_config, f)
-    with open(disagg_config_path, 'w') as f:
-        yaml.dump(disagg_config, f)
+            # Verify output is generated successfully
+            # 验证输出成功生成
+            assert len(result.outputs) > 0
+            output_text = result.outputs[0].text
+            assert len(output_text) > 0
 
-    processes = []
-    try:
-        # Start context server on GPU 0-1
-        # 在GPU 0-1上启动context server
-        print("Starting context server on GPUs 0-1...")
-        ctx_env = os.environ.copy()
-        ctx_env["CUDA_VISIBLE_DEVICES"] = "0,1"
-        ctx_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
-        ctx_proc = subprocess.Popen([
-            "trtllm-serve", model_path, "--host", "localhost", "--port", "8001",
-            "--backend", "pytorch", "--extra_llm_api_options", ctx_config_path
-        ],
-                                    env=ctx_env,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-        processes.append(ctx_proc)
+            # Check for repetitive/meaningless output caused by KV cache corruption
+            # 检查由KV cache损坏导致的重复/无意义输出
+            max_repeat = max(
+                (sum(1 for _ in group)
+                 for char, group in __import__('itertools').groupby(output_text)
+                 ),
+                default=0)
+            assert max_repeat < 20, \
+                f"Found {max_repeat} consecutive identical characters, " \
+                f"suggesting KV cache corruption. Output: {output_text[:200]}"
 
-        # Start generation server on GPU 2-3
-        # 在GPU 2-3上启动generation server
-        print("Starting generation server on GPUs 2-3...")
-        gen_env = os.environ.copy()
-        gen_env["CUDA_VISIBLE_DEVICES"] = "2,3"
-        gen_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
-        gen_proc = subprocess.Popen([
-            "trtllm-serve", model_path, "--host", "localhost", "--port", "8002",
-            "--backend", "pytorch", "--extra_llm_api_options", gen_config_path
-        ],
-                                    env=gen_env,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-        processes.append(gen_proc)
-
-        # Wait for servers to be ready
-        # 等待服务器就绪
-        print("Waiting for context and generation servers to be ready...")
-        time.sleep(30)  # Give servers time to initialize
-
-        # Check if servers are healthy
-        # 检查服务器健康状态
-        for i in range(60):
-            try:
-                ctx_health = requests.get("http://localhost:8001/health",
-                                          timeout=5)
-                gen_health = requests.get("http://localhost:8002/health",
-                                          timeout=5)
-                if ctx_health.status_code == 200 and gen_health.status_code == 200:
-                    print("Both servers are ready!")
-                    break
-            except:
-                pass
-            time.sleep(2)
-        else:
-            raise RuntimeError("Servers failed to start within timeout")
-
-        # Start disaggregated orchestrator
-        # 启动disaggregated orchestrator
-        print("Starting disaggregated orchestrator...")
-        disagg_proc = subprocess.Popen(
-            ["trtllm-serve", "disaggregated", "-c", disagg_config_path],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        processes.append(disagg_proc)
-
-        # Wait for orchestrator to be ready
-        # 等待orchestrator就绪
-        print("Waiting for orchestrator to be ready...")
-        time.sleep(10)
-
-        # Create a long prompt that exceeds max_tokens_in_buffer to trigger the bug
-        # 创建超过max_tokens_in_buffer的长提示以触发bug
-        # Each repetition is ~10 tokens, so 12800 repetitions ≈ 128k tokens
-        base_text = "Machine learning is a fascinating field of study. " * 12800
-        long_prompt = "Summarize the following text: " + base_text
-
-        print(f"Prompt length: {len(long_prompt)} characters")
-        print("Sending request to disaggregated server...")
-
-        # Send request to disaggregated server
-        # 向disaggregated server发送请求
-        response = requests.post("http://localhost:8000/v1/completions",
-                                 json={
-                                     "model": model_path,
-                                     "prompt": long_prompt,
-                                     "max_tokens": 100,
-                                     "temperature": 0.0,
-                                     "ignore_eos": True
-                                 },
-                                 timeout=300)
-
-        result = response.json()
-        print(f"Response: {result}")
-
-        # Verify output is generated
-        # 验证输出已生成
-        assert "choices" in result
-        assert len(result["choices"]) > 0
-        output_text = result["choices"][0]["text"]
-        assert len(output_text) > 0
-
-        print(f"Successfully generated output: {output_text[:100]}...")
-
-    finally:
-        # Cleanup processes
-        # 清理进程
-        print("Cleaning up processes...")
-        for proc in processes:
-            proc.terminate()
-            proc.wait(timeout=10)
-
-        # Cleanup temp directory
-        # 清理临时目录
-        import shutil
-        shutil.rmtree(temp_dir, ignore_errors=True)
+            print(
+                f"Successfully generated output with long context: {output_text[:100]}..."
+            )

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -707,7 +707,6 @@ test_e2e.py::test_ptp_star_attention_example[Llama3.1-8B-BF16-llama-3.1-model/Me
 test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-hf-nvfp4-False-False]
 test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]
 test_e2e.py::test_ptp_quickstart_advanced_deepseek_r1_w4afp8_8gpus[DeepSeek-R1-W4AFP8-DeepSeek-R1/DeepSeek-R1-W4AFP8]
-test_e2e.py::test_llama4_long_context_kv_cache_split_4gpus
 unittest/llmapi/test_llm_pytorch.py::test_gemma3_1b_instruct_multi_lora
 examples/test_medusa.py::test_codellama_medusa_1gpu[CodeLlama-7b-Instruct]
 
@@ -783,6 +782,7 @@ disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_att
 disaggregated/test_disaggregated.py::test_disaggregated_load_balance[TinyLlama-1.1B-Chat-v1.0]
 disaggregated/test_disaggregated.py::test_disaggregated_cache_aware_balance[TinyLlama-1.1B-Chat-v1.0]
 disaggregated/test_disaggregated.py::test_disaggregated_trtllm_sampler[TinyLlama-1.1B-Chat-v1.0]
+disaggregated/test_disaggregated.py::test_llama4_long_context_kv_cache_overflow[llama4-models/nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8]
 disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_qwen3[False-False-Qwen3-8B-FP8]
 disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_qwen3[False-True-Qwen3-8B-FP8]
 disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_qwen3[True-False-Qwen3-8B-FP8]

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -707,6 +707,7 @@ test_e2e.py::test_ptp_star_attention_example[Llama3.1-8B-BF16-llama-3.1-model/Me
 test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-hf-nvfp4-False-False]
 test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]
 test_e2e.py::test_ptp_quickstart_advanced_deepseek_r1_w4afp8_8gpus[DeepSeek-R1-W4AFP8-DeepSeek-R1/DeepSeek-R1-W4AFP8]
+test_e2e.py::test_llama4_long_context_kv_cache_split_4gpus
 unittest/llmapi/test_llm_pytorch.py::test_gemma3_1b_instruct_multi_lora
 examples/test_medusa.py::test_codellama_medusa_1gpu[CodeLlama-7b-Instruct]
 


### PR DESCRIPTION
have verified on 8xH200 locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Added new test coverage for KV cache overflow handling in disaggregated Llama-4 configurations
- Expanded performance profiling framework for distributed model scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
