### PR TITLE
[https://nvbugs/5456493][feat] add fp8 dense for sm120

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_fp8_gemm_1d2d.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_fp8_gemm_1d2d.cuh
@@ -372,7 +372,7 @@ struct SM120BlockScaledKernel
         auto tCrSFA_frg = KT::transform_fragment_for_qmma(tCrSFA);
 
         auto s2r_copy_SFB = make_tiled_copy_impl(
-            typename KT::SmemCopyAtomSF{}, KT::get_layoutSFB_TV(mma), select<1, 2>(tile_shape(mma)));
+            typename KT::SmemCopyAtomSF{}, KT::get_layoutSFB_TV(mma), make_shape(size<1>(tile_shape(mma)), _1{}));
         auto s2r_thr_copy_SFB = s2r_copy_SFB.get_thread_slice(thread_idx);
         auto tXsSFB = s2r_thr_copy_SFB.partition_S(sSFB);                        // (CPY,CPY_M,CPY_K,PIPE)
         auto tCrSFB = KT::partition_fragment_SFB(sSFB(_, _, Int<0>{}), thr_mma); // (MMA,MMA_N,MMA_K)

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_fp8_gemm_1d2d.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_fp8_gemm_1d2d.cuh
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sm120_utils.cuh"
+
+using namespace cute;
+
+namespace sm120_blockscaled_gemm
+{
+
+template <typename KT>
+struct SM120BlockScaledKernel
+{
+
+    static constexpr int MaxThreadsPerBlock = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    static constexpr int NumThreadsPerWarp = 32;
+    static constexpr int NumThreadsPerWarpGroup = 128;
+    static constexpr int NumWarpsPerWarpGroup = NumThreadsPerWarpGroup / NumThreadsPerWarp;
+    static constexpr int NumTmaWarpGroups = 1;
+    static constexpr int NumMmaWarpGroups = 1;
+    static constexpr int NumProducerThreads = NumTmaWarpGroups; // only one thread execute tma copy
+    static constexpr int NumConsumerThreads = NumMmaWarpGroups * NumThreadsPerWarpGroup;
+
+    using ProblemShape = typename KT::ProblemShape;
+
+    struct Params
+    {
+        typename KT::TMA_A tma_load_a;
+        typename KT::TMA_B tma_load_b;
+        typename KT::TMA_SFA tma_load_sfa;
+        typename KT::TMA_SFB tma_load_sfb;
+        typename KT::TMA_D tma_store_d;
+        typename KT::ProblemShape problem_shape;
+        typename KT::ElementD* ptr_D;
+    };
+
+    struct Arguments
+    {
+        typename KT::ElementA* ptr_A;
+        typename KT::ElementB* ptr_B;
+        typename KT::ElementSFLoad* ptr_SFA;
+        typename KT::ElementSFLoad* ptr_SFB;
+        typename KT::ElementD* ptr_D;
+    };
+
+    using TileShape = typename KT::TileShape;
+    using ScaleTileShape = typename KT::ScaleTileShape;
+
+    static constexpr Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args)
+    {
+        auto [M, N, K, L] = problem_shape;
+        auto tensor_A = make_tensor(
+            make_gmem_ptr(args.ptr_A), make_layout(make_shape(M, K, L), make_stride(K, cute::_1{}, M * K)));
+        typename KT::TMA_A tma_load_a
+            = make_tma_copy(SM90_TMA_LOAD{}, tensor_A, typename KT::SmemLayoutA{}(_, _, Int<0>{}),
+                make_shape(shape<0>(typename KT::TileShape{}), shape<2>(typename KT::TileShape{})), _1{});
+
+        auto tensor_B = make_tensor(
+            make_gmem_ptr(args.ptr_B), make_layout(make_shape(N, K, L), make_stride(K, cute::_1{}, N * K)));
+        typename KT::TMA_B tma_load_b
+            = make_tma_copy(SM90_TMA_LOAD{}, tensor_B, typename KT::SmemLayoutB{}(_, _, Int<0>{}),
+                make_shape(shape<1>(typename KT::TileShape{}), shape<2>(typename KT::TileShape{})), _1{});
+
+        auto sfa_layout = KT::deduce_sfa_layout(problem_shape);
+        auto sfb_layout = KT::deduce_sfb_layout(problem_shape);
+
+        auto tensor_sfa = make_tensor(make_gmem_ptr(args.ptr_SFA), sfa_layout);
+        auto tensor_sfb = make_tensor(make_gmem_ptr(args.ptr_SFB), sfb_layout);
+
+        typename KT::TMA_SFA tma_load_sfa
+            = make_tma_copy(SM90_TMA_LOAD{}, tensor_sfa, typename KT::SmemLayoutSFA{}(_, _, Int<0>{}),
+                make_shape(shape<0>(typename KT::ScaleTileShape{}), shape<2>(typename KT::ScaleTileShape{})), _1{});
+
+        typename KT::TMA_SFB tma_load_sfb
+            = make_tma_copy(SM90_TMA_LOAD{}, tensor_sfb, typename KT::SmemLayoutSFB{}(_, _, Int<0>{}),
+                make_shape(shape<1>(typename KT::ScaleTileShape{}), shape<2>(typename KT::ScaleTileShape{})), _1{});
+
+        auto tensor_d
+            = make_tensor(make_gmem_ptr(args.ptr_D), make_layout(make_shape(M, N, L), make_stride(N, _1{}, M * N)));
+        auto tma_store_d = make_tma_copy_C_sm90(
+            typename KT::CopyOpS2G{}, tensor_d, take<0, 2>(typename KT::SmemLayoutD{}), typename KT::EpilogueTile_MN{});
+        return {tma_load_a, tma_load_b, tma_load_sfa, tma_load_sfb, tma_store_d, problem_shape, args.ptr_D};
+    }
+
+    static dim3 get_grid_shape(Params const& params)
+    {
+        return KT::get_grid_shape(params.problem_shape);
+    }
+
+    static dim3 get_block_shape()
+    {
+        return dim3(MaxThreadsPerBlock, 1, 1);
+    }
+
+    CUTE_DEVICE
+    static void prefetch_tma_descriptors(Params const& params)
+    {
+        cute::prefetch_tma_descriptor(params.tma_load_a.get_tma_descriptor());
+        cute::prefetch_tma_descriptor(params.tma_load_b.get_tma_descriptor());
+        cute::prefetch_tma_descriptor(params.tma_load_sfa.get_tma_descriptor());
+        cute::prefetch_tma_descriptor(params.tma_load_sfb.get_tma_descriptor());
+    }
+
+    CUTE_DEVICE
+    static auto load_init(Params const& params)
+    {
+        using X = Underscore;
+        auto [M, N, K, L] = params.problem_shape;
+
+        auto mA_mkl = params.tma_load_a.get_tma_tensor(make_shape(M, K, L));
+        auto mB_nkl = params.tma_load_b.get_tma_tensor(make_shape(N, K, L));
+        auto mSFA_mkl = params.tma_load_sfa.get_tma_tensor(shape(KT::deduce_sfa_layout(params.problem_shape)));
+        auto mSFB_nkl = params.tma_load_sfb.get_tma_tensor(shape(KT::deduce_sfb_layout(params.problem_shape)));
+
+        // Make tiled views, defer the slice
+        auto gA_mkl = local_tile(
+            mA_mkl, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});        // (BLK_M,BLK_K,m,k,l)
+        auto gB_nkl = local_tile(
+            mB_nkl, typename KT::TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});        // (BLK_N,BLK_K,n,k,l)
+        auto gSFA_mkl = local_tile(
+            mSFA_mkl, typename KT::ScaleTileShape{}, make_coord(_, _, _), Step<_1, X, _1>{}); // (TILE_M,TILE_K,m,k,l)
+        auto gSFB_nkl = local_tile(
+            mSFB_nkl, typename KT::ScaleTileShape{}, make_coord(_, _, _), Step<X, _1, _1>{}); // (TILE_N,TILE_K,n,k,l)
+
+        return cute::make_tuple(gA_mkl, gB_nkl, gSFA_mkl, gSFB_nkl);
+    }
+
+    CUTE_DEVICE
+    static auto store_init(Params const& params)
+    {
+        using X = Underscore;
+        auto [M, N, K, L] = params.problem_shape;
+        auto mD_mnl = make_tensor(make_gmem_ptr(params.ptr_D), make_shape(M, N, L), make_stride(N, _1{}, M * N));
+        auto gD_mnl = local_tile(
+            mD_mnl, typename KT::TileShape{}, make_coord(_, _, _), Step<_1, _1, X>{}); // (BLK_M,BLK_N,m,n,l)
+
+        return cute::make_tuple(gD_mnl);
+    }
+
+    template <class Accumulator, class SharedStorage, class BlockCoord>
+    CUTE_DEVICE void epilogue_with_smem(
+        Accumulator const& accum, SharedStorage& shared_storage, Params const& params, BlockCoord const& blk_coord)
+    {
+        auto epi = cute::make_fragment_like<typename KT::ElementD>(accum);
+        cute::for_each(
+            cute::make_int_sequence<cute::size(epi)>{}, [&](auto i) { epi(i) = typename KT::ElementD(accum(i)); });
+
+        auto sD = cute::make_tensor(
+            cute::make_smem_ptr(shared_storage.tensors.store.smem_D.begin()), typename KT::SmemLayoutO{});
+        auto [m_coord, n_coord, k_coord, l_coord] = blk_coord;
+        auto [gD_mnl] = store_init(params);
+        auto gD = gD_mnl(_, _, m_coord, n_coord, l_coord); // (BLK_M,BLK_N)
+        auto cD = cute::make_identity_tensor(cute::make_shape(cute::Int<KT::kTileM>{}, cute::Int<KT::kTileN>{}));
+
+        // copy rf -> smem
+        typename KT::TiledMma mma;
+        auto tiled_copy_R2S = cute::make_tiled_copy_C(typename KT::SmemCopyAtomR2S{}, mma);
+        auto thr_copy_R2S = tiled_copy_R2S.get_slice(threadIdx.x);
+        auto tRS_rD = thr_copy_R2S.retile_S(epi);
+        auto tRS_sD = thr_copy_R2S.partition_D(sD);
+        auto tRS_cD = thr_copy_R2S.partition_D(cD);
+
+        cute::copy(tiled_copy_R2S, tRS_rD, tRS_sD);
+        __syncthreads();
+
+        // copy smem -> rf
+        typename KT::TiledCopyS2G tiled_copy_S2G;
+        auto thr_copy_S2G = tiled_copy_S2G.get_slice(threadIdx.x);
+        auto tSR_sD = thr_copy_S2G.partition_S(sD);
+        auto tSR_rD = cute::make_tensor<typename KT::ElementD>(cute::shape(tSR_sD));
+
+        cute::copy(tiled_copy_S2G, tSR_sD, tSR_rD);
+        __syncthreads();
+
+        // copy rf -> gmem
+        auto tRG_rD = thr_copy_S2G.retile_S(tSR_rD);
+        auto tRG_gD = thr_copy_S2G.partition_D(gD);
+        auto tRG_cD = thr_copy_S2G.partition_D(cD);
+
+        auto [M, N, K, L] = params.problem_shape;
+        int residue_m = M - KT::kTileM * m_coord;
+        int residue_n = N - KT::kTileN * n_coord;
+        CUTE_UNROLL
+        for (int m = 0; m < cute::size<1>(tRG_gD); ++m)
+        {
+            CUTE_UNROLL
+            for (int n = 0; n < cute::size<2>(tRG_gD); ++n)
+            {
+                if (cute::get<0>(tRG_cD(0, m, n)) < residue_m && cute::get<1>(tRG_cD(0, m, n)) < residue_n)
+                {
+                    cute::copy(typename KT::GmemCopyAtomR2G{}, tRG_rD(cute::_, m, n), tRG_gD(cute::_, m, n));
+                }
+            }
+        }
+    }
+
+    template <class Accumulator, class SharedStorage, class BlockCoord>
+    CUTE_DEVICE void tma_store(
+        Accumulator const& accum, SharedStorage& shared_storage, Params const& params, BlockCoord const& blk_coord)
+    {
+        auto epi = cute::make_fragment_like<typename KT::ElementD>(accum);
+        cute::for_each(
+            cute::make_int_sequence<cute::size(epi)>{}, [&](auto i) { epi(i) = typename KT::ElementD(accum(i)); });
+
+        int thread_idx = int(threadIdx.x);
+        typename KT::TiledMma tiled_mma;
+        typename KT::CopyOpR2S copy_atom_r2s;
+        auto tiled_copy_C_atom = make_tiled_copy_C_atom(typename KT::CopyAtomC{}, tiled_mma);
+
+        auto tiled_copy_r2s
+            = make_tiled_copy_S(cute::Copy_Atom<typename KT::CopyOpR2S, typename KT::ElementD>{}, tiled_copy_C_atom);
+        auto thr_copy_r2s = tiled_copy_r2s.get_slice(thread_idx);
+
+        auto sD_epi_ = make_tensor(make_smem_ptr(shared_storage.tensors.store.smem_D.begin()),
+            typename KT::SmemLayoutD{});                                     // (BLK_M,BLK_K,PIPE)
+        auto sD_epi = cute::as_position_independent_swizzle_tensor(sD_epi_); // (EPI_TILE_M,EPI_TILE_N,PIPE_D)
+        auto tRS_rD = thr_copy_r2s.retile_S(epi);
+        auto tRS_sD = thr_copy_r2s.partition_D(sD_epi);
+
+        using EpilogueTile = typename KT::EpilogueTile_MN;
+        auto [M, N, K, L] = params.problem_shape;
+        auto [m_coord, n_coord, k_coord, l_coord] = blk_coord;
+        auto mD_mn = params.tma_store_d.get_tma_tensor(make_shape(M, N, L)); // (M,N,L)
+        auto mD = coalesce(mD_mn, take<0, 2>(TileShape{}));
+        auto gD = local_tile(mD, take<0, 2>(TileShape{}), make_coord(m_coord, n_coord, l_coord));
+
+        auto gD_epi = flat_divide(gD, EpilogueTile{}); // (EPI_TILE_M,EPI_TILE_N,EPI_M,EPI_N)
+
+        auto block_tma_d = params.tma_store_d.get_slice(Int<0>{});
+        auto bSG_sD = block_tma_d.partition_S(sD_epi); // (TMA,TMA_M,TMA_K, PIP)
+        auto bSG_gD = block_tma_d.partition_D(gD_epi); // (TMA,TMA_M,TMA_K, EPI_M, EPI_N)
+
+        __syncthreads();
+        copy(tiled_copy_r2s, tRS_rD, tRS_sD(_, _, _, Int<0>{}));
+
+        uint32_t elect_one_thr = cute::elect_one_sync();
+        uint32_t elect_one_warp = (thread_idx / 32 == 0);
+        bool is_tma_store = elect_one_warp && elect_one_thr;
+        cute::tma_store_fence();
+        __syncthreads();
+        if (is_tma_store)
+        {
+            for (int epi_n = 0; epi_n < size<3>(bSG_gD); ++epi_n)
+            {
+                for (int epi_m = 0; epi_m < size<2>(bSG_gD); ++epi_m)
+                {
+                    cute::copy(params.tma_store_d, bSG_sD(_, _, _, Int<0>{}), bSG_gD(_, _, _, epi_m, epi_n));
+                }
+            }
+            cute::tma_store_arrive();
+            cute::tma_store_wait<0>();
+        }
+        __syncthreads();
+    }
+
+    using TensorStorage = typename KT::TensorStorage;
+    using BarrierStorage = typename KT::BarrierStorage;
+
+    struct SharedStorage
+    {
+        TensorStorage tensors;
+        alignas(16) BarrierStorage barriers;
+    };
+
+    static constexpr int kSmemSize = int(sizeof(SharedStorage));
+
+    CUTE_DEVICE
+    void operator()(Params const& params, char* smem_buf)
+    {
+
+        SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+        int thread_idx = int(threadIdx.x);
+        int lane_idx = canonical_lane_idx();
+        int warp_idx = canonical_warp_idx_sync();
+        int warp_group_idx = canonical_warp_group_idx();
+        int lane_predicate = cute::elect_one_sync();
+        bool is_tma_thread = warp_idx == 0 && lane_predicate;
+
+        if (is_tma_thread)
+        {
+            prefetch_tma_descriptors(params);
+        }
+        __syncthreads();
+
+        // producer part
+        auto sA_ = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_A.begin()),
+            typename KT::SmemLayoutA{});                       // (BLK_M,BLK_K,PIPE)
+        auto sB_ = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_B.begin()), typename KT::SmemLayoutB{});
+        auto sA = as_position_independent_swizzle_tensor(sA_); // (BLK_M,BLK_K,PIPE)
+        auto sB = as_position_independent_swizzle_tensor(sB_); // (BLK_N,BLK_K,PIPE)
+        auto sSFA_ = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFA.begin()),
+            typename KT::SmemLayoutSFA{});                     // (BLK_M,BLK_K,PIPE)
+        auto sSFB_
+            = make_tensor(make_smem_ptr(shared_storage.tensors.load.smem_SFB.begin()), typename KT::SmemLayoutSFB{});
+        auto sSFA = as_position_independent_swizzle_tensor(sSFA_); // (BLK_M,BLK_K,PIPE)
+        auto sSFB = as_position_independent_swizzle_tensor(sSFB_); // (BLK_N,BLK_K,PIPE)
+
+        auto [gA_mkl, gB_nkl, gSFA_mkl, gSFB_nkl] = load_init(params);
+        auto block_tma_a = params.tma_load_a.get_slice(0);
+        auto block_tma_b = params.tma_load_b.get_slice(0);
+        auto block_tma_sfa = params.tma_load_sfa.get_slice(0);
+        auto block_tma_sfb = params.tma_load_sfb.get_slice(0);
+
+        auto m_coord = idx2crd(int(blockIdx.x), shape<2>(gA_mkl));
+        auto n_coord = idx2crd(int(blockIdx.y), shape<2>(gB_nkl));
+        auto l_coord = idx2crd(int(blockIdx.z), shape<4>(gB_nkl));
+        auto blk_coord = make_coord(m_coord, n_coord, _, l_coord);
+
+        auto gA = gA_mkl(_, _, m_coord, _, l_coord);
+        auto gB = gB_nkl(_, _, n_coord, _, l_coord);
+
+        auto tAgA = block_tma_a.partition_S(gA); // (TMA,TMA_M,TMA_K,k)
+        auto tAsA = block_tma_a.partition_D(sA); // (TMA,TMA_M,TMA_K,PIPE)
+        auto tBgB = block_tma_b.partition_S(gB); // (TMA,TMA_N,TMA_K,k)
+        auto tBsB = block_tma_b.partition_D(sB); // (TMA,TMA_N,TMA_K,PIPE)
+
+        auto gSFA = gSFA_mkl(_, _, m_coord, _, l_coord);
+        auto gSFB = gSFB_nkl(_, _, n_coord, _, l_coord);
+
+        auto tAgSFA = block_tma_sfa.partition_S(gSFA); // (TMA,TMA_M,TMA_K,k)
+        auto tAsSFA = block_tma_sfa.partition_D(sSFA); // (TMA,TMA_M,TMA_K,PIPE)
+        auto tBgSFB = block_tma_sfb.partition_S(gSFB); // (TMA,TMA_N,TMA_K,k)
+        auto tBsSFB = block_tma_sfb.partition_D(sSFB); // (TMA,TMA_N,TMA_K,PIPE)
+
+        // consumer part
+
+        typename KT::TiledMma mma;
+        auto tile_shape_mnk = tile_shape(mma);
+        auto thr_mma = mma.get_thread_slice(thread_idx);
+        auto accum = partition_fragment_C(mma, cute::take<0, 2>(TileShape{})); // (MMA,MMA_M,MMA_N)
+        // Allocate fragments and descriptors
+        auto tCrA = thr_mma.partition_fragment_A(sA(_, _, Int<0>{})); // (MMA,MMA_M,MMA_K)
+        auto tCrB = thr_mma.partition_fragment_B(sB(_, _, Int<0>{})); // (MMA,MMA_N,MMA_K)
+
+        // A
+        auto s2r_copy_A = make_tiled_copy_A(typename KT::SmemCopyAtomA{}, mma);
+        auto s2r_thr_copy_A = s2r_copy_A.get_thread_slice(thread_idx);
+        // (((_16,_2,_2,_2),(_16,_1)),(_4,_4,(_1,_2))):(((_128,_16,_2048,_0),(_1,_0)),(_4096,_32,(_0,_16384)))
+        auto tXsA = s2r_thr_copy_A.partition_S(sA); // (CPY,CPY_M,CPY_K,PIPE)
+        auto tXrA = s2r_thr_copy_A.retile_D(tCrA);  // (CPY,CPY_M,CPY_K)
+        // B
+
+        auto s2r_copy_B = make_tiled_copy_B(typename KT::SmemCopyAtomB{}, mma);
+        auto s2r_thr_copy_B = s2r_copy_B.get_thread_slice(thread_idx);
+        // (((_8,_2,_2,_2,_2),(_16,_1)),(_4,_4,(_1,_2))):(((_128,_16,_2048,_0,_1024),(_1,_0)),(_4096,_32,(_0,_16384)))
+        auto tXsB = s2r_thr_copy_B.partition_S(sB); // (CPY,CPY_M,CPY_K,PIPE)
+        auto tXrB = s2r_thr_copy_B.retile_D(tCrB);  // (CPY,CPY_M,CPY_K)
+
+        auto s2r_copy_SFA = make_tiled_copy_impl(
+            typename KT::SmemCopyAtomSF{}, KT::get_layoutSFA_TV(mma), select<0, 2>(tile_shape(mma)));
+        auto s2r_thr_copy_SFA = s2r_copy_SFA.get_thread_slice(thread_idx);
+        auto tXsSFA = s2r_thr_copy_SFA.partition_S(sSFA);                        // (CPY,CPY_M,CPY_K,PIPE)
+        auto tCrSFA = KT::partition_fragment_SFA(sSFA(_, _, Int<0>{}), thr_mma); // (MMA,MMA_M,MMA_K)
+        auto tXrSFA = s2r_thr_copy_SFA.retile_D(tCrSFA);
+        auto tCrSFA_frg = KT::transform_fragment_for_qmma(tCrSFA);
+
+        auto s2r_copy_SFB = make_tiled_copy_impl(
+            typename KT::SmemCopyAtomSF{}, KT::get_layoutSFB_TV(mma), select<1, 2>(tile_shape(mma)));
+        auto s2r_thr_copy_SFB = s2r_copy_SFB.get_thread_slice(thread_idx);
+        auto tXsSFB = s2r_thr_copy_SFB.partition_S(sSFB);                        // (CPY,CPY_M,CPY_K,PIPE)
+        auto tCrSFB = KT::partition_fragment_SFB(sSFB(_, _, Int<0>{}), thr_mma); // (MMA,MMA_N,MMA_K)
+        auto tXrSFB = s2r_thr_copy_SFB.retile_D(tCrSFB);
+        auto tCrSFB_frg = KT::transform_fragment_for_qmma(tCrSFB);
+
+        using FullBarrier = typename KT::FullBarrier;
+        using EmptyBarrier = typename KT::EmptyBarrier;
+        using ProducerBarrierType = typename FullBarrier::ValueType;
+        using ConsumerBarrierType = typename EmptyBarrier::ValueType;
+
+        auto* ab_full_mbar = recast_ptr<FullBarrier>(&shared_storage.barriers.ab_full_mbar[0]);
+        auto* ab_empty_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.ab_empty_mbar[0]);
+        auto* sf_full_mbar = recast_ptr<FullBarrier>(&shared_storage.barriers.sf_full_mbar[0]);
+        auto* sf_empty_mbar = recast_ptr<EmptyBarrier>(&shared_storage.barriers.sf_empty_mbar[0]);
+
+        static_assert(NumProducerThreads == 1, "NumProducerThreads must be 1");
+        static_assert(NumConsumerThreads == 128, "NumConsumerThreads must be 128");
+        // init barriers
+        if (is_tma_thread)
+        {
+#pragma unroll
+            for (uint32_t i = 0; i < KT::SF_Stages; ++i)
+            {
+                sf_full_mbar[i].init(NumProducerThreads);
+                sf_empty_mbar[i].init(NumConsumerThreads);
+            }
+
+#pragma unroll
+            for (uint32_t i = 0; i < KT::AB_Stages; ++i)
+            {
+                ab_full_mbar[i].init(NumProducerThreads);
+                ab_empty_mbar[i].init(NumConsumerThreads);
+            }
+            cutlass::arch::fence_barrier_init();
+        }
+        __syncthreads();
+
+        auto g2s_copy_AB = [&](auto& k_tile_idx, auto& write_stage)
+        {
+            auto& ab_full_barrier = ab_full_mbar[write_stage];
+            auto tma_copy_a = params.tma_load_a.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+            cute::copy(tma_copy_a, tAgA(_, _, _, k_tile_idx), tAsA(_, _, _, write_stage));
+            auto tma_copy_b = params.tma_load_b.with(*recast_ptr<ProducerBarrierType>(&ab_full_barrier));
+            cute::copy(tma_copy_b, tBgB(_, _, _, k_tile_idx), tBsB(_, _, _, write_stage));
+            ab_full_barrier.arrive_and_expect_tx(KT::TmaABTransactionBytes);
+        };
+
+        auto g2s_copy_SF = [&](auto& sf_tile_idx)
+        {
+            auto& sf_full_barrier = sf_full_mbar[0];
+            auto tma_copy_sfa = params.tma_load_sfa.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+            cute::copy(tma_copy_sfa, tAgSFA(_, _, _, sf_tile_idx), tAsSFA(_, _, _, Int<0>{}));
+            auto tma_copy_sfb = params.tma_load_sfb.with(*recast_ptr<ProducerBarrierType>(&sf_full_barrier));
+            cute::copy(tma_copy_sfb, tBgSFB(_, _, _, sf_tile_idx), tBsSFB(_, _, _, Int<0>{}));
+            sf_full_barrier.arrive_and_expect_tx(KT::TmaSFTransactionBytes);
+        };
+
+        auto s2r_copy_AB = [&](auto& read_stage)
+        {
+            cute::copy(s2r_copy_A, tXsA(_, _, _, read_stage), tXrA);
+            cute::copy(s2r_copy_B, tXsB(_, _, _, read_stage), tXrB);
+            ab_empty_mbar[read_stage].arrive();
+        };
+
+        auto s2r_copy_SF = [&]()
+        {
+            cute::copy(s2r_copy_SFA, tXsSFA(_, _, _, Int<0>{}), tXrSFA);
+            cute::copy(s2r_copy_SFB, tXsSFB(_, _, _, Int<0>{}), tXrSFB);
+            sf_empty_mbar[0].arrive();
+        };
+
+        uint32_t phase = 0;
+        int32_t sf_tile_count = cute::size<2>(gSFA);
+        clear(accum);
+        int32_t sf_tile_index = 0;
+
+        // prefetch one sf tile and four ab tiles
+        if (is_tma_thread)
+        {
+            sf_empty_mbar[0].wait(phase ^ 1);
+            g2s_copy_SF(sf_tile_index);
+            CUTE_UNROLL
+            for (int write_stage = 0; write_stage < KT::AB_Stages; ++write_stage)
+            {
+                ab_empty_mbar[write_stage].wait(phase ^ 1);
+                int32_t k_tile_index = sf_tile_index * 4 + write_stage;
+                g2s_copy_AB(k_tile_index, write_stage);
+            }
+        }
+        ++sf_tile_index;
+        __syncthreads();
+
+        // main loop
+        while (sf_tile_index < sf_tile_count)
+        {
+            sf_full_mbar[0].wait(phase);
+            s2r_copy_SF();
+            CUTE_UNROLL
+            for (int read_stage = 0; read_stage < KT::AB_Stages; ++read_stage)
+            {
+                ab_full_mbar[read_stage].wait(phase);
+                s2r_copy_AB(read_stage);
+                auto tCrSFA_stage = tCrSFA_frg(_, _, _, read_stage);
+                auto tCrSFB_stage = tCrSFB_frg(_, _, _, read_stage);
+                cute::gemm(mma, make_zip_tensor(tCrA, tCrSFA_stage), make_zip_tensor(tCrB, tCrSFB_stage), accum);
+            }
+            phase ^= 1; // flip phase
+
+            if (is_tma_thread)
+            {
+                sf_empty_mbar[0].wait(phase ^ 1);
+                g2s_copy_SF(sf_tile_index);
+                CUTE_UNROLL
+                for (int write_stage = 0; write_stage < KT::AB_Stages; ++write_stage)
+                {
+                    ab_empty_mbar[write_stage].wait(phase ^ 1);
+                    int k_tile_index = sf_tile_index * 4 + write_stage;
+                    g2s_copy_AB(k_tile_index, write_stage);
+                }
+            }
+            ++sf_tile_index;
+            __syncthreads();
+        }
+
+        // math tail
+        sf_full_mbar[0].wait(phase);
+        s2r_copy_SF();
+        CUTE_UNROLL
+        for (int read_stage = 0; read_stage < KT::AB_Stages; ++read_stage)
+        {
+            ab_full_mbar[read_stage].wait(phase);
+            s2r_copy_AB(read_stage);
+            auto tCrSFA_stage = tCrSFA_frg(_, _, _, read_stage);
+            auto tCrSFB_stage = tCrSFB_frg(_, _, _, read_stage);
+            cute::gemm(mma, make_zip_tensor(tCrA, tCrSFA_stage), make_zip_tensor(tCrB, tCrSFB_stage), accum);
+        }
+
+        // store
+        __syncthreads();
+        epilogue_with_smem(accum, shared_storage, params, blk_coord);
+        // tma_store(accum, shared_storage, params, blk_coord);
+    }
+};
+
+} // namespace sm120_blockscaled_gemm

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_utils.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_utils.cuh
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "cute/atom/mma_atom.hpp"
+#include <cuda_runtime.h>
+#include <cute/atom/mma_traits_sm120.hpp>
+#include <cute/config.hpp>
+#include <cute/int_tuple.hpp>
+#include <cute/layout.hpp>
+#include <cutlass/cutlass.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/device_kernel.h" // cutlass::device_kernel
+
+using namespace cute;
+using namespace cutlass;
+using namespace cutlass::gemm;
+
+namespace sm120_blockscaled_gemm
+{
+
+template <int TileM_ = 32, int TileN_ = 128>
+struct SM120BlockScaledBuilder
+{
+
+    using ElementA = cute::float_e4m3_t;
+    using ElementB = cute::float_e4m3_t;
+    using ElementSFLoad = int32_t;                // scale load type
+    using ElementSFCompute = cute::float_ue8m0_t; // scale mma type
+    using ElementAccum = float;
+    using ElementD = cute::bfloat16_t;
+
+    static constexpr int AB_Stages = 4;
+    static constexpr int SF_Stages = 1;
+    static constexpr int kTileM = TileM_;
+    static constexpr int kTileN = TileN_;
+    static constexpr int kSFVecSize = 128; // fixed for 1x128 quantization
+    static constexpr int kTileSF = 1;      // 1 sf block contains 4 e8m0 for each 512 k elements
+    static constexpr int kTileK = 128;
+    using TileShape = Shape<Int<kTileM>, Int<kTileN>, Int<kTileK>>;
+    using ScaleTileShape = Shape<Int<kTileM>, Int<kTileN>, Int<kTileSF>>;
+    using ClusterShape = Shape<_1, _1, _1>;
+    using ProblemShape = Shape<int, int, int, int>;
+
+    // ====== mma ======
+    using PermMmaTileM = Int<32>;
+    using PermMmaTileN = Int<32>;
+    // using PermMmaTileN = Layout<Shape<_8,_2,_2>, Stride<_1, _16, _8>>;
+    using PermMmaTileK = Int<kTileK>;
+    using MMA_Atom = MMA_Atom<SM120::BLOCKSCALED::SM120_16x8x32_TN_VS<float_e4m3_t, float_e4m3_t, float, float_ue8m0_t,
+        32>>; // sm120 16x8x32 fp8 mma
+    using TiledMma = TiledMMA<MMA_Atom, Layout<Shape<_2, _2, _1>>, Tile<PermMmaTileM, PermMmaTileN, PermMmaTileK>>;
+
+    CUTE_HOST_DEVICE
+    static auto ceil_div(int const& x, int const& y)
+    {
+        return (x + y - 1) / y;
+    }
+
+    CUTE_HOST_DEVICE
+    static auto align(int const& x, int const& alignment)
+    {
+        return ceil_div(x, alignment) * alignment;
+    }
+
+    CUTE_HOST_DEVICE
+    static auto get_tma_aligned_size(int const& x)
+    {
+        constexpr int kNumTMAAlignmentBytes = 16;
+        CUTE_STATIC_ASSERT(kNumTMAAlignmentBytes % sizeof(ElementSFLoad) == 0, "element_size must be a multiple of 16");
+        auto alignment = kNumTMAAlignmentBytes / sizeof(ElementSFLoad);
+        return align(x, alignment);
+    }
+
+    CUTE_HOST_DEVICE
+    static auto deduce_sfa_layout(ProblemShape const& problem_shape)
+    {
+        auto [M, N, K, L] = problem_shape;
+        auto scale_m = get_tma_aligned_size(M);
+        auto scale_k = ceil_div(K, 128 * 4);
+        return make_ordered_layout(make_shape(scale_m, scale_k, L), Step<_1, _2, _3>{});
+    }
+
+    CUTE_HOST_DEVICE
+    static auto deduce_sfb_layout(ProblemShape const& problem_shape)
+    {
+        auto [M, N, K, L] = problem_shape;
+        auto scale_n = get_tma_aligned_size(N);
+        auto scale_k = ceil_div(K, 128 * 4);
+        return make_ordered_layout(make_shape(scale_n, scale_k, L), Step<_1, _2, _3>{});
+    }
+
+    template <class SFATensor, class Atom, class TiledThr, class TiledPerm>
+    CUTE_HOST_DEVICE static constexpr auto thrfrg_SFA(SFATensor&& sfatensor, TiledMMA<Atom, TiledThr, TiledPerm>& mma)
+    {
+        CUTE_STATIC_ASSERT_V(rank(sfatensor) >= Int<2>{});
+
+        // Reorder the tensor for the TiledAtom
+        auto permutation_mnk = TiledPerm{};
+        auto t_tile = make_tile(get<0>(permutation_mnk), get<2>(permutation_mnk));
+        auto tiled_sfa = logical_divide(sfatensor, t_tile);
+
+        using AtomShape_MNK = typename Atom::Shape_MNK;
+        auto atom_tile = make_tile(make_layout(size<0>(AtomShape_MNK{})), make_layout(size<2>(AtomShape_MNK{})));
+        auto tiled_atom_sfa = zipped_divide(tiled_sfa, atom_tile); // ((AtomM,AtomK),(RestM,RestK))
+        // Transform the Atom mode from (M,K) to (Thr,Val)
+        using AtomLayoutSFA_TV = Layout<Shape<Shape<_2, _2, _8>, _1>,     // Effectively 16 threads due to the 2:0 mode
+            Stride<Stride<_8, _0, _1>, _16>>;
+        auto tv_atom_sfa = tiled_atom_sfa.compose(AtomLayoutSFA_TV{}, _); // ((ThrV,FrgV),(RestM,RestK))
+
+        // Tile the tensor for the Thread
+        auto thr_layout_vmnk = mma.get_thr_layout_vmnk(); // (_32,_4,_1,_1):(_1,_32,_0,_0)
+        auto thr_tile
+            = make_tile(_, make_tile(make_layout(size<1>(thr_layout_vmnk)), make_layout(size<3>(thr_layout_vmnk))));
+        auto thr_tensor = zipped_divide(tv_atom_sfa, thr_tile); // ((ThrV,(ThrM,ThrK)),(FrgV,(RestM,RestK)))
+        return thr_tensor;
+    }
+
+    template <class SFATensor, class ThrMma>
+    CUTE_HOST_DEVICE static constexpr auto partition_fragment_SFA(SFATensor&& sfatensor, ThrMma& thread_mma)
+    {
+        // using ValTypeSF = typename ThrMma::Atom::Traits::ValTypeSF;
+        auto thr_tensor
+            = make_tensor(static_cast<SFATensor&&>(sfatensor).data(), thrfrg_SFA(sfatensor.layout(), thread_mma));
+        auto thr_vmnk = thread_mma.thr_vmnk_;
+        auto thr_vmk = make_coord(get<0>(thr_vmnk), make_coord(get<1>(thr_vmnk), get<3>(thr_vmnk)));
+        auto partition_SFA = thr_tensor(thr_vmk, make_coord(_, repeat<rank<1, 1>(thr_tensor)>(_)));
+        auto frg_SFA = make_fragment_like<ElementSFLoad>(partition_SFA);
+        return frg_SFA;
+    }
+
+    template <class TiledMma>
+    CUTE_HOST_DEVICE static constexpr auto get_layoutSFA_TV(TiledMma& mma)
+    {
+        auto tile_shape_mnk = tile_shape(mma);
+        auto ref_A = make_layout(make_shape(size<0>(tile_shape_mnk), size<2>(tile_shape_mnk)));
+        auto thr_tensor = thrfrg_SFA(ref_A, mma);
+        auto thr_layout_vmnk = mma.get_thr_layout_vmnk(); // (_32,_4,_1,_1):(_1,_32,_0,_0)
+        auto atile = make_tile(_,
+            make_tile(make_layout(make_shape(size<1>(thr_layout_vmnk), size<2>(thr_layout_vmnk)),
+                          make_stride(Int<1>{}, Int<0>{})),
+                _));                                          // (_,((_1,_4):(_1,_0),_))
+        auto tv_sfa = thr_tensor.compose(atile, _);           // mma_sfa_tv_layout
+        auto thridx_2_thrid = right_inverse(thr_layout_vmnk); // (_128:_1)
+        auto tv_layout = tv_sfa.compose(thridx_2_thrid, _);
+        return tv_layout;
+    }
+
+    template <class SFBTensor, class Atom, class TiledThr, class TiledPerm>
+    CUTE_HOST_DEVICE static constexpr auto thrfrg_SFB(SFBTensor&& sfbtensor, TiledMMA<Atom, TiledThr, TiledPerm>& mma)
+    {
+        CUTE_STATIC_ASSERT_V(rank(sfbtensor) >= Int<2>{});
+
+        // Reorder the tensor for the TiledAtom
+        auto permutation_mnk = TiledPerm{};
+        auto t_tile = make_tile(get<1>(permutation_mnk), get<2>(permutation_mnk));
+        auto tiled_sfb = logical_divide(sfbtensor, t_tile);
+
+        using AtomShape_MNK = typename Atom::Shape_MNK;
+        auto atom_tile = make_tile(make_layout(size<1>(AtomShape_MNK{})), make_layout(size<2>(AtomShape_MNK{})));
+        auto tiled_atom_sfb = zipped_divide(tiled_sfb, atom_tile); // ((AtomM,AtomK),(RestM,RestK))
+        // Transform the Atom mode from (M,K) to (Thr,Val)
+        using AtomLayoutSFB_TV = Layout<Shape<Shape<_4, _8>, _1>,         // Effectively 8 threads due to the 4:0 mode
+            Stride<Stride<_0, _1>, _8>>;
+        auto tv_atom_sfb = tiled_atom_sfb.compose(AtomLayoutSFB_TV{}, _); // ((ThrV,FrgV),(RestM,RestK))
+
+        // Tile the tensor for the Thread
+        auto thr_layout_vmnk = mma.get_thr_layout_vmnk(); // (_32,_4,_1,_1):(_1,_32,_0,_0)
+        auto thr_tile
+            = make_tile(_, make_tile(make_layout(size<2>(thr_layout_vmnk)), make_layout(size<3>(thr_layout_vmnk))));
+        auto thr_tensor = zipped_divide(tv_atom_sfb, thr_tile); // ((ThrV,(ThrM,ThrK)),(FrgV,(RestM,RestK)))
+        return thr_tensor;
+    }
+
+    template <class SFBTensor, class ThrMma>
+    CUTE_HOST_DEVICE static constexpr auto partition_fragment_SFB(SFBTensor&& sfbtensor, ThrMma& thread_mma)
+    {
+        // using ValTypeSF = typename ThrMma::Atom::Traits::ValTypeSF;
+        auto thr_tensor
+            = make_tensor(static_cast<SFBTensor&&>(sfbtensor).data(), thrfrg_SFB(sfbtensor.layout(), thread_mma));
+        auto thr_vmnk = thread_mma.thr_vmnk_;
+        auto thr_vmk = make_coord(get<0>(thr_vmnk), make_coord(get<1>(thr_vmnk), get<3>(thr_vmnk)));
+        auto partition_SFB = thr_tensor(thr_vmk, make_coord(_, repeat<rank<1, 1>(thr_tensor)>(_)));
+        auto frg_SFB = make_fragment_like<ElementSFLoad>(partition_SFB);
+        return frg_SFB;
+    }
+
+    template <class TiledMma>
+    CUTE_HOST_DEVICE static constexpr auto get_layoutSFB_TV(TiledMma& mma)
+    {
+        auto tile_shape_mnk = tile_shape(mma);
+        auto ref_B = make_layout(make_shape(size<1>(tile_shape_mnk), size<2>(tile_shape_mnk)));
+        auto thr_tensor = thrfrg_SFB(ref_B, mma);
+        auto thr_layout_vmnk = mma.get_thr_layout_vmnk(); // (_32,_4,_1,_1):(_1,_32,_0,_0)
+        auto btile = make_tile(_,
+            make_tile(make_layout(make_shape(size<1>(thr_layout_vmnk), size<2>(thr_layout_vmnk)),
+                          make_stride(Int<0>{}, Int<1>{})),
+                _));                                          // (_,((_4,_1):(_0,_1),_))
+        auto tv_sfb = thr_tensor.compose(btile, _);           // mma_sfb_tv_layout
+        auto thridx_2_thrid = right_inverse(thr_layout_vmnk); // (_128:_1)
+        auto tv_layout = tv_sfb.compose(thridx_2_thrid, _);
+        return tv_layout;
+    }
+
+    template <class Tensor>
+    CUTE_HOST_DEVICE static constexpr auto transform_fragment_for_qmma(Tensor&& tensor)
+    {
+        CUTE_STATIC_ASSERT_V(rank(tensor) == Int<3>{});
+        auto old_ptr = tensor.data();
+        auto new_ptr = recast_ptr<ElementSFCompute>(old_ptr);
+        auto old_layout = tensor.layout();
+        auto num_mn = size<1>(shape(old_layout));
+        auto num_k = size<2>(shape(old_layout));
+        auto new_layout = make_layout(make_shape(_32{}, num_mn, _4{}, num_k), make_stride(_0{}, _4{}, _0{}, _1{}));
+        auto new_tensor = make_tensor(new_ptr, new_layout);
+        return new_tensor;
+    }
+
+    // ====== load smem -> rf ======
+    using SmemCopyAtomA = Copy_Atom<SM75_U32x4_LDSM_N, ElementA>;
+    using SmemCopyAtomB = Copy_Atom<SM75_U32x4_LDSM_N, ElementB>;
+
+    // ====== smem layout ======
+    using SmemLayoutAtomA = GMMA::Layout_K_SW128_Atom<ElementA>; // ((_8,_16),(_128,_1)):((_128,_1024),(_1,_0))
+    using SmemLayoutAtomB = GMMA::Layout_K_SW128_Atom<ElementB>; // ((_8,_16),(_128,_1)):((_128,_1024),(_1,_0))
+
+    using SmemLayoutA = decltype(tile_to_shape(SmemLayoutAtomA{},
+        make_shape(shape<0>(TileShape{}), shape<2>(TileShape{}), Int<AB_Stages>{}), Step<_1, _2, _3>{}));
+
+    using SmemLayoutB = decltype(tile_to_shape(SmemLayoutAtomB{},
+        make_shape(shape<1>(TileShape{}), shape<2>(TileShape{}), Int<AB_Stages>{}), Step<_1, _2, _3>{}));
+
+    // ====== TMA config ======
+    using StrideA = Stride<int64_t, Int<1>, int64_t>;
+    using StrideB = Stride<int64_t, Int<1>, int64_t>;
+
+    using TMA_A = decltype(make_tma_copy(SM90_TMA_LOAD{},
+        make_tensor(recast_ptr<ElementA>(nullptr), repeat_like(StrideA{}, int32_t(0)), StrideA{}),
+        SmemLayoutA{}(_, _, Int<0>{}), make_shape(shape<0>(TileShape{}), shape<2>(TileShape{})), _1{}));
+
+    using TMA_B = decltype(make_tma_copy(SM90_TMA_LOAD{},
+        make_tensor(recast_ptr<ElementB>(nullptr), repeat_like(StrideB{}, int32_t(0)), StrideB{}),
+        SmemLayoutB{}(_, _, Int<0>{}), make_shape(shape<1>(TileShape{}), shape<2>(TileShape{})), _1{}));
+
+    // ====== scale ======
+    using SmemCopyAtomSF = Copy_Atom<AutoVectorizingCopy, ElementSFLoad>; // auto-vectorized LDS
+
+    using SmemLayoutAtomSFA = decltype(make_ordered_layout(select<0, 2>(ScaleTileShape{}), Step<_1, _2>{}));
+
+    using SmemLayoutAtomSFB = decltype(make_ordered_layout(select<1, 2>(ScaleTileShape{}), Step<_1, _2>{}));
+
+    using SmemLayoutSFA = decltype(tile_to_shape(SmemLayoutAtomSFA{},
+        make_shape(shape<0>(ScaleTileShape{}), shape<2>(ScaleTileShape{}), Int<SF_Stages>{}), Step<_1, _2, _3>{}));
+
+    using SmemLayoutSFB = decltype(tile_to_shape(SmemLayoutAtomSFB{},
+        make_shape(shape<1>(ScaleTileShape{}), shape<2>(ScaleTileShape{}), Int<SF_Stages>{}), Step<_1, _2, _3>{}));
+
+    using StrideSFA = Stride<Int<1>, int64_t, int64_t>; // column major
+    using StrideSFB = Stride<Int<1>, int64_t, int64_t>; // column major
+
+    using TMA_SFA = decltype(make_tma_copy(SM90_TMA_LOAD{},
+        make_tensor(recast_ptr<ElementSFLoad>(nullptr), repeat_like(StrideSFA{}, int32_t(0)), StrideSFA{}),
+        SmemLayoutSFA{}(_, _, cute::Int<0>{}), make_shape(shape<0>(ScaleTileShape{}), shape<2>(ScaleTileShape{})),
+        _1{}));
+
+    using TMA_SFB = decltype(make_tma_copy(SM90_TMA_LOAD{},
+        make_tensor(recast_ptr<ElementSFLoad>(nullptr), repeat_like(StrideSFB{}, int32_t(0)), StrideSFB{}),
+        SmemLayoutSFB{}(_, _, cute::Int<0>{}), make_shape(shape<1>(ScaleTileShape{}), shape<2>(ScaleTileShape{})),
+        _1{}));
+
+    static constexpr uint32_t TmaTransactionBytesA = static_cast<uint32_t>(
+        cutlass::bits_to_bytes(size(take<0, 2>(SmemLayoutA{})) * cute::sizeof_bits_v<ElementA>));
+    static constexpr uint32_t TmaTransactionBytesB = static_cast<uint32_t>(
+        cutlass::bits_to_bytes(size(take<0, 2>(SmemLayoutB{})) * cute::sizeof_bits_v<ElementB>));
+    static constexpr uint32_t TmaABTransactionBytes = TmaTransactionBytesA + TmaTransactionBytesB;
+    static constexpr uint32_t TmaTransactionBytesSFA = static_cast<uint32_t>(
+        cutlass::bits_to_bytes(cosize(take<0, 2>(SmemLayoutSFA{})) * cute::sizeof_bits_v<ElementSFLoad>));
+    static constexpr uint32_t TmaTransactionBytesSFB = static_cast<uint32_t>(
+        cutlass::bits_to_bytes(cosize(take<0, 2>(SmemLayoutSFB{})) * cute::sizeof_bits_v<ElementSFLoad>));
+    static constexpr uint32_t TmaSFTransactionBytes = TmaTransactionBytesSFA + TmaTransactionBytesSFB;
+
+    // ====== store rf -> smem ======
+    using SmemAtomLayoutStore = decltype(composition(
+        // Swizzle<3, 2, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{})); //  8x32
+        Swizzle<3, 3, 3>{}, Layout<Shape<_8, Shape<_8, _8>>, Stride<_8, Stride<_1, _64>>>{})); //  8x64
+
+    using SmemLayoutO = decltype(tile_to_shape(SmemAtomLayoutStore{}, Shape<Int<kTileM>, Int<kTileN>>{}));
+
+    using SmemCopyAtomR2S = Copy_Atom<AutoVectorizingCopy, ElementD>;
+
+    // ====== store smem -> gmem ======
+    using SmemCopyAtomS2R = Copy_Atom<AutoVectorizingCopy, ElementD>;
+    using GmemCopyAtomR2G = SmemCopyAtomS2R;
+
+    using TiledCopyS2G = decltype(make_tiled_copy(SmemCopyAtomS2R{}, Layout<Shape<_16, _8>, Stride<_8, _1>>{},
+        // Layout<Shape<_1, _4>>{})); // 16x32
+        Layout<Shape<_1, _8>>{})); // 16x64
+
+    // ====== TMA store ======
+    using StrideD = Stride<int64_t, Int<1>, int64_t>;
+    using EpilogueTile_MN = Shape<Int<kTileM>, Int<kTileN>>;
+
+    using CopyAtomC = Copy_Atom<SM90_U32x2_STSM_N, cutlass::half_t>;
+
+    using SmemLayoutAtomD = GMMA::Layout_K_SW128_Atom<ElementD>; // ((_8,_16),(_128,_1)):((_128,_1024),(_1,_0))
+
+    static constexpr int StagesD = 1;
+    using SmemLayoutD = decltype(tile_to_shape(SmemLayoutAtomD{},
+        make_shape(size<0>(EpilogueTile_MN{}), size<1>(EpilogueTile_MN{}), Int<StagesD>{}), Step<_1, _2, _3>{}));
+
+    using CopyOpR2S = SM90_U32x2_STSM_N;
+    using CopyOpS2G = SM90_TMA_STORE;
+    using TMA_D = decltype(make_tma_copy_C_sm90(CopyOpS2G{},
+        make_tensor(make_gmem_ptr(static_cast<ElementD*>(nullptr)), repeat_like(StrideD{}, int32_t(0)), StrideD{}),
+        take<0, 2>(SmemLayoutD{}), EpilogueTile_MN{}));
+
+    struct SharedStorageLoad : cute::aligned_struct<128, _0>
+    {
+        alignas(1024) cute::ArrayEngine<ElementA, cute::cosize_v<SmemLayoutA>> smem_A;
+        alignas(1024) cute::ArrayEngine<ElementB, cute::cosize_v<SmemLayoutB>> smem_B;
+        cute::ArrayEngine<ElementSFLoad, cute::cosize_v<SmemLayoutSFA>> smem_SFA;
+        cute::ArrayEngine<ElementSFLoad, cute::cosize_v<SmemLayoutSFB>> smem_SFB;
+    } tensors;
+
+    struct SharedStorageStore : cute::aligned_struct<128, _0>
+    {
+        alignas(1024) cute::ArrayEngine<ElementD, cute::cosize_v<SmemLayoutO>> smem_D;
+        // alignas(1024) cute::ArrayEngine<ElementD, cute::cosize_v<SmemLayoutD>> smem_D;
+    };
+
+    union TensorStorage
+    {
+        SharedStorageLoad load;
+        SharedStorageStore store;
+    };
+
+    using FullBarrier = cutlass::arch::ClusterTransactionBarrier;
+    using EmptyBarrier = cutlass::arch::ClusterBarrier;
+    using ProducerBarrierType = FullBarrier::ValueType;
+    using ConsumerBarrierType = EmptyBarrier::ValueType;
+
+    struct BarrierStorage
+    {
+        FullBarrier ab_full_mbar[AB_Stages];
+        EmptyBarrier ab_empty_mbar[AB_Stages];
+        FullBarrier sf_full_mbar[SF_Stages];
+        EmptyBarrier sf_empty_mbar[SF_Stages];
+    };
+
+    static dim3 get_grid_shape(ProblemShape problem_shape)
+    {
+        auto [M, N, K, L] = problem_shape;
+        int grid_m = (M + kTileM - 1) / kTileM;
+        int grid_n = (N + kTileN - 1) / kTileN;
+        int grid_l = L;
+        return dim3(grid_m, grid_n, grid_l);
+    }
+};
+
+} // namespace sm120_blockscaled_gemm

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_utils.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/6kd_blockwise_gemm/sm120_utils.cuh
@@ -29,7 +29,6 @@
 
 using namespace cute;
 using namespace cutlass;
-using namespace cutlass::gemm;
 
 namespace sm120_blockscaled_gemm
 {

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+#include "6kd_blockwise_gemm/sm120_fp8_gemm_1d2d.cuh"
 #include "ada_blockwise_gemm/sm89_fp8_gemm_1d1d.cuh"
 #include "fp8_blockscale_mma_utils.cuh"
 #include "fp8_blockscale_tma_utils.cuh"
@@ -1633,6 +1634,56 @@ void gemm_dispatch_sm89(void* mat_a, void* mat_b, void* mat_d, float* scales_a, 
     TLLM_CHECK_WITH_INFO(result == cudaSuccess, "sm89 gemm kernel runtime error: %s", cudaGetErrorString(result));
 }
 
+void gemm_dispatch_sm120(void* mat_a, void* mat_b, void* mat_d, float* scales_a, float* scales_b, uint32_t shape_m,
+    uint32_t shape_n, uint32_t shape_k, cudaStream_t stream, int num_device_sms = kNumDeviceSMs)
+{
+    if (num_device_sms < 0)
+    {
+        num_device_sms = kNumDeviceSMs = tensorrt_llm::common::getMultiProcessorCount();
+    }
+    using ElementInput = cute::float_e4m3_t;
+    using ElementOutput = cute::bfloat16_t;
+    using ElementAccum = float;
+    using ElementBlockScale = int32_t;
+    using KT = sm120_blockscaled_gemm::SM120BlockScaledBuilder<32, 128>;
+    using GemmKernel = sm120_blockscaled_gemm::SM120BlockScaledKernel<KT>;
+    using Params = typename GemmKernel::Params;
+    using Arguments = typename GemmKernel::Arguments;
+    using ProblemShape = typename GemmKernel::ProblemShape;
+
+    auto ptr_A = reinterpret_cast<ElementInput*>(mat_a);
+    auto ptr_B = reinterpret_cast<ElementInput*>(mat_b);
+    auto ptr_SFA = reinterpret_cast<ElementBlockScale*>(scales_a);
+    auto ptr_SFB = reinterpret_cast<ElementBlockScale*>(scales_b);
+    auto ptr_D = reinterpret_cast<ElementOutput*>(mat_d);
+    Arguments args = {ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D};
+    ProblemShape problem_shape = make_shape((int) shape_m, (int) shape_n, (int) shape_k, 1);
+
+    Params kernel_params = GemmKernel::to_underlying_arguments(problem_shape, args);
+    auto kernel_ptr = &cutlass::device_kernel<GemmKernel>;
+
+    cudaFuncSetAttribute(kernel_ptr, cudaFuncAttributeMaxDynamicSharedMemorySize, GemmKernel::kSmemSize);
+    auto result = cudaGetLastError();
+    TLLM_CHECK_WITH_INFO(result == cudaSuccess, "sm120 gemm kernel cannot launch: %s", cudaGetErrorString(result));
+
+    cudaLaunchConfig_t launch_config;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = 1;
+
+    launch_config.gridDim = GemmKernel::get_grid_shape(kernel_params);
+    launch_config.blockDim = GemmKernel::get_block_shape();
+    launch_config.dynamicSmemBytes = GemmKernel::kSmemSize;
+    launch_config.stream = stream;
+    launch_config.attrs = attrs;
+    launch_config.numAttrs = 1;
+
+    cudaLaunchKernelEx(&launch_config, kernel_ptr, kernel_params);
+
+    result = cudaGetLastError();
+    TLLM_CHECK_WITH_INFO(result == cudaSuccess, "sm120 gemm kernel runtime error: %s", cudaGetErrorString(result));
+}
+
 void fp8_gemm_run(__nv_fp8_e4m3* mat_a, int ld_a, __nv_fp8_e4m3* mat_b, int ld_b, __nv_bfloat16* mat_d, int ld_d,
     uint32_t shape_m, uint32_t shape_n, uint32_t shape_k, float* scales_a, float* scales_b, cudaStream_t stream)
 {
@@ -1642,9 +1693,14 @@ void fp8_gemm_run(__nv_fp8_e4m3* mat_a, int ld_a, __nv_fp8_e4m3* mat_b, int ld_b
     }
 #ifndef PLACEHOLDER_KERNELS
     int arch = tensorrt_llm::common::getSMVersion();
-    if (arch == 89 || arch == 120)
+    if (arch == 89)
     {
         gemm_dispatch_sm89(mat_a, mat_b, mat_d, scales_a, scales_b, shape_m, shape_n, shape_k, stream);
+        return;
+    }
+    if (arch == 120)
+    {
+        gemm_dispatch_sm120(mat_a, mat_b, mat_d, scales_a, scales_b, shape_m, shape_n, shape_k, stream);
         return;
     }
     if (kDeepGemmEnabled)

--- a/cpp/tensorrt_llm/thop/fp8BlockScalingGemm.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScalingGemm.cpp
@@ -112,6 +112,44 @@ torch::Tensor fp8_block_scaling_gemm_ada(torch::Tensor const& mat1, torch::Tenso
     return out;
 }
 
+torch::Tensor fp8_block_scale_gemm_rtx_6000(torch::Tensor const& mat1, torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale, torch::Tensor const& mat2Scale)
+{
+    TORCH_CHECK(mat1.scalar_type() == at::ScalarType::Float8_e4m3fn, "Matrix dtype must be FP8.");
+    TORCH_CHECK(mat2.scalar_type() == at::ScalarType::Float8_e4m3fn, "Matrix dtype must be FP8.");
+    TORCH_CHECK(mat1Scale.scalar_type() == at::ScalarType::Int, "Scale dtype must be Int32.");
+    TORCH_CHECK(mat2Scale.scalar_type() == at::ScalarType::Int, "Scale dtype must be Int32.");
+
+    TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix");
+    TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
+    TORCH_CHECK(mat1.sizes()[1] == mat2.sizes()[1], "mat1 and mat2 shapes cannot be multiplied (", mat1.sizes()[0], "x",
+        mat1.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")");
+
+    auto const m = mat1.sizes()[0];
+    auto const n = mat2.sizes()[0];
+    auto const k = mat1.sizes()[1];
+    TORCH_CHECK(m <= std::numeric_limits<int32_t>::max(), "M must be within int32");
+    TORCH_CHECK(n <= std::numeric_limits<int32_t>::max(), "N must be within int32");
+    TORCH_CHECK(k <= std::numeric_limits<int32_t>::max(), "K must be within int32");
+
+    TORCH_CHECK(k % 128 == 0, "K must be a multiple of 128, (K=", k, ")");
+    TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
+
+    at::Tensor out = at::detail::empty_cuda({m, n}, at::ScalarType::BFloat16, mat1.device(), std::nullopt);
+
+    auto gemm_runner = get_gemm_runner(mat1.scalar_type(), mat2.scalar_type());
+
+    auto stream = at::cuda::getCurrentCUDAStream(mat1.get_device());
+
+    float const* mat1ScalePtr = reinterpret_cast<float const*>(mat1Scale.data_ptr());
+    float const* mat2ScalePtr = reinterpret_cast<float const*>(mat2Scale.data_ptr());
+
+    gemm_runner->gemm(reinterpret_cast<__nv_fp8_e4m3*>(mat1.data_ptr()), k,
+        reinterpret_cast<__nv_fp8_e4m3*>(mat2.data_ptr()), k, reinterpret_cast<__nv_bfloat16*>(out.data_ptr()), n, m, n,
+        k, mat1ScalePtr, mat2ScalePtr, stream);
+    return out;
+}
+
 torch::Tensor fp8_block_scaling_gemm_hopper(torch::Tensor const& mat1, torch::Tensor const& mat2,
     torch::Tensor const& mat1Scale, torch::Tensor const& mat2Scale)
 {
@@ -209,7 +247,7 @@ extern torch::Tensor fp8_block_scaling_gemm(torch::Tensor const& mat1, torch::Te
     case 100: return fp8_block_scale_gemm_blackwell(mat1, mat2, mat1Scale, mat2Scale);
     case 90: return fp8_block_scaling_gemm_hopper(mat1, mat2, mat1Scale, mat2Scale);
     case 89: return fp8_block_scaling_gemm_ada(mat1, mat2, mat1Scale, mat2Scale);
-    case 120: return fp8_block_scaling_gemm_ada(mat1, mat2, mat1Scale, mat2Scale);
+    case 120: return fp8_block_scale_gemm_rtx_6000(mat1, mat2, mat1Scale, mat2Scale);
     default: TORCH_CHECK(false, "Unsupported SM version for FP8 block scaling GEMM");
     }
 }

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -23,9 +23,10 @@ from tensorrt_llm.quantization.functional import \
     preprocess_weights_for_mixed_gemm
 from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.quantization.utils.fp8_utils import (
-    resmooth_to_fp8_e8m0, transform_sf_into_required_layout)
+    per_token_quant_and_transform, resmooth_to_fp8_e8m0,
+    transform_sf_into_required_layout)
 
-from ..._utils import is_sm_100f
+from ..._utils import get_sm_version, is_sm_100f
 from ...models.modeling_utils import QuantConfig
 from ..cublaslt_utils import IS_CUBLASLT_AVAILABLE
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
@@ -645,6 +646,10 @@ class FP8BlockScalesLinearMethod(LinearMethodBase):
                     module.weight_scale,
                     disable_ue8m0_cast=True,
                 )
+        elif get_sm_version() == 120:
+            act_input_fp8, act_input_sf = per_token_quant_and_transform(input)
+            output = torch.ops.trtllm.fp8_block_scaling_gemm(
+                act_input_fp8, module.weight, act_input_sf, module.weight_scale)
         else:
             act_input_fp8, act_input_sf = torch.ops.trtllm.fp8_quantize_1x128(
                 input)
@@ -730,8 +735,9 @@ class FP8BlockScalesLinearMethod(LinearMethodBase):
 
     def post_load_weights(self, module: Linear):
         super().post_load_weights(module)
-        if is_sm_100f() and not (module.use_cute_dsl_blockscaling_mm
-                                 or module.disable_deep_gemm):
+        if (is_sm_100f() and not (module.use_cute_dsl_blockscaling_mm
+                                 or module.disable_deep_gemm)) or \
+           get_sm_version() == 120:
             weight, weight_scale = resmooth_to_fp8_e8m0(module.weight,
                                                         module.weight_scale)
             transfromed_scale = transform_sf_into_required_layout(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FP8 block-scaled matrix multiplication on RTX 6000 (SM120 architecture), enabling accelerated inference for compatible models.
  
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[https://nvbugs/5456493][feat] Summary**



Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

  * Added support for FP8 block-scaled matrix multiplication on RTX 6000 (SM120 architecture), enabling accelerated inference for compatible models.

## Test Coverage

has passed unit test
<img width="1040" height="436" alt="image" src="https://github.com/user-attachments/assets/08151f78-eaa4-4f51-bc19-950730588c72" />

has passed gsm8k e2e  precision check
<img width="951" height="140" alt="image" src="https://github.com/user-attachments/assets/23d6ddd4-c8b9-44f6-8a0a-adffa477006e" />


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
