### PR TITLE
[#9096][feature] Auto Deploy: configurable fused MoE backend

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -114,9 +114,11 @@ transforms:
   fuse_moe:
     stage: post_load_fusion
     enabled: true
+    backend: trtllm
   fuse_fp8_moe:
     stage: post_load_fusion
     enabled: true
+    backend: trtllm
   fuse_allreduce_residual_rmsnorm:
     stage: post_load_fusion
   # TODO (lucaslie): add backend selection as part of configurable inference optimizers

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -114,7 +114,7 @@ transforms:
   fuse_moe:
     stage: post_load_fusion
     enabled: true
-    backend: trtllm
+    backend: auto
   fuse_fp8_moe:
     stage: post_load_fusion
     enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -114,7 +114,7 @@ transforms:
   fuse_moe:
     stage: post_load_fusion
     enabled: true
-    backend: auto
+    backend: trtllm
   fuse_fp8_moe:
     stage: post_load_fusion
     enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe.py
@@ -341,7 +341,7 @@ def get_moe_configs(
     for config_file_path in config_file_paths:
         if os.path.exists(config_file_path):
             with open(config_file_path) as f:
-                ad_logger.info("Using configuration from %s for MoE layer.", config_file_path)
+                ad_logger.info(f"Using configuration from {config_file_path} for MoE layer.")
                 # If a configuration has been found, return it
                 tuned_config = json.load(f)
                 # Delete triton_version from tuned_config

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe.py
@@ -601,8 +601,16 @@ def triton_fused_moe(
     routing_weights: torch.Tensor,
     w1_stacked_weight: torch.Tensor,
     w2_stacked_weight: torch.Tensor,
+    mlp_style: str = "mlp",
+    act_fn: str = "relu2",
 ) -> torch.Tensor:
     """Triton unquantized MoE with 2-layer MLP and ReLU^2 activation."""
+
+    mlp_style = mlp_style.lower()
+    act_fn = act_fn.lower()
+    assert mlp_style == "mlp", "Triton backend only supports mlp style."
+    assert act_fn == "relu2", "Triton backend only supports relu2 activation."
+
     x_shape = x.shape
     x2d = x.view(-1, x_shape[-1])
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -1,25 +1,44 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Type
 
 import torch
+from pydantic import Field
 from torch.fx import GraphModule, Node
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils.cuda_mem_tracker import cuda_memory_tracker
 from ...utils.node_utils import bfs, extract_op_args, identify_regions_between_residuals, is_op
-from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
 
 
-def _insert_fused_moe_ops(gm: GraphModule) -> int:
+def _insert_fused_moe_ops(gm: GraphModule, backend: str) -> int:
     fused_key_counter = 0
     graph = gm.graph
+    backend = backend.lower()
+
+    assert backend in ["trtllm", "triton"], (
+        f"Invalid backend: {backend}. Must be 'trtllm' or 'triton'."
+    )
+    replacement_op = {
+        "trtllm": torch.ops.auto_deploy.trtllm_moe_fused,
+        "triton": torch.ops.auto_deploy.triton_moe_fused,
+    }[backend]
 
     for node in graph.nodes:
         if not is_op(node, torch.ops.auto_deploy.torch_moe):
             continue
 
-        (mlp_style_val,) = extract_op_args(node, "mlp_style")
+        (mlp_style_val, act_fn_val) = extract_op_args(node, "mlp_style", "act_fn")
+        assert backend != "triton" or mlp_style_val == "mlp", (
+            "Triton backend only supports mlp style."
+        )
 
         hidden_states, selected_experts, routing_weights, w1_list, w2_list, w3_list = (
             extract_op_args(
@@ -43,15 +62,10 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
                 dim=0,
             )
             new_key_w_up = f"fused_moe_w3_w1_stacked_{fused_key_counter}"
-            # TRTLLM fused MoE op supports gated MLP only.
-            replacement_op = torch.ops.auto_deploy.trtllm_moe_fused
 
         elif mlp_style_val == "mlp":
             fused_w_up_experts = torch.stack([gm.get_parameter(n.target) for n in w1_list], dim=0)
             new_key_w_up = f"fused_moe_w1_stacked_{fused_key_counter}"
-            # Triton fused MoE op supports mlp only.
-            replacement_op = torch.ops.auto_deploy.triton_moe_fused
-
         else:
             raise ValueError(f"Unknown mlp_style: {mlp_style_val}")
 
@@ -569,7 +583,7 @@ class MatchNVFP4MoePattern(MatchMoePattern):
         return ["input_scale", "weight_scale", "alpha"]
 
 
-def _stack_fp8_moe_weights(gm: GraphModule) -> int:
+def _stack_fp8_moe_weights(gm: GraphModule, backend: str) -> int:
     """
     Stack per-expert FP8 weights and scales by materializing stacked tensors as parameters.
     This is fast because we directly stack the tensor values (not graph nodes).
@@ -577,6 +591,15 @@ def _stack_fp8_moe_weights(gm: GraphModule) -> int:
     """
     fused_key_counter = 0
     graph = gm.graph
+
+    backend = backend.lower()
+    assert backend in ["trtllm", "triton"], (
+        f"Invalid backend: {backend}. Must be 'trtllm' or 'triton'."
+    )
+    replacement_op = {
+        "trtllm": torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
+        "triton": torch.ops.auto_deploy.triton_quant_fp8_moe,
+    }[backend]
 
     for node in graph.nodes:
         if not is_op(node, torch.ops.auto_deploy.torch_quant_fp8_moe):
@@ -709,7 +732,7 @@ def _stack_fp8_moe_weights(gm: GraphModule) -> int:
         # Create new node with get_attr for stacked parameters
         with graph.inserting_before(node):
             new_node = graph.call_function(
-                torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
+                replacement_op,
                 args=(
                     hidden_states,
                     selected_experts,
@@ -739,12 +762,25 @@ def _stack_fp8_moe_weights(gm: GraphModule) -> int:
     return fused_key_counter
 
 
+class FuseMoeConfig(TransformConfig):
+    """Configuration for MoE fusion transform."""
+
+    backend: str = Field(
+        default="trtllm",
+        description="Backend to use for MoE computation ('trtllm' or 'triton'. default: 'trtllm').",
+    )
+
+
 @TransformRegistry.register("fuse_moe")
 class FuseMoe(BaseTransform):
     """
     Scan the FX graph and replace all calls to torch.ops.auto_deploy.torch_moe with
     torch.ops.auto_deploy.trtllm_moe_fused.
     """
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return FuseMoeConfig
 
     def _apply(
         self,
@@ -754,7 +790,7 @@ class FuseMoe(BaseTransform):
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
         with cuda_memory_tracker():
-            fused_key_counter = _insert_fused_moe_ops(gm)
+            fused_key_counter = _insert_fused_moe_ops(gm, backend=self.config.backend)
 
         info = TransformInfo(
             skipped=False,
@@ -763,6 +799,15 @@ class FuseMoe(BaseTransform):
             has_valid_shapes=fused_key_counter == 0,
         )
         return gm, info
+
+
+class FuseFP8MoeConfig(TransformConfig):
+    """Configuration for FP8 MoE fusion transform."""
+
+    backend: str = Field(
+        default="trtllm",
+        description="Backend to use for FP8 MoE computation ('trtllm' or 'triton'. default: 'trtllm').",
+    )
 
 
 @TransformRegistry.register("fuse_fp8_moe")
@@ -780,7 +825,7 @@ class FuseFP8Moe(BaseTransform):
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
         with cuda_memory_tracker():
-            fused_key_counter = _stack_fp8_moe_weights(gm)
+            fused_key_counter = _stack_fp8_moe_weights(gm, backend=self.config.backend)
 
         info = TransformInfo(
             skipped=(fused_key_counter == 0),

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Literal, Optional, Tuple, Type
 
 import torch
 from pydantic import Field
@@ -18,15 +18,13 @@ from ..interface import (
 )
 
 
-def _insert_fused_moe_ops(gm: GraphModule, backend: str) -> int:
+def _insert_fused_moe_ops(gm: GraphModule, backend: Literal["auto", "trtllm", "triton"]) -> int:
     fused_key_counter = 0
     graph = gm.graph
     backend = backend.lower()
 
-    assert backend in ["trtllm", "triton"], (
-        f"Invalid backend: {backend}. Must be 'trtllm' or 'triton'."
-    )
     replacement_op = {
+        "auto": torch.ops.auto_deploy.trtllm_moe_fused,
         "trtllm": torch.ops.auto_deploy.trtllm_moe_fused,
         "triton": torch.ops.auto_deploy.triton_moe_fused,
     }[backend]

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -762,8 +762,8 @@ class FuseMoeConfig(TransformConfig):
     """Configuration for MoE fusion transform."""
 
     backend: str = Field(
-        default="trtllm",
-        description="Backend to use for MoE computation ('trtllm' or 'triton'. default: 'trtllm').",
+        default="auto",
+        description="Backend to use for MoE computation ('auto', 'trtllm' or 'triton'. default: 'auto').",
     )
 
 
@@ -801,8 +801,8 @@ class FuseFP8MoeConfig(TransformConfig):
     """Configuration for FP8 MoE fusion transform."""
 
     backend: str = Field(
-        default="trtllm",
-        description="Backend to use for FP8 MoE computation ('trtllm' or 'triton'. default: 'trtllm').",
+        default="auto",
+        description="Backend to use for FP8 MoE computation ('auto', 'trtllm' or 'triton'. default: 'auto').",
     )
 
 


### PR DESCRIPTION
Allow configuring Auto Deploy's MoE/FP8-MoE backend from external yaml config file.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

fixes #9096 

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
