### PR TITLE
[None][feature] AutoDeploy: tighter MoE UT thresholds

### DIFF
--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
@@ -119,7 +119,7 @@ def compute_with_experts(
 
 
 def _get_test_data(
-    otype, wtype, batch_size, hidden_size, num_experts, intermediate_size, X_GEN_SCALE
+    otype, wtype, batch_size, hidden_size, num_experts, intermediate_size, X_GEN_SCALE, W_GEN_SCALE
 ):
     input_shape = (batch_size, hidden_size)
     w31_shape = (num_experts, 2 * intermediate_size, hidden_size)
@@ -127,8 +127,8 @@ def _get_test_data(
 
     x = cast_to_representable(gen_tensor(input_shape, otype, scale=X_GEN_SCALE))
     router_logits = gen_tensor((batch_size, num_experts), otype)
-    w31_weight = gen_tensor(w31_shape, otype, wtype)
-    w2_weight = gen_tensor(w2_shape, otype, wtype)
+    w31_weight = gen_tensor(w31_shape, otype, wtype, W_GEN_SCALE)
+    w2_weight = gen_tensor(w2_shape, otype, wtype, W_GEN_SCALE)
     w31_empty_scales = torch.empty(num_experts, 2, dtype=otype).cuda()
     w2_empty_scales = torch.empty(num_experts, 1, dtype=otype).cuda()
     return x, router_logits, w31_weight, w2_weight, w31_empty_scales, w2_empty_scales
@@ -203,9 +203,17 @@ def test_trtllm_fused_moe(
         X_GEN_SCALE = 1.0
     else:
         X_GEN_SCALE = 0.5
+    W_GEN_SCALE = 0.1
 
     x, router_logits, w31_weight, w2_weight, w31_scales, w2_scales = _get_test_data(
-        otype, wtype, batch_size, hidden_size, num_experts, intermediate_size, X_GEN_SCALE
+        otype,
+        wtype,
+        batch_size,
+        hidden_size,
+        num_experts,
+        intermediate_size,
+        X_GEN_SCALE,
+        W_GEN_SCALE,
     )
 
     routing_weights, selected_experts = compute_routing(router_logits, top_k)
@@ -278,14 +286,14 @@ def test_trtllm_fused_moe(
                 w1_weight.contiguous(),
                 w2_weight.contiguous(),
             )[0].view(x.shape)
-            torch.testing.assert_close(output_triton_moe, ad_test_output, rtol=1e-1, atol=1e-1)
+            torch.testing.assert_close(output_triton_moe, ad_test_output, rtol=1e-2, atol=1e-2)
 
     diff = (ref_output - ad_test_output).abs()
     print(f"max diff: {diff.max()}")
     torch.testing.assert_close(ad_test_output, trtllm_test_output, rtol=1e-6, atol=1e-6)
 
     _print_diff_if(lambda diff: diff.max() > 1e-1, diff, ad_test_output, ref_output)
-    torch.testing.assert_close(ref_output, ad_test_output, rtol=1e-1, atol=1e-1)
+    torch.testing.assert_close(ref_output, ad_test_output, rtol=1e-2, atol=1e-2)
 
 
 FP8_TEST_DTYPES = [
@@ -305,7 +313,7 @@ FP8_TEST_DTYPES = [
     not fp8_compatible() or not trtllm_ops_available(),
     reason="Requires fp8 and trtllm support",
 )
-def test_trtllm_fused_fp8moe(
+def test_trtllm_fused_moe_fp8(
     batch_size,
     hidden_size,
     num_experts,
@@ -333,7 +341,9 @@ def test_trtllm_fused_fp8moe(
     else:
         X_GEN_SCALE = 0.5
 
-    def dequantize_weights(w31_weight, w2_weight, w31_scales, w2_scales):
+    W_GEN_SCALE = 0.1
+
+    def dequantize_weights(w31_weight, w2_weight, w31_scales, w2_scales, W_GEN_SCALE):
         # input_shape = (batch_size, hidden_size)
         w31_shape = (num_experts, 2 * intermediate_size, hidden_size)
         w2_shape = (num_experts, hidden_size, intermediate_size)
@@ -341,8 +351,8 @@ def test_trtllm_fused_fp8moe(
         w31_dequantized = gen_tensor(w31_weight.shape, otype)
         w2_dequantized = gen_tensor(w2_weight.shape, otype)
         for expert_id in range(num_experts):
-            w31 = cast_to_representable(gen_tensor(w31_shape[1:], otype, scale=0.1))
-            w2 = cast_to_representable(gen_tensor(w2_shape[1:], otype, scale=0.09))
+            w31 = cast_to_representable(gen_tensor(w31_shape[1:], otype, scale=W_GEN_SCALE))
+            w2 = cast_to_representable(gen_tensor(w2_shape[1:], otype, scale=W_GEN_SCALE))
             w31_quant, s31 = dynamic_per_tensor_fp8_quant(w31)
             w2_quant, s2 = dynamic_per_tensor_fp8_quant(w2)
             w31_weight.data[expert_id].copy_(w31_quant)
@@ -354,11 +364,18 @@ def test_trtllm_fused_fp8moe(
         return w31_dequantized, w2_dequantized
 
     x, router_logits, w31_weight, w2_weight, w31_scales, w2_scales = _get_test_data(
-        otype, wtype, batch_size, hidden_size, num_experts, intermediate_size, X_GEN_SCALE
+        otype,
+        wtype,
+        batch_size,
+        hidden_size,
+        num_experts,
+        intermediate_size,
+        X_GEN_SCALE,
+        W_GEN_SCALE,
     )
 
     w31_dequantized, w2_dequantized = dequantize_weights(
-        w31_weight, w2_weight, w31_scales, w2_scales
+        w31_weight, w2_weight, w31_scales, w2_scales, W_GEN_SCALE
     )
 
     routing_weights, selected_experts = compute_routing(router_logits, top_k)


### PR DESCRIPTION
Scale down the weights in the MoE test so that the output has reasonable magnitude, allowing for tighter atol and rtol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for MoE (Mixture of Experts) operations with improved parameter control and stricter validation thresholds across standard and FP8 fusion test paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
