### PR TITLE
[https://nvbugs/5644632][fix] Use correct memory pool

### DIFF
--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -26,6 +26,7 @@ from .remove_copy_pass import remove_copy_for_mutates_args
 
 class Backend:
 
+    _custom_pass_instances: List[PatternMatcherPass] = None
     _graph_pool_handle: tuple[int, int] = None
 
     # Following classes are used to let weakref ref the stream and eventlist objects.
@@ -62,7 +63,8 @@ class Backend:
         inductor_config.enable_auto_functionalized_v2 = False
 
         if Backend._graph_pool_handle is None:
-            Backend._graph_pool_handle = torch.cuda.graph_pool_handle()
+            Backend._graph_pool = torch.cuda.MemPool()
+            Backend._graph_pool_handle = Backend._graph_pool.id
 
         self.match_count = []
         self.match_count_by_pass = OrderedDict()

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -79,40 +79,55 @@ class Buffers:
                 best_fit_block = block
                 smallest_sufficient_size = block.buffer.numel()
 
-        if best_fit_block is not None:
-            if reserve_buffer:
-                best_fit_block.is_reserved = True
-            # A suitable buffer was found, so reuse it.
-            return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
-
         for block in list(candidate_blocks):
             if not block.is_reserved:
-                # Need to call del BufferBlock.buffer, otherwise memory isn't
-                # released and OOM may happen.
-                buffer_size = block.buffer.numel()
-                del block.buffer
-                if buffer_size >= 1024 * 1024 * 1024:
-                    torch.cuda.empty_cache()
-                candidate_blocks.remove(block)
+                if best_fit_block is not None:
+                    if block is not best_fit_block:
+                        # Need to call del BufferBlock.buffer, otherwise memory isn't
+                        # released and OOM may happen.
+                        del block.buffer
+                        candidate_blocks.remove(block)
+                else:
+                    del block.buffer
+                    candidate_blocks.remove(block)
+
+        if best_fit_block is not None:
+            if reserve_buffer:
+                # A suitable buffer was found, so reuse it.
+                best_fit_block.is_reserved = True
+                return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
+            else:
+                # TODO: to reuse tensors both in graph pool and normal pool.
+                if best_fit_block.is_reserved:
+                    return self._view_as(best_fit_block.buffer, tensor_shape,
+                                         dtype)
+                else:
+                    del best_fit_block.buffer
+                    candidate_blocks.remove(best_fit_block)
+
+        def _create_buffer():
+            return torch.zeros((required_memory_size, ),
+                               device='cuda',
+                               dtype=torch.uint8)
 
         # No suitable buffer was found, so allocate a new one.
         # The new buffer is created with uint8 to represent raw bytes.
         new_buffer_tensor = None
         try:
-            with torch.cuda.memory.use_mem_pool(get_shared_pool()):
-                new_buffer_tensor = torch.empty((required_memory_size, ),
-                                                device='cuda',
-                                                dtype=torch.uint8)
+            new_buffer_tensor = _create_buffer()
         except Exception as ex:
-            # Need to check if this is an OOM exception
+            # Need to check if this is an OOM exception``
             logger.debug(
                 f"Exception happened to create tensor from given memory pool: {str(ex)}"
             )
-            # if exception happens during allocating memory from shared pool, retry
-            # to allocate from default pool
-            new_buffer_tensor = torch.empty((required_memory_size, ),
-                                            device='cuda',
-                                            dtype=torch.uint8)
+            # if exception happens during allocating memory from default pool, retry
+            # to allocate from shared pool. Try best to avoid fragmentation in shared pool.
+            mem_pool = get_shared_pool()
+            if mem_pool is not None:
+                with torch.cuda.memory.use_mem_pool(mem_pool):
+                    new_buffer_tensor = _create_buffer()
+            else:
+                raise ex
 
         new_block = BufferBlock(buffer=new_buffer_tensor,
                                 is_reserved=reserve_buffer)

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -123,7 +123,7 @@ class Buffers:
             # if exception happens during allocating memory from default pool, retry
             # to allocate from shared pool. Try best to avoid fragmentation in shared pool.
             mem_pool = get_shared_pool()
-            if mem_pool is not None:
+            if mem_pool is not None and not reserve_buffer:
                 with torch.cuda.memory.use_mem_pool(mem_pool):
                     new_buffer_tensor = _create_buffer()
             else:

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -79,6 +79,20 @@ class Buffers:
                 best_fit_block = block
                 smallest_sufficient_size = block.buffer.numel()
 
+        if best_fit_block is not None:
+            if reserve_buffer:
+                # A suitable buffer was found, so reuse it.
+                best_fit_block.is_reserved = True
+                return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
+            # else:
+            # TODO: to reuse tensors both in graph pool and normal pool.
+            # if best_fit_block.is_reserved:
+            #     return self._view_as(best_fit_block.buffer, tensor_shape,
+            #                          dtype)
+            # else:
+            # del best_fit_block.buffer
+            # candidate_blocks.remove(best_fit_block)
+
         for block in list(candidate_blocks):
             if not block.is_reserved:
                 if best_fit_block is not None:
@@ -91,22 +105,8 @@ class Buffers:
                     del block.buffer
                     candidate_blocks.remove(block)
 
-        if best_fit_block is not None:
-            if reserve_buffer:
-                # A suitable buffer was found, so reuse it.
-                best_fit_block.is_reserved = True
-                return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
-            else:
-                # TODO: to reuse tensors both in graph pool and normal pool.
-                if best_fit_block.is_reserved:
-                    return self._view_as(best_fit_block.buffer, tensor_shape,
-                                         dtype)
-                else:
-                    del best_fit_block.buffer
-                    candidate_blocks.remove(best_fit_block)
-
         def _create_buffer():
-            return torch.zeros((required_memory_size, ),
+            return torch.empty((required_memory_size, ),
                                device='cuda',
                                dtype=torch.uint8)
 

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -84,26 +84,6 @@ class Buffers:
                 # A suitable buffer was found, so reuse it.
                 best_fit_block.is_reserved = True
             return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
-            # else:
-            # TODO: to reuse tensors both in graph pool and normal pool.
-            # if best_fit_block.is_reserved:
-            #     return self._view_as(best_fit_block.buffer, tensor_shape,
-            #                          dtype)
-            # else:
-            # del best_fit_block.buffer
-            # candidate_blocks.remove(best_fit_block)
-
-        # for block in list(candidate_blocks):
-        #     if not block.is_reserved:
-        #         if best_fit_block is not None:
-        #             if block is not best_fit_block:
-        #                 # Need to call del BufferBlock.buffer, otherwise memory isn't
-        #                 # released and OOM may happen.
-        #                 del block.buffer
-        #                 candidate_blocks.remove(block)
-        #         else:
-        #             del block.buffer
-        #             candidate_blocks.remove(block)
 
         for block in list(candidate_blocks):
             if not block.is_reserved:

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -71,7 +71,7 @@ class CUDAGraphRunnerConfig:
     max_beam_width: int
     max_num_tokens: int
     spec_config: Optional[DecodingBaseConfig]
-    cuda_graph_mem_pool: Any
+    cuda_graph_mem_pool: torch.cuda.MemPool
     use_mrope: bool
     original_max_draft_len: int
     original_max_total_draft_tokens: int
@@ -111,7 +111,9 @@ class CUDAGraphRunner:
         self.graph_outputs: Dict[KeyType,
                                  Callable[[], Optional[torch.Tensor]]] = {}
         self.graph_metadata: Dict[KeyType, Dict[str, Any]] = {}
-        self.memory_pool = config.cuda_graph_mem_pool
+        self.memory_pool = config.cuda_graph_mem_pool if config.cuda_graph_mem_pool else torch.cuda.MemPool(
+        )
+        self.memory_pool_handle = self.memory_pool.id
         self.padding_dummy_requests: Dict[int, "Request"] = {}
         self.dynamic_draft_len_mapping = config.dynamic_draft_len_mapping
 
@@ -373,6 +375,10 @@ class CUDAGraphRunner:
                 capture_inputs['attn_metadata'].use_spec_decoding = True
             return forward_fn(capture_inputs)
 
+        if self.memory_pool_handle is None or self.memory_pool is None:
+            self.memory_pool = torch.cuda.MemPool()
+            self.memory_pool_handle = self.memory_pool.id
+
         # We have to do warm up runs to initialize PyTorch's
         # internal states according to the docs:
         # https://pytorch.org/docs/stable/notes/cuda.html#cuda-graph-semantics
@@ -385,7 +391,7 @@ class CUDAGraphRunner:
                 if postprocess_fn is not None:
                     postprocess_fn(capture_inputs)
 
-            with torch.cuda.graph(graph, pool=self.memory_pool):
+            with torch.cuda.graph(graph, pool=self.memory_pool_handle):
                 output = _setup_spec_decoding_and_forward(
                     key, forward_fn, capture_inputs)
             if postprocess_fn is not None:
@@ -393,7 +399,6 @@ class CUDAGraphRunner:
 
         self.graphs[key] = graph
         self.graph_outputs[key] = make_weak_ref(output)
-        self.memory_pool = graph.pool()
 
     def replay(self, key: KeyType,
                current_inputs: Dict[str, Any]) -> Optional[torch.Tensor]:
@@ -563,6 +568,8 @@ class CUDAGraphRunner:
         self.graph_outputs.clear()
         self.graph_metadata.clear()
         self.padding_dummy_requests = {}
+        del self.memory_pool_handle
+        self.memory_pool_handle = None
         del self.memory_pool
         self.memory_pool = None
         torch.cuda.empty_cache()

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -572,7 +572,7 @@ class CUDAGraphRunner:
         self.memory_pool_handle = None
         del self.memory_pool
         self.memory_pool = None
-        torch.cuda.empty_cache()
+        # torch.cuda.empty_cache()
 
 
 EncoderKeyType: TypeAlias = Tuple[int, int, int]

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -542,7 +542,6 @@ class PyTorchModelEngine(ModelEngine):
         self.attn_metadata = None
         self.encoder_attn_metadata = None
         self.iter_states = {}
-
         self._cuda_graph_mem_pool = self._torch_compile_backend._graph_pool if self._torch_compile_enabled else None
         self._cuda_graph_mem_pool_handle = self._cuda_graph_mem_pool.id if self._cuda_graph_mem_pool else None
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -542,7 +542,9 @@ class PyTorchModelEngine(ModelEngine):
         self.attn_metadata = None
         self.encoder_attn_metadata = None
         self.iter_states = {}
-        self._cuda_graph_mem_pool = self._torch_compile_backend._graph_pool_handle if self._torch_compile_enabled else None
+
+        self._cuda_graph_mem_pool = self._torch_compile_backend._graph_pool if self._torch_compile_enabled else None
+        self._cuda_graph_mem_pool_handle = self._cuda_graph_mem_pool.id if self._cuda_graph_mem_pool else None
 
         self._cuda_graph_padding_enabled = cuda_graph_padding_enabled
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CUDA memory pool management and buffer reservation logic for more efficient resource allocation.

* **Tests**
  * Extended test coverage by removing previously skipped test configurations, improving validation of model compilation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
