### PR TITLE
[TRTLLM-8946][feat] Improved heuristics to detect shardable regions

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from transformers import AutoConfig, AutoModelForCausalLM
 
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _bamba_mixer_torch_forward
 
 
@@ -186,6 +187,19 @@ def get_model_from_config_patched(config, **kwargs):
 
     return model
 
+
+def _set_sharding_config_patched(self, *args, **kwargs):
+    self._sharding_config["head_dim"] = 128
+    self._sharding_config["tp_plan"] = {
+        "in_proj": "mamba",
+        "out_proj": "rowwise",
+        "up_proj": "colwise",
+        "down_proj": "rowwise",
+        "*": "gather",
+    }
+
+
+AutoModelForCausalLMFactory._set_sharding_config = _set_sharding_config_patched
 
 # TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -187,19 +187,6 @@ def get_model_from_config_patched(config, **kwargs):
     return model
 
 
-def _set_sharding_config_patched(self, *args, **kwargs):
-    self._sharding_config["head_dim"] = 128
-    self._sharding_config["tp_plan"] = {
-        "in_proj": "mamba",
-        "out_proj": "rowwise",
-        "up_proj": "colwise",
-        "down_proj": "rowwise",
-        "*": "gather",
-    }
-
-
-# AutoModelForCausalLMFactory._set_sharding_config = _set_sharding_config_patched
-
 # TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched
 

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 import torch
 import torch.nn.functional as F
 from einops import rearrange
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM
 
 from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _bamba_mixer_torch_forward
 
@@ -190,41 +190,41 @@ def get_model_from_config_patched(config, **kwargs):
 # TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched
 
-_config_from_pretrained_original = AutoConfig.from_pretrained
-_nemotron_h_base_model_tp_plan = {
-    # mamba SSM layer
-    "in_proj": "mamba",
-    "out_proj": "rowwise",
-    # attention layer
-    "q_proj": "colwise",
-    "k_proj": "colwise",
-    "v_proj": "colwise",
-    "o_proj": "rowwise",
-    # NOTE: consider not sharding shared experts and/or
-    # latent projections at all, keeping them replicated.
-    # To do so, comment out the corresponding entries.
-    # moe layer: SHARED experts
-    "up_proj": "colwise",
-    "down_proj": "rowwise",
-    # MoLE: latent projections: simple shard
-    "fc1_latent_proj": "gather",
-    "fc2_latent_proj": "gather",
-}
+# _config_from_pretrained_original = AutoConfig.from_pretrained
+# _nemotron_h_base_model_tp_plan = {
+#     # mamba SSM layer
+#     "in_proj": "mamba",
+#     "out_proj": "rowwise",
+#     # attention layer
+#     "q_proj": "colwise",
+#     "k_proj": "colwise",
+#     "v_proj": "colwise",
+#     "o_proj": "rowwise",
+#     # NOTE: consider not sharding shared experts and/or
+#     # latent projections at all, keeping them replicated.
+#     # To do so, comment out the corresponding entries.
+#     # moe layer: SHARED experts
+#     "up_proj": "colwise",
+#     "down_proj": "rowwise",
+#     # MoLE: latent projections: simple shard
+#     "fc1_latent_proj": "gather",
+#     "fc2_latent_proj": "gather",
+# }
 
 
-def get_config_from_pretrained_patched(*args, **kwargs):
-    ret = _config_from_pretrained_original(*args, **kwargs)
-    config = ret[0] if isinstance(ret, tuple) else ret
-    # heuristic to check if it's a NemotronH MoE Model
-    model_type = getattr(config, "model_type", None)
-    num_moe_layers = getattr(config, "layers_block_type", []).count("moe")
-    if model_type == "nemotron_h" and num_moe_layers > 0:
-        config.base_model_tp_plan = _nemotron_h_base_model_tp_plan
-    return (config, *ret[1:]) if isinstance(ret, tuple) else config
+# def get_config_from_pretrained_patched(*args, **kwargs):
+#     ret = _config_from_pretrained_original(*args, **kwargs)
+#     config = ret[0] if isinstance(ret, tuple) else ret
+#     # heuristic to check if it's a NemotronH MoE Model
+#     model_type = getattr(config, "model_type", None)
+#     num_moe_layers = getattr(config, "layers_block_type", []).count("moe")
+#     if model_type == "nemotron_h" and num_moe_layers > 0:
+#         config.base_model_tp_plan = _nemotron_h_base_model_tp_plan
+#     return (config, *ret[1:]) if isinstance(ret, tuple) else config
 
 
-# TODO: figure out how this can be incorporated into the export patch system
-AutoConfig.from_pretrained = get_config_from_pretrained_patched
+# # TODO: figure out how this can be incorporated into the export patch system
+# AutoConfig.from_pretrained = get_config_from_pretrained_patched
 
 # TODO: figure out how this can be incorporated into the export patch system
 # Only patch if the module isn't available

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from einops import rearrange
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _bamba_mixer_torch_forward
 
 
@@ -199,7 +198,7 @@ def _set_sharding_config_patched(self, *args, **kwargs):
     }
 
 
-AutoModelForCausalLMFactory._set_sharding_config = _set_sharding_config_patched
+# AutoModelForCausalLMFactory._set_sharding_config = _set_sharding_config_patched
 
 # TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -469,7 +469,7 @@ class MatchMoePattern(BaseTransform):
             common_ancessor2 = _find_lowest_common_ancessor(arg2_list)
             if not common_ancessor2:
                 continue
-            selected_experts, _ = bfs(
+            selected_experts = bfs(
                 common_ancessor2,
                 lambda node: is_op(node, torch.ops.aten.one_hot),
                 attr_next="all_input_nodes",

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -469,7 +469,7 @@ class MatchMoePattern(BaseTransform):
             common_ancessor2 = _find_lowest_common_ancessor(arg2_list)
             if not common_ancessor2:
                 continue
-            selected_experts = bfs(
+            selected_experts, _ = bfs(
                 common_ancessor2,
                 lambda node: is_op(node, torch.ops.aten.one_hot),
                 attr_next="all_input_nodes",

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -796,7 +796,7 @@ def detect_ssm_shard(
     )
 
 
-def detect_column_row_shard_new(
+def detect_column_row_shard(
     gm: GraphModule,
     sharding_config: ShardingTransformContainer,
 ) -> TransformInfo:
@@ -817,11 +817,7 @@ def detect_column_row_shard_new(
     splitting, e.g., the individual heads into smaller shards.
     """
     ad_logger.debug("Before sharding graph: " + str(gm))
-
     rank, world_size = sharding_config.rank, sharding_config.world_size
-    if world_size < 2:
-        ad_logger.info("Skipping TP sharding for single device")
-        return TransformInfo(skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True)
 
     assert isinstance(gm, GraphModule), "Expecting GraphModule"
     ad_logger.info("Running TP sharding detection")

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -824,8 +824,11 @@ def detect_column_row_shard_new(
         return TransformInfo(skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True)
 
     assert isinstance(gm, GraphModule), "Expecting GraphModule"
-
     ad_logger.info("Running TP sharding detection")
+    linear_nodes = list(filtered_nodes(gm.graph.nodes, is_any_lin_op))
+    if len(linear_nodes) == 0:
+        ad_logger.warning("Could not find any linear nodes in the graph. Skipping TP sharding.")
+        return TransformInfo(skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True)
 
     layer_subgraphs, unprocessed_linear_nodes = get_all_layer_subgraphs(gm)
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -671,7 +671,7 @@ def detect_sharding_from_config(
                             world_size=world_size,
                             dist_op=None,
                             min_local_shape=min_local_shape,
-                            layer_type=LayerType.MAMBA,
+                            layer_type=LayerType.MAMBA_FULL,
                         )
                     )
                     num_row_col_shards += 1

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -660,9 +660,15 @@ def get_layer_after_linear_node(
     def boundary_condition(node: Node) -> bool:
         return is_any_lin_op(node)  # or is_op(node, ops=[torch.ops.aten.arange, torch.ops.aten.to])
 
-    # last linear node (output embedding) cannot be a part of any layer
-    def filter_condition(node: Node) -> bool:
-        return is_any_lin_op(node) and node != linear_nodes[-1]
+    # If the last linear node is the output embedding, it cannot be a part of any layer
+    if "lm_head" in extract_weight_node(linear_nodes[-1]).name:
+
+        def filter_condition(node: Node) -> bool:
+            return is_any_lin_op(node) and node != linear_nodes[-1]
+    else:
+
+        def filter_condition(node: Node) -> bool:
+            return is_any_lin_op(node)
 
     lin_nodes_in_subgraph = []
     start_lin_index = terminating_indices[-1] + 1

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -276,6 +276,37 @@ def is_any_lin_op(node: Node) -> bool:
     return is_linear_op(node) or is_fake_quantized_linear_op(node)
 
 
+def is_any_moe_op(node: Node) -> bool:
+    return is_op(
+        node,
+        ops=[
+            torch.ops.auto_deploy.torch_moe,
+            torch.ops.auto_deploy.torch_quant_fp8_moe,
+            torch.ops.auto_deploy.torch_quant_nvfp4_moe,
+            torch.ops.auto_deploy.triton_mxfp4_moe,
+        ],
+    )
+
+
+def is_any_ssm_op(node: Node) -> bool:
+    return is_op(
+        node,
+        ops=[
+            torch.ops.auto_deploy.torch_ssm,
+        ],
+    )
+
+
+def is_any_attention_op(node: Node) -> bool:
+    return is_op(
+        node,
+        ops=[
+            torch.ops.auto_deploy.torch_attention_sdpa,
+            torch.ops.auto_deploy.torch_attention,
+        ],
+    )
+
+
 def is_linear_op(node: Node) -> bool:
     """Check if the node is a linear op.
 
@@ -393,7 +424,32 @@ def identify_regions_between_residuals(gm: GraphModule) -> List[Node]:
 
 
 def get_all_layer_subgraphs(gm: GraphModule) -> List[List[Node]]:
-    """Get subgraphs corresponding to all consecutive layers (attention, MLP, SSM, MoE) in the graph."""
+    """
+    Get subgraphs corresponding to all consecutive layers (attention, MLP, SSM, MoE) in the graph.
+
+    Assumptions:
+        1. each layer (each subgraph) is contained between a list of opening
+        linear layers (e.g., q/k/v_proj, gate/up_proj, in_proj, etc.) and a single closing linear layer
+        (e.g., out_proj, down_proj, etc.)
+        2. all layers are connected in sequence, there are no "parallel" layers.
+
+    Consequence:
+        1. We can linearize both all linear nodes in the graph and the layers itself, having a single
+        linear history and define layers by the indices of corresponding opening and closing linear nodes,
+        with no overlap between layers.
+        E.g., if layer i is defined between linear nodes start_i and end_i, then all linear nodes between
+        start_i and end_i necessarily belong to layer i.
+        2. It does not mean that every linear node in the graph belongs to a layer, that is. Then, if:
+            end_i < start_{{i+1}}, then all linear nodes in[end_i + 1, start_{{i+1}} - 1] do not belong
+            to any layer, and are marked as "unprocessed".
+    Note:
+        The interesting case is MoE with shared experts. In this case, there are two parallel paths:
+        1. Routed experts
+        2. Shared experts
+        In this case, "shared experts" path will be marked as an MLP layer, and "routed experts" path will
+        be "unprocessed". This is desired, since routed experts should not be sharded by the TP transform,
+        but a corresponding EP/BMM transforms.
+    """
 
     assert gm.graph.nodes, "Graph is empty"
     layer_subgraphs = []
@@ -406,6 +462,9 @@ def get_all_layer_subgraphs(gm: GraphModule) -> List[List[Node]]:
 
     # for each linear node, find its layer subgraph defined as regions between consecutive linear nodes
     while last_lin_index < len(linear_nodes):
+        # opening is the list of linear nodes
+        # layer_subgraph is the list of nodes between the opening and closing linear nodes
+        # closing is the last linear node in the layer
         opening, layer_subgraph, closing = get_layer_after_linear_node(
             linear_nodes, terminating_indices
         )
@@ -655,20 +714,26 @@ def subgraph(
 def get_layer_after_linear_node(
     linear_nodes: List[Node], terminating_indices: List[int]
 ) -> List[Node]:
-    """Get the layer after a linear node."""
+    """
+    Get the next model layer.
+    The previous layer was closed by the terminating linear node with index terminating_indices[-1].
+
+    Since we assume a layer is always terminated by a single linear node, we iteratively query subgraph
+    and check for the condition len(lin_nodes_in_subgraph) == 1. If a given linear node
+    linear_nodes[start_lin_index] does not have a corresponding single sink linear node, it will
+    be classified as "unprocessed", and the next linear node is picked as a candidate to open
+    a new layer.
+    """
 
     def boundary_condition(node: Node) -> bool:
-        return is_any_lin_op(node)  # or is_op(node, ops=[torch.ops.aten.arange, torch.ops.aten.to])
+        return (
+            is_any_lin_op(node)
+            or is_any_moe_op(node)
+            or is_op(node, ops=[torch.ops.aten.sym_size, torch.ops.aten.bmm])
+        )
 
-    # If the last linear node is the output embedding, it cannot be a part of any layer
-    if "lm_head" in extract_weight_node(linear_nodes[-1]).name:
-
-        def filter_condition(node: Node) -> bool:
-            return is_any_lin_op(node) and node != linear_nodes[-1]
-    else:
-
-        def filter_condition(node: Node) -> bool:
-            return is_any_lin_op(node)
+    def filter_condition(node: Node) -> bool:
+        return is_any_lin_op(node)
 
     lin_nodes_in_subgraph = []
     start_lin_index = terminating_indices[-1] + 1

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -648,6 +648,7 @@ class ShardingTransformInfo(BaseModel, ABC):
 class LayerType(Enum):
     ATTENTION = "attention"
     MAMBA = "mamba"
+    MAMBA_FULL = "mamba_full"
     MLP = "mlp"
     MOE = "moe"
 
@@ -709,7 +710,7 @@ class WeightShardingInfo(ShardingTransformInfo):
 
     def apply(self, gm: GraphModule, node: Node) -> None:
         """Apply TP sharding transformation to the graph module."""
-        if self.layer_type == LayerType.MAMBA:
+        if self.layer_type == LayerType.MAMBA_FULL:
             _insert_sharded_mamba(
                 gm=gm,
                 entry_node=node,

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -32,6 +32,8 @@ from .quantization_utils import (
     modelopt_fp4_scale_to_cutlass_fp4_scale,
 )
 
+INSERT_ALL_REDUCE = False
+
 
 def validate_allreduce_strategy(v):
     """Convert string names like 'AUTO' to AllReduceStrategy enum.
@@ -187,8 +189,9 @@ def _validate_sharded_shapes(
         split_nodes = subgraph(
             [node],
             [next_lin_node],
-            include=lambda n: is_op(n, [torch.ops.aten.split, torch.ops.aten.split_with_sizes]),
+            include=lambda n: is_op(n, [torch.ops.aten.split_with_sizes]),
         )
+        world_size = min(world_size, 4)
         for split_node in split_nodes:
             orig_sizes = split_node.args[1]
             new_sizes = [orig_sizes[i] // world_size for i in range(len(orig_sizes))]
@@ -230,6 +233,9 @@ def shard_weight_tensor(
         Tuple of (sharded_tensor, sharded_shape)
     """
 
+    def ceil(x: int, y: int) -> int:
+        return (x + y - 1) // y
+
     def split_tensor(
         t: torch.Tensor,
         d: int = dim,
@@ -246,7 +252,7 @@ def shard_weight_tensor(
                 + f"Splitting tensor to {num_groups} chunks"
             )
             return torch.tensor_split(t, max_split_size, dim=d)[r // num_groups]
-        return torch.tensor_split(t, ws, dim=d)[r]
+        return torch.tensor_split(t, min(ws, 4), dim=d)[r // ceil(ws, 4)]
 
     # Handle fused weights
     if fused_weight_dims is not None:

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -764,6 +764,7 @@ class WeightShardingInfo(ShardingTransformInfo):
             rank=self.rank,
             world_size=self.world_size,
             add_dist=self.dist_op is not None,
+            dist_backend=self.dist_backend,
             min_local_shape=self.min_local_shape,
             fused_weight_dims=self.fused_weight_dims,
             quantization_cb=self.quantization_cb,

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -820,6 +820,9 @@ class QuantizationShardingMixin(ABC):
                 self.shard_load_hook,
                 weight_name=weight_key,
                 weight_shape=weight_new_shape,
+                dim=dim,
+                rank=rank,
+                world_size=world_size,
             )
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -820,9 +820,6 @@ class QuantizationShardingMixin(ABC):
                 self.shard_load_hook,
                 weight_name=weight_key,
                 weight_shape=weight_new_shape,
-                dim=dim,
-                rank=rank,
-                world_size=world_size,
             )
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -1329,7 +1329,6 @@ class ShardingSource(Enum):
 class ShardingDim(Enum):
     """Enum for sharding dimension."""
 
-    SSM = "ssm"
     TP = "tp"
     EP = "ep"
     BMM = "bmm"
@@ -1357,7 +1356,7 @@ class ShardingTransformContainer(BaseModel):
         default_factory=lambda: [ShardingSource.HEURISTIC]
     )
     sharding_dims: List[ShardingDim] = Field(
-        default_factory=lambda: [ShardingDim.SSM, ShardingDim.TP, ShardingDim.EP, ShardingDim.BMM]
+        default_factory=lambda: [ShardingDim.TP, ShardingDim.EP, ShardingDim.BMM]
     )
     allreduce_strategy: AllReduceStrategy = Field(
         default=AllReduceStrategy.AUTO,

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -580,10 +580,10 @@ def _shard_parameter_node(
 
     # # # column shard with no gather: the output is sharded
     if not add_dist:
-        if is_any_lin_op(node):
-            _validate_sharded_shapes(
-                node, fused_weight_dims=fused_weight_dims, world_size=world_size
-            )
+        # if is_any_lin_op(node):
+        #     _validate_sharded_shapes(
+        #         node, fused_weight_dims=fused_weight_dims, world_size=world_size
+        #     )
         return
 
     # figure out the right dist op (backend-aware)

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -767,6 +767,7 @@ class WeightShardingInfo(ShardingTransformInfo):
             min_local_shape=self.min_local_shape,
             fused_weight_dims=self.fused_weight_dims,
             quantization_cb=self.quantization_cb,
+            allreduce_strategy=self.allreduce_strategy,
         )
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -19,7 +19,7 @@ from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
 )
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_linear_op, is_op
-from tensorrt_llm._torch.auto_deploy.utils.sharding_utils import FP8TPShardingInfo
+from tensorrt_llm._torch.auto_deploy.utils.sharding_utils import FP8TPShardingInfo, LayerType
 from tensorrt_llm.functional import AllReduceStrategy
 
 base_model_tp_plan = {
@@ -123,7 +123,7 @@ class FP8MLP(nn.Module):
         return self.linear2(y)
 
 
-def _run_job(
+def _run_sharding_execution_job(
     model_cls: nn.Module,
     dist_op_expected: str,
     bias: bool,
@@ -212,7 +212,6 @@ def _run_job(
         has_expected_dist_ops = any(is_op(n, op_expected) for n in gm.graph.nodes) == (
             world_size > 1
         )
-        # Check weight size constraints
         weight_sizes_valid = verify_local_weight_sizes(gm)
         return has_expected_dist_ops and weight_sizes_valid
 
@@ -282,6 +281,7 @@ def _run_pattern_detection_job(
                             min_local_shape=min_local_shape,
                             allreduce_strategy=AllReduceStrategy.AUTO,
                             dist_backend="auto",
+                            layer_type=LayerType.ATTENTION,
                         )
                     )
         elif model_cls == MLP:
@@ -390,7 +390,7 @@ def test_sharding(
     from_config: bool,
 ):
     dist_common.spawn_multiprocess_job(
-        job=partial(_run_job, model_cls, dist_op_expected, bias, from_config),
+        job=partial(_run_sharding_execution_job, model_cls, dist_op_expected, bias, from_config),
         size=device_count,
     )
 
@@ -420,7 +420,3 @@ def test_sharding_pattern_detection(
     No need to run distributed job, can be run on single process.
     """
     _run_pattern_detection_job(model_cls, bias, 0, world_size, from_config)
-
-
-if __name__ == "__main__":
-    _run_pattern_detection_job(nn.Linear, False, 0, 8, False)


### PR DESCRIPTION
The new logic in detect_column_row_shard extracts individual layers (attention/MoE/MLP/SSM) not based on residual connections, but on consecutive pairs of opening/closing linear layers. Each extracted subgraph is defined by a set of opening layers (e.g,. q, k, v for attention, gate and up for MLP, etc) and a single closing linear layer (e.g., o_proj or down_proj).

For each of the subgraphs, the validity of column-row sharding is checked, and then applied either the megatron-style column-row TP sharding, or simple sharding if conditions are not met.

fixes #8946 
fixes #8947 
fixes #8949 
fixes #4320


@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
