### PR TITLE
[None][doc] Update DS-R1 example doc

### DIFF
--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -311,7 +311,6 @@ trtllm-serve \
   --tp_size 8 \
   --ep_size 8 \
   --pp_size 1 \
-  --kv_cache_free_gpu_memory_fraction 0.9 \
   --extra_llm_api_options ./extra-llm-api-config.yml
 ```
 It's possible seeing OOM issues on some configs. Considering reducing `kv_cache_free_gpu_mem_fraction` to a smaller value as a workaround. We're working on the investigation and addressing the problem. If you are using max-throughput config, reduce `max_num_tokens` to `3072` to avoid OOM issues.

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -256,7 +256,26 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
   enable_padding: true
-  max_batch_size: 2048
+  batch_sizes:
+  - 2048
+  - 1024
+  - 896
+  - 512
+  - 384
+  - 256
+  - 192
+  - 160
+  - 128
+  - 96
+  - 64
+  - 48
+  - 32
+  - 24
+  - 16
+  - 8
+  - 4
+  - 2
+  - 1
 kv_cache_config:
   enable_block_reuse: false
   dtype: fp8

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -262,6 +262,10 @@ kv_cache_config:
   dtype: fp8
 stream_interval: 10
 enable_attention_dp: true
+attention_dp_config:
+  batching_wait_iters: 0
+  enable_balance: true
+  timeout_iters: 60
 EOF
 ```
 
@@ -290,6 +294,10 @@ cuda_graph_config:
     enable_padding: true
     max_batch_size: 512
 enable_attention_dp: true
+attention_dp_config:
+  batching_wait_iters: 0
+  enable_balance: true
+  timeout_iters: 60
 kv_cache_config:
     enable_block_reuse: false
     dtype: fp8

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -242,10 +242,10 @@ To serve the model using `trtllm-serve`:
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
-    enable_block_reuse: false
     max_batch_size: 1024
 enable_attention_dp: false
 kv_cache_config:
+    enable_block_reuse: false
     dtype: fp8
 stream_interval: 10
 EOF
@@ -256,9 +256,9 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
   enable_padding: true
-  enable_block_reuse: false
   max_batch_size: 2048
 kv_cache_config:
+  enable_block_reuse: false
   dtype: fp8
 stream_interval: 10
 enable_attention_dp: true
@@ -270,10 +270,10 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
-    enable_block_reuse: false
     max_batch_size: 1024
 enable_attention_dp: false
 kv_cache_config:
+    enable_block_reuse: false
     dtype: fp8
     free_gpu_memory_fraction: 0.8
 stream_interval: 10
@@ -288,10 +288,10 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
-    enable_block_reuse: false
     max_batch_size: 512
 enable_attention_dp: true
 kv_cache_config:
+    enable_block_reuse: false
     dtype: fp8
     free_gpu_memory_fraction: 0.8
 stream_interval: 10

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -242,6 +242,7 @@ To serve the model using `trtllm-serve`:
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
+    enable_block_reuse: false
     max_batch_size: 1024
 enable_attention_dp: false
 kv_cache_config:
@@ -255,19 +256,8 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
   enable_padding: true
-  batch_sizes:
-  - 1024
-  - 896
-  - 512
-  - 256
-  - 128
-  - 64
-  - 32
-  - 16
-  - 8
-  - 4
-  - 2
-  - 1
+  enable_block_reuse: false
+  max_batch_size: 2048
 kv_cache_config:
   dtype: fp8
 stream_interval: 10
@@ -280,6 +270,7 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
+    enable_block_reuse: false
     max_batch_size: 1024
 enable_attention_dp: false
 kv_cache_config:
@@ -297,6 +288,7 @@ EOF
 cat >./extra-llm-api-config.yml <<EOF
 cuda_graph_config:
     enable_padding: true
+    enable_block_reuse: false
     max_batch_size: 512
 enable_attention_dp: true
 kv_cache_config:
@@ -314,7 +306,7 @@ trtllm-serve \
   --host localhost \
   --port 8000 \
   --backend pytorch \
-  --max_batch_size 1024 \
+  --max_batch_size 2048 \
   --max_num_tokens 8192 \
   --tp_size 8 \
   --ep_size 8 \


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated DeepSeek v3 model configuration examples and documentation with revised deployment settings.

* **Chores**
  * Adjusted CUDA graph configuration parameters and increased batch size limits in the OpenAI-compatible API server examples for optimized performance configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:


Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Update DS-R1 example guide to disable the KV reuse and reset cuda graph size

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
