### PR TITLE
[None][feat] Update the indexer topK

### DIFF
--- a/cpp/tensorrt_llm/kernels/IndexerTopK.h
+++ b/cpp/tensorrt_llm/kernels/IndexerTopK.h
@@ -24,12 +24,12 @@
 
 namespace tensorrt_llm::kernels
 {
-void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* outIndices, float* auxLogits,
-    int* auxIndices, int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0,
-    int const stride1, int const next_n, int const index_topk = 2048, cudaStream_t const stream = 0);
+void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indices, float* outLogitsAux,
+    int* outIndicesAux, int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0,
+    int const stride1, int const next_n, int const topK = 2048, cudaStream_t const stream = 0);
 
-void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int const* rowEnds, int* outIndices,
-    int const numRows, int const numColumns, int const stride0, int const stride1, int const index_topk = 2048,
+void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int const* rowEnds, int* indices,
+    int const numRows, int const numColumns, int const stride0, int const stride1, int const topK = 2048,
     cudaStream_t const stream = 0);
 
 } // namespace tensorrt_llm::kernels

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1059,13 +1059,6 @@ class Indexer(nn.Module):
         weights: torch.Tensor,
         use_custom_topk: bool = True,
     ) -> torch.Tensor:
-        use_custom_topk = use_custom_topk and self.index_topk == 2048
-        if self.index_topk != 2048:
-            logger.warning_once(
-                f"Using custom topk indexer with index_topk={self.index_topk} is not supported. "
-                f"Please use index_topk=2048 instead.",
-                key="indexer_topk_not_2048_warning")
-
         num_contexts = metadata.num_contexts
         num_generations = metadata.num_generations
         num_ctx_tokens = metadata.num_ctx_tokens

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1059,7 +1059,13 @@ class Indexer(nn.Module):
         weights: torch.Tensor,
         use_custom_topk: bool = True,
     ) -> torch.Tensor:
-        use_custom_topk = use_custom_topk and self.index_topk == 2048  #@TODO: Do we need to add a warning?
+        use_custom_topk = use_custom_topk and self.index_topk == 2048
+        if self.index_topk != 2048:
+            logger.warning_once(
+                f"Using custom topk indexer with index_topk={self.index_topk} is not supported. "
+                f"Please use index_topk=2048 instead.",
+                key="indexer_topk_not_2048_warning")
+
         num_contexts = metadata.num_contexts
         num_generations = metadata.num_generations
         num_ctx_tokens = metadata.num_ctx_tokens
@@ -1091,7 +1097,7 @@ class Indexer(nn.Module):
                         chunk.cu_seqlen_ke,
                     )
                     if use_custom_topk:
-                        torch.ops.trtllm.indexer_topk_prefill_op(
+                        torch.ops.trtllm.indexer_topk_prefill(
                             logits, chunk.cu_seqlen_ks, chunk.cu_seqlen_ke,
                             topk_indices_buffer[
                                 chunk.token_start:chunk.token_end, :])
@@ -1127,7 +1133,7 @@ class Indexer(nn.Module):
                     cu_seqlen_ke,
                 )
                 if use_custom_topk:
-                    torch.ops.trtllm.indexer_topk_prefill_op(
+                    torch.ops.trtllm.indexer_topk_prefill(
                         logits, cu_seqlen_ks, cu_seqlen_ke,
                         topk_indices_buffer[:num_ctx_tokens, :])
                 else:
@@ -1195,7 +1201,7 @@ class Indexer(nn.Module):
                 # This is because rowEnd = seq_len - next_n + offset + 1
                 gen_kv_lens_cuda = metadata.kv_lens_cuda_runtime[
                     num_contexts:num_contexts + num_generations]
-                torch.ops.trtllm.indexer_topk_decode_op(
+                torch.ops.trtllm.indexer_topk_decode(
                     logits_decode, gen_kv_lens_cuda,
                     topk_indices_buffer[num_ctx_tokens:num_ctx_tokens +
                                         num_gen_tokens, :], next_n)

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -183,12 +183,12 @@ def _register_fake():
                                 dtype=scores_with_bias.dtype), scores.new_empty(
                                     shape, dtype=torch.int32)
 
-    @torch.library.register_fake("trtllm::indexer_topk_prefill_op")
+    @torch.library.register_fake("trtllm::indexer_topk_prefill")
     def _(logits, row_starts, row_ends, indices, index_topk):
         # In-place operation, no return value (void function)
         pass
 
-    @torch.library.register_fake("trtllm::indexer_topk_decode_op")
+    @torch.library.register_fake("trtllm::indexer_topk_decode")
     def _(logits, seq_lens, indices, next_n, index_topk):
         # In-place operation, no return value (void function)
         pass

--- a/tests/unittest/_torch/attention/sparse/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/test_dsa_indexer.py
@@ -1336,7 +1336,7 @@ def test_indexer_decode_custom_vs_fallback(batch_size, next_n, index_topk,
     in the decode phase of sparse_attn_indexer.
 
     This test validates:
-    1. Custom CUDA top-k kernel (indexer_topk_decode_op) correctness
+    1. Custom CUDA top-k kernel (indexer_topk_decode) correctness
     2. Consistency with PyTorch fallback implementation
     3. Handling of decode scenarios with next_n > 1 (speculative decoding)
     4. Proper masking and handling of variable-length sequences
@@ -1555,7 +1555,7 @@ def test_indexer_prefill_chunked_custom_vs_fallback(batch_size, index_topk,
     with metadata.indexer_prefill_chunks != None.
 
     This test validates:
-    1. Custom CUDA top-k kernel (indexer_topk_prefill_op) correctness in chunked mode
+    1. Custom CUDA top-k kernel (indexer_topk_prefill) correctness in chunked mode
     2. Consistency with PyTorch fallback implementation
     3. Proper handling of multiple chunks
     4. Correct masking and local index computation per chunk

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-# Import tensorrt_llm to load custom CUDA operators (indexer_topk_decode_op, indexer_topk_prefill_op)
+# Import tensorrt_llm to load custom CUDA operators (indexer_topk_decode, indexer_topk_prefill)
 import tensorrt_llm  # noqa: F401
 
 
@@ -179,7 +179,7 @@ def test_indexer_topk_decode(batch_size, next_n, index_topk, num_tokens):
     indices = torch.empty((num_gen_tokens, index_topk), dtype=torch.int32, device="cuda")
 
     # Run CUDA implementation
-    torch.ops.trtllm.indexer_topk_decode_op(logits, seq_lens, indices, next_n)
+    torch.ops.trtllm.indexer_topk_decode(logits, seq_lens, indices, next_n)
 
     torch.cuda.synchronize()
 
@@ -214,7 +214,7 @@ def test_indexer_topk_prefill(batch_size, index_topk, num_tokens):
     indices = torch.empty((batch_size, index_topk), dtype=torch.int32, device="cuda")
 
     # Run CUDA implementation
-    torch.ops.trtllm.indexer_topk_prefill_op(logits, row_starts, row_ends, indices)
+    torch.ops.trtllm.indexer_topk_prefill(logits, row_starts, row_ends, indices)
 
     # Run reference implementation
     torch_indices = logits.topk(min(index_topk, max(row_ends)), dim=-1)[1]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified CUDA operator names by removing "_op" suffix for cleaner interface: `indexer_topk_decode` and `indexer_topk_prefill`.
  * Standardized parameter naming across indexing functions for improved consistency and clarity.
  * Top-K threshold parameter now supports runtime configuration with default value of 2048.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Update the indexer topK for Deepseek v3.2

## Test Coverage

pytest -v -s tests/unittest/_torch/thop/parallel/test_indexer_topk.py
pytest -v -s tests/unittest/_torch/attention/sparse/test_dsa_indexer.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
