### PR TITLE
[None][fix] Prevent memory leaks with iter_stats_max_iterations

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -1230,5 +1230,6 @@ def create_autodeploy_executor(ad_config: LlmArgs, tokenizer: Optional[Tokenizer
         max_beam_width=ad_config.max_beam_width,
         guided_decoder=guided_decoder,
         drafter=drafter,
+        iter_stats_max_iterations=ad_config.iter_stats_max_iterations,
     )
     return py_executor

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -907,7 +907,8 @@ def create_py_executor_instance(
         max_seq_len=max_seq_len,
         peft_cache_config=peft_cache_config,
         virtual_memory_pools=virtual_memory_pools,
-        execution_stream=execution_stream)
+        execution_stream=execution_stream,
+        iter_stats_max_iterations=llm_args.iter_stats_max_iterations)
 
 
 def create_torch_sampler_args(

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -86,8 +86,8 @@ class BaseWorker(GenerationExecutor):
         super().__init__(
             num_postprocess_workers=postproc_config.num_postprocess_workers,
             postprocess_tokenizer_dir=postproc_config.postprocess_tokenizer_dir,
-            max_iteration_result_size=postproc_config.max_iteration_result_size,
             is_llm_executor=is_llm_executor,
+            iter_stats_max_iterations=llm_args.iter_stats_max_iterations,
         )
 
         # inputs

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -86,6 +86,7 @@ class BaseWorker(GenerationExecutor):
         super().__init__(
             num_postprocess_workers=postproc_config.num_postprocess_workers,
             postprocess_tokenizer_dir=postproc_config.postprocess_tokenizer_dir,
+            max_iteration_result_size=postproc_config.max_iteration_result_size,
             is_llm_executor=is_llm_executor,
         )
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -80,10 +80,12 @@ class GenerationExecutor(ABC):
     def __init__(self,
                  num_postprocess_workers: int = 0,
                  postprocess_tokenizer_dir: Optional[str] = None,
+                 max_iteration_result_size: int = 0,
                  is_llm_executor: Optional[bool] = None):
         self.postproc_config = PostprocWorkerConfig(
             num_postprocess_workers=num_postprocess_workers,
-            postprocess_tokenizer_dir=postprocess_tokenizer_dir)
+            postprocess_tokenizer_dir=postprocess_tokenizer_dir,
+            max_iteration_result_size=max_iteration_result_size)
 
         self.kv_events_queues = IterationResultQueue()
         self.stats_queues = IterationResultQueue()
@@ -239,7 +241,8 @@ class GenerationExecutor(ABC):
         if self._is_llm_executor:
             if self._iter_stats_result is None:
                 # singleton to store cpp runtime stats
-                self._iter_stats_result = IterationResult()
+                self._iter_stats_result = IterationResult(
+                    self.postproc_config.max_iteration_result_size)
             else:
                 # expect more engine stats whenever new prompts are submitted
                 self._iter_stats_result.mark_undone()

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -43,6 +43,7 @@ class PostprocWorkerConfig:
     ''' The config for the postprocess worker. '''
     num_postprocess_workers: int = 0
     postprocess_tokenizer_dir: Optional[str] = None
+    max_iteration_result_size: int = 0
 
     @property
     def enabled(self) -> bool:

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -43,7 +43,6 @@ class PostprocWorkerConfig:
     ''' The config for the postprocess worker. '''
     num_postprocess_workers: int = 0
     postprocess_tokenizer_dir: Optional[str] = None
-    max_iteration_result_size: int = 0
 
     @property
     def enabled(self) -> bool:

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -50,15 +50,17 @@ class GenerationExecutorProxy(GenerationExecutor):
     ) -> None:
         postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
         )
-        super().__init__(
-            num_postprocess_workers=postproc_worker_config.
-            num_postprocess_workers,
-            postprocess_tokenizer_dir=postproc_worker_config.
-            postprocess_tokenizer_dir,
-            max_iteration_result_size=postproc_worker_config.
-            max_iteration_result_size,
-            is_llm_executor=is_llm_executor,
-        )
+
+        iter_stats_max_iterations = worker_kwargs[
+            "llm_args"].iter_stats_max_iterations if worker_kwargs.get(
+                "llm_args", None) is not None else 0
+
+        super().__init__(num_postprocess_workers=postproc_worker_config.
+                         num_postprocess_workers,
+                         postprocess_tokenizer_dir=postproc_worker_config.
+                         postprocess_tokenizer_dir,
+                         is_llm_executor=is_llm_executor,
+                         iter_stats_max_iterations=iter_stats_max_iterations)
 
         self.workers_started = False
         self.worker_cls = worker_cls

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -55,6 +55,8 @@ class GenerationExecutorProxy(GenerationExecutor):
             num_postprocess_workers,
             postprocess_tokenizer_dir=postproc_worker_config.
             postprocess_tokenizer_dir,
+            max_iteration_result_size=postproc_worker_config.
+            max_iteration_result_size,
             is_llm_executor=is_llm_executor,
         )
 

--- a/tensorrt_llm/executor/ray_executor.py
+++ b/tensorrt_llm/executor/ray_executor.py
@@ -41,8 +41,14 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
         os.environ['RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES'] = '1'
         os.environ["RAY_DEDUP_LOGS"] = "0"  # for debug
 
-        super().__init__(model_world_size, postproc_worker_config,
-                         is_llm_executor)
+        iter_stats_max_iterations = worker_kwargs[
+            "llm_args"].iter_stats_max_iterations if worker_kwargs.get(
+                "llm_args", None) is not None else 0
+
+        super().__init__(num_postprocess_workers=model_world_size,
+                         postprocess_tokenizer_dir=postproc_worker_config,
+                         is_llm_executor=is_llm_executor,
+                         iter_stats_max_iterations=iter_stats_max_iterations)
 
         self.has_start_local_cluser = False
         runtime_env = {

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -854,15 +854,15 @@ class IterationResult:
     Runtime results for all available iterations.
     """
 
-    def __init__(self):
+    def __init__(self, maxsize=0):
         self._done = False
         self._timeout = 2
 
         if has_event_loop():
-            self.aqueue = AsyncQueue()
+            self.aqueue = AsyncQueue(maxsize if maxsize > 0 else None)
             self.queue = self.aqueue.sync_q
         else:
-            self.queue = Queue()
+            self.queue = Queue(maxsize)
             self.aqueue = None
 
     def set_timeout(self, timeout: float):

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -854,15 +854,15 @@ class IterationResult:
     Runtime results for all available iterations.
     """
 
-    def __init__(self, maxsize: int = 0):
+    def __init__(self, max_size: int = 0):
         self._done = False
         self._timeout = 2
 
         if has_event_loop():
-            self.aqueue = AsyncQueue(maxsize if maxsize > 0 else None)
+            self.aqueue = AsyncQueue(max_size if max_size > 0 else None)
             self.queue = self.aqueue.sync_q
         else:
-            self.queue = Queue(maxsize)
+            self.queue = Queue(max_size)
             self.aqueue = None
 
     def set_timeout(self, timeout: float):

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -854,7 +854,7 @@ class IterationResult:
     Runtime results for all available iterations.
     """
 
-    def __init__(self, maxsize=0):
+    def __init__(self, maxsize: int = 0):
         self._done = False
         self._timeout = 2
 

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -40,14 +40,17 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
         )
 
+        iter_stats_max_iterations = worker_kwargs[
+            "llm_args"].iter_stats_max_iterations if worker_kwargs.get(
+                "llm_args", None) is not None else 0
+
         super().__init__(
             num_postprocess_workers=postproc_worker_config.
             num_postprocess_workers,
             postprocess_tokenizer_dir=postproc_worker_config.
             postprocess_tokenizer_dir,
-            max_iteration_result_size=postproc_worker_config.
-            max_iteration_result_size,
             is_llm_executor=is_llm_executor,
+            iter_stats_max_iterations=iter_stats_max_iterations,
         )
 
         self._create_mpi_session(model_world_size, mpi_session)

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -45,6 +45,8 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
             num_postprocess_workers,
             postprocess_tokenizer_dir=postproc_worker_config.
             postprocess_tokenizer_dir,
+            max_iteration_result_size=postproc_worker_config.
+            max_iteration_result_size,
             is_llm_executor=is_llm_executor,
         )
 

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1140,9 +1140,7 @@ class _TorchLLM(BaseLLM):
             return_logits=return_logits,
             postproc_worker_config=PostprocWorkerConfig(
                 num_postprocess_workers=self.args.num_postprocess_workers,
-                postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
-                max_iteration_result_size=self.args.max_iteration_result_size,
-            ),
+                postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir),
             is_llm_executor=True,
             hf_model_dir=self._hf_model_dir,
             tokenizer=self.tokenizer,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1141,6 +1141,7 @@ class _TorchLLM(BaseLLM):
             postproc_worker_config=PostprocWorkerConfig(
                 num_postprocess_workers=self.args.num_postprocess_workers,
                 postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
+                max_iteration_result_size=self.args.max_iteration_result_size,
             ),
             is_llm_executor=True,
             hf_model_dir=self._hf_model_dir,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2107,6 +2107,12 @@ class BaseLlmArgs(StrictBaseModel):
         description="The path to the tokenizer directory for postprocessing.",
         status="prototype")
 
+    max_iteration_result_size: int = Field(
+        default=16384,
+        description="Maximum size of the iteration result queue. "
+        "When the queue is full, the oldest result will be removed.",
+        status="prototype")
+
     reasoning_parser: Optional[str] = Field(
         default=None,
         description="The parser to separate reasoning content from output.",

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2042,8 +2042,11 @@ class BaseLlmArgs(StrictBaseModel):
         })
 
     iter_stats_max_iterations: Optional[int] = Field(
-        default=None,
-        description="The maximum number of iterations for iter stats.",
+        default=16384,
+        description=
+        "Maximum number of iterations to keep in the iteration statistics history. "
+        "Defaults to 16384 iterations. "
+        "When exceeded, older statistics are automatically removed to maintain this limit.",
         status="prototype")
 
     request_stats_max_iterations: Optional[int] = Field(
@@ -2105,12 +2108,6 @@ class BaseLlmArgs(StrictBaseModel):
     postprocess_tokenizer_dir: Optional[str] = Field(
         default=None,
         description="The path to the tokenizer directory for postprocessing.",
-        status="prototype")
-
-    max_iteration_result_size: int = Field(
-        default=16384,
-        description="Maximum size of the iteration result queue. "
-        "When the queue is full, the oldest result will be removed.",
         status="prototype")
 
     reasoning_parser: Optional[str] = Field(

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -374,8 +374,8 @@ class AsyncQueue:
     class MixedSyncAsyncAPIError(Exception):
         pass
 
-    def __init__(self):
-        self._q = collections.deque()
+    def __init__(self, maxsize: int = None):
+        self._q = collections.deque(maxsize)
         self._event = asyncio.Event()
         self._tainted = False
         self._sync_q = _SyncQueue(self)

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -374,8 +374,8 @@ class AsyncQueue:
     class MixedSyncAsyncAPIError(Exception):
         pass
 
-    def __init__(self, maxsize: Optional[int] = None):
-        self._q = collections.deque(maxlen=maxsize)
+    def __init__(self, max_size: Optional[int] = None):
+        self._q = collections.deque(maxlen=max_size)
         self._event = asyncio.Event()
         self._tainted = False
         self._sync_q = _SyncQueue(self)

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -374,8 +374,8 @@ class AsyncQueue:
     class MixedSyncAsyncAPIError(Exception):
         pass
 
-    def __init__(self, maxsize: int = None):
-        self._q = collections.deque(maxsize)
+    def __init__(self, maxsize: Optional[int] = None):
+        self._q = collections.deque(maxlen=maxsize)
         self._event = asyncio.Event()
         self._tainted = False
         self._sync_q = _SyncQueue(self)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable iteration result size limit (default: 16384) to enable users to optimize memory consumption and control resource allocation during model execution. This enhancement supports bounded-size storage for runtime iteration results, improving memory efficiency across inference workflows while maintaining backward compatibility with existing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
We discovered that when TRT runs without ever calling the /metrics API (which we do not invoke in production), the `_iter_stats_result` queue in the executor keeps growing indefinitely until it causes an OOM error. To address this, we introduced a `max_iteration_result_size` parameter to cap the queue size. When the queue reaches its maximum capacity, the oldest results are automatically discarded.

Before the fix, memory utilization kept increasing.
<img width="2824" height="1354" alt="image" src="https://github.com/user-attachments/assets/4538d140-8168-4cbd-9fee-ba40827d9736" />

After the fix, the results are still under stress testing, coming soon~


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
