### PR TITLE
[TRTLLM-9164][infra] Enable checking duplicate items in waives.txt in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1460,11 +1460,6 @@ repos:
         entry: ./scripts/format_test_list.py
         language: script
         files: tests/integration/test_lists/.*\.txt$
-    -   id: waive list check
-        name: Checks for duplicated test items in waives.txt
-        entry: ./scripts/check_test_list.py --check-duplicates
-        language: script
-        pass_filenames: false
     -   id: DCO check
         name: Checks the commit message for a developer certificate of origin signature
         entry: ./scripts/dco_check.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1460,6 +1460,11 @@ repos:
         entry: ./scripts/format_test_list.py
         language: script
         files: tests/integration/test_lists/.*\.txt$
+    -   id: waive list check
+        name: Checks for duplicated test items in waives.txt
+        entry: ./scripts/check_test_list.py --check-duplicates
+        language: script
+        pass_filenames: false
     -   id: DCO check
         name: Checks the commit message for a developer certificate of origin signature
         entry: ./scripts/dco_check.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1460,6 +1460,11 @@ repos:
         entry: ./scripts/format_test_list.py
         language: script
         files: tests/integration/test_lists/.*\.txt$
+    -   id: waive list check
+        name: Checks for duplicated test items in waives.txt
+        entry: ./scripts/check_test_list.py --check-duplicate-waives
+        language: script
+        pass_filenames: false
     -   id: DCO check
         name: Checks the commit message for a developer certificate of origin signature
         entry: ./scripts/dco_check.py

--- a/scripts/check_test_list.py
+++ b/scripts/check_test_list.py
@@ -129,16 +129,8 @@ def check_waive_duplicates(llm_src):
         if not line:
             continue
 
-        # Skip Perf tests due to they are dynamically generated
-        if "perf/test_perf.py" in line:
-            continue
-
         # Check for SKIP marker in waives.txt and split by the first occurrence
         line = line.split(" SKIP", 1)[0].strip()
-
-        # Skip unittests due to we don't need to have an entry in test-db yml
-        if line.startswith("unittest/"):
-            continue
 
         # Track all occurrences of each processed line
         if line in dedup_lines:
@@ -238,7 +230,7 @@ def main():
                         action="store_true",
                         help="Enable test list verification for waive file.")
     parser.add_argument(
-        "--check-duplicates",
+        "--check-duplicate-waives",
         action="store_true",
         help="Enable duplicate check in waives.txt (fails if duplicates found)."
     )

--- a/scripts/check_test_list.py
+++ b/scripts/check_test_list.py
@@ -271,7 +271,7 @@ def main():
               flush=True)
 
     # Check for duplicates in waives.txt if requested
-    if args.check_duplicates:
+    if args.check_duplicate_waives:
         print("-----------Checking for duplicates in waives.txt...-----------",
               flush=True)
         check_waive_duplicates(llm_src)

--- a/scripts/check_test_list.py
+++ b/scripts/check_test_list.py
@@ -294,7 +294,7 @@ def main():
         print(
             "Duplicate test names found in waives.txt, please delete one or combine them first!!!\n"
         )
-        if args.check_duplicates:
+        if args.check_duplicate_waives:
             pass_flag = False
 
     non_existent_cases_file = os.path.join(llm_src, "nonexits_cases.json")

--- a/scripts/check_test_list.py
+++ b/scripts/check_test_list.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This script is used to verify test lists for L0, QA, and waives file.
 
@@ -110,14 +111,14 @@ def verify_qa_test_lists(llm_src):
                         f.write(f"{cleaned_line}\n")
 
 
-def verify_waive_list(llm_src, args):
+def check_waive_duplicates(llm_src):
+    """Check for duplicate entries in waives.txt and write report."""
     waives_list_path = f"{llm_src}/tests/integration/test_lists/waives.txt"
     dup_cases_record = f"{llm_src}/dup_cases.txt"
-    non_existent_cases_record = f"{llm_src}/nonexits_cases.json"
-    # Remove prefix and markers in wavies.txt
-    dedup_lines = {
-    }  # Track all occurrences: processed_line -> [(line_no, original_line), ...]
-    processed_lines = set()
+
+    # Track all occurrences: processed_line -> [(line_no, original_line), ...]
+    dedup_lines = {}
+
     with open(waives_list_path, "r") as f:
         lines = f.readlines()
 
@@ -135,11 +136,50 @@ def verify_waive_list(llm_src, args):
         # Check for SKIP marker in waives.txt and split by the first occurrence
         line = line.split(" SKIP", 1)[0].strip()
 
+        # Skip unittests due to we don't need to have an entry in test-db yml
+        if line.startswith("unittest/"):
+            continue
+
         # Track all occurrences of each processed line
         if line in dedup_lines:
             dedup_lines[line].append((line_no, original_line))
         else:
             dedup_lines[line] = [(line_no, original_line)]
+
+    # Write duplicate report after processing all lines
+    for processed_line, occurrences in dedup_lines.items():
+        if len(occurrences) > 1:
+            with open(dup_cases_record, "a") as f:
+                f.write(
+                    f"Duplicate waive records found for '{processed_line}' ({len(occurrences)} occurrences):\n"
+                )
+                for i, (line_no, original_line) in enumerate(occurrences, 1):
+                    f.write(
+                        f"  Occurrence {i} at line {line_no}: '{original_line}'\n"
+                    )
+                f.write(f"\n")
+
+
+def verify_waive_list(llm_src, args):
+    waives_list_path = f"{llm_src}/tests/integration/test_lists/waives.txt"
+    non_existent_cases_record = f"{llm_src}/nonexits_cases.json"
+
+    processed_lines = set()
+    with open(waives_list_path, "r") as f:
+        lines = f.readlines()
+
+    for line in lines:
+        line = line.strip()
+
+        if not line:
+            continue
+
+        # Skip Perf tests due to they are dynamically generated
+        if "perf/test_perf.py" in line:
+            continue
+
+        # Check for SKIP marker in waives.txt and split by the first occurrence
+        line = line.split(" SKIP", 1)[0].strip()
 
         # If the line starts with 'full:', process it
         if line.startswith("full:"):
@@ -173,19 +213,6 @@ def verify_waive_list(llm_src, args):
 
         processed_lines.add(line)
 
-    # Write duplicate report after processing all lines
-    for processed_line, occurrences in dedup_lines.items():
-        if len(occurrences) > 1:
-            with open(dup_cases_record, "a") as f:
-                f.write(
-                    f"Duplicate waive records found for '{processed_line}' ({len(occurrences)} occurrences):\n"
-                )
-                for i, (line_no, original_line) in enumerate(occurrences, 1):
-                    f.write(
-                        f"  Occurrence {i} at line {line_no}: '{original_line}'\n"
-                    )
-                f.write(f"\n")
-
     # Write the processed lines to a tmp file
     tmp_waives_file = f"{llm_src}/processed_waive_list.txt"
     with open(tmp_waives_file, "w") as f:
@@ -210,11 +237,19 @@ def main():
     parser.add_argument("--waive",
                         action="store_true",
                         help="Enable test list verification for waive file.")
+    parser.add_argument(
+        "--check-duplicates",
+        action="store_true",
+        help="Enable duplicate check in waives.txt (fails if duplicates found)."
+    )
     args = parser.parse_args()
     script_dir = os.path.dirname(os.path.realpath(__file__))
     llm_src = os.path.abspath(os.path.join(script_dir, "../"))
 
-    install_python_dependencies(llm_src)
+    # Only skip installing dependencies if ONLY --check-duplicates is used
+    if args.l0 or args.qa or args.waive:
+        install_python_dependencies(llm_src)
+
     pass_flag = True
     # Verify L0 test lists
     if args.l0:
@@ -243,6 +278,12 @@ def main():
         print("-----------Skipping waive list verification.-----------",
               flush=True)
 
+    # Check for duplicates in waives.txt if requested
+    if args.check_duplicates:
+        print("-----------Checking for duplicates in waives.txt...-----------",
+              flush=True)
+        check_waive_duplicates(llm_src)
+
     invalid_json_file = os.path.join(llm_src, "invalid_tests.json")
     if os.path.isfile(invalid_json_file) and os.path.getsize(
             invalid_json_file) > 0:
@@ -261,7 +302,8 @@ def main():
         print(
             "Duplicate test names found in waives.txt, please delete one or combine them first!!!\n"
         )
-        # pass_flag = False
+        if args.check_duplicates:
+            pass_flag = False
 
     non_existent_cases_file = os.path.join(llm_src, "nonexits_cases.json")
     if os.path.isfile(non_existent_cases_file) and os.path.getsize(

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -395,8 +395,6 @@ accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[True] SKIP
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_empty_batch[DeepSeek-V3-Lite-bf16] SKIP (https://nvbugs/5601682)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=False-overlap_scheduler=False] SKIP (https://nvbugs/5655584)
 accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_chunked_prefill SKIP (https://nvbugs/5608930)
-accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[False] SKIP (https://nvbugspro.nvidia.com/bug/5651854)
-test_e2e.py::test_ptp_quickstart_multimodal_chunked_prefill[phi4-multimodal-instruct-fp4-multimodals/Phi-4-multimodal-instruct-FP4-0.8-image] SKIP (https://nvbugs/5568836)
 test_e2e.py::test_ptp_quickstart_multimodal_chunked_prefill[phi4-multimodal-instruct-fp4-multimodals/Phi-4-multimodal-instruct-FP4-0.8-image] SKIP (https://nvbugs/5568836)
 test_e2e.py::test_ptp_quickstart_multimodal_kv_cache_reuse[phi4-multimodal-instruct-fp4-multimodals/Phi-4-multimodal-instruct-FP4-0.8-image] SKIP (https://nvbugs/5568836)
 test_e2e.py::test_ptp_quickstart_multimodal_multiturn[phi4-multimodal-instruct-fp4-multimodals/Phi-4-multimodal-instruct-FP4] SKIP (https://nvbugs/5568836)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* Re-enabled two previously skipped tests.

## Chores
* Added automated duplicate detection for test configuration validation.
* Integrated new validation checks into pre-commit workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
