### PR TITLE
[TRTLLM-9191][feat] support out-of-tree models in trtllm-serve

### DIFF
--- a/examples/llm-api/out_of_tree_example/__init__.py
+++ b/examples/llm-api/out_of_tree_example/__init__.py
@@ -1,0 +1,1 @@
+from . import modeling_opt

--- a/examples/llm-api/out_of_tree_example/readme.md
+++ b/examples/llm-api/out_of_tree_example/readme.md
@@ -45,8 +45,11 @@ Prepare the dataset:
 python ./benchmarks/cpp/prepare_dataset.py --tokenizer ./model_ckpt --stdout dataset --dataset-name lmms-lab/MMMU --dataset-split test --dataset-image-key image --dataset-prompt-key "question" --num-requests 100 --output-len-dist 128,5 > mm_data.jsonl
 ```
 
-
 Run the benchmark:
 ```
 trtllm-bench --model ./model_ckpt --model_path ./model_ckpt throughput --dataset mm_data.jsonl --backend pytorch --num_requests 100 --max_batch_size 4 --modality image --streaming --custom_module_dirs ../modeling_custom_phi
 ```
+
+### Serving
+
+Similar to `trtllm-bench` above, `trtllm-serve` also supports the `--custom_module_dirs` option.

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -5,6 +5,7 @@ import os
 import signal  # Added import
 import subprocess  # nosec B404
 import sys
+from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence
 
 import click
@@ -33,6 +34,7 @@ from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 from tensorrt_llm.logger import logger, severity_map
 from tensorrt_llm.serve import OpenAIDisaggServer, OpenAIServer
 from tensorrt_llm.serve.tool_parser import ToolParserFactory
+from tensorrt_llm.tools.importlib_utils import import_custom_module_from_dir
 
 # Global variable to store the Popen object of the child process
 _child_p_global: Optional[subprocess.Popen] = None
@@ -244,6 +246,16 @@ class ChoiceWithAlias(click.Choice):
                          {"trt": "tensorrt"}),
     default="pytorch",
     help="The backend to use to serve the model. Default is pytorch backend.")
+@click.option(
+    "--custom_module_dirs",
+    type=click.Path(exists=True,
+                    readable=True,
+                    path_type=Path,
+                    resolve_path=True),
+    default=None,
+    multiple=True,
+    help="Paths to custom module directories to import.",
+)
 @click.option('--log_level',
               type=click.Choice(severity_map.keys()),
               default='info',
@@ -366,12 +378,21 @@ def serve(
         server_role: Optional[str],
         fail_fast_on_attention_window_too_large: bool,
         otlp_traces_endpoint: Optional[str], enable_chunked_prefill: bool,
-        disagg_cluster_uri: Optional[str], media_io_kwargs: Optional[str]):
+        disagg_cluster_uri: Optional[str], media_io_kwargs: Optional[str],
+        custom_module_dirs: list[Path]):
     """Running an OpenAI API compatible server
 
     MODEL: model name | HF checkpoint path | TensorRT engine path
     """
     logger.set_level(log_level)
+
+    for custom_module_dir in custom_module_dirs:
+        try:
+            import_custom_module_from_dir(custom_module_dir)
+        except Exception as e:
+            logger.error(
+                f"Failed to import custom module from {custom_module_dir}: {e}")
+            raise e
 
     llm_args, _ = get_llm_args(
         model=model,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -776,7 +776,10 @@ class BaseLLM:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+    def __exit__(
+        self, exc_type, exc_value, traceback
+    ) -> Literal[
+            False]:  # https://github.com/microsoft/pyright/issues/7009#issuecomment-1894135045
         del exc_value, traceback
         self.shutdown()
         return False  # propagate exceptions

--- a/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
+++ b/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
@@ -1,65 +1,134 @@
-import unittest
+import re
+from contextlib import nullcontext
+from pathlib import Path
+from typing import cast
 
-from parameterized import parameterized
+import pytest
 
 from tensorrt_llm import LLM
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.sampling_params import SamplingParams
 
 # isort: off
-from utils.util import unittest_name_func, similar
+from utils.util import similar
 from utils.llm_data import llm_models_root
 # isort: on
 
+from llmapi.apps.openai_server import RemoteOpenAIServer
 
-class TestOutOfTree(unittest.TestCase):
 
-    @parameterized.expand([False, True], name_func=unittest_name_func)
-    def test_llm_api(self, import_oot_code: bool):
-        if import_oot_code:
-            # Import out-of-tree modeling code for OPTForCausalLM
-            import os
-            import sys
-            sys.path.append(
-                os.path.join(
-                    os.path.dirname(__file__),
-                    '../../../../examples/llm-api/out_of_tree_example'))
-            import modeling_opt  # noqa
+class TestOutOfTree:
 
-        model_dir = str(llm_models_root() / "opt-125m")
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
+    @pytest.fixture
+    @staticmethod
+    def oot_path() -> Path:
+        return Path(
+            __file__
+        ).parent / ".." / ".." / ".." / ".." / "examples" / "llm-api" / "out_of_tree_example"
 
-        if not import_oot_code:
-            with self.assertRaises(RuntimeError):
-                # estimate_max_kv_cache_tokens will create a request of max_num_tokens for forward.
-                # Default 8192 will exceed the max length of absolute positional embedding in OPT, leading to out of range indexing.
-                llm = LLM(model=model_dir,
-                          kv_cache_config=kv_cache_config,
-                          max_num_tokens=2048)
-            return
+    @pytest.fixture
+    @staticmethod
+    def model_dir() -> Path:
+        models_root = llm_models_root()
+        assert models_root is not None
+        return models_root / "opt-125m"
 
-        llm = LLM(model=model_dir,
-                  kv_cache_config=kv_cache_config,
-                  max_num_tokens=2048,
-                  disable_overlap_scheduler=True)
-
-        prompts = [
+    @pytest.fixture
+    @staticmethod
+    def prompts() -> list[str]:
+        return [
             "Hello, my name is",
             "The president of the United States is",
             "The capital of France is",
             "The future of AI is",
         ]
 
-        references = [
+    @pytest.fixture
+    @staticmethod
+    def references() -> list[str]:
+        return [
             " J.C. and I am a student at",
             " not a racist. He is a racist.\n",
             " the capital of the French Republic.\n\nThe",
             " in the hands of the people.\n\nThe",
         ]
 
-        sampling_params = SamplingParams(max_tokens=10)
-        with llm:
-            outputs = llm.generate(prompts, sampling_params=sampling_params)
+    @pytest.fixture
+    @staticmethod
+    def sampling_params() -> SamplingParams:
+        return SamplingParams(max_tokens=10)
 
-        for output, ref in zip(outputs, references):
-            assert similar(output.outputs[0].text, ref)
+    @pytest.fixture
+    @staticmethod
+    def max_num_tokens() -> int:
+        # estimate_max_kv_cache_tokens will create a request of max_num_tokens for forward.
+        # Default 8192 will exceed the max length of absolute positional embedding in OPT, leading to out of range indexing.
+        return 2048
+
+    @pytest.mark.parametrize("import_oot_code", [False, True])
+    def test_llm_api(
+        self,
+        import_oot_code: bool,
+        oot_path: Path,
+        model_dir: Path,
+        prompts: list[str],
+        references: list[str],
+        sampling_params: SamplingParams,
+        max_num_tokens: int,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        if import_oot_code:
+            # Import out-of-tree modeling code for OPTForCausalLM
+            monkeypatch.syspath_prepend(oot_path)
+            import modeling_opt  # noqa
+
+        with (nullcontext() if import_oot_code else
+              pytest.raises(RuntimeError,
+                            match=".*Executor worker returned error.*")) as ctx:
+            with LLM(
+                    model=str(model_dir),
+                    kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.2),
+                    max_num_tokens=max_num_tokens,
+            ) as llm:
+                outputs = llm.generate(prompts, sampling_params=sampling_params)
+
+            for output, ref in zip(outputs, references):
+                assert similar(output.outputs[0].text, ref)
+
+        if not import_oot_code:
+            exc_val = cast(pytest.ExceptionInfo, ctx).value
+            assert re.match(
+                ".*Unknown architecture for AutoModelForCausalLM: OPTForCausalLM.*",
+                str(exc_val.__cause__),
+            ) is not None
+
+    @pytest.mark.parametrize("import_oot_code", [False, True])
+    def test_serve(
+        self,
+        import_oot_code: bool,
+        oot_path: Path,
+        model_dir: Path,
+        prompts: list[str],
+        references: list[str],
+        sampling_params: SamplingParams,
+        max_num_tokens: int,
+    ):
+        with (nullcontext()
+              if import_oot_code else pytest.raises(RuntimeError)):
+            args = []
+            args.extend(["--kv_cache_free_gpu_memory_fraction",
+                         "0.2"])  # for co-existence with other servers
+            args.extend(["--max_num_tokens", str(max_num_tokens)])
+            if import_oot_code:
+                args.extend(["--custom_module_dirs", str(oot_path)])
+            with RemoteOpenAIServer(str(model_dir), args) as remote_server:
+                client = remote_server.get_client()
+                result = client.completions.create(
+                    model="model_name",
+                    prompt=prompts,
+                    max_tokens=sampling_params.max_tokens,
+                    temperature=0.0,
+                )
+
+            for choice, ref in zip(result.choices, references):
+                assert similar(choice.text, ref)


### PR DESCRIPTION
## Description

Adds `--custom_module_dirs` option (from `trtllm-bench`) to `trtllm-serve`.

## Test Coverage

Refactored existing out-of-tree model tests to use `pytest` and updated them to cover `trtllm-serve`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--custom_module_dirs` CLI option to the serve command to support importing custom Python modules from specified directories.

* **Documentation**
  * Updated Serving documentation to reflect custom module directory import capabilities.

* **Improvements**
  * Enhanced type annotations in the LLM API for improved type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->