### PR TITLE
[#9237][feat] enable iter stats in autodeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -197,6 +197,16 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
         "backends, this should equal max_seq_len. Temporary field until tokens_per_block gets "
         "properly passed through.",
     )
+    enable_iter_perf_stats: bool = Field(
+        default=False, description="Enable iteration performance statistics.", status="prototype"
+    )
+
+    enable_iter_req_stats: bool = Field(
+        default=False,
+        description="If true, enables per request stats per iteration. Must also set "
+        "enable_iter_perf_stats to true to get request stats.",
+        status="prototype",
+    )
 
     ### VALIDATION #################################################################################
     @model_validator(mode="after")

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 
@@ -44,6 +45,13 @@ from ..llm_args import LlmArgs
 from ..transform.optimizer import InferenceOptimizer
 from ..utils.logger import ad_logger
 from .interface import CachedSequenceInterface, GetInferenceModel
+
+
+@dataclass
+class ReportingInfo:
+    print_log: bool = False
+    enable_iter_perf_stats: bool = False
+    enable_iter_req_stats: bool = False
 
 
 class _CacheManagerWithFakePool(KVCacheManager):
@@ -123,6 +131,11 @@ class ADEngine(ModelEngine):
             vocab_size_padded=factory.vocab_size_padded,
             chunk_size=factory.chunk_size,
         )
+        reporting_info = ReportingInfo(
+            print_log=False,
+            enable_iter_perf_stats=ad_config.enable_iter_perf_stats,
+            enable_iter_req_stats=ad_config.enable_iter_req_stats,
+        )
         # TODO (lucaslie): consider how we move args around InferenceOptimizer.__init__,
         # ADEngine.__init__, and ADEngine.build_from_config. Seems a bit unnatural atm.
 
@@ -130,7 +143,7 @@ class ADEngine(ModelEngine):
         build_and_optimize = InferenceOptimizer(factory=factory, config=ad_config.transforms)
 
         # construct engine
-        return cls(build_and_optimize, seq_info, device, max_beam_width)
+        return cls(build_and_optimize, seq_info, device, max_beam_width, reporting_info)
 
     @torch.inference_mode()
     def __init__(
@@ -139,20 +152,23 @@ class ADEngine(ModelEngine):
         seq_info: SequenceInfo,
         device: DeviceLikeType,
         max_beam_width: int = 1,
+        reporting_info: ReportingInfo = ReportingInfo(),
     ) -> None:
         """Initialize the engine with model and sequence information."""
         # NOTE (lucaslie): create a fake Namespace to satisfy PyExecutor requirements...
         # This is not correctly declared in the base ModelEngine class though...
         self.llm_args = SimpleNamespace()
-        self.llm_args.print_iter_log = False
-        self.llm_args.enable_iter_perf_stats = False
-        self.llm_args.enable_iter_req_stats = False
+        self.llm_args.print_iter_log = reporting_info.print_log
+        self.llm_args.enable_iter_perf_stats = reporting_info.enable_iter_perf_stats
+        self.llm_args.enable_iter_req_stats = reporting_info.enable_iter_req_stats
         self.llm_args.stream_interval = 1
         self.llm_args.attention_dp_config = None
         self.llm_args.batch_wait_timeout_ms = 0
         self.llm_args.batch_wait_timeout_iters = 0
         self.llm_args.batch_wait_max_tokens_ratio = 0.0
         self.llm_args.max_num_tokens = seq_info.max_num_tokens
+        self.iter_counter = 0
+        self.iter_states = {}
 
         # NOTE (lucaslie): not a declared base member in the base class; required by PyExecutor...
         self.max_beam_width = max_beam_width
@@ -196,6 +212,9 @@ class ADEngine(ModelEngine):
         extra_args: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         dummy_token = -1
+        num_ctx_requests = len(context_requests)
+        num_ctx_tokens = 0
+        num_generation_tokens = 0
 
         # look at context requests first
         for request in context_requests:
@@ -206,6 +225,7 @@ class ADEngine(ModelEngine):
             begin_compute = request.context_current_position
             end_compute = begin_compute + request.context_chunk_size
             prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
+            num_ctx_tokens += len(prompt_tokens)
 
             input_ids.append(prompt_tokens)
             input_pos.append(begin_compute)
@@ -238,6 +258,7 @@ class ADEngine(ModelEngine):
                 input_pos.append(request.max_beam_num_tokens)
                 flat_gather_idx.append(request.py_batch_idx)
 
+            num_generation_tokens += 1
             request.py_batch_idx = request.seq_slot
 
             # store seq slot idx
@@ -267,6 +288,10 @@ class ADEngine(ModelEngine):
                 scatter_ref=dummy_token,
             )
 
+        self.iter_states["num_ctx_requests"] = num_ctx_requests
+        self.iter_states["num_ctx_tokens"] = num_ctx_tokens
+        # TODO: handle extend requests and draft requests for specdec
+        self.iter_states["num_generation_tokens"] = num_generation_tokens
         return last_logit_only
 
     @nvtx_range("ad_compute_logits")
@@ -294,6 +319,7 @@ class ADEngine(ModelEngine):
         # convert requests and store in sequence info object
         new_tokens = getattr(new_tensors_device, "new_tokens", None)
         last_logit_only = self._prepare_inputs(scheduled_requests, resource_manager, new_tokens)
+        self.iter_counter += 1
 
         # compute all logits
         logits = self._compute_logits()

--- a/tensorrt_llm/bench/benchmark/__init__.py
+++ b/tensorrt_llm/bench/benchmark/__init__.py
@@ -107,11 +107,11 @@ def get_llm(runtime_config: RuntimeConfig, kwargs: dict):
     if runtime_config.backend != None:
         ignore_trt_only_args(kwargs, runtime_config.backend)
 
+    if runtime_config.iteration_log is not None:
+        kwargs["enable_iter_perf_stats"] = True
+
     if runtime_config.backend == 'pytorch':
         llm_cls = PyTorchLLM
-
-        if runtime_config.iteration_log is not None:
-            kwargs["enable_iter_perf_stats"] = True
 
     elif runtime_config.backend == "_autodeploy":
         from tensorrt_llm._torch.auto_deploy import LLM as AutoDeployLLM

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_bench.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_bench.py
@@ -31,12 +31,19 @@ def run_benchmark(
             "_autodeploy",
             "--dataset",
             dataset_path,
+            "--iteration_log",
+            "iteration_log.log",
             "--extra_llm_api_options",
             f"{extra_llm_api_options_path}",
         ]
     )
     result = runner.invoke(main, args, catch_exceptions=False)
     assert result.exit_code == 0
+
+    with open("iteration_log.log", "r") as f:
+        lines = f.readlines()
+    assert len(lines) > 0
+    # TODO: add more checks
 
 
 def prepare_dataset(root_dir: str, temp_dir: str, model_path_or_name: str):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration options to enable iteration-level performance statistics and per-request statistics tracking during model inference.
  * Iteration performance tracking is now available across multiple backends.

* **Tests**
  * Added verification of iteration log file generation in benchmarking tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Closes [#9237 ](https://github.com/NVIDIA/TensorRT-LLM/issues/9237) Add config arguments to enable iteration perf and request stats. Outputs look like this - 
```json
{'cpuMemUsage': 0, 'gpuMemUsage': 84337360896, 'inflightBatchingStats': {'avgNumDecodedTokensPerIter': 0.0, 'microBatchId': 0, 'numContextRequests': 9, 'numCtxTokens': 8128, 'numGenRequests': 1, 'numPausedRequests': 0, 'numScheduledRequests': 10}, 'iter': 1005, 'iterLatencyMS': 20223.264455795288, 'kvCacheStats': {'allocNewBlocks': 352, 'allocTotalBlocks': 352, 'cacheHitRate': 0.0, 'freeNumBlocks': 61071, 'maxNumBlocks': 61359, 'missedBlocks': 0, 'reusedBlocks': 0, 'tokensPerBlock': 64, 'usedNumBlocks': 288}, 'maxBatchSizeRuntime': 0, 'maxBatchSizeStatic': 0, 'maxBatchSizeTunerRecommended': 0, 'maxNumActiveRequests': 384, 'maxNumTokensRuntime': 0, 'maxNumTokensStatic': 0, 'maxNumTokensTunerRecommended': 0, 'newActiveRequestsQueueLatencyMS': 33.22242760658264, 'numActiveRequests': 256, 'numCompletedRequests': 0, 'numNewActiveRequests': 255, 'numQueuedRequests': 0, 'pinnedMemUsage': 0, 'specDecodingStats': None, 'staticBatchingStats': {'emptyGenSlots': 0, 'numContextRequests': 0, 'numCtxTokens': 0, 'numGenTokens': 0, 'numScheduledRequests': 0}, 'timestamp': '11-18-2025 18:12:23.091437', 'requestStats': [{'allocNewBlocksPerRequest': 16, 'allocTotalBlocksPerRequest': 16, 'avgNumDecodedTokensPerIter': 1.0, 'contextPrefillPosition': 1000, 'disServingStats': None, 'id': 386, 'kvCacheHitRatePerRequest': 0.0, 'missedBlocksPerRequest': 0, 'numGeneratedTokens': 2, 'paused': False, 'reusedBlocksPerRequest': 0, 'scheduled': True, 'stage': 'GENERATION_IN_PROGRESS'}, {'allocNewBlocksPerRequest': 16, 'allocTotalBlocksPerRequest': 16, 'avgNumDecodedTokensPerIter': 1.0, 'contextPrefillPosition': 1000, 'disServingStats': None, 'id': 387, 'kvCacheHitRatePerRequest': 0.0, 'missedBlocksPerRequest': 0, 'numGeneratedTokens': 1, 'paused': False, 'reusedBlocksPerRequest': 0, 'scheduled': True, 'stage': 'GENERATION_IN_PROGRESS'},
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
