### PR TITLE
[TRTLLM-909][feat] Overlap context chunks in pipeline parallel mode

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/pauseRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/pauseRequests.cpp
@@ -50,8 +50,8 @@ void tensorrt_llm::batch_manager::PauseRequests::operator()(RequestVector& reque
         for (auto& llmReq : requestsToPause)
         {
             auto const reqId = llmReq->mRequestId;
-            inflightReqIds.erase(reqId);
-            TLLM_LOG_DEBUG("request with ID %lu removed from DECODER model inflight set", reqId);
+            auto const removed = inflightReqIds.erase(reqId);
+            TLLM_LOG_DEBUG("request with ID %lu removed from DECODER model inflight set: %d", reqId, removed);
 
             // If a request in this context had been flagged to be paused, pause it right away
             if (reqIdsToPause.find(reqId) != reqIdsToPause.end())

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -674,8 +674,10 @@ def create_py_executor_instance(
 
     spec_config = model_engine.spec_config
 
+    max_num_sequences = max_batch_size * mapping.pp_size
+
     logger.info(
-        f"max_seq_len={max_seq_len}, max_num_requests={max_batch_size}, max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}"
+        f"max_seq_len={max_seq_len}, max_num_requests={max_num_sequences}, max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}"
     )
 
     for key, value in llm_args.extra_resource_managers.items():
@@ -759,8 +761,6 @@ def create_py_executor_instance(
             lora_config.lora_target_modules,
             lora_config.trtllm_modules_to_hf_modules,
             lora_config.swap_gate_up_proj_lora_b_weight)
-
-    max_num_sequences = max_batch_size * mapping.pp_size
 
     resources[ResourceManagerType.SEQ_SLOT_MANAGER] = SeqSlotManager(
         max_num_sequences)

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2046,39 +2046,64 @@ def test_llm_handling_per_request_submit_error():
     batch_task()
 
 
-def validate_stats(results,
-                   pytorch_backend,
-                   max_tokens,
-                   enable_iter_req_stats=False):
+def validate_stats(
+    *,
+    results,
+    pytorch_backend,
+    max_tokens,
+    use_overlap=False,
+    enable_chunked_prefill=False,
+    enable_iter_req_stats=False,
+):
     assert results
-    assert len(results) == max_tokens if pytorch_backend else max_tokens + 1
+    expected_num_results = max_tokens if pytorch_backend else max_tokens + 1
+    if enable_chunked_prefill:
+        expected_num_results += 1
+    assert len(results) == expected_num_results
+
+    context_iterations = 2 if enable_chunked_prefill else 1
+    generation_iterations = max_tokens - 1
     for iter, result in enumerate(results):
         ifbStats = result["inflightBatchingStats"]
-        expected_num_scheduled = 1 if (iter < max_tokens) else 0
-        assert ifbStats["numScheduledRequests"] == expected_num_scheduled
-        if iter == 0:
+
+        if iter < context_iterations:
+            assert ifbStats["numScheduledRequests"] == 1
             assert ifbStats["numContextRequests"] == 1
             assert ifbStats["numGenRequests"] == 0
             assert result["numActiveRequests"] == 1
-        elif iter == max_tokens:
-            assert ifbStats["numContextRequests"] == 0
-            assert ifbStats["numGenRequests"] == 0
-            assert result["numActiveRequests"] == 0
-        else:
+        elif iter < (context_iterations + generation_iterations):
+            assert ifbStats["numScheduledRequests"] == 1
             assert ifbStats["numContextRequests"] == 0
             assert ifbStats["numGenRequests"] == 1
             assert result["numActiveRequests"] == 1
+        else:
+            assert ifbStats["numScheduledRequests"] == 0
+            assert ifbStats["numContextRequests"] == 0
+            assert ifbStats["numGenRequests"] == 0
+            assert result["numActiveRequests"] == 0
 
         if enable_iter_req_stats:
             assert "requestStats" in result
             req_stats = result["requestStats"]
             assert len(req_stats) == 1
             req_stat = req_stats[0]
-            assert req_stat["numGeneratedTokens"] == iter + 1
+            if iter < (context_iterations - 1):
+                # If use_overlap, the stats are one iteration ahead
+                assert req_stat[
+                    "stage"] == "GENERATION_IN_PROGRESS" if use_overlap else "CONTEXT_IN_PROGRESS"
+                assert req_stat[
+                    "contextPrefillPosition"] == 54 if use_overlap else 32
+                assert req_stat["numGeneratedTokens"] == 0
+            elif iter < (context_iterations - 1 + generation_iterations):
+                assert req_stat["stage"] == "GENERATION_IN_PROGRESS"
+                assert req_stat["contextPrefillPosition"] == 54
+                assert req_stat["numGeneratedTokens"] == iter - (
+                    context_iterations - 1) + 1
+            else:
+                assert req_stat["stage"] == "GENERATION_COMPLETE"
+                assert req_stat["contextPrefillPosition"] == 54
+                assert req_stat["numGeneratedTokens"] == max_tokens
             assert req_stat["scheduled"] == True
-            assert req_stat[
-                "stage"] == "GENERATION_IN_PROGRESS" if iter + 1 < max_tokens else "GENERATION_COMPLETE"
-            assert req_stat["contextPrefillPosition"] == 4
 
         expected_num_completed = 1 if iter == len(results) - 1 else 0
 
@@ -2088,9 +2113,11 @@ def validate_stats(results,
 
 
 def llm_get_stats_test_harness(tp_size: int = 1,
+                               pp_size: int = 1,
                                return_context_logits: bool = False,
                                pytorch_backend: bool = False,
                                use_overlap: bool = False,
+                               enable_chunked_prefill: bool = False,
                                enable_iter_req_stats: bool = False):
 
     if return_context_logits and pytorch_backend:
@@ -2104,6 +2131,7 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     print("return_context_logits: ", return_context_logits)
     print("pytorch_backend: ", pytorch_backend)
     print("use_overlap: ", use_overlap)
+    print("enable_chunked_prefill: ", enable_chunked_prefill)
     print("enable_iter_req_stats: ", enable_iter_req_stats)
     print("-------------")
 
@@ -2113,6 +2141,10 @@ def llm_get_stats_test_harness(tp_size: int = 1,
         llm_args_extra["build_config"] = BuildConfig(gather_context_logits=True)
         llm_args_extra["gather_generation_logits"] = True
         sampling_args_extra["return_context_logits"] = True
+
+    if enable_chunked_prefill:
+        llm_args_extra["enable_chunked_prefill"] = True
+        llm_args_extra["max_num_tokens"] = 32
 
     if pytorch_backend:
         llm_args_extra.update(
@@ -2126,27 +2158,38 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     if not pytorch_backend:
         llm_args_extra["fast_build"] = True
 
-    llm = LLM_CLASS(model=llama_model_path,
-                    kv_cache_config=global_kvcache_config,
-                    tensor_parallel_size=tp_size,
-                    **llm_args_extra)
+    with LLM_CLASS(model=llama_model_path,
+                   kv_cache_config=global_kvcache_config,
+                   tensor_parallel_size=tp_size,
+                   pipeline_parallel_size=pp_size,
+                   **llm_args_extra) as llm:
 
-    max_tokens = 5
-    sampling_params = SamplingParams(max_tokens=max_tokens,
-                                     **sampling_args_extra)
+        max_tokens = 5
+        sampling_params = SamplingParams(max_tokens=max_tokens,
+                                         **sampling_args_extra)
 
-    for output in llm.generate(prompts, sampling_params=sampling_params):
-        print(output)
+        long_prompts = [
+            "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z " * 2
+        ]
 
-    results = llm.get_stats(2)
+        for output in llm.generate(long_prompts,
+                                   sampling_params=sampling_params):
+            print(output)
 
-    validate_stats(results, pytorch_backend, max_tokens, enable_iter_req_stats)
+        results = llm.get_stats(2)
 
-    assert not llm.get_stats(2)
+        validate_stats(results=results,
+                       pytorch_backend=pytorch_backend,
+                       max_tokens=max_tokens,
+                       use_overlap=use_overlap,
+                       enable_chunked_prefill=enable_chunked_prefill,
+                       enable_iter_req_stats=enable_iter_req_stats)
 
-    # test that IterationResult()._done is properly set
-    _ = llm.generate(prompts, sampling_params=sampling_params)
-    assert llm.get_stats(2)
+        assert not llm.get_stats(2)
+
+        # test that IterationResult()._done is properly set
+        _ = llm.generate(prompts, sampling_params=sampling_params)
+        assert llm.get_stats(2)
 
 
 @pytest.mark.parametrize("return_context_logits", [True, False])
@@ -2214,9 +2257,11 @@ def test_llm_get_queued_stats():
 
 
 def llm_get_stats_async_test_harness(tp_size: int = 1,
+                                     pp_size: int = 1,
                                      return_context_logits: bool = False,
                                      pytorch_backend: bool = False,
                                      use_overlap: bool = False,
+                                     enable_chunked_prefill: bool = False,
                                      enable_iter_req_stats: bool = False):
 
     if return_context_logits and pytorch_backend:
@@ -2230,6 +2275,7 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
     print("return_context_logits: ", return_context_logits)
     print("pytorch_backend: ", pytorch_backend)
     print("use_overlap: ", use_overlap)
+    print("enable_chunked_prefill: ", enable_chunked_prefill)
     print("enable_iter_req_stats: ", enable_iter_req_stats)
     print("-------------")
 
@@ -2238,6 +2284,10 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
     if return_context_logits:
         llm_args_extra["build_config"] = BuildConfig(gather_context_logits=True)
         sampling_args_extra["return_context_logits"] = True
+
+    if enable_chunked_prefill:
+        llm_args_extra["enable_chunked_prefill"] = True
+        llm_args_extra["max_num_tokens"] = 32
 
     if pytorch_backend:
         llm_args_extra.update(
@@ -2249,38 +2299,47 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
         LLM_CLASS = LLM
         llm_args_extra["fast_build"] = True
 
-    llm = LLM_CLASS(model=llama_model_path,
-                    kv_cache_config=global_kvcache_config,
-                    tensor_parallel_size=tp_size,
-                    **llm_args_extra)
+    with LLM_CLASS(model=llama_model_path,
+                   kv_cache_config=global_kvcache_config,
+                   tensor_parallel_size=tp_size,
+                   **llm_args_extra) as llm:
 
-    max_tokens = 6
-    sampling_params = SamplingParams(max_tokens=max_tokens,
-                                     **sampling_args_extra)
+        max_tokens = 6
+        sampling_params = SamplingParams(max_tokens=max_tokens,
+                                         **sampling_args_extra)
 
-    async def task0():
-        async for output in llm.generate_async(prompts[0],
-                                               streaming=True,
-                                               sampling_params=sampling_params):
-            print(output)
+        long_prompts = [
+            "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z " * 2
+        ]
 
-    async def task1():
-        results = []
-        await asyncio.sleep(
-            3)  # ensure there's stats to collect for the assertion
-        async for stats in llm.get_stats_async(timeout=2):
-            results.append(stats)
+        async def task0():
+            async for output in llm.generate_async(
+                    long_prompts[0],
+                    streaming=True,
+                    sampling_params=sampling_params):
+                print(output)
 
-        assert results
-        if not use_overlap:
-            validate_stats(results, pytorch_backend, max_tokens,
-                           enable_iter_req_stats)
+        async def task1():
+            results = []
+            await asyncio.sleep(
+                3)  # ensure there's stats to collect for the assertion
+            async for stats in llm.get_stats_async(timeout=2):
+                results.append(stats)
 
-    async def main():
-        for i in range(2):  # test recurrent usage
-            await asyncio.gather(task0(), task1())
+            assert results
+            if not use_overlap:
+                validate_stats(results=results,
+                               pytorch_backend=pytorch_backend,
+                               max_tokens=max_tokens,
+                               use_overlap=use_overlap,
+                               enable_chunked_prefill=enable_chunked_prefill,
+                               enable_iter_req_stats=enable_iter_req_stats)
 
-    asyncio.run(main())
+        async def main():
+            for i in range(2):  # test recurrent usage
+                await asyncio.gather(task0(), task1())
+
+        asyncio.run(main())
 
 
 @pytest.mark.parametrize("return_context_logits", [True, False])

--- a/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
@@ -11,6 +11,7 @@ from .lora_test_utils import (
     check_llama_7b_multi_lora_from_request_test_harness,
     check_phi3_lora_fused_modules_output_tp2_identical_to_tp1)
 from .test_llm import (_test_llm_capture_request_error, llama_model_path,
+                       llm_get_stats_test_harness,
                        llm_return_logprobs_test_harness,
                        tinyllama_logits_processor_test_harness)
 from .test_llm_pytorch import llama_7b_lora_from_dir_test_harness
@@ -125,3 +126,45 @@ def test_llm_return_logprobs_streaming_tp2(prompt_logprobs, logprobs,
                                      streaming=True,
                                      backend="pytorch",
                                      tp_size=2)
+
+
+@skip_ray
+@pytest.mark.gpu2
+@pytest.mark.parametrize(
+    "return_context_logits, enable_chunked_prefill, enable_iter_req_stats",
+    [
+        (False, False, True),
+        (False, True, True),
+    ],
+)
+def test_llm_get_stats_pp2(return_context_logits, enable_chunked_prefill,
+                           enable_iter_req_stats):
+    llm_get_stats_test_harness(
+        tp_size=1,
+        pp_size=2,
+        return_context_logits=return_context_logits,
+        pytorch_backend=True,
+        enable_chunked_prefill=enable_chunked_prefill,
+        enable_iter_req_stats=enable_iter_req_stats,
+    )
+
+
+@skip_ray
+@pytest.mark.gpu4
+@pytest.mark.parametrize(
+    "return_context_logits, enable_chunked_prefill, enable_iter_req_stats",
+    [
+        (False, False, True),
+        (False, True, True),
+    ],
+)
+def test_llm_get_stats_pp4(return_context_logits, enable_chunked_prefill,
+                           enable_iter_req_stats):
+    llm_get_stats_test_harness(
+        tp_size=1,
+        pp_size=4,
+        return_context_logits=return_context_logits,
+        pytorch_backend=True,
+        enable_chunked_prefill=enable_chunked_prefill,
+        enable_iter_req_stats=enable_iter_req_stats,
+    )

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -54,36 +54,40 @@ def test_tinyllama_logits_processor(enable_chunked_prefill):
 
 @skip_ray
 @pytest.mark.parametrize(
-    "return_context_logits, use_overlap, enable_iter_req_stats", [
-        (False, False, False),
-        (False, False, True),
-        (False, True, False),
-        (False, True, True),
+    "return_context_logits, use_overlap, enable_chunked_prefill, enable_iter_req_stats",
+    [
+        (False, False, False, True),
+        (False, False, True, True),
+        (False, True, False, True),
+        (False, True, True, True),
     ])
 def test_llm_get_stats(return_context_logits, use_overlap,
-                       enable_iter_req_stats):
+                       enable_chunked_prefill, enable_iter_req_stats):
     llm_get_stats_test_harness(tp_size=1,
+                               pp_size=1,
                                return_context_logits=return_context_logits,
                                pytorch_backend=True,
                                use_overlap=use_overlap,
+                               enable_chunked_prefill=enable_chunked_prefill,
                                enable_iter_req_stats=enable_iter_req_stats)
 
 
 @skip_ray
 @pytest.mark.parametrize(
-    "return_context_logits, use_overlap, enable_iter_req_stats", [
-        (False, False, False),
-        (False, False, True),
-        (False, True, False),
-        (False, True, True),
+    "return_context_logits, use_overlap, enable_chunked_prefill, enable_iter_req_stats",
+    [
+        (False, False, False, True),
+        (False, True, False, True),
     ])
 def test_llm_get_stats_async(return_context_logits, use_overlap,
-                             enable_iter_req_stats):
+                             enable_chunked_prefill, enable_iter_req_stats):
     llm_get_stats_async_test_harness(
         tp_size=1,
+        pp_size=1,
         return_context_logits=return_context_logits,
         pytorch_backend=True,
         use_overlap=use_overlap,
+        enable_chunked_prefill=enable_chunked_prefill,
         enable_iter_req_stats=enable_iter_req_stats)
 
 

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -77,7 +77,9 @@ def test_llm_get_stats(return_context_logits, use_overlap,
     "return_context_logits, use_overlap, enable_chunked_prefill, enable_iter_req_stats",
     [
         (False, False, False, True),
+        (False, False, True, True),
         (False, True, False, True),
+        (False, True, True, True),
     ])
 def test_llm_get_stats_async(return_context_logits, use_overlap,
                              enable_chunked_prefill, enable_iter_req_stats):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch request tracking and processing to correctly manage context and generation request flows in pipeline execution.
  * Enhanced concurrent request capacity calculations to properly account for distributed processing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- For context chunks there is no dependency on the results of the last pipeline rank, so they can be scheduled in each iteration.
- To achieve this context requests that are chunking are not added to inflight set, so they are scheduled in the next micro batch.
- Context requests that reach the last context chunk are added to inflight set, so they are not scheduled in the next micro batch and generation can run without overlap.

## Benchmark

Somewhat artificial benchmark to show the benefits:
- Hardware: 2xA100 PCIe with pipeline parallelism (PP=2)
- Model: Qwen3-0.6B
- Dataset: 256 requests, ISL=8K, OSL=1
- trtllm-bench with concurrency=1

| Backend  | Branch   | max_num_tokens | Req/s | Out tok/s | Total tok/s | Avg Latency (ms) |
|----------|----------|----------------|-------|-----------|-------------|------------------|
| pytorch  | main     | 32768 (no chunking)    | 7.80  | 7.80      | 63929.70    | 128.12           |
| pytorch  | overlap  | 32768 (no chunking)    | 7.81  | 7.81      | 63974.95    | 128.03           |
| pytorch  | main     | 2048 (chunking)        | 6.86  | 6.86      | 56213.56    | 145.71           |
| **pytorch**  | **overlap**  | **2048 (chunking)**        | **9.98**  | **9.98**      | **81730.08**    | **100.21**           |
| tensorrt | main     | 32768 (no chunking)    | 6.97  | 6.97      | 57126.19    | 143.38           |
| tensorrt | overlap  | 32768 (no chunking)    | 7.14  | 7.14      | 58478.51    | 140.07           |
| tensorrt | main     | 2048 (chunking)        | 4.84  | 4.84      | 39644.04    | 206.63           |
| **tensorrt** | **overlap**  | **2048 (chunking)**        | **6.87**  | **6.87**      | **56272.15**    | **145.56**           |

## Test Coverage

- Updated the `llm_get_stats_test_harness` to include chunked prefill and pipeline parallelism support. 
- Added micro batch ID tracking to verify the new pipeline parallel mode behavior with chunked prefill enabled.
- Added test cases for PP size 2 and 4.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
