### PR TITLE
[TRTLLM-9228][infra] Verify thirdparty C++ process

### DIFF
--- a/tests/integration/defs/thirdparty/test_cmake_third_party.py
+++ b/tests/integration/defs/thirdparty/test_cmake_third_party.py
@@ -1,0 +1,163 @@
+"""Find bad third-party usage in cmake.
+
+This script searches for cmake function invocations that might indicate
+the addition of new third-party dependencies outside of the intended
+process (3rdparty/README.md).
+"""
+
+import argparse
+import collections
+import logging
+import os
+import pathlib
+import sys
+from typing import Generator
+
+logger = logging.getLogger(__name__)
+
+IGNORE_PATTERNS = [
+    ".*",  # Hidden files and directories, like .git
+    # This is where we actually want third-party stuff to go
+    "3rdparty/CMakeLists.txt",
+    # Historical use of ExternalProject_Add that is not yet migrated to 3rdparty
+    "cpp/tensorrt_llm/deep_ep/CMakeLists.txt",
+    # Historical build that is not included in the wheel build and thus exempt
+    # from the third-party process.
+    "triton_backend/inflight_batcher_llm/*",
+    "build",  # Default build directory
+    "cpp/build",  # Default extension module build directory
+]
+
+
+class DirectoryFilter:
+    """Callable filter for directories.
+
+    This filter excludes any paths matching IGNORE_PATTERNS.
+    """
+
+    def __init__(self, parent: pathlib.Path):
+        self.parent = parent
+
+    def __call__(self, name: str) -> bool:
+        path = self.parent / name
+        if any(path.match(pat) for pat in IGNORE_PATTERNS):
+            return False
+        return True
+
+
+class FileFilter:
+    """Callable filter for file entries.
+
+    In order of precedence:
+
+    1. excludes any paths matching IGNORE_PATTERNS
+    2. includes only CMakeLists.txt and *.cmake files
+    """
+
+    def __init__(self, parent: pathlib.Path):
+        self.parent = parent
+
+    def __call__(self, name: str) -> bool:
+        path = self.parent / name
+        if any(path.match(pat) for pat in IGNORE_PATTERNS):
+            return False
+
+        if name == "CMakeLists.txt":
+            return True
+        elif name.endswith(".cmake"):
+            return True
+
+        return False
+
+
+def yield_sources(src_tree: pathlib.Path):
+    """Perform a filesystem walk and yield any paths that should be scanned."""
+    for parent, dirs, files in os.walk(src_tree):
+        parent = pathlib.Path(parent)
+        relpath_parent = parent.relative_to(src_tree)
+
+        # Filter out ignored directories
+        dirs[:] = sorted(filter(DirectoryFilter(relpath_parent), dirs))
+
+        for file in sorted(filter(FileFilter(relpath_parent), files)):
+            yield parent / file
+
+
+ThirdpartyViolation = collections.namedtuple(
+    "ThirdpartyViolation", ["srcfile", "lineno", "note", "line"]
+)
+
+
+def yield_potential_thirdparty(
+    fullpath: pathlib.Path, relpath: pathlib.Path
+) -> Generator[ThirdpartyViolation, None, None]:
+    """Look for bad patterns with third-party sources.
+
+    Look for patterns that might indicate the addition of new third-party
+    sources.
+    """
+    with fullpath.open("r", encoding="utf-8") as infile:
+        for lineno, line in enumerate(infile):
+            lineno += 1  # Make line numbers 1-based
+
+            if "FetchContent_Declare" in line:
+                note = "Invalid use of FetchContent_Declare outside of 3rdparty/CMakeLists.txt"
+                yield ThirdpartyViolation(relpath, lineno, note, line.strip())
+
+            if "ExternalProject_Add" in line:
+                note = "Invalid use of ExternalProject_Add outside of 3rdparty/CMakeLists.txt"
+                yield ThirdpartyViolation(relpath, lineno, note, line.strip())
+
+
+def check_sources(src_tree: pathlib.Path) -> int:
+    """Common entry-point between main() and pytest.
+
+    Prints any violations to stderr and returns non-zero if any violations are
+    found.
+    """
+    violations = []
+    for filepath in yield_sources(src_tree):
+        for violation in yield_potential_thirdparty(filepath, filepath.relative_to(src_tree)):
+            violations.append(violation)
+
+    if not violations:
+        return 0
+
+    for violation in sorted(violations):
+        sys.stderr.write(
+            f"{violation.srcfile}:{violation.lineno}: {violation.note}\n"
+            + f"    {violation.line}\n"
+        )
+
+    logger.error(
+        "Found %d potential third-party violations. "
+        "If you are trying to add a new third-party dependency, "
+        "please follow the instructions in 3rdparty/cpp-thirdparty.md",
+        len(violations),
+    )
+    return 1
+
+
+def test_cmake_listfiles():
+    """Test that no third-party violations are found in the source tree."""
+    source_tree = pathlib.Path(__file__).parents[1]
+    result = check_sources(source_tree)
+    assert result == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="__doc__")
+    parser.add_argument(
+        "--src-tree",
+        default=pathlib.Path.cwd(),
+        type=pathlib.Path,
+        help="Path to the source tree, defaults to current directory",
+    )
+    args = parser.parse_args()
+    result = check_sources(args.src_tree)
+    sys.exit(result)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/integration/defs/thirdparty/test_git_modules.py
+++ b/tests/integration/defs/thirdparty/test_git_modules.py
@@ -1,0 +1,105 @@
+"""This script audits the .gitmodules file.
+
+... to make sure that new git submodules are not added without following the
+proper process (cpp/3rdparty/cpp-thirdparty.md)
+"""
+
+import argparse
+import collections
+import configparser
+import logging
+import pathlib
+import sys
+
+logger = logging.getLogger(__name__)
+
+ALLOWLIST_SUBMODULES = [
+    # NOTE: please do not add new sobmodules here without following the process
+    # in 3rdparty/cpp-thirdparty.md. Prefer to use FetchContent or other methods
+    # to avoid adding new git submodules unless absolutely necessary.
+]
+
+ThirdpartyViolation = collections.namedtuple("ThirdpartyViolation", ["section", "path", "note"])
+
+
+def find_violations(config: configparser.ConfigParser) -> list[str]:
+    violations = []
+    for section in config.sections():
+        if not section.startswith("submodule "):
+            raise ValueError(f"Unexpected section in .gitmodules: {section}")
+
+        path = config[section].get("path", "")
+        if not path:
+            raise ValueError(f"Missing path for submodule {section}")
+
+        if path not in ALLOWLIST_SUBMODULES:
+            violations.append(
+                ThirdpartyViolation(
+                    section=section,
+                    path=path,
+                    note="Submodule not in allowlist (see test_git_modules.py)",
+                )
+            )
+
+        if not path.startswith("3rdparty/"):
+            violations.append(
+                ThirdpartyViolation(
+                    section=section,
+                    path=path,
+                    note="Submodule path must be under 3rdparty/",
+                )
+            )
+    return violations
+
+
+def check_modules_file(git_modules_path: pathlib.Path) -> int:
+    """Common entry-point between main() and pytest.
+
+    Prints any violations to stderr and returns non-zero if any violations are
+    found.
+    """
+    config = configparser.ConfigParser()
+    config.read(git_modules_path)
+
+    violations = find_violations(config)
+
+    if violations:
+        for violation in violations:
+            sys.stderr.write(f"{violation.section} (path={violation.path}): {violation.note}\n")
+
+        logger.error(
+            "Found %d potential third-party violations. "
+            "If you are trying to add a new third-party dependency, "
+            "please follow the instructions in cpp/3rdparty/cpp-thirdparty.md",
+            len(violations),
+        )
+        return 1
+    return 0
+
+
+def test_gitmodules():
+    """Test that no git submodules are added to .gitmodules.
+
+    ... without following the defined process.
+    """
+    git_modules_path = pathlib.Path(__file__).parents[1] / ".gitmodules"
+    result = check_modules_file(git_modules_path)
+    assert result == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="__doc__")
+    parser.add_argument(
+        "--git-modules-path",
+        default=pathlib.Path(".gitmodules"),
+        type=pathlib.Path,
+        help="Path to the .gitmodules file, defaults to .gitmodules in current directory",
+    )
+    args = parser.parse_args()
+    result = check_modules_file(args.git_modules_path)
+    sys.exit(result)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -93,6 +93,9 @@ l0_a10:
   - llmapi/test_llm_api_connector.py::test_connector_disagg_prefill[False]
   - llmapi/test_llm_api_connector.py::test_connector_disagg_prefill[True]
   - llmapi/test_llm_api_connector.py::test_connector_multi_request
+  # third-party policy checks CPU-only
+  - thirdparty/test_cmake_third_party.py::test_cmake_listfiles
+  - thirdparty/test_git_modules.py::test_gitmodules
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
## Description

This change adds two tests to help ensure that thirdparty C++ code is integrated according to the process descripted in
3rdparty/cpp-thirdparty.md. The desired process requires folks to use FetchContent_Declare in 3rdparty/CMakeLists.txt. The two tests added here search the following deviations of the desired process:

1. uses of FetchContent_Declare or ExternalProject_Add outside of 3rdparty/CMakeLists.txt
2. new git-submodules added to the repo

Both scripts have the ability to allow-list exemptions if there are any cases in the future where a deviation is warranted. The scripts live in 3rdparty/* where CODEOWNERS ensures that process reviewers will be required on any new exemptions added to the allowlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation suite for third-party dependency management
  * Includes automated checks for CMake configuration patterns and git submodule organization
  * Ensures adherence to project dependency policies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
