### PR TITLE
[TRTLLM-9227][infra] Add Dockerfile step to copy sources

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -129,6 +129,9 @@ ARG BUILD_WHEEL_ARGS="--clean --benchmarks"
 ARG BUILD_WHEEL_SCRIPT="scripts/build_wheel.py"
 RUN --mount=type=cache,target=/root/.cache/pip --mount=type=cache,target=${CCACHE_DIR} \
     GITHUB_MIRROR=$GITHUB_MIRROR python3 ${BUILD_WHEEL_SCRIPT} ${BUILD_WHEEL_ARGS}
+RUN python3 scripts/copy_third_party_sources.py \
+      --deps-dir cpp/build/_deps \
+      --output-dir /third-party-sources
 
 FROM ${DEVEL_IMAGE} AS release
 
@@ -168,6 +171,8 @@ RUN chmod -R a+w examples && \
       benchmarks/cpp/disaggServerBenchmark.cpp \
       benchmarks/cpp/CMakeLists.txt && \
     rm -rf /root/.cache/pip
+
+COPY --from=wheel /third-party-sources /third-party-sources
 
 ARG GIT_COMMIT
 ARG TRT_LLM_VER

--- a/scripts/copy_third_party_sources.py
+++ b/scripts/copy_third_party_sources.py
@@ -1,0 +1,52 @@
+"""Copy third-party sources used in the cmake build to a container directory.
+
+The purpose of this script is to simplify the process of producing third party
+sources "as used" in the build. We package up all of the sources we use and
+stash them in a location in the container so that they are automatically
+distributed alongside the build artifacts ensuring that we comply with the
+license requirements in an obvious and transparent manner.
+"""
+
+import argparse
+import logging
+import pathlib
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--deps-dir",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the third party dependencies directory, e.g. ${CMAKE_BINARY_DIR}/_deps",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the output directory where third party sources will be copied",
+    )
+
+    args = parser.parse_args()
+
+    src_dirs = list(sorted(args.deps_dir.glob("*-src")))
+    if not src_dirs:
+        raise ValueError(f"No source directories found in {args.deps_dir}")
+
+    for src_dir in src_dirs:
+        tarball_name = src_dir.name[:-4] + ".tar.gz"
+        output_path = args.output_dir / tarball_name
+        logger.info(f"Creating tarball {output_path} from {src_dir}")
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["tar", "-czf", str(output_path), "-C", str(src_dir.parent), src_dir.name],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
## Description

In this change we add a new Dockerfile step which copies third-party source files into the container image. This is necessary for compliance with certain open source licenses which require source code availability. Distributing the sources as-used in the container image is a simple and direct way of ensuring the sources are used and mapped to the version that was built in the container.

The script to perform this step relies on the C++ third-party process which requires third-party libraries to be integrated with CMake's FetchContent modules. The script scans the _deps/ directory and collects all the *-src directories which are created by FetchContent. It archives these into same-named tarballs and places them in `/third_party_sources/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to package and distribute third-party sources with release artifacts, enabling dependency access for benchmarking tools and supporting license compliance requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Test Coverage

To verify this change, I ran the following two docker builds locally and checked the contents of the /third-party-sources folder:

```
make -C docker wheel_build
make -C docker wheel_run
root@ef0a361-lcedt-wheel:/src/tensorrt_llm# ls -l /third-party-sources/
total 514132
-rw-r--r-- 1 root root    189287 Nov 21 21:27 cppzmq.tar.gz
-rw-r--r-- 1 root root  88219963 Nov 21 21:27 cutlass.tar.gz
-rw-r--r-- 1 root root    412553 Nov 21 21:27 cxxopts.tar.gz
-rw-r--r-- 1 root root   1248001 Nov 21 21:27 deep_ep_download.tar.gz
-rw-r--r-- 1 root root 113610083 Nov 21 21:27 deepgemm.tar.gz
-rw-r--r-- 1 root root  91733403 Nov 21 21:27 flashmla.tar.gz
-rw-r--r-- 1 root root   3875168 Nov 21 21:27 googletest.tar.gz
-rw-r--r-- 1 root root 175653443 Nov 21 21:28 json.tar.gz
-rw-r--r-- 1 root root   5660149 Nov 21 21:28 nanobind.tar.gz
-rw-r--r-- 1 root root  14621183 Nov 21 21:28 pybind11.tar.gz
-rw-r--r-- 1 root root   3418436 Nov 21 21:28 ucxx.tar.gz
-rw-r--r-- 1 root root  27792205 Nov 21 21:28 xgrammar.tar.gz
```

```
make -C docker release_build
make -C docker release_run

root@ef0a361-lcedt-release:/app/tensorrt_llm# ls -l /third-party-sources/
total 513696
-rw-r--r-- 1 root root    189480 Nov 24 10:15 cppzmq.tar.gz
-rw-r--r-- 1 root root  88221022 Nov 24 10:15 cutlass.tar.gz
-rw-r--r-- 1 root root    412565 Nov 24 10:15 cxxopts.tar.gz
-rw-r--r-- 1 root root   1247997 Nov 24 10:15 deep_ep_download.tar.gz
-rw-r--r-- 1 root root 113541698 Nov 24 10:15 deepgemm.tar.gz
-rw-r--r-- 1 root root  91733800 Nov 24 10:15 flashmla.tar.gz
-rw-r--r-- 1 root root   3860713 Nov 24 10:15 googletest.tar.gz
-rw-r--r-- 1 root root 175648406 Nov 24 10:15 json.tar.gz
-rw-r--r-- 1 root root   5650106 Nov 24 10:15 nanobind.tar.gz
-rw-r--r-- 1 root root  14272506 Nov 24 10:15 pybind11.tar.gz
-rw-r--r-- 1 root root   3402718 Nov 24 10:15 ucxx.tar.gz
-rw-r--r-- 1 root root  27822117 Nov 24 10:15 xgrammar.tar.gz
```

For completeness: I had to use the following additional patch in order to successfully build locally due to the RAM:core ratio on my machine, and the fact that the source directory is a git-worktree.  

```
diff --git a/docker/Dockerfile.multi b/docker/Dockerfile.multi
index e4b7c74faf..78e981c3b9 100644
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -125,7 +125,7 @@ RUN mkdir -p /root/.cache/pip /root/.cache/ccache
 ENV CCACHE_DIR=/root/.cache/ccache
 # Build the TRT-LLM wheel
 ARG GITHUB_MIRROR=""
-ARG BUILD_WHEEL_ARGS="--clean --benchmarks"
+ARG BUILD_WHEEL_ARGS="--clean --benchmarks --job_count 16"
 ARG BUILD_WHEEL_SCRIPT="scripts/build_wheel.py"
 RUN --mount=type=cache,target=/root/.cache/pip --mount=type=cache,target=${CCACHE_DIR} \
     GITHUB_MIRROR=$GITHUB_MIRROR python3 ${BUILD_WHEEL_SCRIPT} ${BUILD_WHEEL_ARGS}
diff --git a/docker/Makefile b/docker/Makefile
index b51ae8dfc2..1bf6d4684b 100644
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -155,6 +155,7 @@ ifeq ($(LOCAL_USER),1)
 endif
        docker run $(DOCKER_RUN_OPTS) $(DOCKER_RUN_ARGS) \
                $(GPU_OPTS) \
+                               --volume $(HOME):$(HOME) \
                --volume $(SOURCE_DIR):$(CODE_DIR) \
                $(EXTRA_VOLUMES) \
                $(if $(and $(filter 1,$(LOCAL_USER)),$(shell [ -w "$(USER_CACHE_DIR)" ] && echo 1)),--volume $(USER_CACHE_DIR):/home/$(USER_NAME)/.cache:rw) \

```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
