### PR TITLE
[TRTLLM-7967][chore] Add more tests

### DIFF
--- a/tests/integration/test_lists/qa/llm_perf_core.yml
+++ b/tests/integration/test_lists/qa/llm_perf_core.yml
@@ -22,7 +22,10 @@ llm_perf_core:
   - perf/test_perf.py::test_perf[llama_v3.1_8b-bench-pytorch-streaming-bfloat16-input_output_len:128,128]
 
   - perf/test_perf.py::test_perf[qwen2_7b_instruct-bench-pytorch-float16-input_output_len:128,128]
-  - perf/test_perf.py::test_perf[starcoder2_3b-bench-pytorch-float16-input_output_len:512,200]
+  - perf/test_perf.py::test_perf[starcoder2_3b-bench-pytorch-bfloat16-input_output_len:512,200]
+  - perf/test_perf.py::test_perf[starcoder2_3b-bench-pytorch-bfloat16-input_output_len:500,2000-con:50]
+  - perf/test_perf.py::test_perf[starcoder2_7b-bench-pytorch-bfloat16-input_output_len:500,2000-con:50]
+  - perf/test_perf.py::test_perf[starcoder2_15b-bench-pytorch-bfloat16-input_output_len:500,2000-con:100]
   - perf/test_perf.py::test_perf[mistral_7b_v0.1-bench-pytorch-float16-input_output_len:128,128]
 
   # Ministral-8B

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -172,7 +172,6 @@ perf/test_perf.py::test_perf[flan_t5_xxl-cppmanager-exe-plugin_ifb-float16-input
 perf/test_perf.py::test_perf[qwen_14b_chat-cppmanager-exe-plugin_ifb-float16-input_output_len:128,128-gpus:4] SKIP (https://nvbugspro.nvidia.com/bug/5295390)
 perf/test_perf.py::test_perf[llama_v3.1_70b-bench-bfloat16-input_output_len:1024,1024-tp:2-gpus:2] SKIP (https://nvbugspro.nvidia.com/bug/5295411)
 perf/test_perf.py::test_perf[llama_v3.1_8b_instruct-bench-bfloat16-input_output_len:128,128-quant:int8-gpus:2] SKIP (https://nvbugspro.nvidia.com/bug/5295411)
-perf/test_perf.py::test_perf[starcoder2_3b-bench-pytorch-float16-input_output_len:512,200] SKIP (https://nvbugspro.nvidia.com/bug/5295411)
 perf/test_perf.py::test_perf[bart_large_cnn-bench-float16-input_output_len:128,20] SKIP (https://nvbugspro.nvidia.com/bug/5295411)
 perf/test_perf.py::test_perf[mamba_130m-bench-float16-input_output_len:128,128] SKIP (https://nvbugspro.nvidia.com/bug/5295411)
 perf/test_perf.py::test_perf[bert_large-bench-float16-maxbs:32-input_len:128+512] SKIP (https://nvbugspro.nvidia.com/bug/5295411)

--- a/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
+++ b/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
 
@@ -323,7 +321,7 @@ def test_starcoder2_allclose_to_hf(scenario: Scenario) -> None:
 
 
 @torch.no_grad()
-def test_starcoder2_multi_lora() -> None:
+def test_starcoder2_multi_lora(tmp_path) -> None:
     """
     Test StarCoder2 3b model with multiple synthetic LoRA adapters created using PEFT.
 
@@ -341,105 +339,88 @@ def test_starcoder2_multi_lora() -> None:
 
     # Check for pretrained model
     model_path = f"{llm_models_root()}/starcoder2-3b"
-    if not os.path.exists(model_path):
-        model_path = None
-
-    if model_path is None:
-        pytest.skip("StarCoder2 3b pretrained model not found. ")
 
     # Target modules for LoRA - attention projections
     target_modules = ["attn_q", "attn_k", "attn_v", "attn_dense"]
 
-    # Set up temporary directory for LoRA adapters
-    with tempfile.TemporaryDirectory() as lora_dir:
-        print("Creating synthetic LoRA adapters for StarCoder2...")
+    # Load the pretrained model to create LoRA adapters
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True
+    )
 
-        # Load the pretrained model to create LoRA adapters
-        model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True
+    # HuggingFace module names for StarCoder2 attention
+    hf_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
+
+    peft_lora_config = PeftLoraConfig(
+        r=8,  # LoRA rank
+        lora_alpha=16,
+        target_modules=hf_modules,
+        lora_dropout=0.0,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+
+    # Create two synthetic LoRA adapters with zeroed weights
+    lora_paths = []
+    for i in range(2):
+        lora_model = get_peft_model(model, peft_lora_config)
+
+        # Zero out all LoRA parameters for deterministic testing
+        for name, param in lora_model.named_parameters():
+            if "lora_" in name:
+                param.data.zero_()
+
+        # Save the LoRA adapter
+        lora_path = tmp_path / f"lora_{i}"
+        lora_model.save_pretrained(lora_path)
+        lora_paths.append(str(lora_path))
+
+    del model
+    del lora_model
+    torch.cuda.empty_cache()
+
+    # Configure TensorRT-LLM LoRA
+    trtllm_lora_config = LoraConfig(
+        lora_target_modules=target_modules, max_lora_rank=8, max_loras=2, max_cpu_loras=2
+    )
+
+    llm = LLM(
+        model_path,
+        lora_config=trtllm_lora_config,
+        # Disable CUDA graph for LoRA (LoRA is not supported with CUDA graphs yet)
+        cuda_graph_config=None,
+    )
+
+    with llm:
+        prompts = [
+            "def fibonacci(n):",
+            "def quick_sort(arr):",
+        ]
+
+        lora_req1 = LoRARequest("lora-1", 0, lora_paths[0])
+        lora_req2 = LoRARequest("lora-2", 1, lora_paths[1])
+        lora_requests = [lora_req1, lora_req2]
+
+        # Sampling parameters
+        sampling_params = SamplingParams(
+            max_tokens=50,
+            temperature=0.0,  # Greedy decoding for deterministic output
         )
 
-        # HuggingFace module names for StarCoder2 attention
-        hf_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
+        outputs = llm.generate(prompts, sampling_params, lora_request=lora_requests)
 
-        peft_lora_config = PeftLoraConfig(
-            r=8,  # LoRA rank
-            lora_alpha=16,
-            target_modules=hf_modules,
-            lora_dropout=0.0,
-            bias="none",
-            task_type="CAUSAL_LM",
-        )
+        # Verify we got outputs for both prompts
+        assert len(outputs) == 2, f"Expected 2 outputs, got {len(outputs)}"
 
-        # Create two synthetic LoRA adapters with zeroed weights
-        lora_paths = []
-        for i in range(2):
-            print(f"Creating LoRA adapter {i + 1}/2...")
-            lora_model = get_peft_model(model, peft_lora_config)
+        # Verify each output has text
+        for i, output in enumerate(outputs):
+            assert len(output.outputs) > 0, f"Output {i} has no results"
+            assert len(output.outputs[0].text) > 0, f"Output {i} generated empty text"
 
-            # Zero out all LoRA parameters for deterministic testing
-            for name, param in lora_model.named_parameters():
-                if "lora_" in name:
-                    param.data.zero_()
+        # Test without LoRA for comparison
+        outputs_no_lora = llm.generate(prompts, sampling_params, lora_request=None)
 
-            # Save the LoRA adapter
-            lora_path = f"{lora_dir}/lora_{i}"
-            lora_model.save_pretrained(lora_path)
-            lora_paths.append(lora_path)
-            print(f"Saved LoRA adapter to {lora_path}")
+        assert len(outputs_no_lora) == 2
 
-        del model
-        del lora_model
-        torch.cuda.empty_cache()
-
-        # Configure TensorRT-LLM LoRA
-        trtllm_lora_config = LoraConfig(
-            lora_target_modules=target_modules, max_lora_rank=8, max_loras=2, max_cpu_loras=2
-        )
-
-        print("Initializing LLM with LoRA support...")
-        llm = LLM(
-            model_path,
-            lora_config=trtllm_lora_config,
-            # Disable CUDA graph for LoRA (LoRA is not supported with CUDA graphs yet)
-            cuda_graph_config=None,
-        )
-
-        try:
-            prompts = [
-                "def fibonacci(n):",
-                "def quick_sort(arr):",
-            ]
-
-            lora_req1 = LoRARequest("lora-1", 0, lora_paths[0])
-            lora_req2 = LoRARequest("lora-2", 1, lora_paths[1])
-            lora_requests = [lora_req1, lora_req2]
-
-            # Sampling parameters
-            sampling_params = SamplingParams(
-                max_tokens=50,
-                temperature=0.0,  # Greedy decoding for deterministic output
-            )
-
-            print("Generating with multiple LoRA adapters...")
-            outputs = llm.generate(prompts, sampling_params, lora_request=lora_requests)
-
-            # Verify we got outputs for both prompts
-            assert len(outputs) == 2, f"Expected 2 outputs, got {len(outputs)}"
-
-            # Verify each output has text
-            for i, output in enumerate(outputs):
-                assert len(output.outputs) > 0, f"Output {i} has no results"
-                assert len(output.outputs[0].text) > 0, f"Output {i} generated empty text"
-                print(f"\nPrompt {i + 1}: {prompts[i]}")
-                print(f"Output {i + 1}: {output.outputs[0].text[:100]}...")
-
-            # Test without LoRA for comparison
-            print("\nGenerating without LoRA adapters for comparison...")
-            outputs_no_lora = llm.generate(prompts[:1], sampling_params, lora_request=None)
-
-            assert len(outputs_no_lora) == 1
-            print(f"Output without LoRA: {outputs_no_lora[0].outputs[0].text[:100]}...")
-
-        finally:
-            llm.shutdown()
+        assert outputs[0].outputs[0].text == outputs_no_lora[0].outputs[0].text
+        assert outputs[1].outputs[0].text == outputs_no_lora[1].outputs[0].text

--- a/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
+++ b/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
-from dataclasses import dataclass
 import os
 import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
 
 import pytest
 import torch
@@ -321,143 +321,125 @@ def test_starcoder2_allclose_to_hf(scenario: Scenario) -> None:
         graph_runner.clear()
     kv_cache_manager.shutdown()
 
+
 @torch.no_grad()
 def test_starcoder2_multi_lora() -> None:
     """
     Test StarCoder2 3b model with multiple synthetic LoRA adapters created using PEFT.
-    
+
     This test creates dummy LoRA adapters for StarCoder2 and verifies that:
     1. Multiple LoRA adapters can be loaded and used simultaneously
     2. Different requests can use different LoRA adapters
     3. The model produces reasonable outputs with LoRA adapters applied
     """
-    
+
     # Check if we have enough GPU memory (need ~10GB for StarCoder2-3B + LoRA)
     _, total_mem = torch.cuda.mem_get_info()
     min_mem_required = 10 * (2**30)  # 10 GB
     if total_mem < min_mem_required:
         pytest.skip("Insufficient GPU memory for StarCoder2 with LoRA test")
-    
+
     # Check for pretrained model
-    try:
-        model_path = f"{llm_models_root()}/starcoder2-3b"
-        if not os.path.exists(model_path):
-            model_path = None
-    except:
+    model_path = f"{llm_models_root()}/starcoder2-3b"
+    if not os.path.exists(model_path):
         model_path = None
-    
+
     if model_path is None:
-        pytest.skip(
-            "StarCoder2 3b pretrained model not found. "
-        )
-    
+        pytest.skip("StarCoder2 3b pretrained model not found. ")
+
     # Target modules for LoRA - attention projections
-    target_modules = ['attn_q', 'attn_k', 'attn_v', 'attn_dense']
-    
+    target_modules = ["attn_q", "attn_k", "attn_v", "attn_dense"]
+
     # Set up temporary directory for LoRA adapters
     with tempfile.TemporaryDirectory() as lora_dir:
         print("Creating synthetic LoRA adapters for StarCoder2...")
-        
+
         # Load the pretrained model to create LoRA adapters
         model = AutoModelForCausalLM.from_pretrained(
-            model_path,
-            torch_dtype=torch.bfloat16,
-            device_map="auto",
-            trust_remote_code=True
+            model_path, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True
         )
-        
+
         # HuggingFace module names for StarCoder2 attention
         hf_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
-        
+
         peft_lora_config = PeftLoraConfig(
             r=8,  # LoRA rank
             lora_alpha=16,
             target_modules=hf_modules,
             lora_dropout=0.0,
             bias="none",
-            task_type="CAUSAL_LM"
+            task_type="CAUSAL_LM",
         )
-        
+
         # Create two synthetic LoRA adapters with zeroed weights
         lora_paths = []
         for i in range(2):
-            print(f"Creating LoRA adapter {i+1}/2...")
+            print(f"Creating LoRA adapter {i + 1}/2...")
             lora_model = get_peft_model(model, peft_lora_config)
-            
+
             # Zero out all LoRA parameters for deterministic testing
             for name, param in lora_model.named_parameters():
                 if "lora_" in name:
                     param.data.zero_()
-            
+
             # Save the LoRA adapter
             lora_path = f"{lora_dir}/lora_{i}"
             lora_model.save_pretrained(lora_path)
             lora_paths.append(lora_path)
             print(f"Saved LoRA adapter to {lora_path}")
-        
+
         del model
         del lora_model
         torch.cuda.empty_cache()
-        
+
         # Configure TensorRT-LLM LoRA
         trtllm_lora_config = LoraConfig(
-            lora_target_modules=target_modules,
-            max_lora_rank=8,
-            max_loras=2,
-            max_cpu_loras=2
+            lora_target_modules=target_modules, max_lora_rank=8, max_loras=2, max_cpu_loras=2
         )
-        
-        print(f"Initializing LLM with LoRA support...")
+
+        print("Initializing LLM with LoRA support...")
         llm = LLM(
             model_path,
             lora_config=trtllm_lora_config,
             # Disable CUDA graph for LoRA (LoRA is not supported with CUDA graphs yet)
-            cuda_graph_config=None
+            cuda_graph_config=None,
         )
-        
+
         try:
             prompts = [
                 "def fibonacci(n):",
                 "def quick_sort(arr):",
             ]
-            
+
             lora_req1 = LoRARequest("lora-1", 0, lora_paths[0])
             lora_req2 = LoRARequest("lora-2", 1, lora_paths[1])
             lora_requests = [lora_req1, lora_req2]
-            
+
             # Sampling parameters
             sampling_params = SamplingParams(
                 max_tokens=50,
                 temperature=0.0,  # Greedy decoding for deterministic output
             )
-            
+
             print("Generating with multiple LoRA adapters...")
-            outputs = llm.generate(
-                prompts,
-                sampling_params,
-                lora_request=lora_requests
-            )
-            
+            outputs = llm.generate(prompts, sampling_params, lora_request=lora_requests)
+
             # Verify we got outputs for both prompts
             assert len(outputs) == 2, f"Expected 2 outputs, got {len(outputs)}"
-            
+
             # Verify each output has text
             for i, output in enumerate(outputs):
                 assert len(output.outputs) > 0, f"Output {i} has no results"
                 assert len(output.outputs[0].text) > 0, f"Output {i} generated empty text"
-                print(f"\nPrompt {i+1}: {prompts[i]}")
-                print(f"Output {i+1}: {output.outputs[0].text[:100]}...")
-            
+                print(f"\nPrompt {i + 1}: {prompts[i]}")
+                print(f"Output {i + 1}: {output.outputs[0].text[:100]}...")
+
             # Test without LoRA for comparison
             print("\nGenerating without LoRA adapters for comparison...")
-            outputs_no_lora = llm.generate(
-                prompts[:1], 
-                sampling_params,
-                lora_request=None
-            )
-            
+            outputs_no_lora = llm.generate(prompts[:1], sampling_params, lora_request=None)
+
             assert len(outputs_no_lora) == 1
             print(f"Output without LoRA: {outputs_no_lora[0].outputs[0].text[:100]}...")
-            
+
         finally:
             llm.shutdown()

--- a/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
+++ b/tests/unittest/_torch/modeling/test_modeling_starcoder2.py
@@ -1,13 +1,19 @@
 from copy import deepcopy
 from dataclasses import dataclass
+import os
+import tempfile
 
 import pytest
 import torch
-from transformers import Starcoder2Config
+from peft import LoraConfig as PeftLoraConfig
+from peft import get_peft_model
+from transformers import AutoModelForCausalLM, Starcoder2Config
 from transformers import Starcoder2ForCausalLM as HFStarcoder2ForCausalLM
+from utils.llm_data import llm_models_root
 from utils.util import default_dtype
 
 import tensorrt_llm
+from tensorrt_llm import LLM
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
@@ -15,7 +21,10 @@ from tensorrt_llm._torch.models.modeling_starcoder2 import Starcoder2ForCausalLM
 from tensorrt_llm._torch.modules.layer_norm import LayerNorm
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.lora_manager import LoraConfig
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.sampling_params import SamplingParams
 
 # Base config for all StarCoder2 models (based on HuggingFace configs)
 _STARCODER2_BASE_CONFIG = {
@@ -311,3 +320,144 @@ def test_starcoder2_allclose_to_hf(scenario: Scenario) -> None:
     if graph_runner is not None:
         graph_runner.clear()
     kv_cache_manager.shutdown()
+
+@torch.no_grad()
+def test_starcoder2_multi_lora() -> None:
+    """
+    Test StarCoder2 3b model with multiple synthetic LoRA adapters created using PEFT.
+    
+    This test creates dummy LoRA adapters for StarCoder2 and verifies that:
+    1. Multiple LoRA adapters can be loaded and used simultaneously
+    2. Different requests can use different LoRA adapters
+    3. The model produces reasonable outputs with LoRA adapters applied
+    """
+    
+    # Check if we have enough GPU memory (need ~10GB for StarCoder2-3B + LoRA)
+    _, total_mem = torch.cuda.mem_get_info()
+    min_mem_required = 10 * (2**30)  # 10 GB
+    if total_mem < min_mem_required:
+        pytest.skip("Insufficient GPU memory for StarCoder2 with LoRA test")
+    
+    # Check for pretrained model
+    try:
+        model_path = f"{llm_models_root()}/starcoder2-3b"
+        if not os.path.exists(model_path):
+            model_path = None
+    except:
+        model_path = None
+    
+    if model_path is None:
+        pytest.skip(
+            "StarCoder2 3b pretrained model not found. "
+        )
+    
+    # Target modules for LoRA - attention projections
+    target_modules = ['attn_q', 'attn_k', 'attn_v', 'attn_dense']
+    
+    # Set up temporary directory for LoRA adapters
+    with tempfile.TemporaryDirectory() as lora_dir:
+        print("Creating synthetic LoRA adapters for StarCoder2...")
+        
+        # Load the pretrained model to create LoRA adapters
+        model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            trust_remote_code=True
+        )
+        
+        # HuggingFace module names for StarCoder2 attention
+        hf_modules = ["q_proj", "k_proj", "v_proj", "o_proj"]
+        
+        peft_lora_config = PeftLoraConfig(
+            r=8,  # LoRA rank
+            lora_alpha=16,
+            target_modules=hf_modules,
+            lora_dropout=0.0,
+            bias="none",
+            task_type="CAUSAL_LM"
+        )
+        
+        # Create two synthetic LoRA adapters with zeroed weights
+        lora_paths = []
+        for i in range(2):
+            print(f"Creating LoRA adapter {i+1}/2...")
+            lora_model = get_peft_model(model, peft_lora_config)
+            
+            # Zero out all LoRA parameters for deterministic testing
+            for name, param in lora_model.named_parameters():
+                if "lora_" in name:
+                    param.data.zero_()
+            
+            # Save the LoRA adapter
+            lora_path = f"{lora_dir}/lora_{i}"
+            lora_model.save_pretrained(lora_path)
+            lora_paths.append(lora_path)
+            print(f"Saved LoRA adapter to {lora_path}")
+        
+        del model
+        del lora_model
+        torch.cuda.empty_cache()
+        
+        # Configure TensorRT-LLM LoRA
+        trtllm_lora_config = LoraConfig(
+            lora_target_modules=target_modules,
+            max_lora_rank=8,
+            max_loras=2,
+            max_cpu_loras=2
+        )
+        
+        print(f"Initializing LLM with LoRA support...")
+        llm = LLM(
+            model_path,
+            lora_config=trtllm_lora_config,
+            # Disable CUDA graph for LoRA (LoRA is not supported with CUDA graphs yet)
+            cuda_graph_config=None
+        )
+        
+        try:
+            prompts = [
+                "def fibonacci(n):",
+                "def quick_sort(arr):",
+            ]
+            
+            lora_req1 = LoRARequest("lora-1", 0, lora_paths[0])
+            lora_req2 = LoRARequest("lora-2", 1, lora_paths[1])
+            lora_requests = [lora_req1, lora_req2]
+            
+            # Sampling parameters
+            sampling_params = SamplingParams(
+                max_tokens=50,
+                temperature=0.0,  # Greedy decoding for deterministic output
+            )
+            
+            print("Generating with multiple LoRA adapters...")
+            outputs = llm.generate(
+                prompts,
+                sampling_params,
+                lora_request=lora_requests
+            )
+            
+            # Verify we got outputs for both prompts
+            assert len(outputs) == 2, f"Expected 2 outputs, got {len(outputs)}"
+            
+            # Verify each output has text
+            for i, output in enumerate(outputs):
+                assert len(output.outputs) > 0, f"Output {i} has no results"
+                assert len(output.outputs[0].text) > 0, f"Output {i} generated empty text"
+                print(f"\nPrompt {i+1}: {prompts[i]}")
+                print(f"Output {i+1}: {output.outputs[0].text[:100]}...")
+            
+            # Test without LoRA for comparison
+            print("\nGenerating without LoRA adapters for comparison...")
+            outputs_no_lora = llm.generate(
+                prompts[:1], 
+                sampling_params,
+                lora_request=None
+            )
+            
+            assert len(outputs_no_lora) == 1
+            print(f"Output without LoRA: {outputs_no_lora[0].outputs[0].text[:100]}...")
+            
+        finally:
+            llm.shutdown()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for multiple LoRA adapters on StarCoder2 models
  * Updated performance benchmark configurations for StarCoder models with bf16 format support
  * Adjusted test waives and performance test entries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Add LoRA adapter and perf test for the pytorch backend implementation of starcoder2
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
