### PR TITLE
[https://nvbugs/5667922][fix] Update long context evaluation config

### DIFF
--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -450,89 +450,10 @@ class LongBenchV2(AccuracyTask):
     EVALUATOR_KWARGS = dict(
         dataset_path=DATASET_DIR,
         length="medium",
-        max_len=1280000,
+        max_len=120000,
         apply_chat_template=True,
         random_seed=0,
     )
-
-    @staticmethod
-    def create_modified_model_dir(original_model_dir: str,
-                                  max_position_embeddings: int = 1280000,
-                                  model_max_length: int = 1280000) -> str:
-        """
-        Create temporary directory with modified config files for long context evaluation.
-
-        This method creates a temporary directory with symlinks to all model files except
-        config files, which are copied and modified to support longer context lengths.
-        This is useful for evaluating models on long context tasks that exceed the
-        original model's max_position_embeddings.
-
-        Args:
-            original_model_dir: Path to the original model directory
-            max_position_embeddings: New value for max_position_embeddings in config.json
-            model_max_length: New value for model_max_length in tokenizer_config.json
-
-        Returns:
-            Path to the temporary modified model directory
-
-        Note:
-            The caller is responsible for cleaning up the temporary directory after use.
-        """
-        import tempfile
-
-        # Create temporary model directory with symlinks
-        temp_dir = tempfile.mkdtemp(prefix="longbench_v2_modified_model_")
-        logger.info(f"Created temporary model directory: {temp_dir}")
-
-        # Create symlinks for all files except config files
-        for item in os.listdir(original_model_dir):
-            src = os.path.join(original_model_dir, item)
-            dst = os.path.join(temp_dir, item)
-
-            # Skip config files - will handle them separately
-            if item in ["config.json", "tokenizer_config.json"]:
-                continue
-
-            # Create symlink for other files/directories
-            os.symlink(src, dst)
-            logger.info(f"  Symlinked: {item}")
-
-        # Modify and copy config.json
-        config_src = os.path.join(original_model_dir, "config.json")
-        config_dst = os.path.join(temp_dir, "config.json")
-        if os.path.exists(config_src):
-            with open(config_src, 'r', encoding='utf-8') as f:
-                config = json.load(f)
-
-            # Modify max_position_embeddings
-            original_max_pos = config.get('max_position_embeddings')
-            config['max_position_embeddings'] = max_position_embeddings
-            logger.info(
-                f"  Modified config.json: max_position_embeddings {original_max_pos} -> {max_position_embeddings}"
-            )
-
-            with open(config_dst, 'w', encoding='utf-8') as f:
-                json.dump(config, f, indent=2, ensure_ascii=False)
-
-        # Modify and copy tokenizer_config.json
-        tokenizer_config_src = os.path.join(original_model_dir,
-                                            "tokenizer_config.json")
-        tokenizer_config_dst = os.path.join(temp_dir, "tokenizer_config.json")
-        if os.path.exists(tokenizer_config_src):
-            with open(tokenizer_config_src, 'r', encoding='utf-8') as f:
-                tokenizer_config = json.load(f)
-
-            # Modify model_max_length
-            original_max_len = tokenizer_config.get('model_max_length')
-            tokenizer_config['model_max_length'] = model_max_length
-            logger.info(
-                f"  Modified tokenizer_config.json: model_max_length {original_max_len} -> {model_max_length}"
-            )
-
-            with open(tokenizer_config_dst, 'w', encoding='utf-8') as f:
-                json.dump(tokenizer_config, f, indent=2, ensure_ascii=False)
-
-        return temp_dir
 
 
 class CliFlowAccuracyTestHarness:

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -4167,103 +4167,88 @@ class TestDeepSeekR1LongBenchV2(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_mpi_world_size(8)
     def test_fp8_8gpus(self):
-        original_model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528"
-        if not os.path.exists(original_model_dir):
+        model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528"
+        if not os.path.exists(model_dir):
             pytest.skip(f"Model directory {original_model_dir} does not exist")
 
-        temp_dir = None
-        try:
-            # Create modified model directory using LongBenchV2 static method
-            # This is a WAR for the fact that the model config is not modified to support long context.
-            # TODO: remove this once the model config is modified to support long context.
-            temp_dir = LongBenchV2.create_modified_model_dir(original_model_dir)
+        # Configure model settings
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
+                                        enable_block_reuse=True,
+                                        enable_partial_reuse=False,
+                                        dtype="fp8")
 
-            # Configure model settings
-            kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
-                                            enable_block_reuse=True,
-                                            enable_partial_reuse=False,
-                                            dtype="fp8")
+        cuda_graph_config = CudaGraphConfig(enable_padding=True,
+                                            max_batch_size=32)
 
-            cuda_graph_config = CudaGraphConfig(enable_padding=True,
-                                                max_batch_size=32)
+        mtp_config = MTPDecodingConfig(num_nextn_predict_layers=3)
 
-            mtp_config = MTPDecodingConfig(num_nextn_predict_layers=3)
+        moe_config = MoeConfig(backend='DEEPGEMM', max_num_tokens=32000)
 
-            moe_config = MoeConfig(backend='DEEPGEMM', max_num_tokens=32000)
+        pytorch_config = dict(cuda_graph_config=cuda_graph_config,
+                              kv_cache_config=kv_cache_config,
+                              speculative_config=mtp_config,
+                              moe_config=moe_config,
+                              enable_chunked_prefill=True,
+                              enable_autotuner=True)
 
-            pytorch_config = dict(cuda_graph_config=cuda_graph_config,
-                                  kv_cache_config=kv_cache_config,
-                                  speculative_config=mtp_config,
-                                  moe_config=moe_config,
-                                  enable_chunked_prefill=True,
-                                  enable_autotuner=True)
+        # Create LLM instance and evaluate
+        with LLM(temp_dir,
+                 tensor_parallel_size=8,
+                 moe_expert_parallel_size=8,
+                 max_num_tokens=32000,
+                 max_batch_size=32,
+                 **pytorch_config) as llm:
 
-            # Create LLM instance and evaluate
-            with LLM(temp_dir,
-                     tensor_parallel_size=8,
-                     moe_expert_parallel_size=8,
-                     max_num_tokens=32000,
-                     max_batch_size=32,
-                     **pytorch_config) as llm:
+            task = LongBenchV2(self.MODEL_NAME)
 
-                task = LongBenchV2(self.MODEL_NAME)
+            sampling_params = SamplingParams(
+                max_tokens=32000,
+                truncate_prompt_tokens=128000,
+            )
 
-                sampling_params = SamplingParams(max_tokens=32000)
-
-                task.evaluate(llm, sampling_params=sampling_params)
-
-        finally:
-            # Cleanup temporary files
-            if temp_dir and os.path.exists(temp_dir):
-                import shutil
-                shutil.rmtree(temp_dir, ignore_errors=True)
+            task.evaluate(llm, sampling_params=sampling_params)
 
     @pytest.mark.skip_less_mpi_world_size(4)
     def test_nvfp4_4gpus(self):
-        original_model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528-FP4"
-        temp_dir = None
-        try:
-            # Create modified model directory using LongBenchV2 static method
-            temp_dir = LongBenchV2.create_modified_model_dir(original_model_dir)
+        model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528-FP4"
+        if not os.path.exists(model_dir):
+            pytest.skip(f"Model directory {original_model_dir} does not exist")
 
-            # Configure model settings (no MOE config for FP4 version)
-            kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
-                                            enable_block_reuse=True,
-                                            enable_partial_reuse=False,
-                                            dtype="fp8")
+        # Configure model settings (no MOE config for FP4 version)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
+                                        enable_block_reuse=True,
+                                        enable_partial_reuse=False,
+                                        dtype="fp8")
 
-            cuda_graph_config = CudaGraphConfig(enable_padding=True,
-                                                max_batch_size=32)
+        cuda_graph_config = CudaGraphConfig(enable_padding=True,
+                                            max_batch_size=32)
 
-            mtp_config = MTPDecodingConfig(num_nextn_predict_layers=3)
+        mtp_config = MTPDecodingConfig(num_nextn_predict_layers=3)
 
-            pytorch_config = dict(cuda_graph_config=cuda_graph_config,
-                                  kv_cache_config=kv_cache_config,
-                                  speculative_config=mtp_config,
-                                  enable_chunked_prefill=True,
-                                  enable_autotuner=True)
+        pytorch_config = dict(cuda_graph_config=cuda_graph_config,
+                              kv_cache_config=kv_cache_config,
+                              speculative_config=mtp_config,
+                              enable_chunked_prefill=True,
+                              enable_autotuner=True)
 
-            # Create LLM instance and evaluate
-            with LLM(temp_dir,
-                     tensor_parallel_size=4,
-                     moe_expert_parallel_size=4,
-                     max_num_tokens=32000,
-                     max_batch_size=32,
-                     **pytorch_config) as llm:
+        # Create LLM instance and evaluate
+        with LLM(temp_dir,
+                 tensor_parallel_size=4,
+                 moe_expert_parallel_size=4,
+                 max_num_tokens=32000,
+                 max_batch_size=32,
+                 **pytorch_config) as llm:
 
-                assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
+            assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
 
-                task = LongBenchV2(self.MODEL_NAME)
+            task = LongBenchV2(self.MODEL_NAME)
 
-                sampling_params = SamplingParams(max_tokens=32000)
+            sampling_params = SamplingParams(
+                max_tokens=32000,
+                truncate_prompt_tokens=128000,
+            )
 
-                task.evaluate(llm, sampling_params=sampling_params)
-
-        finally:
-            # Cleanup temporary files
-            if temp_dir and os.path.exists(temp_dir):
-                import shutil
-                shutil.rmtree(temp_dir, ignore_errors=True)
+            task.evaluate(llm, sampling_params=sampling_params)
 
 
 class TestStarcoder2_3B(LlmapiAccuracyTestHarness):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -4169,7 +4169,7 @@ class TestDeepSeekR1LongBenchV2(LlmapiAccuracyTestHarness):
     def test_fp8_8gpus(self):
         model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528"
         if not os.path.exists(model_dir):
-            pytest.skip(f"Model directory {original_model_dir} does not exist")
+            pytest.skip(f"Model directory {model_dir} does not exist")
 
         # Configure model settings
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
@@ -4192,7 +4192,7 @@ class TestDeepSeekR1LongBenchV2(LlmapiAccuracyTestHarness):
                               enable_autotuner=True)
 
         # Create LLM instance and evaluate
-        with LLM(temp_dir,
+        with LLM(model_dir,
                  tensor_parallel_size=8,
                  moe_expert_parallel_size=8,
                  max_num_tokens=32000,
@@ -4212,7 +4212,7 @@ class TestDeepSeekR1LongBenchV2(LlmapiAccuracyTestHarness):
     def test_nvfp4_4gpus(self):
         model_dir = f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1-0528-FP4"
         if not os.path.exists(model_dir):
-            pytest.skip(f"Model directory {original_model_dir} does not exist")
+            pytest.skip(f"Model directory {model_dir} does not exist")
 
         # Configure model settings (no MOE config for FP4 version)
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
@@ -4232,7 +4232,7 @@ class TestDeepSeekR1LongBenchV2(LlmapiAccuracyTestHarness):
                               enable_autotuner=True)
 
         # Create LLM instance and evaluate
-        with LLM(temp_dir,
+        with LLM(model_dir,
                  tensor_parallel_size=4,
                  moe_expert_parallel_size=4,
                  max_num_tokens=32000,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated long-context evaluation configuration by reducing the maximum context length parameter from 1,280,000 to 120,000 tokens
  * Streamlined test setup by simplifying model directory handling

* **Chores**
  * Refactored test infrastructure to eliminate intermediate configuration modification steps

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Avoid modifying the model configuration when evaluating.
- Limit the length of prompts.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
