### PR TITLE
[https://nvbugs/5689262][fix] use proper tokens when exclude_input_in_output is true

### DIFF
--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
@@ -496,11 +496,12 @@ class Decoder:
     def reset_decoder(self):
         self._accumulated_tokens = []
 
-    def load_model_configs(self,
-                           target_model_config_api_url: Optional[str] = None,
-                           draft_model_config_api_url: Optional[str] = None,
-                           n_retries: Optional[int] = 5,
-                           retry_interval_sec: Optional[int] = 3):
+    def load_model_configs_for_spec_decoding(
+            self,
+            target_model_config_api_url: Optional[str] = None,
+            draft_model_config_api_url: Optional[str] = None,
+            n_retries: Optional[int] = 5,
+            retry_interval_sec: Optional[int] = 3):
         raise NotImplementedError()
 
     def is_input_excluded_from_output_for_target(self,

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
@@ -656,12 +656,13 @@ class TritonDecoder(Decoder):
             ]
 
     @override
-    def load_model_configs(self,
-                           triton_host_and_port: Optional[str] = None,
-                           target_model_name: Optional[str] = None,
-                           draft_model_name: Optional[str] = None,
-                           n_retries: Optional[int] = 5,
-                           retry_interval_sec: Optional[int] = 3):
+    def load_model_configs_for_spec_decoding(
+            self,
+            triton_host_and_port: Optional[str] = None,
+            target_model_name: Optional[str] = None,
+            draft_model_name: Optional[str] = None,
+            n_retries: Optional[int] = 5,
+            retry_interval_sec: Optional[int] = 3):
         if self._exclude_input_in_output_for_target is not None and self._exclude_input_in_output_for_draft is not None:
             # Already loaded. Skip.
             return

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
@@ -176,34 +176,36 @@ class TritonPythonModel:
     def execute(self, requests):
 
         responses = []
-        try:
-            # Check if draft model is configured as
+        if self.draft_llm_model_name is not None:
+            # When draft model is specified,
+            # check if draft model is configured as
             # `exclude_input_in_output: true` or not.
-            self.decoder.load_model_configs(
-                triton_host_and_port=self.triton_host_and_port,
-                target_model_name=self.llm_model_name,
-                draft_model_name=self.draft_llm_model_name)
-        except Exception:
-            # Stop main executions immediately.
-            self.logger.log_error(traceback.format_exc())
-            # If encountering an error, send a response with err msg
-            error_response = pb_utils.InferenceResponse(
-                output_tensors=[],
-                error=pb_utils.TritonError(traceback.format_exc()))
+            try:
+                self.decoder.load_model_configs_for_spec_decoding(
+                    triton_host_and_port=self.triton_host_and_port,
+                    target_model_name=self.llm_model_name,
+                    draft_model_name=self.draft_llm_model_name)
+            except Exception:
+                # Stop main executions immediately.
+                self.logger.log_error(traceback.format_exc())
+                # If encountering an error, send a response with err msg
+                error_response = pb_utils.InferenceResponse(
+                    output_tensors=[],
+                    error=pb_utils.TritonError(traceback.format_exc()))
 
-            for request in requests:
+                for request in requests:
+                    if self.decoupled:
+                        response_sender = request.get_response_sender()
+                        response_sender.send(error_response)
+                        response_sender.send(
+                            flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
+                    else:
+                        responses.append(error_response)
                 if self.decoupled:
-                    response_sender = request.get_response_sender()
-                    response_sender.send(error_response)
-                    response_sender.send(
-                        flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
+                    return None
                 else:
-                    responses.append(error_response)
-            if self.decoupled:
-                return None
-            else:
-                assert len(responses) == len(requests)
-                return responses
+                    assert len(responses) == len(requests)
+                    return responses
 
         for request in requests:
             if self.decoupled:

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
@@ -88,7 +88,7 @@ class TritonPythonModel:
         # NOTE: this is a temporal solution related to
         # the implementation of `decoder.load_model_configs()`.
         # Assuming the gRPC endpoint is running with 8001 port.
-        self.model_config_api_baseurl = "localhost:8001/v2/models/"
+        self.triton_host_and_port = "localhost:8001"
 
     def get_batch_index(self, response):
         if hasattr(
@@ -180,7 +180,7 @@ class TritonPythonModel:
             # Check if draft model is configured as
             # `exclude_input_in_output: true` or not.
             self.decoder.load_model_configs(
-                model_config_api_baseurl=self.model_config_api_baseurl,
+                triton_host_and_port=self.triton_host_and_port,
                 target_model_name=self.llm_model_name,
                 draft_model_name=self.draft_llm_model_name)
         except Exception:

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/model.py
@@ -85,6 +85,11 @@ class TritonPythonModel:
             draft_llm_model_name=self.draft_llm_model_name,
             multimodal_encoders_name=self.multimodal_encoders_name)
 
+        # NOTE: this is a temporal solution related to
+        # the implementation of `decoder.load_model_configs()`.
+        # Assuming the gRPC endpoint is running with 8001 port.
+        self.model_config_api_baseurl = "localhost:8001/v2/models/"
+
     def get_batch_index(self, response):
         if hasattr(
                 response, 'batch_index'
@@ -171,6 +176,34 @@ class TritonPythonModel:
     def execute(self, requests):
 
         responses = []
+        try:
+            # Check if draft model is configured as
+            # `exclude_input_in_output: true` or not.
+            self.decoder.load_model_configs(
+                model_config_api_baseurl=self.model_config_api_baseurl,
+                target_model_name=self.llm_model_name,
+                draft_model_name=self.draft_llm_model_name)
+        except Exception:
+            # Stop main executions immediately.
+            self.logger.log_error(traceback.format_exc())
+            # If encountering an error, send a response with err msg
+            error_response = pb_utils.InferenceResponse(
+                output_tensors=[],
+                error=pb_utils.TritonError(traceback.format_exc()))
+
+            for request in requests:
+                if self.decoupled:
+                    response_sender = request.get_response_sender()
+                    response_sender.send(error_response)
+                    response_sender.send(
+                        flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
+                else:
+                    responses.append(error_response)
+            if self.decoupled:
+                return None
+            else:
+                assert len(responses) == len(requests)
+                return responses
 
         for request in requests:
             if self.decoupled:

--- a/triton_backend/all_models/tests/test_decode.py
+++ b/triton_backend/all_models/tests/test_decode.py
@@ -230,29 +230,28 @@ decode_testcases = [
         "text_input":
         "Deep learning is",
         "max_tokens":
-        10,
+        6,
         "use_speculative":
         True,
         "num_draft_tokens":
         3,
         "use_draft_logits":
         False,
-        "exclude_input_in_output":
+        "exclude_input_in_output_on_request":
         True,
         "input_ids": [1, 10, 11, 23],
         "target_output": [{
-            "output_ids": [1, 10, 11, 23, 7, 9, 21],
-            "output_text": "Deep learning is a subset of"
+            "output_ids": [7, 9, 21, 22],
+            "output_text": " a subset of Machine"
         }, {
-            "output_ids": [1, 10, 11, 23, 7, 9, 21, 22, 11],
-            "output_text":
-            "Deep learning is a subset of Machine learning"
+            "output_ids": [11, 19, 27],
+            "output_text": " learning method which"
         }],
         "draft_output": [{
             "output_ids": [7, 9, 21],
             "sequence_length": 3,
         }, {
-            "output_ids": [22, 11],
+            "output_ids": [11, 19],
             "sequence_length": 2,
         }]
     },
@@ -273,8 +272,9 @@ def test_decode(test_case):
                           if "use_draft_logits" in test_case else None),
         stop_words=np.array([[[]]]),
         exclude_input_in_output=(np.array(
-            [[test_case["exclude_input_in_output"]]],
-            dtype=bool) if "exclude_input_in_output" in test_case else None))
+            [[test_case["exclude_input_in_output_on_request"]]], dtype=bool)
+                                 if "exclude_input_in_output_on_request"
+                                 in test_case else None))
     # Last index is the expected response
     expected_res = Response(text_output=np.array(
         [test_case["target_output"][-1]["output_text"]], dtype=object))

--- a/triton_backend/all_models/tests/test_triton_decoder.py
+++ b/triton_backend/all_models/tests/test_triton_decoder.py
@@ -185,8 +185,8 @@ mock_reponse = {
     "acceptance_rate": [[0.0]],
     "total_accepted_draft_tokens": [[0]],
     "total_draft_tokens": [[0]],
-    "num_input_tokens": None,
-    "num_output_tokens": None
+    "num_input_tokens": [[0]],
+    "num_output_tokens": [[0]]
 }
 
 mock_request = {"text_input": [["Hello world"]], "max_tokens": [[24]]}

--- a/triton_backend/all_models/tests/test_triton_decoder.py
+++ b/triton_backend/all_models/tests/test_triton_decoder.py
@@ -120,6 +120,8 @@ def response(request) -> MockTritonResponse:
         "acceptance_rate",
         "total_accepted_draft_tokens",
         "total_draft_tokens",
+        "num_input_tokens",
+        "num_output_tokens",
     ]
     response = Response()
     for output_name in output_names:
@@ -182,7 +184,9 @@ mock_reponse = {
     "last_token_time_ns": [[3]],
     "acceptance_rate": [[0.0]],
     "total_accepted_draft_tokens": [[0]],
-    "total_draft_tokens": [[0]]
+    "total_draft_tokens": [[0]],
+    "num_input_tokens": None,
+    "num_output_tokens": None
 }
 
 mock_request = {"text_input": [["Hello world"]], "max_tokens": [[24]]}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for excluding input tokens from model output based on configuration
  * Implemented automatic model configuration loading to determine per-model exclusion behavior
  * Enhanced error handling during configuration initialization with informative error responses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

A response is broken when using `"exclude_input_in_output": true` and speculative decoding together.
This fix resolves an wrong draft model output token handling.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Added one new test case in `triton_backend/all_models/tests/test_decode.py` to cover the error pattern, ran tests below and confirmed there's no failed test:

```
cd triton_backend/all_models/tests/
PYTHONPATH="../inflight_batcher_llm/tensorrt_llm_bls/1/" pytest ./test_decode.py ./test_triton_decoder.py
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
