### PR TITLE
[#9150][feat] Add code for nano v3 to custom implementation in AD

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -45,7 +45,9 @@ def _template_moe(
         valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
     )
     # Create one-hot encoding with an extra class.
-    one_hot = F.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
+    # NOTE: `F.one_hot` only accepts `LongTensor` as an input, and will throw an error if the tensor is of another
+    # dtype, even if `torch.int32`.
+    one_hot = F.one_hot(selected_experts_fixed.long(), num_classes=num_experts + 1)
     expert_mask = one_hot[..., :num_experts].permute(2, 1, 0)
 
     for expert_idx in range(num_experts):

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -222,6 +222,7 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
             if custom_model_cls is not None:
                 # `_from_config` has some behavior we would like to use where possible. It is
                 # defined in the `PreTrainedModel` mixin.
+                ad_logger.info(f"Using custom model implementation {custom_model_cls}")
                 if not hasattr(custom_model_cls, "_from_config"):
                     raise ValueError(
                         f"`{custom_model_cls.__name__}` must have a `_from_config` class method. "

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_nemotron_h_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_nemotron_h_patches.py
@@ -1,3 +1,4 @@
+import functools
 import types
 
 import pytest
@@ -5,15 +6,40 @@ import torch
 from _model_test_utils import _hf_model_dir_or_hub_id
 from transformers import AutoConfig
 
+from tensorrt_llm._torch.auto_deploy.models.modeling_nemotron_h import NemotronHForCausalLM
 from tensorrt_llm._torch.auto_deploy.models.patches.nemotron_h import (
     _from_config_original,
     _nemotron_h_moe_forward,
 )
 
-torch.manual_seed(42)
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
 
 
-def _load_nemotron_moe_layer(model_name_or_path: str):
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def skip_on_no_hf_access(func):
+    """Decorator for skipping tests that fail due to HF access issues.
+
+    This allows us to share the same test code for CI (where access may be restricted, especially for private
+    repositories) and locally.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except OSError as e:
+            if "not a valid model identifier" in str(e):
+                pytest.skip("Test skipped due to (no) HF access.")
+            raise
+
+    return wrapper
+
+
+def _load_nemotron_moe_layer(model_name_or_path: str, custom_model_cls=None):
     """
     Build a tiny NemotronH model (1 layer, small dims) and return the first NemotronHMOE module.
     """
@@ -34,11 +60,14 @@ def _load_nemotron_moe_layer(model_name_or_path: str):
     cfg.num_key_value_heads = 2
     cfg.ssm_state_size = 32
 
-    model = _from_config_original(cfg, trust_remote_code=True)
+    if custom_model_cls is None:
+        model = _from_config_original(cfg, trust_remote_code=True)
+    else:
+        model = custom_model_cls._from_config(cfg)
     model.eval()
 
     nemotron_moe = None
-    for name, mod in model.named_modules():
+    for _, mod in model.named_modules():
         if type(mod).__name__ == "NemotronHMOE":
             nemotron_moe = mod
             break
@@ -46,7 +75,20 @@ def _load_nemotron_moe_layer(model_name_or_path: str):
     if nemotron_moe is None:
         raise RuntimeError("NemotronHMOE layer not found. Check your model id or config.")
 
+    _set_gate_weights(nemotron_moe)
+
     return nemotron_moe
+
+
+def _set_gate_weights(module):
+    # This helper function is necessary because the `weight` parameter of the `NemotronHTopkRouter`
+    # is initialized as `torch.empty` in the original model code, which no manner of random seed
+    # setting will have any effect on. We therefore set it like the below to ensure the
+    # reproducibility of the tests.
+    for _, mod in module.named_modules():
+        if type(mod).__name__ == "NemotronHTopkRouter":
+            if hasattr(mod, "weight"):
+                mod.weight = torch.nn.Parameter(torch.randn_like(mod.weight))
 
 
 @pytest.mark.parametrize(
@@ -57,10 +99,11 @@ def _load_nemotron_moe_layer(model_name_or_path: str):
         ),
     ],
 )
-@pytest.mark.parametrize("B,S", [(2, 6), (1, 8)])
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+@skip_on_no_hf_access
 def test_nemotronh_moe_patch_forward(model_name, B, S, dtype):
-    pytest.skip("Skipping due to permission issue")
     device = "cuda"
 
     module = _load_nemotron_moe_layer(model_name)
@@ -69,12 +112,45 @@ def test_nemotronh_moe_patch_forward(model_name, B, S, dtype):
     H = module.config.hidden_size
     x = torch.randn(B, S, H, device=device, dtype=dtype)
 
-    with torch.no_grad():
-        ref = module(x)
+    ref = module(x)
 
     module.forward = types.MethodType(_nemotron_h_moe_forward, module)
-    with torch.no_grad():
-        test = module(x)
+    test = module(x)
+
+    rtol = 0.05
+    atol = 0.05
+
+    torch.testing.assert_close(test, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        _hf_model_dir_or_hub_id(
+            "NVIDIA-Nemotron-Nano-31B-A3-v3", "nvidia/NVIDIA-Nemotron-Nano-31B-A3-v3"
+        ),
+    ],
+)
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+@skip_on_no_hf_access
+def test_nemotronh_moe_custom_implementation(model_name, B, S, dtype):
+    device = "cuda"
+
+    module = _load_nemotron_moe_layer(model_name)
+    module.to(device)
+
+    H = module.config.hidden_size
+    x = torch.randn(B, S, H, device=device, dtype=dtype)
+
+    ref = module(x)
+
+    new_module = _load_nemotron_moe_layer(model_name, custom_model_cls=NemotronHForCausalLM)
+    new_module.to(device)
+    new_module.load_state_dict(module.state_dict())
+
+    test = new_module(x)
 
     rtol = 0.05
     atol = 0.05


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Mixture-of-Experts (MOE) support for NemotronH model, including routing gate and shared expert handling
  * Added logging when custom model implementations are used

* **Tests**
  * Expanded test coverage for MOE functionality with improved determinism and custom model implementation verification
  * Enhanced numeric tolerance handling in forward pass validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

We would like to show an alternative to monkey-patching in AutoDeploy.

* What?

This commit builds on the existing custom model implementation for NemotronH and adds the bits relevant for MoE layers.

Part of #9150.

## Test Coverage

- Fixes existing unit tests for the patches.
- Extends them for the new implementation.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
