### PR TITLE
[TRTLLM-8164][feat] Add dynamic tree support on CDL

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -138,6 +138,7 @@ def add_llm_args(parser):
                         default=False,
                         action='store_true')
     parser.add_argument('--dynamic_tree_max_topK', type=int, default=None)
+    parser.add_argument('--max_total_draft_tokens', type=int, default=None)
 
     # Relaxed acceptance
     parser.add_argument('--use_relaxed_acceptance_for_thinking',
@@ -205,7 +206,8 @@ def setup_llm(args, **kwargs):
             eagle3_one_model=args.use_one_model,
             eagle_choices=args.eagle_choices,
             use_dynamic_tree=args.use_dynamic_tree,
-            dynamic_tree_max_topK=args.dynamic_tree_max_topK)
+            dynamic_tree_max_topK=args.dynamic_tree_max_topK,
+            max_total_draft_tokens=args.max_total_draft_tokens)
     elif spec_decode_algo == "DRAFT_TARGET":
         spec_config = DraftTargetDecodingConfig(
             max_draft_len=args.spec_decode_max_draft_len,

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -10,8 +10,6 @@ import torch
 from typing_extensions import Self
 
 if TYPE_CHECKING:
-    from ..speculative.utils import SpecDecodingTensor
-    from ..speculative.interface import SpecMetadata
     from ..speculative.spec_tree_manager import SpecTreeManager
 
 from tensorrt_llm.functional import (PositionEmbeddingType, RopeEmbeddingUtils,
@@ -346,10 +344,9 @@ class AttentionMetadata:
             is_spec_dec_dynamic_tree,
             max_draft_len,
             max_total_draft_tokens,
+            is_target_model: bool = True,
             model_is_wrapped: bool = False,
-            spec_metadata: Optional['SpecMetadata'] = None,
-            spec_tree_manager: Optional['SpecTreeManager'] = None,
-            spec_decoding_tensor: Optional['SpecDecodingTensor'] = None):
+            spec_tree_manager: Optional['SpecTreeManager'] = None):
         """
         Hook to be called when using TRTLLM attention backend in spec-dec mode.
         """

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -496,24 +496,21 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
     # This function is only used to create the expanded buffers when the max_draft_tokens is changed.
     # TODO: remove this function when fp8_paged_mqa_logits can support MTP > 1.
     def update_spec_dec_param(
-        self,
-        batch_size,
-        is_spec_decoding_enabled,
-        is_spec_dec_tree,
-        is_spec_dec_dynamic_tree,
-        max_draft_len,
-        max_total_draft_tokens,
-        model_is_wrapped: bool = False,
-        spec_metadata: Optional['SpecMetadata'] = None,
-        spec_tree_manager: Optional['SpecTreeManager'] = None,
-        spec_decoding_tensor: Optional['SpecDecodingTensor'] = None,
-    ):
+            self,
+            batch_size,
+            is_spec_decoding_enabled,
+            is_spec_dec_tree,
+            is_spec_dec_dynamic_tree,
+            max_draft_len,
+            max_total_draft_tokens,
+            is_target_model: bool = True,
+            model_is_wrapped: bool = False,
+            spec_tree_manager: Optional['SpecTreeManager'] = None):
         super().update_spec_dec_param(batch_size, is_spec_decoding_enabled,
                                       is_spec_dec_tree,
                                       is_spec_dec_dynamic_tree, max_draft_len,
-                                      max_total_draft_tokens, model_is_wrapped,
-                                      spec_metadata, spec_tree_manager,
-                                      spec_decoding_tensor)
+                                      max_total_draft_tokens, is_target_model,
+                                      model_is_wrapped, spec_tree_manager)
         self.max_draft_tokens = max_draft_len
         init_shape = self.kv_lens_expanded_host.shape[0]
         if self.max_num_sequences * (1 + self.max_draft_tokens) != init_shape:

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1209,10 +1209,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         self.is_spec_decoding_enabled = is_spec_decoding_enabled and (
             get_sm_version() < 100 or get_sm_version() == 120)
 
-        if get_sm_version() >= 100 and get_sm_version() != 120:
-            if self.is_spec_dec_tree or self.is_spec_dec_dynamic_tree:
-                assert not self.is_spec_dec_tree, "Spec-dec tree is not supported on this machine. Please use a pre-Blackwell machine for a spec-dec tree."
-
         # use_spec_decoding is default to true by default, change in runtime by layers / requests
         self.use_spec_decoding = self.is_spec_decoding_enabled
         self.is_spec_dec_tree = is_spec_dec_tree

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -50,7 +50,6 @@ from ..speculative import (SpecMetadata, get_num_extra_kv_tokens,
 from ..speculative.drafting_loops import BaseDraftingLoopWrapper
 from ..speculative.eagle3 import Eagle3ResourceManager, Eagle3SpecMetadata
 from ..speculative.mtp import SampleStateTensorsMTP
-from ..speculative.utils import SpecDecodingTensor
 from ..utils import (get_model_extra_attrs,
                      set_per_request_piecewise_cuda_graph_flag,
                      set_torch_compiling, with_model_extra_attrs)
@@ -2610,7 +2609,6 @@ class PyTorchModelEngine(ModelEngine):
                 new_tensors_device: Optional[SampleStateTensors] = None,
                 gather_context_logits: bool = False,
                 cache_indirection_buffer: Optional[torch.Tensor] = None,
-                spec_decoding_tensor: Optional[SpecDecodingTensor] = None,
                 num_accepted_tokens_device: Optional[torch.Tensor] = None,
                 req_id_to_old_request: Optional[Dict[int, LlmRequest]] = None):
         kv_cache_manager = resource_manager.get_resource_manager(
@@ -2637,10 +2635,9 @@ class PyTorchModelEngine(ModelEngine):
                 is_spec_dec_dynamic_tree=spec_metadata.is_spec_dec_dynamic_tree,
                 max_draft_len=self.original_max_draft_len,
                 max_total_draft_tokens=self.original_max_total_draft_tokens,
+                is_target_model=not self.is_draft_model,
                 model_is_wrapped=self.model_is_wrapped,
-                spec_metadata=spec_metadata,
-                spec_tree_manager=spec_tree_manager,
-                spec_decoding_tensor=spec_decoding_tensor)
+                spec_tree_manager=spec_tree_manager)
         else:
             spec_resource_manager = None
             spec_metadata = None

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1198,8 +1198,11 @@ class PyExecutor:
                         with request_context(
                                 is_draft=self.draft_model_engine is not None,
                                 scheduled_requests=scheduled_batch):
+                            print(f"============================ before prepare_draft_tokens ============================")
                             self.drafter.prepare_draft_tokens(
                                 scheduled_batch, self.resource_manager)
+                            print(f"============================ after prepare_draft_tokens ============================")
+                            import pdb; pdb.set_trace()
                             # Pad draft tokens to the max draft length. This is for CUDA graph compatibility.
                             self.drafter.pad_draft_tokens_for_cuda_graph(
                                 scheduled_batch)
@@ -1209,7 +1212,10 @@ class PyExecutor:
                             if hasattr(self.drafter, "guided_decoder"):
                                 self.guided_decoder.rollback_draft_tokens()
 
+                    print(f"============================ before _forward_step ============================")
                     batch_outputs = self._forward_step(scheduled_batch)
+                    print(f"============================ after _forward_step ============================")
+                    import pdb; pdb.set_trace()
                     if self.guided_decoder is not None:
                         self.guided_decoder.execute(batch_outputs['logits'])
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1198,11 +1198,8 @@ class PyExecutor:
                         with request_context(
                                 is_draft=self.draft_model_engine is not None,
                                 scheduled_requests=scheduled_batch):
-                            print(f"============================ before prepare_draft_tokens ============================")
                             self.drafter.prepare_draft_tokens(
                                 scheduled_batch, self.resource_manager)
-                            print(f"============================ after prepare_draft_tokens ============================")
-                            import pdb; pdb.set_trace()
                             # Pad draft tokens to the max draft length. This is for CUDA graph compatibility.
                             self.drafter.pad_draft_tokens_for_cuda_graph(
                                 scheduled_batch)
@@ -1212,10 +1209,7 @@ class PyExecutor:
                             if hasattr(self.drafter, "guided_decoder"):
                                 self.guided_decoder.rollback_draft_tokens()
 
-                    print(f"============================ before _forward_step ============================")
                     batch_outputs = self._forward_step(scheduled_batch)
-                    print(f"============================ after _forward_step ============================")
-                    import pdb; pdb.set_trace()
                     if self.guided_decoder is not None:
                         self.guided_decoder.execute(batch_outputs['logits'])
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -363,7 +363,9 @@ def create_py_executor(
 
                 def drafting_loop_wrapper(model):
                     from tensorrt_llm._torch.speculative.drafting_loops import (
-                        LinearDraftingLoopWrapper, StaticTreeDraftingLoopWrapper, DynamicTreeDraftingLoopWrapper)
+                        DynamicTreeDraftingLoopWrapper,
+                        LinearDraftingLoopWrapper,
+                        StaticTreeDraftingLoopWrapper)
                     from tensorrt_llm.llmapi import EagleDecodingConfig
 
                     use_tree_drafter = isinstance(
@@ -386,7 +388,8 @@ def create_py_executor(
                     elif dynamic_tree_drafter:
                         return DynamicTreeDraftingLoopWrapper(
                             spec_config.max_draft_len,
-                            spec_config.max_total_draft_tokens, max_batch_size, draft_spec_config.dynamic_tree_max_topK, model)
+                            spec_config.max_total_draft_tokens, max_batch_size,
+                            draft_spec_config.dynamic_tree_max_topK, model)
                     else:
                         return LinearDraftingLoopWrapper(
                             spec_config.max_draft_len,

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -855,6 +855,7 @@ class TorchSampler(Sampler):
         # For the target model, we will do the tree verification logic.
         seq_slot = request.py_seq_slot
         assert seq_slot is not None
+        # import pdb; pdb.set_trace()
         eagle_paths = spec_tree_manager.get_eagle_paths(seq_slot)
 
         all_draft_tokens = torch.tensor(request.py_draft_tokens)  # [max_total_draft_tokens]

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -855,7 +855,6 @@ class TorchSampler(Sampler):
         # For the target model, we will do the tree verification logic.
         seq_slot = request.py_seq_slot
         assert seq_slot is not None
-        # import pdb; pdb.set_trace()
         eagle_paths = spec_tree_manager.get_eagle_paths(seq_slot)
 
         all_draft_tokens = torch.tensor(request.py_draft_tokens)  # [max_total_draft_tokens]

--- a/tensorrt_llm/_torch/speculative/drafting_loops.py
+++ b/tensorrt_llm/_torch/speculative/drafting_loops.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from typing import Optional, final
 
 import torch
+import torch.nn as nn
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3SpecMetadata
@@ -197,7 +198,7 @@ class LinearDraftingLoopWrapper(BaseDraftingLoopWrapper):
         return new_position_ids
 
 
-class TreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
+class StaticTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
     def __init__(self, max_draft_len: int, max_total_draft_tokens: int,
                  max_batch_size: int, draft_model: torch.nn.Module):
@@ -221,11 +222,8 @@ class TreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
     def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor,
                 attn_metadata: AttentionMetadata, spec_metadata: SpecMetadata,
                 **kwargs) -> dict[str, torch.Tensor]:
-        spec_tree_manager = None
-        if isinstance(spec_metadata, Eagle3SpecMetadata):
-            spec_tree_manager = spec_metadata.eagle3_resource_manager.spec_tree_manager
-
-        assert spec_tree_manager is not None
+        assert isinstance(spec_metadata, Eagle3SpecMetadata)
+        spec_tree_manager = spec_metadata.eagle3_resource_manager.spec_tree_manager
 
         logits = self.draft_model.forward(input_ids=input_ids,
                                           position_ids=position_ids,
@@ -496,6 +494,454 @@ class TreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
             self.max_total_draft_tokens +
             1)] = hidden_states_read_indices_offset.reshape(-1)
 
+        hidden_states_write_offset = torch.arange(
+            1, self.max_total_draft_tokens + 1 + 1,
+            device=position_ids.device).unsqueeze(0).repeat(
+                batch_size, 1) + start_idx.unsqueeze(1)
+        spec_metadata.hidden_states_write_indices[:batch_size * (
+            self.max_total_draft_tokens +
+            1)] = hidden_states_write_offset.reshape(-1)
+
+        ## 3.3) is_first_draft
+        spec_metadata.eagle3_resource_manager.is_first_draft = False
+        spec_metadata.is_first_draft = False
+
+        return
+
+class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
+
+    def __init__(self, max_draft_len: int, max_total_draft_tokens: int,
+                 max_batch_size: int, dynamic_tree_max_topK, draft_model: torch.nn.Module):
+        super().__init__()
+        self.draft_model = draft_model
+        self.config = self.draft_model.config
+        self.model_config = self.draft_model.model_config
+        self.max_draft_len = max_draft_len
+        self.max_total_draft_tokens = max_total_draft_tokens
+        self.max_batch_size = max_batch_size
+        self.dynamic_tree_max_topK = dynamic_tree_max_topK
+        self.logsoftmax = nn.LogSoftmax(dim=-1)
+
+        self.draft_tokens_buffer = torch.zeros(
+            (max_batch_size, max_total_draft_tokens + 1),
+            dtype=torch.int64,
+            device='cuda')
+        self.position_ids_buffer = torch.zeros(
+            (max_batch_size, max_total_draft_tokens + 1),
+            dtype=torch.int64,
+            device='cuda')
+        self.history_draft_tokens_buffer = torch.zeros(
+            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            dtype=torch.int64,
+            device='cuda')
+        self.history_score_buffer = torch.zeros(
+            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            dtype=torch.float32,
+            device='cuda')
+        self.history_draft_tokens_parent_buffer = torch.ones(
+            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            dtype=torch.int64,
+            device='cuda') * -1
+
+    def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor,
+                attn_metadata: AttentionMetadata, spec_metadata: SpecMetadata,
+                **kwargs) -> dict[str, torch.Tensor]:
+        
+        assert isinstance(spec_metadata, Eagle3SpecMetadata)
+        spec_tree_manager = spec_metadata.eagle3_resource_manager.spec_tree_manager
+
+        logits = self.draft_model.forward(input_ids=input_ids,
+                                          position_ids=position_ids,
+                                          attn_metadata=attn_metadata,
+                                          spec_metadata=spec_metadata,
+                                          return_context_logits=True)
+        batch_size = attn_metadata.num_seqs
+        vocab_size = logits.shape[-1]
+        logits = logits[spec_metadata.gather_ids]  # [batch_size, vocab_size]
+
+        # new_draft_tokens: [batch_size * dynamic_tree_max_topK]
+        # new_draft_scores: [batch_size * dynamic_tree_max_topK]
+        new_draft_tokens, new_draft_scores = self.sample(logits=logits, max_top_k=self.dynamic_tree_max_topK)
+
+        cur_scores = self.update_draft_tokens_and_scores(
+            cur_draft_idx=0,
+            batch_size=batch_size,
+            new_draft_tokens=new_draft_tokens,
+            new_draft_scores=new_draft_scores,
+            previous_draft_scores=None,
+            attn_metadata=attn_metadata,
+            spec_metadata=spec_metadata)
+
+        return_draft_logits = None
+        with save_metadata_state(attn_metadata, spec_metadata):
+            batch_size = attn_metadata.num_seqs
+
+            self.prepare_for_generation(
+                attn_metadata=attn_metadata,
+                spec_metadata=spec_metadata,
+                spec_tree_manager=spec_tree_manager,
+                position_ids=position_ids)
+
+            for layer_idx in range(1, self.max_draft_len):
+                # input_ids: [batch_size * (max_total_draft_tokens + 1)]
+                # position_ids: [batch_size * (max_total_draft_tokens + 1)]
+                # logits: [batch_size * (max_total_draft_tokens + 1), vocab_size]
+                logits = self.draft_model.forward(
+                    input_ids=self.draft_tokens_buffer[:batch_size, :].reshape(
+                        -1),
+                    position_ids=self.position_ids_buffer[:batch_size, :].
+                    reshape(-1),
+                    attn_metadata=attn_metadata,
+                    spec_metadata=spec_metadata,
+                    return_context_logits=True)
+
+                # new_draft_tokens: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
+                # new_draft_scores: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
+                new_draft_tokens, new_draft_scores = self.sample(
+                    logits=logits, max_top_k=spec_tree_manager.dynamic_tree_max_topK)
+                # Keep updating
+                cur_scores = self.update_draft_tokens_and_scores(
+                    cur_draft_idx=layer_idx,
+                    batch_size=batch_size,
+                    new_draft_tokens=new_draft_tokens,
+                    new_draft_scores=new_draft_scores,
+                    previous_draft_scores=cur_scores,
+                    attn_metadata=attn_metadata,
+                    spec_metadata=spec_metadata)
+
+                if layer_idx == self.max_draft_len - 1:
+                    # FIXME: Actually the logits is incorrect; we don't have compatibility with that yet.
+                    return_draft_logits = logits
+
+        # Resampling the final draft tokens
+        # real_draft_tokens: [batch_size, self.max_total_draft_tokens]
+        # topk_score_indices: [batch_size, self.max_total_draft_tokens]
+        real_draft_tokens, topk_score_indices = self.resampling_final_draft_tokens(batch_size=batch_size)
+
+        # return_new_draft_tokens: [max_total_draft_tokens, batch_size]
+        return_new_draft_tokens = torch.transpose(real_draft_tokens, 0, 1)
+
+        # return_draft_logits: [batch_size, max_total_draft_tokens + 1, vocab_size] -> [max_total_draft_tokens, batch_size, vocab_size]
+        return_draft_logits = return_draft_logits.reshape(
+            batch_size, self.max_total_draft_tokens + 1, vocab_size)
+        return_draft_logits = torch.transpose(return_draft_logits[:, :-1, :], 0,
+                                              1)
+
+        assert return_new_draft_tokens.shape == (self.max_total_draft_tokens,
+                                                 batch_size)
+        assert return_draft_logits.shape == (self.max_total_draft_tokens,
+                                             batch_size, vocab_size)
+
+        print(f"======= return_new_draft_tokens: {return_new_draft_tokens} ========")
+
+        return {
+            "new_draft_tokens": return_new_draft_tokens,
+            "draft_logits": return_draft_logits,
+            "dynamic_tree_buffers": {
+                "topk_score_indices": topk_score_indices,
+                "history_draft_tokens_parent_buffer": self.history_draft_tokens_parent_buffer[:batch_size, :]}
+        }
+
+    def sample(self, logits: torch.Tensor, max_top_k: int) -> torch.Tensor:
+        # TODO: inject the sampler here so we can support non-greedy
+
+        # for draft_layer_idx == 0, logits is of shape [batch_size, vocab_size]
+        # for draft_layer_idx > 0, logits is of shape [batch_size * (max_total_draft_tokens + 1), vocab_size]
+        last_p = self.logsoftmax(logits)
+        topk_values, topk_indices = torch.topk(last_p, k=max_top_k, dim=-1) # [batch_size, max_top_k] or [batch_size * max_total_draft_tokens, max_top_k]
+
+        tokens = topk_indices.reshape(-1)
+        scores = topk_values.reshape(-1)
+
+        if hasattr(self.draft_model.model, "d2t"):
+            d2t = self.draft_model.model.d2t.data
+            tokens = tokens + d2t[tokens]
+
+        return tokens, scores
+
+    def update_draft_tokens_and_scores(self, cur_draft_idx: int, batch_size: int,
+                                  new_draft_tokens: torch.Tensor,
+                                  new_draft_scores: torch.Tensor,
+                                  previous_draft_scores: torch.Tensor,
+                                  attn_metadata: AttentionMetadata,
+                                  spec_metadata: SpecMetadata):
+        '''
+        Args:
+            cur_draft_idx: int, already finished forward.
+            batch_size: int
+            new_draft_tokens: 
+                when cur_draft_idx == 0: [batch_size * dynamic_tree_max_topK]
+                when cur_draft_idx > 0: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
+            previous_draft_scores:
+                when cur_draft_idx == 0: None
+                when cur_draft_idx > 0: [batch_size, dynamic_tree_max_topK]
+        '''
+
+        print(f"======= cur_draft_idx: {cur_draft_idx} ========")
+        # import pdb; pdb.set_trace()
+        '''
+        What this function does:
+        1) Update the scores (exclude the first drafter layer)
+        2) Extract the real draft tokens this layer
+        3) Save the draft tokens and scores to self.history_draft_tokens_buffer and self.history_score_buffer, respectively.
+        4) Update the attn_metadata.spec_decoding_packed_mask for the subsequent drafter layer.
+        5) Update the spec_metadata.hidden_states_read_indices for the subsequent drafter layer.
+        6) Update the parent nodes of the next layer's new nodes in advance.
+        '''
+        # After the first drafter layer, new_draft_tokens: [batch_size * dynamic_tree_max_topK]
+        # For other drafter layers, new_draft_tokens: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
+        if cur_draft_idx == 0:
+            assert new_draft_tokens.shape[0] == (batch_size * self.dynamic_tree_max_topK)
+            assert new_draft_scores.shape[0] == (batch_size * self.dynamic_tree_max_topK)
+        else:
+            assert new_draft_tokens.shape[0] == (batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK)
+            assert new_draft_scores.shape[0] == (batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK)
+
+        if cur_draft_idx == 0:
+            # new_draft_tokens: [batch_size, self.dynamic_tree_max_topK]
+            # new_draft_scores: [batch_size, self.dynamic_tree_max_topK]
+            new_draft_tokens = new_draft_tokens.reshape(batch_size, self.dynamic_tree_max_topK)
+            new_draft_scores = new_draft_scores.reshape(batch_size, self.dynamic_tree_max_topK)
+            
+            # 2) & 3) Update draft tokens and scores buffer.
+            self.draft_tokens_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_tokens[:, :]
+            self.history_draft_tokens_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_tokens[:, :]
+            self.history_score_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_scores[:, :]
+
+            # 4) Update the attn_metadata.spec_decoding_packed_mask
+            attn_metadata.spec_decoding_packed_mask[:batch_size, :, :].fill_(0)
+            dummy_idx = torch.arange(self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')
+            packed_mask = torch.pow(2, dummy_idx) # [self.dynamic_tree_max_topK]
+            attn_metadata.spec_decoding_packed_mask[:batch_size, :self.dynamic_tree_max_topK, :] = packed_mask.unsqueeze(1)
+            print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
+
+            # 5) Update the attn_metadata.hidden_states_read_indices
+            ## Will be updated in the prepare_for_generation function. Because it will need the information of the old_write_indices and so on.
+
+            # 6) Process the parent buffer.
+            self.history_draft_tokens_parent_buffer[:batch_size, :self.dynamic_tree_max_topK] = -1 # Use -1 to represent the root node
+            # These selected nodes will expand into new nodes at the next layer. 
+            # We update the parent nodes of these new nodes in advance.
+            parents_indices_for_next_layer_draft_tokens = torch.repeat_interleave(torch.arange(0, self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda'), self.dynamic_tree_max_topK, dim=0) # [self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+            self.history_draft_tokens_parent_buffer[:batch_size, self.dynamic_tree_max_topK : self.dynamic_tree_max_topK + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK] = parents_indices_for_next_layer_draft_tokens
+
+            print(f"======= new_draft_tokens.shape: {new_draft_tokens.shape}, new_draft_tokens: {new_draft_tokens} ========")
+            print(f"======= new_draft_scores.shape: {new_draft_scores.shape}, new_draft_scores: {new_draft_scores} ========")
+            
+            print(f"======= self.draft_tokens_buffer: {self.draft_tokens_buffer} ========")
+            print(f"======= self.history_draft_tokens_buffer: {self.history_draft_tokens_buffer} ========")
+            print(f"======= self.parents_indices_for_next_layer_draft_tokens: {parents_indices_for_next_layer_draft_tokens} ========")
+            print(f"======= self.history_draft_tokens_parent_buffer: {self.history_draft_tokens_parent_buffer} ========")
+            print(f"======= self.history_score_buffer: {self.history_score_buffer} ========")
+            return new_draft_scores # [batch_size, self.dynamic_tree_max_topK]
+        else:
+            # new_draft_tokens: [batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK]
+            # new_draft_scores: [batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK]
+
+            new_draft_tokens = new_draft_tokens.reshape(batch_size, (self.max_total_draft_tokens + 1), self.dynamic_tree_max_topK)
+            new_draft_scores = new_draft_scores.reshape(batch_size, (self.max_total_draft_tokens + 1), self.dynamic_tree_max_topK)
+            print(f"======= new_draft_tokens.shape: {new_draft_tokens.shape}, new_draft_tokens: {new_draft_tokens} ========")
+            print(f"======= new_draft_scores.shape: {new_draft_scores.shape}, new_draft_scores: {new_draft_scores} ========")
+
+            # We process 'self.max_total_draft_tokens + 1' draft tokens, but we only need specific draft tokens for each layer.
+            gather_draft_tokens_start_offset = (cur_draft_idx - 1) * self.dynamic_tree_max_topK
+            gather_draft_tokens_end_offset = gather_draft_tokens_start_offset + self.dynamic_tree_max_topK
+            gather_new_draft_tokens = new_draft_tokens[:, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :].reshape(batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+            gather_new_draft_scores = new_draft_scores[:, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :] # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
+            print(f"======= gather_draft_tokens_start_offset: {gather_draft_tokens_start_offset}, gather_draft_tokens_end_offset: {gather_draft_tokens_end_offset} ========")
+            print(f"======= gather_new_draft_tokens.shape: {gather_new_draft_tokens.shape}, gather_new_draft_tokens: {gather_new_draft_tokens} ========")
+            print(f"======= gather_new_draft_scores.shape: {gather_new_draft_scores.shape}, gather_new_draft_scores: {gather_new_draft_scores} ========")
+
+            # 1) Update the scores with the previous layer's scores
+            assert previous_draft_scores.shape == (batch_size, self.dynamic_tree_max_topK)
+            gather_new_draft_scores = gather_new_draft_scores + previous_draft_scores.unsqueeze(2) # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
+            gather_new_draft_scores = gather_new_draft_scores.reshape(batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+            print(f"======= previous_draft_scores.shape: {previous_draft_scores.shape}, previous_draft_scores: {previous_draft_scores} ========")
+            print(f"======= gather_new_draft_scores.shape: {gather_new_draft_scores.shape}, gather_new_draft_scores: {gather_new_draft_scores} ========")
+
+            # 2) Extract the real draft tokens this layer, topk again.
+            # topk_values: [batch_size, self.dynamic_tree_max_topK], the output scores of this layer
+            # topk_indices: [batch_size, self.dynamic_tree_max_topK]
+            topk_values, topk_indices = torch.topk(gather_new_draft_scores, k=self.dynamic_tree_max_topK, dim=-1) 
+            real_draft_tokens = torch.gather(gather_new_draft_tokens, dim=1, index=topk_indices) # [batch_size, self.dynamic_tree_max_topK]
+            write_back_real_draft_tokens_start_offset = cur_draft_idx * self.dynamic_tree_max_topK
+            write_back_real_draft_tokens_end_offset = write_back_real_draft_tokens_start_offset + self.dynamic_tree_max_topK
+            self.draft_tokens_buffer[:batch_size, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset] = real_draft_tokens[:, :]
+            print(f"======= write_back_real_draft_tokens_start_offset: {write_back_real_draft_tokens_start_offset}, write_back_real_draft_tokens_end_offset: {write_back_real_draft_tokens_end_offset} ========")
+            print(f"======= topk_values: {topk_values}, topk_indices: {topk_indices} ========")
+            print(f"======= real_draft_tokens.shape: {real_draft_tokens.shape}, real_draft_tokens: {real_draft_tokens} ========")
+            print(f"======= self.draft_tokens_buffer: {self.draft_tokens_buffer} ========")
+
+            # 3) Save the draft tokens and scores to self.history_draft_tokens_buffer and self.history_score_buffer.
+            write_history_start_offset = self.dynamic_tree_max_topK + (cur_draft_idx - 1) * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+            write_history_end_offset = write_history_start_offset + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+            self.history_draft_tokens_buffer[:batch_size, write_history_start_offset:write_history_end_offset] = gather_new_draft_tokens[:, :]
+            self.history_score_buffer[:batch_size, write_history_start_offset:write_history_end_offset] = gather_new_draft_scores[:, :]
+            print(f"======= write_history_start_offset: {write_history_start_offset}, write_history_end_offset: {write_history_end_offset} ========")
+            print(f"======= self.history_draft_tokens_buffer: {self.history_draft_tokens_buffer} ========")
+            print(f"======= self.history_score_buffer: {self.history_score_buffer} ========")
+
+            # 4) Update the attn_metadata.spec_decoding_packed_mask, shape: [max_num_requests, max_total_draft_tokens + 1, math.ceil(max_total_draft_tokens + 1 / 32)]
+            selected_parents = topk_indices // self.dynamic_tree_max_topK # [batch_size, self.dynamic_tree_max_topK]
+            # For simplicity, we will only consider the case where math.ceil(max_total_draft_tokens + 1 / 32) == 1.
+            parents_packed_mask = torch.gather(attn_metadata.spec_decoding_packed_mask[:batch_size, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :].squeeze(-1), dim=1, index=selected_parents) # [batch_size, self.dynamic_tree_max_topK]
+            child_packed_mask = torch.pow(2, torch.arange(cur_draft_idx * self.dynamic_tree_max_topK, cur_draft_idx * self.dynamic_tree_max_topK + self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')) # [self.dynamic_tree_max_topK]
+            print(f"======= child_packed_mask1111.shape: {child_packed_mask.shape}, child_packed_mask1111: {child_packed_mask} ========")
+            child_packed_mask = child_packed_mask + parents_packed_mask # [batch_size, self.dynamic_tree_max_topK]
+            attn_metadata.spec_decoding_packed_mask[:batch_size, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset, :] = child_packed_mask.unsqueeze(-1)
+            print(f"======= selected_parents.shape: {selected_parents.shape}, selected_parents: {selected_parents} ========")
+            print(f"======= parents_packed_mask.shape: {parents_packed_mask.shape}, parents_packed_mask: {parents_packed_mask} ========")
+            print(f"======= child_packed_mask2222.shape: {child_packed_mask.shape}, child_packed_mask22222: {child_packed_mask} ========")
+            print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
+
+            # 5) Update the spec_metadata.hidden_states_read_indices, shape: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
+            selected_parents_write_indices = selected_parents + gather_draft_tokens_start_offset # [batch_size, self.dynamic_tree_max_topK]
+            hidden_states_write_indices_view = spec_metadata.hidden_states_write_indices[:batch_size * (self.max_total_draft_tokens + 1)] # [batch_size, self.max_total_draft_tokens + 1]
+            hidden_states_write_indices_view = hidden_states_write_indices_view.view(batch_size, self.max_total_draft_tokens + 1) # [batch_size, self.max_total_draft_tokens + 1]
+            child_hidden_states_read_indices = torch.gather(hidden_states_write_indices_view, dim=1, index=selected_parents_write_indices) # [batch_size, self.dynamic_tree_max_topK]
+            print(f"======= selected_parents_write_indices.shape: {selected_parents_write_indices.shape}, selected_parents_write_indices: {selected_parents_write_indices} ========")
+            print(f"======= hidden_states_write_indices_view.shape: {hidden_states_write_indices_view.shape}, hidden_states_write_indices_view: {hidden_states_write_indices_view} ========")
+            print(f"======= child_hidden_states_read_indices.shape: {child_hidden_states_read_indices.shape}, child_hidden_states_read_indices: {child_hidden_states_read_indices} ========")
+            print(f"======= spec_metadata.hidden_states_write_indices: {spec_metadata.hidden_states_write_indices} ========")
+
+            hidden_states_read_indices_view = spec_metadata.hidden_states_read_indices[:batch_size * (self.max_total_draft_tokens + 1)] # [batch_size * (max_total_draft_tokens + 1)]
+            hidden_states_read_indices_view = hidden_states_read_indices_view.view(batch_size, self.max_total_draft_tokens + 1) # [batch_size, self.max_total_draft_tokens + 1]
+            hidden_states_read_indices_view[:, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset] = child_hidden_states_read_indices[:, :] 
+            print(f"======= hidden_states_read_indices_view.shape: {hidden_states_read_indices_view.shape}, hidden_states_read_indices_view: {hidden_states_read_indices_view} ========")
+            print(f"======= spec_metadata.hidden_states_read_indices: {spec_metadata.hidden_states_read_indices} ========")
+
+            if cur_draft_idx < self.max_draft_len - 1:
+                # 6) Update the parent nodes of the next layer's new nodes in advance.
+                # We need to know next layer's draft tokens are expaned from which parents. 
+                # i.e. calculate the index of the selected draft tokens in the entire tree (including all historical nodes, for subsequent reconstruction of the entire tree).
+                parents_indices = topk_indices + (self.dynamic_tree_max_topK + (cur_draft_idx - 1) * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK]
+                parents_indices = torch.repeat_interleave(parents_indices, self.dynamic_tree_max_topK, dim=1) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+                next_layer_draft_tokens_start_offset = self.dynamic_tree_max_topK + cur_draft_idx * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+                next_layer_draft_tokens_end_offset = next_layer_draft_tokens_start_offset + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+                self.history_draft_tokens_parent_buffer[:batch_size, next_layer_draft_tokens_start_offset:next_layer_draft_tokens_end_offset] = parents_indices[:, :]
+                print(f"======= parents_indices.shape: {parents_indices.shape}, parents_indices: {parents_indices} ========")
+                print(f"======= next_layer_draft_tokens_start_offset: {next_layer_draft_tokens_start_offset}, next_layer_draft_tokens_end_offset: {next_layer_draft_tokens_end_offset} ========")
+                print(f"======= self.history_draft_tokens_parent_buffer: {self.history_draft_tokens_parent_buffer} ========")
+
+            return topk_values # [batch_size, self.dynamic_tree_max_topK]
+    
+
+    def resampling_final_draft_tokens(self, batch_size: int):
+        '''
+        Restruct the tree based on the self.history_draft_tokens_buffer, self.history_draft_tokens_parent_buffer and self.history_score_buffer.
+        '''
+        # self.history_score_buffer[:batch_size, :] shape: [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
+        topk_score_indices = torch.topk(self.history_score_buffer[:batch_size, :], k=self.max_total_draft_tokens, dim=-1).indices
+        topk_score_indices = torch.sort(topk_score_indices).values # [batch_size, self.max_total_draft_tokens]
+
+        # The final output draft tokens
+        real_draft_tokens = torch.gather(self.history_draft_tokens_buffer[:batch_size, :], dim=1, index=topk_score_indices) # [batch_size, self.max_total_draft_tokens]
+
+        # self.history_draft_tokens_parent_buffer[:batch_size, :] shape: [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
+        # real_draft_tokens_parents = torch.gather(self.history_draft_tokens_parent_buffer[:batch_size, :], dim=1, index=topk_score_indices) # [batch_size, self.max_total_draft_tokens]
+
+
+        # return real_draft_tokens, topk_score_indices, real_draft_tokens_parents
+        return real_draft_tokens, topk_score_indices
+
+
+
+    def prepare_for_generation(self, attn_metadata: AttentionMetadata,
+                               spec_metadata: SpecMetadata,
+                               spec_tree_manager: SpecTreeManager,
+                               position_ids: torch.Tensor):
+        '''
+        Setup the attn_metadata and spec_metadata for the subsequent drafter layer. Therefore, only call once after the first drafter layer.
+        To the subsequent drafter layer, we take 'max_total_drafter_tokens + 1' draft tokens as input.
+        Only the first part of the draft tokens is meaningful, and the later tokens can be regarded as padding
+        until we continuously write the correct value.
+
+        This introduces additional redundant computation, but it makes it compatible with cuda graphs.
+
+        What we need to prepare are:
+            1) position_ids
+            2) attn_metadata
+                2.1) kv_lens_cuda
+                2.2) _seq_lens, _seq_lens_cuda
+                2.3) host_request_types
+                2.4) num_contexts
+                2.5) use_spec_decoding
+                2.6) spec_decoding_position_offsets
+                2.7) spec_decoding_packed_mask
+                2.8) spec_decoding_generation_lengths
+            3) spec_metadata
+                3.1) num_tokens
+                3.2) hidden_states_read_indices, hidden_states_write_indices
+                3.3) is_first_draft
+        '''
+        batch_size = attn_metadata.num_seqs
+
+        # 1) Prepare the position_ids
+        num_accepted_draft_tokens = spec_metadata.num_accepted_draft_tokens[:
+                                                                            batch_size]
+        seq_lens = attn_metadata.seq_lens_cuda[:batch_size]
+        # Calculate last accepted token indices
+        last_tokens_idx = torch.cumsum(
+            seq_lens, dim=0,
+            dtype=torch.long) - seq_lens + num_accepted_draft_tokens
+        position_start_idx = position_ids[0,
+                                          last_tokens_idx] + 1  # [batch_size]
+        self.position_ids_buffer[:batch_size, :] = position_start_idx.unsqueeze(
+            1) + spec_tree_manager.spec_dec_position_offsets_for_drafter_model[0, :].unsqueeze(0) # [batch_size, max_total_draft_tokens + 1]
+
+        # 2) Prepare the attn_metadata
+        ## 2.1) kv_lens_cuda
+        attn_metadata.kv_lens_cuda[:
+                                   batch_size] -= seq_lens - num_accepted_draft_tokens - 1
+        attn_metadata.kv_lens_cuda[:batch_size] += (
+            self.max_total_draft_tokens + 1)
+
+        ## 2.2) _seq_lens, _seq_lens_cuda
+        attn_metadata._seq_lens[:batch_size].fill_(self.max_total_draft_tokens +
+                                                   1)
+        attn_metadata._seq_lens_cuda[:batch_size].fill_(
+            self.max_total_draft_tokens + 1)
+        attn_metadata.on_update()
+
+        ## 2.3) host_request_types
+        attn_metadata.host_request_types[:attn_metadata.num_contexts].fill_(1)
+
+        ## 2.4) num_contexts
+        attn_metadata.num_contexts = 0
+
+        ## 2.5) use_spec_decoding
+        attn_metadata.use_spec_decoding = True
+
+        ## 2.6) spec_decoding_position_offsets
+        ### attn_metadata.spec_decoding_position_offsets: [max_num_requests, max_total_draft_tokens + 1]
+        attn_metadata.spec_decoding_position_offsets[:batch_size, :] = spec_tree_manager.spec_dec_position_offsets_for_drafter_model[0, :].unsqueeze(0) # [batch_size, max_total_draft_tokens + 1]
+
+        ## 2.7) spec_decoding_packed_mask 
+        ### NOTE: spec_decoding_packed_mask will be updated for each drafter layer in 'update_draft_tokens_and_scores'
+        # attn_metadata.spec_decoding_packed_mask[:batch_size, :, :].fill_(0)
+        # dummy_idx = torch.arange(self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')
+        # packed_mask = torch.pow(2, dummy_idx + 1) - 1
+        # attn_metadata.spec_decoding_packed_mask[:batch_size, :self.dynamic_tree_max_topK, :] = packed_mask.unsqueeze(1)
+
+        ## 2.8) spec_decoding_generation_lengths
+        ### attn_metadata.spec_decoding_generation_lengths: [max_num_requests]
+        attn_metadata.spec_decoding_generation_lengths[:batch_size] = self.max_total_draft_tokens + 1
+
+        # 3) Update spec_metadata
+        ## 3.1) num_tokens
+        spec_metadata.num_tokens = batch_size * (self.max_total_draft_tokens +
+                                                 1)
+        ## 3.2) hidden_states_read_indices, hidden_states_write_indices
+        old_write_indices = spec_metadata.hidden_states_write_indices
+        start_idx = old_write_indices[
+            last_tokens_idx]  # [batch_size], already take the accepted tokens into account.
+
+        ### spec_metadata.hidden_states_read_indices: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
+        ### NOTE: spec_metadata.hidden_states_read_indices needs to be updated for each drafter layer
+        hidden_states_read_offset = start_idx.unsqueeze(1).repeat(1, self.max_total_draft_tokens + 1) # [batch_size, max_total_draft_tokens + 1]
+        spec_metadata.hidden_states_read_indices[:batch_size * (self.max_total_draft_tokens + 1)] = hidden_states_read_offset.reshape(-1)
+
+        ### spec_metadata.hidden_states_write_indices: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
         hidden_states_write_offset = torch.arange(
             1, self.max_total_draft_tokens + 1 + 1,
             device=position_ids.device).unsqueeze(0).repeat(

--- a/tensorrt_llm/_torch/speculative/drafting_loops.py
+++ b/tensorrt_llm/_torch/speculative/drafting_loops.py
@@ -508,10 +508,12 @@ class StaticTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         return
 
+
 class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
     def __init__(self, max_draft_len: int, max_total_draft_tokens: int,
-                 max_batch_size: int, dynamic_tree_max_topK, draft_model: torch.nn.Module):
+                 max_batch_size: int, dynamic_tree_max_topK,
+                 draft_model: torch.nn.Module):
         super().__init__()
         self.draft_model = draft_model
         self.config = self.draft_model.config
@@ -531,22 +533,28 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
             dtype=torch.int64,
             device='cuda')
         self.history_draft_tokens_buffer = torch.zeros(
-            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            (max_batch_size, dynamic_tree_max_topK +
+             dynamic_tree_max_topK * dynamic_tree_max_topK *
+             (max_draft_len - 1)),
             dtype=torch.int64,
             device='cuda')
         self.history_score_buffer = torch.zeros(
-            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            (max_batch_size, dynamic_tree_max_topK +
+             dynamic_tree_max_topK * dynamic_tree_max_topK *
+             (max_draft_len - 1)),
             dtype=torch.float32,
             device='cuda')
         self.history_draft_tokens_parent_buffer = torch.ones(
-            (max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)),
+            (max_batch_size, dynamic_tree_max_topK +
+             dynamic_tree_max_topK * dynamic_tree_max_topK *
+             (max_draft_len - 1)),
             dtype=torch.int64,
             device='cuda') * -1
 
     def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor,
                 attn_metadata: AttentionMetadata, spec_metadata: SpecMetadata,
                 **kwargs) -> dict[str, torch.Tensor]:
-        
+
         assert isinstance(spec_metadata, Eagle3SpecMetadata)
         spec_tree_manager = spec_metadata.eagle3_resource_manager.spec_tree_manager
 
@@ -561,7 +569,8 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         # new_draft_tokens: [batch_size * dynamic_tree_max_topK]
         # new_draft_scores: [batch_size * dynamic_tree_max_topK]
-        new_draft_tokens, new_draft_scores = self.sample(logits=logits, max_top_k=self.dynamic_tree_max_topK)
+        new_draft_tokens, new_draft_scores = self.sample(
+            logits=logits, max_top_k=self.dynamic_tree_max_topK)
 
         cur_scores = self.update_draft_tokens_and_scores(
             cur_draft_idx=0,
@@ -576,11 +585,10 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         with save_metadata_state(attn_metadata, spec_metadata):
             batch_size = attn_metadata.num_seqs
 
-            self.prepare_for_generation(
-                attn_metadata=attn_metadata,
-                spec_metadata=spec_metadata,
-                spec_tree_manager=spec_tree_manager,
-                position_ids=position_ids)
+            self.prepare_for_generation(attn_metadata=attn_metadata,
+                                        spec_metadata=spec_metadata,
+                                        spec_tree_manager=spec_tree_manager,
+                                        position_ids=position_ids)
 
             for layer_idx in range(1, self.max_draft_len):
                 # input_ids: [batch_size * (max_total_draft_tokens + 1)]
@@ -598,7 +606,8 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
                 # new_draft_tokens: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
                 # new_draft_scores: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
                 new_draft_tokens, new_draft_scores = self.sample(
-                    logits=logits, max_top_k=spec_tree_manager.dynamic_tree_max_topK)
+                    logits=logits,
+                    max_top_k=spec_tree_manager.dynamic_tree_max_topK)
                 # Keep updating
                 cur_scores = self.update_draft_tokens_and_scores(
                     cur_draft_idx=layer_idx,
@@ -616,7 +625,8 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         # Resampling the final draft tokens
         # real_draft_tokens: [batch_size, self.max_total_draft_tokens]
         # topk_score_indices: [batch_size, self.max_total_draft_tokens]
-        real_draft_tokens, topk_score_indices = self.resampling_final_draft_tokens(batch_size=batch_size)
+        real_draft_tokens, topk_score_indices = self.resampling_final_draft_tokens(
+            batch_size=batch_size)
 
         # return_new_draft_tokens: [max_total_draft_tokens, batch_size]
         return_new_draft_tokens = torch.transpose(real_draft_tokens, 0, 1)
@@ -632,14 +642,15 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         assert return_draft_logits.shape == (self.max_total_draft_tokens,
                                              batch_size, vocab_size)
 
-        print(f"======= return_new_draft_tokens: {return_new_draft_tokens} ========")
-
         return {
             "new_draft_tokens": return_new_draft_tokens,
             "draft_logits": return_draft_logits,
             "dynamic_tree_buffers": {
-                "topk_score_indices": topk_score_indices,
-                "history_draft_tokens_parent_buffer": self.history_draft_tokens_parent_buffer[:batch_size, :]}
+                "topk_score_indices":
+                topk_score_indices,
+                "history_draft_tokens_parent_buffer":
+                self.history_draft_tokens_parent_buffer[:batch_size, :]
+            }
         }
 
     def sample(self, logits: torch.Tensor, max_top_k: int) -> torch.Tensor:
@@ -648,7 +659,9 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         # for draft_layer_idx == 0, logits is of shape [batch_size, vocab_size]
         # for draft_layer_idx > 0, logits is of shape [batch_size * (max_total_draft_tokens + 1), vocab_size]
         last_p = self.logsoftmax(logits)
-        topk_values, topk_indices = torch.topk(last_p, k=max_top_k, dim=-1) # [batch_size, max_top_k] or [batch_size * max_total_draft_tokens, max_top_k]
+        topk_values, topk_indices = torch.topk(
+            last_p, k=max_top_k, dim=-1
+        )  # [batch_size, max_top_k] or [batch_size * max_total_draft_tokens, max_top_k]
 
         tokens = topk_indices.reshape(-1)
         scores = topk_values.reshape(-1)
@@ -659,26 +672,22 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         return tokens, scores
 
-    def update_draft_tokens_and_scores(self, cur_draft_idx: int, batch_size: int,
-                                  new_draft_tokens: torch.Tensor,
-                                  new_draft_scores: torch.Tensor,
-                                  previous_draft_scores: torch.Tensor,
-                                  attn_metadata: AttentionMetadata,
-                                  spec_metadata: SpecMetadata):
+    def update_draft_tokens_and_scores(
+            self, cur_draft_idx: int, batch_size: int,
+            new_draft_tokens: torch.Tensor, new_draft_scores: torch.Tensor,
+            previous_draft_scores: torch.Tensor,
+            attn_metadata: AttentionMetadata, spec_metadata: SpecMetadata):
         '''
         Args:
             cur_draft_idx: int, already finished forward.
             batch_size: int
-            new_draft_tokens: 
+            new_draft_tokens:
                 when cur_draft_idx == 0: [batch_size * dynamic_tree_max_topK]
                 when cur_draft_idx > 0: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
             previous_draft_scores:
                 when cur_draft_idx == 0: None
                 when cur_draft_idx > 0: [batch_size, dynamic_tree_max_topK]
         '''
-
-        print(f"======= cur_draft_idx: {cur_draft_idx} ========")
-        # import pdb; pdb.set_trace()
         '''
         What this function does:
         1) Update the scores (exclude the first drafter layer)
@@ -691,160 +700,226 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         # After the first drafter layer, new_draft_tokens: [batch_size * dynamic_tree_max_topK]
         # For other drafter layers, new_draft_tokens: [batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK]
         if cur_draft_idx == 0:
-            assert new_draft_tokens.shape[0] == (batch_size * self.dynamic_tree_max_topK)
-            assert new_draft_scores.shape[0] == (batch_size * self.dynamic_tree_max_topK)
+            assert new_draft_tokens.shape[0] == (batch_size *
+                                                 self.dynamic_tree_max_topK)
+            assert new_draft_scores.shape[0] == (batch_size *
+                                                 self.dynamic_tree_max_topK)
         else:
-            assert new_draft_tokens.shape[0] == (batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK)
-            assert new_draft_scores.shape[0] == (batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK)
+            assert new_draft_tokens.shape[0] == (
+                batch_size * (self.max_total_draft_tokens + 1) *
+                self.dynamic_tree_max_topK)
+            assert new_draft_scores.shape[0] == (
+                batch_size * (self.max_total_draft_tokens + 1) *
+                self.dynamic_tree_max_topK)
 
         if cur_draft_idx == 0:
             # new_draft_tokens: [batch_size, self.dynamic_tree_max_topK]
             # new_draft_scores: [batch_size, self.dynamic_tree_max_topK]
-            new_draft_tokens = new_draft_tokens.reshape(batch_size, self.dynamic_tree_max_topK)
-            new_draft_scores = new_draft_scores.reshape(batch_size, self.dynamic_tree_max_topK)
-            
+            new_draft_tokens = new_draft_tokens.reshape(
+                batch_size, self.dynamic_tree_max_topK)
+            new_draft_scores = new_draft_scores.reshape(
+                batch_size, self.dynamic_tree_max_topK)
+
             # 2) & 3) Update draft tokens and scores buffer.
-            self.draft_tokens_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_tokens[:, :]
-            self.history_draft_tokens_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_tokens[:, :]
-            self.history_score_buffer[:batch_size, :self.dynamic_tree_max_topK] = new_draft_scores[:, :]
+            self.draft_tokens_buffer[:batch_size, :self.
+                                     dynamic_tree_max_topK] = new_draft_tokens[:, :]
+            self.history_draft_tokens_buffer[:batch_size, :self.
+                                             dynamic_tree_max_topK] = new_draft_tokens[:, :]
+            self.history_score_buffer[:batch_size, :self.
+                                      dynamic_tree_max_topK] = new_draft_scores[:, :]
 
             # 4) Update the attn_metadata.spec_decoding_packed_mask
             attn_metadata.spec_decoding_packed_mask[:batch_size, :, :].fill_(0)
-            dummy_idx = torch.arange(self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')
-            packed_mask = torch.pow(2, dummy_idx) # [self.dynamic_tree_max_topK]
-            attn_metadata.spec_decoding_packed_mask[:batch_size, :self.dynamic_tree_max_topK, :] = packed_mask.unsqueeze(1)
-            print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
+            dummy_idx = torch.arange(self.dynamic_tree_max_topK,
+                                     dtype=torch.int32,
+                                     device='cuda')
+            packed_mask = torch.pow(2,
+                                    dummy_idx)  # [self.dynamic_tree_max_topK]
+            attn_metadata.spec_decoding_packed_mask[:batch_size, :self.
+                                                    dynamic_tree_max_topK, :] = packed_mask.unsqueeze(
+                                                        1)
 
             # 5) Update the attn_metadata.hidden_states_read_indices
             ## Will be updated in the prepare_for_generation function. Because it will need the information of the old_write_indices and so on.
 
             # 6) Process the parent buffer.
-            self.history_draft_tokens_parent_buffer[:batch_size, :self.dynamic_tree_max_topK] = -1 # Use -1 to represent the root node
-            # These selected nodes will expand into new nodes at the next layer. 
+            self.history_draft_tokens_parent_buffer[:batch_size, :self.
+                                                    dynamic_tree_max_topK] = -1  # Use -1 to represent the root node
+            # These selected nodes will expand into new nodes at the next layer.
             # We update the parent nodes of these new nodes in advance.
-            parents_indices_for_next_layer_draft_tokens = torch.repeat_interleave(torch.arange(0, self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda'), self.dynamic_tree_max_topK, dim=0) # [self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
-            self.history_draft_tokens_parent_buffer[:batch_size, self.dynamic_tree_max_topK : self.dynamic_tree_max_topK + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK] = parents_indices_for_next_layer_draft_tokens
+            parents_indices_for_next_layer_draft_tokens = torch.repeat_interleave(
+                torch.arange(0,
+                             self.dynamic_tree_max_topK,
+                             dtype=torch.int32,
+                             device='cuda'),
+                self.dynamic_tree_max_topK,
+                dim=0
+            )  # [self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+            self.history_draft_tokens_parent_buffer[:batch_size,
+                                                    self.dynamic_tree_max_topK:
+                                                    self.dynamic_tree_max_topK +
+                                                    self.dynamic_tree_max_topK *
+                                                    self.
+                                                    dynamic_tree_max_topK] = parents_indices_for_next_layer_draft_tokens
 
-            print(f"======= new_draft_tokens.shape: {new_draft_tokens.shape}, new_draft_tokens: {new_draft_tokens} ========")
-            print(f"======= new_draft_scores.shape: {new_draft_scores.shape}, new_draft_scores: {new_draft_scores} ========")
-            
-            print(f"======= self.draft_tokens_buffer: {self.draft_tokens_buffer} ========")
-            print(f"======= self.history_draft_tokens_buffer: {self.history_draft_tokens_buffer} ========")
-            print(f"======= self.parents_indices_for_next_layer_draft_tokens: {parents_indices_for_next_layer_draft_tokens} ========")
-            print(f"======= self.history_draft_tokens_parent_buffer: {self.history_draft_tokens_parent_buffer} ========")
-            print(f"======= self.history_score_buffer: {self.history_score_buffer} ========")
-            return new_draft_scores # [batch_size, self.dynamic_tree_max_topK]
+            return new_draft_scores  # [batch_size, self.dynamic_tree_max_topK]
         else:
             # new_draft_tokens: [batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK]
             # new_draft_scores: [batch_size * (self.max_total_draft_tokens + 1) * self.dynamic_tree_max_topK]
 
-            new_draft_tokens = new_draft_tokens.reshape(batch_size, (self.max_total_draft_tokens + 1), self.dynamic_tree_max_topK)
-            new_draft_scores = new_draft_scores.reshape(batch_size, (self.max_total_draft_tokens + 1), self.dynamic_tree_max_topK)
-            print(f"======= new_draft_tokens.shape: {new_draft_tokens.shape}, new_draft_tokens: {new_draft_tokens} ========")
-            print(f"======= new_draft_scores.shape: {new_draft_scores.shape}, new_draft_scores: {new_draft_scores} ========")
+            new_draft_tokens = new_draft_tokens.reshape(
+                batch_size, (self.max_total_draft_tokens + 1),
+                self.dynamic_tree_max_topK)
+            new_draft_scores = new_draft_scores.reshape(
+                batch_size, (self.max_total_draft_tokens + 1),
+                self.dynamic_tree_max_topK)
 
             # We process 'self.max_total_draft_tokens + 1' draft tokens, but we only need specific draft tokens for each layer.
-            gather_draft_tokens_start_offset = (cur_draft_idx - 1) * self.dynamic_tree_max_topK
+            gather_draft_tokens_start_offset = (cur_draft_idx -
+                                                1) * self.dynamic_tree_max_topK
             gather_draft_tokens_end_offset = gather_draft_tokens_start_offset + self.dynamic_tree_max_topK
-            gather_new_draft_tokens = new_draft_tokens[:, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :].reshape(batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
-            gather_new_draft_scores = new_draft_scores[:, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :] # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
-            print(f"======= gather_draft_tokens_start_offset: {gather_draft_tokens_start_offset}, gather_draft_tokens_end_offset: {gather_draft_tokens_end_offset} ========")
-            print(f"======= gather_new_draft_tokens.shape: {gather_new_draft_tokens.shape}, gather_new_draft_tokens: {gather_new_draft_tokens} ========")
-            print(f"======= gather_new_draft_scores.shape: {gather_new_draft_scores.shape}, gather_new_draft_scores: {gather_new_draft_scores} ========")
+            gather_new_draft_tokens = new_draft_tokens[:,
+                                                       gather_draft_tokens_start_offset:
+                                                       gather_draft_tokens_end_offset, :].reshape(
+                                                           batch_size, self.
+                                                           dynamic_tree_max_topK
+                                                           * self.
+                                                           dynamic_tree_max_topK
+                                                       )  # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+            gather_new_draft_scores = new_draft_scores[:,
+                                                       gather_draft_tokens_start_offset:
+                                                       gather_draft_tokens_end_offset, :]  # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
 
             # 1) Update the scores with the previous layer's scores
-            assert previous_draft_scores.shape == (batch_size, self.dynamic_tree_max_topK)
-            gather_new_draft_scores = gather_new_draft_scores + previous_draft_scores.unsqueeze(2) # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
-            gather_new_draft_scores = gather_new_draft_scores.reshape(batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
-            print(f"======= previous_draft_scores.shape: {previous_draft_scores.shape}, previous_draft_scores: {previous_draft_scores} ========")
-            print(f"======= gather_new_draft_scores.shape: {gather_new_draft_scores.shape}, gather_new_draft_scores: {gather_new_draft_scores} ========")
+            assert previous_draft_scores.shape == (batch_size,
+                                                   self.dynamic_tree_max_topK)
+            gather_new_draft_scores = gather_new_draft_scores + previous_draft_scores.unsqueeze(
+                2
+            )  # [batch_size, self.dynamic_tree_max_topK, self.dynamic_tree_max_topK]
+            gather_new_draft_scores = gather_new_draft_scores.reshape(
+                batch_size,
+                self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+            )  # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
 
             # 2) Extract the real draft tokens this layer, topk again.
             # topk_values: [batch_size, self.dynamic_tree_max_topK], the output scores of this layer
             # topk_indices: [batch_size, self.dynamic_tree_max_topK]
-            topk_values, topk_indices = torch.topk(gather_new_draft_scores, k=self.dynamic_tree_max_topK, dim=-1) 
-            real_draft_tokens = torch.gather(gather_new_draft_tokens, dim=1, index=topk_indices) # [batch_size, self.dynamic_tree_max_topK]
+            topk_values, topk_indices = torch.topk(gather_new_draft_scores,
+                                                   k=self.dynamic_tree_max_topK,
+                                                   dim=-1)
+            real_draft_tokens = torch.gather(
+                gather_new_draft_tokens, dim=1,
+                index=topk_indices)  # [batch_size, self.dynamic_tree_max_topK]
             write_back_real_draft_tokens_start_offset = cur_draft_idx * self.dynamic_tree_max_topK
             write_back_real_draft_tokens_end_offset = write_back_real_draft_tokens_start_offset + self.dynamic_tree_max_topK
-            self.draft_tokens_buffer[:batch_size, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset] = real_draft_tokens[:, :]
-            print(f"======= write_back_real_draft_tokens_start_offset: {write_back_real_draft_tokens_start_offset}, write_back_real_draft_tokens_end_offset: {write_back_real_draft_tokens_end_offset} ========")
-            print(f"======= topk_values: {topk_values}, topk_indices: {topk_indices} ========")
-            print(f"======= real_draft_tokens.shape: {real_draft_tokens.shape}, real_draft_tokens: {real_draft_tokens} ========")
-            print(f"======= self.draft_tokens_buffer: {self.draft_tokens_buffer} ========")
+            self.draft_tokens_buffer[:batch_size,
+                                     write_back_real_draft_tokens_start_offset:
+                                     write_back_real_draft_tokens_end_offset] = real_draft_tokens[:, :]
 
             # 3) Save the draft tokens and scores to self.history_draft_tokens_buffer and self.history_score_buffer.
-            write_history_start_offset = self.dynamic_tree_max_topK + (cur_draft_idx - 1) * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+            write_history_start_offset = self.dynamic_tree_max_topK + (
+                cur_draft_idx -
+                1) * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
             write_history_end_offset = write_history_start_offset + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
-            self.history_draft_tokens_buffer[:batch_size, write_history_start_offset:write_history_end_offset] = gather_new_draft_tokens[:, :]
-            self.history_score_buffer[:batch_size, write_history_start_offset:write_history_end_offset] = gather_new_draft_scores[:, :]
-            print(f"======= write_history_start_offset: {write_history_start_offset}, write_history_end_offset: {write_history_end_offset} ========")
-            print(f"======= self.history_draft_tokens_buffer: {self.history_draft_tokens_buffer} ========")
-            print(f"======= self.history_score_buffer: {self.history_score_buffer} ========")
+            self.history_draft_tokens_buffer[:batch_size,
+                                             write_history_start_offset:
+                                             write_history_end_offset] = gather_new_draft_tokens[:, :]
+            self.history_score_buffer[:batch_size, write_history_start_offset:
+                                      write_history_end_offset] = gather_new_draft_scores[:, :]
 
             # 4) Update the attn_metadata.spec_decoding_packed_mask, shape: [max_num_requests, max_total_draft_tokens + 1, math.ceil(max_total_draft_tokens + 1 / 32)]
-            selected_parents = topk_indices // self.dynamic_tree_max_topK # [batch_size, self.dynamic_tree_max_topK]
+            selected_parents = topk_indices // self.dynamic_tree_max_topK  # [batch_size, self.dynamic_tree_max_topK]
             # For simplicity, we will only consider the case where math.ceil(max_total_draft_tokens + 1 / 32) == 1.
-            parents_packed_mask = torch.gather(attn_metadata.spec_decoding_packed_mask[:batch_size, gather_draft_tokens_start_offset:gather_draft_tokens_end_offset, :].squeeze(-1), dim=1, index=selected_parents) # [batch_size, self.dynamic_tree_max_topK]
-            child_packed_mask = torch.pow(2, torch.arange(cur_draft_idx * self.dynamic_tree_max_topK, cur_draft_idx * self.dynamic_tree_max_topK + self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')) # [self.dynamic_tree_max_topK]
-            print(f"======= child_packed_mask1111.shape: {child_packed_mask.shape}, child_packed_mask1111: {child_packed_mask} ========")
-            child_packed_mask = child_packed_mask + parents_packed_mask # [batch_size, self.dynamic_tree_max_topK]
-            attn_metadata.spec_decoding_packed_mask[:batch_size, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset, :] = child_packed_mask.unsqueeze(-1)
-            print(f"======= selected_parents.shape: {selected_parents.shape}, selected_parents: {selected_parents} ========")
-            print(f"======= parents_packed_mask.shape: {parents_packed_mask.shape}, parents_packed_mask: {parents_packed_mask} ========")
-            print(f"======= child_packed_mask2222.shape: {child_packed_mask.shape}, child_packed_mask22222: {child_packed_mask} ========")
-            print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
+            parents_packed_mask = torch.gather(
+                attn_metadata.
+                spec_decoding_packed_mask[:batch_size,
+                                          gather_draft_tokens_start_offset:
+                                          gather_draft_tokens_end_offset, :].
+                squeeze(-1),
+                dim=1,
+                index=selected_parents
+            )  # [batch_size, self.dynamic_tree_max_topK]
+            child_packed_mask = torch.pow(
+                2,
+                torch.arange(cur_draft_idx * self.dynamic_tree_max_topK,
+                             cur_draft_idx * self.dynamic_tree_max_topK +
+                             self.dynamic_tree_max_topK,
+                             dtype=torch.int32,
+                             device='cuda'))  # [self.dynamic_tree_max_topK]
+            child_packed_mask = child_packed_mask + parents_packed_mask  # [batch_size, self.dynamic_tree_max_topK]
+            attn_metadata.spec_decoding_packed_mask[:batch_size,
+                                                    write_back_real_draft_tokens_start_offset:
+                                                    write_back_real_draft_tokens_end_offset, :] = child_packed_mask.unsqueeze(
+                                                        -1)
 
             # 5) Update the spec_metadata.hidden_states_read_indices, shape: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
-            selected_parents_write_indices = selected_parents + gather_draft_tokens_start_offset # [batch_size, self.dynamic_tree_max_topK]
-            hidden_states_write_indices_view = spec_metadata.hidden_states_write_indices[:batch_size * (self.max_total_draft_tokens + 1)] # [batch_size, self.max_total_draft_tokens + 1]
-            hidden_states_write_indices_view = hidden_states_write_indices_view.view(batch_size, self.max_total_draft_tokens + 1) # [batch_size, self.max_total_draft_tokens + 1]
-            child_hidden_states_read_indices = torch.gather(hidden_states_write_indices_view, dim=1, index=selected_parents_write_indices) # [batch_size, self.dynamic_tree_max_topK]
-            print(f"======= selected_parents_write_indices.shape: {selected_parents_write_indices.shape}, selected_parents_write_indices: {selected_parents_write_indices} ========")
-            print(f"======= hidden_states_write_indices_view.shape: {hidden_states_write_indices_view.shape}, hidden_states_write_indices_view: {hidden_states_write_indices_view} ========")
-            print(f"======= child_hidden_states_read_indices.shape: {child_hidden_states_read_indices.shape}, child_hidden_states_read_indices: {child_hidden_states_read_indices} ========")
-            print(f"======= spec_metadata.hidden_states_write_indices: {spec_metadata.hidden_states_write_indices} ========")
+            selected_parents_write_indices = selected_parents + gather_draft_tokens_start_offset  # [batch_size, self.dynamic_tree_max_topK]
+            hidden_states_write_indices_view = spec_metadata.hidden_states_write_indices[:batch_size * (
+                self.max_total_draft_tokens +
+                1)]  # [batch_size, self.max_total_draft_tokens + 1]
+            hidden_states_write_indices_view = hidden_states_write_indices_view.view(
+                batch_size, self.max_total_draft_tokens +
+                1)  # [batch_size, self.max_total_draft_tokens + 1]
+            child_hidden_states_read_indices = torch.gather(
+                hidden_states_write_indices_view,
+                dim=1,
+                index=selected_parents_write_indices
+            )  # [batch_size, self.dynamic_tree_max_topK]
 
-            hidden_states_read_indices_view = spec_metadata.hidden_states_read_indices[:batch_size * (self.max_total_draft_tokens + 1)] # [batch_size * (max_total_draft_tokens + 1)]
-            hidden_states_read_indices_view = hidden_states_read_indices_view.view(batch_size, self.max_total_draft_tokens + 1) # [batch_size, self.max_total_draft_tokens + 1]
-            hidden_states_read_indices_view[:, write_back_real_draft_tokens_start_offset:write_back_real_draft_tokens_end_offset] = child_hidden_states_read_indices[:, :] 
-            print(f"======= hidden_states_read_indices_view.shape: {hidden_states_read_indices_view.shape}, hidden_states_read_indices_view: {hidden_states_read_indices_view} ========")
-            print(f"======= spec_metadata.hidden_states_read_indices: {spec_metadata.hidden_states_read_indices} ========")
+            hidden_states_read_indices_view = spec_metadata.hidden_states_read_indices[:batch_size * (
+                self.max_total_draft_tokens +
+                1)]  # [batch_size * (max_total_draft_tokens + 1)]
+            hidden_states_read_indices_view = hidden_states_read_indices_view.view(
+                batch_size, self.max_total_draft_tokens +
+                1)  # [batch_size, self.max_total_draft_tokens + 1]
+            hidden_states_read_indices_view[:,
+                                            write_back_real_draft_tokens_start_offset:
+                                            write_back_real_draft_tokens_end_offset] = child_hidden_states_read_indices[:, :]
 
             if cur_draft_idx < self.max_draft_len - 1:
                 # 6) Update the parent nodes of the next layer's new nodes in advance.
-                # We need to know next layer's draft tokens are expaned from which parents. 
+                # We need to know next layer's draft tokens are expanded from which parents.
                 # i.e. calculate the index of the selected draft tokens in the entire tree (including all historical nodes, for subsequent reconstruction of the entire tree).
-                parents_indices = topk_indices + (self.dynamic_tree_max_topK + (cur_draft_idx - 1) * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK) # [batch_size, self.dynamic_tree_max_topK]
-                parents_indices = torch.repeat_interleave(parents_indices, self.dynamic_tree_max_topK, dim=1) # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
+                parents_indices = topk_indices + (
+                    self.dynamic_tree_max_topK + (cur_draft_idx - 1) *
+                    self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
+                )  # [batch_size, self.dynamic_tree_max_topK]
+                parents_indices = torch.repeat_interleave(
+                    parents_indices, self.dynamic_tree_max_topK, dim=1
+                )  # [batch_size, self.dynamic_tree_max_topK * self.dynamic_tree_max_topK]
                 next_layer_draft_tokens_start_offset = self.dynamic_tree_max_topK + cur_draft_idx * self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
                 next_layer_draft_tokens_end_offset = next_layer_draft_tokens_start_offset + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK
-                self.history_draft_tokens_parent_buffer[:batch_size, next_layer_draft_tokens_start_offset:next_layer_draft_tokens_end_offset] = parents_indices[:, :]
-                print(f"======= parents_indices.shape: {parents_indices.shape}, parents_indices: {parents_indices} ========")
-                print(f"======= next_layer_draft_tokens_start_offset: {next_layer_draft_tokens_start_offset}, next_layer_draft_tokens_end_offset: {next_layer_draft_tokens_end_offset} ========")
-                print(f"======= self.history_draft_tokens_parent_buffer: {self.history_draft_tokens_parent_buffer} ========")
+                self.history_draft_tokens_parent_buffer[:batch_size,
+                                                        next_layer_draft_tokens_start_offset:
+                                                        next_layer_draft_tokens_end_offset] = parents_indices[:, :]
 
-            return topk_values # [batch_size, self.dynamic_tree_max_topK]
-    
+            return topk_values  # [batch_size, self.dynamic_tree_max_topK]
 
     def resampling_final_draft_tokens(self, batch_size: int):
         '''
         Restruct the tree based on the self.history_draft_tokens_buffer, self.history_draft_tokens_parent_buffer and self.history_score_buffer.
         '''
         # self.history_score_buffer[:batch_size, :] shape: [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
-        topk_score_indices = torch.topk(self.history_score_buffer[:batch_size, :], k=self.max_total_draft_tokens, dim=-1).indices
-        topk_score_indices = torch.sort(topk_score_indices).values # [batch_size, self.max_total_draft_tokens]
+        topk_score_indices = torch.topk(
+            self.history_score_buffer[:batch_size, :],
+            k=self.max_total_draft_tokens,
+            dim=-1).indices
+        topk_score_indices = torch.sort(
+            topk_score_indices
+        ).values  # [batch_size, self.max_total_draft_tokens]
 
         # The final output draft tokens
-        real_draft_tokens = torch.gather(self.history_draft_tokens_buffer[:batch_size, :], dim=1, index=topk_score_indices) # [batch_size, self.max_total_draft_tokens]
+        real_draft_tokens = torch.gather(
+            self.history_draft_tokens_buffer[:batch_size, :],
+            dim=1,
+            index=topk_score_indices
+        )  # [batch_size, self.max_total_draft_tokens]
 
         # self.history_draft_tokens_parent_buffer[:batch_size, :] shape: [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
         # real_draft_tokens_parents = torch.gather(self.history_draft_tokens_parent_buffer[:batch_size, :], dim=1, index=topk_score_indices) # [batch_size, self.max_total_draft_tokens]
 
-
         # return real_draft_tokens, topk_score_indices, real_draft_tokens_parents
         return real_draft_tokens, topk_score_indices
-
-
 
     def prepare_for_generation(self, attn_metadata: AttentionMetadata,
                                spec_metadata: SpecMetadata,
@@ -887,7 +962,8 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
         position_start_idx = position_ids[0,
                                           last_tokens_idx] + 1  # [batch_size]
         self.position_ids_buffer[:batch_size, :] = position_start_idx.unsqueeze(
-            1) + spec_tree_manager.spec_dec_position_offsets_for_drafter_model[0, :].unsqueeze(0) # [batch_size, max_total_draft_tokens + 1]
+            1) + spec_tree_manager.spec_dec_position_offsets_for_drafter_model[
+                0, :].unsqueeze(0)  # [batch_size, max_total_draft_tokens + 1]
 
         # 2) Prepare the attn_metadata
         ## 2.1) kv_lens_cuda
@@ -914,9 +990,10 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         ## 2.6) spec_decoding_position_offsets
         ### attn_metadata.spec_decoding_position_offsets: [max_num_requests, max_total_draft_tokens + 1]
-        attn_metadata.spec_decoding_position_offsets[:batch_size, :] = spec_tree_manager.spec_dec_position_offsets_for_drafter_model[0, :].unsqueeze(0) # [batch_size, max_total_draft_tokens + 1]
+        attn_metadata.spec_decoding_position_offsets[:batch_size, :] = spec_tree_manager.spec_dec_position_offsets_for_drafter_model[
+            0, :].unsqueeze(0)  # [batch_size, max_total_draft_tokens + 1]
 
-        ## 2.7) spec_decoding_packed_mask 
+        ## 2.7) spec_decoding_packed_mask
         ### NOTE: spec_decoding_packed_mask will be updated for each drafter layer in 'update_draft_tokens_and_scores'
         # attn_metadata.spec_decoding_packed_mask[:batch_size, :, :].fill_(0)
         # dummy_idx = torch.arange(self.dynamic_tree_max_topK, dtype=torch.int32, device='cuda')
@@ -925,7 +1002,8 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         ## 2.8) spec_decoding_generation_lengths
         ### attn_metadata.spec_decoding_generation_lengths: [max_num_requests]
-        attn_metadata.spec_decoding_generation_lengths[:batch_size] = self.max_total_draft_tokens + 1
+        attn_metadata.spec_decoding_generation_lengths[:
+                                                       batch_size] = self.max_total_draft_tokens + 1
 
         # 3) Update spec_metadata
         ## 3.1) num_tokens
@@ -938,8 +1016,12 @@ class DynamicTreeDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
         ### spec_metadata.hidden_states_read_indices: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
         ### NOTE: spec_metadata.hidden_states_read_indices needs to be updated for each drafter layer
-        hidden_states_read_offset = start_idx.unsqueeze(1).repeat(1, self.max_total_draft_tokens + 1) # [batch_size, max_total_draft_tokens + 1]
-        spec_metadata.hidden_states_read_indices[:batch_size * (self.max_total_draft_tokens + 1)] = hidden_states_read_offset.reshape(-1)
+        hidden_states_read_offset = start_idx.unsqueeze(1).repeat(
+            1, self.max_total_draft_tokens +
+            1)  # [batch_size, max_total_draft_tokens + 1]
+        spec_metadata.hidden_states_read_indices[:batch_size * (
+            self.max_total_draft_tokens +
+            1)] = hidden_states_read_offset.reshape(-1)
 
         ### spec_metadata.hidden_states_write_indices: [max_num_tokens], but we save as [:batch_size * (max_total_draft_tokens + 1)]
         hidden_states_write_offset = torch.arange(

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -65,7 +65,8 @@ class Eagle3ResourceManager(BaseResourceManager):
         self.spec_tree_manager = None
 
         if isinstance(config,
-                      EagleDecodingConfig) and (config.eagle_choices is not None or config.use_dynamic_tree):
+                      EagleDecodingConfig) and (config.eagle_choices is not None
+                                                or config.use_dynamic_tree):
             self.spec_tree_manager = SpecTreeManager(
                 max_num_requests=self.max_num_requests,
                 use_dynamic_tree=config.use_dynamic_tree,

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -65,7 +65,7 @@ class Eagle3ResourceManager(BaseResourceManager):
         self.spec_tree_manager = None
 
         if isinstance(config,
-                      EagleDecodingConfig) and config.eagle_choices is not None:
+                      EagleDecodingConfig) and (config.eagle_choices is not None or config.use_dynamic_tree):
             self.spec_tree_manager = SpecTreeManager(
                 max_num_requests=self.max_num_requests,
                 use_dynamic_tree=config.use_dynamic_tree,

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -8,6 +8,7 @@ import torch
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 
+from ...llmapi.llm_args import EagleDecodingConfig
 from ..attention_backend.trtllm import TrtllmAttention
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
@@ -19,7 +20,6 @@ from ..pyexecutor.scheduler import ScheduledRequests
 from ..pyexecutor.seq_slot_manager import SeqSlotManager
 from ..speculative.mtp import SampleStateTensorsMTP
 from .drafter import Drafter
-from ...llmapi.llm_args import EagleDecodingConfig
 
 if TYPE_CHECKING:
     from ...llmapi.llm_args import DecodingBaseConfig
@@ -617,15 +617,20 @@ class ModelDrafter(Drafter):
             draft_logits = outputs[0]
             draft_tokens_host = outputs[1].host.new_tokens
             outputs[1].sampler_event.synchronize()
-        
+
         # Get the dynamic tree buffers
         topk_score_indices, history_draft_tokens_parent_buffer = None, None
         spec_tree_manager = None
-        if isinstance(self.spec_config, EagleDecodingConfig) and self.spec_config.use_dynamic_tree:
+        if isinstance(
+                self.spec_config,
+                EagleDecodingConfig) and self.spec_config.use_dynamic_tree:
             dynamic_tree_buffers = outputs["dynamic_tree_buffers"]
-            topk_score_indices = dynamic_tree_buffers["topk_score_indices"].cpu() # [batch_size, self.max_total_draft_tokens]
-            history_draft_tokens_parent_buffer = dynamic_tree_buffers["history_draft_tokens_parent_buffer"].cpu() # [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
-            
+            topk_score_indices = dynamic_tree_buffers["topk_score_indices"].cpu(
+            )  # [batch_size, self.max_total_draft_tokens]
+            history_draft_tokens_parent_buffer = dynamic_tree_buffers[
+                "history_draft_tokens_parent_buffer"].cpu(
+                )  # [batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
+
             spec_tree_manager = self.spec_resource_manager.spec_tree_manager
             assert spec_tree_manager is not None
 
@@ -646,13 +651,15 @@ class ModelDrafter(Drafter):
                 target_model_req.py_draft_logits = torch.stack(py_draft_logits)
 
             if topk_score_indices is not None and history_draft_tokens_parent_buffer is not None:
-                self.reconstruct_dynamic_tree(req_idx, topk_score_indices[req_idx], history_draft_tokens_parent_buffer[req_idx], spec_tree_manager)
+                self.reconstruct_dynamic_tree(
+                    req_idx, topk_score_indices[req_idx],
+                    history_draft_tokens_parent_buffer[req_idx],
+                    spec_tree_manager)
 
-            
-    def reconstruct_dynamic_tree(self, req_idx: int, 
-                                 cur_topk_score_indices: torch.Tensor, 
-                                 cur_history_draft_tokens_parent_buffer: torch.Tensor, 
-                                 spec_tree_manager: "SpecTreeManager") -> None:
+    def reconstruct_dynamic_tree(
+            self, req_idx: int, cur_topk_score_indices: torch.Tensor,
+            cur_history_draft_tokens_parent_buffer: torch.Tensor,
+            spec_tree_manager: "SpecTreeManager") -> None:
         '''
         Reconstruct the dynamic tree based on the current topk score indices and draft tokens parents.
         Update the spec_tree_manager buffers:
@@ -661,32 +668,30 @@ class ModelDrafter(Drafter):
             - spec_tree_manager.spec_dec_packed_mask
             - spec_tree_manager.spec_dec_position_offsets
             All these buffers will be used to update the attn_metadata for the target model's tree attention.
-            And the verfication after forward the target model.
+            And the verification after forward the target model.
         Args:
             req_idx: The index of the request.
-            cur_topk_score_indices: The topk score indices for the final output draft tokens. 
-                                    The indices will take all history draft tokens into account. 
+            cur_topk_score_indices: The topk score indices for the final output draft tokens.
+                                    The indices will take all history draft tokens into account.
                                     shape: [self.max_total_draft_tokens]
-            cur_history_draft_tokens_parent_buffer: The draft tokens' parent indices. 
+            cur_history_draft_tokens_parent_buffer: The draft tokens' parent indices.
                                      The indices will also take all history draft tokens into account.
                                      shape: [dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1)]
             spec_tree_manager: The spec tree manager.
         '''
 
-    
         topk_score_indices_list = cur_topk_score_indices.tolist()
-        cur_history_draft_tokens_parent_buffer = cur_history_draft_tokens_parent_buffer.tolist()
-        print(f"======= topk_score_indices_list: {topk_score_indices_list}")
-        print(f"======= cur_history_draft_tokens_parent_buffer: {cur_history_draft_tokens_parent_buffer}")
+        cur_history_draft_tokens_parent_buffer = cur_history_draft_tokens_parent_buffer.tolist(
+        )
 
         # 1) Generate the mapping
         # Because these indices will take all history draft tokens into account,
         # We need to generate a mapping between the current node index and the index of the final output tree.
         idx_mapping = {}
-        idx_mapping[-1] = 0 # root node
+        idx_mapping[-1] = 0  # root node
         for i in range(len(cur_topk_score_indices)):
-            idx_mapping[topk_score_indices_list[i]] = i + 1 # shift by 1 for the root node
-        print(f"======= idx_mapping: {idx_mapping}")
+            idx_mapping[topk_score_indices_list[
+                i]] = i + 1  # shift by 1 for the root node
 
         # 2) Update the eagle_paths
         spec_tree_manager.eagle_paths[req_idx].fill_(-1)
@@ -700,25 +705,23 @@ class ModelDrafter(Drafter):
                 parent_idx = cur_history_draft_tokens_parent_buffer[parent_idx]
                 tmp_path = [parent_idx] + tmp_path
 
-            print(f"======= path_idx: {path_idx}, cur_node_idx: {cur_node_idx}, tmp_path: {tmp_path}")
-            
-            assert len(tmp_path) >= 2 and len(tmp_path) <= self.max_draft_len + 1
+            assert len(tmp_path) >= 2 and len(
+                tmp_path) <= self.max_draft_len + 1
             # Map the indices
             tmp_map_path = [idx_mapping[idx] for idx in tmp_path]
-            print(f"======= tmp_map_path1111: {tmp_map_path}, tmp_path: {tmp_path}")
-            tmp_map_path += [-1] * (self.max_draft_len + 1 - len(tmp_map_path)) # pad with -1
-            print(f"======= tmp_map_path2222: {tmp_map_path}")
-            spec_tree_manager.eagle_paths[req_idx, path_idx + 1, :] = torch.tensor(tmp_map_path, dtype=torch.int32)
-            print(f"======= spec_tree_manager.eagle_paths[req_idx, path_idx + 1, :]: {spec_tree_manager.eagle_paths[req_idx, path_idx + 1, :]}")
+            tmp_map_path += [-1] * (self.max_draft_len + 1 - len(tmp_map_path)
+                                    )  # pad with -1
+            spec_tree_manager.eagle_paths[req_idx,
+                                          path_idx + 1, :] = torch.tensor(
+                                              tmp_map_path, dtype=torch.int32)
 
-        print(f"============================ after update eagle_paths: {spec_tree_manager.eagle_paths[req_idx]} ============================")
         # 3) Update the spec_dec_mask_matrix
         spec_tree_manager.compute_spec_dec_mask_matrix(req_idx)
-        print(f"======= spec_tree_manager.spec_dec_mask_matrix[req_idx]: {spec_tree_manager.spec_dec_mask_matrix[req_idx]}")
 
         # 4）Update the spec_dec_packed_mask
-        spec_tree_manager.compute_spec_dec_packed_mask(spec_tree_manager.spec_dec_mask_matrix, spec_tree_manager.spec_dec_packed_mask)
-        print(f"======= spec_tree_manager.spec_dec_packed_mask[req_idx]: {spec_tree_manager.spec_dec_packed_mask[req_idx]}")
+        spec_tree_manager.compute_spec_dec_packed_mask(
+            spec_tree_manager.spec_dec_mask_matrix,
+            spec_tree_manager.spec_dec_packed_mask)
 
         # 5) Update the spec_dec_position_offsets
         spec_tree_manager.spec_dec_position_offsets[req_idx, :] = 0
@@ -727,12 +730,9 @@ class ModelDrafter(Drafter):
             tmp_set = set(spec_tree_manager.eagle_paths[req_idx, :, i].tolist())
             tmp_set.discard(-1)
             num_nodes_this_layer = len(tmp_set)
-            print(f"======= i: {i}, num_nodes_this_layer: {num_nodes_this_layer}")
-            spec_tree_manager.spec_dec_position_offsets[req_idx, start_idx:start_idx + num_nodes_this_layer] = i
+            spec_tree_manager.spec_dec_position_offsets[
+                req_idx, start_idx:start_idx + num_nodes_this_layer] = i
             start_idx += num_nodes_this_layer
-
-        print(f"======= spec_tree_manager.spec_dec_position_offsets[req_idx]: {spec_tree_manager.spec_dec_position_offsets[req_idx]}")
-
 
     def process_dynamic_draft_outputs(
             self,
@@ -998,11 +998,8 @@ class ModelDrafter(Drafter):
         self.previous_scheduled_batch = scheduled_batch
 
     @nvtx_range("prepare_draft_tokens")
-    def prepare_draft_tokens(
-        self,
-        scheduled_requests: ScheduledRequests,
-        resource_manager: ResourceManager
-    ) -> None:
+    def prepare_draft_tokens(self, scheduled_requests: ScheduledRequests,
+                             resource_manager: ResourceManager) -> None:
         """
         Prepare draft tokens for the scheduled requests.
 

--- a/tensorrt_llm/_torch/speculative/spec_tree_manager.py
+++ b/tensorrt_llm/_torch/speculative/spec_tree_manager.py
@@ -68,7 +68,7 @@ class SpecTreeManager:
     draft_tokens_indices_cumsum: torch.Tensor = None
 
     ############################ Auxiliary buffers for the dynamic tree. ############################
-    # For the dynamic tree, before reconstructing the tree, 
+    # For the dynamic tree, before reconstructing the tree,
     # the draft token offsets of each draft layer are fixed, which we can set in advance.
     # shape: [1, max_total_draft_tokens + 1], device tensor.
     spec_dec_position_offsets_for_drafter_model: torch.Tensor = None
@@ -118,8 +118,7 @@ class SpecTreeManager:
         else:
             self.init_tree_info_for_static_tree()
 
-        self.dump_tree_info()
-        import pdb; pdb.set_trace()
+        # self.dump_tree_info()
 
     def init_tree_info_for_dynamic_tree(self):
         # For the dynamic tree
@@ -132,10 +131,13 @@ class SpecTreeManager:
         tmp_position_offsets = []
         for i in range(self.max_draft_len):
             tmp_position_offsets.extend([i] * self.dynamic_tree_max_topK)
-        self.spec_dec_position_offsets_for_drafter_model[0, :len(tmp_position_offsets)].copy_(
-            torch.tensor(tmp_position_offsets, dtype=torch.int32, device='cuda'),
-            non_blocking=True,
-        )
+        self.spec_dec_position_offsets_for_drafter_model[
+            0, :len(tmp_position_offsets)].copy_(
+                torch.tensor(tmp_position_offsets,
+                             dtype=torch.int32,
+                             device='cuda'),
+                non_blocking=True,
+            )
 
     # For the static tree
     def init_tree_info_for_static_tree(self):
@@ -324,7 +326,9 @@ class SpecTreeManager:
         print(f"TopK list: {self.top_k_list}")
         if self.use_dynamic_tree:
             print(f"Dynamic max top k: {self.dynamic_tree_max_topK}")
-            print(f"Spec dec position offsets for drafter model: {self.spec_dec_position_offsets_for_drafter_model}")
+            print(
+                f"Spec dec position offsets for drafter model: {self.spec_dec_position_offsets_for_drafter_model}"
+            )
         else:
             print(f"Max top k list cuda: {self.max_top_k}")
             print(f"Eagle paths: {self.eagle_paths}")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -817,7 +817,6 @@ class EagleDecodingConfig(DecodingBaseConfig):
                 )
             else:
                 assert self.max_total_draft_tokens <= total_history_draft_tokens and self.max_total_draft_tokens >= default_max_total_draft_tokens, f"max_total_draft_tokens should be between {default_max_total_draft_tokens} and {total_history_draft_tokens}"
-            assert self.max_total_draft_tokens + 1 <= 32
 
         # Linear tree
         if self.max_total_draft_tokens is None:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -780,7 +780,7 @@ class EagleDecodingConfig(DecodingBaseConfig):
             setattr(self, attr_name, attr_value)
 
         assert self.max_draft_len is not None, "max_draft_len is required for Eagle"
-        
+
         # Static tree logic
         # Checks whether the input eagle choices is valid
         # and reset the max_draft_len and num_eagle_layers if necessary
@@ -806,20 +806,23 @@ class EagleDecodingConfig(DecodingBaseConfig):
             self.use_dynamic_tree = True
             assert self.dynamic_tree_max_topK is not None and self.dynamic_tree_max_topK > 0, "dynamic_tree_max_topK is required for dynamic tree"
             assert self.eagle_choices is None, "If use_dynamic_tree is True, eagle_choices should be None"
-            total_history_draft_tokens = self.dynamic_tree_max_topK + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK * (self.max_draft_len - 1)
+            total_history_draft_tokens = self.dynamic_tree_max_topK + self.dynamic_tree_max_topK * self.dynamic_tree_max_topK * (
+                self.max_draft_len - 1)
             default_max_total_draft_tokens = self.dynamic_tree_max_topK * self.max_draft_len
 
             if self.max_total_draft_tokens is None:
                 self.max_total_draft_tokens = default_max_total_draft_tokens
-                logger.warning(f"max_total_draft_tokens is not provided, use the default value {default_max_total_draft_tokens} (default_max_total_draft_tokens = dynamic_tree_max_topK * max_draft_len)")
+                logger.warning(
+                    f"max_total_draft_tokens is not provided, use the default value {default_max_total_draft_tokens} (default_max_total_draft_tokens = dynamic_tree_max_topK * max_draft_len)"
+                )
             else:
                 assert self.max_total_draft_tokens <= total_history_draft_tokens and self.max_total_draft_tokens >= default_max_total_draft_tokens, f"max_total_draft_tokens should be between {default_max_total_draft_tokens} and {total_history_draft_tokens}"
             assert self.max_total_draft_tokens + 1 <= 32
-        
+
         # Linear tree
         if self.max_total_draft_tokens is None:
             self.max_total_draft_tokens = self.max_draft_len
-            
+
     @classmethod
     def from_dict(cls, data: dict):
         return cls(**data)

--- a/tests/integration/defs/accuracy/test_llm_api.py
+++ b/tests/integration/defs/accuracy/test_llm_api.py
@@ -496,7 +496,8 @@ class TestEagle2Vicuna_7B_v1_3(LlmapiAccuracyTestHarness):
     MODEL_PATH = f"{llm_models_root()}/vicuna-7b-v1.3"
 
     speculative_config = EagleDecodingConfig(
-        max_draft_len=63,
+        max_draft_len=4,
+        max_total_draft_tokens=63,
         speculative_model_dir=f"{llm_models_root()}/EAGLE-Vicuna-7B-v1.3",
         num_eagle_layers=4,
         max_non_leaves_per_layer=10,

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -2073,9 +2073,8 @@ def test_ptp_quickstart_advanced_eagle3(llm_root, llm_venv, model_name,
     ("Llama-3.1-8b-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct",
      "EAGLE3-LLaMA3.1-Instruct-8B"),
 ])
-def test_static_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
-                                                     model_name, model_path,
-                                                     eagle_model_path):
+def test_static_draft_token_tree_quickstart_advanced_eagle3(
+        llm_root, llm_venv, model_name, model_path, eagle_model_path):
     print(f"Testing {model_name}.")
     example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
     with tempfile.NamedTemporaryFile(mode='w+t',
@@ -2108,9 +2107,8 @@ def test_static_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
     ("Llama-3.1-8b-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct",
      "EAGLE3-LLaMA3.1-Instruct-8B"),
 ])
-def test_dynamic_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
-                                                     model_name, model_path,
-                                                     eagle_model_path):
+def test_dynamic_draft_token_tree_quickstart_advanced_eagle3(
+        llm_root, llm_venv, model_name, model_path, eagle_model_path):
     print(f"Testing {model_name}.")
     example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
     with tempfile.NamedTemporaryFile(mode='w+t',
@@ -2132,7 +2130,7 @@ def test_dynamic_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
             f"{llm_models_root()}/{eagle_model_path}",
             "--disable_kv_cache_reuse",
             "--disable_overlap_scheduler",
-            "--use_dynamic_tree", 
+            "--use_dynamic_tree",
             "--dynamic_tree_max_topK",
             "3",
             "--max_total_draft_tokens",
@@ -2140,6 +2138,7 @@ def test_dynamic_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
         ],
                          stdout=running_log)
         _check_mem_usage(running_log, [27, 0, 0, 0])
+
 
 @pytest.mark.parametrize("model_name,model_path", [
     ("Llama-3.1-8B-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct"),

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -2073,7 +2073,7 @@ def test_ptp_quickstart_advanced_eagle3(llm_root, llm_venv, model_name,
     ("Llama-3.1-8b-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct",
      "EAGLE3-LLaMA3.1-Instruct-8B"),
 ])
-def test_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
+def test_static_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
                                                      model_name, model_path,
                                                      eagle_model_path):
     print(f"Testing {model_name}.")
@@ -2103,6 +2103,43 @@ def test_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
                          stdout=running_log)
         _check_mem_usage(running_log, [27, 0, 0, 0])
 
+
+@pytest.mark.parametrize("model_name,model_path,eagle_model_path", [
+    ("Llama-3.1-8b-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct",
+     "EAGLE3-LLaMA3.1-Instruct-8B"),
+])
+def test_dynamic_draft_token_tree_quickstart_advanced_eagle3(llm_root, llm_venv,
+                                                     model_name, model_path,
+                                                     eagle_model_path):
+    print(f"Testing {model_name}.")
+    example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
+    with tempfile.NamedTemporaryFile(mode='w+t',
+                                     suffix=f".{model_name}.log",
+                                     dir="./",
+                                     delete=True,
+                                     delete_on_close=True) as running_log:
+        llm_venv.run_cmd([
+            str(example_root / "quickstart_advanced.py"),
+            "--prompt",
+            "You are a good assistant. Please tell me the capital of France is",
+            "--spec_decode_max_draft_len",
+            "3",
+            "--spec_decode_algo",
+            "eagle3",
+            "--model_dir",
+            f"{llm_models_root()}/{model_path}",
+            "--draft_model_dir",
+            f"{llm_models_root()}/{eagle_model_path}",
+            "--disable_kv_cache_reuse",
+            "--disable_overlap_scheduler",
+            "--use_dynamic_tree", 
+            "--dynamic_tree_max_topK",
+            "3",
+            "--max_total_draft_tokens",
+            "12",
+        ],
+                         stdout=running_log)
+        _check_mem_usage(running_log, [27, 0, 0, 0])
 
 @pytest.mark.parametrize("model_name,model_path", [
     ("Llama-3.1-8B-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct"),

--- a/tests/unittest/_torch/speculative/test_draft_token_prepare_for_generation.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_prepare_for_generation.py
@@ -7,10 +7,11 @@ import torch
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
-from tensorrt_llm._torch.speculative.drafting_loops import TreeDraftingLoopWrapper
+from tensorrt_llm._torch.speculative.drafting_loops import StaticTreeDraftingLoopWrapper, DynamicTreeDraftingLoopWrapper
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3ResourceManager, Eagle3SpecMetadata
 from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
 from tensorrt_llm.llmapi import EagleDecodingConfig
+from tensorrt_llm._torch.speculative.model_drafter import ModelDrafter
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -21,6 +22,7 @@ class DummyModel(torch.nn.Module):
         self.model_config = None
         self.config = None
         self.model = {}
+        self.model_is_wrapped = True
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
         pass
@@ -138,8 +140,8 @@ def test_draft_token_static_tree_prepare_for_generation():
             input_hidden_states_read_indices  # set from input
         )
 
-        # 3) Create TreeDraftingLoopWrapper
-        tree_drafting_loop_wrapper = TreeDraftingLoopWrapper(
+        # 3) Create StaticTreeDraftingLoopWrapper
+        static_tree_drafting_loop_wrapper = StaticTreeDraftingLoopWrapper(
             max_batch_size=max_batch_size,
             max_draft_len=max_draft_len,
             max_total_draft_tokens=max_total_draft_tokens,
@@ -147,7 +149,7 @@ def test_draft_token_static_tree_prepare_for_generation():
         )
 
         # 3) Run the function
-        tree_drafting_loop_wrapper.prepare_for_generation(
+        static_tree_drafting_loop_wrapper.prepare_for_generation(
             attn_metadata=attn_metadata,
             spec_metadata=spec_metadata,
             spec_tree_manager=spec_tree_manager,
@@ -156,7 +158,7 @@ def test_draft_token_static_tree_prepare_for_generation():
 
         # Compare input_ids and position_ids
         print(
-            f"tree_drafting_loop_wrapper.position_ids_buffer: {tree_drafting_loop_wrapper.position_ids_buffer}, \
+            f"static_tree_drafting_loop_wrapper.position_ids_buffer: {static_tree_drafting_loop_wrapper.position_ids_buffer}, \
             ref_output_position_ids: {ref_position_ids}"
         )
 
@@ -208,7 +210,7 @@ def test_draft_token_static_tree_prepare_for_generation():
             ref_spec_metadata.hidden_states_write_indices: {ref_spec_metadata['hidden_states_write_indices']}"
         )
 
-        assert torch.all(tree_drafting_loop_wrapper.position_ids_buffer == ref_position_ids)
+        assert torch.all(static_tree_drafting_loop_wrapper.position_ids_buffer == ref_position_ids)
         assert torch.all(attn_metadata.kv_lens_cuda == ref_attn_metadata["kv_lens_cuda"])
         assert torch.all(attn_metadata._seq_lens == ref_attn_metadata["_seq_lens"])
         assert torch.all(attn_metadata._seq_lens_cuda == ref_attn_metadata["_seq_lens_cuda"])
@@ -452,6 +454,476 @@ def test_draft_token_static_tree_prepare_for_generation():
         ref_attn_metadata,
         ref_spec_metadata,
     )
+
+
+
+def test_dynamic_tree_update_draft_tokens_and_scores():
+    # Fix parameters
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
+    use_dynamic_tree = True
+    max_new_tokens = 128
+    kv_cache_manager = None
+    
+    def run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+                 cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
+                 input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
+                 ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
+                 ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices):
+
+        # 1) Create attention metadata
+        attn_metadata = TrtllmAttentionMetadata(
+            max_num_requests=max_batch_size,
+            max_num_tokens=max_new_tokens,
+            kv_cache_manager=kv_cache_manager,
+        )
+        # Set initial values
+        attn_metadata.spec_decoding_packed_mask = input_spec_decoding_packed_mask
+        attn_metadata.spec_decoding_generation_lengths = torch.zeros(
+            [max_batch_size],
+            dtype=torch.int,
+            device="cuda",
+        )
+
+        # 3) Create spec metadata
+        spec_config = EagleDecodingConfig(
+            max_draft_len=max_draft_len,
+            max_total_draft_tokens=max_total_draft_tokens,
+            speculative_model_dir=eagle_model_dir,
+            eagle3_one_model=False,
+            eagle_choices=None,
+            use_dynamic_tree=use_dynamic_tree,
+            dynamic_tree_max_topK=dynamic_tree_max_topK,
+        )
+        eagle3_resource_manager = Eagle3ResourceManager(
+            config=spec_config,
+            dtype=torch.bfloat16,
+            hidden_size=1024,
+            max_num_requests=max_batch_size,
+            max_seq_len=max_new_tokens,
+            max_num_tokens=max_new_tokens,
+        )
+        spec_tree_manager = SpecTreeManager(
+            max_num_requests=max_batch_size,
+            use_dynamic_tree=spec_config.use_dynamic_tree,
+            max_draft_len=spec_config.max_draft_len,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
+        )
+        spec_metadata = Eagle3SpecMetadata(
+            max_draft_len=spec_config.max_draft_len,
+            spec_dec_mode=spec_config.spec_dec_mode,
+            max_num_requests=max_batch_size,
+            num_layers=32,
+            hidden_size=1024,
+            max_num_tokens=max_new_tokens,
+            dtype=torch.bfloat16,
+            is_draft_model=True,
+            eagle3_resource_manager=eagle3_resource_manager,
+            layers_to_capture=spec_config.eagle3_layers_to_capture,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            is_spec_dec_tree=spec_config.eagle_choices is not None or spec_config.use_dynamic_tree,
+            is_spec_dec_dynamic_tree=spec_config.use_dynamic_tree,
+        )
+        spec_metadata.hidden_states_write_indices = input_hidden_states_write_indices
+        spec_metadata.hidden_states_read_indices = input_hidden_states_read_indices
+
+        # 4) Create DynamicTreeDraftingLoopWrapper
+        dynamic_tree_drafting_loop_wrapper = DynamicTreeDraftingLoopWrapper(
+            max_draft_len=max_draft_len,
+            max_total_draft_tokens=max_total_draft_tokens,
+            max_batch_size=max_batch_size,
+            dynamic_tree_max_topK=dynamic_tree_max_topK,
+            draft_model=DummyModel(),
+        )
+
+        # 5) Run the function
+        cur_scores = dynamic_tree_drafting_loop_wrapper.update_draft_tokens_and_scores(
+            cur_draft_idx=cur_draft_idx,
+            batch_size=max_batch_size,
+            new_draft_tokens=new_draft_tokens,
+            new_draft_scores=new_draft_scores,
+            previous_draft_scores=previous_draft_scores,
+            attn_metadata=attn_metadata,
+            spec_metadata=spec_metadata,
+        )
+        
+        # 5) Check the results
+        print("==================================")
+        print(f"======= ref_draft_tokens_buffer: {ref_draft_tokens_buffer} ========")
+        print(f"======= dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer: {dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer} ========")
+        
+        print(f"======= ref_history_draft_tokens_buffer: {ref_history_draft_tokens_buffer} ========")
+        print(f"======= dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer: {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer} ========")
+        
+        print(f"======= ref_history_draft_tokens_parent_buffer: {ref_history_draft_tokens_parent_buffer} ========")
+        print(f"======= dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer: {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer} ========")
+        
+        print(f"======= ref_history_score_buffer: {ref_history_score_buffer} ========")
+        print(f"======= dynamic_tree_drafting_loop_wrapper.history_score_buffer: {dynamic_tree_drafting_loop_wrapper.history_score_buffer} ========")
+        
+        print(f"======= ref_spec_decoding_packed_mask: {ref_spec_decoding_packed_mask} ========")
+        print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
+        
+        print(f"======= ref_hidden_states_read_indices: {ref_hidden_states_read_indices} ========")
+        print(f"======= spec_metadata.hidden_states_read_indices: {spec_metadata.hidden_states_read_indices} ========")
+
+
+        assert torch.all(dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer == ref_draft_tokens_buffer)
+        assert torch.all(dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer == ref_history_draft_tokens_buffer)
+        if ref_history_draft_tokens_parent_buffer is not None:
+            assert torch.all(dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer == ref_history_draft_tokens_parent_buffer)
+        assert torch.allclose(dynamic_tree_drafting_loop_wrapper.history_score_buffer, ref_history_score_buffer, atol=1e-3)
+        if ref_spec_decoding_packed_mask is not None:
+            assert torch.all(attn_metadata.spec_decoding_packed_mask == ref_spec_decoding_packed_mask)
+        if ref_hidden_states_read_indices is not None:
+            assert torch.all(spec_metadata.hidden_states_read_indices == ref_hidden_states_read_indices)
+
+    ##### CASE 1 dynamic tree, batch size = 1, cur_draft_idx = 0 #############
+    max_batch_size = 1
+    max_draft_len = 3
+    max_total_draft_tokens = 15
+    dynamic_tree_max_topK = 3
+    cur_draft_idx = 0
+
+    new_draft_tokens = torch.tensor([2, 6, 3], dtype=torch.int32, device="cuda")
+    new_draft_scores = torch.tensor([0.3, 0.2, 0.1], dtype=torch.float32, device="cuda")
+    previous_draft_scores = None
+
+    input_spec_decoding_packed_mask = torch.zeros(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32), dtype=torch.int32, device="cuda")
+    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
+    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+
+    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer[:, :3] = new_draft_tokens
+
+    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer[:, :3] = new_draft_tokens
+
+    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
+    ref_history_draft_tokens_parent_buffer[:, 0:12] = torch.tensor([-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=torch.int32, device="cuda")
+
+    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
+    ref_history_score_buffer[:, :3] = new_draft_scores
+
+    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ref_hidden_states_read_indices = None
+    
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
+             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
+             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
+             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+
+             
+    ##### CASE 2 dynamic tree, batch size = 1, cur_draft_idx = 1 #############
+    max_batch_size = 1
+    max_draft_len = 3
+    max_total_draft_tokens = 15
+    dynamic_tree_max_topK = 3
+    cur_draft_idx = 1
+
+    # new_draft_tokens: [[48, 47, 46], [45, 44, 43], ..., [6, 5, 4], [3, 2, 1]]
+    # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
+    # But the valuable draft tokens are new_draft_tokens[3:]
+    new_draft_tokens = torch.arange(
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.int32, device="cuda"
+    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+    new_draft_scores = torch.arange(
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.float32, device="cuda"
+    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK) * 0.01
+    previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4]], dtype=torch.float32, device="cuda")
+
+    input_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
+    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+
+    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer[:, 3:6] = torch.tensor([48, 47, 46], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor([48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
+    ref_history_draft_tokens_parent_buffer[:, 12:12+9] = torch.tensor([3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda")
+
+    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
+    ref_history_score_buffer[:, 3:12] = torch.tensor([1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda")
+
+    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+    
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
+             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
+             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
+             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+
+
+    ##### CASE 2 dynamic tree, batch size = 1, cur_draft_idx = 1 #############
+    max_batch_size = 1
+    max_draft_len = 3
+    max_total_draft_tokens = 15
+    dynamic_tree_max_topK = 3
+    cur_draft_idx = 2
+
+    # new_draft_tokens: [[48, 47, 46], [45, 44, 43], ..., [6, 5, 4], [3, 2, 1]]
+    # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
+    # But the valuable draft tokens are new_draft_tokens[3:]
+    new_draft_tokens = torch.arange(
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.int32, device="cuda"
+    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+    new_draft_scores = torch.arange(
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.float32, device="cuda"
+    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK) * 0.01
+    previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4]], dtype=torch.float32, device="cuda")
+
+    input_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
+    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+
+    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer[:, 6:9] = torch.tensor([39, 38, 37], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer[:, 12:21] = torch.tensor([39, 38, 37, 36, 35, 34, 33, 32, 31], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_parent_buffer = None # will not be updated for this layer
+
+    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
+    ref_history_score_buffer[:, 12:21] = torch.tensor([1.89, 1.88, 1.87, 1.06, 1.05, 1.04, 0.73, 0.72, 0.71], dtype=torch.float32, device="cuda")
+
+    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 73, 137, 265, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+    
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
+             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
+             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
+             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+
+
+    ##### CASE 4 dynamic tree, batch size = 2, cur_draft_idx = 1 #############
+    max_batch_size = 2
+    max_draft_len = 3
+    max_total_draft_tokens = 15
+    dynamic_tree_max_topK = 3
+    cur_draft_idx = 1
+
+    # new_draft_tokens: [[48, 47, 46], [45, 44, 43], ..., [6, 5, 4], [3, 2, 1]]
+    # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
+    # But the valuable draft tokens are new_draft_tokens[3:]
+    new_draft_tokens = torch.arange(
+        (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.int32, device="cuda"
+    ).reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK).repeat(max_batch_size)
+    new_draft_scores = torch.arange(
+        (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
+        dtype=torch.float32, device="cuda"
+    ).reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK).repeat(max_batch_size) * 0.01
+    previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4], [2.5, 1.7, 1.4]], dtype=torch.float32, device="cuda")
+
+    input_spec_decoding_packed_mask = torch.tensor([[1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
+    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
+                                                     16, 16, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
+                                                     ], dtype=torch.int32, device="cuda")
+
+    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer[:, 3:6] = torch.tensor([48, 47, 46], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor([48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda")
+
+    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
+    ref_history_draft_tokens_parent_buffer[:, 12:12+9] = torch.tensor([3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda")
+
+    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
+    ref_history_score_buffer[0:, 3:12] = torch.tensor([1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda")
+    ref_history_score_buffer[1:, 3:12] = torch.tensor([2.98, 2.97, 2.96, 2.15, 2.14, 2.13, 1.82, 1.81, 1.80], dtype=torch.float32, device="cuda")
+
+    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
+                                                  1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
+                                                  ], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
+                                                   16, 16, 16, 17, 17, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
+                                                   ], dtype=torch.int32, device="cuda")
+    
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
+             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
+             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
+             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+
+
+def test_dynamic_tree_restruct_tree():
+    # Fix parameters
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
+    use_dynamic_tree = True
+    max_new_tokens = 128
+    kv_cache_manager = None
+
+    def run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK, 
+                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
+                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets):
+        # 1) Create spec metadata
+        spec_config = EagleDecodingConfig(
+            max_draft_len=max_draft_len,
+            max_total_draft_tokens=max_total_draft_tokens,
+            speculative_model_dir=eagle_model_dir,
+            eagle3_one_model=False,
+            eagle_choices=None,
+            use_dynamic_tree=use_dynamic_tree,
+            dynamic_tree_max_topK=dynamic_tree_max_topK,
+        )
+
+        eagle3_resource_manager = Eagle3ResourceManager(
+            config=spec_config,
+            dtype=torch.bfloat16,
+            hidden_size=1024,
+            max_num_requests=max_batch_size,
+            max_seq_len=max_new_tokens,
+            max_num_tokens=max_new_tokens,
+        )
+
+        spec_tree_manager = SpecTreeManager(
+            max_num_requests=max_batch_size,
+            use_dynamic_tree=spec_config.use_dynamic_tree,
+            max_draft_len=spec_config.max_draft_len,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
+        )
+
+        spec_metadata = Eagle3SpecMetadata(
+            max_draft_len=spec_config.max_draft_len,
+            spec_dec_mode=spec_config.spec_dec_mode,
+            max_num_requests=max_batch_size,
+            num_layers=32,
+            hidden_size=1024,
+            max_num_tokens=max_new_tokens,
+            dtype=torch.bfloat16,
+            is_draft_model=True,
+            eagle3_resource_manager=eagle3_resource_manager,
+            layers_to_capture=spec_config.eagle3_layers_to_capture,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            is_spec_dec_tree=spec_config.eagle_choices is not None or spec_config.use_dynamic_tree,
+            is_spec_dec_dynamic_tree=spec_config.use_dynamic_tree,
+        )
+
+        # 2) Create model drafter
+        model_drafter = ModelDrafter(
+            spec_config=spec_config,
+            draft_model_engine=DummyModel(),
+            max_draft_len=max_draft_len,
+            max_total_draft_tokens=max_total_draft_tokens,
+            draft_seq_slot_manager=None,
+            sampler=None,
+            spec_resource_manager=eagle3_resource_manager,
+            guided_decoder=None,
+        )
+
+        # 3) Reconstruct the dynamic tree
+        model_drafter.reconstruct_dynamic_tree(
+            0,
+            cur_topk_score_indices,
+            cur_history_draft_tokens_parent_buffer,
+            spec_tree_manager)
+
+        print("==================================")
+        print(f"ref_eagle_paths: {ref_eagle_paths}")
+        print(f"spec_tree_manager.eagle_paths: {spec_tree_manager.eagle_paths}")
+
+        print(f"ref_spec_dec_packed_mask: {ref_spec_dec_packed_mask}")
+        print(f"spec_tree_manager.spec_dec_packed_mask: {spec_tree_manager.spec_dec_packed_mask}")
+
+        print(f"ref_spec_dec_position_offsets: {ref_spec_dec_position_offsets}")
+        print(f"spec_tree_manager.spec_dec_position_offsets: {spec_tree_manager.spec_dec_position_offsets}")
+
+        import pdb; pdb.set_trace()
+
+        assert torch.all(ref_eagle_paths == spec_tree_manager.eagle_paths)
+        assert torch.all(ref_spec_dec_packed_mask == spec_tree_manager.spec_dec_packed_mask) 
+        assert torch.all(ref_spec_dec_position_offsets == spec_tree_manager.spec_dec_position_offsets) 
+
+    ##### CASE 1 dynamic tree, batch size = 1 #############
+    max_batch_size = 1
+    max_draft_len = 3
+    max_total_draft_tokens = 10
+    dynamic_tree_max_topK = 3
+
+    cur_topk_score_indices = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 9, 12], dtype=torch.int32, device="cpu")
+    cur_history_draft_tokens_parent_buffer = torch.tensor(
+        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cpu")
+
+    ref_eagle_paths = torch.tensor(
+        [[[ 0, -1, -1, -1],                             
+         [ 0,  1, -1, -1],
+         [ 0,  2, -1, -1],          
+         [ 0,  3, -1, -1],                            
+         [ 0,  1,  4, -1],                                                                                                                 
+         [ 0,  1,  5, -1],
+         [ 0,  1,  6, -1],
+         [ 0,  2,  7, -1],                                                                                                                 
+         [ 0,  2,  8, -1],    
+         [ 0,  3,  9, -1],
+         [ 0,  1,  4, 10]]], dtype=torch.int32, device='cpu', pin_memory=True,
+    )
+
+    ref_spec_dec_packed_mask = torch.tensor(
+        [1, 3, 5, 9, 19, 35, 67, 133, 261, 521, 1043], dtype=torch.int32, device="cuda"
+    ).reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+
+    ref_spec_dec_position_offsets = torch.tensor([[0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3]], dtype=torch.int32, device="cuda")
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
+                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets)
+
+    ##### CASE 2 dynamic tree, batch size = 1 #############
+    max_batch_size = 1
+    max_draft_len = 3
+    max_total_draft_tokens = 9
+    dynamic_tree_max_topK = 3
+
+    cur_topk_score_indices = torch.tensor([0, 1, 2, 3, 4, 6, 12, 13, 18], dtype=torch.int32, device="cpu")
+    cur_history_draft_tokens_parent_buffer = torch.tensor(
+        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 6, 6, 6], dtype=torch.int32, device="cpu")
+
+    ref_eagle_paths = torch.tensor(
+        [[[ 0, -1, -1, -1],                             
+         [ 0,  1, -1, -1],
+         [ 0,  2, -1, -1],          
+         [ 0,  3, -1, -1],                            
+         [ 0,  1,  4, -1],                                                                                                                 
+         [ 0,  1,  5, -1],
+         [ 0,  2,  6, -1],
+         [ 0,  1,  4, 7],                                                                                                                 
+         [ 0,  1,  4, 8],    
+         [ 0,  2,  6, 9]]], dtype=torch.int32, device='cpu', pin_memory=True,
+    )
+
+    ref_spec_dec_packed_mask = torch.tensor(
+        [1, 3, 5, 9, 19, 35, 69, 147, 275, 581], dtype=torch.int32, device="cuda"
+    ).reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+
+    ref_spec_dec_position_offsets = torch.tensor([[0, 1, 1, 1, 2, 2, 2, 3, 3, 3]], dtype=torch.int32, device="cuda")
+
+    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
+                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
+                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/speculative/test_draft_token_prepare_for_generation.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_prepare_for_generation.py
@@ -7,11 +7,14 @@ import torch
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
-from tensorrt_llm._torch.speculative.drafting_loops import StaticTreeDraftingLoopWrapper, DynamicTreeDraftingLoopWrapper
+from tensorrt_llm._torch.speculative.drafting_loops import (
+    DynamicTreeDraftingLoopWrapper,
+    StaticTreeDraftingLoopWrapper,
+)
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3ResourceManager, Eagle3SpecMetadata
+from tensorrt_llm._torch.speculative.model_drafter import ModelDrafter
 from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
 from tensorrt_llm.llmapi import EagleDecodingConfig
-from tensorrt_llm._torch.speculative.model_drafter import ModelDrafter
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -158,7 +161,8 @@ def test_draft_token_static_tree_prepare_for_generation():
 
         # Compare input_ids and position_ids
         print(
-            f"static_tree_drafting_loop_wrapper.position_ids_buffer: {static_tree_drafting_loop_wrapper.position_ids_buffer}, \
+            f"static_tree_drafting_loop_wrapper.position_ids_buffer: \
+            {static_tree_drafting_loop_wrapper.position_ids_buffer}, \
             ref_output_position_ids: {ref_position_ids}"
         )
 
@@ -456,7 +460,6 @@ def test_draft_token_static_tree_prepare_for_generation():
     )
 
 
-
 def test_dynamic_tree_update_draft_tokens_and_scores():
     # Fix parameters
     models_path = llm_models_root()
@@ -464,13 +467,26 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
     use_dynamic_tree = True
     max_new_tokens = 128
     kv_cache_manager = None
-    
-    def run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-                 cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
-                 input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
-                 ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
-                 ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices):
 
+    def run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_draft_idx,
+        new_draft_tokens,
+        new_draft_scores,
+        previous_draft_scores,
+        input_spec_decoding_packed_mask,
+        input_hidden_states_write_indices,
+        input_hidden_states_read_indices,
+        ref_draft_tokens_buffer,
+        ref_history_draft_tokens_buffer,
+        ref_history_draft_tokens_parent_buffer,
+        ref_history_score_buffer,
+        ref_spec_decoding_packed_mask,
+        ref_hidden_states_read_indices,
+    ):
         # 1) Create attention metadata
         attn_metadata = TrtllmAttentionMetadata(
             max_num_requests=max_batch_size,
@@ -503,14 +519,6 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
             max_seq_len=max_new_tokens,
             max_num_tokens=max_new_tokens,
         )
-        spec_tree_manager = SpecTreeManager(
-            max_num_requests=max_batch_size,
-            use_dynamic_tree=spec_config.use_dynamic_tree,
-            max_draft_len=spec_config.max_draft_len,
-            max_total_draft_tokens=spec_config.max_total_draft_tokens,
-            eagle_choices=spec_config.eagle_choices,
-            dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
-        )
         spec_metadata = Eagle3SpecMetadata(
             max_draft_len=spec_config.max_draft_len,
             spec_dec_mode=spec_config.spec_dec_mode,
@@ -540,7 +548,7 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
         )
 
         # 5) Run the function
-        cur_scores = dynamic_tree_drafting_loop_wrapper.update_draft_tokens_and_scores(
+        _ = dynamic_tree_drafting_loop_wrapper.update_draft_tokens_and_scores(
             cur_draft_idx=cur_draft_idx,
             batch_size=max_batch_size,
             new_draft_tokens=new_draft_tokens,
@@ -549,37 +557,76 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
             attn_metadata=attn_metadata,
             spec_metadata=spec_metadata,
         )
-        
+
         # 5) Check the results
         print("==================================")
-        print(f"======= ref_draft_tokens_buffer: {ref_draft_tokens_buffer} ========")
-        print(f"======= dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer: {dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer} ========")
-        
-        print(f"======= ref_history_draft_tokens_buffer: {ref_history_draft_tokens_buffer} ========")
-        print(f"======= dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer: {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer} ========")
-        
-        print(f"======= ref_history_draft_tokens_parent_buffer: {ref_history_draft_tokens_parent_buffer} ========")
-        print(f"======= dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer: {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer} ========")
-        
-        print(f"======= ref_history_score_buffer: {ref_history_score_buffer} ========")
-        print(f"======= dynamic_tree_drafting_loop_wrapper.history_score_buffer: {dynamic_tree_drafting_loop_wrapper.history_score_buffer} ========")
-        
-        print(f"======= ref_spec_decoding_packed_mask: {ref_spec_decoding_packed_mask} ========")
-        print(f"======= attn_metadata.spec_decoding_packed_mask: {attn_metadata.spec_decoding_packed_mask} ========")
-        
-        print(f"======= ref_hidden_states_read_indices: {ref_hidden_states_read_indices} ========")
-        print(f"======= spec_metadata.hidden_states_read_indices: {spec_metadata.hidden_states_read_indices} ========")
+        print(f"ref_draft_tokens_buffer: {ref_draft_tokens_buffer}")
+        print(
+            f"dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer: \
+                {dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer}"
+        )
 
+        print(f"ref_history_draft_tokens_buffer: {ref_history_draft_tokens_buffer}")
+        print(
+            f"dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer: \
+            {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer}"
+        )
 
-        assert torch.all(dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer == ref_draft_tokens_buffer)
-        assert torch.all(dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer == ref_history_draft_tokens_buffer)
+        print(
+            f"ref_history_draft_tokens_parent_buffer: \
+                {ref_history_draft_tokens_parent_buffer}"
+        )
+        print(
+            f"dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer: \
+                {dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer}"
+        )
+
+        print(f"ref_history_score_buffer: {ref_history_score_buffer}")
+        print(
+            f"dynamic_tree_drafting_loop_wrapper.history_score_buffer: \
+            {dynamic_tree_drafting_loop_wrapper.history_score_buffer}"
+        )
+
+        print(
+            f"ref_spec_decoding_packed_mask: \
+              {ref_spec_decoding_packed_mask}"
+        )
+        print(
+            f"attn_metadata.spec_decoding_packed_mask: \
+                {attn_metadata.spec_decoding_packed_mask}"
+        )
+
+        print(f"ref_hidden_states_read_indices: {ref_hidden_states_read_indices}")
+        print(
+            f"spec_metadata.hidden_states_read_indices: \
+                {spec_metadata.hidden_states_read_indices}"
+        )
+
+        assert torch.all(
+            dynamic_tree_drafting_loop_wrapper.draft_tokens_buffer == ref_draft_tokens_buffer
+        )
+        assert torch.all(
+            dynamic_tree_drafting_loop_wrapper.history_draft_tokens_buffer
+            == ref_history_draft_tokens_buffer
+        )
         if ref_history_draft_tokens_parent_buffer is not None:
-            assert torch.all(dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer == ref_history_draft_tokens_parent_buffer)
-        assert torch.allclose(dynamic_tree_drafting_loop_wrapper.history_score_buffer, ref_history_score_buffer, atol=1e-3)
+            assert torch.all(
+                dynamic_tree_drafting_loop_wrapper.history_draft_tokens_parent_buffer
+                == ref_history_draft_tokens_parent_buffer
+            )
+        assert torch.allclose(
+            dynamic_tree_drafting_loop_wrapper.history_score_buffer,
+            ref_history_score_buffer,
+            atol=1e-3,
+        )
         if ref_spec_decoding_packed_mask is not None:
-            assert torch.all(attn_metadata.spec_decoding_packed_mask == ref_spec_decoding_packed_mask)
+            assert torch.all(
+                attn_metadata.spec_decoding_packed_mask == ref_spec_decoding_packed_mask
+            )
         if ref_hidden_states_read_indices is not None:
-            assert torch.all(spec_metadata.hidden_states_read_indices == ref_hidden_states_read_indices)
+            assert torch.all(
+                spec_metadata.hidden_states_read_indices == ref_hidden_states_read_indices
+            )
 
     ##### CASE 1 dynamic tree, batch size = 1, cur_draft_idx = 0 #############
     max_batch_size = 1
@@ -592,33 +639,82 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
     new_draft_scores = torch.tensor([0.3, 0.2, 0.1], dtype=torch.float32, device="cuda")
     previous_draft_scores = None
 
-    input_spec_decoding_packed_mask = torch.zeros(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32), dtype=torch.int32, device="cuda")
-    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
-    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+    input_spec_decoding_packed_mask = torch.zeros(
+        max_batch_size,
+        max_total_draft_tokens + 1,
+        math.ceil((max_total_draft_tokens + 1) / 32),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    input_hidden_states_write_indices = torch.arange(
+        1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda"
+    )
+    input_hidden_states_read_indices = torch.tensor(
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    )
 
-    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer = torch.zeros(
+        max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda"
+    )
     ref_draft_tokens_buffer[:, :3] = new_draft_tokens
 
-    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.int32,
+        device="cuda",
+    )
     ref_history_draft_tokens_buffer[:, :3] = new_draft_tokens
 
-    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
-    ref_history_draft_tokens_parent_buffer[:, 0:12] = torch.tensor([-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_parent_buffer = (
+        torch.ones(
+            max_batch_size,
+            dynamic_tree_max_topK
+            + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        * -1
+    )
+    ref_history_draft_tokens_parent_buffer[:, 0:12] = torch.tensor(
+        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
+    ref_history_score_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.float32,
+        device="cuda",
+    )
     ref_history_score_buffer[:, :3] = new_draft_scores
 
-    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ref_spec_decoding_packed_mask = torch.tensor(
+        [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
     ref_hidden_states_read_indices = None
-    
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
-             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
-             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
-             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_draft_idx,
+        new_draft_tokens,
+        new_draft_scores,
+        previous_draft_scores,
+        input_spec_decoding_packed_mask,
+        input_hidden_states_write_indices,
+        input_hidden_states_read_indices,
+        ref_draft_tokens_buffer,
+        ref_history_draft_tokens_buffer,
+        ref_history_draft_tokens_parent_buffer,
+        ref_history_score_buffer,
+        ref_spec_decoding_packed_mask,
+        ref_hidden_states_read_indices,
+    )
 
-             
     ##### CASE 2 dynamic tree, batch size = 1, cur_draft_idx = 1 #############
     max_batch_size = 1
     max_draft_len = 3
@@ -630,41 +726,103 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
     # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
     # But the valuable draft tokens are new_draft_tokens[3:]
     new_draft_tokens = torch.arange(
-        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.int32, device="cuda"
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+        0,
+        -1,
+        dtype=torch.int32,
+        device="cuda",
     ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
-    new_draft_scores = torch.arange(
-        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.float32, device="cuda"
-    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK) * 0.01
+    new_draft_scores = (
+        torch.arange(
+            max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+            0,
+            -1,
+            dtype=torch.float32,
+            device="cuda",
+        ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+        * 0.01
+    )
     previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4]], dtype=torch.float32, device="cuda")
 
-    input_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
-    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+    input_spec_decoding_packed_mask = torch.tensor(
+        [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    input_hidden_states_write_indices = torch.arange(
+        1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda"
+    )
+    input_hidden_states_read_indices = torch.tensor(
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    )
 
-    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer = torch.zeros(
+        max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda"
+    )
     ref_draft_tokens_buffer[:, 3:6] = torch.tensor([48, 47, 46], dtype=torch.int32, device="cuda")
 
-    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
-    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor([48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor(
+        [48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
-    ref_history_draft_tokens_parent_buffer[:, 12:12+9] = torch.tensor([3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_parent_buffer = (
+        torch.ones(
+            max_batch_size,
+            dynamic_tree_max_topK
+            + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        * -1
+    )
+    ref_history_draft_tokens_parent_buffer[:, 12 : 12 + 9] = torch.tensor(
+        [3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
-    ref_history_score_buffer[:, 3:12] = torch.tensor([1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda")
+    ref_history_score_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    ref_history_score_buffer[:, 3:12] = torch.tensor(
+        [1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda"
+    )
 
-    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
-    
+    ref_spec_decoding_packed_mask = torch.tensor(
+        [1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    ref_hidden_states_read_indices = torch.tensor(
+        [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    )
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
-             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
-             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
-             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
-
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_draft_idx,
+        new_draft_tokens,
+        new_draft_scores,
+        previous_draft_scores,
+        input_spec_decoding_packed_mask,
+        input_hidden_states_write_indices,
+        input_hidden_states_read_indices,
+        ref_draft_tokens_buffer,
+        ref_history_draft_tokens_buffer,
+        ref_history_draft_tokens_parent_buffer,
+        ref_history_score_buffer,
+        ref_spec_decoding_packed_mask,
+        ref_hidden_states_read_indices,
+    )
 
     ##### CASE 2 dynamic tree, batch size = 1, cur_draft_idx = 1 #############
     max_batch_size = 1
@@ -677,40 +835,91 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
     # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
     # But the valuable draft tokens are new_draft_tokens[3:]
     new_draft_tokens = torch.arange(
-        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.int32, device="cuda"
+        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+        0,
+        -1,
+        dtype=torch.int32,
+        device="cuda",
     ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
-    new_draft_scores = torch.arange(
-        max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.float32, device="cuda"
-    ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK) * 0.01
+    new_draft_scores = (
+        torch.arange(
+            max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+            0,
+            -1,
+            dtype=torch.float32,
+            device="cuda",
+        ).reshape(max_batch_size * (max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+        * 0.01
+    )
     previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4]], dtype=torch.float32, device="cuda")
 
-    input_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
-    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
+    input_spec_decoding_packed_mask = torch.tensor(
+        [1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    input_hidden_states_write_indices = torch.arange(
+        1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda"
+    )
+    input_hidden_states_read_indices = torch.tensor(
+        [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    )
 
-    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer = torch.zeros(
+        max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda"
+    )
     ref_draft_tokens_buffer[:, 6:9] = torch.tensor([39, 38, 37], dtype=torch.int32, device="cuda")
 
-    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
-    ref_history_draft_tokens_buffer[:, 12:21] = torch.tensor([39, 38, 37, 36, 35, 34, 33, 32, 31], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    ref_history_draft_tokens_buffer[:, 12:21] = torch.tensor(
+        [39, 38, 37, 36, 35, 34, 33, 32, 31], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_draft_tokens_parent_buffer = None # will not be updated for this layer
+    ref_history_draft_tokens_parent_buffer = None  # will not be updated for this layer
 
-    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
-    ref_history_score_buffer[:, 12:21] = torch.tensor([1.89, 1.88, 1.87, 1.06, 1.05, 1.04, 0.73, 0.72, 0.71], dtype=torch.float32, device="cuda")
+    ref_history_score_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    ref_history_score_buffer[:, 12:21] = torch.tensor(
+        [1.89, 1.88, 1.87, 1.06, 1.05, 1.04, 0.73, 0.72, 0.71], dtype=torch.float32, device="cuda"
+    )
 
-    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 73, 137, 265, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda")
-    
+    ref_spec_decoding_packed_mask = torch.tensor(
+        [1, 2, 4, 9, 17, 33, 73, 137, 265, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    ref_hidden_states_read_indices = torch.tensor(
+        [0, 0, 0, 1, 1, 1, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0], dtype=torch.int32, device="cuda"
+    )
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
-             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
-             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
-             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
-
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_draft_idx,
+        new_draft_tokens,
+        new_draft_scores,
+        previous_draft_scores,
+        input_spec_decoding_packed_mask,
+        input_hidden_states_write_indices,
+        input_hidden_states_read_indices,
+        ref_draft_tokens_buffer,
+        ref_history_draft_tokens_buffer,
+        ref_history_draft_tokens_parent_buffer,
+        ref_history_score_buffer,
+        ref_spec_decoding_packed_mask,
+        ref_hidden_states_read_indices,
+    )
 
     ##### CASE 4 dynamic tree, batch size = 2, cur_draft_idx = 1 #############
     max_batch_size = 2
@@ -722,48 +931,225 @@ def test_dynamic_tree_update_draft_tokens_and_scores():
     # new_draft_tokens: [[48, 47, 46], [45, 44, 43], ..., [6, 5, 4], [3, 2, 1]]
     # new_draft_scores: [[0.48, 0.47, 0.46], [0.45, 0.44, 0.43], ..., [0.06, 0.05, 0.04], [0.03, 0.02, 0.01]]
     # But the valuable draft tokens are new_draft_tokens[3:]
-    new_draft_tokens = torch.arange(
-        (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.int32, device="cuda"
-    ).reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK).repeat(max_batch_size)
-    new_draft_scores = torch.arange(
-        (max_total_draft_tokens + 1) * dynamic_tree_max_topK, 0, -1,
-        dtype=torch.float32, device="cuda"
-    ).reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK).repeat(max_batch_size) * 0.01
-    previous_draft_scores = torch.tensor([[1.5, 0.7, 0.4], [2.5, 1.7, 1.4]], dtype=torch.float32, device="cuda")
+    new_draft_tokens = (
+        torch.arange(
+            (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+            0,
+            -1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        .reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+        .repeat(max_batch_size)
+    )
+    new_draft_scores = (
+        torch.arange(
+            (max_total_draft_tokens + 1) * dynamic_tree_max_topK,
+            0,
+            -1,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        .reshape((max_total_draft_tokens + 1) * dynamic_tree_max_topK)
+        .repeat(max_batch_size)
+        * 0.01
+    )
+    previous_draft_scores = torch.tensor(
+        [[1.5, 0.7, 0.4], [2.5, 1.7, 1.4]], dtype=torch.float32, device="cuda"
+    )
 
-    input_spec_decoding_packed_mask = torch.tensor([[1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    input_hidden_states_write_indices = torch.arange(1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda")
-    input_hidden_states_read_indices = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
-                                                     16, 16, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
-                                                     ], dtype=torch.int32, device="cuda")
+    input_spec_decoding_packed_mask = torch.tensor(
+        [
+            [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    input_hidden_states_write_indices = torch.arange(
+        1, max_batch_size * (max_total_draft_tokens + 1) + 1, dtype=torch.int32, device="cuda"
+    )
+    input_hidden_states_read_indices = torch.tensor(
+        [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req1
+            16,
+            16,
+            16,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req2
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    )
 
-    ref_draft_tokens_buffer = torch.zeros(max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda")
+    ref_draft_tokens_buffer = torch.zeros(
+        max_batch_size, max_total_draft_tokens + 1, dtype=torch.int32, device="cuda"
+    )
     ref_draft_tokens_buffer[:, 3:6] = torch.tensor([48, 47, 46], dtype=torch.int32, device="cuda")
 
-    ref_history_draft_tokens_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda")
-    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor([48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    ref_history_draft_tokens_buffer[:, 3:12] = torch.tensor(
+        [48, 47, 46, 45, 44, 43, 42, 41, 40], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_draft_tokens_parent_buffer = torch.ones(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.int32, device="cuda") * -1
-    ref_history_draft_tokens_parent_buffer[:, 12:12+9] = torch.tensor([3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda")
+    ref_history_draft_tokens_parent_buffer = (
+        torch.ones(
+            max_batch_size,
+            dynamic_tree_max_topK
+            + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        * -1
+    )
+    ref_history_draft_tokens_parent_buffer[:, 12 : 12 + 9] = torch.tensor(
+        [3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cuda"
+    )
 
-    ref_history_score_buffer = torch.zeros(max_batch_size, dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1), dtype=torch.float32, device="cuda")
-    ref_history_score_buffer[0:, 3:12] = torch.tensor([1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda")
-    ref_history_score_buffer[1:, 3:12] = torch.tensor([2.98, 2.97, 2.96, 2.15, 2.14, 2.13, 1.82, 1.81, 1.80], dtype=torch.float32, device="cuda")
+    ref_history_score_buffer = torch.zeros(
+        max_batch_size,
+        dynamic_tree_max_topK + dynamic_tree_max_topK * dynamic_tree_max_topK * (max_draft_len - 1),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    ref_history_score_buffer[0:, 3:12] = torch.tensor(
+        [1.98, 1.97, 1.96, 1.15, 1.14, 1.13, 0.82, 0.81, 0.80], dtype=torch.float32, device="cuda"
+    )
+    ref_history_score_buffer[1:, 3:12] = torch.tensor(
+        [2.98, 2.97, 2.96, 2.15, 2.14, 2.13, 1.82, 1.81, 1.80], dtype=torch.float32, device="cuda"
+    )
 
-    ref_spec_decoding_packed_mask = torch.tensor([1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
-                                                  1, 2, 4, 9, 17, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
-                                                  ], dtype=torch.int32, device="cuda").reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
-    ref_hidden_states_read_indices = torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req1
-                                                   16, 16, 16, 17, 17, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # req2
-                                                   ], dtype=torch.int32, device="cuda")
-    
+    ref_spec_decoding_packed_mask = torch.tensor(
+        [
+            1,
+            2,
+            4,
+            9,
+            17,
+            33,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req1
+            1,
+            2,
+            4,
+            9,
+            17,
+            33,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req2
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
+    ref_hidden_states_read_indices = torch.tensor(
+        [
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req1
+            16,
+            16,
+            16,
+            17,
+            17,
+            17,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # req2
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    )
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-             cur_draft_idx, new_draft_tokens, new_draft_scores, previous_draft_scores,
-             input_spec_decoding_packed_mask, input_hidden_states_write_indices, input_hidden_states_read_indices, 
-             ref_draft_tokens_buffer, ref_history_draft_tokens_buffer, ref_history_draft_tokens_parent_buffer, 
-             ref_history_score_buffer, ref_spec_decoding_packed_mask, ref_hidden_states_read_indices)
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_draft_idx,
+        new_draft_tokens,
+        new_draft_scores,
+        previous_draft_scores,
+        input_spec_decoding_packed_mask,
+        input_hidden_states_write_indices,
+        input_hidden_states_read_indices,
+        ref_draft_tokens_buffer,
+        ref_history_draft_tokens_buffer,
+        ref_history_draft_tokens_parent_buffer,
+        ref_history_score_buffer,
+        ref_spec_decoding_packed_mask,
+        ref_hidden_states_read_indices,
+    )
 
 
 def test_dynamic_tree_restruct_tree():
@@ -772,11 +1158,18 @@ def test_dynamic_tree_restruct_tree():
     eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
     use_dynamic_tree = True
     max_new_tokens = 128
-    kv_cache_manager = None
 
-    def run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK, 
-                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
-                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets):
+    def run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_topk_score_indices,
+        cur_history_draft_tokens_parent_buffer,
+        ref_eagle_paths,
+        ref_spec_dec_packed_mask,
+        ref_spec_dec_position_offsets,
+    ):
         # 1) Create spec metadata
         spec_config = EagleDecodingConfig(
             max_draft_len=max_draft_len,
@@ -806,23 +1199,6 @@ def test_dynamic_tree_restruct_tree():
             dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
         )
 
-        spec_metadata = Eagle3SpecMetadata(
-            max_draft_len=spec_config.max_draft_len,
-            spec_dec_mode=spec_config.spec_dec_mode,
-            max_num_requests=max_batch_size,
-            num_layers=32,
-            hidden_size=1024,
-            max_num_tokens=max_new_tokens,
-            dtype=torch.bfloat16,
-            is_draft_model=True,
-            eagle3_resource_manager=eagle3_resource_manager,
-            layers_to_capture=spec_config.eagle3_layers_to_capture,
-            max_total_draft_tokens=spec_config.max_total_draft_tokens,
-            eagle_choices=spec_config.eagle_choices,
-            is_spec_dec_tree=spec_config.eagle_choices is not None or spec_config.use_dynamic_tree,
-            is_spec_dec_dynamic_tree=spec_config.use_dynamic_tree,
-        )
-
         # 2) Create model drafter
         model_drafter = ModelDrafter(
             spec_config=spec_config,
@@ -837,10 +1213,8 @@ def test_dynamic_tree_restruct_tree():
 
         # 3) Reconstruct the dynamic tree
         model_drafter.reconstruct_dynamic_tree(
-            0,
-            cur_topk_score_indices,
-            cur_history_draft_tokens_parent_buffer,
-            spec_tree_manager)
+            0, cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, spec_tree_manager
+        )
 
         print("==================================")
         print(f"ref_eagle_paths: {ref_eagle_paths}")
@@ -850,13 +1224,15 @@ def test_dynamic_tree_restruct_tree():
         print(f"spec_tree_manager.spec_dec_packed_mask: {spec_tree_manager.spec_dec_packed_mask}")
 
         print(f"ref_spec_dec_position_offsets: {ref_spec_dec_position_offsets}")
-        print(f"spec_tree_manager.spec_dec_position_offsets: {spec_tree_manager.spec_dec_position_offsets}")
-
-        import pdb; pdb.set_trace()
+        print(
+            f"spec_tree_manager.spec_dec_position_offsets: {spec_tree_manager.spec_dec_position_offsets}"
+        )
 
         assert torch.all(ref_eagle_paths == spec_tree_manager.eagle_paths)
-        assert torch.all(ref_spec_dec_packed_mask == spec_tree_manager.spec_dec_packed_mask) 
-        assert torch.all(ref_spec_dec_position_offsets == spec_tree_manager.spec_dec_position_offsets) 
+        assert torch.all(ref_spec_dec_packed_mask == spec_tree_manager.spec_dec_packed_mask)
+        assert torch.all(
+            ref_spec_dec_position_offsets == spec_tree_manager.spec_dec_position_offsets
+        )
 
     ##### CASE 1 dynamic tree, batch size = 1 #############
     max_batch_size = 1
@@ -864,33 +1240,57 @@ def test_dynamic_tree_restruct_tree():
     max_total_draft_tokens = 10
     dynamic_tree_max_topK = 3
 
-    cur_topk_score_indices = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 9, 12], dtype=torch.int32, device="cpu")
+    cur_topk_score_indices = torch.tensor(
+        [0, 1, 2, 3, 4, 5, 6, 7, 9, 12], dtype=torch.int32, device="cpu"
+    )
     cur_history_draft_tokens_parent_buffer = torch.tensor(
-        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5], dtype=torch.int32, device="cpu")
+        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5],
+        dtype=torch.int32,
+        device="cpu",
+    )
 
     ref_eagle_paths = torch.tensor(
-        [[[ 0, -1, -1, -1],                             
-         [ 0,  1, -1, -1],
-         [ 0,  2, -1, -1],          
-         [ 0,  3, -1, -1],                            
-         [ 0,  1,  4, -1],                                                                                                                 
-         [ 0,  1,  5, -1],
-         [ 0,  1,  6, -1],
-         [ 0,  2,  7, -1],                                                                                                                 
-         [ 0,  2,  8, -1],    
-         [ 0,  3,  9, -1],
-         [ 0,  1,  4, 10]]], dtype=torch.int32, device='cpu', pin_memory=True,
+        [
+            [
+                [0, -1, -1, -1],
+                [0, 1, -1, -1],
+                [0, 2, -1, -1],
+                [0, 3, -1, -1],
+                [0, 1, 4, -1],
+                [0, 1, 5, -1],
+                [0, 1, 6, -1],
+                [0, 2, 7, -1],
+                [0, 2, 8, -1],
+                [0, 3, 9, -1],
+                [0, 1, 4, 10],
+            ]
+        ],
+        dtype=torch.int32,
+        device="cpu",
+        pin_memory=True,
     )
 
     ref_spec_dec_packed_mask = torch.tensor(
         [1, 3, 5, 9, 19, 35, 67, 133, 261, 521, 1043], dtype=torch.int32, device="cuda"
-    ).reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
 
-    ref_spec_dec_position_offsets = torch.tensor([[0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3]], dtype=torch.int32, device="cuda")
+    ref_spec_dec_position_offsets = torch.tensor(
+        [[0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3]], dtype=torch.int32, device="cuda"
+    )
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
-                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets)
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_topk_score_indices,
+        cur_history_draft_tokens_parent_buffer,
+        ref_eagle_paths,
+        ref_spec_dec_packed_mask,
+        ref_spec_dec_position_offsets,
+    )
 
     ##### CASE 2 dynamic tree, batch size = 1 #############
     max_batch_size = 1
@@ -898,32 +1298,56 @@ def test_dynamic_tree_restruct_tree():
     max_total_draft_tokens = 9
     dynamic_tree_max_topK = 3
 
-    cur_topk_score_indices = torch.tensor([0, 1, 2, 3, 4, 6, 12, 13, 18], dtype=torch.int32, device="cpu")
+    cur_topk_score_indices = torch.tensor(
+        [0, 1, 2, 3, 4, 6, 12, 13, 18], dtype=torch.int32, device="cpu"
+    )
     cur_history_draft_tokens_parent_buffer = torch.tensor(
-        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 6, 6, 6], dtype=torch.int32, device="cpu")
+        [-1, -1, -1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 6, 6, 6],
+        dtype=torch.int32,
+        device="cpu",
+    )
 
     ref_eagle_paths = torch.tensor(
-        [[[ 0, -1, -1, -1],                             
-         [ 0,  1, -1, -1],
-         [ 0,  2, -1, -1],          
-         [ 0,  3, -1, -1],                            
-         [ 0,  1,  4, -1],                                                                                                                 
-         [ 0,  1,  5, -1],
-         [ 0,  2,  6, -1],
-         [ 0,  1,  4, 7],                                                                                                                 
-         [ 0,  1,  4, 8],    
-         [ 0,  2,  6, 9]]], dtype=torch.int32, device='cpu', pin_memory=True,
+        [
+            [
+                [0, -1, -1, -1],
+                [0, 1, -1, -1],
+                [0, 2, -1, -1],
+                [0, 3, -1, -1],
+                [0, 1, 4, -1],
+                [0, 1, 5, -1],
+                [0, 2, 6, -1],
+                [0, 1, 4, 7],
+                [0, 1, 4, 8],
+                [0, 2, 6, 9],
+            ]
+        ],
+        dtype=torch.int32,
+        device="cpu",
+        pin_memory=True,
     )
 
     ref_spec_dec_packed_mask = torch.tensor(
         [1, 3, 5, 9, 19, 35, 69, 147, 275, 581], dtype=torch.int32, device="cuda"
-    ).reshape(max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32))
+    ).reshape(
+        max_batch_size, max_total_draft_tokens + 1, math.ceil((max_total_draft_tokens + 1) / 32)
+    )
 
-    ref_spec_dec_position_offsets = torch.tensor([[0, 1, 1, 1, 2, 2, 2, 3, 3, 3]], dtype=torch.int32, device="cuda")
+    ref_spec_dec_position_offsets = torch.tensor(
+        [[0, 1, 1, 1, 2, 2, 2, 3, 3, 3]], dtype=torch.int32, device="cuda"
+    )
 
-    run_test(max_batch_size, max_draft_len, max_total_draft_tokens, dynamic_tree_max_topK,
-                 cur_topk_score_indices, cur_history_draft_tokens_parent_buffer, 
-                 ref_eagle_paths, ref_spec_dec_packed_mask, ref_spec_dec_position_offsets)
+    run_test(
+        max_batch_size,
+        max_draft_len,
+        max_total_draft_tokens,
+        dynamic_tree_max_topK,
+        cur_topk_score_indices,
+        cur_history_draft_tokens_parent_buffer,
+        ref_eagle_paths,
+        ref_spec_dec_packed_mask,
+        ref_spec_dec_position_offsets,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/speculative/test_draft_token_tree_sampling.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_tree_sampling.py
@@ -6,7 +6,7 @@ import torch
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.speculative.drafting_loops import \
-    TreeDraftingLoopWrapper
+    StaticTreeDraftingLoopWrapper
 from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
 from tensorrt_llm.llmapi import EagleDecodingConfig
 
@@ -53,7 +53,7 @@ def test_draft_token_static_tree_sampling():
         )
 
         # Create the chain drafter
-        tree_drafter = TreeDraftingLoopWrapper(
+        tree_drafter = StaticTreeDraftingLoopWrapper(
             max_batch_size=max_batch_size,
             max_draft_len=spec_config.max_draft_len,
             max_total_draft_tokens=spec_config.max_total_draft_tokens,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for dynamic tree drafting in speculative decoding for flexible token generation strategies
  * Introduced `--max_total_draft_tokens` CLI parameter for granular control over draft token allocation

* **Chores**
  * Enhanced test coverage for speculative decoding scenarios
  * Refactored internal speculative decoding parameter handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This PR adds runtime support for dynamic trees based on CDL. AR has not yet been verified. This will be done in future work.

The execution flow of a dynamic tree is as follows.

<img width="3144" height="3199" alt="dynamic_tree_details" src="https://github.com/user-attachments/assets/9fb8a8e5-469e-4d13-a6a7-d21b3b726443" />



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
