### PR TITLE
[TRTC-1975] [feat] BREAKING: Enable chunked prefill by default

### DIFF
--- a/docs/source/_includes/note_sections.rst
+++ b/docs/source/_includes/note_sections.rst
@@ -23,15 +23,15 @@
    values in each configuration represent the **maximum supported values** for that config.
    Requests exceeding these limits may result in errors.
 
-   To handle requests with input sequences **longer than the configured ISL**, add the following
-   to your config file:
+   To handle requests with input sequences **longer than the configured ISL**, chunked prefill
+   is enabled by default. If you need to explicitly disable it, add the following to your config file:
 
    .. code-block:: yaml
 
-      enable_chunked_prefill: true
+      enable_chunked_prefill: false
 
-   This enables chunked prefill, which processes long input sequences in chunks rather than
-   requiring them to fit within a single prefill operation. Note that enabling chunked prefill
+   Chunked prefill processes long input sequences in chunks rather than
+   requiring them to fit within a single prefill operation. Note that chunked prefill
    does **not** guarantee optimal performance—these configs are tuned for the specified ISL/OSL.
 
 .. end-note-traffic-patterns

--- a/docs/source/features/long-sequence.md
+++ b/docs/source/features/long-sequence.md
@@ -11,14 +11,18 @@ With the chunked context feature, there are two benefits:
 - This can prevent the context phase from becoming a bottleneck, enable more parallelization with tokens in the decode phase, and increase GPU utilization.
 - Chunked context allows TensorRT LLM to handle requests with longer contexts while achieving higher concurrency. Since memory usage depends on the number of tokens processed per iteration, chunked context decouples memory consumption from the input request's context length, changing it to the smaller chunk size. This enables TensorRT LLM to process longer contexts without increasing memory requirements, which can also help increase the concurrency under the same memory consumption.
 
-To enable chunked context, please set the `enable_chunked_prefill` in `LLM` API to `True`.
+Chunked context is enabled by default. To disable it, set `enable_chunked_prefill` to `False` in the `LLM` API, or pass `--disable_chunked_prefill` when using `trtllm-serve`.
+
 ```python
+    # To explicitly disable chunked prefill:
     llm = LLM(
         ...
-        enable_chunked_prefill=True,
+        enable_chunked_prefill=False,
         ...
     )
 ```
+
+Note: Some model architectures (e.g., Mamba/SSM hybrids like NemotronH and Qwen3Next, and Gemma3) automatically disable chunked prefill via model-specific defaults.
 
 Note that if chunked context is enabled, please set the `max_num_tokens` to be an integer multiple of the kv-cache block size `tokens_per_block`, which defaults to 64.
 

--- a/examples/llm-api/llm_sparse_attention.py
+++ b/examples/llm-api/llm_sparse_attention.py
@@ -132,10 +132,10 @@ def parse_arguments():
                         nargs='+',
                         type=int,
                         default=None)
-    parser.add_argument('--enable_chunked_prefill',
+    parser.add_argument('--disable_chunked_prefill',
                         default=False,
                         action='store_true',
-                        help='Enable chunked prefill')
+                        help='Disable chunked prefill (enabled by default)')
     args = parser.parse_args()
     return args
 
@@ -175,7 +175,7 @@ def run_llm(args, sparse_attention_config):
         print_iter_log=args.print_iter_log,
         enable_iter_perf_stats=args.print_iter_log,
         moe_config=MoeConfig(backend=args.moe_backend),
-        enable_chunked_prefill=args.enable_chunked_prefill,
+        enable_chunked_prefill=not args.disable_chunked_prefill,
     )
 
     prompts = []

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -134,9 +134,10 @@ def add_llm_args(parser):
     parser.add_argument('--disable_overlap_scheduler',
                         default=False,
                         action='store_true')
-    parser.add_argument('--enable_chunked_prefill',
+    parser.add_argument('--disable_chunked_prefill',
                         default=False,
-                        action='store_true')
+                        action='store_true',
+                        help='Disable chunked prefill (enabled by default)')
     parser.add_argument('--use_cuda_graph', default=False, action='store_true')
     parser.add_argument('--cuda_graph_padding_enabled',
                         default=False,
@@ -320,7 +321,7 @@ def setup_llm(args, **kwargs):
         moe_expert_parallel_size=args.moe_ep_size,
         moe_tensor_parallel_size=args.moe_tp_size,
         moe_cluster_parallel_size=args.moe_cluster_size,
-        enable_chunked_prefill=args.enable_chunked_prefill,
+        enable_chunked_prefill=not args.disable_chunked_prefill,
         speculative_config=spec_config,
         trust_remote_code=args.trust_remote_code,
         gather_generation_logits=args.return_generation_logits,

--- a/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
+++ b/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
@@ -60,7 +60,7 @@ class TRTLLMEvalBase(TemplateLM):
         max_context_length: Optional[int] = None,
         moe_expert_parallel_size: Optional[int] = None,
         moe_backend: Optional[str] = "TRTLLM",
-        enable_chunked_prefill: bool = False,
+        enable_chunked_prefill: bool = True,
         max_num_tokens: Optional[int] = None,
         **kwargs,
     ):

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -866,13 +866,13 @@ The converted checkpoint could be used as `<YOUR_MODEL_DIR>` and consumed by oth
 KV cache reuse is supported for MLA on SM90, SM100 and SM120. It is enabled by default. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
 
 ### Chunked Prefill
-Chunked Prefill is supported for MLA only on SM90 and SM100 currently. You should add `--enable_chunked_prefill` to enable it. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
+Chunked Prefill is supported for MLA only on SM90 and SM100 currently. It is enabled by default. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
 
 More specifically, we can imitate what we did in the [Quick Start](#quick-start):
 
 ``` bash
 cd examples/llm-api
-python quickstart_advanced.py --model_dir <YOUR_MODEL_DIR> --enable_chunked_prefill
+python quickstart_advanced.py --model_dir <YOUR_MODEL_DIR>
 ```
 
 ## Notes and Troubleshooting

--- a/examples/models/core/exaone/README.md
+++ b/examples/models/core/exaone/README.md
@@ -284,7 +284,6 @@ cat > ctx_extra-llm-api-config.yaml << EOF
 backend: pytorch
 trust_remote_code: true
 disable_overlap_scheduler: true
-enable_chunked_prefill: true
 
 tensor_parallel_size: $TP_SIZE
 moe_expert_parallel_size: $MOE_EP_SIZE
@@ -304,7 +303,6 @@ cat > gen_extra-llm-api-config.yaml << EOF
 backend: pytorch
 trust_remote_code: true
 disable_overlap_scheduler: false
-enable_chunked_prefill: true
 
 tensor_parallel_size: $TP_SIZE
 moe_expert_parallel_size: $MOE_EP_SIZE
@@ -342,12 +340,12 @@ Start all components in the following order:
 ```bash
 # 1. Start context server (GPUs 0-3)
 CUDA_VISIBLE_DEVICES=0,1,2,3 trtllm-serve $HF_MODEL_DIR \
-    --host localhost --port 8001 --enable_chunked_prefill \
+    --host localhost --port 8001 \
     --extra_llm_api_options ./ctx_extra-llm-api-config.yaml &> log_ctx.log &
 
 # 2. Start generation server (GPUs 4-7)
 CUDA_VISIBLE_DEVICES=4,5,6,7 trtllm-serve $HF_MODEL_DIR \
-    --host localhost --port 8002 --enable_chunked_prefill \
+    --host localhost --port 8002 \
     --extra_llm_api_options ./gen_extra-llm-api-config.yaml &> log_gen.log &
 
 # 3. Start disaggregated orchestrator

--- a/examples/models/core/nemotron/README_nano-v2-vl.md
+++ b/examples/models/core/nemotron/README_nano-v2-vl.md
@@ -23,10 +23,10 @@
 python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code
 ```
 
- * Image modality input with chunked_prefill:
+ * Image modality input with chunked_prefill (enabled by default):
 
 ```bash
-python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code --enable_chunked_prefill --max_num_tokens=256
+python3 examples/llm-api/quickstart_multimodal.py --model_dir nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 --disable_kv_cache_reuse --max_batch_size 128 --trust_remote_code --max_num_tokens=256
 ```
 
  * Video modality input:

--- a/examples/models/core/nemotron/README_nemotron_nano_v3.md
+++ b/examples/models/core/nemotron/README_nemotron_nano_v3.md
@@ -33,7 +33,6 @@ runtime: trtllm
 compile_backend: torch-cudagraph
 max_batch_size: 384
 max_seq_len: 65536
-enable_chunked_prefill: true
 attn_backend: flashinfer
 model_factory: AutoModelForCausalLM
 skip_loading_weights: false
@@ -168,7 +167,6 @@ model:
   nvidia/NVIDIA-Nemotron-Nano-31B-A3-v3
 args:
   compile_backend: torch-cudagraph
-  enable_chunked_prefill: true
   kv_cache_config:
     # disable kv_cache reuse since not supported for hybrid/ssm models
     enable_block_reuse: false
@@ -183,7 +181,6 @@ The CLI can also be used to override certain config values:
 python examples/auto_deploy/build_and_run_ad.py \
   --model nvidia/NVIDIA-Nemotron-Nano-31B-A3-v3 \
   --args.compile_backend torch-cudagraph \
-  --args.enable_chunked_prefill true \
   --args.kv_cache_config.enable_block_reuse false
 ```
 

--- a/examples/sparse_attention/RocketKV.md
+++ b/examples/sparse_attention/RocketKV.md
@@ -25,7 +25,7 @@ RocketKV is integrated into TensorRT LLM as a specialized attention backend, acc
 
 **Note:** 
 1. RocketKV currently requires `enable_block_reuse=False` in the KV cache configuration, as the sparse eviction logic is incompatible with standard block reuse mechanisms. 
-2. RocketKV doesn't support `enable_chunked_prefill=True` for now.
+2. RocketKV doesn't support chunked prefill. Since chunked prefill is enabled by default, you must explicitly disable it via `enable_chunked_prefill=False` in the LLM API or `--disable_chunked_prefill` when using `trtllm-serve`.
 3. RocketKV doesn't support *disagg-serving* as well, since it needs the KV cache transmission from prefill engine to the decode engine. But currently RocketKV uses a python kt cache manager and it cannot support this transmission.
 
 ## Usage

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -264,8 +264,12 @@ class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
 
     @classmethod
     def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
-        """Gemma3 image tokens require bidirectional attention,
-        which is incompatible with chunked prefill."""
+        """Model-specific defaults for Gemma3.
+
+        Disables chunked prefill because Gemma3 image tokens require
+        bidirectional attention, which is incompatible with chunked
+        prefill.
+        """
         return {"enable_chunked_prefill": False}
 
     def __init__(

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -262,6 +262,12 @@ class Gemma3TextModel(DecoderModel):
 class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
                                                 Gemma3TextConfig]):
 
+    @classmethod
+    def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
+        """Gemma3 image tokens require bidirectional attention,
+        which is incompatible with chunked prefill."""
+        return {"enable_chunked_prefill": False}
+
     def __init__(
         self,
         model_config: ModelConfig[Gemma3TextConfig],

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
@@ -1,6 +1,10 @@
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import torch
+
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+
 from torch import nn
 from tqdm import tqdm
 from transformers import PretrainedConfig
@@ -617,6 +621,30 @@ class HunYuanModel(DecoderModel):
 class HunYuanDenseV1ForCausalLM(DecoderModelForCausalLM[HunYuanModel,
                                                         HunYuanPretrainedConfig]
                                 ):
+
+    @classmethod
+    def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
+        """Model-specific defaults for HunyuanDense.
+
+        Conditionally disables block reuse and chunked prefill when the
+        model uses hybrid Mamba mode, due to SSM/hybrid architecture
+        constraints.
+        """
+        import json
+        from pathlib import Path
+
+        config_path = Path(str(llm_args.model)) / "config.json"
+        if config_path.is_file():
+            with open(config_path) as f:
+                hf_config = json.load(f)
+            if hf_config.get("mamba", False):
+                return {
+                    "kv_cache_config": {
+                        "enable_block_reuse": False
+                    },
+                    "enable_chunked_prefill": False,
+                }
+        return {}
 
     def __init__(self, model_config: ModelConfig[HunYuanPretrainedConfig]):
         super().__init__(HunYuanModel(model_config),

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -744,11 +744,17 @@ class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
     def get_model_defaults(cls, llm_args: "TorchLlmArgs") -> dict:
         """Model-specific defaults for NemotronH.
 
-        Disables block reuse due to SSM/hybrid architecture constraints.
+        Disables block reuse and chunked prefill due to SSM/hybrid
+        architecture constraints.
         """
         # TODO: Remove enable_block_reuse=False once KV cache block reuse
         # is supported for Mamba/SSM-based models
-        return {"kv_cache_config": {"enable_block_reuse": False}}
+        return {
+            "kv_cache_config": {
+                "enable_block_reuse": False
+            },
+            "enable_chunked_prefill": False,
+        }
 
 
 class NemotronHMTPDecoderLayer(NemotronHLayer):

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1335,7 +1335,12 @@ class Qwen3NextForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel,
     def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
         # TODO: Remove enable_block_reuse=False once KV cache block reuse
         # is supported for Mamba/SSM-based models
-        return {"kv_cache_config": {"enable_block_reuse": False}}
+        return {
+            "kv_cache_config": {
+                "enable_block_reuse": False
+            },
+            "enable_chunked_prefill": False,
+        }
 
     def load_weights(self, weights: dict, weight_mapper: BaseWeightMapper):
         new_weights = weight_mapper.preprocess_weights(weights)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1744,6 +1744,24 @@ class PyExecutor:
 
         self._pad_attention_dp_dummy_request()
 
+        # For one-model speculative decoding (e.g., MTP), normalize C++
+        # draft_tokens before scheduling. The overlap extend path in
+        # _prepare_tp_inputs always materializes runtime_draft_len tokens,
+        # so the C++ scheduler must budget the same per generation request.
+        # This mirrors the two-model drafter normalization below (lines
+        # 1699-1707). Without this, the scheduler can under-budget newly
+        # promoted or fitDraftTokens-trimmed requests, causing the
+        # total_num_tokens > max_num_tokens assertion in model_engine.py.
+        if self.drafter is None and self.model_engine.enable_spec_decode:
+            max_draft = self.model_engine.max_total_draft_tokens
+            if max_draft > 0:
+                for request in self.active_requests:
+                    if request.state not in (
+                            LlmRequestState.GENERATION_IN_PROGRESS,
+                            LlmRequestState.DISAGG_GENERATION_INIT):
+                        continue
+                    request.draft_tokens = [0] * max_draft
+
         if self.drafter is not None:
             # Honor permanent disable flag based on rolling acceptance first
             if self.drafter.draft_len_schedule is not None:

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -55,6 +55,23 @@ def help_info_with_stability_tag(
     return f":tag:`{tag}` {help_str}"
 
 
+def _resolve_chunked_prefill(enable: Optional[bool], disable: bool) -> bool:
+    """Resolve --enable_chunked_prefill / --disable_chunked_prefill flags.
+
+    Chunked prefill is enabled by default. The two flags are mutually
+    exclusive: passing both is an error.  --enable_chunked_prefill is
+    kept for backward compatibility.
+    """
+    if enable and disable:
+        raise click.UsageError(
+            "--enable_chunked_prefill and --disable_chunked_prefill "
+            "are mutually exclusive.")
+    if disable:
+        return False
+    # Default is True (enable is None when not passed, or True when passed)
+    return True
+
+
 def _signal_handler_cleanup_child(signum, frame):
     """Signal handler to clean up the child process."""
     global _child_p_global
@@ -156,7 +173,7 @@ def get_llm_args(
         reasoning_parser: Optional[str] = None,
         fail_fast_on_attention_window_too_large: bool = True,
         otlp_traces_endpoint: Optional[str] = None,
-        enable_chunked_prefill: bool = False,
+        enable_chunked_prefill: bool = True,
         enable_attention_dp: bool = False,
         video_pruning_rate: Optional[float] = None,
         **llm_args_extra_dict: Any):
@@ -728,9 +745,15 @@ class ChoiceWithAlias(click.Choice):
                   "URI of the disaggregated cluster.", "prototype"))
 @click.option("--enable_chunked_prefill",
               is_flag=True,
+              default=None,
+              help=help_info_with_stability_tag(
+                  "Enable chunked prefill (now enabled by default; "
+                  "kept for backward compatibility)", "prototype"))
+@click.option("--disable_chunked_prefill",
+              is_flag=True,
               default=False,
-              help=help_info_with_stability_tag("Enable chunked prefill",
-                                                "prototype"))
+              help=help_info_with_stability_tag(
+                  "Disable chunked prefill (enabled by default)", "prototype"))
 @click.option("--enable_attention_dp",
               is_flag=True,
               default=False,
@@ -789,7 +812,8 @@ def serve(
         reasoning_parser: Optional[str], tool_parser: Optional[str],
         metadata_server_config_file: Optional[str], server_role: Optional[str],
         fail_fast_on_attention_window_too_large: bool,
-        otlp_traces_endpoint: Optional[str], enable_chunked_prefill: bool,
+        otlp_traces_endpoint: Optional[str],
+        enable_chunked_prefill: Optional[bool], disable_chunked_prefill: bool,
         enable_attention_dp: bool, disagg_cluster_uri: Optional[str],
         media_io_kwargs: Optional[str], video_pruning_rate: Optional[float],
         custom_module_dirs: list[Path], chat_template: Optional[str],
@@ -877,7 +901,8 @@ def serve(
             fail_fast_on_attention_window_too_large=
             fail_fast_on_attention_window_too_large,
             otlp_traces_endpoint=otlp_traces_endpoint,
-            enable_chunked_prefill=enable_chunked_prefill,
+            enable_chunked_prefill=_resolve_chunked_prefill(
+                enable_chunked_prefill, disable_chunked_prefill),
             enable_attention_dp=enable_attention_dp,
             video_pruning_rate=video_pruning_rate)
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2506,7 +2506,7 @@ class BaseLlmArgs(StrictBaseModel):
     kv_cache_config: KvCacheConfig = Field(default_factory=KvCacheConfig,
                                            description="KV cache config.")
 
-    enable_chunked_prefill: bool = Field(default=False,
+    enable_chunked_prefill: bool = Field(default=True,
                                          description="Enable chunked prefill.")
 
     guided_decoding_backend: Optional[Literal["xgrammar", "llguidance"]] = Field(

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -107,11 +107,18 @@ class AttentionLayerConfig:
     def window_size(self) -> int | None: ...
 
 @dataclass(slots=True)
+class SsmLayerConfig:
+    layer_id: LayerId
+    buffers: list[BufferConfig]
+
+LayerConfig = AttentionLayerConfig | SsmLayerConfig
+
+@dataclass(slots=True)
 class KVCacheManagerConfig:
     tokens_per_block: int
     vocab_size: int
     cache_tiers: list[CacheTierConfig]
-    layers: list[AttentionLayerConfig]
+    layers: list[LayerConfig]
     max_util_for_resume: float = ...
     helix_config: HelixConfig | None = None
 
@@ -164,6 +171,9 @@ class _KVCache:
     def get_base_page_indices(
         self, layer_group_id: LayerGroupId, beam_id: BeamIndex = DEFAULT_BEAM_INDEX
     ) -> IndexSeq: ...
+    def get_ssm_block_base_index(
+        self, layer_group_id: LayerGroupId, beam_id: BeamIndex = DEFAULT_BEAM_INDEX
+    ) -> int: ...
     def get_aggregated_page_indices(
         self,
         layer_group_id: LayerGroupId,

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -189,6 +189,8 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
             config["enable_chunked_prefill"] = True
             # NOTE: must be > max(tokens_per_block, max_batch_size)
             config["max_num_tokens"] = 512
+        else:
+            config["enable_chunked_prefill"] = False
         return config
 
     def get_default_sampling_params(self):
@@ -348,6 +350,8 @@ class TestNemotronH(LlmapiAccuracyTestHarness):
             config["enable_chunked_prefill"] = True
             config[
                 "max_num_tokens"] = 512  # NOTE: must be > max(tokens_per_block, max_batch_size)
+        else:
+            config["enable_chunked_prefill"] = False
         return config
 
     def get_default_sampling_params(self):
@@ -393,6 +397,8 @@ class TestNemotronV2(LlmapiAccuracyTestHarness):
             config["enable_chunked_prefill"] = True
             # NOTE: must be > max(tokens_per_block, max_batch_size)
             config["max_num_tokens"] = 512
+        else:
+            config["enable_chunked_prefill"] = False
         return config
 
     def get_default_sampling_params(self):
@@ -624,6 +630,8 @@ class TestGLM4Flash(LlmapiAccuracyTestHarness):
             config["transforms"]["compile_model"] = {
                 "piecewise_enabled": True,
             }
+        else:
+            config["enable_chunked_prefill"] = False
         return config
 
     def get_default_sampling_params(self):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -2162,6 +2162,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
 
         with LLM(f"{llm_models_root()}/DeepSeek-V3-Lite/nvfp4_moe_only_mtp",
                  kv_cache_config=kv_cache_config,
+                 enable_chunked_prefill=False,
                  **pytorch_config,
                  enable_attention_dp=attention_dp,
                  speculative_config=mtp_config) as llm:
@@ -2201,6 +2202,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             kv_cache_config.dtype = "fp8"
         with LLM(f"{llm_models_root()}/DeepSeek-V3-Lite/nvfp4_moe_only_mtp",
                  kv_cache_config=kv_cache_config,
+                 enable_chunked_prefill=False,
                  **pytorch_config,
                  enable_attention_dp=False,
                  speculative_config=mtp_config) as llm:
@@ -2267,6 +2269,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
                 pipeline_parallel_size=pp_size,
                 moe_expert_parallel_size=ep_size,
                 kv_cache_config=kv_cache_config,
+                enable_chunked_prefill=False,
                 **pytorch_config,
                 enable_attention_dp=attention_dp,
                 speculative_config=mtp_config,

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1857,7 +1857,6 @@ def test_ptp_quickstart_advanced(llm_root, llm_venv, model_name, model_path):
         }
         cmds = [
             str(example_root / "quickstart_advanced.py"),
-            "--enable_chunked_prefill",
             f"--model_dir={llm_models_root()}/{model_path}",
         ]
         if "Qwen3" in model_name:
@@ -2343,7 +2342,6 @@ def test_ptp_quickstart_advanced_multi_gpus(llm_root, llm_venv, model_name,
     }
     llm_venv.run_cmd([
         str(example_root / "quickstart_advanced.py"),
-        "--enable_chunked_prefill",
         "--model_dir",
         f"{llm_models_root()}/{model_path}",
         f"--tp_size={gpu_count}",
@@ -2370,7 +2368,6 @@ def test_ptp_quickstart_advanced_pp_enabled(llm_root, llm_venv, model_name,
     example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
     cmd = [
         str(example_root / "quickstart_advanced.py"),
-        "--enable_chunked_prefill",
         "--model_dir",
         f"{llm_models_root()}/{model_path}",
         f"--tp_size={tp_size}",
@@ -2404,7 +2401,6 @@ def test_ptp_quickstart_advanced_8gpus_chunked_prefill_sq_22k(
     example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
     cmd = [
         str(example_root / "quickstart_advanced.py"),
-        "--enable_chunked_prefill",
         "--model_dir",
         f"{llm_models_root()}/{model_path}",
         "--tp_size=8",

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -7,6 +7,7 @@ to PyExecutor, including:
 - waiting_queue management
 - is_shutdown state management
 - expected_num_active_requests tracking
+- one-model MTP draft token normalization before scheduling
 """
 
 from unittest.mock import Mock
@@ -17,6 +18,7 @@ from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     SHUTDOWN_REQUEST_ID,
     RequestQueueItem,
 )
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
 from tensorrt_llm._torch.pyexecutor.scheduler import FCFSWaitingQueue
 
 
@@ -178,3 +180,110 @@ def test_getter_methods(mock_executor):
     assert mock_executor.get_expected_num_active_requests() == 5
     assert mock_executor._get_new_active_requests_queue_latency() == 10.5
     assert mock_executor.get_waiting_queue_size() == 1
+
+
+def _normalize_one_model_mtp_draft_tokens(drafter, model_engine, active_requests):
+    """Replicate the one-model MTP draft token normalization from
+    PyExecutor._prepare_and_schedule_batch so it can be unit-tested
+    without standing up a full executor.
+    """
+    if drafter is None and model_engine.enable_spec_decode:
+        max_draft = model_engine.max_total_draft_tokens
+        if max_draft > 0:
+            for request in active_requests:
+                if request.state not in (
+                    LlmRequestState.GENERATION_IN_PROGRESS,
+                    LlmRequestState.DISAGG_GENERATION_INIT,
+                ):
+                    continue
+                request.draft_tokens = [0] * max_draft
+
+
+def test_one_model_mtp_draft_token_normalization():
+    """Verify that one-model MTP normalizes C++ draft_tokens for all
+    generation requests before the scheduler runs.
+
+    Without this normalization the C++ scheduler can under-budget
+    generation requests (seeing fewer draft tokens than the runtime
+    will actually materialize), causing a total_num_tokens overflow.
+    """
+    max_total_draft_tokens = 2  # e.g. MTP nextn=2
+
+    model_engine = Mock()
+    model_engine.enable_spec_decode = True
+    model_engine.max_total_draft_tokens = max_total_draft_tokens
+
+    # Generation request with stale (empty) draft_tokens — simulates
+    # a request that just transitioned from context to generation.
+    gen_req = Mock()
+    gen_req.state = LlmRequestState.GENERATION_IN_PROGRESS
+    gen_req.draft_tokens = []
+
+    # Context request — should NOT be touched.
+    ctx_req = Mock()
+    ctx_req.state = LlmRequestState.CONTEXT_INIT
+    ctx_req.draft_tokens = []
+
+    # Disagg generation init — should be normalized.
+    disagg_req = Mock()
+    disagg_req.state = LlmRequestState.DISAGG_GENERATION_INIT
+    disagg_req.draft_tokens = [99]  # stale value
+
+    active_requests = [gen_req, ctx_req, disagg_req]
+
+    _normalize_one_model_mtp_draft_tokens(
+        drafter=None,
+        model_engine=model_engine,
+        active_requests=active_requests,
+    )
+
+    assert gen_req.draft_tokens == [0] * max_total_draft_tokens, (
+        "GENERATION_IN_PROGRESS request should have normalized draft_tokens"
+    )
+    assert ctx_req.draft_tokens == [], "CONTEXT_INIT request should not be modified"
+    assert disagg_req.draft_tokens == [0] * max_total_draft_tokens, (
+        "DISAGG_GENERATION_INIT request should have normalized draft_tokens"
+    )
+
+
+def test_one_model_mtp_normalization_skipped_with_drafter():
+    """When a two-model drafter is present, one-model normalization
+    should be skipped (the drafter path handles it separately)."""
+    model_engine = Mock()
+    model_engine.enable_spec_decode = True
+    model_engine.max_total_draft_tokens = 3
+
+    drafter = Mock()  # non-None drafter
+
+    gen_req = Mock()
+    gen_req.state = LlmRequestState.GENERATION_IN_PROGRESS
+    gen_req.draft_tokens = []
+
+    _normalize_one_model_mtp_draft_tokens(
+        drafter=drafter,
+        model_engine=model_engine,
+        active_requests=[gen_req],
+    )
+
+    assert gen_req.draft_tokens == [], (
+        "With a two-model drafter, one-model normalization should not run"
+    )
+
+
+def test_one_model_mtp_normalization_skipped_when_spec_decode_off():
+    """When spec decode is disabled, normalization should be skipped."""
+    model_engine = Mock()
+    model_engine.enable_spec_decode = False
+    model_engine.max_total_draft_tokens = 2
+
+    gen_req = Mock()
+    gen_req.state = LlmRequestState.GENERATION_IN_PROGRESS
+    gen_req.draft_tokens = []
+
+    _normalize_one_model_mtp_draft_tokens(
+        drafter=None,
+        model_engine=model_engine,
+        active_requests=[gen_req],
+    )
+
+    assert gen_req.draft_tokens == [], "With spec decode disabled, normalization should not run"

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -83,7 +83,7 @@ methods:
         default: 0
       enable_chunked_prefill:
         annotation: bool
-        default: false
+        default: true
       kv_cache_config:
         annotation: tensorrt_llm.llmapi.llm_args.KvCacheConfig
         default: null

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py
@@ -91,6 +91,7 @@ def test_create_autodeploy_executor_with_guided_decoding(
         max_input_len=64,
         guided_decoding_backend=guided_decoding_backend,
         backend="_autodeploy",
+        enable_chunked_prefill=False,
     )
 
     # Mock guided decoding config

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2162,6 +2162,8 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     if enable_chunked_prefill:
         llm_args_extra["enable_chunked_prefill"] = True
         llm_args_extra["max_num_tokens"] = 32
+    else:
+        llm_args_extra["enable_chunked_prefill"] = False
 
     if pytorch_backend:
         llm_args_extra.update(
@@ -2310,6 +2312,8 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
     if enable_chunked_prefill:
         llm_args_extra["enable_chunked_prefill"] = True
         llm_args_extra["max_num_tokens"] = 32
+    else:
+        llm_args_extra["enable_chunked_prefill"] = False
 
     if pytorch_backend:
         llm_args_extra.update(

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2426,6 +2426,7 @@ def _test_llm_capture_request_error(pytorch_backend: bool, tp_size: int = 1):
     if pytorch_backend:
         LLM_CLASS = LLM_torch
         llm_args_extra["max_num_tokens"] = 64
+        llm_args_extra["enable_chunked_prefill"] = False
     else:
         LLM_CLASS = LLM
         build_config = BuildConfig()

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -5,6 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args, get_origin
 
+import click
 import pydantic_core
 import pytest
 import yaml
@@ -21,7 +22,8 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_llama import LlamaForCausalLM
 from tensorrt_llm._torch.virtual_memory import RestoreMode
 from tensorrt_llm.builder import LoraConfig
-from tensorrt_llm.commands.serve import get_llm_args, is_non_default_or_required
+from tensorrt_llm.commands.serve import (_resolve_chunked_prefill, get_llm_args,
+                                         is_non_default_or_required)
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
                                  SchedulerConfig)
 # fmt: off
@@ -1536,3 +1538,33 @@ class TestPydanticBestPractices:
                 + "\n".join(violations) +
                 "\n\nThese should be replaced with alternatives like validators, model_post_init, or classmethods. See this test's docstring for more details."
             )
+
+
+class TestResolveChunkedPrefill:
+    """Tests for the _resolve_chunked_prefill CLI flag resolver."""
+
+    @pytest.mark.part0
+    def test_default_returns_true(self):
+        """Neither flag passed: chunked prefill is enabled by default."""
+        assert _resolve_chunked_prefill(enable=None, disable=False) is True
+
+    @pytest.mark.part0
+    def test_enable_flag_returns_true(self):
+        """--enable_chunked_prefill passed explicitly."""
+        assert _resolve_chunked_prefill(enable=True, disable=False) is True
+
+    @pytest.mark.part0
+    def test_disable_flag_returns_false(self):
+        """--disable_chunked_prefill passed."""
+        assert _resolve_chunked_prefill(enable=None, disable=True) is False
+
+    @pytest.mark.part0
+    def test_both_flags_raises_error(self):
+        """Both --enable and --disable passed: should raise UsageError."""
+        with pytest.raises(click.UsageError, match="mutually exclusive"):
+            _resolve_chunked_prefill(enable=True, disable=True)
+
+    @pytest.mark.part0
+    def test_enable_false_disable_false(self):
+        """enable=False (not typical from Click, but defensive check)."""
+        assert _resolve_chunked_prefill(enable=False, disable=False) is True

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1001,7 +1001,8 @@ class TestLlmError:
         """ LLM should raise error when got prompt length exceed the valid range. """
         llm = LLM(llama_model_path,
                   kv_cache_config=global_kvcache_config,
-                  max_num_tokens=100)
+                  max_num_tokens=100,
+                  enable_chunked_prefill=False)
 
         try:
             with pytest.raises(RequestError,
@@ -1174,7 +1175,8 @@ class TestLlmError:
         """ LLM should raise error when got prompt length exceed the valid range. """
         llm = LLM(llama_model_path,
                   kv_cache_config=global_kvcache_config,
-                  max_num_tokens=100)
+                  max_num_tokens=100,
+                  enable_chunked_prefill=False)
 
         try:
             with pytest.raises(RequestError,


### PR DESCRIPTION
## Description

- [x] Change LLM API default behavior
- [x] Add `--disable_chunked_prefill` options to serve, quickstart advanced CLI
- [x] Add a test to enforce default behavior
- [x] Change API llm.yml
- [x] Update docs
- [x] Update error messages to be more informative for models that don't support chunked context
- [x] Auto-disable chunked context for models that can't support - as a better alternative to erroring out.
- [x] Fix one-model MTP + overlap scheduler token accounting bug exposed by the new default
- [x] Opt out DeepSeek-V3-Lite nvfp4/MTP tests from chunked prefill (preserves pre-PR test intent)
- [x] Fix unit tests that relied on the old `enable_chunked_prefill=False` default

### One-model MTP scheduler/runtime token accounting fix

Enabling chunked prefill by default exposed a pre-existing bug in the
`chunked prefill + one-model MTP + overlap scheduler` path. Two CI tests
failed on DGX_B200 with:

```
total_num_tokens (N) should be less than or equal to max_num_tokens (8192)
```

**Root cause:** The two-model drafter path normalizes C++ `draft_tokens` to
`max_total_draft_tokens` for all generation requests before the C++ scheduler
runs (so `getNumDraftTokens()` matches the runtime's fixed `runtime_draft_len`).
The one-model MTP path (`self.drafter is None`) skipped this normalization entirely.
The C++ scheduler would then see stale or zero draft tokens for generation requests,
under-budgeting them, while the Python runtime always materializes the full
`1 + runtime_draft_len` tokens in the overlap extend path - causing the assertion.

**Fix:** Added the same draft token normalization for one-model MTP before scheduling
in `py_executor.py`, mirroring the existing two-model drafter pattern.

### Unit test fixes for new default

Several unit tests relied on the old `enable_chunked_prefill=False` default:

- **AutoDeploy `test_create_ad_executor`**: Mock engine lacks real `tokens_per_block`,
  causing `TypeError` in `ContextChunkingConfig` construction when chunked prefill is enabled.
  Fixed by setting `enable_chunked_prefill=False` in the test's `LlmArgs`.
- **`test_max_num_token_check`**: Expects `RequestError` for prompts exceeding `max_num_tokens`,
  but this validation is skipped when chunked prefill handles the input via chunking.
  Fixed by explicitly disabling chunked prefill in the test.
- **`_test_llm_capture_request_error`**: Same `max_num_tokens` validation skip as above.
  Fixed by adding `enable_chunked_prefill=False` for the pytorch backend path.

### Integration test fixes

- Set `enable_chunked_prefill=False` on 3 DeepSeek-V3-Lite nvfp4/MTP accuracy tests
  that relied on the old default and should not inherit chunked prefill behavior.

## Summary

### Release Notes

* **Behavior Changes**
  * Chunked prefill is now enabled by default, automatically chunking long sequences and processing shorter sequences as single chunks instead of erroring.
  * Models without chunked context support are automatically disabled with a warning.
  * Previous behavior can be restored by explicitly disabling the feature.

* **Bug Fixes**
  * Fixed a token-accounting mismatch between the C++ scheduler and Python runtime for one-model MTP with overlap scheduler enabled. The scheduler now correctly budgets draft tokens for one-model speculative decoding paths.

* **Documentation**
  * Updated guides and release notes to document the new default behavior and breaking changes.

## Test Coverage

- `tests/unittest/_torch/executor/test_py_executor.py`: 3 new unit tests validating draft token normalization logic for one-model MTP (normalization applied, skipped with drafter, skipped with spec decode off)
- `tests/unittest/_torch/executor/test_overlap_scheduler.py`: 4 existing overlap scheduler consistency tests pass
- `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4`: B200 accuracy tests with explicit `enable_chunked_prefill=False`
- `tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py`: Fixed mock executor test for chunked prefill default
- `tests/unittest/llmapi/test_llm_pytorch.py`: Fixed `test_max_num_token_check` for chunked prefill default
- `tests/unittest/llmapi/test_llm.py`: Fixed `_test_llm_capture_request_error` for chunked prefill default
- Reproducer script validated on H100 with `max_num_tokens=8192, MTP nextn=2, overlap+chunked prefill`

### Key files changed

| File | Change |
|------|--------|
| `tensorrt_llm/_torch/pyexecutor/py_executor.py` | Add one-model MTP draft token normalization before scheduling |
| `tests/integration/defs/accuracy/test_llm_api_pytorch.py` | Set `enable_chunked_prefill=False` on 3 nvfp4/MTP tests |
| `tests/unittest/_torch/executor/test_py_executor.py` | 3 new unit tests for normalization logic |
| `tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py` | Disable chunked prefill in mock executor test |
| `tests/unittest/llmapi/test_llm_pytorch.py` | Disable chunked prefill in max_num_tokens validation tests |
| `tests/unittest/llmapi/test_llm.py` | Disable chunked prefill in request error capture test |

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
