### PR TITLE
[None][ci] Waive blackwell test on spec gate.

### DIFF
--- a/tests/unittest/_torch/speculative/test_spec_gate.py
+++ b/tests/unittest/_torch/speculative/test_spec_gate.py
@@ -5,7 +5,7 @@ import unittest
 import pytest
 import torch
 from utils.llm_data import llm_models_root
-from utils.util import similar
+from utils.util import similar, skip_blackwell
 
 from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm._torch.speculative.speculation_gate import SpeculationGate
@@ -20,6 +20,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 # It is set with acceptance window and acceptance threshold in spec_config.
 # This test set the max_concurrency to a large value to prevent spec decode turned off due to number of effective requests > max_concurrency,
 # So that we can only focus on the turning off effect from the SpeculationGate.
+@skip_blackwell  # TODO: Remove after fixing TRTLLM-GEN FMHA segfault on Blackwell
 @pytest.mark.high_cuda_memory
 def test_spec_gate_e2e():
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9

--- a/tests/unittest/_torch/speculative/test_spec_gate.py
+++ b/tests/unittest/_torch/speculative/test_spec_gate.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 # It is set with acceptance window and acceptance threshold in spec_config.
 # This test set the max_concurrency to a large value to prevent spec decode turned off due to number of effective requests > max_concurrency,
 # So that we can only focus on the turning off effect from the SpeculationGate.
-@skip_blackwell  # TODO: Remove after fixing TRTLLM-GEN FMHA segfault on Blackwell
+@skip_blackwell  # TODO: Remove after fixing TRTLLM-GEN FMHA segfault on Blackwell. NVBugs: https://nvbugspro.nvidia.com/bug/5698292
 @pytest.mark.high_cuda_memory
 def test_spec_gate_e2e():
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to skip specific test conditions on certain hardware configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Waive blackwell test on spec gate.

There is segmentation fault on TensorRT-LLM/tests/unittest/_torch/speculative/test_spec_gate.py::test_spec_gate_e2e with blackwell. Running on hopper is fine.

```
[05c13c77a145:111139:0:111139] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x2c)
==== backtrace (tid: 111139) ====
 0  /usr/local/ucx//lib/libucs.so.0(ucs_handle_error+0x304) [0x73a55f1cf474]
 1  /usr/local/ucx//lib/libucs.so.0(+0x39672) [0x73a55f1cf672]
 2  /usr/local/ucx//lib/libucs.so.0(+0x398b8) [0x73a55f1cf8b8]
 3  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZNK12tensorrt_llm7kernels17TllmGenFmhaKernel20hashFromRunnerParamsB5cxx11ERKNS0_23TllmGenFmhaRunnerParamsERNS0_25TllmGenSelectKernelParamsE+0x240) [0x73a22e5389a0]
 4  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZNK12tensorrt_llm7kernels17TllmGenFmhaRunner11isSupportedERKNS0_23TllmGenFmhaRunnerParamsE+0x9d) [0x73a22e53573d]
 5  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm7kernels14FmhaDispatcher11isSupportedEv+0x104) [0x73a22e7e5284]
 6  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm7kernels14FmhaDispatcherC2ENS0_20MHARunnerFixedParamsE+0x145) [0x73a22e7e5775]
 7  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm6common2op11AttentionOp10initializeEv+0xc47) [0x73a22e46cb27]
 8  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libth_common.so(_ZN9torch_ext9attentionEN2at6TensorESt8optionalIS1_ES3_RS1_S3_S2_IN3c1010ScalarTypeEES3_S1_S1_S1_S1_S1_S1_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_bblllllS2_IlEllllllldlldlSt6vectorIdSaIdEES9_IlSaIlEEbS8_bS8_S8_S8_S8_S8_S8_S3_S3_S9_IS3_SaIS3_EES8_S3_S9_IbSaIbEESF_S3_S3_S3_S3_lS8_S3_S3_S3_S3_S3_S3_+0x2df0) [0x73a24c581270]
 9  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x163dd7) [0x73a2536e3dd7]
10  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x16620b) [0x73a2536e620b]
11  /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x244091) [0x73a2537c4091]
12  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
13  /usr/bin/python() [0x54cf04]
14  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
15  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
16  /usr/bin/python() [0x54cf04]
17  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
18  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
19  /usr/bin/python(_PyObject_Call_Prepend+0x18a) [0x54ac0a]
20  /usr/bin/python() [0x5a30c8]
21  /usr/bin/python(PyObject_Call+0x6c) [0x54b47c]
22  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
23  /usr/bin/python() [0x54cf04]
24  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
25  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
26  /usr/bin/python() [0x54cf04]
27  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
28  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
29  /usr/bin/python(_PyObject_Call_Prepend+0x18a) [0x54ac0a]
30  /usr/bin/python() [0x5a30c8]
31  /usr/bin/python(_PyObject_MakeTpCall+0x13e) [0x5493be]
32  /usr/bin/python(_PyEval_EvalFrameDefault+0xadf) [0x5d68bf]
33  /usr/bin/python() [0x54cf04]
34  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
35  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
36  /usr/bin/python() [0x54cf04]
37  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
38  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
39  /usr/bin/python(_PyObject_Call_Prepend+0x18a) [0x54ac0a]
40  /usr/bin/python() [0x5a30c8]
41  /usr/bin/python(PyObject_Call+0x6c) [0x54b47c]
42  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
43  /usr/bin/python() [0x54cf04]
44  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
45  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
46  /usr/bin/python() [0x54cf04]
47  /usr/bin/python(PyObject_Call+0x115) [0x54b525]
48  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
49  /usr/bin/python(_PyObject_Call_Prepend+0x18a) [0x54ac0a]
50  /usr/bin/python() [0x59da4f]
51  /usr/bin/python() [0x599513]
52  /usr/bin/python(PyObject_Call+0x6c) [0x54b47c]
53  /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0) [0x5daa90]
54  /usr/bin/python(_PyObject_Call_Prepend+0x18a) [0x54ac0a]
55  /usr/bin/python() [0x59da4f]
56  /usr/bin/python() [0x599513]
57  /usr/bin/python(_PyObject_MakeTpCall+0x13e) [0x5493be]
58  /usr/bin/python(_PyEval_EvalFrameDefault+0xadf) [0x5d68bf]
59  /usr/bin/python(PyEval_EvalCode+0x15b) [0x5d4dab]
60  /usr/bin/python() [0x5d2bac]
=================================
[05c13c77a145:111139] *** Process received signal ***
[05c13c77a145:111139] Signal: Segmentation fault (11)
[05c13c77a145:111139] Signal code:  (-6)
[05c13c77a145:111139] Failing at address: 0x245920001b223
[05c13c77a145:111139] [ 0] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x73a568b1d330]
[05c13c77a145:111139] [ 1] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZNK12tensorrt_llm7kernels17TllmGenFmhaKernel20hashFromRunnerParamsB5cxx11ERKNS0_23TllmGenFmhaRunnerParamsERNS0_25TllmGenSelectKernelParamsE+0x240)[0x73a22e5389a0]
[05c13c77a145:111139] [ 2] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZNK12tensorrt_llm7kernels17TllmGenFmhaRunner11isSupportedERKNS0_23TllmGenFmhaRunnerParamsE+0x9d)[0x73a22e53573d]
[05c13c77a145:111139] [ 3] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm7kernels14FmhaDispatcher11isSupportedEv+0x104)[0x73a22e7e5284]
[05c13c77a145:111139] [ 4] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm7kernels14FmhaDispatcherC2ENS0_20MHARunnerFixedParamsE+0x145)[0x73a22e7e5775]
[05c13c77a145:111139] [ 5] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libtensorrt_llm.so(_ZN12tensorrt_llm6common2op11AttentionOp10initializeEv+0xc47)[0x73a22e46cb27]
[05c13c77a145:111139] [ 6] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/libs/libth_common.so(_ZN9torch_ext9attentionEN2at6TensorESt8optionalIS1_ES3_RS1_S3_S2_IN3c1010ScalarTypeEES3_S1_S1_S1_S1_S1_S1_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_S3_bblllllS2_IlEllllllldlldlSt6vectorIdSaIdEES9_IlSaIlEEbS8_bS8_S8_S8_S8_S8_S8_S3_S3_S9_IS3_SaIS3_EES8_S3_S9_IbSaIbEESF_S3_S3_S3_S3_lS8_S3_S3_S3_S3_S3_S3_+0x2df0)[0x73a24c581270]
[05c13c77a145:111139] [ 7] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x163dd7)[0x73a2536e3dd7]
[05c13c77a145:111139] [ 8] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x16620b)[0x73a2536e620b]
[05c13c77a145:111139] [ 9] /code/tensorrt_llm/tests/unittest/utils/../../../tensorrt_llm/bindings.cpython-312-x86_64-linux-gnu.so(+0x244091)[0x73a2537c4091]
[05c13c77a145:111139] [10] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [11] /usr/bin/python[0x54cf04]
[05c13c77a145:111139] [12] /usr/bin/python(PyObject_Call+0x115)[0x54b525]
[05c13c77a145:111139] [13] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [14] /usr/bin/python[0x54cf04]
[05c13c77a145:111139] [15] /usr/bin/python(PyObject_Call+0x115)[0x54b525]
[05c13c77a145:111139] [16] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [17] /usr/bin/python(_PyObject_Call_Prepend+0x18a)[0x54ac0a]
[05c13c77a145:111139] [18] /usr/bin/python[0x5a30c8]
[05c13c77a145:111139] [19] /usr/bin/python(PyObject_Call+0x6c)[0x54b47c]
[05c13c77a145:111139] [20] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [21] /usr/bin/python[0x54cf04]
[05c13c77a145:111139] [22] /usr/bin/python(PyObject_Call+0x115)[0x54b525]
[05c13c77a145:111139] [23] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [24] /usr/bin/python[0x54cf04]
[05c13c77a145:111139] [25] /usr/bin/python(PyObject_Call+0x115)[0x54b525]
[05c13c77a145:111139] [26] /usr/bin/python(_PyEval_EvalFrameDefault+0x4cb0)[0x5daa90]
[05c13c77a145:111139] [27] /usr/bin/python(_PyObject_Call_Prepend+0x18a)[0x54ac0a]
[05c13c77a145:111139] [28] /usr/bin/python[0x5a30c8]
[05c13c77a145:111139] [29] /usr/bin/python(_PyObject_MakeTpCall+0x13e)[0x5493be]
[05c13c77a145:111139] *** End of error message ***
```
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
