### PR TITLE
[https://nvbugs/5651854][fix] revert #8805 to fix disagg perf issue

### DIFF
--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -2,13 +2,11 @@ import copy
 import datetime
 import enum
 import json
-import os
 import weakref
 from pathlib import Path
 from queue import Queue
 from typing import Dict, List, Optional, Tuple, Union
 
-import psutil
 import torch
 
 from tensorrt_llm.logger import logger
@@ -21,7 +19,7 @@ from ..builder import ConfigEncoder, Engine, EngineConfig
 from ..llmapi.llm_args import BaseLlmArgs, PybindMirror
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import _SyncQueue, get_numa_aware_cpu_affinity, logger_debug
+from ..llmapi.utils import _SyncQueue, logger_debug
 from ..lora_manager import LoraManager
 from ..metrics import RequestEventTiming
 from ..prompt_adapter_manager import PromptAdapterManager
@@ -116,48 +114,6 @@ class BaseWorker(GenerationExecutor):
         if global_mpi_size() > 1:
             logger.set_rank(self.global_rank)
 
-    def _configure_affinity(self, device_id):
-        '''Probe and configure the CPU affinity of the worker based on NUMA topology.
-
-        Args:
-            device_id: The CUDA device ID to determine optimal CPU affinity.
-
-        Note:
-            If the process already has constrained affinity, a warning is logged.
-            Configuration is handled as follows:
-                TLLM_NUMA_WORKER_AFFINITY = <unset>
-                    -> affinity is auto-configured only if it is unconstrained
-                TLLM_NUMA_WORKER_AFFINITY = 1
-                    -> affinity is unconditionally auto-configured
-                TLLM_NUMA_WORKER_AFFINITY = 0 or any other value
-                    -> affinity is unconditionally _not_ auto-configured
-        '''
-
-        # Get the current affinity setting
-        pid = os.getpid()
-        process = psutil.Process(pid)
-        cpu_affinity = process.cpu_affinity()
-
-        all_cpus = list(range(psutil.cpu_count()))
-
-        constrained_affinity = (cpu_affinity != all_cpus)
-
-        # If the process is affined to a constrained set of CPUs, warn the user
-        # so as to ensure that this is what is intended
-        if constrained_affinity:
-            logger.warning(
-                f"Worker process {pid} is affined to run on the following CPUs: "
-                f"{cpu_affinity} (subset of all logical CPUs). This may harm "
-                f"performance if set incorrectly.")
-
-        # If affinity is unconstrained and the user hasn't explicitly
-        # prohibited it or the user has explicitly requested it, choose the
-        # optimal affinity based upon the NUMA topology
-        numa_aware_affinity = os.environ.get("TLLM_NUMA_AWARE_WORKER_AFFINITY")
-        if ((numa_aware_affinity is None and not constrained_affinity)
-                or (numa_aware_affinity == "1")):
-            process.cpu_affinity(get_numa_aware_cpu_affinity(device_id))
-
     def _get_comm_ranks_device_id(self):
         device_id = self.global_rank % torch.cuda.device_count()
         torch.cuda.set_device(device_id)
@@ -165,9 +121,6 @@ class BaseWorker(GenerationExecutor):
         global_rank = global_mpi_rank()
         comm_ranks = mpi_comm().allgather(global_rank)
         device_ids = mpi_comm().allgather(device_id)
-
-        self._configure_affinity(device_id)
-
         return comm_ranks, device_ids
 
     def setup_engine(self):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -18,7 +18,8 @@ from ..llmapi.llm_args import BaseLlmArgs
 from ..llmapi.mpi_session import set_mpi_session_cpp
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import VizTracer, set_global_tracer
-from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue, logger_debug,
+from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
+                            clear_sched_affinity, logger_debug,
                             print_traceback_on_error)
 from ..sampling_params import BatchedLogitsProcessor
 from .base_worker import BaseWorker, _init_hf_modules
@@ -247,6 +248,15 @@ def worker_main(
         _init_hf_modules()
 
     logger_debug(f"Worker {mpi_rank()} entering worker_main...\n", "green")
+
+    pid = os.getpid()
+    cpus = os.sched_getaffinity(pid)
+    if cpus:
+        logger.warning(
+            f"Found worker process {pid} was bound to {cpus}, this may harm "
+            "performance.", )
+        logger.warning(f"Will clear the cpu affinity")
+        clear_sched_affinity(pid)
 
     result_queue: Optional[IpcQueue] = None
     result_queues: Optional[List[IpcQueue]] = None

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -1,11 +1,9 @@
 import asyncio
 import collections
-import ctypes
 import datetime
 import hashlib
 import inspect
 import io
-import math
 import os
 import re
 import sys
@@ -515,57 +513,24 @@ class _SyncQueue:
                 time.sleep(0.01)
 
 
-def get_numa_aware_cpu_affinity(device_id):
-    '''Query NVML for NUMA-aware CPU affinity for the specified CUDA device.
+def set_sched_setaffinity(required_cores: int):
+    ''' Set the CPU affinity of the current process to the required number of
+    cores.
 
-    Args:
-        device_id: The CUDA device ID to query for optimal CPU affinity.
-
-    Returns:
-        List of CPU IDs representing the optimal CPU affinity mask for the device.
-
-    Raises:
-        pynvml.NVMLError: If NVML operations fail or device_id is invalid.
+    Known issue: This may race with other processes that also set the affinity.
     '''
-    cpu_count = psutil.cpu_count()
+    cpu_percentages = psutil.cpu_percent(percpu=True)
+    # sort the cores by usage
+    free_cores = sorted(range(len(cpu_percentages)),
+                        key=lambda i: cpu_percentages[i])
 
-    # If this is not a NUMA system, or we hit an exception, default to
-    # unconstrained CPU affinity
-    cpu_affinity = list(range(cpu_count))
+    pid = os.getpid()
+    os.sched_setaffinity(pid, set(free_cores[:required_cores]))
 
-    if not os.path.isdir("/sys/devices/system/node/node1"):
-        return cpu_affinity
 
-    try:
-        # initialize NVML
-        import pynvml
-        pynvml.nvmlInit()
-
-        # Get the number of bits per ulong
-        c_ulong_bits = ctypes.sizeof(ctypes.c_ulong) * 8
-
-        # Determine how large our cpu set array from NVML needs to be
-        cpu_set_size = math.ceil(cpu_count / c_ulong_bits)
-
-        # Get the optimal CPU affinity for this device according to the NUMA
-        # topology
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
-        affinity_masks = pynvml.nvmlDeviceGetCpuAffinity(handle, cpu_set_size)
-
-        # Convert CPU masks to python list
-        cpu_affinity = []
-        for cpu_id in range(cpu_count):
-            mask_array_index = cpu_id // c_ulong_bits
-            mask_bit_index = cpu_id % c_ulong_bits
-            if affinity_masks[mask_array_index] & (1 << mask_bit_index):
-                cpu_affinity.append(cpu_id)
-    finally:
-        try:
-            pynvml.nvmlShutdown()
-        except:
-            pass  # Ignore shutdown errors
-
-    return cpu_affinity
+def clear_sched_affinity(pid: int):
+    ''' Clear the CPU affinity of the current process. '''
+    os.sched_setaffinity(pid, set(range(psutil.cpu_count())))
 
 
 def generate_api_docs_as_docstring(model: Type[BaseModel],

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -352,8 +352,6 @@ examples/test_multimodal.py::test_llm_multimodal_general[nougat-base-pp:1-tp:1-b
 accuracy/test_llm_api_pytorch_multimodal.py::TestNVILA_8B::test_auto_dtype SKIP (https://nvbugs/5648441)
 accuracy/test_llm_api_pytorch_multimodal.py::TestVILA1_5_3B::test_auto_dtype SKIP (https://nvbugs/5648441)
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_nixl_backend SKIP (https://nvbugs/5651824)
-accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[False] SKIP (https://nvbugs/5651854)
-accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[True] SKIP (https://nvbugs/5651854)
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_empty_batch[DeepSeek-V3-Lite-bf16] SKIP (https://nvbugs/5601682)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=False-overlap_scheduler=False] SKIP (https://nvbugs/5655584)
 examples/test_multimodal.py::test_llm_multimodal_general[llava-1.5-7b-hf-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] SKIP (https://nvbugs/5655832)


### PR DESCRIPTION
#8805 is the main culprit of recent disagg-test timeout. The kv cache transmission BW decreases dramatically with #8805, and the cpu utilization drops from 100% to ~40% in 5  mpi worker processes .

before 8805
<img width="882" height="172" alt="image" src="https://github.com/user-attachments/assets/1f362a83-f880-4aa3-8018-1dc0e2de7501" />
after 8805
<img width="719" height="112" alt="image" src="https://github.com/user-attachments/assets/1db2863c-c0c8-45ec-982e-7bf207c12ea8" />

Verified on umbriel-B200-027:
```          
          branch  median send BW  mean send BW test time
0         pr8805        87.45335    140.575009  1364.98s
1         pr8820       909.69600   1311.015826   365.51s  
2           main        90.14800    148.060053
3     revert8805       658.93500   1160.401199   452.06s
4  revert8805ucx       580.38700   1109.102071   420.46s
5       pr8805ucx       46.215901   8.98985  1117.96s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified CPU affinity management throughout the executor by removing complex NUMA topology-specific logic and replacing it with a more straightforward approach that detects and clears CPU process bindings that could negatively impact performance.

* **Tests**
  * Enabled previously skipped disaggregated serving test cases to improve overall test coverage, validation, and reliability of the serving infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
