### PR TITLE
[#8733][feat] Add Llama4 MoE handling to AutoDeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -28,6 +28,8 @@ transforms:
     stage: pattern_matcher
   match_dense_moe_pattern:
     stage: pattern_matcher
+  match_bmm_moe_pattern:
+    stage: pattern_matcher
   match_repeat_kv:
     stage: pattern_matcher
     run_shape_prop: true

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -18,11 +18,203 @@ from ..interface import (
 )
 
 
+def _process_regular_moe_node(
+    gm: GraphModule,
+    graph: torch.fx.Graph,
+    node: Node,
+    replacement_op,
+    mlp_style_val: str,
+    act_fn_val: str,
+    fused_key_counter: int,
+) -> None:
+    """Process a single torch_moe node with per-expert weight lists.
+
+    Stacks weight parameters and creates a fused MoE node.
+    The kernel applies routing weights to the output.
+    """
+    hidden_states, selected_experts, routing_weights, w1_list, w2_list, w3_list = extract_op_args(
+        node,
+        "x",
+        "selected_experts",
+        "routing_weights",
+        "w1_weight",
+        "w2_weight",
+        "w3_weight",
+    )
+
+    # Stack weights based on MLP style
+    if mlp_style_val == "gated_mlp":
+        # For gated MLP, concatenate w3 and w1 then stack across experts
+        fused_w_up_experts = torch.stack(
+            [
+                torch.cat(
+                    [gm.get_parameter(w3_node.target), gm.get_parameter(w1_node.target)],
+                    dim=-2,
+                )
+                for w1_node, w3_node in zip(w1_list, w3_list)
+            ],
+            dim=0,
+        )
+        new_key_w_up = f"fused_moe_w3_w1_stacked_{fused_key_counter}"
+    elif mlp_style_val == "mlp":
+        # For regular MLP, just stack w1
+        fused_w_up_experts = torch.stack([gm.get_parameter(n.target) for n in w1_list], dim=0)
+        new_key_w_up = f"fused_moe_w1_stacked_{fused_key_counter}"
+    else:
+        raise ValueError(f"Unknown mlp_style: {mlp_style_val}")
+
+    # Stack w2/down weights
+    fused_w_down_experts = torch.stack([gm.get_parameter(n.target) for n in w2_list], dim=0)
+    new_key_w_down = f"fused_moe_w2_stacked_{fused_key_counter}"
+
+    # Register the stacked weights as parameters
+    param_w_up = torch.nn.Parameter(fused_w_up_experts)
+    gm.register_parameter(new_key_w_up, param_w_up)
+    w_up_arg = graph.get_attr(new_key_w_up)
+
+    param_w_down = torch.nn.Parameter(fused_w_down_experts)
+    gm.register_parameter(new_key_w_down, param_w_down)
+    w_down_arg = graph.get_attr(new_key_w_down)
+
+    # Create fused MoE node - kernel applies routing to output
+    with graph.inserting_before(node):
+        new_node = graph.call_function(
+            replacement_op,
+            args=(hidden_states, selected_experts, routing_weights, w_up_arg, w_down_arg),
+            kwargs={
+                "mlp_style": mlp_style_val,
+                "act_fn": act_fn_val,
+            },
+        )
+
+    node.replace_all_uses_with(new_node)
+    graph.erase_node(node)
+
+
+def _process_llama4_stacked_moe_node(
+    gm: GraphModule,
+    graph: torch.fx.Graph,
+    node: Node,
+    replacement_op,
+    act_fn_val: str,
+    fused_key_counter: int,
+) -> None:
+    """Process a single Llama4 MoE node with pre-stacked weight tensors (torch_moe_bmm).
+
+    Only supports gated MLP (SwiGLU-style) architecture.
+    Converts Llama4 format weights to TRT-LLM format to standardize all downstream ops.
+    Applies routing weights to INPUT before the fused kernel to prevent double multiplication.
+    This is the Llama4 pattern where weights are already stacked across experts.
+    Result: silu(input * routing_weight) - routing affects activation.
+    """
+    hidden_states, selected_experts, routing_weights, w3_w1_stacked, w2_stacked = extract_op_args(
+        node,
+        "x",
+        "selected_experts",
+        "routing_weights",
+        "w3_w1_stacked",
+        "w2_stacked",
+    )
+
+    # Convert Llama4 format to TRT-LLM format if needed
+    # This standardizes all downstream ops to only handle TRT-LLM format
+    if w3_w1_stacked.op == "get_attr" and w2_stacked.op == "get_attr":
+        gate_up_weight = gm.get_parameter(w3_w1_stacked.target)
+        down_weight = gm.get_parameter(w2_stacked.target)
+
+        # Detect format: Llama4 has gate_up[0] == down[1]
+        is_llama4 = gate_up_weight.shape[1] == down_weight.shape[0]
+
+        if is_llama4:
+            # Convert Llama4 (H, 2*I) -> TRT-LLM (2*I, H)
+            gate_up_trtllm = gate_up_weight.transpose(1, 2).contiguous()
+            down_trtllm = down_weight.transpose(1, 2).contiguous()
+
+            # Register converted weights
+            new_key_w_up = f"llama4_to_trtllm_w3_w1_{fused_key_counter}"
+            new_key_w_down = f"llama4_to_trtllm_w2_{fused_key_counter}"
+
+            gm.register_parameter(new_key_w_up, torch.nn.Parameter(gate_up_trtllm))
+            gm.register_parameter(new_key_w_down, torch.nn.Parameter(down_trtllm))
+
+            w_up_arg = graph.get_attr(new_key_w_up)
+            w_down_arg = graph.get_attr(new_key_w_down)
+        else:
+            # Already TRT-LLM format, use directly
+            w_up_arg = w3_w1_stacked
+            w_down_arg = w2_stacked
+    else:
+        # Not get_attr nodes (might be intermediate ops), use directly
+        w_up_arg = w3_w1_stacked
+        w_down_arg = w2_stacked
+
+    # Get weight dtype to ensure dtype consistency for Llama4 stacked tensors
+    # The fused kernel requires input and weights to have matching dtypes
+    weight_dtype = None
+    if w_up_arg.op == "get_attr":
+        try:
+            weight_tensor = gm.get_parameter(w_up_arg.target)
+            weight_dtype = weight_tensor.dtype
+        except (AttributeError, KeyError):
+            pass
+
+    # Llama4 INPUT-SIDE routing: apply routing to INPUT before kernel
+    # Cast BOTH input and routing_weights to weight dtype if needed
+    # Critical: BFloat16 * Float32 → Float32 (type promotion) so we cast both to same dtype
+    with graph.inserting_before(node):
+        input_to_scale = hidden_states
+        routing_to_scale = routing_weights
+
+        if weight_dtype is not None and weight_dtype != torch.float32:
+            input_to_scale = graph.call_function(
+                torch.ops.aten._to_copy.default,
+                args=(hidden_states,),
+                kwargs={"dtype": weight_dtype},
+            )
+            routing_to_scale = graph.call_function(
+                torch.ops.aten._to_copy.default,
+                args=(routing_weights,),
+                kwargs={"dtype": weight_dtype},
+            )
+
+        # Scale input: hidden_states = hidden_states * routing_weights (both same dtype now)
+        scaled_input = graph.call_function(
+            torch.ops.aten.mul.Tensor,
+            args=(input_to_scale, routing_to_scale),
+        )
+
+        # Pass ones to kernel to prevent it from multiplying routing again (already applied)
+        ones_node = graph.call_function(
+            torch.ops.aten.ones_like.default,
+            args=(routing_weights,),
+        )
+
+        new_node = graph.call_function(
+            replacement_op,
+            args=(scaled_input, selected_experts, ones_node, w_up_arg, w_down_arg),
+            kwargs={
+                "act_fn": act_fn_val,
+            },
+        )
+
+    node.replace_all_uses_with(new_node)
+    graph.erase_node(node)
+
+
 def _insert_fused_moe_ops(gm: GraphModule, backend: Literal["auto", "trtllm", "triton"]) -> int:
+    """Replace torch MoE ops with fused backend-specific implementations.
+
+    Handles both:
+    - Standard MoE (per-expert weight lists): torch_moe
+    - Llama4 MoE (pre-stacked weight tensors): torch_moe_bmm
+
+    For Llama4 stacked tensors, applies routing weights to input before the fused kernel.
+    """
     fused_key_counter = 0
     graph = gm.graph
     backend = backend.lower()
 
+    # Map backend to fused MoE op (handles both standard and Llama4 stacked tensor patterns)
     replacement_op = {
         "auto": torch.ops.auto_deploy.trtllm_moe_fused,
         "trtllm": torch.ops.auto_deploy.trtllm_moe_fused,
@@ -30,71 +222,31 @@ def _insert_fused_moe_ops(gm: GraphModule, backend: Literal["auto", "trtllm", "t
     }[backend]
 
     for node in graph.nodes:
-        if not is_op(node, torch.ops.auto_deploy.torch_moe):
+        if not (
+            is_op(node, torch.ops.auto_deploy.torch_moe)
+            or is_op(node, torch.ops.auto_deploy.torch_moe_bmm)
+        ):
             continue
 
-        (mlp_style_val, act_fn_val) = extract_op_args(node, "mlp_style", "act_fn")
-        assert backend != "triton" or mlp_style_val == "mlp", (
-            "Triton backend only supports mlp style."
-        )
+        is_llama4_stacked_moe = is_op(node, torch.ops.auto_deploy.torch_moe_bmm)
 
-        hidden_states, selected_experts, routing_weights, w1_list, w2_list, w3_list = (
-            extract_op_args(
-                node,
-                "x",
-                "selected_experts",
-                "routing_weights",
-                "w1_weight",
-                "w2_weight",
-                "w3_weight",
+        if is_llama4_stacked_moe:
+            # torch_moe_bmm: only supports gated MLP, no mlp_style parameter
+            (act_fn_val,) = extract_op_args(node, "act_fn")
+            _process_llama4_stacked_moe_node(
+                gm, graph, node, replacement_op, act_fn_val, fused_key_counter
             )
-        )
-        if mlp_style_val == "gated_mlp":
-            fused_w_up_experts = torch.stack(
-                [
-                    torch.cat(
-                        [gm.get_parameter(w3_node.target), gm.get_parameter(w1_node.target)], dim=-2
-                    )
-                    for w1_node, w3_node in zip(w1_list, w3_list)
-                ],
-                dim=0,
-            )
-            new_key_w_up = f"fused_moe_w3_w1_stacked_{fused_key_counter}"
-
-        elif mlp_style_val == "mlp":
-            fused_w_up_experts = torch.stack([gm.get_parameter(n.target) for n in w1_list], dim=0)
-            new_key_w_up = f"fused_moe_w1_stacked_{fused_key_counter}"
         else:
-            raise ValueError(f"Unknown mlp_style: {mlp_style_val}")
-
-        fused_w_down_experts = torch.stack([gm.get_parameter(n.target) for n in w2_list], dim=0)
-
-        new_key_w_down = f"fused_moe_w2_stacked_{fused_key_counter}"
-        fused_key_counter += 1
-        param_w_up = torch.nn.Parameter(fused_w_up_experts)
-        param_w_down = torch.nn.Parameter(fused_w_down_experts)
-        gm.register_parameter(new_key_w_up, param_w_up)
-        gm.register_parameter(new_key_w_down, param_w_down)
-
-        with graph.inserting_before(node):
-            new_node = graph.call_function(
-                # TODO(Fridah-nv): torch.ops.auto_deploy.trtllm_moe_fused for quantized models
-                replacement_op,
-                args=(
-                    hidden_states,
-                    selected_experts,
-                    routing_weights,
-                    graph.get_attr(new_key_w_up),
-                    graph.get_attr(new_key_w_down),
-                ),
-                kwargs={
-                    "mlp_style": mlp_style_val,
-                    "act_fn": act_fn_val,
-                },
+            # torch_moe: supports both gated_mlp and mlp styles
+            (mlp_style_val, act_fn_val) = extract_op_args(node, "mlp_style", "act_fn")
+            assert backend != "triton" or mlp_style_val == "mlp", (
+                "Triton backend only supports mlp style."
+            )
+            _process_regular_moe_node(
+                gm, graph, node, replacement_op, mlp_style_val, act_fn_val, fused_key_counter
             )
 
-        node.replace_all_uses_with(new_node)
-        graph.erase_node(node)
+        fused_key_counter += 1
 
         # Delete the unstacked weights immediately to save GPU memory
         # This will happen automatically after the graph is canonicalized, but for large models we'll run out of memory
@@ -583,6 +735,467 @@ class MatchNVFP4MoePattern(MatchMoePattern):
 
     def scale_keys(self) -> List[str]:
         return ["input_scale", "weight_scale", "alpha"]
+
+
+class MatchBmmMoePatternConfig(TransformConfig):
+    """Configuration for MatchBmmMoePattern transform."""
+
+    pass
+
+
+@TransformRegistry.register("match_bmm_moe_pattern")
+class MatchBmmMoePattern(BaseTransform):
+    """Match and fuse Llama4 MoE pattern with pre-stacked weight tensors.
+
+    This pattern uses batch matrix multiply (BMM) operations for parallel expert computation
+    with weights already stacked across the expert dimension.
+
+    Only matches patterns where topk uses k=1 (single expert per token).
+    """
+
+    config: MatchBmmMoePatternConfig
+
+    @classmethod
+    def get_config_class(cls):
+        return MatchBmmMoePatternConfig
+
+    @staticmethod
+    def _find_gate_up_bmm(final_bmm: Node) -> Optional[Tuple[Node, Node]]:
+        """Find the MoE gate_up BMM and chunk node from the final BMM.
+
+        BMM MoE pattern traces back: final_bmm <- mul(up, silu(gate)) <- chunk <- first_bmm (gate_up)
+
+        Returns:
+            Tuple of (first_bmm, gate_up_weight) or None if not found
+        """
+        # Input to final bmm should be mul(up, silu(gate))
+        mul_node = final_bmm.args[0]
+        if not isinstance(mul_node, Node) or not is_op(mul_node, torch.ops.aten.mul):
+            return None
+
+        if not mul_node.args or len(mul_node.args) < 2:
+            return None
+
+        # Find silu node (one of the mul inputs)
+        arg_a, arg_b = mul_node.args[:2]
+        silu_node = (
+            arg_a
+            if is_op(arg_a, torch.ops.aten.silu)
+            else arg_b
+            if is_op(arg_b, torch.ops.aten.silu)
+            else None
+        )
+        if silu_node is None:
+            return None
+
+        up_node = arg_b if arg_a is silu_node else arg_a
+        if not isinstance(up_node, Node):
+            return None
+
+        # silu input should be gate from chunk
+        if not silu_node.args or not isinstance(silu_node.args[0], Node):
+            return None
+        gate_node = silu_node.args[0]
+
+        # Both gate and up come from chunk (getitem nodes)
+        if gate_node.op != "call_function" or up_node.op != "call_function":
+            return None
+
+        # Find the chunk node
+        chunk_node = None
+        if hasattr(gate_node, "args") and gate_node.args:
+            potential_chunk = gate_node.args[0]
+            if isinstance(potential_chunk, Node) and is_op(potential_chunk, torch.ops.aten.chunk):
+                chunk_node = potential_chunk
+
+        if chunk_node is None or not chunk_node.args or chunk_node.args[1] != 2:
+            return None
+
+        # chunk input is the first batched BMM for Llama4 (gate_up_proj)
+        first_bmm = chunk_node.args[0]
+        if not isinstance(first_bmm, Node) or not is_op(first_bmm, torch.ops.aten.bmm):
+            return None
+
+        if not first_bmm.args or len(first_bmm.args) < 2:
+            return None
+
+        # Llama4: gate_up_weight is pre-stacked [num_experts, hidden, 2*intermediate]
+        gate_up_weight = first_bmm.args[1]
+        if not isinstance(gate_up_weight, Node) or gate_up_weight.op != "get_attr":
+            return None
+
+        return (first_bmm, gate_up_weight)
+
+    @staticmethod
+    def _find_input_and_routing(batched_input: Node) -> Optional[Tuple[Node, Node]]:
+        """Find the input hidden states and routing weights from batched input.
+
+        BMM MoE pattern traces back: batched_input <- mul(repeat(input), routing) <- repeat <- input
+
+        Only matches patterns where topk uses k=1 (single expert per token).
+
+        Returns:
+            Tuple of (input_hidden_states, topk_node) or None if not found
+        """
+        # batched_input comes from mul(repeated_input, routing_weights)
+        if not batched_input.args or not isinstance(batched_input.args[0], Node):
+            return None
+
+        mul_routing = batched_input.args[0]
+        if (
+            not is_op(mul_routing, torch.ops.aten.mul)
+            or not mul_routing.args
+            or len(mul_routing.args) < 2
+        ):
+            return None
+
+        # One arg is repeat (input), other is routing weights
+        repeat_node = None
+        routing_weight_node = None
+        for arg in mul_routing.args[:2]:
+            if isinstance(arg, Node):
+                if is_op(arg, torch.ops.aten.repeat):
+                    repeat_node = arg
+                else:
+                    routing_weight_node = arg
+
+        if not repeat_node or not routing_weight_node:
+            return None
+
+        # Get original input from repeat
+        if not repeat_node.args or not isinstance(repeat_node.args[0], Node):
+            return None
+        input_hidden_states = repeat_node.args[0]
+
+        # Trace back from routing_weight to find topk
+        try:
+            topk_node, _ = bfs(
+                routing_weight_node,
+                lambda n: is_op(n, torch.ops.aten.topk),
+                attr_next="all_input_nodes",
+            )
+            router_logits = topk_node.args[0] if topk_node.args else None
+            if not router_logits:
+                return None
+
+            # Verify topk is using k=1 (only match single-expert-per-token routing)
+            if len(topk_node.args) < 2:
+                return None
+            k_value = topk_node.args[1]
+            if k_value != 1:
+                return None
+
+        except RuntimeError:
+            return None
+
+        return (input_hidden_states, topk_node)
+
+    @staticmethod
+    def _find_output_and_routing_flavor(final_bmm: Node) -> Optional[Tuple[Node, bool]]:
+        """Find the output node and detect routing application method.
+
+        Llama4 stacked MoE pattern traces forward: final_bmm -> view -> reshape -> sum [-> mul?]
+
+        Returns:
+            Tuple of (output_node, apply_routing_on_input) or None if not found
+            apply_routing_on_input is True if routing is applied to input, False if applied to output
+        """
+        # Llama4 pattern: bmm -> view([-1, hidden]) -> reshape([num_experts, -1, hidden]) -> sum(dim=0)
+        output_view = None
+        for user in final_bmm.users:
+            if is_op(user, torch.ops.aten.view):
+                output_view = user
+                break
+
+        if not output_view:
+            return None
+
+        # Find reshape after view
+        reshape_node = None
+        for user in output_view.users:
+            if is_op(user, torch.ops.aten.reshape):
+                reshape_node = user
+                break
+
+        if not reshape_node:
+            return None
+
+        # Find sum after reshape
+        sum_node = None
+        for user in reshape_node.users:
+            if is_op(user, torch.ops.aten.sum):
+                sum_node = user
+                break
+
+        if not sum_node:
+            return None
+
+        # Detect routing application method: check if routing is applied after sum (OUTPUT)
+        apply_routing_on_input = True  # Default for Llama4 (routing already applied before BMM)
+        output_node = sum_node
+
+        for user in sum_node.users:
+            if is_op(user, torch.ops.aten.mul):
+                # Found multiplication after sum - routing is applied to OUTPUT
+                apply_routing_on_input = False
+                output_node = user
+                break
+
+        return (output_node, apply_routing_on_input)
+
+    @staticmethod
+    def _match_bmm_moe_pattern(
+        start_boundary: Node,
+        end_boundary: Node,
+    ):
+        """
+        Match the BMM MoE pattern (ONE pattern per layer, not per expert).
+
+        This BMM MoE pattern uses batch matrix multiply (BMM) operations for parallel expert
+        computation with pre-stacked weight tensors.
+
+        Only matches patterns where topk uses k=1 (single expert per token).
+
+        Supports TWO routing flavors:
+
+        1. INPUT-SIDE routing (most common):
+            - Pattern: mul(input, routing) -> bmm -> silu -> bmm -> sum
+            - Result: silu(input * routing_weight) - routing affects activation
+            - Routing multiplication happens BEFORE BMM operations
+
+        2. OUTPUT-SIDE routing (alternative):
+            - Pattern: bmm -> silu -> bmm -> sum -> mul(output, routing)
+            - Result: silu(input) * routing_weight) - routing scales output
+            - Routing multiplication happens AFTER sum
+
+        The function auto-detects which flavor is present and returns metadata.
+
+        The BMM MoE pattern corresponds to:
+            repeated_input = repeat(input, [num_experts, 1])
+            routing_weights = reshape(transpose(sigmoid(scatter(topk(router_logits)))))
+            routed_input = mul(repeated_input, routing_weights)  # <-- INPUT-SIDE MULTIPLICATION
+            batched_input = view(routed_input, [num_experts, -1, hidden])
+            gate_up = bmm(batched_input, gate_up_proj)  # gate_up_proj: pre-stacked [num_experts, hidden, 2*inter]
+            gate, up = chunk(gate_up, 2)
+            output = bmm(up * silu(gate), down_proj)  # down_proj: pre-stacked [num_experts, inter, hidden]
+            final_output = view(output, [-1, hidden])
+
+        Returns:
+            List of dicts, one per MoE layer found:
+            {
+                "input": Node,                      # Unmultiplied input tensor
+                "router_logits": Node,              # Router logits tensor
+                "gate_up_weight": Node,             # Stacked gate+up weights
+                "down_weight": Node,                # Stacked down weights
+                "output": Node,                     # Output node to replace (sum or mul)
+                "topk": Node,                       # TopK node for routing
+                "apply_routing_on_input": bool,     # True if routing on input, False if on output
+            }
+        """
+        moe_layers = []
+
+        nodes = list(start_boundary.graph.nodes)
+        region_nodes = nodes[nodes.index(start_boundary) + 1 : nodes.index(end_boundary)]
+
+        for node in region_nodes:
+            # Look for the final bmm (down_proj) - this is the BATCHED bmm
+            if not is_op(node, torch.ops.aten.bmm):
+                continue
+
+            final_bmm = node
+            if not final_bmm.args or len(final_bmm.args) < 2:
+                continue
+
+            # Step 1: Get down_proj weight
+            down_weight = final_bmm.args[1]
+            if not isinstance(down_weight, Node) or down_weight.op != "get_attr":
+                continue
+
+            # Step 2: Find the first BMM (gate_up) by tracing back through chunk and mul
+            result = MatchBmmMoePattern._find_gate_up_bmm(final_bmm)
+            if result is None:
+                continue
+            first_bmm, gate_up_weight = result
+
+            # Step 3: Get batched input and trace back to original input and routing
+            batched_input = first_bmm.args[0]
+            if not isinstance(batched_input, Node) or not is_op(batched_input, torch.ops.aten.view):
+                continue
+
+            result = MatchBmmMoePattern._find_input_and_routing(batched_input)
+            if result is None:
+                continue
+            input_hidden_states, topk_node = result
+
+            # Get router_logits for metadata
+            router_logits = topk_node.args[0] if topk_node.args else None
+            if not router_logits:
+                continue
+
+            # Step 4: Find output node and detect routing application method
+            result = MatchBmmMoePattern._find_output_and_routing_flavor(final_bmm)
+            if result is None:
+                continue
+            output_node, apply_routing_on_input = result
+
+            # Step 5: Add the matched layer
+            moe_layers.append(
+                {
+                    "input": input_hidden_states,
+                    "router_logits": router_logits,
+                    "gate_up_weight": gate_up_weight,
+                    "down_weight": down_weight,
+                    "output": output_node,
+                    "topk": topk_node,
+                    "apply_routing_on_input": apply_routing_on_input,
+                }
+            )
+
+        return moe_layers
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+
+        # Preprocessing: Identify boundary nodes (e.g. residual connections) in the graph.
+        boundary_nodes = identify_regions_between_residuals(gm)
+
+        num_moe_patterns = 0
+
+        for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
+            # Step 1: Match BMM MoE patterns (one pattern per MoE layer)
+            moe_layers = self._match_bmm_moe_pattern(start_boundary, end_boundary)
+
+            if not moe_layers:
+                continue
+
+            # Process each MoE layer
+            for layer_info in moe_layers:
+                input_hidden_states = layer_info["input"]
+                gate_up_weight = layer_info["gate_up_weight"]
+                down_weight = layer_info["down_weight"]
+                output_node = layer_info["output"]
+                topk_node = layer_info["topk"]
+                # Get routing application method from pattern matcher
+                # Default to True (apply on input) which is the common Llama4 pattern
+                input_routing = layer_info.get("apply_routing_on_input", True)
+
+                # Step 2: Extract routing information
+                # selected_experts: topk indices [tokens, top_k]
+                # routing_weights: topk values [tokens, top_k]
+                selected_experts = None
+                routing_weights_node = None
+
+                for user in topk_node.users:
+                    if (
+                        user.op == "call_function"
+                        and hasattr(user.target, "__name__")
+                        and user.target.__name__ == "getitem"
+                    ):
+                        if len(user.args) >= 2:
+                            if user.args[1] == 1:  # indices
+                                selected_experts = user
+                            elif user.args[1] == 0:  # values
+                                # For the fused MoE op, we use topk values directly
+                                # (shape: tokens x top_k), NOT the scattered version
+                                routing_weights_node = user
+
+                if not selected_experts:
+                    continue
+
+                if not routing_weights_node:
+                    continue
+
+                # Find scatter and sigmoid nodes - we need the sigmoid output for routing weights!
+                # The original pattern: sigmoid(scatter(topk_values)) normalizes routing to [0,1]
+                # The fused op must use the same normalized values, not raw topk logits.
+                scatter_node = None
+                sigmoid_node = None
+
+                # Find scatter operation
+                for user in routing_weights_node.users:
+                    if is_op(user, {torch.ops.aten.scatter, torch.ops.aten.scatter_}):
+                        scatter_node = user
+                        # Check if sigmoid exists after scatter (may have to.dtype in between)
+                        current = user
+                        for _ in range(2):  # Allow up to 2 hops
+                            for next_user in current.users:
+                                if is_op(next_user, torch.ops.aten.sigmoid):
+                                    sigmoid_node = next_user
+                                    break
+                                elif is_op(next_user, torch.ops.aten.to):
+                                    current = next_user
+                                    break
+                            if sigmoid_node:
+                                break
+                        break
+
+                if not scatter_node:
+                    continue
+
+                if not sigmoid_node:
+                    continue
+
+                # Extract normalized routing weights from the sigmoid output
+                # The sigmoid output has shape [tokens, num_experts] (scattered)
+                # We need to gather it back to [tokens, top_k] using selected_experts indices
+                # This gives us sigmoid(scatter(topk_values)) in the compact [tokens, top_k] format
+                graph = gm.graph
+                with graph.inserting_after(sigmoid_node):
+                    # Create gather operation: routing_weights_normalized = sigmoid_output.gather(1, selected_experts)
+                    routing_weights_normalized = graph.call_function(
+                        torch.ops.aten.gather,
+                        args=(sigmoid_node, 1, selected_experts),
+                    )
+
+                # Use the normalized routing weights instead of raw topk values
+                routing_weights_node = routing_weights_normalized
+
+                # Step 4: Apply MoE fusion
+                # If input_routing is True: kernel applies routing to input
+                # If input_routing is False: kernel applies routing to output
+                apply_routing_on_input = input_routing
+
+                with graph.inserting_before(output_node):
+                    fused_moe_node = graph.call_function(
+                        torch.ops.auto_deploy.torch_moe_bmm,
+                        args=(
+                            input_hidden_states,
+                            selected_experts,
+                            routing_weights_node,
+                            gate_up_weight,
+                            down_weight,
+                        ),
+                        kwargs={
+                            "apply_routing_on_input": apply_routing_on_input,
+                        },
+                    )
+
+                # Replace the output node with fused MoE
+                output_node.replace_all_uses_with(fused_moe_node)
+                graph.erase_node(output_node)
+
+                # Clean up dead nodes
+                gm.graph.eliminate_dead_code()
+
+                # Clean up dead inplace nodes in the region
+                while _remove_dead_inplace_nodes_in_region(gm.graph, start_boundary, end_boundary):
+                    gm.graph.eliminate_dead_code()
+
+                # Delete unused submodules/parameters
+                gm.delete_all_unused_submodules()
+
+                num_moe_patterns += 1
+
+        info = TransformInfo(
+            skipped=False, num_matches=num_moe_patterns, is_clean=False, has_valid_shapes=False
+        )
+        return gm, info
 
 
 def _stack_fp8_moe_weights(gm: GraphModule, backend: Literal["auto", "trtllm", "triton"]) -> int:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -39,7 +39,6 @@ from ...utils.node_utils import (
     subgraph,
 )
 from ...utils.sharding_utils import (
-    BmmEPShardingInfo,
     BMMShardingInfo,
     EPShardingInfo,
     LayerType,
@@ -137,9 +136,6 @@ class ShardingTransformExecutor(BaseTransform):
                 num_matches += 1
         for ep_transform in transforms.ep_transforms:
             if check_and_apply(ep_transform):
-                num_matches += 1
-        for stacked_ep_transform in transforms.stacked_ep_transforms:
-            if check_and_apply(stacked_ep_transform):
                 num_matches += 1
 
         # post-sharding cleanup transformations
@@ -1062,31 +1058,20 @@ def detect_ep_shard(gm: GraphModule, sharding_config: ShardingTransformContainer
             node,
             (
                 torch.ops.auto_deploy.torch_moe,
-                torch.ops.auto_deploy.torch_moe_bmm,
                 torch.ops.auto_deploy.torch_quant_fp8_moe,
                 torch.ops.auto_deploy.torch_quant_nvfp4_moe,
                 torch.ops.auto_deploy.triton_mxfp4_moe,
             ),
         ):
             continue
-        if is_op(node, torch.ops.auto_deploy.torch_moe_bmm):
-            if sharding_config.add(
-                BmmEPShardingInfo.from_node(
-                    node,
-                    rank=rank,
-                    world_size=world_size,
-                )
-            ):
-                num_moe_patterns += 1
-        else:
-            if sharding_config.add(
-                EPShardingInfo.from_node(
-                    node,
-                    rank=rank,
-                    world_size=world_size,
-                )
-            ):
-                num_moe_patterns += 1
+        if sharding_config.add(
+            EPShardingInfo.from_node(
+                node,
+                rank=rank,
+                world_size=world_size,
+            )
+        ):
+            num_moe_patterns += 1
 
     ad_logger.info(f"Found {num_moe_patterns} MoE patterns")
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/sharding_utils.py
@@ -254,7 +254,7 @@ def shard_weight_tensor(
     if update_param:
         modname, _, param_name = param_key.rpartition(".")
         submod = gm.get_submodule(modname)
-        param_new = nn.Parameter(sharded_weight.detach().clone(), requires_grad=requires_grad)
+        param_new = nn.Parameter(sharded_weight.detach().clone(), requires_grad=False)
         setattr(submod, param_name, param_new)
 
     return sharded_weight, sharded_shape
@@ -1153,7 +1153,7 @@ def _slice_expert_dim(
     )
 
     # Replace the parameter with the sliced version
-    new_param = nn.Parameter(sliced_param, requires_grad=full_param.requires_grad)
+    new_param = nn.Parameter(sliced_param, requires_grad=False)
     setattr(submod, param_name, new_param)
 
     # Return the same node (it now points to the sliced parameter)
@@ -1199,7 +1199,7 @@ def _transform_bmm_moe_weight_param(
         sliced_param = torch.cat([w3, w1], dim=2)
 
     # Transpose: Llama4 (E, H, X) -> TRT-LLM (E, X, H)
-    transposed_param = sliced_param.transpose(1, 2).contiguous()
+    transposed_param = sliced_param.transpose(1, 2)
     transposed_shape = transposed_param.shape
 
     # Define transformation function for load hook
@@ -1223,7 +1223,7 @@ def _transform_bmm_moe_weight_param(
     )
 
     # Replace the parameter with the transformed version
-    new_param = nn.Parameter(transposed_param, requires_grad=full_param.requires_grad)
+    new_param = nn.Parameter(transposed_param, requires_grad=False)
     setattr(submod, param_name, new_param)
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
@@ -160,8 +160,8 @@ def test_sharding_pattern_detection(world_size: int, num_experts: int):
 
 
 def test_llama4_stacked_moe_pattern_detection():
-    """Minimal test: verify torch_moe_bmm is detected for EP sharding."""
-    # Create a simple graph with torch_moe_bmm node
+    """Minimal test: verify torch_moe with stacked format is detected for EP sharding."""
+    # Create a simple graph with torch_moe node using stacked tensor format
     gm = torch.fx.GraphModule({}, torch.fx.Graph())
     graph = gm.graph
 
@@ -172,9 +172,15 @@ def test_llama4_stacked_moe_pattern_detection():
         w3_w1 = graph.placeholder("w3_w1_stacked")
         w2 = graph.placeholder("w2_stacked")
 
+        # Create single-element lists for stacked tensor format
+        w1_list = graph.call_function(list, args=([w3_w1],))
+        w2_list = graph.call_function(list, args=([w2],))
+        w3_list = graph.call_function(list, args=([],))
+
         moe_node = graph.call_function(
-            torch.ops.auto_deploy.torch_moe_bmm,
-            args=(x, selected_experts, routing_weights, w3_w1, w2),
+            torch.ops.auto_deploy.torch_moe,
+            args=(x, selected_experts, routing_weights, w1_list, w2_list, w3_list),
+            kwargs={"mlp_style": "gated_mlp", "apply_routing_on_input": True},
         )
         graph.output(moe_node)
 
@@ -195,7 +201,7 @@ def test_llama4_stacked_moe_pattern_detection():
     optimizer.shared_config.world_size = 2
     _ = optimizer(None, gm)
 
-    # Verify torch_moe_bmm is detected for EP sharding
-    detected = optimizer.shared_config.sharding_config.stacked_ep_transforms
+    # Verify torch_moe with stacked format is detected for EP sharding
+    detected = optimizer.shared_config.sharding_transform_container.ep_transforms
     assert len(detected) == 1, f"Expected 1 EP transform, got {len(detected)}"
     assert detected[0].target_node == moe_node.name

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch.helpers import reference_moe_torch
+from _torch.helpers import reference_bmm_moe_torch, reference_moe_torch
 from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
@@ -62,6 +62,50 @@ def setup_moe_test(dtype, num_experts):
     )
 
 
+def setup_bmm_moe_test(dtype, num_experts):
+    """Setup for stacked MoE (torch_moe_bmm) with topk=1 in TRT-LLM format."""
+    SEQ_LEN = 8
+    HIDDEN_SIZE = 64
+    INTERMEDIATE_SIZE = 32
+    NUM_EXPERTS = num_experts
+    TOP_K = 1  # Llama4 stacked pattern requires topk=1
+
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)
+    x = torch.rand(SEQ_LEN, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+
+    router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS), dtype=torch.float32).cuda()
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    final_scales, selected_experts = torch.topk(routing_weights, TOP_K, dim=-1)
+    final_scales = final_scales / final_scales.sum(dim=-1, keepdim=True)
+    final_scales = final_scales.to(x.dtype)
+
+    # TRT-LLM format: gate_up is (2*I, H), down is (H, I)
+    w3_w1_stacked_weight = torch.empty(
+        (NUM_EXPERTS, INTERMEDIATE_SIZE * 2, HIDDEN_SIZE), dtype=dtype
+    ).cuda()
+    w2_stacked_weight = torch.empty(
+        (NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype
+    ).cuda()
+
+    for expert_id in range(NUM_EXPERTS):
+        w1 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+        w2 = torch.rand(HIDDEN_SIZE, INTERMEDIATE_SIZE, dtype=dtype).cuda() * 0.1
+        w3 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+
+        # TRT-LLM format: concat w3 and w1 along intermediate dim
+        w3_w1_stacked_weight.data[expert_id].copy_(torch.cat([w3, w1], dim=0))  # (2*I, H)
+        w2_stacked_weight.data[expert_id].copy_(w2)  # (H, I)
+
+    return (
+        x,
+        selected_experts,
+        final_scales,
+        w3_w1_stacked_weight,
+        w2_stacked_weight,
+    )
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_moe_op_run(dtype):
     num_experts = 3
@@ -101,6 +145,57 @@ def test_moe_op_run(dtype):
             fused_w2_weight,
         )
         ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output_trt_fused_moe, output_torch_fused_moe, rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(output_trt_fused_moe, ref_output, rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(output_torch_fused_moe, ref_output, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(output_torch_moe, ref_output, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_bmm_based_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    ) = setup_bmm_moe_test(dtype, num_experts)
+
+    with torch.inference_mode():
+        x = final_scales * x
+        selected_experts = torch.ones_like(selected_experts)
+        output_torch_moe = torch.ops.auto_deploy.torch_moe_bmm(
+            x,
+            selected_experts,
+            final_scales,
+            fused_w3_w1_stacked_weight,
+            fused_w2_weight,
+        )
+        output_torch_fused_moe = torch.ops.auto_deploy.torch_moe_fused(
+            x,
+            selected_experts,
+            final_scales,
+            fused_w3_w1_stacked_weight,
+            fused_w2_weight,
+        )
+        output_trt_fused_moe = torch.ops.auto_deploy.trtllm_moe_fused(
+            x,
+            selected_experts,
+            final_scales,
+            fused_w3_w1_stacked_weight,
+            fused_w2_weight,
+        )
+        ref_output = reference_bmm_moe_torch(
+            x,
+            selected_experts,
+            final_scales,
+            fused_w3_w1_stacked_weight,
+            fused_w2_weight,
+            apply_routing_on_input=True,
+        )
 
     torch.cuda.synchronize()
     torch.testing.assert_close(output_trt_fused_moe, output_torch_fused_moe, rtol=5e-2, atol=5e-2)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -89,12 +89,10 @@ def setup_bmm_moe_test(dtype, num_experts):
     ).cuda()
 
     for expert_id in range(NUM_EXPERTS):
-        w1 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+        w31 = torch.rand(INTERMEDIATE_SIZE * 2, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
         w2 = torch.rand(HIDDEN_SIZE, INTERMEDIATE_SIZE, dtype=dtype).cuda() * 0.1
-        w3 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
-
         # TRT-LLM format: concat w3 and w1 along intermediate dim
-        w3_w1_stacked_weight.data[expert_id].copy_(torch.cat([w3, w1], dim=0))  # (2*I, H)
+        w3_w1_stacked_weight.data[expert_id].copy_(w31, dim=0))  # (2*I, H)
         w2_stacked_weight.data[expert_id].copy_(w2)  # (H, I)
 
     return (

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -93,9 +93,12 @@ def calc_woq_tolerence(x: torch.Tensor, weight_dtype: torch.dtype):
     return atol
 
 
-def reference_moe_torch(x: torch.Tensor, selected_experts: torch.Tensor,
-                        final_scales: torch.Tensor, num_experts: int,
-                        weights: Dict[str, torch.Tensor]) -> torch.Tensor:
+def reference_moe_torch(x: torch.Tensor,
+                        selected_experts: torch.Tensor,
+                        final_scales: torch.Tensor,
+                        num_experts: int,
+                        weights: Dict[str, torch.Tensor],
+                        apply_routing_on_input: bool = False) -> torch.Tensor:
     # cast back to the input dtype
     results = torch.zeros_like(x)
 
@@ -106,9 +109,63 @@ def reference_moe_torch(x: torch.Tensor, selected_experts: torch.Tensor,
         w2_weight = weights[f"{expert_id}.w2.weight"]
         w3_weight = weights[f"{expert_id}.w3.weight"]
         expert_inputs = x[batch_idx]
+        if apply_routing_on_input:
+            expert_inputs = expert_inputs * final_scales[batch_idx, nth_expert,
+                                                         None]
         output = (F.silu(expert_inputs @ w1_weight.t()) *
                   (expert_inputs @ w3_weight.t())) @ w2_weight.t()
-        results[batch_idx] += final_scales[batch_idx, nth_expert, None] * output
+        if not apply_routing_on_input:
+            output = output * final_scales[batch_idx, nth_expert, None]
+        results[batch_idx] += output
+
+    return results.view_as(x)
+
+
+def reference_bmm_moe_torch(
+        x: torch.Tensor,
+        selected_experts: torch.Tensor,
+        final_scales: torch.Tensor,
+        w3_w1_stacked_weight: torch.Tensor,
+        w2_stacked_weight: torch.Tensor,
+        apply_routing_on_input: bool = True) -> torch.Tensor:
+    """Reference for stacked MoE (torch_moe_bmm) in TRT-LLM format.
+
+    Args:
+        x: (seq_len, hidden_size)
+        selected_experts: (seq_len, topk)
+        final_scales: (seq_len, topk)
+        w3_w1_stacked_weight: (num_experts, 2*intermediate_size, hidden_size) - TRT-LLM format
+        w2_stacked_weight: (num_experts, hidden_size, intermediate_size) - TRT-LLM format
+    """
+    num_experts = w3_w1_stacked_weight.shape[0]
+    intermediate_size = w3_w1_stacked_weight.shape[1] // 2
+    results = torch.zeros_like(x)
+
+    # Loop over experts (matches reference_moe_torch pattern)
+    for expert_id in range(num_experts):
+        batch_idx, nth_expert = torch.where(selected_experts == expert_id)
+        if len(batch_idx) == 0:
+            continue
+
+        # Get weights for this expert (TRT-LLM format)
+        gate_up = w3_w1_stacked_weight[expert_id]  # (2*I, H)
+        w3_weight = gate_up[:intermediate_size, :]  # (I, H)
+        w1_weight = gate_up[intermediate_size:, :]  # (I, H)
+        w2_weight = w2_stacked_weight[expert_id]  # (H, I)
+
+        expert_inputs = x[batch_idx]
+        if apply_routing_on_input:
+            expert_inputs = expert_inputs * final_scales[batch_idx, nth_expert,
+                                                         None]
+
+        # Gated MLP computation - TRT-LLM format uses .t()
+        output = (F.silu(expert_inputs @ w1_weight.t()) *
+                  (expert_inputs @ w3_weight.t())) @ w2_weight.t()
+
+        if not apply_routing_on_input:
+            output = output * final_scales[batch_idx, nth_expert, None]
+
+        results[batch_idx] += output
 
     return results.view_as(x)
 

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -128,7 +128,7 @@ def reference_bmm_moe_torch(
         w3_w1_stacked_weight: torch.Tensor,
         w2_stacked_weight: torch.Tensor,
         apply_routing_on_input: bool = True) -> torch.Tensor:
-    """Reference for stacked MoE (torch_moe_bmm) in TRT-LLM format.
+    """Reference for stacked MoE in TRT-LLM format.
 
     Args:
         x: (seq_len, hidden_size)


### PR DESCRIPTION
Add handling for Lllama4 MoE where experts are calculated in BMM with swiglu
Perf is up by ~2.5x compared to baseline, there is still a gap of 35% to trtllm, probably due to comms.
Added tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for BMM-based Mixture-of-Experts with stacked weights, including Llama4 pattern support
  * Introduced flexible routing application modes (input-side and output-side routing options)
  * Added automatic pattern matching and fusion for optimized MoE performance
  * Extended multi-GPU support with sharding capabilities for new MoE patterns

* **Tests**
  * Added tests for BMM-based MoE pattern detection and operator validation across different data types

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.



`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
