### PR TITLE
[TRTLLM-9493][feat] Custom AllToAll for helix parallelism

### DIFF
--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -528,4 +528,10 @@ bool getEnvEplbForceGdrcopy()
     return getBoolEnv("TRTLLM_EPLB_FORCE_GDRCOPY");
 }
 
+bool getEnvUseNcclForHelix()
+{
+    static bool const useNcclForHelix = getBoolEnv("TRTLLM_USE_NCCL_FOR_HELIX");
+    return useNcclForHelix;
+}
+
 } // namespace tensorrt_llm::common

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -153,4 +153,7 @@ bool getEnvKVCacheTransferAllBlocksForWindow();
 
 bool getEnvEplbForceGdrcopy();
 
+// Whether to use NCCL-based all-to-all for Helix parallelism.
+bool getEnvUseNcclForHelix();
+
 } // namespace tensorrt_llm::common

--- a/cpp/tensorrt_llm/kernels/cudaAsyncOps.cuh
+++ b/cpp/tensorrt_llm/kernels/cudaAsyncOps.cuh
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "tensorrt_llm/kernels/moeCommKernelsCommon.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// ============================================================================
+// Address Conversion Utilities
+// ============================================================================
+
+static __device__ __forceinline__ uint32_t __as_ptr_smem(void const* __ptr)
+{
+    // Consider adding debug asserts here.
+    return static_cast<uint32_t>(__cvta_generic_to_shared(__ptr));
+}
+
+static __device__ __forceinline__ uint64_t __as_ptr_gmem(void const* __ptr)
+{
+    // Consider adding debug asserts here.
+    return static_cast<uint64_t>(__cvta_generic_to_global(__ptr));
+}
+
+// ============================================================================
+// Memory Fence Operations
+// ============================================================================
+
+__device__ __forceinline__ void fence_release_sys()
+{
+    asm volatile("fence.release.sys;" : : : "memory");
+}
+
+// ============================================================================
+// Memory Barrier Operations (mbarrier)
+// ============================================================================
+
+__device__ __forceinline__ void mbarrier_init(uint64_t* addr, uint32_t const& count)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm("mbarrier.init.shared.b64 [%0], %1;" : : "r"(__as_ptr_smem(addr)), "r"(count) : "memory");
+#endif
+}
+
+__device__ __forceinline__ void mbarrier_expect_tx(uint64_t* addr, const uint32_t txCount)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("mbarrier.expect_tx.relaxed.cta.shared::cta.b64 [%0], %1;"
+        :
+        : "r"(__as_ptr_smem(addr)), "r"(txCount)
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ uint64_t mbarrier_arrive(uint64_t* addr)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    uint64_t state;
+    asm("mbarrier.arrive.shared.b64 %0, [%1];" : "=l"(state) : "r"(__as_ptr_smem(addr)) : "memory");
+    return state;
+#else
+    return 0;
+#endif
+}
+
+__device__ __forceinline__ uint64_t mbarrier_arrive_expect_tx(uint64_t* addr, const uint32_t txCount)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    uint64_t state;
+    asm("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 %0, [%1], %2;"
+        : "=l"(state)
+        : "r"(__as_ptr_smem(addr)), "r"(txCount)
+        : "memory");
+    return state;
+#else
+    return 0;
+#endif
+}
+
+__device__ __forceinline__ bool mbarrier_try_wait_parity(uint64_t* addr, uint32_t const& phaseParity)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    uint32_t waitComplete;
+    asm("{\n\t .reg .pred P_OUT; \n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64  P_OUT, [%1], %2;\n\t"
+        "selp.b32 %0, 1, 0, P_OUT; \n"
+        "}"
+        : "=r"(waitComplete)
+        : "r"(__as_ptr_smem(addr)), "r"(phaseParity)
+        : "memory");
+    return static_cast<bool>(waitComplete);
+#else
+    return false;
+#endif
+}
+
+// ============================================================================
+// Async Copy Operations (cp.async for SM80+)
+// ============================================================================
+
+template <int COPY_SIZE = 4>
+__device__ __forceinline__ void ldgsts(int* dstShm, int const* srcMem, bool predGuard)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile(
+        "{\n"
+        "  .reg .pred p;\n"
+        "  setp.ne.b32 p, %0, 0;\n"
+        "  @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+        "}\n" ::"r"((int) predGuard),
+        "r"(__as_ptr_smem(dstShm)), "l"(__as_ptr_gmem(srcMem)), "n"(COPY_SIZE));
+#endif
+}
+
+__device__ __forceinline__ void cp_async_commit_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.commit_group;" : : :);
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_wait_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.wait_group %0;" : : "n"(N) : "memory");
+#endif
+}
+
+// ============================================================================
+// Bulk Async Copy Operations (cp.async.bulk for SM90+)
+// ============================================================================
+
+__device__ __forceinline__ void cp_async_bulk_g2s(void* dstMem, void const* srcMem, int copySize, uint64_t* smemBar)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+        :
+        : "r"(__as_ptr_smem(dstMem)), "l"(__as_ptr_gmem(srcMem)), "r"(copySize), "r"(__as_ptr_smem(smemBar))
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ void cp_async_bulk_s2g(void* dstMem, void const* srcMem, int copySize)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;"
+        :
+        : "l"(__as_ptr_gmem(dstMem)), "r"(__as_ptr_smem(srcMem)), "r"(copySize)
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ void cp_async_bulk_commit_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.commit_group;" : : :);
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_bulk_wait_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.wait_group %0;" : : "n"(N) : "memory");
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_bulk_wait_group_read()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(N) : "memory");
+#endif
+}
+
+// ============================================================================
+// Shared Memory Barrier Helpers
+// ============================================================================
+
+__device__ __forceinline__ void initSmemBar(uint64_t* smemBar, int laneId)
+{
+    if (laneId == 0)
+    {
+        mbarrier_init(smemBar, WARP_SIZE);
+    }
+    __syncwarp();
+}
+
+__device__ __forceinline__ void smemBarWait(uint64_t* smemBar, uint32_t* phaseParity)
+{
+    while (!mbarrier_try_wait_parity(smemBar, *phaseParity))
+    {
+    }
+    *phaseParity = 1 - *phaseParity;
+}
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.cu
+++ b/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.cu
@@ -20,6 +20,8 @@
 
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/kernels/cudaAsyncOps.cuh"
+#include "tensorrt_llm/kernels/ll128Proto.cuh"
 #include "tensorrt_llm/kernels/quantization.cuh"
 
 namespace tensorrt_llm
@@ -336,154 +338,6 @@ __device__ __forceinline__ void dequantize_nvfp4_sharedmem(uint8_t* compact_ptr,
 #endif
 }
 
-static __device__ __forceinline__ uint32_t __as_ptr_smem(void const* __ptr)
-{
-    // Consider adding debug asserts here.
-    return static_cast<uint32_t>(__cvta_generic_to_shared(__ptr));
-}
-
-static __device__ __forceinline__ uint64_t __as_ptr_gmem(void const* __ptr)
-{
-    // Consider adding debug asserts here.
-    return static_cast<uint64_t>(__cvta_generic_to_global(__ptr));
-}
-
-__device__ __forceinline__ void fence_release_sys()
-{
-    asm volatile("fence.release.sys;" : : : "memory");
-}
-
-__device__ __forceinline__ void mbarrier_init(uint64_t* addr, uint32_t const& count)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
-    asm("mbarrier.init.shared.b64 [%0], %1;" : : "r"(__as_ptr_smem(addr)), "r"(count) : "memory");
-#endif
-}
-
-__device__ __forceinline__ void mbarrier_expect_tx(uint64_t* addr, const uint32_t txCount)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm("mbarrier.expect_tx.relaxed.cta.shared::cta.b64 [%0], %1;"
-        :
-        : "r"(__as_ptr_smem(addr)), "r"(txCount)
-        : "memory");
-#endif
-}
-
-__device__ __forceinline__ uint64_t mbarrier_arrive(uint64_t* addr)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
-    uint64_t state;
-    asm("mbarrier.arrive.shared.b64 %0, [%1];" : "=l"(state) : "r"(__as_ptr_smem(addr)) : "memory");
-    return state;
-#else
-    return 0;
-#endif
-}
-
-__device__ __forceinline__ uint64_t mbarrier_arrive_expect_tx(uint64_t* addr, const uint32_t txCount)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    uint64_t state;
-    asm("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 %0, [%1], %2;"
-        : "=l"(state)
-        : "r"(__as_ptr_smem(addr)), "r"(txCount)
-        : "memory");
-    return state;
-#else
-    return 0;
-#endif
-}
-
-__device__ __forceinline__ bool mbarrier_try_wait_parity(uint64_t* addr, uint32_t const& phaseParity)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    uint32_t waitComplete;
-    asm("{\n\t .reg .pred P_OUT; \n\t"
-        "mbarrier.try_wait.parity.shared::cta.b64  P_OUT, [%1], %2;\n\t"
-        "selp.b32 %0, 1, 0, P_OUT; \n"
-        "}"
-        : "=r"(waitComplete)
-        : "r"(__as_ptr_smem(addr)), "r"(phaseParity)
-        : "memory");
-    return static_cast<bool>(waitComplete);
-#else
-    return false;
-#endif
-}
-
-template <int COPY_SIZE = 4>
-__device__ __forceinline__ void ldgsts(int* dstShm, int const* srcMem, bool predGuard)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
-    asm volatile(
-        "{\n"
-        "  .reg .pred p;\n"
-        "  setp.ne.b32 p, %0, 0;\n"
-        "  @p cp.async.ca.shared.global [%1], [%2], %3;\n"
-        "}\n" ::"r"((int) predGuard),
-        "r"(__as_ptr_smem(dstShm)), "l"(__as_ptr_gmem(srcMem)), "n"(COPY_SIZE));
-#endif
-}
-
-__device__ __forceinline__ void cp_async_commit_group()
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
-    asm volatile("cp.async.commit_group;" : : :);
-#endif
-}
-
-template <int N = 0>
-__device__ __forceinline__ void cp_async_wait_group()
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
-    asm volatile("cp.async.wait_group %0;" : : "n"(N) : "memory");
-#endif
-}
-
-__device__ __forceinline__ void cp_async_bulk_g2s(void* dstMem, void const* srcMem, int copySize, uint64_t* smemBar)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
-        :
-        : "r"(__as_ptr_smem(dstMem)), "l"(__as_ptr_gmem(srcMem)), "r"(copySize), "r"(__as_ptr_smem(smemBar))
-        : "memory");
-#endif
-}
-
-__device__ __forceinline__ void cp_async_bulk_s2g(void* dstMem, void const* srcMem, int copySize)
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm("cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;"
-        :
-        : "l"(__as_ptr_gmem(dstMem)), "r"(__as_ptr_smem(srcMem)), "r"(copySize)
-        : "memory");
-#endif
-}
-
-__device__ __forceinline__ void cp_async_bulk_commit_group()
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm volatile("cp.async.bulk.commit_group;" : : :);
-#endif
-}
-
-template <int N = 0>
-__device__ __forceinline__ void cp_async_bulk_wait_group()
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm volatile("cp.async.bulk.wait_group %0;" : : "n"(N) : "memory");
-#endif
-}
-
-template <int N = 0>
-__device__ __forceinline__ void cp_async_bulk_wait_group_read()
-{
-#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
-    asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(N) : "memory");
-#endif
-}
-
 __host__ void MoeCommFieldInfo::fillFieldInfo(
     uint8_t* dataPtr, size_t elementSize, int vectorSize, int stride, cudaDataType_t dataType)
 {
@@ -526,143 +380,47 @@ __host__ void MoeCommFieldInfo::fillFieldInfo(
     originalDataType = dataType;
 }
 
-class Ll128Proto
+// Wrapper class that delegates to LL128Proto but accepts extra warpId parameter for backward compatibility
+class Ll128ProtoWrapper
 {
 public:
-    static constexpr uint32_t INITIALIZED_VALUE = 0xFFFFFFFFU;
+    static constexpr uint32_t INITIALIZED_VALUE = LL128Proto::INITIALIZED_VALUE;
 
     template <bool USE_FINISH>
     static __device__ __forceinline__ int checkDataReceivedInShm(uint8_t* sharedMemoryBase, uint64_t step,
-        int countIn128Bytes, int fifoEntry128ByteIndexBase, int loaded128ByteCount, int warpId, int laneId)
+        int countIn128Bytes, int fifoEntry128ByteIndexBase, int loaded128ByteCount, int /*warpId*/, int laneId)
     {
-        // return value should be how many package already been received.
-        // 0 means no data received, -1 means has received finish package(should be the very first 128 Byte).
-        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
-        int totalValidCount = 0;
-        for (int idxBase = loaded128ByteCount; idxBase < countIn128Bytes; idxBase += WARP_SIZE)
-        {
-            int idx = idxBase + laneId;
-            bool valid = false;
-            bool finish = false;
-            if (idx < countIn128Bytes)
-            {
-                int indexInFifoEntry = fifoEntry128ByteIndexBase + idx;
-                uint64_t value = aligned128BytesShm[idx * MoeCommFieldInfo::UINT64_PER_128B_BLOCK
-                    + indexInFifoEntry % MoeCommFieldInfo::UINT64_PER_128B_BLOCK];
-                if (USE_FINISH)
-                {
-                    finish = (value == (step & (1ULL << 63ULL)));
-                    valid = (value == step) || finish;
-                }
-                else
-                {
-                    valid = (value == step);
-                }
-            }
-            __syncwarp();
-            unsigned validMask = __ballot_sync(WARP_MASK, valid);
-            // here we check valid in order, if previous valid is not true, we ignore the current valid.
-            int validCount = (validMask == WARP_MASK) ? WARP_SIZE : (__ffs(~validMask) - 1);
-            if (USE_FINISH)
-            {
-                unsigned finishedMask = __ballot_sync(WARP_MASK, finish);
-                // finish should be the very first 128 Byte.
-                if (finishedMask & 0x1)
-                {
-                    return -1;
-                }
-            }
-            totalValidCount += validCount;
-
-            if (validCount != WARP_SIZE)
-            {
-                break;
-            }
-        }
-        return totalValidCount;
+        return LL128Proto::checkDataReceivedInShm<USE_FINISH>(
+            sharedMemoryBase, step, countIn128Bytes, fifoEntry128ByteIndexBase, loaded128ByteCount, laneId);
     }
 
     static __device__ __forceinline__ void protoPack(uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes,
-        int fifoEntry128ByteIndexBase, int warpId, int laneId)
+        int fifoEntry128ByteIndexBase, int /*warpId*/, int laneId)
     {
-        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
-        int halfLaneId = laneId % 16;
-        int halfIndex = laneId / 16;
-        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
-        // for LL128 15 * 128 Bytes will be packed to 16 * 128 Bytes, each 16 threads is used for one 15 * 128 bytes.
-        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
-        {
-            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
-            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % MoeCommFieldInfo::UINT64_PER_128B_BLOCK;
-            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
-            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
-            uint64_t tailValue = step;
-            uint64_t tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
-            if (halfLaneId == 15)
-            {
-                tailInnerIndex = tailFlagInnerIndex;
-            }
-            int targetTailIndex = tailOffsetIn128Bytes * MoeCommFieldInfo::UINT64_PER_128B_BLOCK + tailInnerIndex;
-            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
-            {
-                int flagIndex = idxIn128Bytes * MoeCommFieldInfo::UINT64_PER_128B_BLOCK
-                    + idxFromFifoEntry % MoeCommFieldInfo::UINT64_PER_128B_BLOCK;
-                tailValue = aligned128BytesShm[flagIndex];
-                aligned128BytesShm[flagIndex] = step;
-            }
-            aligned128BytesShm[targetTailIndex] = tailValue;
-            tailOffsetIn128Bytes += 2;
-        }
-        __syncwarp();
+        LL128Proto::protoPack(sharedMemoryBase, step, countIn128Bytes, fifoEntry128ByteIndexBase, laneId);
     }
 
     static __device__ __forceinline__ void protoUnpack(uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes,
-        int fifoEntry128ByteIndexBase, int loaded128ByteCount, int warpId, int laneId)
+        int fifoEntry128ByteIndexBase, int loaded128ByteCount, int /*warpId*/, int laneId)
     {
-        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
-        int halfLaneId = laneId % 16;
-        int halfIndex = laneId / 16;
-        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
-        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
-        {
-            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
-            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % MoeCommFieldInfo::UINT64_PER_128B_BLOCK;
-            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
-            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
-            uint64_t tailValue = 0;
-            int tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
-            int targetTailIndex = tailOffsetIn128Bytes * MoeCommFieldInfo::UINT64_PER_128B_BLOCK + tailInnerIndex;
-            if (halfLaneId < 15)
-            {
-                tailValue = aligned128BytesShm[targetTailIndex];
-            }
-            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
-            {
-                int flagIndex = idxIn128Bytes * MoeCommFieldInfo::UINT64_PER_128B_BLOCK
-                    + idxFromFifoEntry % MoeCommFieldInfo::UINT64_PER_128B_BLOCK;
-                aligned128BytesShm[flagIndex] = tailValue;
-            }
-            tailOffsetIn128Bytes += 2;
-        }
-        __syncwarp();
+        LL128Proto::protoUnpack(
+            sharedMemoryBase, step, countIn128Bytes, fifoEntry128ByteIndexBase, loaded128ByteCount, laneId);
     }
 
-    static __device__ __forceinline__ void rearm(
-        uint32_t* u32FifoPtr, uint64_t step, int countIn128Bytes, int fifoEntry128ByteIndexBase, int warpId, int laneId)
+    static __device__ __forceinline__ void rearm(uint32_t* u32FifoPtr, uint64_t step, int countIn128Bytes,
+        int fifoEntry128ByteIndexBase, int /*warpId*/, int laneId)
     {
-        // LL128 don't need rearm
+        LL128Proto::rearm(u32FifoPtr, step, countIn128Bytes, fifoEntry128ByteIndexBase, laneId);
     }
 
     static __device__ __host__ __forceinline__ int computeProtoTransfer128ByteAlignedSize(
         int compact128ByteSizeBeforeProto)
     {
-        // each 15 * 128 byte need one tail 128 byte
-        int tail128ByteSize = (compact128ByteSizeBeforeProto + 15 * 128 - 1) / (15 * 128) * 128;
-        return compact128ByteSizeBeforeProto + tail128ByteSize;
+        return LL128Proto::computeProtoTransfer128ByteAlignedSize(compact128ByteSizeBeforeProto);
     }
 };
 
-using FusedMoeProto = Ll128Proto;
+using FusedMoeProto = Ll128ProtoWrapper;
 
 // using FusedMoeProto = LamportProto;
 
@@ -796,23 +554,6 @@ __device__ __forceinline__ void unpackAllFields(
     __syncwarp();
 }
 
-__device__ __forceinline__ void initSmemBar(uint64_t* smemBar, int laneId)
-{
-    if (laneId == 0)
-    {
-        mbarrier_init(smemBar, WARP_SIZE);
-    }
-    __syncwarp();
-}
-
-__device__ __forceinline__ void smemBarWait(uint64_t* smemBar, uint32_t* phaseParity)
-{
-    while (!mbarrier_try_wait_parity(smemBar, *phaseParity))
-    {
-    }
-    *phaseParity = 1 - *phaseParity;
-}
-
 __device__ __forceinline__ void startWorkspaceS2G(
     uint64_t* fifoEntry, uint8_t* sharedMemoryBase, int send128ByteCount, int fifo128ByteOffset, int warpId, int laneId)
 {
@@ -900,7 +641,7 @@ __device__ __forceinline__ void waitG2SBasicFields()
 
 __device__ __forceinline__ void waitG2SOtherFields(uint64_t* memBar, uint32_t* phaseParity)
 {
-    tensorrt_llm::kernels::fused_moe_impl::smemBarWait(memBar, phaseParity);
+    smemBarWait(memBar, phaseParity);
 }
 
 template <bool HAS_BASIC_FIELDS = true>
@@ -987,7 +728,7 @@ public:
         mFifoEntry128ByteIndexBase = kFifoEntry128ByteCount;
         mFifoEntryIndex = -1;
 
-        tensorrt_llm::kernels::fused_moe_impl::initSmemBar(mSmemBar, mLaneId);
+        initSmemBar(mSmemBar, mLaneId);
     }
 
     __device__ __forceinline__ uint64_t* getFifoEntryPtr() const
@@ -1174,7 +915,7 @@ public:
                     updateReadEntry();
                     needRelease = false;
                 }
-                tensorrt_llm::kernels::fused_moe_impl::smemBarWait(mSmemBar, &phaseParity);
+                smemBarWait(mSmemBar, &phaseParity);
                 loaded128ByteCount += FusedMoeProto::template checkDataReceivedInShm<false>(mShmemBase, mTail,
                     mSingleTransfer128ByteCount, mFifoEntry128ByteIndexBase, loaded128ByteCount, mWarpId, mLaneId);
             }
@@ -1520,7 +1261,7 @@ __global__ void g2sKernel(FusedMoeFieldInfo allFieldInfo, MoeExpertParallelInfo 
 
     int singleShmSize = singleCommMeta.singleUncompactAlignedSize;
 
-    tensorrt_llm::kernels::fused_moe_impl::initSmemBar(&allWarpSmemBar[warpId], laneId);
+    initSmemBar(&allWarpSmemBar[warpId], laneId);
     uint32_t phaseParity = 0;
 
     uint8_t* sharedMemoryBase = reinterpret_cast<uint8_t*>(allWarpShm) + singleShmSize * warpId;
@@ -1631,7 +1372,7 @@ __global__ void loopbackKernel(FusedMoeFieldInfo sendFieldInfo, FusedMoeFieldInf
 
     int recvTokenIndex = recvIndexMapping[tokenIndex];
 
-    tensorrt_llm::kernels::fused_moe_impl::initSmemBar(&allWarpSmemBar[warpId], laneId);
+    initSmemBar(&allWarpSmemBar[warpId], laneId);
     uint32_t phaseParity = 0;
 
     int singleShmSize = sendCommMeta.getSingleShmSize();

--- a/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.h
+++ b/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.h
@@ -82,11 +82,11 @@ struct MoeCommFieldInfo
     static constexpr uint64_t kAlign16BytePtrMask = (1ULL << 4) - 1;
     static constexpr uint32_t kAligned16BMask = (1 << 4) - 1;
 
-    // Constants for memory alignment and access
-    static constexpr int BYTES_PER_128B_BLOCK = 128;
-    static constexpr int INTS_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(int);
-    static constexpr int UINT64_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(uint64_t);
-    static constexpr int BYTES_PER_16B_BLOCK = 16;
+    // Constants for memory alignment and access (reference common constants for consistency)
+    static constexpr int BYTES_PER_128B_BLOCK = tensorrt_llm::kernels::BYTES_PER_128B_BLOCK;
+    static constexpr int INTS_PER_128B_BLOCK = tensorrt_llm::kernels::INTS_PER_128B_BLOCK;
+    static constexpr int UINT64_PER_128B_BLOCK = tensorrt_llm::kernels::UINT64_PER_128B_BLOCK;
+    static constexpr int BYTES_PER_16B_BLOCK = tensorrt_llm::kernels::BYTES_PER_16B_BLOCK;
     // Will pad one 16 byte for each unaligned field, then head and tail 16 byte might not be aligned
 
     // Fill single field info, the fields that need global info is not filled here.
@@ -252,9 +252,11 @@ public:
     static constexpr int FIFO_ENTRY_128_BYTE_COUNT = FIFO_ENTRY_BYTES / 128;
     static constexpr int FIFO_TOTAL_BYTES = FIFO_ENTRY_BYTES * FIFO_DEPTH;
     static constexpr int FIFO_TOTAL_U64 = FIFO_TOTAL_BYTES / sizeof(uint64_t);
-    static constexpr int MAX_GROUP_COUNT_PER_BLOCK = 8;
+    // Reference common constant for consistency
+    static constexpr int MAX_GROUP_COUNT_PER_BLOCK = tensorrt_llm::kernels::MAX_GROUP_COUNT_PER_BLOCK;
 
-    static constexpr int WARP_SIZE = 32;
+    // Reference common constant for consistency
+    static constexpr int WARP_SIZE = tensorrt_llm::kernels::WARP_SIZE;
 
     static int maxSmCount;
     static bool maxSmCountUsed;

--- a/cpp/tensorrt_llm/kernels/helixAllToAll.cu
+++ b/cpp/tensorrt_llm/kernels/helixAllToAll.cu
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/kernels/cudaAsyncOps.cuh"
+#include "tensorrt_llm/kernels/helixAllToAll.h"
+#include "tensorrt_llm/kernels/ll128Proto.cuh"
+
+#include <cstdint>
+#include <cstdio>
+#include <unordered_map>
+
+#include <cooperative_groups.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+// WARP_SIZE, WARP_MASK, and other constants are defined in moeCommKernelsCommon.h
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+__host__ __device__ inline int getFieldSize(HelixFieldInfo const& fieldInfo)
+{
+    return fieldInfo.elementCount * fieldInfo.elementSize;
+}
+
+__host__ __device__ inline uint8_t* getPtr(HelixFieldInfo const& fieldInfo, int blockIdx)
+{
+    return fieldInfo.dataPtr + blockIdx * fieldInfo.stride;
+}
+
+__device__ __forceinline__ void waitG2sAllFields(uint64_t* smemBar, uint32_t* phaseParity)
+{
+    cp_async_wait_group<0>();
+    smemBarWait(smemBar, phaseParity);
+}
+
+// Align size to 128 bytes
+__host__ __device__ __forceinline__ int align128(int size)
+{
+    return align_up(size, BYTES_PER_128B_BLOCK);
+}
+
+// ============================================================================
+// G2S (Global to Shared) Operations
+// ============================================================================
+
+__device__ __forceinline__ void g2sField(
+    HelixFieldInfo const& fieldInfo, int dataIndex, uint8_t* shmemBase, int shmemOffset, uint64_t* smemBar, int laneId)
+{
+    int copySize = getFieldSize(fieldInfo);
+    if (copySize > 0 && laneId == 0)
+    {
+        uint8_t* srcPtr = getPtr(fieldInfo, dataIndex);
+        uint8_t* dstPtr = shmemBase + shmemOffset;
+        cp_async_bulk_g2s(dstPtr, srcPtr, copySize, smemBar);
+    }
+}
+
+template <bool ALLOW_VARIABLE_FIELD1>
+__device__ __forceinline__ int g2sAllFields(
+    HelixFieldInfo const* fieldInfo, int dataIndex, uint8_t* shmemBase, uint64_t* smemBar, int laneId)
+{
+    int totalSize = 0;
+
+    // Load field 0 (variable size half)
+    g2sField(fieldInfo[0], dataIndex, shmemBase, 0, smemBar, laneId);
+    int field0Size = getFieldSize(fieldInfo[0]);
+    totalSize += field0Size;
+
+    // Load field 1 (single float2)
+    if constexpr (ALLOW_VARIABLE_FIELD1)
+    {
+        g2sField(fieldInfo[1], dataIndex, shmemBase, totalSize, smemBar, laneId);
+        totalSize += getFieldSize(fieldInfo[1]);
+    }
+    else
+    {
+        ldgsts<8>(reinterpret_cast<int*>(shmemBase + totalSize),
+            reinterpret_cast<int const*>(getPtr(fieldInfo[1], dataIndex)), laneId == 0);
+        cp_async_commit_group();
+    }
+
+    return totalSize;
+}
+
+// ============================================================================
+// S2G (Shared to Global) Operations
+// ============================================================================
+
+__device__ __forceinline__ void s2gField(
+    HelixFieldInfo const& fieldInfo, int dataIndex, uint8_t* shmemBase, int shmemOffset, int laneId)
+{
+    int copySize = getFieldSize(fieldInfo);
+    if (copySize > 0 && laneId == 0)
+    {
+        uint8_t* srcPtr = shmemBase + shmemOffset;
+        uint8_t* dstPtr = getPtr(fieldInfo, dataIndex);
+        cp_async_bulk_s2g(dstPtr, srcPtr, copySize);
+    }
+}
+
+template <bool ALLOW_VARIABLE_FIELD1>
+__device__ __forceinline__ void s2gAllFields(
+    HelixFieldInfo const* fieldInfo, int dataIndex, uint8_t* shmemBase, int laneId)
+{
+    int offset = 0;
+
+    // Store field 0 (variable size half)
+    s2gField(fieldInfo[0], dataIndex, shmemBase, offset, laneId);
+    int field0Size = getFieldSize(fieldInfo[0]);
+    offset += field0Size;
+
+    // Store field 1 (single float2)
+    if constexpr (ALLOW_VARIABLE_FIELD1)
+    {
+        s2gField(fieldInfo[1], dataIndex, shmemBase, offset, laneId);
+        offset += getFieldSize(fieldInfo[1]);
+    }
+    else
+    {
+        if (laneId == 0)
+        {
+            auto* srcPtr = reinterpret_cast<float2*>(reinterpret_cast<uint8_t*>(shmemBase) + offset);
+            auto* dstPtr = reinterpret_cast<float2*>(getPtr(fieldInfo[1], dataIndex));
+            dstPtr[0] = srcPtr[0];
+        }
+    }
+    cp_async_bulk_commit_group();
+}
+
+// ============================================================================
+// Workspace FIFO Operations
+// ============================================================================
+
+__device__ __forceinline__ uint64_t* getFifoBasePtr(HelixAllToAllParams const& params, HelixPairInfo const& pairInfo)
+{
+    // FIFO is physically located at receiver rank
+    int mappedMemoryRank = pairInfo.receiverRank;
+    int rankInsideMappedMemory = pairInfo.senderRank;
+
+    auto* mappedMemory = params.workspace + mappedMemoryRank * params.workspaceStrideInU64;
+    // Navigate to the right FIFO: [peer_rank][channel]
+    size_t fifoOffset = rankInsideMappedMemory * params.maxChannelCount * HELIX_FIFO_TOTAL_U64;
+    fifoOffset += pairInfo.channel * HELIX_FIFO_TOTAL_U64;
+
+    return mappedMemory + fifoOffset;
+}
+
+__device__ __forceinline__ FifoInfo* getSenderFifoInfo(HelixAllToAllParams const& params, HelixPairInfo const& pairInfo)
+{
+    // SenderSideFifoInfo is physically located at sender rank
+    int mappedMemoryRank = pairInfo.senderRank;
+    int rankInsideMappedMemory = pairInfo.receiverRank;
+
+    auto* mappedMemory = reinterpret_cast<uint8_t*>(params.workspace + mappedMemoryRank * params.workspaceStrideInU64);
+    size_t fieldOffset = static_cast<size_t>(HELIX_FIFO_TOTAL_BYTES) * params.cpSize * params.maxChannelCount;
+    mappedMemory += fieldOffset;
+    mappedMemory += rankInsideMappedMemory * params.maxChannelCount * sizeof(FifoInfo);
+    mappedMemory += pairInfo.channel * sizeof(FifoInfo);
+
+    return reinterpret_cast<FifoInfo*>(mappedMemory);
+}
+
+__device__ __forceinline__ FifoInfo* getReceiverFifoInfo(
+    HelixAllToAllParams const& params, HelixPairInfo const& pairInfo)
+{
+    // ReceiverSideFifoInfo is physically located at receiver rank
+    int mappedMemoryRank = pairInfo.receiverRank;
+    int rankInsideMappedMemory = pairInfo.senderRank;
+
+    auto* mappedMemory = reinterpret_cast<uint8_t*>(params.workspace + mappedMemoryRank * params.workspaceStrideInU64);
+    size_t fieldOffset = static_cast<size_t>(HELIX_FIFO_TOTAL_BYTES) * params.cpSize * params.maxChannelCount;
+    fieldOffset += sizeof(FifoInfo) * params.cpSize * params.maxChannelCount;
+    mappedMemory += fieldOffset;
+    mappedMemory += rankInsideMappedMemory * params.maxChannelCount * sizeof(FifoInfo);
+    mappedMemory += pairInfo.channel * sizeof(FifoInfo);
+
+    return reinterpret_cast<FifoInfo*>(mappedMemory);
+}
+
+__device__ __forceinline__ void startWorkspaceS2G(
+    uint64_t* fifoEntry, uint8_t* shmemBase, int send128ByteCount, int fifo128ByteOffset, int laneId)
+{
+    int copyByteCount = send128ByteCount * BYTES_PER_128B_BLOCK;
+    if (laneId == 0)
+    {
+        cp_async_bulk_s2g(
+            fifoEntry + fifo128ByteOffset * BYTES_PER_128B_BLOCK / sizeof(uint64_t), shmemBase, copyByteCount);
+    }
+    cp_async_bulk_commit_group();
+}
+
+__device__ __forceinline__ void startWorkspaceS2GReg(
+    uint64_t* fifoEntry, uint8_t* sharedMemoryBase, int send128ByteCount, int fifo128ByteOffset, int laneId)
+{
+    int copyInt4Count = send128ByteCount * BYTES_PER_128B_BLOCK / sizeof(int4);
+    int4* sharedMemoryInt4 = reinterpret_cast<int4*>(sharedMemoryBase);
+    uint64_t* fifoPtr = fifoEntry + fifo128ByteOffset * UINT64_PER_128B_BLOCK;
+    int4* fifoPtrInt4 = reinterpret_cast<int4*>(fifoPtr);
+#pragma unroll 4
+    for (int i = laneId; i < copyInt4Count; i += WARP_SIZE)
+    {
+        fifoPtrInt4[i] = sharedMemoryInt4[i];
+    }
+}
+
+__device__ __forceinline__ uint64_t startWorkspaceG2S(uint8_t* shmemBase, uint64_t* fifoEntry, int allLoad128ByteCount,
+    int fifo128ByteOffset, int loaded128ByteCount, uint64_t* smemBar, int laneId)
+{
+    int copyByteCount = (allLoad128ByteCount - loaded128ByteCount) * BYTES_PER_128B_BLOCK;
+    if (laneId == 0)
+    {
+        cp_async_bulk_g2s(shmemBase + loaded128ByteCount * BYTES_PER_128B_BLOCK,
+            fifoEntry + (fifo128ByteOffset + loaded128ByteCount) * UINT64_PER_128B_BLOCK, copyByteCount, smemBar);
+    }
+    return mbarrier_arrive_expect_tx(smemBar, laneId == 0 ? copyByteCount : 0);
+}
+
+// LL128Proto is now defined in ll128Proto.cuh
+
+// ============================================================================
+// Size helpers
+// ============================================================================
+
+// Compute total size needed for both fields
+__host__ __device__ __forceinline__ int computeTotalUnpackedSize(HelixFieldInfo const* fields)
+{
+    int size = 0;
+    // Field 0: note it must be aligned to 16 bytes
+    size += align_up(getFieldSize(fields[0]), 16);
+    // Field 1: single float2
+    size += align_up(getFieldSize(fields[1]), 16);
+    return align128(size);
+}
+
+__host__ __device__ __forceinline__ int computeTotalPackedSize(HelixFieldInfo const* fields)
+{
+    // because field 0 must be aligned to 16 bytes, this is the same as unpacked
+    return computeTotalUnpackedSize(fields);
+}
+
+__host__ __device__ __forceinline__ int computeProtoTransferSize(HelixFieldInfo const* fields)
+{
+    return LL128Proto::computeProtoTransfer128ByteAlignedSize(computeTotalPackedSize(fields));
+}
+
+// ============================================================================
+// Main All-to-All Kernel
+// ============================================================================
+
+template <bool ALLOW_VARIABLE_FIELD1>
+__global__ void helixAllToAllKernel(HelixAllToAllParams params)
+{
+    extern __shared__ uint8_t allWarpShmem[];
+    __shared__ uint64_t allWarpSmemBar[MAX_GROUP_COUNT_PER_BLOCK];
+
+    bool isSender = (blockIdx.z == 0);
+    // Each warp is a group handling a different peer rank
+    int group = __shfl_sync(WARP_MASK, threadIdx.y, 0);
+    int laneId = threadIdx.x % WARP_SIZE;
+    int runChannelCount = gridDim.y;
+
+    // Compute peer rank: blockIdx.x determines which set of peers, group
+    // determines which peer in that set
+    int peerRank = blockIdx.x * blockDim.y + group;
+
+    if (peerRank >= params.cpSize)
+    {
+        return;
+    }
+
+    // Setup pair info for this communication
+    HelixPairInfo pairInfo;
+    pairInfo.channel = blockIdx.y;
+    pairInfo.runChannelCount = runChannelCount;
+    pairInfo.senderRank = isSender ? params.cpRank : peerRank;
+    pairInfo.receiverRank = isSender ? peerRank : params.cpRank;
+
+    // Initialize barrier for this group
+    initSmemBar(&allWarpSmemBar[group], laneId);
+    uint32_t phaseParity = 0;
+
+    // Get shared memory for this group
+    int singlePackedSize = computeTotalPackedSize(params.sendFields);
+    int singlePacked128ByteCount = singlePackedSize / BYTES_PER_128B_BLOCK;
+    int singleUnpackedSize = computeTotalUnpackedSize(params.sendFields);
+    int singleProtoTransferSize = computeProtoTransferSize(params.sendFields);
+    int singleProtoTransfer128ByteCount = singleProtoTransferSize / BYTES_PER_128B_BLOCK;
+    int singleShmSize = std::max(singleUnpackedSize, singleProtoTransferSize);
+    uint8_t* shmem = allWarpShmem + group * singleShmSize;
+
+    // Get FIFO pointers
+    uint64_t* fifoBase = getFifoBasePtr(params, pairInfo);
+    FifoInfo* senderFifo = getSenderFifoInfo(params, pairInfo);
+    FifoInfo* receiverFifo = getReceiverFifoInfo(params, pairInfo);
+
+    int fifoEntry128ByteIndexBase = HELIX_FIFO_ENTRY_128B_COUNT;
+    int fifoEntryIndex = -1;
+
+    // regardless of sender or receiver, we wait for the previous kernel here
+    // receiver blocks do not need to wait at all, but they should not start
+    // to stress the memory system regardless
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaGridDependencySynchronize();
+#endif
+
+    if (isSender)
+    {
+        // sender blocks should trigger next kernel immediately, s.t. they
+        // do not block the next kernel from starting
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+        // Sender logic: send data from cpRank's slice to peerRank
+        int64_t head = senderFifo->head;
+        int64_t tail = senderFifo->tail;
+
+        // Each channel processes entries with stride
+        // Start at channel index, increment by total channel count
+        for (int entryIdx = pairInfo.channel; entryIdx < params.entryCount; entryIdx += runChannelCount)
+        {
+
+            // dataIndex points to the data for peerRank in this entry
+            int dataIndex = entryIdx * params.cpSize + peerRank;
+
+            // Load data from global to shared, then arrive on barrier
+            int loadedSize = g2sAllFields<ALLOW_VARIABLE_FIELD1>(
+                params.sendFields, dataIndex, shmem, &allWarpSmemBar[group], laneId);
+            uint64_t arriveState = mbarrier_arrive_expect_tx(&allWarpSmemBar[group], laneId == 0 ? loadedSize : 0);
+
+            // update FIFO entry index and head if needed
+            if (fifoEntry128ByteIndexBase + singleProtoTransfer128ByteCount > HELIX_FIFO_ENTRY_128B_COUNT)
+            {
+                if (fifoEntryIndex >= 0)
+                {
+                    head++;
+                    __syncwarp();
+                    senderFifo->head = head;
+                }
+                fifoEntryIndex = head % HELIX_FIFO_DEPTH;
+                fifoEntry128ByteIndexBase = 0;
+                while (tail + HELIX_FIFO_DEPTH <= head)
+                {
+                    tail = senderFifo->tail;
+                }
+                __syncwarp();
+            }
+
+            // wait for data to be loaded into shared memory
+            waitG2sAllFields(&allWarpSmemBar[group], &phaseParity);
+            // note: we don't need to pack anything, fields are already packed in
+            // shared memory
+
+            LL128Proto::protoPack(shmem, head, singlePacked128ByteCount, fifoEntry128ByteIndexBase, laneId);
+
+            uint64_t* fifoEntry = fifoBase + fifoEntryIndex * (HELIX_FIFO_ENTRY_BYTES / sizeof(uint64_t));
+
+            // Copy from shared to workspace FIFO
+            startWorkspaceS2GReg(fifoEntry, shmem, singleProtoTransfer128ByteCount, fifoEntry128ByteIndexBase, laneId);
+
+            fifoEntry128ByteIndexBase += singleProtoTransfer128ByteCount;
+
+            // ensure that we can over-write shmem in next iteration
+            // (it must be fully read by all threads when doing S2G above)
+            __syncwarp();
+        }
+        if (fifoEntry128ByteIndexBase > 0)
+        {
+            head++;
+            senderFifo->head = head;
+        }
+    }
+    else
+    {
+        // Receiver logic: receive data from peerRank to cpRank's slice
+        int64_t tail = receiverFifo->tail;
+        bool needRelease = false;
+
+        // Each channel processes entries with stride
+        // Start at channel index, increment by total channel count
+        for (int entryIdx = pairInfo.channel; entryIdx < params.entryCount; entryIdx += runChannelCount)
+        {
+            // receiver blocks should trigger next kernel at last iteration
+            // note: some blocks might not even go into this for-loop, but they
+            // would exit which is equivalent to the pre-exit trigger
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+            if (entryIdx + runChannelCount >= params.entryCount)
+            {
+                cudaTriggerProgrammaticLaunchCompletion();
+            }
+#endif
+            // dataIndex points to where we receive data from peerRank in this entry
+            int dataIndex = entryIdx * params.cpSize + peerRank;
+            int loaded128ByteCount = 0;
+
+            if (fifoEntry128ByteIndexBase + singleProtoTransfer128ByteCount > HELIX_FIFO_ENTRY_128B_COUNT)
+            {
+                if (fifoEntryIndex >= 0)
+                {
+                    tail++;
+                    needRelease = true;
+                }
+                fifoEntryIndex = tail % HELIX_FIFO_DEPTH;
+                fifoEntry128ByteIndexBase = 0;
+                // receiver doesn't need to wait on FIFO entry being readable: it's
+                // always readable
+                __syncwarp();
+            }
+
+            uint64_t* fifoEntry = fifoBase + fifoEntryIndex * (HELIX_FIFO_ENTRY_BYTES / sizeof(uint64_t));
+            while (loaded128ByteCount < singleProtoTransfer128ByteCount)
+            {
+                startWorkspaceG2S(shmem, fifoEntry, singleProtoTransfer128ByteCount, fifoEntry128ByteIndexBase,
+                    loaded128ByteCount, &allWarpSmemBar[group], laneId);
+                if (needRelease)
+                {
+                    receiverFifo->tail = tail;
+                    senderFifo->tail = tail;
+                    needRelease = false;
+                }
+                smemBarWait(&allWarpSmemBar[group], &phaseParity);
+                loaded128ByteCount += LL128Proto::template checkDataReceivedInShm<false>(shmem, tail,
+                    singleProtoTransfer128ByteCount, fifoEntry128ByteIndexBase, loaded128ByteCount, laneId);
+            }
+
+            LL128Proto::protoUnpack(
+                shmem, tail, singlePacked128ByteCount, fifoEntry128ByteIndexBase, loaded128ByteCount, laneId);
+
+            // note: fields are already unpacked in shared memory
+            s2gAllFields<ALLOW_VARIABLE_FIELD1>(params.recvFields, dataIndex, shmem, laneId);
+            // wait for data to be read from shared memory
+            cp_async_bulk_wait_group_read<0>();
+
+            // note: LL128Proto doesn't need rearm
+            // rearmFifoBuffer();
+            fifoEntry128ByteIndexBase += singleProtoTransfer128ByteCount;
+        }
+        if (fifoEntry128ByteIndexBase > 0)
+        {
+            tail++;
+            receiverFifo->tail = tail;
+            senderFifo->tail = tail;
+        }
+    }
+}
+
+// ============================================================================
+// Compute actual channel count
+// ============================================================================
+
+struct hash_cache_key
+{
+    size_t operator()(std::tuple<int, int, int> const& x) const
+    {
+        return std::get<0>(x) ^ std::get<1>(x) ^ std::get<2>(x);
+    }
+};
+
+template <bool ALLOW_VARIABLE_FIELD1>
+std::tuple<int, int, int> computeChannelAndGroupCount(int cpSize, HelixFieldInfo const* fields)
+{
+    static std::unordered_map<std::tuple<int, int, int>, std::tuple<int, int, int>, hash_cache_key> cache;
+    int deviceId = 0;
+    TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
+    int singleShmSize = std::max(computeTotalUnpackedSize(fields), computeProtoTransferSize(fields));
+    auto key = std::make_tuple(deviceId, cpSize, singleShmSize);
+    auto it = cache.find(key);
+    if (it != cache.end())
+    {
+        return it->second;
+    }
+
+    int maxGroupCountPerCta = std::min(cpSize, MAX_GROUP_COUNT_PER_BLOCK);
+    int groupCountPerCta = maxGroupCountPerCta; // Start with max
+    int totalDynamicShmemSize = singleShmSize * groupCountPerCta;
+    int maxDynamicShmSize = 0;
+    TLLM_CUDA_CHECK(cudaDeviceGetAttribute(&maxDynamicShmSize, cudaDevAttrMaxSharedMemoryPerBlockOptin, deviceId));
+
+    while (totalDynamicShmemSize > maxDynamicShmSize)
+    {
+        groupCountPerCta--;
+        totalDynamicShmemSize = singleShmSize * groupCountPerCta;
+    }
+
+    TLLM_CHECK_WITH_INFO(totalDynamicShmemSize <= maxDynamicShmSize, "Single packed size %d exceeds limit %d",
+        singleShmSize, maxDynamicShmSize);
+
+    // Set shared memory attribute if needed
+    if (totalDynamicShmemSize > 48 * 1024)
+    {
+        TLLM_CUDA_CHECK(cudaFuncSetAttribute(helixAllToAllKernel<ALLOW_VARIABLE_FIELD1>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, totalDynamicShmemSize));
+    }
+
+    int blockCountPerChannel = ceil_div(cpSize, groupCountPerCta);
+    blockCountPerChannel *= 2; // for send and recv
+
+    int smCount = 0;
+    TLLM_CUDA_CHECK(cudaDeviceGetAttribute(&smCount, cudaDevAttrMultiProcessorCount, deviceId));
+    // TODO: we might only want to use half the SMs to overlap with other kernels.
+    // note that overlap with FMHA is almost impossible because it must use
+    // all SMs and probably uses >50% shmem per SM.
+    // overlap with the subsequent BMM / out proj GEMMs might be possible,
+    // so we need experiments to see whether it makes sense.
+    int channelCount = std::max(smCount / blockCountPerChannel, 1);
+    auto value = std::make_tuple(channelCount, groupCountPerCta, totalDynamicShmemSize);
+    cache[key] = value;
+    return value;
+}
+
+// ============================================================================
+// Host Launch Function
+// ============================================================================
+
+template <bool ALLOW_VARIABLE_FIELD1>
+void launchHelixAllToAllImpl(HelixAllToAllParams const& params, cudaStream_t stream)
+{
+    int maxChannelCount = computeHelixMaxChannelCount(params.cpSize);
+    TLLM_CHECK_WITH_INFO(params.maxChannelCount == maxChannelCount,
+        "maxChannelCount %d does not match computed maxChannelCount %d", params.maxChannelCount, maxChannelCount);
+    auto [channelCount, groupCountPerCta, totalDynamicShmemSize]
+        = computeChannelAndGroupCount<ALLOW_VARIABLE_FIELD1>(params.cpSize, params.sendFields);
+    if (params.channelCount > 0)
+    {
+        channelCount = params.channelCount;
+        TLLM_CHECK_WITH_INFO(channelCount <= maxChannelCount, "channelCount %d exceeds maxChannelCount %d",
+            channelCount, maxChannelCount);
+    }
+
+    // Compute grid dimensions
+    // grid.x = blocks per channel (how many blocks needed to cover all peer
+    // ranks) grid.y = number of channels (parallel channels) grid.z = 2 (sender
+    // and receiver)
+    int ctaPerChannel = ceil_div(params.cpSize, groupCountPerCta);
+
+    auto* kernel_instance = &helixAllToAllKernel<ALLOW_VARIABLE_FIELD1>;
+    cudaLaunchConfig_t config;
+    config.gridDim = dim3(ctaPerChannel, channelCount, 2);
+    config.blockDim = dim3(WARP_SIZE, groupCountPerCta);
+    config.dynamicSmemBytes = totalDynamicShmemSize;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, kernel_instance, params));
+}
+
+void launchHelixAllToAll(HelixAllToAllParams const& params, bool allowVariableField1, cudaStream_t stream)
+{
+    if (allowVariableField1)
+    {
+        launchHelixAllToAllImpl<true>(params, stream);
+    }
+    else
+    {
+        launchHelixAllToAllImpl<false>(params, stream);
+    }
+}
+
+// ============================================================================
+// Workspace Initialization
+// ============================================================================
+
+void initializeHelixWorkspace(uint64_t* local_workspace_ptr, int cpSize, cudaStream_t stream)
+{
+    int maxChannelCount = computeHelixMaxChannelCount(cpSize);
+    // Calculate sizes with channel dimension
+    size_t fifoSize = static_cast<size_t>(HELIX_FIFO_TOTAL_BYTES) * cpSize * maxChannelCount;
+    size_t senderInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+    size_t receiverInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+
+    // Initialize FIFO buffers to 0xFFFFFFFF (-1 for signed integer types)
+    TLLM_CUDA_CHECK(cudaMemsetAsync(local_workspace_ptr, 0xFF, fifoSize, stream));
+
+    // Initialize sender and receiver info to zero (single call for both)
+    uint8_t* infoPtr = reinterpret_cast<uint8_t*>(local_workspace_ptr) + fifoSize;
+    TLLM_CUDA_CHECK(cudaMemsetAsync(infoPtr, 0, senderInfoSize + receiverInfoSize, stream));
+}
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/helixAllToAll.h
+++ b/cpp/tensorrt_llm/kernels/helixAllToAll.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/moeCommKernelsCommon.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// ============================================================================
+// Helix-specific FIFO constants
+// Note: Helix uses 128KB FIFO entries vs 256KB in FusedMoe
+// ============================================================================
+
+constexpr int HELIX_FIFO_DEPTH = 4;
+constexpr int HELIX_FIFO_ENTRY_BYTES = 128 * 1024;
+constexpr int HELIX_FIFO_ENTRY_128B_COUNT = HELIX_FIFO_ENTRY_BYTES / BYTES_PER_128B_BLOCK;
+constexpr int HELIX_FIFO_TOTAL_BYTES = HELIX_FIFO_ENTRY_BYTES * HELIX_FIFO_DEPTH;
+constexpr int HELIX_FIFO_TOTAL_U64 = HELIX_FIFO_TOTAL_BYTES / sizeof(uint64_t);
+
+// Backward compatibility aliases (reference common constants from moeCommKernelsCommon.h)
+// WARP_SIZE, WARP_MASK, BYTES_PER_128B_BLOCK, UINT64_PER_128B_BLOCK, MAX_GROUP_COUNT_PER_BLOCK
+// are now defined in moeCommKernelsCommon.h
+
+// ============================================================================
+// Structure declarations and definitions
+// ============================================================================
+
+struct HelixPairInfo
+{
+    int senderRank;
+    int receiverRank;
+    int channel;
+    int runChannelCount;
+};
+
+// ALIGN_256 is defined in moeCommKernelsCommon.h
+
+struct ALIGN_256 FifoInfo
+{
+    volatile int64_t head;
+    volatile int64_t tail;
+};
+
+struct HelixFieldInfo
+{
+    uint8_t* dataPtr;
+    int elementCount; // Number of elements (e.g., kv_lora_rank for field 0, 1 for
+                      // field 1)
+    int elementSize;  // Size of each element in bytes (2 for half, 8 for float2)
+    int stride;       // Stride between rows in bytes
+};
+
+struct HelixAllToAllParams
+{
+    HelixFieldInfo sendFields[2];
+    HelixFieldInfo recvFields[2];
+    int entryCount; // Number of entries per peer rank to process
+    uint64_t* workspace;
+    int workspaceStrideInU64;
+    int cpRank;
+    int cpSize;
+    int channelCount; // use 0 to auto-compute
+    int maxChannelCount;
+};
+
+// ============================================================================
+// Utility Functions
+// ceil_div and align_up are now defined in moeCommKernelsCommon.h
+// ============================================================================
+
+// ============================================================================
+// Workspace Management Functions
+// ============================================================================
+
+/**
+ * Compute number of channels for communication based on cpSize.
+ *
+ * @param cpSize Number of context parallel ranks
+ * @param smCount Number of SMs available (0 = auto-detect)
+ * @return Number of channels to use
+ */
+inline int computeHelixMaxChannelCount(int cpSize, int smCount = 0)
+{
+    if (smCount == 0)
+    {
+        int deviceId = 0;
+        TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
+        TLLM_CUDA_CHECK(cudaDeviceGetAttribute(&smCount, cudaDevAttrMultiProcessorCount, deviceId));
+    }
+
+    int blockCountPerChannel = ceil_div(cpSize, MAX_GROUP_COUNT_PER_BLOCK);
+    blockCountPerChannel *= 2; // for send and recv
+
+    int preferredChannel = smCount / blockCountPerChannel;
+    return std::max(preferredChannel, 1); // at least one channel
+}
+
+/**
+ * Compute the workspace size required per rank for the all-to-all operation.
+ *
+ * @param cpSize Number of context parallel ranks
+ * @return Size in bytes
+ */
+inline size_t computeHelixWorkspaceSizePerRank(int cpSize)
+{
+    static int maxChannelCount = 0;
+    if (maxChannelCount == 0)
+    {
+        maxChannelCount = computeHelixMaxChannelCount(cpSize);
+    }
+
+    // FIFO buffers: cpSize * channelCount pairs
+    size_t fifoSize = static_cast<size_t>(HELIX_FIFO_TOTAL_BYTES) * cpSize * maxChannelCount;
+
+    // Sender and receiver FIFO info structures
+    size_t senderInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+    size_t receiverInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+
+    return fifoSize + senderInfoSize + receiverInfoSize;
+}
+
+/**
+ * Initialize workspace memory for a given rank.
+ * Should be called once during setup.
+ *
+ * @param workspace Pointer to workspace memory (per-rank view)
+ * @param cpSize Number of context parallel ranks
+ * @param stream CUDA stream for asynchronous operations
+ */
+void initializeHelixWorkspace(uint64_t* workspace, int cpSize, cudaStream_t stream);
+
+/**
+ * Launch the helix all-to-all kernel.
+ *
+ * @param params Kernel parameters including field info and workspace
+ * @param allowVariableField1 Whether to allow variable field 1
+ * @param stream CUDA stream for kernel launch
+ */
+void launchHelixAllToAll(HelixAllToAllParams const& params, bool allowVariableField1, cudaStream_t stream);
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/helixKernels.cu
+++ b/cpp/tensorrt_llm/kernels/helixKernels.cu
@@ -239,5 +239,189 @@ void helixPostProcess(HelixPostProcParams<T> const& params, cudaStream_t stream)
 INSTANTIATE_POST_PROC(__half);
 INSTANTIATE_POST_PROC(__nv_bfloat16);
 
+static constexpr int MAX_THREADS = 256;
+static constexpr int MAX_KV_LORA_BYTES = (MAX_THREADS - WARP_SIZE) * BYTES_O_PER_THREAD;
+
+// Kernel: fused helix post-processing
+// output: [num_tokens, num_heads * kv_lora_rank] (half)
+// gathered_o: [num_tokens, num_heads, cp_size, kv_lora_rank] (half)
+// gathered_stats: [num_tokens, num_heads, cp_size, 2] (fp32)
+// note: we explicitly avoid using restrict here, to avoid getting ld.global.nc
+// which may have longer latency
+template <typename T>
+__global__ void __launch_bounds__(MAX_THREADS) helix_postprocess_kernel_native(
+    T* output, T const* gathered_o, float2 const* gathered_stats, int cp_size, int kv_lora_rank)
+{
+    // Each block processes one (token, head)
+    // gridDim.x: num_tokens, gridDim.y: num_heads
+    // there are two separate types of warps:
+    // warp 0 calculates the correction values (one per cp_size)
+    // all other warps pre-load the gathered_o elements for the current token/head
+    // and once warp 0 is done, all other warps can start accumulating the output
+    static constexpr int NUM_O_PER_THREAD = BYTES_O_PER_THREAD / sizeof(T);
+
+    int tok_idx = blockIdx.x;
+    int head_idx = blockIdx.y;
+    int num_tokens = gridDim.x;
+    int num_heads = gridDim.y;
+
+    int const cp_size_aligned = ((cp_size + NUM_PRE_LOAD - 1) / NUM_PRE_LOAD) * NUM_PRE_LOAD;
+    __shared__ float smem_correction[MAX_CP];
+
+    int lane_idx = threadIdx.x % WARP_SIZE;
+    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / WARP_SIZE, 0);
+
+    // all warps except first pre-load the gathered_o elements for the current
+    // token/head
+    T const* gathered_o_off;
+    gathered_o_off = gathered_o + tok_idx * num_heads * cp_size * kv_lora_rank + head_idx * cp_size * kv_lora_rank;
+    // we subtract WARP_SIZE because first warp is not participating in pre-load
+    gathered_o_off += (threadIdx.x - WARP_SIZE) * NUM_O_PER_THREAD;
+    float4 const* gathered_o_16b = reinterpret_cast<float4 const*>(gathered_o_off);
+    int gathered_16b_stride = (kv_lora_rank) / NUM_O_PER_THREAD;
+    int stats_offset = tok_idx * num_heads * cp_size + head_idx * cp_size;
+    int stats_stride = 1;
+
+    // here we have to wait for memory operations of the previous kernel to
+    // complete
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaGridDependencySynchronize();
+#endif
+
+    float max_values[MAX_CP_VAL_PER_THREAD];
+    float sum_values[MAX_CP_VAL_PER_THREAD];
+    T vals[NUM_PRE_LOAD][NUM_O_PER_THREAD];
+    float final_sum[NUM_O_PER_THREAD];
+    float corr_vals[NUM_PRE_LOAD];
+    T output_typed[NUM_O_PER_THREAD];
+
+    if (warp_idx == 0)
+    {
+        // the warp collectively calculates the correction values
+#pragma unroll
+        for (int cp_val_idx = 0; cp_val_idx < MAX_CP_VAL_PER_THREAD; ++cp_val_idx)
+        {
+            auto cp_idx = cp_val_idx * WARP_SIZE + lane_idx;
+            auto stats_idx = stats_offset + cp_idx * stats_stride;
+            float2 stats = cp_idx < cp_size ? gathered_stats[stats_idx] : make_float2(-INFINITY, 0.F);
+            max_values[cp_val_idx] = stats.x;
+            sum_values[cp_val_idx] = stats.y;
+        }
+        float corrected_values[MAX_CP_VAL_PER_THREAD];
+        warpReduceCorrectedSum(corrected_values, max_values, sum_values);
+#pragma unroll
+        for (int cp_val_idx = 0; cp_val_idx < MAX_CP_VAL_PER_THREAD; ++cp_val_idx)
+        {
+            auto cp_idx = cp_val_idx * WARP_SIZE + lane_idx;
+            smem_correction[cp_idx] = corrected_values[cp_val_idx];
+        }
+    }
+    else
+    {
+        // all other warps pre-load the gathered_o elements
+#pragma unroll
+        for (int cp_idx = 0; cp_idx < NUM_PRE_LOAD && cp_idx < cp_size; ++cp_idx)
+        {
+            auto val = gathered_o_16b[cp_idx * gathered_16b_stride];
+            *reinterpret_cast<float4*>(vals[cp_idx]) = val;
+        }
+#pragma unroll
+        for (int o_idx = 0; o_idx < NUM_O_PER_THREAD; ++o_idx)
+        {
+            final_sum[o_idx] = 0.F;
+        }
+    }
+    __syncthreads();
+
+    // warp 0 exits early
+    if (warp_idx == 0)
+        return;
+
+        // here we can trigger the dependent kernels to start
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+#pragma unroll
+    for (int cp_idx = 0; cp_idx < NUM_PRE_LOAD && cp_idx < cp_size; ++cp_idx)
+    {
+        corr_vals[cp_idx] = smem_correction[cp_idx];
+    }
+
+    for (int cp_idx_base = NUM_PRE_LOAD; cp_idx_base < cp_size_aligned; cp_idx_base += NUM_PRE_LOAD)
+    {
+#pragma unroll
+        for (int cp_idx = 0; cp_idx < NUM_PRE_LOAD; ++cp_idx)
+        {
+#pragma unroll
+            for (int o_idx = 0; o_idx < NUM_O_PER_THREAD; ++o_idx)
+            {
+                final_sum[o_idx] += static_cast<float>(vals[cp_idx][o_idx]) * corr_vals[cp_idx];
+            }
+        }
+#pragma unroll
+        for (int cp_idx = 0; cp_idx < NUM_PRE_LOAD; ++cp_idx)
+        {
+            *reinterpret_cast<float4*>(vals[cp_idx]) = cp_idx_base + cp_idx < cp_size
+                ? gathered_o_16b[(cp_idx_base + cp_idx) * gathered_16b_stride]
+                : make_float4(0.F, 0.F, 0.F, 0.F);
+            corr_vals[cp_idx] = cp_idx_base + cp_idx < cp_size ? smem_correction[cp_idx_base + cp_idx] : 0.F;
+        }
+    }
+#pragma unroll
+    for (int cp_idx = 0; cp_idx < NUM_PRE_LOAD && cp_idx < cp_size; ++cp_idx)
+    {
+#pragma unroll
+        for (int o_idx = 0; o_idx < NUM_O_PER_THREAD; ++o_idx)
+        {
+            final_sum[o_idx] += static_cast<float>(vals[cp_idx][o_idx]) * corr_vals[cp_idx];
+        }
+    }
+#pragma unroll
+    for (int o_idx = 0; o_idx < NUM_O_PER_THREAD; ++o_idx)
+    {
+        output_typed[o_idx] = static_cast<T>(final_sum[o_idx]);
+    }
+    auto* output_off = output + tok_idx * num_heads * kv_lora_rank + head_idx * kv_lora_rank;
+    output_off += (threadIdx.x - WARP_SIZE) * NUM_O_PER_THREAD;
+    *reinterpret_cast<float4*>(output_off) = *reinterpret_cast<float4*>(output_typed);
+}
+
+template <typename T>
+void helixPostProcessNative(HelixPostProcParams<T> const& params, cudaStream_t stream)
+{
+    // Check that gathered_o is 16-byte aligned
+    TLLM_CHECK_WITH_INFO(reinterpret_cast<uintptr_t>(params.gathered_o) % 16 == 0,
+        "gathered_o must be 16-byte aligned for async memcpy");
+    // TODO: Figure why this constraint is specific to this implementation and not legacy one.
+    TLLM_CHECK_WITH_INFO((params.kv_lora_rank * sizeof(T)) <= MAX_KV_LORA_BYTES,
+        "kv_lora_rank * sizeof(T) must be <= ", MAX_KV_LORA_BYTES, " bytes");
+    // Check that kv_lora_rank * sizeof(T) is a multiple of 16
+    TLLM_CHECK_WITH_INFO((params.kv_lora_rank * sizeof(T)) % 16 == 0,
+        "kv_lora_rank * sizeof(T) must be a multiple of 16 for async memcpy");
+    // Check that cp_size is not larger than the max fallback CP size
+    TLLM_CHECK_WITH_INFO(params.cp_size <= MAX_CP, "cp_size > fallback max CP size");
+
+    auto kernel_instance = helix_postprocess_kernel_native<T>;
+    cudaLaunchConfig_t config;
+    config.gridDim = dim3(params.num_tokens, params.num_heads);
+    config.blockDim = WARP_SIZE + params.kv_lora_rank * sizeof(T) / 16;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, kernel_instance, params.output, params.gathered_o,
+        params.gathered_stats, params.cp_size, params.kv_lora_rank));
+}
+
+#define INSTANTIATE_POST_PROC_NATIVE(T)                                                                                \
+    template void helixPostProcessNative<T>(HelixPostProcParams<T> const& params, cudaStream_t stream);
+
+INSTANTIATE_POST_PROC_NATIVE(__half);
+INSTANTIATE_POST_PROC_NATIVE(__nv_bfloat16);
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/helixKernels.h
+++ b/cpp/tensorrt_llm/kernels/helixKernels.h
@@ -42,5 +42,8 @@ struct HelixPostProcParams
 template <typename T>
 void helixPostProcess(HelixPostProcParams<T> const& params, cudaStream_t stream);
 
+template <typename T>
+void helixPostProcessNative(HelixPostProcParams<T> const& params, cudaStream_t stream);
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/ll128Proto.cuh
+++ b/cpp/tensorrt_llm/kernels/ll128Proto.cuh
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "tensorrt_llm/kernels/moeCommKernelsCommon.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+class LL128Proto
+{
+public:
+    static constexpr uint32_t INITIALIZED_VALUE = 0xFFFFFFFFU;
+
+    template <bool USE_FINISH>
+    static __device__ __forceinline__ int checkDataReceivedInShm(uint8_t* sharedMemoryBase, uint64_t step,
+        int countIn128Bytes, int fifoEntry128ByteIndexBase, int loaded128ByteCount, int laneId)
+    {
+        // return value should be how many package already been received.
+        // 0 means no data received, -1 means has received finish package(should be the very first 128 Byte).
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int totalValidCount = 0;
+        for (int idxBase = loaded128ByteCount; idxBase < countIn128Bytes; idxBase += WARP_SIZE)
+        {
+            int idx = idxBase + laneId;
+            bool valid = false;
+            bool finish = false;
+            if (idx < countIn128Bytes)
+            {
+                int indexInFifoEntry = fifoEntry128ByteIndexBase + idx;
+                uint64_t value
+                    = aligned128BytesShm[idx * UINT64_PER_128B_BLOCK + indexInFifoEntry % UINT64_PER_128B_BLOCK];
+                if (USE_FINISH)
+                {
+                    finish = (value == (step & (1ULL << 63ULL)));
+                    valid = (value == step) || finish;
+                }
+                else
+                {
+                    valid = (value == step);
+                }
+            }
+            __syncwarp();
+            unsigned validMask = __ballot_sync(WARP_MASK, valid);
+            // here we check valid in order, if previous valid is not true, we ignore the current valid.
+            int validCount = (validMask == WARP_MASK) ? WARP_SIZE : (__ffs(~validMask) - 1);
+            if (USE_FINISH)
+            {
+                unsigned finishedMask = __ballot_sync(WARP_MASK, finish);
+                // finish should be the very first 128 Byte.
+                if (finishedMask & 0x1)
+                {
+                    return -1;
+                }
+            }
+            totalValidCount += validCount;
+
+            if (validCount != WARP_SIZE)
+            {
+                break;
+            }
+        }
+        return totalValidCount;
+    }
+
+    static __device__ __forceinline__ void protoPack(
+        uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes, int fifoEntry128ByteIndexBase, int laneId)
+    {
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int halfLaneId = laneId % 16;
+        int halfIndex = laneId / 16;
+        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
+        // for LL128 15 * 128 Bytes will be packed to 16 * 128 Bytes, each 16 threads is used for one 15 * 128 bytes.
+        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
+        {
+            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
+            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % UINT64_PER_128B_BLOCK;
+            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
+            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
+            uint64_t tailValue = step;
+            uint64_t tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
+            if (halfLaneId == 15)
+            {
+                tailInnerIndex = tailFlagInnerIndex;
+            }
+            int targetTailIndex = tailOffsetIn128Bytes * UINT64_PER_128B_BLOCK + tailInnerIndex;
+            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
+            {
+                int flagIndex = idxIn128Bytes * UINT64_PER_128B_BLOCK + idxFromFifoEntry % UINT64_PER_128B_BLOCK;
+                tailValue = aligned128BytesShm[flagIndex];
+                aligned128BytesShm[flagIndex] = step;
+            }
+            aligned128BytesShm[targetTailIndex] = tailValue;
+            tailOffsetIn128Bytes += 2;
+        }
+        __syncwarp();
+    }
+
+    static __device__ __forceinline__ void protoUnpack(uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes,
+        int fifoEntry128ByteIndexBase, int loaded128ByteCount, int laneId)
+    {
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int halfLaneId = laneId % 16;
+        int halfIndex = laneId / 16;
+        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
+        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
+        {
+            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
+            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % UINT64_PER_128B_BLOCK;
+            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
+            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
+            uint64_t tailValue = 0;
+            int tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
+            int targetTailIndex = tailOffsetIn128Bytes * UINT64_PER_128B_BLOCK + tailInnerIndex;
+            if (halfLaneId < 15)
+            {
+                tailValue = aligned128BytesShm[targetTailIndex];
+            }
+            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
+            {
+                int flagIndex = idxIn128Bytes * UINT64_PER_128B_BLOCK + idxFromFifoEntry % UINT64_PER_128B_BLOCK;
+                aligned128BytesShm[flagIndex] = tailValue;
+            }
+            tailOffsetIn128Bytes += 2;
+        }
+        __syncwarp();
+    }
+
+    static __device__ __forceinline__ void rearm(
+        uint32_t* u32FifoPtr, uint64_t step, int countIn128Bytes, int fifoEntry128ByteIndexBase, int laneId)
+    {
+        // LL128 don't need rearm
+    }
+
+    static __device__ __host__ __forceinline__ int computeProtoTransfer128ByteAlignedSize(
+        int compact128ByteSizeBeforeProto)
+    {
+        // each 15 * 128 byte need one tail 128 byte
+        int tail128ByteSize = (compact128ByteSizeBeforeProto + 15 * 128 - 1) / (15 * 128) * 128;
+        return compact128ByteSizeBeforeProto + tail128ByteSize;
+    }
+};
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/moeCommKernelsCommon.h
+++ b/cpp/tensorrt_llm/kernels/moeCommKernelsCommon.h
@@ -22,14 +22,71 @@ namespace tensorrt_llm
 namespace kernels
 {
 
+// ============================================================================
+// Alignment Macro
+// ============================================================================
+
 #ifdef __CUDACC__
 #define ALIGN_256 __align__(256)
 #else
 #define ALIGN_256 alignas(256)
 #endif
 
+// ============================================================================
+// Warp Constants
+// ============================================================================
+
 constexpr int WARP_SIZE = 32;
 constexpr uint32_t WARP_MASK = 0xffffffff;
+
+// ============================================================================
+// Memory Block Constants
+// ============================================================================
+
+// Size of a 128-byte aligned block (used for bulk async copies)
+constexpr int BYTES_PER_128B_BLOCK = 128;
+
+// Size of a 16-byte aligned block (used for field alignment)
+constexpr int BYTES_PER_16B_BLOCK = 16;
+
+// Number of int elements per 128-byte block
+constexpr int INTS_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(int);
+
+// Number of uint64_t elements per 128-byte block
+constexpr int UINT64_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(uint64_t);
+
+// ============================================================================
+// Block Organization Constants
+// ============================================================================
+
+// Maximum number of groups (warps) per CTA for MoE communication kernels
+constexpr int MAX_GROUP_COUNT_PER_BLOCK = 8;
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Ceiling division: compute ceil(a / b) for integers
+ */
+template <typename T>
+inline constexpr T ceil_div(T a, T b)
+{
+    return (a + b - 1) / b;
+}
+
+/**
+ * Align value up to nearest multiple of alignment
+ */
+template <typename T>
+inline constexpr T align_up(T value, T alignment)
+{
+    return ceil_div(value, alignment) * alignment;
+}
+
+// ============================================================================
+// MoE Parallel Info Structures
+// ============================================================================
 
 struct MoeEpWorldInfo
 {

--- a/cpp/tensorrt_llm/thop/alltoallOp.cpp
+++ b/cpp/tensorrt_llm/thop/alltoallOp.cpp
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
+#include "alltoallOp.h"
 #include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include "thUtils.h"
 
 #include <NvInferRuntime.h>
 #include <c10/cuda/CUDAStream.h>
@@ -117,14 +119,171 @@ std::vector<torch::Tensor> alltoall_helix(
 #endif // ENABLE_MULTI_DEVICE
 }
 
+/**
+ * Helix All-to-All operation with two fields.
+ *
+ * Input tensors have shape [..., cp_size, kv_lora_rank] for field0 and [...,
+ * cp_size, 2] for field1. The operation exchanges data along the cp_size
+ * dimension across all ranks.
+ *
+ * @param field0 Field 0 tensor (half precision, shape [..., cp_size,
+ * kv_lora_rank])
+ * @param field1 Field 1 tensor (float32, shape [..., cp_size, 2])
+ * @param workspace Workspace tensor (uint64, strided across ranks)
+ * @param cp_rank Current context parallel rank
+ * @param cp_size Total number of context parallel ranks
+ * @return tuple of (field0_out, field1_out) with same shapes as inputs
+ */
+std::tuple<torch::Tensor, torch::Tensor> helixAllToAllNative(
+    torch::Tensor field0, torch::Tensor field1, torch::Tensor workspace, int64_t cp_rank, int64_t cp_size)
+{
+
+    // Input validation
+    CHECK_TH_CUDA(field0);
+    CHECK_TH_CUDA(field1);
+    CHECK_TH_CUDA(workspace);
+    CHECK_CONTIGUOUS(field0);
+    CHECK_CONTIGUOUS(field1);
+
+    // Type checks
+    TORCH_CHECK(field0.scalar_type() == at::ScalarType::Half || field0.scalar_type() == at::ScalarType::BFloat16,
+        "field0 must be half or bfloat16");
+    CHECK_TYPE(field1, at::ScalarType::Float);
+    CHECK_TYPE(workspace, at::ScalarType::UInt64);
+
+    // Shape validation
+    TORCH_CHECK(field0.dim() >= 2, "field0 must have at least 2 dimensions");
+    TORCH_CHECK(field1.dim() >= 2, "field1 must have at least 2 dimensions");
+    TORCH_CHECK(field0.dim() == field1.dim(), "field0 and field1 must have same number of dimensions");
+
+    // Get dimensions
+    int kv_lora_rank = field0.size(-1);
+    TORCH_CHECK(field0.size(-2) == cp_size && field1.size(-2) == cp_size,
+        "field0/1 second-to-last dimension must equal cp_size");
+    TORCH_CHECK(
+        field1.size(-1) % 2 == 0 && field1.size(-1) >= 2, "field1 last dimension must be divisible by 2 (float2)");
+    bool allowVariableField1 = field1.size(-1) > 2;
+
+    // Check that leading dimensions match
+    for (int i = 0; i < field0.dim() - 2; i++)
+    {
+        TORCH_CHECK(
+            field0.size(i) == field1.size(i), "field0 and field1 must have matching dimensions except last two");
+    }
+    TORCH_CHECK(field0.size(-1) * field0.element_size() % 16 == 0, "field0 must be aligned to 16 bytes");
+
+    TORCH_CHECK(workspace.dim() == 2, "workspace must be 2D (strided across ranks)");
+    TORCH_CHECK(workspace.size(0) == cp_size, "workspace must have cp_size rows");
+
+    // Calculate entry count (product of all dimensions before cp_size)
+    // This is the number of entries to process per peer rank
+    int entry_count = 1;
+    for (int i = 0; i < field0.dim() - 2; i++)
+    {
+        entry_count *= field0.size(i);
+    }
+
+    // Reshape to 3D: [entry_count, cp_size, feature_dim]
+    torch::Tensor field0_3d = field0.reshape({entry_count, cp_size, kv_lora_rank});
+    torch::Tensor field1_3d = field1.reshape({entry_count, cp_size, field1.size(-1)});
+
+    // Allocate output tensors (same shape as input)
+    torch::Tensor field0_out = torch::empty_like(field0);
+    torch::Tensor field1_out = torch::empty_like(field1);
+
+    torch::Tensor field0_out_3d = field0_out.reshape({entry_count, cp_size, kv_lora_rank});
+    torch::Tensor field1_out_3d = field1_out.reshape({entry_count, cp_size, field1.size(-1)});
+
+    // Setup parameters
+    tensorrt_llm::kernels::HelixAllToAllParams params;
+
+    // Field 0 (variable size half)
+    params.sendFields[0].dataPtr = reinterpret_cast<uint8_t*>(field0_3d.data_ptr());
+    params.sendFields[0].elementCount = kv_lora_rank;
+    params.sendFields[0].elementSize = field0.element_size();
+    params.sendFields[0].stride = field0_3d.stride(1) * field0.element_size();
+
+    params.recvFields[0].dataPtr = reinterpret_cast<uint8_t*>(field0_out_3d.data_ptr());
+    params.recvFields[0].elementCount = kv_lora_rank;
+    params.recvFields[0].elementSize = field0.element_size();
+    params.recvFields[0].stride = field0_out_3d.stride(1) * field0.element_size();
+
+    // Field 1 (single float2)
+    params.sendFields[1].dataPtr = reinterpret_cast<uint8_t*>(field1_3d.data_ptr<float>());
+    params.sendFields[1].elementCount = field1.size(-1);
+    params.sendFields[1].elementSize = field1.element_size();
+    params.sendFields[1].stride = field1_3d.stride(1) * field1.element_size();
+
+    params.recvFields[1].dataPtr = reinterpret_cast<uint8_t*>(field1_out_3d.data_ptr<float>());
+    params.recvFields[1].elementCount = field1.size(-1);
+    params.recvFields[1].elementSize = field1.element_size();
+    params.recvFields[1].stride = field1_out_3d.stride(1) * field1.element_size();
+
+    // Entry count and workspace
+    params.entryCount = entry_count;
+    params.workspace = workspace.data_ptr<uint64_t>();
+    params.workspaceStrideInU64 = workspace.stride(0);
+
+    // CP info
+    params.cpRank = cp_rank;
+    params.cpSize = cp_size;
+    params.channelCount = 0; // auto-compute
+    params.maxChannelCount = tensorrt_llm::kernels::computeHelixMaxChannelCount(cp_size);
+
+    // Launch kernel
+    auto stream = at::cuda::getCurrentCUDAStream();
+    tensorrt_llm::kernels::launchHelixAllToAll(params, allowVariableField1, stream);
+
+    return std::make_tuple(field0_out, field1_out);
+}
+
+/**
+ * Get workspace size per rank in bytes.
+ * Use dummy tensor argument to allow using torch.ops
+ */
+int64_t getHelixWorkspaceSizePerRank(torch::Tensor __dummy__, int64_t cp_size)
+{
+    return tensorrt_llm::kernels::computeHelixWorkspaceSizePerRank(cp_size);
+}
+
+/**
+ * Initialize workspace for helix all-to-all
+ */
+void initializeHelixWorkspace(torch::Tensor workspace, int64_t cp_rank, int64_t cp_size)
+{
+    CHECK_TH_CUDA(workspace);
+    CHECK_TYPE(workspace, at::ScalarType::UInt64);
+    TORCH_CHECK(workspace.dim() == 2, "workspace must be 2D");
+    TORCH_CHECK(workspace.size(0) == cp_size, "workspace must have cp_size rows");
+    TORCH_CHECK(cp_rank >= 0 && cp_rank < cp_size, "cp_rank must be in [0, cp_size)");
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+    uint64_t* global_workspace_ptr = workspace.data_ptr<uint64_t>();
+    uint64_t* local_workspace_ptr = workspace[cp_rank].data_ptr<uint64_t>();
+    TORCH_CHECK(local_workspace_ptr == global_workspace_ptr + cp_rank * workspace.stride(0),
+        "local_workspace_ptr must be at the correct offset in the global "
+        "workspace");
+    tensorrt_llm::kernels::initializeHelixWorkspace(local_workspace_ptr, cp_size, stream);
+}
+
 } // namespace torch_ext
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def("alltoall_helix(Tensor[] input_list, int[] group, int? num_lists) -> Tensor[]");
+    m.def(
+        "helixAllToAllNative(Tensor field0, Tensor field1, Tensor workspace, int "
+        "cp_rank, int cp_size) -> (Tensor, Tensor)");
+    m.def("getHelixWorkspaceSizePerRank(Tensor __dummy__, int cp_size) -> int");
+    m.def(
+        "initializeHelixWorkspace(Tensor workspace, int cp_rank, int cp_size) "
+        "-> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("alltoall_helix", &torch_ext::alltoall_helix);
+    m.impl("helixAllToAllNative", &torch_ext::helixAllToAllNative);
+    m.impl("getHelixWorkspaceSizePerRank", &torch_ext::getHelixWorkspaceSizePerRank);
+    m.impl("initializeHelixWorkspace", &torch_ext::initializeHelixWorkspace);
 }

--- a/cpp/tensorrt_llm/thop/alltoallOp.h
+++ b/cpp/tensorrt_llm/thop/alltoallOp.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tensorrt_llm/common/cudaUtils.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// ============================================================================
+// Field and memory constants
+// ============================================================================
+
+constexpr int FIFO_DEPTH = 4;
+constexpr int FIFO_ENTRY_BYTES = 128 * 1024;
+constexpr int FIFO_ENTRY_128B_COUNT = FIFO_ENTRY_BYTES / 128;
+constexpr int FIFO_TOTAL_BYTES = FIFO_ENTRY_BYTES * FIFO_DEPTH;
+constexpr int FIFO_TOTAL_U64 = FIFO_TOTAL_BYTES / sizeof(uint64_t);
+constexpr int BYTES_PER_128B_BLOCK = 128;
+constexpr int UINT64_PER_128B_BLOCK = 16;
+
+// Block organization constants
+constexpr int MAX_GROUP_COUNT_PER_BLOCK = 8; // Max warps per block
+constexpr int WARP_SIZE = 32;
+constexpr uint32_t WARP_MASK = 0xffffffff;
+
+// ============================================================================
+// Structure declarations and definitions
+// ============================================================================
+
+struct HelixPairInfo
+{
+    int senderRank;
+    int receiverRank;
+    int channel;
+    int runChannelCount;
+};
+
+// 256-byte aligned for optimal performance (matches TensorRT-LLM)
+#ifdef __CUDACC__
+#define ALIGN_256 __align__(256)
+#else
+#define ALIGN_256 alignas(256)
+#endif
+
+struct ALIGN_256 FifoInfo
+{
+    volatile int64_t head;
+    volatile int64_t tail;
+};
+
+struct HelixFieldInfo
+{
+    uint8_t* dataPtr;
+    int elementCount; // Number of elements (e.g., kv_lora_rank for field 0, 1 for
+                      // field 1)
+    int elementSize;  // Size of each element in bytes (2 for half, 8 for float2)
+    int stride;       // Stride between rows in bytes
+};
+
+struct HelixAllToAllParams
+{
+    HelixFieldInfo sendFields[2];
+    HelixFieldInfo recvFields[2];
+    int entryCount; // Number of entries per peer rank to process
+    uint64_t* workspace;
+    int workspaceStrideInU64;
+    int cpRank;
+    int cpSize;
+    int channelCount; // use 0 to auto-compute
+    int maxChannelCount;
+};
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Ceiling division: compute ceil(a / b) for integers
+ */
+template <typename T>
+inline constexpr T ceil_div(T a, T b)
+{
+    return (a + b - 1) / b;
+}
+
+/**
+ * Align value up to nearest multiple of alignment
+ */
+template <typename T>
+inline constexpr T align_up(T value, T alignment)
+{
+    return ceil_div(value, alignment) * alignment;
+}
+
+// ============================================================================
+// Workspace Management Functions
+// ============================================================================
+
+/**
+ * Compute number of channels for communication based on cpSize.
+ *
+ * @param cpSize Number of context parallel ranks
+ * @param smCount Number of SMs available (0 = auto-detect)
+ * @return Number of channels to use
+ */
+inline int computeHelixMaxChannelCount(int cpSize, int smCount = 0)
+{
+    if (smCount == 0)
+    {
+        int deviceId = 0;
+        TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
+        TLLM_CUDA_CHECK(cudaDeviceGetAttribute(&smCount, cudaDevAttrMultiProcessorCount, deviceId));
+    }
+
+    int blockCountPerChannel = ceil_div(cpSize, MAX_GROUP_COUNT_PER_BLOCK);
+    blockCountPerChannel *= 2; // for send and recv
+
+    int preferredChannel = smCount / blockCountPerChannel;
+    return std::max(preferredChannel, 1); // at least one channel
+}
+
+/**
+ * Compute the workspace size required per rank for the all-to-all operation.
+ *
+ * @param cpSize Number of context parallel ranks
+ * @return Size in bytes
+ */
+inline size_t computeHelixWorkspaceSizePerRank(int cpSize)
+{
+    static int maxChannelCount = 0;
+    if (maxChannelCount == 0)
+    {
+        maxChannelCount = computeHelixMaxChannelCount(cpSize);
+    }
+
+    // FIFO buffers: cpSize * channelCount pairs
+    size_t fifoSize = static_cast<size_t>(FIFO_TOTAL_BYTES) * cpSize * maxChannelCount;
+
+    // Sender and receiver FIFO info structures
+    size_t senderInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+    size_t receiverInfoSize = sizeof(FifoInfo) * cpSize * maxChannelCount;
+
+    return fifoSize + senderInfoSize + receiverInfoSize;
+}
+
+/**
+ * Initialize workspace memory for a given rank.
+ * Should be called once during setup.
+ *
+ * @param workspace Pointer to workspace memory (per-rank view)
+ * @param cpSize Number of context parallel ranks
+ * @param stream CUDA stream for asynchronous operations
+ */
+void initializeHelixWorkspace(uint64_t* workspace, int cpSize, cudaStream_t stream);
+
+/**
+ * Launch the helix all-to-all kernel.
+ *
+ * @param params Kernel parameters including field info and workspace
+ * @param allowVariableField1 Whether to allow variable field 1
+ * @param stream CUDA stream for kernel launch
+ */
+void launchHelixAllToAll(HelixAllToAllParams const& params, bool allowVariableField1, cudaStream_t stream);
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/helixPostProcessOp.cpp
+++ b/cpp/tensorrt_llm/thop/helixPostProcessOp.cpp
@@ -97,14 +97,107 @@ torch::Tensor helix_post_process(torch::Tensor const& gathered_o, torch::Tensor 
     return output;
 }
 
+template <typename T, typename Fn>
+inline torch::Tensor helix_post_process_native_impl(
+    torch::Tensor const& gathered_o, torch::Tensor const& gathered_stats, double scale, int cp_dim, Fn fn)
+{
+    CHECK_TH_CUDA(gathered_o);
+    CHECK_CONTIGUOUS(gathered_o);
+    CHECK_TH_CUDA(gathered_stats);
+    CHECK_CONTIGUOUS(gathered_stats);
+
+    // Only cp_dim=2 is supported
+    TORCH_CHECK(cp_dim == 2,
+        "cp_dim must be 2. Expects tensor shapes to be: \n"
+        "gathered_o: [num_tokens, num_heads, cp_size, kv_lora_rank], \n"
+        "gathered_stats: [num_tokens, num_heads, cp_size, 2]");
+
+    // For cp_dim=2: tokens_dim=0, heads_dim=1
+    auto tokens_dim = 0;
+    auto heads_dim = 1;
+
+    TORCH_CHECK(gathered_o.dim() == 4, "gathered_o must be 4D tensor [num_tokens, num_heads, cp_size, kv_lora_rank]");
+    TORCH_CHECK(gathered_stats.dim() == 4, "gathered_stats must be 4D tensor [num_tokens, num_heads, cp_size, 2]");
+
+    auto const num_tokens = gathered_stats.sizes()[tokens_dim];
+    auto const num_heads = gathered_stats.sizes()[heads_dim];
+    auto const cp_size = gathered_stats.sizes()[2];
+    auto const kv_lora_rank = gathered_o.sizes()[3];
+
+    // check remaining input tensor dimensions
+    TORCH_CHECK(gathered_o.sizes()[2] == cp_size, "gathered_o cp_size dim must match");
+    TORCH_CHECK(gathered_o.sizes()[tokens_dim] == num_tokens, "gathered_o tokens_dim must match num_tokens");
+    TORCH_CHECK(gathered_o.sizes()[heads_dim] == num_heads, "gathered_o heads_dim must match num_heads");
+
+    TORCH_CHECK(gathered_stats.sizes()[3] == 2, "gathered_stats last dimension must be 2");
+
+    // Check data types
+    TORCH_CHECK(
+        gathered_o.scalar_type() == at::ScalarType::Half || gathered_o.scalar_type() == at::ScalarType::BFloat16,
+        "gathered_o must be half or bfloat16");
+    TORCH_CHECK(gathered_stats.scalar_type() == at::ScalarType::Float, "gathered_stats must be float32");
+
+    // Check alignment requirements for gathered_o (16-byte aligned for async
+    // memcpy)
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(gathered_o.data_ptr()) % 16 == 0, "gathered_o must be 16-byte aligned");
+
+    // Check that kv_lora_rank * sizeof(data_type) is a multiple of 16
+    size_t data_type_size = torch::elementSize(gathered_o.scalar_type());
+    TORCH_CHECK((kv_lora_rank * data_type_size) % 16 == 0, "kv_lora_rank * sizeof(data_type) must be a multiple of 16");
+
+    // Create output tensor
+    std::vector<int64_t> output_shape = {num_tokens, num_heads * kv_lora_rank};
+    torch::Tensor output = torch::empty(output_shape, gathered_o.options());
+
+    // Get CUDA stream
+    auto stream = at::cuda::getCurrentCUDAStream(gathered_o.get_device());
+
+    tensorrt_llm::kernels::HelixPostProcParams<T> params{reinterpret_cast<T*>(output.mutable_data_ptr()),
+        reinterpret_cast<T const*>(gathered_o.data_ptr()), reinterpret_cast<float2 const*>(gathered_stats.data_ptr()),
+        static_cast<int>(cp_size), static_cast<int>(num_tokens), static_cast<int>(num_heads),
+        static_cast<int>(kv_lora_rank)};
+    fn(params, stream);
+
+    if (scale != 1.0)
+    {
+        output *= scale;
+    }
+
+    return output;
+}
+
+inline torch::Tensor helix_post_process_native(
+    torch::Tensor const& gathered_o, torch::Tensor const& gathered_stats, double scale, int64_t cp_dim)
+{
+    TORCH_CHECK(cp_dim == 2, "cp_dim must be 2. Only cp_dim=2 layout is supported.");
+    if (gathered_o.scalar_type() == at::ScalarType::Half)
+    {
+        return helix_post_process_native_impl<__half>(
+            gathered_o, gathered_stats, scale, int(cp_dim), tensorrt_llm::kernels::helixPostProcessNative<__half>);
+    }
+    else if (gathered_o.scalar_type() == at::ScalarType::BFloat16)
+    {
+        return helix_post_process_native_impl<__nv_bfloat16>(gathered_o, gathered_stats, scale, int(cp_dim),
+            tensorrt_llm::kernels::helixPostProcessNative<__nv_bfloat16>);
+    }
+    else
+    {
+        TLLM_THROW("helix_post_process_native only supports half and bfloat16 tensors.");
+    }
+}
+
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def("helix_post_process(Tensor gathered_o, Tensor gathered_stats, float scale) -> Tensor");
+    m.def(
+        "helix_post_process_native(Tensor gathered_o, Tensor gathered_stats, float "
+        "scale, int cp_dim) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("helix_post_process", helix_post_process);
+    m.impl("helix_post_process_native", &helix_post_process_native);
 }
 
 } // namespace torch_ext

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -568,13 +568,12 @@ class PyTorchModelEngine(ModelEngine):
         # Reset the global cuda graph dummy request to None in warmup.
         self.cuda_graph_runner.padding_dummy_request = None
 
-        cp_type = self.mapping.cp_config.get('cp_type', None)
-        if cp_type is not None:
-            if cp_type in [CpType.ULYSSES, CpType.STAR]:
-                logger.info(
-                    "[ModelEngine::warmup] Skipping warmup for cp_type: ",
-                    cp_type.name)
-                return
+        if self.mapping.cp_size > 1:
+            cp_type = self.mapping.cp_config.get("cp_type", None)
+            logger.info(
+                f"[ModelEngine::warmup] Skipping warmup for cp_type: {None if cp_type is None else cp_type.name}."
+            )
+            return
 
         self._run_torch_compile_warmup(resource_manager)
         self._run_autotuner_warmup(resource_manager)

--- a/tests/unittest/_torch/thop/parallel/test_helix_postprocess.py
+++ b/tests/unittest/_torch/thop/parallel/test_helix_postprocess.py
@@ -22,21 +22,49 @@ from parameterized import parameterized
 import tensorrt_llm
 
 
-def baseline(gathered_o, gathered_stats, kv_lora_rank, scale):
-    """Reference implementation (libtorch)"""
-    # [cp_size, num_tokens, num_heads]
-    global_max = gathered_stats[..., 0].max(dim=0, keepdim=True)[0]
-    # [cp_size, num_tokens, num_heads]
-    corrected_max = gathered_stats[..., 0] - global_max
-    corrected_max_exp = torch.exp(corrected_max)
-    corrected_sum = gathered_stats[..., 1] * corrected_max_exp
-    global_sum = corrected_sum.sum(dim=0, keepdim=True)
-    correction = (gathered_stats[..., 1] * corrected_max_exp / global_sum).unsqueeze(-1)
-    # Cast gathered_o to float32 for computation, then cast output to bf16 at the end
-    gathered_o_fp32 = gathered_o.to(torch.float32).view(*correction.shape[:-1], kv_lora_rank)
-    corrected_o = gathered_o_fp32 * correction
-    # [num_tokens, num_heads * kv_lora_rank] (bf16)
-    corrected_o = corrected_o.view(*gathered_o.shape[:-1], -1).sum(dim=0)
+def baseline(gathered_o, gathered_stats, kv_lora_rank, scale, native=False):
+    """Reference implementation (libtorch)
+
+    Args:
+        gathered_o: Input tensor
+            - native=False: [cp_size, num_tokens, num_heads * kv_lora_rank]
+            - native=True: [num_tokens, num_heads, cp_size, kv_lora_rank]
+        gathered_stats: Stats tensor
+            - native=False: [cp_size, num_tokens, num_heads, 2]
+            - native=True: [num_tokens, num_heads, cp_size, 2]
+        kv_lora_rank: KV LoRA rank
+        scale: Scale factor
+        native: Whether to use native layout (cp_dim=2)
+    """
+    if native:
+        # Native layout: cp_dim=2
+        # [num_tokens, num_heads, cp_size]
+        global_max = gathered_stats[..., 0].max(dim=-1, keepdim=True)[0]
+        corrected_max = gathered_stats[..., 0] - global_max
+        corrected_max_exp = torch.exp(corrected_max)
+        corrected_sum = gathered_stats[..., 1] * corrected_max_exp
+        global_sum = corrected_sum.sum(dim=-1, keepdim=True)
+        correction = (gathered_stats[..., 1] * corrected_max_exp / global_sum).unsqueeze(-1)
+        gathered_o_fp32 = gathered_o.to(torch.float32)
+        corrected_o = gathered_o_fp32 * correction
+        # Sum over cp_size dimension (dim=2), result: [num_tokens, num_heads, kv_lora_rank]
+        corrected_o = corrected_o.sum(dim=2)
+        # Reshape to [num_tokens, num_heads * kv_lora_rank]
+        corrected_o = corrected_o.view(corrected_o.shape[0], -1)
+    else:
+        # Original layout: cp_dim=0
+        # [cp_size, num_tokens, num_heads]
+        global_max = gathered_stats[..., 0].max(dim=0, keepdim=True)[0]
+        corrected_max = gathered_stats[..., 0] - global_max
+        corrected_max_exp = torch.exp(corrected_max)
+        corrected_sum = gathered_stats[..., 1] * corrected_max_exp
+        global_sum = corrected_sum.sum(dim=0, keepdim=True)
+        correction = (gathered_stats[..., 1] * corrected_max_exp / global_sum).unsqueeze(-1)
+        gathered_o_fp32 = gathered_o.to(torch.float32).view(*correction.shape[:-1], kv_lora_rank)
+        corrected_o = gathered_o_fp32 * correction
+        # [num_tokens, num_heads * kv_lora_rank]
+        corrected_o = corrected_o.view(*gathered_o.shape[:-1], -1).sum(dim=0)
+
     return corrected_o.to(gathered_o.dtype) * scale
 
 
@@ -46,71 +74,134 @@ class TestHelixPostProcess(unittest.TestCase):
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
 
-    def _test_helix_postprocess(self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype):
-        """Test helix postprocessing with given parameters"""
+    def _test_helix_postprocess(
+        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native=False
+    ):
+        """Test helix postprocessing with given parameters
+
+        Args:
+            cp_size: Context parallelism size
+            num_tokens: Number of tokens
+            num_heads: Number of attention heads
+            kv_lora_rank: KV LoRA rank
+            scale: Scale factor
+            dtype: Data type (float16 or bfloat16)
+            native: Whether to use native layout (cp_dim=2)
+        """
         device = torch.device("cuda")
 
-        # Create test tensors
-        # gathered_o_init: [cp_size, num_tokens, num_heads, kv_lora_rank]
-        gathered_o_init = torch.empty(
-            cp_size, num_tokens, num_heads, kv_lora_rank, dtype=dtype, device=device
-        ).uniform_(-1, 1)
+        if native:
+            # Native layout: [num_tokens, num_heads, cp_size, kv_lora_rank]
+            gathered_o = torch.empty(
+                num_tokens, num_heads, cp_size, kv_lora_rank, dtype=dtype, device=device
+            ).uniform_(-1, 1)
+            # gathered_stats: [num_tokens, num_heads, cp_size, 2]
+            gathered_stats = torch.empty(
+                num_tokens, num_heads, cp_size, 2, dtype=torch.float32, device=device
+            )
+            gathered_o_max = torch.max(gathered_o, dim=-1, keepdim=True)[0]
+            gathered_stats[..., 0] = gathered_o_max[..., 0]
+            gathered_o_sum = torch.sum(torch.exp(gathered_o - gathered_o_max), dim=-1)
+            gathered_stats[..., 1] = gathered_o_sum
 
-        # gathered_stats: [cp_size, num_tokens, num_heads, 2]
-        gathered_stats = torch.empty(
-            cp_size, num_tokens, num_heads, 2, dtype=torch.float32, device=device
-        )
-        gathered_o_max = torch.max(gathered_o_init, dim=-1, keepdim=True)[0]
-        gathered_stats[..., 0] = gathered_o_max[..., 0]
-        gathered_o_sum = torch.sum(torch.exp(gathered_o_init - gathered_o_max), dim=-1)
-        gathered_stats[..., 1] = gathered_o_sum
+            # Call the custom operator with cp_dim=2
+            output = torch.ops.trtllm.helix_post_process_native(
+                gathered_o, gathered_stats, scale, 2
+            )
+        else:
+            # Original layout: [cp_size, num_tokens, num_heads, kv_lora_rank]
+            gathered_o_init = torch.empty(
+                cp_size, num_tokens, num_heads, kv_lora_rank, dtype=dtype, device=device
+            ).uniform_(-1, 1)
+            # gathered_stats: [cp_size, num_tokens, num_heads, 2]
+            gathered_stats = torch.empty(
+                cp_size, num_tokens, num_heads, 2, dtype=torch.float32, device=device
+            )
+            gathered_o_max = torch.max(gathered_o_init, dim=-1, keepdim=True)[0]
+            gathered_stats[..., 0] = gathered_o_max[..., 0]
+            gathered_o_sum = torch.sum(torch.exp(gathered_o_init - gathered_o_max), dim=-1)
+            gathered_stats[..., 1] = gathered_o_sum
 
-        gathered_o = gathered_o_init.view(cp_size, num_tokens, num_heads * kv_lora_rank)
+            gathered_o = gathered_o_init.view(cp_size, num_tokens, num_heads * kv_lora_rank)
 
-        # Call the custom operator
-        output = torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, scale)
+            # Call the custom operator
+            output = torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, scale)
 
         # Compute baseline
-        expected_output = baseline(gathered_o, gathered_stats, kv_lora_rank, scale)
+        expected_output = baseline(gathered_o, gathered_stats, kv_lora_rank, scale, native=native)
 
         # Compare results
         torch.testing.assert_close(output, expected_output, atol=1e-3, rtol=1e-2)
 
     @parameterized.expand(
         [
-            # (cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype)
-            (4, 8, 2, 64, 1.0, torch.float16),
-            (8, 16, 4, 128, 0.5, torch.float16),
-            (16, 32, 8, 256, 2.0, torch.float16),
-            (4, 8, 2, 64, 1.0, torch.bfloat16),
-            (8, 16, 4, 128, 0.5, torch.bfloat16),
-            (16, 32, 8, 256, 2.0, torch.bfloat16),
+            # (cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native)
+            (4, 8, 2, 64, 1.0, torch.float16, False),
+            (8, 16, 4, 128, 0.5, torch.float16, False),
+            (16, 32, 8, 256, 2.0, torch.float16, False),
+            (4, 8, 2, 64, 1.0, torch.bfloat16, False),
+            (8, 16, 4, 128, 0.5, torch.bfloat16, False),
+            (16, 32, 8, 256, 2.0, torch.bfloat16, False),
+            (4, 8, 2, 64, 1.0, torch.float16, True),
+            (8, 16, 4, 128, 0.5, torch.float16, True),
+            (16, 32, 8, 256, 2.0, torch.float16, True),
+            (4, 8, 2, 64, 1.0, torch.bfloat16, True),
+            (8, 16, 4, 128, 0.5, torch.bfloat16, True),
+            (16, 32, 8, 256, 2.0, torch.bfloat16, True),
         ]
     )
     def test_helix_postprocess_basic(
-        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype
+        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
     ):
         """Test basic helix postprocessing functionality"""
-        self._test_helix_postprocess(cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype)
+        self._test_helix_postprocess(
+            cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
+        )
 
     @parameterized.expand(
         [
-            # Test edge cases
-            (1, 1, 1, 16, 1.0, torch.float16),  # Minimal sizes
-            (256, 1, 1, 16, 1.0, torch.float16),  # Max cp_size
-            (128, 1, 1, 16, 1.0, torch.float16),  # Single token
-            (4, 8, 1, 16, 1.0, torch.float16),  # Single head
-            (4, 8, 2, 2048, 1.0, torch.float16),  # Large kv_lora_rank
+            # (cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native)
+            # Edge cases for non-native layout
+            (1, 1, 1, 16, 1.0, torch.float16, False),  # Minimal sizes
+            (256, 1, 1, 16, 1.0, torch.float16, False),  # Max cp_size
+            (128, 1, 1, 16, 1.0, torch.float16, False),  # Single token
+            (4, 8, 1, 16, 1.0, torch.float16, False),  # Single head
+            (4, 8, 2, 2048, 1.0, torch.float16, False),  # Large kv_lora_rank
+            # Edge cases for native layout
+            (1, 1, 1, 16, 1.0, torch.float16, True),  # Minimal sizes
+            (256, 1, 1, 16, 1.0, torch.float16, True),  # Max cp_size
+            (128, 1, 1, 16, 1.0, torch.float16, True),  # Single token
+            (4, 8, 1, 16, 1.0, torch.float16, True),  # Single head
+            # Note: Large kv_lora_rank (2048) exceeds MAX_KV_LORA_BYTES for native kernel
         ]
     )
     def test_helix_postprocess_edge_cases(
-        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype
+        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
     ):
         """Test edge cases with minimal dimensions"""
-        self._test_helix_postprocess(cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype)
+        self._test_helix_postprocess(
+            cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
+        )
+
+    @parameterized.expand(
+        [
+            # (cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native)
+            (16, 16, 64, 512, 1.0, torch.float16, False),
+            (16, 16, 64, 512, 1.0, torch.bfloat16, False),
+            (16, 16, 64, 512, 1.0, torch.float16, True),
+            (16, 16, 64, 512, 1.0, torch.bfloat16, True),
+        ]
+    )
+    def test_helix_postprocess_large_inputs(
+        self, cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
+    ):
+        """Test with larger inputs to ensure performance and correctness"""
+        self._test_helix_postprocess(
+            cp_size, num_tokens, num_heads, kv_lora_rank, scale, dtype, native
+        )
 
     def test_helix_postprocess_invalid_inputs(self):
-        """Test error handling for invalid inputs"""
+        """Test error handling for invalid inputs (non-native)"""
         device = torch.device("cuda")
 
         # Test with wrong tensor dimensions
@@ -137,34 +228,83 @@ class TestHelixPostProcess(unittest.TestCase):
         with pytest.raises(RuntimeError):
             torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
 
-    def test_helix_postprocess_alignment_requirements(self):
+    def test_helix_postprocess_native_invalid_inputs(self):
+        """Test error handling for invalid inputs (native layout)"""
+        device = torch.device("cuda")
+
+        # Test with wrong cp_dim (only cp_dim=2 is supported)
+        gathered_o = torch.randn(8, 2, 4, 64, dtype=torch.float16, device=device)
+        gathered_stats = torch.randn(8, 2, 4, 2, dtype=torch.float32, device=device)
+
+        with pytest.raises(RuntimeError):
+            torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 0)
+        with pytest.raises(RuntimeError):
+            torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 1)
+
+        # Test with wrong tensor dimensions (3D instead of 4D)
+        gathered_o = torch.randn(8, 2, 256, dtype=torch.float16, device=device)
+        gathered_stats = torch.randn(8, 2, 4, 2, dtype=torch.float32, device=device)
+
+        with pytest.raises(RuntimeError):
+            torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 2)
+
+        # Test with wrong data types
+        gathered_o = torch.randn(8, 2, 4, 64, dtype=torch.float32, device=device)
+        gathered_stats = torch.randn(8, 2, 4, 2, dtype=torch.float32, device=device)
+
+        with pytest.raises(RuntimeError):
+            torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 2)
+
+        # Test with non-contiguous tensors
+        gathered_o = torch.randn(8, 2, 4, 64, dtype=torch.float16, device=device).transpose(0, 1)
+        gathered_stats = torch.randn(8, 2, 4, 2, dtype=torch.float32, device=device)
+
+        with pytest.raises(RuntimeError):
+            torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 2)
+
+    @parameterized.expand(
+        [
+            # (native,)
+            (False,),
+            (True,),
+        ]
+    )
+    def test_helix_postprocess_alignment_requirements(self, native):
         """Test alignment requirements"""
         device = torch.device("cuda")
 
-        # Test with kv_lora_rank that doesn't satisfy alignment requirements
         # For float16 (2 bytes), kv_lora_rank must be multiple of 8 for 16-byte alignment
-        # For bfloat16 (2 bytes), kv_lora_rank must be multiple of 8 for 16-byte alignment
 
-        # This should work (kv_lora_rank = 64 is multiple of 8)
-        gathered_o = torch.randn(4, 8, 2 * 64, dtype=torch.float16, device=device)
-        gathered_stats = torch.randn(4, 8, 2, 2, dtype=torch.float32, device=device)
+        if native:
+            # This should work (kv_lora_rank = 64 is multiple of 8)
+            gathered_o = torch.randn(8, 2, 4, 64, dtype=torch.float16, device=device)
+            gathered_stats = torch.randn(8, 2, 4, 2, dtype=torch.float32, device=device)
 
-        try:
-            torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
-            # Should not raise an error
-        except RuntimeError as e:
-            pytest.fail(f"Should not raise error for valid alignment: {e}")
+            try:
+                torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 2)
+            except RuntimeError as e:
+                pytest.fail(f"Should not raise error for valid alignment: {e}")
 
-        # Test with kv_lora_rank that doesn't satisfy alignment requirements
-        gathered_o = torch.randn(4, 8, 4, dtype=torch.float16, device=device)
-        gathered_stats = torch.randn(4, 8, 1, 2, dtype=torch.float32, device=device)
-        with pytest.raises(RuntimeError):
-            torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
+            # Test with kv_lora_rank that doesn't satisfy alignment requirements
+            gathered_o = torch.randn(8, 1, 4, 4, dtype=torch.float16, device=device)
+            gathered_stats = torch.randn(8, 1, 4, 2, dtype=torch.float32, device=device)
+            with pytest.raises(RuntimeError):
+                torch.ops.trtllm.helix_post_process_native(gathered_o, gathered_stats, 1.0, 2)
+        else:
+            # This should work (kv_lora_rank = 64 is multiple of 8)
+            gathered_o = torch.randn(4, 8, 2 * 64, dtype=torch.float16, device=device)
+            gathered_stats = torch.randn(4, 8, 2, 2, dtype=torch.float32, device=device)
 
-    def test_helix_postprocess_large_inputs(self):
-        """Test with larger inputs to ensure performance and correctness"""
-        self._test_helix_postprocess(16, 16, 64, 512, 1.0, torch.float16)
-        self._test_helix_postprocess(16, 16, 64, 512, 1.0, torch.bfloat16)
+            try:
+                torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
+            except RuntimeError as e:
+                pytest.fail(f"Should not raise error for valid alignment: {e}")
+
+            # Test with kv_lora_rank that doesn't satisfy alignment requirements
+            gathered_o = torch.randn(4, 8, 4, dtype=torch.float16, device=device)
+            gathered_stats = torch.randn(4, 8, 1, 2, dtype=torch.float32, device=device)
+            with pytest.raises(RuntimeError):
+                torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This MR adds a new implementation of alltoall for use with helix parallelism. High-level details:
- Current implementation on ToT for this is based on NCCL. Incoming change follows `fusedMoeCommKernels.cu` closely using LL128Proto and MnnvlMemory.
- We keep around the old implementation as well. It's needed in cases where Mnnvl isn't supported.

Implementation details:
- `cudaAsyncOps.cuh` has functionality **_moved_** from  `fusedMoeCommKernels.cu`. No change in functionality intended.
- `ll128Proto.cuh` has functionality  **_moved_** from  `fusedMoeCommKernels.cu`. No change in functionality intended.
- Above changes are meant to reuse the same code across `fusedMoeCommKernels.cu` and `helixKernels.cu`.
- Remaining changes to helix are new.

## Test Coverage
```
$ .cpp/build/tests/unit_tests/kernels/fusedMoeCommKernelTest
$ pytest tests/unittest/_torch/thop/parallel/test_helix_postprocess.py -s -v
$ pytest tests/unittest/_torch/modules/test_mla_helix.py -s -v
$ TRTLLM_USE_NCCL_FOR_HELIX=0/1 pytest tests/integration/defs/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Helix all-to-all communication now provides flexible backend selection for different deployment scenarios.
  * Added native layout support for Helix post-processing operations with improved data handling.

* **Tests**
  * Expanded test coverage for Helix communication and post-processing pathways, including validation of both available code paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->