### PR TITLE
[TRTLLM-7136][feat] Update load_weights method to include mapping parameter in checkpoint loaders

### DIFF
--- a/docs/source/features/checkpoint-loading.md
+++ b/docs/source/features/checkpoint-loading.md
@@ -31,7 +31,7 @@ The `BaseCheckpointLoader` is the central base interface for all checkpoint load
 
 **Key Methods:**
 - `load_config(checkpoint_dir, **kwargs)`: Loads and returns a `ModelConfig` object
-- `load_weights(checkpoint_dir, **kwargs)`: Loads and returns a dictionary of weights
+- `load_weights(checkpoint_dir, mapping, **kwargs)`: Loads and returns a dictionary of weights
 - `get_initialized_weight_mapper(model, config)`: Returns a runtime initialized weight mapper for the model
 - `cleanup()`: Releases resources and cleans up internal state
 
@@ -63,7 +63,7 @@ Handles the loading of model weights from storage:
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
 
 class CustomWeightLoader(BaseWeightLoader):
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping) -> dict[str, Any]:
         # Load weights from your custom format
         # Return a dictionary mapping parameter names to tensors
         return weights_dict
@@ -186,11 +186,12 @@ from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_weight
 
 @register_checkpoint_weight_loader("CUSTOM_FORMAT")
 class CustomWeightLoader(BaseWeightLoader):
-    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
         """
         Load weights from your custom format.
         Args:
             checkpoint_dir: Directory containing checkpoint files
+            mapping: A mapping object containing the distributed configuration.
             **kwargs: Additional loading parameters
         Returns:
             Dictionary mapping parameter names to tensors

--- a/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
@@ -14,6 +14,8 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
 from tensorrt_llm._torch.models.modeling_utils import \
     CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
 
 
 class BaseCheckpointLoader(ABC):
@@ -51,10 +53,17 @@ class BaseCheckpointLoader(ABC):
         ...
 
     def load_config(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        logger.debug(f"Loading config from {checkpoint_dir}")
         return self.config_loader.load(checkpoint_dir, **kwargs)
 
-    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
-        return self.weight_loader.load_weights(checkpoint_dir, **kwargs)
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping,
+                     **kwargs) -> dict[str, Any]:
+        logger.debug(
+            f"Loading weights from {checkpoint_dir} with mapping {mapping.to_dict()}"
+        )
+        return self.weight_loader.load_weights(checkpoint_dir,
+                                               mapping=mapping,
+                                               **kwargs)
 
     @classmethod
     def get(cls, checkpoint_format: str, **kwargs) -> "BaseCheckpointLoader":

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -1,16 +1,20 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from tensorrt_llm.mapping import Mapping
+
 
 class BaseWeightLoader(ABC):
 
     @abstractmethod
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str,
+                     mapping: Mapping) -> dict[str, Any]:
         """
         Loads weights from a checkpoint directory.
 
         Args:
             checkpoint_dir: A path to the checkpoint directory.
+            mapping: A mapping object containing the distributed configuration.
 
         Returns:
             A dictionary where keys are tensor names and values are the tensors.

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -16,6 +16,7 @@ from tensorrt_llm._torch.models.modeling_utils import (
 from tensorrt_llm._utils import (local_mpi_barrier, local_mpi_rank,
                                  local_mpi_size)
 from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
 
 
 @register_checkpoint_weight_loader("HF")
@@ -24,7 +25,8 @@ class HfWeightLoader(BaseWeightLoader):
     Loads weights from SafeTensors/bin/pth files.
     """
 
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str,
+                     mapping: Mapping) -> dict[str, Any]:
         weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
         # Some model checkpoint directories contain not only the sharded safetensors, but one
         # consolidated tensor. In the presence of both, we favor the former, as there really is no need

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -265,9 +265,10 @@ class ModelLoader:
             if load_format == LoadFormat.AUTO:
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
-                        model.llm_checkpoint_dir)
+                        model.llm_checkpoint_dir, mapping=self.mapping)
                 else:
-                    weights = checkpoint_loader.load_weights(checkpoint_dir)
+                    weights = checkpoint_loader.load_weights(
+                        checkpoint_dir, mapping=self.mapping)
 
                 self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                     model, config)
@@ -277,7 +278,8 @@ class ModelLoader:
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
                     weights = checkpoint_loader.load_weights(
-                        self.spec_config.speculative_model_dir)
+                        self.spec_config.speculative_model_dir,
+                        mapping=self.mapping)
 
                     draft_model_arch = model.draft_config.pretrained_config.architectures[
                         0]

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -23,6 +23,7 @@ l0_a10:
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no
   # test list either).
   - unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+  - unittest/_torch/models/checkpoints/hf/test_checkpoint_loader.py
   - unittest/others/test_time_breakdown.py
   - unittest/disaggregated/test_disagg_utils.py
   - unittest/disaggregated/test_router.py

--- a/tests/unittest/_torch/models/checkpoints/hf/test_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_checkpoint_loader.py
@@ -1,0 +1,111 @@
+import pathlib as _pl
+from typing import Any, Optional
+
+import pytest
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+from tensorrt_llm import LLM, Mapping
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints import HfCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_auto_model
+
+
+class DummyConfig(PretrainedConfig):
+    def __init__(self):
+        self.architectures: list[str] = ["DummyModel"]
+        self.dtype: torch.dtype = torch.float16
+        self.num_attention_heads: int = 16
+        self.hidden_size: int = 256
+        self.vocab_size: int = 1000
+        self.num_hidden_layers: int = 1
+
+
+@register_auto_model("DummyModel")
+class DummyModel(torch.nn.Module):
+    def __init__(self, model_config: ModelConfig):
+        super().__init__()
+        self.model_config = model_config
+
+    def infer_max_seq_len(self):
+        return 2048
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(self, *args, input_ids: torch.Tensor, **kwargs) -> torch.Tensor:
+        num_batch_tokens = input_ids.size(0)
+        vocab_size = self.config.vocab_size
+
+        # Logits: dummy values for testing
+        logits = torch.ones((num_batch_tokens, vocab_size), device="cuda") * 0.1
+
+        return {
+            "logits": logits,
+        }
+
+    def load_weights(
+        self,
+        weights: dict,
+        weight_mapper: Optional[BaseWeightMapper] = None,
+        skip_modules: list[str] = [],
+    ):
+        pass
+
+
+class DummyWeightLoader(BaseWeightLoader):
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
+        """Load weights from your dummy format.
+
+        Args:
+            checkpoint_dir: Directory containing checkpoint files
+            mapping: Mapping object containing the distributed configuration
+            **kwargs: Additional loading parameters
+        Returns:
+            Dictionary mapping parameter names to tensors
+        """
+
+        assert mapping is not None
+        assert isinstance(mapping, Mapping)
+        assert mapping.world_size == 1
+        assert mapping.rank == 0
+
+        weights = {}
+
+        return weights
+
+
+class DummyConfigLoader(BaseConfigLoader):
+    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        """Load and parse configuration from your dummy format.
+
+        Args:
+            checkpoint_dir: Directory containing configuration files
+            **kwargs: Additional loading parameters
+        Returns:
+            ModelConfig object containing parsed configuration
+        """
+        return ModelConfig(pretrained_config=DummyConfig())
+
+
+def test_weight_loader_mapping():
+    """Test that the mapping in weight loader is correct."""
+
+    # Create LLM with the provided model
+    with LLM(
+        model=_pl.Path("dummy_path"),
+        backend="pytorch",
+        cuda_graph_config=None,
+        checkpoint_loader=HfCheckpointLoader(
+            weight_loader=DummyWeightLoader(), config_loader=DummyConfigLoader()
+        ),
+    ):
+        pass
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from tensorrt_llm._torch.models.checkpoints import HfWeightLoader
+from tensorrt_llm.mapping import Mapping
 
 
 class MyError(Exception):
@@ -69,7 +70,7 @@ def test_load_weights_ignores_consolidated_ckpt_when_sharded_ckpt_exists(
         mock.patch.object(loader, "prefetch_files") as prefetch_files,
         pytest.raises(MyError),
     ):
-        loader.load_weights(checkpoint_dir=str(checkpoint_dir))
+        loader.load_weights(checkpoint_dir=str(checkpoint_dir), mapping=Mapping())
 
     prefetch_files.assert_called_once()
     prefetched_files = prefetch_files.call_args[0][0]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Checkpoint weight loading API signatures updated: `load_weights` methods now require a `mapping` parameter. Callers must provide this parameter when loading checkpoint weights.

* **Documentation**
  * Updated weight loader documentation and docstrings to reflect the new required `mapping` parameter in checkpoint loading workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Modified the `load_weights` method in `BaseCheckpointLoader`, `BaseWeightLoader`, and derived classes to accept a `mapping` parameter.
- Updated documentation to reflect changes in method signatures and added logging for weight loading operations.
- Ensured compatibility across various weight loaders by incorporating the mapping functionality.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
