### PR TITLE
[#9432][fix] Resolve NameError in memory profiler for v0.12.0-jetson branch.

### DIFF
--- a/tensorrt_llm/profiler.py
+++ b/tensorrt_llm/profiler.py
@@ -154,6 +154,14 @@ def host_memory_info(pid: Optional[int] = None) -> Tuple[int, int, int]:
 def device_memory_info(
         device: Optional[Union[torch.device,
                                int]] = None) -> Tuple[int, int, int]:
+    if on_jetson_l4t:
+        if not getattr(device_memory_info, "_has_logged_jetson_warning", False):
+            logger.warning(
+                "Device memory monitoring is not fully supported on Jetson/Tegra. Reporting 0 usage."
+            )
+            device_memory_info._has_logged_jetson_warning = True
+        return 0, 0, 0
+
     if pynvml is not None:
         if device is None:
             device = torch.cuda.current_device()


### PR DESCRIPTION
## Description
This PR fixes the issue #9432 specifically for the `v0.12.0-jetson` branch.

On Jetson platforms (where `on_jetson_l4t` is True), the memory profiler currently throws a `NameError` because `_device_get_memory_info_fn` is undefined. This occurs specifically when `nvidia-ml-py` (or `pynvml`) is installed, causing the benchmark script's background monitoring process to fail. This change is necessary to allow benchmarks to run correctly on edge devices without crashing.

## Summary of Changes
This PR modifies `tensorrt_llm/profiler.py` to add a guard clause in the `device_memory_info` function. It explicitly checks if the platform is Jetson (`on_jetson_l4t`). If true, it returns early (reporting 0 memory usage) and logs a one-time warning to inform the user that memory monitoring is skipped, preventing the `NameError` and avoiding log flooding.
