### PR TITLE
[None][chore] Fix trtllm-eval and move GroupedGemmInputsHelper

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -19,6 +19,199 @@ try:
 except ImportError:
     from cuda import cuda
 
+
+class GroupedGemmInputsHelper:
+
+    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
+                 local_expert_offset: int, tile_size: int):
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.num_local_experts = num_local_experts
+        self.local_expert_offset = local_expert_offset
+        self.tile_size = tile_size
+        # Padding values should never be accessed.
+        # Intentionally use a large padding value to expose issues early.
+        self.pad_val = int(2e9)
+
+    def get_max_num_tiles(self, num_tokens: int) -> int:
+        num_expanded_tokens = num_tokens * self.top_k
+        if num_expanded_tokens <= self.num_local_experts:
+            return num_expanded_tokens
+        return (num_expanded_tokens +
+                (self.tile_size - 1) * self.num_local_experts) // self.tile_size
+
+    def get_max_num_permuted_tokens(self, num_tokens: int) -> int:
+        return self.get_max_num_tiles(num_tokens) * self.tile_size
+
+    def infer_num_tokens(self, max_num_permuted_tokens: int) -> int:
+        """Infer the maximum possible number of tokens given the max_num_permuted_tokens.
+        """
+        max_num_tiles = max_num_permuted_tokens // self.tile_size
+        if max_num_tiles >= self.num_local_experts:
+            return (max_num_permuted_tokens - (self.tile_size - 1) *
+                    (self.num_local_experts - 1)) // self.top_k
+        return max_num_tiles // self.top_k
+
+    def gen_tuning_buckets(self, max_num_tokens: int) -> List[int]:
+        buckets = get_last_power_of_2_num_tokens_buckets(
+            self.infer_num_tokens(max_num_tokens))
+        return sorted(
+            list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
+
+    def map_to_tuning_buckets(self, x: int) -> int:
+        return self.get_max_num_permuted_tokens(
+            last_positive_power_of_2(self.infer_num_tokens(x)))
+
+    def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
+        return self.infer_num_tokens(input_shapes[0][0])
+
+    def infer_shape_max_num_tiles(self, input_shapes: List[torch.Size]) -> int:
+        return input_shapes[0][0] // self.tile_size
+
+    def infer_shape_max_num_permuted_tokens(
+            self, input_shapes: List[torch.Size]) -> int:
+        return self.infer_shape_max_num_tiles(input_shapes) * self.tile_size
+
+    def generate_num_tokens_per_expert(self, num_tokens: int) -> List[int]:
+        average_num_tokens_per_expert = num_tokens * self.top_k / self.num_experts
+        balance = 0
+        num_tokens_per_expert = []
+        for i in range(self.num_local_experts):
+            balance += average_num_tokens_per_expert
+            if balance <= 1e-3:
+                continue
+            curr_num_tokens = int(balance) + 1
+            num_tokens_per_expert.append(curr_num_tokens)
+            balance -= curr_num_tokens
+        return num_tokens_per_expert
+
+    def generate_tile_idx_to_group_idx(
+            self, num_tokens_per_expert: List[int]) -> List[int]:
+        tile_idx_to_group_idx = []
+        for i, curr_num_tokens in enumerate(num_tokens_per_expert):
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
+            tile_idx_to_group_idx.extend([i] * curr_num_tiles)
+        return tile_idx_to_group_idx
+
+    def generate_tile_idx_to_mn_limit(
+            self, num_tokens_per_expert: List[int]) -> List[int]:
+        tile_idx_to_mn_limit = []
+        for i, curr_num_tokens in enumerate(num_tokens_per_expert):
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
+            prev_mn_limit = len(tile_idx_to_mn_limit) * self.tile_size
+            for j in range(curr_num_tiles):
+                tile_idx_to_mn_limit.append(prev_mn_limit + min(
+                    (j + 1) * self.tile_size, curr_num_tokens))
+        return tile_idx_to_mn_limit
+
+    def generate_permuted_idx_to_expanded_idx(
+            self, num_tokens: int,
+            num_tokens_per_expert: List[int]) -> List[int]:
+        permuted_idx_to_expanded_idx = []
+        colmajor_expanded_idx = 0
+        for i, curr_num_tokens in enumerate(num_tokens_per_expert):
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
+            for j in range(curr_num_tiles * self.tile_size):
+                if j < curr_num_tokens:
+                    token_idx = colmajor_expanded_idx % num_tokens
+                    topk_idx = colmajor_expanded_idx // num_tokens
+                    expanded_idx = token_idx * self.top_k + topk_idx
+                    permuted_idx_to_expanded_idx.append(expanded_idx)
+                    colmajor_expanded_idx += 1
+                else:
+                    permuted_idx_to_expanded_idx.append(self.pad_val)
+        return permuted_idx_to_expanded_idx
+
+    def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others = inputs
+        num_tokens = self.infer_num_tokens(a.size(0))
+        num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
+        tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
+            num_tokens_per_expert)
+        num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
+        num_padding_tiles_val = tile_idx_to_group_idx.size(
+            0) - num_non_exiting_tiles_val
+        assert num_non_exiting_tiles_val > 0
+        assert num_padding_tiles_val >= 0
+
+        tile_idx_to_group_idx = torch.tensor(
+            tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
+            dtype=tile_idx_to_group_idx.dtype,
+            device=tile_idx_to_group_idx.device)
+        num_non_exiting_tiles = torch.tensor(
+            [num_non_exiting_tiles_val],
+            dtype=num_non_exiting_tiles.dtype,
+            device=num_non_exiting_tiles.device)
+        return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others
+
+    def inputs_pre_hook_finalize_fusion(
+            self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
+        num_tokens = self.infer_num_tokens(a.size(0))
+        num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
+        tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
+            num_tokens_per_expert)
+        tile_idx_to_mn_limit_list = self.generate_tile_idx_to_mn_limit(
+            num_tokens_per_expert)
+        permuted_idx_to_expanded_idx_list = self.generate_permuted_idx_to_expanded_idx(
+            num_tokens, num_tokens_per_expert)
+        num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
+        num_padding_tiles_val = tile_idx_to_group_idx.size(
+            0) - num_non_exiting_tiles_val
+        assert num_non_exiting_tiles_val > 0
+        assert num_padding_tiles_val >= 0
+        assert len(tile_idx_to_mn_limit_list) == num_non_exiting_tiles_val
+        assert len(permuted_idx_to_expanded_idx_list
+                   ) == num_non_exiting_tiles_val * self.tile_size
+
+        tile_idx_to_group_idx = torch.tensor(
+            tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
+            dtype=tile_idx_to_group_idx.dtype,
+            device=tile_idx_to_group_idx.device)
+        tile_idx_to_mn_limit = torch.tensor(
+            tile_idx_to_mn_limit_list + [self.pad_val] * num_padding_tiles_val,
+            dtype=tile_idx_to_mn_limit.dtype,
+            device=tile_idx_to_mn_limit.device)
+        permuted_idx_to_expanded_idx = torch.tensor(
+            permuted_idx_to_expanded_idx_list + [self.pad_val] *
+            (num_padding_tiles_val * self.tile_size),
+            dtype=permuted_idx_to_expanded_idx.dtype,
+            device=permuted_idx_to_expanded_idx.device)
+        num_non_exiting_tiles = torch.tensor(
+            [num_non_exiting_tiles_val],
+            dtype=num_non_exiting_tiles.dtype,
+            device=num_non_exiting_tiles.device)
+        return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales
+
+
+class FusedMoEInputsHelper:
+
+    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
+                 local_expert_offset: int):
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.num_local_experts = num_local_experts
+        self.local_expert_offset = local_expert_offset
+
+    def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
+        return input_shapes[0][0]
+
+    def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        x, x_sf, token_selected_experts, token_final_scales, *others = inputs
+        num_tokens = token_selected_experts.size(0)
+        new_token_final_scales, new_token_selected_experts = torch.randn(
+            num_tokens, self.num_experts,
+            device=token_selected_experts.device).topk(self.top_k, dim=-1)
+        new_token_selected_experts = new_token_selected_experts.to(
+            token_selected_experts.dtype)
+        new_token_final_scales = new_token_final_scales.softmax(dim=-1).to(
+            token_final_scales.dtype)
+        return x, x_sf, new_token_selected_experts, new_token_final_scales, *others
+
+
 if IS_CUTLASS_DSL_AVAILABLE:
 
     import cutlass
@@ -442,180 +635,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
         # output is fixed as bf16
         ret = mat_a.new_empty(shape, dtype=torch.bfloat16)
         return ret
-
-    class GroupedGemmInputsHelper:
-
-        def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
-                     local_expert_offset: int, tile_size: int):
-            self.num_experts = num_experts
-            self.top_k = top_k
-            self.num_local_experts = num_local_experts
-            self.local_expert_offset = local_expert_offset
-            self.tile_size = tile_size
-            # Padding values should never be accessed.
-            # Intentionally use a large padding value to expose issues early.
-            self.pad_val = int(2e9)
-
-        def get_max_num_tiles(self, num_tokens: int) -> int:
-            num_expanded_tokens = num_tokens * self.top_k
-            if num_expanded_tokens <= self.num_local_experts:
-                return num_expanded_tokens
-            return (
-                num_expanded_tokens +
-                (self.tile_size - 1) * self.num_local_experts) // self.tile_size
-
-        def get_max_num_permuted_tokens(self, num_tokens: int) -> int:
-            return self.get_max_num_tiles(num_tokens) * self.tile_size
-
-        def infer_num_tokens(self, max_num_permuted_tokens: int) -> int:
-            """Infer the maximum possible number of tokens given the max_num_permuted_tokens.
-            """
-            max_num_tiles = max_num_permuted_tokens // self.tile_size
-            if max_num_tiles >= self.num_local_experts:
-                return (max_num_permuted_tokens - (self.tile_size - 1) *
-                        (self.num_local_experts - 1)) // self.top_k
-            return max_num_tiles // self.top_k
-
-        def gen_tuning_buckets(self, max_num_tokens: int) -> List[int]:
-            buckets = get_last_power_of_2_num_tokens_buckets(
-                self.infer_num_tokens(max_num_tokens))
-            return sorted(
-                list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
-
-        def map_to_tuning_buckets(self, x: int) -> int:
-            return self.get_max_num_permuted_tokens(
-                last_positive_power_of_2(self.infer_num_tokens(x)))
-
-        def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
-            return self.infer_num_tokens(input_shapes[0][0])
-
-        def infer_shape_max_num_tiles(self,
-                                      input_shapes: List[torch.Size]) -> int:
-            return input_shapes[0][0] // self.tile_size
-
-        def infer_shape_max_num_permuted_tokens(
-                self, input_shapes: List[torch.Size]) -> int:
-            return self.infer_shape_max_num_tiles(input_shapes) * self.tile_size
-
-        def generate_num_tokens_per_expert(self, num_tokens: int) -> List[int]:
-            average_num_tokens_per_expert = num_tokens * self.top_k / self.num_experts
-            balance = 0
-            num_tokens_per_expert = []
-            for i in range(self.num_local_experts):
-                balance += average_num_tokens_per_expert
-                if balance <= 1e-3:
-                    continue
-                curr_num_tokens = int(balance) + 1
-                num_tokens_per_expert.append(curr_num_tokens)
-                balance -= curr_num_tokens
-            return num_tokens_per_expert
-
-        def generate_tile_idx_to_group_idx(
-                self, num_tokens_per_expert: List[int]) -> List[int]:
-            tile_idx_to_group_idx = []
-            for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-                curr_num_tiles = (curr_num_tokens + self.tile_size -
-                                  1) // self.tile_size
-                tile_idx_to_group_idx.extend([i] * curr_num_tiles)
-            return tile_idx_to_group_idx
-
-        def generate_tile_idx_to_mn_limit(
-                self, num_tokens_per_expert: List[int]) -> List[int]:
-            tile_idx_to_mn_limit = []
-            for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-                curr_num_tiles = (curr_num_tokens + self.tile_size -
-                                  1) // self.tile_size
-                prev_mn_limit = len(tile_idx_to_mn_limit) * self.tile_size
-                for j in range(curr_num_tiles):
-                    tile_idx_to_mn_limit.append(prev_mn_limit + min(
-                        (j + 1) * self.tile_size, curr_num_tokens))
-            return tile_idx_to_mn_limit
-
-        def generate_permuted_idx_to_expanded_idx(
-                self, num_tokens: int,
-                num_tokens_per_expert: List[int]) -> List[int]:
-            permuted_idx_to_expanded_idx = []
-            colmajor_expanded_idx = 0
-            for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-                curr_num_tiles = (curr_num_tokens + self.tile_size -
-                                  1) // self.tile_size
-                for j in range(curr_num_tiles * self.tile_size):
-                    if j < curr_num_tokens:
-                        token_idx = colmajor_expanded_idx % num_tokens
-                        topk_idx = colmajor_expanded_idx // num_tokens
-                        expanded_idx = token_idx * self.top_k + topk_idx
-                        permuted_idx_to_expanded_idx.append(expanded_idx)
-                        colmajor_expanded_idx += 1
-                    else:
-                        permuted_idx_to_expanded_idx.append(self.pad_val)
-            return permuted_idx_to_expanded_idx
-
-        def inputs_pre_hook(self,
-                            inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others = inputs
-            num_tokens = self.infer_num_tokens(a.size(0))
-            num_tokens_per_expert = self.generate_num_tokens_per_expert(
-                num_tokens)
-            tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-                num_tokens_per_expert)
-            num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-            num_padding_tiles_val = tile_idx_to_group_idx.size(
-                0) - num_non_exiting_tiles_val
-            assert num_non_exiting_tiles_val > 0
-            assert num_padding_tiles_val >= 0
-
-            tile_idx_to_group_idx = torch.tensor(
-                tile_idx_to_group_idx_list +
-                [self.pad_val] * num_padding_tiles_val,
-                dtype=tile_idx_to_group_idx.dtype,
-                device=tile_idx_to_group_idx.device)
-            num_non_exiting_tiles = torch.tensor(
-                [num_non_exiting_tiles_val],
-                dtype=num_non_exiting_tiles.dtype,
-                device=num_non_exiting_tiles.device)
-            return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others
-
-        def inputs_pre_hook_finalize_fusion(
-                self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
-            num_tokens = self.infer_num_tokens(a.size(0))
-            num_tokens_per_expert = self.generate_num_tokens_per_expert(
-                num_tokens)
-            tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-                num_tokens_per_expert)
-            tile_idx_to_mn_limit_list = self.generate_tile_idx_to_mn_limit(
-                num_tokens_per_expert)
-            permuted_idx_to_expanded_idx_list = self.generate_permuted_idx_to_expanded_idx(
-                num_tokens, num_tokens_per_expert)
-            num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-            num_padding_tiles_val = tile_idx_to_group_idx.size(
-                0) - num_non_exiting_tiles_val
-            assert num_non_exiting_tiles_val > 0
-            assert num_padding_tiles_val >= 0
-            assert len(tile_idx_to_mn_limit_list) == num_non_exiting_tiles_val
-            assert len(permuted_idx_to_expanded_idx_list
-                       ) == num_non_exiting_tiles_val * self.tile_size
-
-            tile_idx_to_group_idx = torch.tensor(
-                tile_idx_to_group_idx_list +
-                [self.pad_val] * num_padding_tiles_val,
-                dtype=tile_idx_to_group_idx.dtype,
-                device=tile_idx_to_group_idx.device)
-            tile_idx_to_mn_limit = torch.tensor(
-                tile_idx_to_mn_limit_list +
-                [self.pad_val] * num_padding_tiles_val,
-                dtype=tile_idx_to_mn_limit.dtype,
-                device=tile_idx_to_mn_limit.device)
-            permuted_idx_to_expanded_idx = torch.tensor(
-                permuted_idx_to_expanded_idx_list + [self.pad_val] *
-                (num_padding_tiles_val * self.tile_size),
-                dtype=permuted_idx_to_expanded_idx.dtype,
-                device=permuted_idx_to_expanded_idx.device)
-            num_non_exiting_tiles = torch.tensor(
-                [num_non_exiting_tiles_val],
-                dtype=num_non_exiting_tiles.dtype,
-                device=num_non_exiting_tiles.device)
-            return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales
 
     class Sm100BlockScaledContiguousGroupedGemmRunner(TunableRunner):
         kernel_class = Sm100BlockScaledContiguousGroupedGemmKernel
@@ -1543,32 +1562,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                    dtype=input_scale.dtype,
                                    device=input_scale.device)
         return output, output_scale
-
-    class FusedMoEInputsHelper:
-
-        def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
-                     local_expert_offset: int):
-            self.num_experts = num_experts
-            self.top_k = top_k
-            self.num_local_experts = num_local_experts
-            self.local_expert_offset = local_expert_offset
-
-        def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
-            return input_shapes[0][0]
-
-        def inputs_pre_hook(self,
-                            inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-            x, x_sf, token_selected_experts, token_final_scales, *others = inputs
-            num_tokens = token_selected_experts.size(0)
-            new_token_final_scales, new_token_selected_experts = torch.randn(
-                num_tokens,
-                self.num_experts,
-                device=token_selected_experts.device).topk(self.top_k, dim=-1)
-            new_token_selected_experts = new_token_selected_experts.to(
-                token_selected_experts.dtype)
-            new_token_final_scales = new_token_final_scales.softmax(dim=-1).to(
-                token_final_scales.dtype)
-            return x, x_sf, new_token_selected_experts, new_token_final_scales, *others
 
     class Sm100BlockScaledFusedMoERunner(TunableRunner):
         tuning_config_cache = dict()

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -136,6 +136,10 @@ def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
         "trust_remote_code": trust_remote_code,
         "revision": revision,
         "build_config": build_config,
+        "max_batch_size": max_batch_size,
+        "max_num_tokens": max_num_tokens,
+        "max_beam_width": max_beam_width,
+        "max_seq_len": max_seq_len,
         "kv_cache_config": kv_cache_config,
     }
 

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -117,10 +117,6 @@ def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
          revision: Optional[str], extra_llm_api_options: Optional[str],
          disable_kv_cache_reuse: bool):
     logger.set_level(log_level)
-    build_config = BuildConfig(max_batch_size=max_batch_size,
-                               max_num_tokens=max_num_tokens,
-                               max_beam_width=max_beam_width,
-                               max_seq_len=max_seq_len)
 
     kv_cache_config = KvCacheConfig(
         free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
@@ -135,11 +131,6 @@ def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
         "gpus_per_node": gpus_per_node,
         "trust_remote_code": trust_remote_code,
         "revision": revision,
-        "build_config": build_config,
-        "max_batch_size": max_batch_size,
-        "max_num_tokens": max_num_tokens,
-        "max_beam_width": max_beam_width,
-        "max_seq_len": max_seq_len,
         "kv_cache_config": kv_cache_config,
     }
 
@@ -149,10 +140,17 @@ def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
 
     profiler.start("trtllm init")
     if backend == 'pytorch':
-        llm_args.pop("build_config", None)
-        llm = PyTorchLLM(**llm_args)
+        llm = PyTorchLLM(**llm_args,
+                         max_batch_size=max_batch_size,
+                         max_num_tokens=max_num_tokens,
+                         max_beam_width=max_beam_width,
+                         max_seq_len=max_seq_len)
     elif backend == 'tensorrt':
-        llm = LLM(**llm_args)
+        build_config = BuildConfig(max_batch_size=max_batch_size,
+                                   max_num_tokens=max_num_tokens,
+                                   max_beam_width=max_beam_width,
+                                   max_seq_len=max_seq_len)
+        llm = LLM(**llm_args, build_config=build_config)
     else:
         raise click.BadParameter(
             f"{backend} is not a known backend, check help for available options.",


### PR DESCRIPTION
## Description

This PR:
* Fixes trtllm-eval arguments
* Moves `GroupedGemmInputsHelper` so TensorRT-LLM can optionally work without cutedsl

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
