### PR TITLE
[https://nvbugs/5703953][fix] Preserving ip:port for trtllm-serve before initializing llm

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -178,7 +178,10 @@ def launch_server(
     backend = llm_args["backend"]
     model = llm_args["model"]
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((host, port))
+        try:
+            s.bind((host, port))
+        except OSError as e:
+            raise RuntimeError(f"Failed to bind socket to {host}:{port}: {e}")
 
         if backend == 'pytorch':
             llm_args.pop("build_config", None)

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -991,7 +991,7 @@ class OpenAIServer:
         return JSONResponse(content={"detail": "None"})
 
 
-    async def __call__(self, host, port, sockets: list[socket.socket] = None):
+    async def __call__(self, host, port, sockets: list[socket.socket] | None = None):
         # Store the binding address for server registration
         self.binding_addr = f"http://{host}:{port}"
         self.host = host

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 import re
 import signal
+import socket
 import traceback
 from collections import deque
 from contextlib import asynccontextmanager
@@ -990,7 +991,7 @@ class OpenAIServer:
         return JSONResponse(content={"detail": "None"})
 
 
-    async def __call__(self, host, port):
+    async def __call__(self, host, port, sockets: list[socket.socket] = None):
         # Store the binding address for server registration
         self.binding_addr = f"http://{host}:{port}"
         self.host = host
@@ -1000,4 +1001,4 @@ class OpenAIServer:
                                 port=port,
                                 log_level="info",
                                 timeout_keep_alive=TIMEOUT_KEEP_ALIVE)
-        await uvicorn.Server(config).serve()
+        await uvicorn.Server(config).serve(sockets=sockets)

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -13,8 +13,8 @@ import openai
 import pytest
 import requests
 import yaml
+from defs.common import revise_disaggregated_server_config_urls_with_free_ports
 
-from tensorrt_llm._utils import get_free_port
 from tensorrt_llm.executor.result import GenerationResultBase
 from tensorrt_llm.llmapi import CompletionOutput, RequestOutput, SamplingParams
 from tensorrt_llm.llmapi.llm_args import LlmArgs
@@ -66,23 +66,6 @@ class MyThreadPoolExecutor(ThreadPoolExecutor):
             future.cancel()
         self.shutdown(wait=True, cancel_futures=True)
         return False
-
-
-def revise_disaggregated_server_config_urls_with_free_ports(
-        disaggregated_server_config: Dict[str, Any]) -> Dict[str, Any]:
-    num_ctx_ports = len(disaggregated_server_config["context_servers"]["urls"])
-    num_gen_ports = len(
-        disaggregated_server_config["generation_servers"]["urls"])
-
-    disaggregated_server_config['port'] = get_free_port()
-    disaggregated_server_config["context_servers"]["urls"] = [
-        f"localhost:{get_free_port()}" for _ in range(num_ctx_ports)
-    ]
-    disaggregated_server_config["generation_servers"]["urls"] = [
-        f"localhost:{get_free_port()}" for _ in range(num_gen_ports)
-    ]
-
-    return disaggregated_server_config
 
 
 @contextlib.contextmanager

--- a/tests/integration/defs/common.py
+++ b/tests/integration/defs/common.py
@@ -17,11 +17,13 @@ import os
 import platform
 import re
 import socket
+import tempfile
 import time
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
+import yaml
 from packaging import version
 
 from tensorrt_llm import LLM as LLM_torch
@@ -1172,3 +1174,18 @@ def revise_disaggregated_server_config_urls_with_free_ports(
             i] = f"{url_map[url][0]}:{url_map[url][1]}"
 
     return disaggregated_server_config
+
+
+def revise_disagg_config_file_with_free_ports(disagg_config_file: str) -> str:
+    # Revise the config file to use free ports
+    new_config = None
+    with open(disagg_config_file, 'r') as f:
+        config = yaml.safe_load(f)
+        new_config = revise_disaggregated_server_config_urls_with_free_ports(
+            config)
+
+    temp_fd, new_config_file = tempfile.mkstemp(suffix='.yaml')
+    with os.fdopen(temp_fd, 'w') as f:
+        yaml.dump(new_config, f)
+
+    return new_config_file

--- a/tests/integration/defs/common.py
+++ b/tests/integration/defs/common.py
@@ -1153,16 +1153,22 @@ def wait_for_server(host, port, timeout_seconds=180):
 
 def revise_disaggregated_server_config_urls_with_free_ports(
         disaggregated_server_config: dict[str, Any]) -> dict[str, Any]:
-    num_ctx_ports = len(disaggregated_server_config["context_servers"]["urls"])
-    num_gen_ports = len(
-        disaggregated_server_config["generation_servers"]["urls"])
-
+    # Revise serve port
     disaggregated_server_config['port'] = get_free_port()
-    disaggregated_server_config["context_servers"]["urls"] = [
-        f"localhost:{get_free_port()}" for _ in range(num_ctx_ports)
-    ]
-    disaggregated_server_config["generation_servers"]["urls"] = [
-        f"localhost:{get_free_port()}" for _ in range(num_gen_ports)
-    ]
+
+    # Revise context and generation server urls
+    ctx_urls = disaggregated_server_config["context_servers"]["urls"]
+    gen_urls = disaggregated_server_config["generation_servers"]["urls"]
+    url_map = dict()
+    for url in set(ctx_urls + gen_urls):
+        url_map[url] = (url.split(':')[0], get_free_port())
+
+    for i, url in enumerate(ctx_urls):
+        disaggregated_server_config["context_servers"]["urls"][
+            i] = f"{url_map[url][0]}:{url_map[url][1]}"
+
+    for i, url in enumerate(gen_urls):
+        disaggregated_server_config["generation_servers"]["urls"][
+            i] = f"{url_map[url][0]}:{url_map[url][1]}"
 
     return disaggregated_server_config

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -22,7 +22,8 @@ from typing import Callable
 
 import pytest
 import yaml
-from defs.common import wait_for_server
+from defs.common import (
+    revise_disaggregated_server_config_urls_with_free_ports, wait_for_server)
 from defs.conftest import (get_sm_version, llm_models_root, skip_arm,
                            skip_no_hopper)
 from defs.trt_test_alternative import check_call, check_output, popen
@@ -277,7 +278,8 @@ def get_test_config(test_desc, example_dir, test_root):
         raise ValueError(f"Invalid test description: {test_desc}, "
                          f"valid descriptions are: {config_map.keys()}")
 
-    return config_map[test_desc]
+    return revise_disaggregated_server_config_urls_with_free_ports(
+        config_map[test_desc])
 
 
 def get_extra_llm_config(config, suffix, cwd):

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -278,8 +278,17 @@ def get_test_config(test_desc, example_dir, test_root):
         raise ValueError(f"Invalid test description: {test_desc}, "
                          f"valid descriptions are: {config_map.keys()}")
 
-    return revise_disaggregated_server_config_urls_with_free_ports(
-        config_map[test_desc])
+    # Revise the config file to use free ports
+    new_config = None
+    with open(config_map[test_desc][1], 'r') as f:
+        config = yaml.safe_load(f)
+        new_config = revise_disaggregated_server_config_urls_with_free_ports(
+            config)
+
+    with open(config_map[test_desc][1], 'w') as f:
+        yaml.dump(new_config, f)
+
+    return config_map[test_desc]
 
 
 def get_extra_llm_config(config, suffix, cwd):

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -22,8 +22,8 @@ from typing import Callable
 
 import pytest
 import yaml
-from defs.common import (
-    revise_disaggregated_server_config_urls_with_free_ports, wait_for_server)
+from defs.common import (revise_disagg_config_file_with_free_ports,
+                         wait_for_server)
 from defs.conftest import (get_sm_version, llm_models_root, skip_arm,
                            skip_no_hopper)
 from defs.trt_test_alternative import check_call, check_output, popen
@@ -278,18 +278,8 @@ def get_test_config(test_desc, example_dir, test_root):
         raise ValueError(f"Invalid test description: {test_desc}, "
                          f"valid descriptions are: {config_map.keys()}")
 
-    # Revise the config file to use free ports
-    new_config = None
-    with open(config_map[test_desc][1], 'r') as f:
-        config = yaml.safe_load(f)
-        new_config = revise_disaggregated_server_config_urls_with_free_ports(
-            config)
-
-    temp_fd, new_config_file = tempfile.mkstemp(suffix=f'_{test_desc}.yaml')
-    with os.fdopen(temp_fd, 'w') as f:
-        yaml.dump(new_config, f)
-
-    return (config_map[test_desc][0], new_config_file)
+    return (config_map[test_desc][0],
+            revise_disagg_config_file_with_free_ports(config_map[test_desc][1]))
 
 
 def get_extra_llm_config(config, suffix, cwd):

--- a/tests/integration/defs/disaggregated/test_workers.py
+++ b/tests/integration/defs/disaggregated/test_workers.py
@@ -9,6 +9,7 @@ from typing import Generator, List, Optional, Tuple
 import aiohttp
 import pytest
 import yaml
+from defs.common import revise_disagg_config_file_with_free_ports
 from defs.conftest import skip_no_hopper
 from defs.trt_test_alternative import popen
 from transformers import AutoTokenizer
@@ -42,6 +43,7 @@ def run_disaggregated_workers(
     num_ranks: Optional[int] = None
 ) -> Tuple[Generator[subprocess.Popen, None, None], List[str], List[str]]:
 
+    config_file = revise_disagg_config_file_with_free_ports(config_file)
     ctx_servers, gen_servers = get_ctx_gen_server_urls_from_cfg(config_file)
 
     # TODO: auto detect num_ranks


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Ports conflict happens very frequently after we migrated to OCI cluster. The main reason of the conflict is the container shares the ports with the machine when starting the container with enroot. This issue caused the disagg serving tests flaky. We had https://github.com/NVIDIA/TensorRT-LLM/pull/9474 and https://github.com/NVIDIA/TensorRT-LLM/pull/9582 to find a free port before starting the tests. But the port could still meets conflict since there is a large time period between finding a free port and binding the port, which is used to initialize llm instance.

In this PR, we preserve the ip:port by binding them before initializing llm instance. And reuse the socket in uvicorn server. This can reduce the duration between find available port and actually bind the port, reducing the possibility of port conflict in the tests.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- accuracy/test_disaggregated_serving.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
