### PR TITLE
[none][perf] AutoDeploy: remove redundant slice and cat in generate-only batches

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -295,12 +295,11 @@ class ADEngine(ModelEngine):
         return last_logit_only
 
     @nvtx_range("ad_compute_logits")
-    def _compute_logits(self) -> List[torch.Tensor]:
+    def _compute_logits(self) -> torch.Tensor:
         # run the model
         logits: torch.Tensor = self.model(**self.cache_seq_interface.named_args)[0]
 
-        # return a list of tensors
-        return self.cache_seq_interface.info.unnest_sequences(logits)
+        return logits
 
     def get_max_num_sequences(self) -> int:
         """Maximum number of sequences supported by the engine."""
@@ -324,11 +323,17 @@ class ADEngine(ModelEngine):
         # compute all logits
         logits = self._compute_logits()
 
-        # gather+cat logits
-        logits_flat = torch.cat(
-            [ls_one_seq[-last_only:] for ls_one_seq, last_only in zip(logits, last_logit_only)],
-            dim=0,
-        )
+        if self.cache_seq_interface.info.is_generate:
+            logits = logits.squeeze(1)  # [b,1,vocab_size]->[b,vocab_size]
+        else:
+            # mixed prefill and decode
+            logits = logits.squeeze(0)
+            logits = list(torch.split(logits, self.cache_seq_interface.info.seq_len))
+            # gather+cat logits
+            logits_flat = torch.cat(
+                [ls_one_seq[-last_only:] for ls_one_seq, last_only in zip(logits, last_logit_only)],
+                dim=0,
+            )
 
         return {"logits": logits_flat}
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -324,7 +324,7 @@ class ADEngine(ModelEngine):
         logits = self._compute_logits()
 
         if self.cache_seq_interface.info.is_generate:
-            logits = logits.squeeze(1)  # [b,1,vocab_size]->[b,vocab_size]
+            logits_flat = logits.squeeze(1)  # [b,1,vocab_size]->[b,vocab_size]
         else:
             # mixed prefill and decode
             logits = logits.squeeze(0)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal model execution logic for generation and prefill/decode operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Removes the concat (~97us) for generate-only batches

before
<img width="588" height="377" alt="Screenshot 2025-12-03 at 12 38 46 AM" src="https://github.com/user-attachments/assets/97bd0e28-5583-486c-9a2c-4ad77d363470" />

now:
<img width="327" height="207" alt="Screenshot 2025-12-03 at 12 40 34 AM" src="https://github.com/user-attachments/assets/09891374-46d7-4c06-a421-b7379d67bfeb" />

