### PR TITLE
[None][feat] Add weights initialization and context phase parser to layer-wise benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ cpp/include/tensorrt_llm/executor/version.h
 cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu/
 cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/cubin/fmha_cubin.h
 .devcontainer/.env
-/examples/layer_wise_benchmarks/autotune/
 /examples/layer_wise_benchmarks/profiles/
 
 # User config files

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ cpp/include/tensorrt_llm/executor/version.h
 cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu/
 cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/cubin/fmha_cubin.h
 .devcontainer/.env
+/examples/layer_wise_benchmarks/autotune/
 /examples/layer_wise_benchmarks/profiles/
 
 # User config files

--- a/examples/layer_wise_benchmarks/README.md
+++ b/examples/layer_wise_benchmarks/README.md
@@ -135,6 +135,9 @@ python3 parse.py --world-size 4
 
 # Specify the location of the .nsys-rep file
 python3 parse.py --profile-dir ./profiles --world-size 4 --rank 0
+
+# Parse a specific module. The module must appear exactly once in each run.
+python3 parse.py --world-size 4 --module MoE
 ```
 
 You will receive three reports, each containing kernel timing statistics grouped by module:

--- a/examples/layer_wise_benchmarks/README.md
+++ b/examples/layer_wise_benchmarks/README.md
@@ -15,9 +15,6 @@ pip install -e ../..
 **Step 3:** In the container, run benchmarks and generate profiles:
 
 ```bash
-# Set autotune cache path
-export TLLM_AUTOTUNER_CACHE_PATH=autotune/cache.json
-
 # Run DeepSeek-R1 NVFP4
 NP=4 ./mpi_launch.sh ./run.sh config_ctx.yaml
 NP=4 ./mpi_launch.sh ./run.sh config_gen.yaml
@@ -96,9 +93,6 @@ It uses the image recorded in `../../jenkins/current_image_tags.properties`. The
 **Step 3:** Run benchmarks to generate profiles. Run the following command on the controller node, where `NODES` &le; the number of allocated nodes:
 
 ```bash
-# Set autotune cache path
-export TLLM_AUTOTUNER_CACHE_PATH=autotune/cache.json
-
 # Run DeepSeek-R1 NVFP4 with wide ep: uses MNNVL A2A if applicable
 SLURM_JOB_ID=$SLURM_JOB_ID NODES=4 NP=16 ./slurm_launch.sh ./run.sh config_gen.yaml --moe-backend WIDEEP
 

--- a/examples/layer_wise_benchmarks/README.md
+++ b/examples/layer_wise_benchmarks/README.md
@@ -143,8 +143,6 @@ python3 parse.py --world-size 4
 python3 parse.py --profile-dir ./profiles --world-size 4 --rank 0
 ```
 
-It can parse only GEN phase profiles for now.
-
 You will receive three reports, each containing kernel timing statistics grouped by module:
 1. A printed report on stdout
 2. A CSV report at `profiles/report_np4_rank0.csv`

--- a/examples/layer_wise_benchmarks/README.md
+++ b/examples/layer_wise_benchmarks/README.md
@@ -15,6 +15,9 @@ pip install -e ../..
 **Step 3:** In the container, run benchmarks and generate profiles:
 
 ```bash
+# Set autotune cache path
+export TLLM_AUTOTUNER_CACHE_PATH=autotune/cache.json
+
 # Run DeepSeek-R1 NVFP4
 NP=4 ./mpi_launch.sh ./run.sh config_ctx.yaml
 NP=4 ./mpi_launch.sh ./run.sh config_gen.yaml
@@ -93,6 +96,9 @@ It uses the image recorded in `../../jenkins/current_image_tags.properties`. The
 **Step 3:** Run benchmarks to generate profiles. Run the following command on the controller node, where `NODES` &le; the number of allocated nodes:
 
 ```bash
+# Set autotune cache path
+export TLLM_AUTOTUNER_CACHE_PATH=autotune/cache.json
+
 # Run DeepSeek-R1 NVFP4 with wide ep: uses MNNVL A2A if applicable
 SLURM_JOB_ID=$SLURM_JOB_ID NODES=4 NP=16 ./slurm_launch.sh ./run.sh config_gen.yaml --moe-backend WIDEEP
 

--- a/examples/layer_wise_benchmarks/config_ctx.yaml
+++ b/examples/layer_wise_benchmarks/config_ctx.yaml
@@ -5,7 +5,6 @@ scaled_from: null
 
 # KV cache related args
 tokens_per_block: 32
-max_seq_len: 9220  # 8192 + 1024 + 4
 enable_attention_dp: true
 
 # Model init args

--- a/examples/layer_wise_benchmarks/config_gen.yaml
+++ b/examples/layer_wise_benchmarks/config_gen.yaml
@@ -5,7 +5,6 @@ scaled_from: null
 
 # KV cache related args
 tokens_per_block: 32
-max_seq_len: 9220  # 8192 + 1024 + 4
 enable_attention_dp: true
 
 # Model init args

--- a/examples/layer_wise_benchmarks/parse.py
+++ b/examples/layer_wise_benchmarks/parse.py
@@ -17,7 +17,8 @@ parser.add_argument("--profile-dir", type=str, default="profiles")
 parser.add_argument("--world-size", "--np", type=int)
 parser.add_argument("--rank", type=int, default=0)
 parser.add_argument("--warmup-times", type=int)
-group = parser.add_mutually_exclusive_group(required=False)
+parser.add_argument("--query", type=str)
+group = parser.add_mutually_exclusive_group()
 group.add_argument("--error-on-unknown-kernel", action="store_true", dest="error_on_unknown_kernel")
 group.add_argument(
     "--no-error-on-unknown-kernel", action="store_false", dest="error_on_unknown_kernel"
@@ -390,6 +391,9 @@ for problem_id, converted_seq in enumerate(converted_seqs):
         merged_data[cur][problem_id] = t
         cur += 1
 
+print("Run args:")
+print(run_args)
+
 print("Problem set:")
 for problem in problem_set:
     print(
@@ -447,3 +451,17 @@ with html_file_path.open("w") as f:
             headerConfig=js_header_config, rawData=js_data, runArgs=json.dumps(run_args, indent=4)
         )
     )
+
+if args.query is not None:
+    print("Query:")
+    for query in args.query.split(","):
+        query = query.strip()
+        query_matched = [0.0] * len(problem_set)
+        for title, time_data in zip(merged_title, merged_data):
+            if query in ".".join(title):
+                for i, x in enumerate(time_data):
+                    query_matched[i] += x
+        print(
+            query + " " * (max_title_len - len(query)),
+            *[f"{x / 1000:-6.1f}" for x in query_matched],
+        )

--- a/examples/layer_wise_benchmarks/parse.py
+++ b/examples/layer_wise_benchmarks/parse.py
@@ -433,7 +433,7 @@ for title, time_data in zip(merged_title, merged_data):
         stack.append(level_title)
         level = len(stack)
         print("|--" * (level - 1) + level_title)
-        csv_data.append(["|--" * (level - 1) + level_title])
+        csv_data.append(["|--" * (level - 1) + level_title] + [""] * len(problem_set))
         js_stack.append([])
     level = len(stack) + 1
     print(

--- a/examples/layer_wise_benchmarks/parse.py
+++ b/examples/layer_wise_benchmarks/parse.py
@@ -387,7 +387,7 @@ def parse_kernel_name(demangledName):
             raise NotImplementedError(f"Unknown kernel name: {name}")
     if "<" in name:
         name = name[: name.index("<")]
-    elif "(" in name:
+    if "(" in name:
         name = name[: name.index("(")]
     return name
 

--- a/examples/layer_wise_benchmarks/run.py
+++ b/examples/layer_wise_benchmarks/run.py
@@ -51,7 +51,7 @@ group.add_argument(
     "--use-low-precision-moe-combine", action="store_true", dest="use_low_precision_moe_combine"
 )
 group.add_argument(
-    "--no-use-use-low-precision-moe-combine",
+    "--no-use-low-precision-moe-combine",
     action="store_false",
     dest="use_low_precision_moe_combine",
 )

--- a/examples/layer_wise_benchmarks/run.py
+++ b/examples/layer_wise_benchmarks/run.py
@@ -1,6 +1,7 @@
 import argparse
 import itertools
 import json
+import os
 
 import numpy as np
 import nvtx
@@ -196,7 +197,8 @@ for autotune_flag, batch_size, seq_len_q, seq_len_kv_cache, balance_ratio in [
         capture_stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(capture_stream):
             if autotune_flag:
-                with autotune():
+                cache_path = os.getenv("TLLM_AUTOTUNER_CACHE_PATH") or None
+                with autotune(cache_path=cache_path, rank=rank):
                     run_pack()
                 if args.run_type == "GEN":
                     logger.info("Layer-wise benchmarks: Prefill KV cache")

--- a/examples/layer_wise_benchmarks/run.py
+++ b/examples/layer_wise_benchmarks/run.py
@@ -36,7 +36,7 @@ parser.add_argument("--scaled-from", type=int)
 parser.add_argument("--max-batch-size", type=int)
 parser.add_argument("--tokens-per-block", type=int)
 parser.add_argument("--max-seq-len", type=int)
-group = parser.add_mutually_exclusive_group(required=False)
+group = parser.add_mutually_exclusive_group()
 group.add_argument("--enable-attention-dp", action="store_true", dest="enable_attention_dp")
 group.add_argument("--no-enable-attention-dp", action="store_false", dest="enable_attention_dp")
 parser.set_defaults(enable_attention_dp=None)
@@ -44,7 +44,7 @@ parser.set_defaults(enable_attention_dp=None)
 parser.add_argument("--max-num-tokens", type=int)
 parser.add_argument("--moe-backend", type=str)
 parser.add_argument("--moe-max-num-tokens", type=int)
-group = parser.add_mutually_exclusive_group(required=False)
+group = parser.add_mutually_exclusive_group()
 group.add_argument("--use-cuda-graph", action="store_true", dest="use_cuda_graph")
 group.add_argument("--no-use-cuda-graph", action="store_false", dest="use_cuda_graph")
 parser.set_defaults(use_cuda_graph=None)
@@ -86,6 +86,8 @@ if config:
 # Set default values
 if args.max_batch_size is None:
     args.max_batch_size = max(args.batch_size_list)
+if args.max_seq_len is None:
+    args.max_seq_len = max(args.seq_len_q_list) + max(args.seq_len_kv_cache_list)
 if args.max_num_tokens is None:
     args.max_num_tokens = args.max_batch_size * max(args.seq_len_q_list)
 print(args)

--- a/examples/layer_wise_benchmarks/run.sh
+++ b/examples/layer_wise_benchmarks/run.sh
@@ -17,15 +17,21 @@ PROFILE_DIR=${PROFILE_DIR:-profiles}
 mkdir -p ${PROFILE_DIR}
 
 PROFILE=${PROFILE:-1}
+BACKTRACE=${BACKTRACE:-0}
 GPU_METRICS=${GPU_METRICS:-0}
 if [ "$PROFILE" -eq 1 ]; then
     PROFILE_CMD="nsys profile
-        -t cuda,nvtx -s none
+        -t cuda,nvtx
         --cpuctxsw none --cuda-event-trace false
         --cuda-graph-trace node
         -c cudaProfilerApi --capture-range-end stop
         -o ${PROFILE_DIR}/report_np${WORLD_SIZE}_rank${RANK}.nsys-rep
         --force-overwrite true"
+    if [ "$BACKTRACE" -eq 1 ]; then
+        PROFILE_CMD+=" --python-backtrace=cuda --cudabacktrace all"
+    else
+        PROFILE_CMD+=" -s none"
+    fi
     if [ "$GPU_METRICS" -eq 1 ]; then
         PROFILE_CMD+=" --gpu-metrics-devices $LOCAL_RANK
             --gpu-metrics-frequency 10000"

--- a/examples/layer_wise_benchmarks/template.html
+++ b/examples/layer_wise_benchmarks/template.html
@@ -272,7 +272,7 @@
 <div class="config-panel">
     <details>
         <summary>🔧 Configuration (Click to expand)</summary>
-        <pre>{{ runArgs }}</pre>
+        <pre>{{ configText }}</pre>
     </details>
 </div>
 

--- a/examples/layer_wise_benchmarks/template.html
+++ b/examples/layer_wise_benchmarks/template.html
@@ -747,15 +747,15 @@
         if (container) {
             container.innerHTML = '';
             for (let i = 1; i < maxDepth; i++) {
-                 const btn = document.createElement('button');
-                 btn.innerText = 'Level ' + i;
-                 btn.onclick = function() { expandToLevel(i); };
-                 // Copy styles from other buttons if possible, or rely on CSS
-                 // The existing buttons don't have inline styles, just CSS class likely.
-                 // But wait, <button> elements in this file might be styled by tag selector.
-                 container.appendChild(btn);
-                 // Add a space
-                 container.appendChild(document.createTextNode(' '));
+                const btn = document.createElement('button');
+                btn.innerText = 'Level ' + i;
+                btn.onclick = function() { expandToLevel(i); };
+                // Copy styles from other buttons if possible, or rely on CSS
+                // The existing buttons don't have inline styles, just CSS class likely.
+                // But wait, <button> elements in this file might be styled by tag selector.
+                container.appendChild(btn);
+                // Add a space
+                container.appendChild(document.createTextNode(' '));
             }
         }
     }

--- a/examples/layer_wise_benchmarks/template.html
+++ b/examples/layer_wise_benchmarks/template.html
@@ -412,7 +412,7 @@
 
             // Name Col
             html += `<td onclick="toggleFold('${uniqueId}', event)" style="padding-left: ${10 + level * 20}px">
-                        <div class="cell-content">${toggleIcon} ${node.name}</div>
+                        <div class="cell-content" title="${node.name}">${toggleIcon} ${node.name}</div>
                      </td>`;
 
             // Data Cols

--- a/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
@@ -30,8 +30,10 @@ class DeepSeekV3Runner(RunnerMixin, RunnerBase):
         max_seq_len: int,
         max_num_tokens: int,
         moe_max_num_tokens: int,
+        use_low_precision_moe_combine: bool,
         use_cuda_graph: bool,
     ):
+        super().__init__()
         self.model_config = ModelConfig.from_pretrained(
             pretrained_model_name_or_path,
             mapping=mapping,
@@ -50,7 +52,7 @@ class DeepSeekV3Runner(RunnerMixin, RunnerBase):
             attn_backend="TRTLLM",
             moe_backend=moe_backend,
             moe_disable_finalize_fusion=False,
-            use_low_precision_moe_combine=False,
+            use_low_precision_moe_combine=use_low_precision_moe_combine,
             skip_create_weights_in_init=True,
         )
         pretrained_config = self.model_config.pretrained_config

--- a/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/deepseekv3_runner.py
@@ -5,6 +5,7 @@ import torch
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_deepseekv3 import DeepseekV3DecoderLayer
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+from tensorrt_llm._torch.pyexecutor.model_loader import initialize_dummy_weights
 from tensorrt_llm._torch.utils import AuxStreamType
 from tensorrt_llm.functional import AllReduceStrategy
 from tensorrt_llm.mapping import Mapping
@@ -83,12 +84,14 @@ class DeepSeekV3Runner(RunnerMixin, RunnerBase):
                     if callable(getattr(module, "create_weights", None)):
                         module.create_weights()
                 layer.cuda()
+                initialize_dummy_weights(layer)
                 for module in layer.modules():
                     if hasattr(module, "post_load_weights") and not getattr(
                         module, "_weights_removed", False
                     ):
                         module.post_load_weights()
             next_layer_layernorm.cuda()
+            initialize_dummy_weights(next_layer_layernorm)
             for layer, next_layer in zip(layers[:-1], layers[1:]):
                 layer.next_layer_layernorm = next_layer.input_layernorm
             layers[-1].next_layer_layernorm = next_layer_layernorm

--- a/tensorrt_llm/tools/layer_wise_benchmarks/qwen3_next_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/qwen3_next_runner.py
@@ -29,8 +29,10 @@ class Qwen3NextRunner(RunnerMixin, RunnerBase):
         max_seq_len: int,
         max_num_tokens: int,
         moe_max_num_tokens: int,
+        use_low_precision_moe_combine: bool,
         use_cuda_graph: bool,
     ):
+        super().__init__()
         self.model_config = ModelConfig.from_pretrained(
             pretrained_model_name_or_path,
             mapping=mapping,
@@ -49,7 +51,7 @@ class Qwen3NextRunner(RunnerMixin, RunnerBase):
             attn_backend="TRTLLM",
             moe_backend=moe_backend,
             moe_disable_finalize_fusion=False,
-            use_low_precision_moe_combine=False,
+            use_low_precision_moe_combine=use_low_precision_moe_combine,
             skip_create_weights_in_init=True,
         )
         pretrained_config = self.model_config.pretrained_config

--- a/tensorrt_llm/tools/layer_wise_benchmarks/qwen3_next_runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/qwen3_next_runner.py
@@ -5,6 +5,7 @@ import torch
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_qwen3_next import ALL_DECODER_LAYER_TYPES
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+from tensorrt_llm._torch.pyexecutor.model_loader import initialize_dummy_weights
 from tensorrt_llm.functional import AllReduceStrategy
 from tensorrt_llm.mapping import Mapping
 
@@ -77,12 +78,14 @@ class Qwen3NextRunner(RunnerMixin, RunnerBase):
                     if callable(getattr(module, "create_weights", None)):
                         module.create_weights()
                 layer.cuda()
+                initialize_dummy_weights(layer)
                 for module in layer.modules():
                     if hasattr(module, "post_load_weights") and not getattr(
                         module, "_weights_removed", False
                     ):
                         module.post_load_weights()
             next_layer_layernorm.cuda()
+            initialize_dummy_weights(next_layer_layernorm)
             for layer, next_layer in zip(layers[:-1], layers[1:]):
                 layer.next_layer_layernorm = next_layer.input_layernorm
             layers[-1].next_layer_layernorm = next_layer_layernorm

--- a/tests/unittest/tools/test_layer_wise_benchmarks.py
+++ b/tests/unittest/tools/test_layer_wise_benchmarks.py
@@ -27,6 +27,10 @@ def test_deepseek_r1_ctx_dep(llm_root, world_size):
             "PROFILE_DIR": profile_dir,
         },
     )
+    check_call(
+        ["python3", "parse.py", "--profile-dir", profile_dir, f"--world-size={world_size}"],
+        cwd=llm_root / "examples" / "layer_wise_benchmarks",
+    )
 
 
 @pytest.mark.parametrize("world_size", [1, 4])
@@ -54,6 +58,10 @@ def test_deepseek_r1_ctx_tep(llm_root, world_size):
             "TRTLLM_ENABLE_PDL": "1",
         },
     )
+    check_call(
+        ["python3", "parse.py", "--profile-dir", profile_dir, f"--world-size={world_size}"],
+        cwd=llm_root / "examples" / "layer_wise_benchmarks",
+    )
 
 
 @pytest.mark.parametrize("world_size", [1, 4])
@@ -78,6 +86,10 @@ def test_deepseek_v32_ctx_dep(llm_root, world_size):
             "NP": f"{world_size:d}",
             "PROFILE_DIR": profile_dir,
         },
+    )
+    check_call(
+        ["python3", "parse.py", "--profile-dir", profile_dir, f"--world-size={world_size}"],
+        cwd=llm_root / "examples" / "layer_wise_benchmarks",
     )
 
 


### PR DESCRIPTION
1. Randomly initialize weights and KV cache
2. Support parsing CTX
3. Minor updates:
   1. Support autotuner cache
   2. Support parsing specified modules
   3. Add `--use-low-precision-moe-combine` option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line options for advanced optimizations: low-precision MOE combine, autotuner, attention data parallelism, and CUDA graphs.
  * Added module-based filtering and query capabilities for profiling analysis.
  * Enhanced HTML report generation with improved display formatting and node name tooltips.

* **Documentation**
  * Updated benchmark documentation to reflect current parsing capabilities.

* **Chores**
  * Updated configuration and build settings for improved flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
