### PR TITLE
[None][refactor] Improve request processing function in sampler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1715,7 +1715,6 @@ class TorchSampler(Sampler):
             seq_slots=seq_slots_host,
             return_log_probs=return_log_probs,
             seq_lens=seq_lens_host,
-            resource_manager=resource_manager,
         )
 
         finish_reasons = self.store.finish_reasons
@@ -2396,7 +2395,6 @@ class TorchSampler(Sampler):
         seq_slots: torch.Tensor,
         seq_lens: torch.Tensor | None = None,
         return_log_probs: bool,
-        resource_manager: Optional[ResourceManager] = None,
     ) -> torch.Tensor:
         seq_slots = seq_slots.to(dtype=torch.int32)  # int32 suffices here
 

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -60,28 +60,26 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type):
                                      use_beam_search=True)
 
     # Test with overlap scheduler enabled
-    llm = create_llm(model_path,
-                     disable_overlap_scheduler=False,
-                     sampler_type=sampler_type)
-    outputs_with_overlap = llm.generate(prompts,
-                                        sampling_params=sampling_config,
-                                        use_tqdm=True)
-    texts_with_overlap = [[
-        completion.text for completion in request_output.outputs
-    ] for request_output in outputs_with_overlap]
-    llm.shutdown()
+    with create_llm(model_path,
+                    disable_overlap_scheduler=False,
+                    sampler_type=sampler_type) as llm:
+        outputs_with_overlap = llm.generate(prompts,
+                                            sampling_params=sampling_config,
+                                            use_tqdm=True)
+        texts_with_overlap = [[
+            completion.text for completion in request_output.outputs
+        ] for request_output in outputs_with_overlap]
 
     # Test with overlap scheduler disabled
-    llm = create_llm(model_path,
-                     disable_overlap_scheduler=True,
-                     sampler_type=sampler_type)
-    outputs_without_overlap = llm.generate(prompts,
-                                           sampling_params=sampling_config,
-                                           use_tqdm=True)
-    texts_without_overlap = [[
-        completion.text for completion in request_output.outputs
-    ] for request_output in outputs_without_overlap]
-    llm.shutdown()
+    with create_llm(model_path,
+                    disable_overlap_scheduler=True,
+                    sampler_type=sampler_type) as llm:
+        outputs_without_overlap = llm.generate(prompts,
+                                               sampling_params=sampling_config,
+                                               use_tqdm=True)
+        texts_without_overlap = [[
+            completion.text for completion in request_output.outputs
+        ] for request_output in outputs_without_overlap]
 
     # Verify outputs are consistent
     for with_overlap, without_overlap in zip(texts_with_overlap,

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -430,8 +430,15 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
     @contextmanager
     def _test_runner(is_warmup: bool) -> Generator[Callable[[], None], None, None]:
+        draft_len_req1 = draft_len
+        draft_len_req2 = draft_len + 1  # test with different draft lens
+
         class ContextRequestMock:
-            def __init__(self, return_context_logits: bool):
+            def __init__(self, is_last_context_chunk: bool, return_context_logits: bool):
+                self.is_context_init_state = True
+                self.is_last_context_chunk = is_last_context_chunk
+                self.py_draft_tokens = torch.tensor([], dtype=torch.int32, device=device)
+                self.sampling_config = SamplingConfig(beam_width=1)
                 self._return_context_logits = return_context_logits
 
             @property
@@ -439,7 +446,10 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 return self._return_context_logits
 
         class GenRequestMock:
-            pass
+            def __init__(self, draft_len: int):
+                self.is_context_init_state = False
+                self.py_draft_tokens = torch.empty(draft_len, dtype=torch.int32, device=device)
+                self.sampling_config = SamplingConfig(beam_width=1)
 
         class ScheduledRequestsMock:
             @property
@@ -448,9 +458,24 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                     [
                         # NB: One request with py_return_context_logits is enough
                         #     to trigger tested code.
-                        cast(LlmRequest, ContextRequestMock(True)),
-                        cast(LlmRequest, ContextRequestMock(False)),
-                        cast(LlmRequest, ContextRequestMock(True)),
+                        cast(
+                            LlmRequest,
+                            ContextRequestMock(
+                                is_last_context_chunk=True, return_context_logits=True
+                            ),
+                        ),
+                        cast(
+                            LlmRequest,
+                            ContextRequestMock(
+                                is_last_context_chunk=True, return_context_logits=False
+                            ),
+                        ),
+                        cast(
+                            LlmRequest,
+                            ContextRequestMock(
+                                is_last_context_chunk=True, return_context_logits=True
+                            ),
+                        ),
                     ]
                     if with_ctx
                     else []
@@ -462,14 +487,18 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 #     is not empty.
                 return (
                     [
-                        cast(LlmRequest, GenRequestMock()),
-                        cast(LlmRequest, GenRequestMock()),
+                        cast(LlmRequest, GenRequestMock(draft_len=draft_len_req1)),
+                        cast(LlmRequest, GenRequestMock(draft_len=draft_len_req2)),
                     ]
                     if with_gen
                     else []
                 )
 
-        vocab_size = 12
+            def all_requests(self) -> list[LlmRequest]:
+                return self.context_requests + self.generation_requests
+
+        expected_num_requests = with_ctx * 3 + with_gen * 2
+        expected_req_num_beams = torch.tensor([1] * expected_num_requests, dtype=torch.int32)
 
         num_context_logits_prefix_sum = [
             0,
@@ -483,9 +512,7 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 else []
             ),
         ]
-        draft_len_req1 = draft_len
-        draft_len_req2 = draft_len + 1  # test with different draft lens
-        req_num_generation_steps = [
+        expected_req_num_generation_steps = [
             *(
                 [
                     1,  # context req. 1
@@ -504,11 +531,19 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 else []
             ),
         ]
-        req_num_generation_steps_tensor = torch.tensor(req_num_generation_steps, dtype=torch.int32)
-        num_logits_to_keep = cast(int, req_num_generation_steps_tensor.sum().item())
+        expected_req_num_generation_steps_tensor = torch.tensor(
+            expected_req_num_generation_steps, dtype=torch.int32
+        )
+
+        expected_req_offsets = torch.cumsum(expected_req_num_generation_steps_tensor, dim=0).roll(1)
+        expected_req_offsets[0] = 0
+
+        # num_logits_to_keep = cast(int, req_num_generation_steps_tensor.sum().item())
         generation_requests_total_steps = (draft_len_req1 + 1) + (
             draft_len_req2 + 1
         )  # cf. req_num_generation_steps
+
+        vocab_size = 12
 
         num_total_steps = num_context_logits_prefix_sum[-1] + generation_requests_total_steps
         all_logits = torch.empty((num_total_steps, vocab_size))
@@ -537,8 +572,14 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 ),  # gen logits from gen. req. 2
             ]
 
+        expected_logits = all_logits[expected_logit_indices]
+
         @dataclass
         class UutResult:
+            req_num_generated_tokens: torch.Tensor
+            req_num_beams: torch.Tensor
+            req_num_steps: torch.Tensor
+            req_offsets: torch.Tensor
             selected_logits: torch.Tensor
 
         @dataclass
@@ -548,22 +589,39 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
         res = UutResultWrapper()
 
         def _uut(res=res):
-            selected_logits = TorchSampler._select_generated_logits(
+            (
+                req_num_generated_tokens,
+                req_num_beams,
+                req_num_steps,
+                req_offsets,
+                selected_logits,
+            ) = TorchSampler._select_generated_logits(
                 cast(ScheduledRequests, ScheduledRequestsMock()),
                 all_logits_cuda,
-                req_num_generation_steps=req_num_generation_steps_tensor,
                 num_context_logits_prefix_sum=num_context_logits_prefix_sum,
-                generation_requests_total_steps=generation_requests_total_steps,
-                num_logits_to_keep=num_logits_to_keep,
             )
-            res.result = UutResult(selected_logits=selected_logits)
+            res.result = UutResult(
+                req_num_generated_tokens=req_num_generated_tokens,
+                req_num_beams=req_num_beams,
+                req_num_steps=req_num_steps,
+                req_offsets=req_offsets,
+                selected_logits=selected_logits,
+            )
 
         yield _uut
 
-        # Check logits
+        # Check results
         assert res.result is not None
-        selected_logits = res.result.selected_logits
-        torch.testing.assert_close(selected_logits.to("cpu"), all_logits[expected_logit_indices])
+
+        torch.testing.assert_close(
+            res.result.req_num_generated_tokens.to("cpu"), expected_req_num_generation_steps_tensor
+        )
+        torch.testing.assert_close(res.result.req_num_beams.to("cpu"), expected_req_num_beams)
+        torch.testing.assert_close(
+            res.result.req_num_steps.to("cpu"), expected_req_num_generation_steps_tensor
+        )
+        torch.testing.assert_close(res.result.req_offsets.to("cpu"), expected_req_offsets)
+        torch.testing.assert_close(res.result.selected_logits.to("cpu"), expected_logits)
 
     _run_test_with_warmup(_test_runner, max_sync_s=0.3)
 

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -590,10 +590,7 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
         def _uut(res=res):
             (
-                req_num_generated_tokens,
-                req_num_beams,
-                req_num_steps,
-                req_offsets,
+                sampling_requests_metadata,
                 selected_logits,
             ) = TorchSampler._select_generated_logits(
                 cast(ScheduledRequests, ScheduledRequestsMock()),
@@ -601,10 +598,10 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 num_context_logits_prefix_sum=num_context_logits_prefix_sum,
             )
             res.result = UutResult(
-                req_num_generated_tokens=req_num_generated_tokens,
-                req_num_beams=req_num_beams,
-                req_num_steps=req_num_steps,
-                req_offsets=req_offsets,
+                req_num_generated_tokens=sampling_requests_metadata.req_num_generated_tokens,
+                req_num_beams=sampling_requests_metadata.req_num_beams,
+                req_num_steps=sampling_requests_metadata.req_num_steps,
+                req_offsets=sampling_requests_metadata.req_offsets,
                 selected_logits=selected_logits,
             )
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized log-probability handling in the sampling pipeline for improved code maintainability and separation of concerns.
  * Enhanced internal method structures and return types to better support logprob computation workflows.
  * Improved test resource management with automatic cleanup patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
