### PR TITLE
[TRTLLM-9735][feat] Add processed logprobs functionality to TorchSampler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1022,7 +1022,7 @@ common-files: &common_files |
         tests/unittest/_torch/ray_orchestrator/single_gpu/test_cache_transceiver_comm.py |
         tests/unittest/_torch/sampler/test_beam_search.py |
         tests/unittest/_torch/sampler/test_best_of_n.py |
-        tests/unittest/_torch/sampler/test_return_logits.py |
+        tests/unittest/_torch/sampler/test_logits_logprobs.py |
         tests/unittest/_torch/sampler/test_torch_multi_arange.py |
         tests/unittest/_torch/sampler/test_trtllm_sampler.py |
         tests/unittest/_torch/speculative/test_draft_target.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1022,7 +1022,6 @@ common-files: &common_files |
         tests/unittest/_torch/ray_orchestrator/single_gpu/test_cache_transceiver_comm.py |
         tests/unittest/_torch/sampler/test_beam_search.py |
         tests/unittest/_torch/sampler/test_best_of_n.py |
-        tests/unittest/_torch/sampler/test_logits_logprobs.py |
         tests/unittest/_torch/sampler/test_torch_multi_arange.py |
         tests/unittest/_torch/sampler/test_trtllm_sampler.py |
         tests/unittest/_torch/speculative/test_draft_target.py |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1063,7 +1063,7 @@ exclude = [
     "tests/unittest/_torch/ray_orchestrator/single_gpu/test_cache_transceiver_comm.py",
     "tests/unittest/_torch/sampler/test_beam_search.py",
     "tests/unittest/_torch/sampler/test_best_of_n.py",
-    "tests/unittest/_torch/sampler/test_return_logits.py",
+    "tests/unittest/_torch/sampler/test_logits_logprobs.py",
     "tests/unittest/_torch/sampler/test_torch_multi_arange.py",
     "tests/unittest/_torch/sampler/test_trtllm_sampler.py",
     "tests/unittest/_torch/speculative/test_draft_target.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1063,7 +1063,6 @@ exclude = [
     "tests/unittest/_torch/ray_orchestrator/single_gpu/test_cache_transceiver_comm.py",
     "tests/unittest/_torch/sampler/test_beam_search.py",
     "tests/unittest/_torch/sampler/test_best_of_n.py",
-    "tests/unittest/_torch/sampler/test_logits_logprobs.py",
     "tests/unittest/_torch/sampler/test_torch_multi_arange.py",
     "tests/unittest/_torch/sampler/test_trtllm_sampler.py",
     "tests/unittest/_torch/speculative/test_draft_target.py",

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -485,6 +485,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             is_first_draft: bool = False,
             use_chunked_generation_logits: bool = True,
             logits_chunk_size: int = 8,
+            logprobs_mode: str = "raw",
             **kwargs):
 
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
@@ -565,6 +566,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         # TODO: remove this when use DynamicDecodeOp in pytorch flow.
         # currently, keep py_stop_words_list as python list, rather than tensor.
         self.py_stop_words_list = stop_words_list
+
+        self.py_logprobs_mode = logprobs_mode
 
         self.py_result = PyResult(
             prompt_len=self.py_prompt_len,
@@ -825,7 +828,9 @@ def executor_request_to_llm_request(
         arrival_time=getattr(executor_request, "py_arrival_time", None),
         py_multimodal_data=getattr(executor_request, "py_multimodal_data",
                                    None),
-        kv_cache_retention_config=executor_request.kv_cache_retention_config)
+        kv_cache_retention_config=executor_request.kv_cache_retention_config,
+        logprobs_mode=getattr(executor_request, "py_logprobs_mode", "raw"),
+    )
     if child_req_ids:
         for child_id in child_req_ids:
             llm_request.create_child_request(child_id)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1899,6 +1899,8 @@ class PyExecutor:
                     f"Request beam width {sampling_config.beam_width} "
                     f"is not equal to max_beam_width {self.max_beam_width}. This is not supported!"
                 )
+        # Validate logprobs mode
+        request.validate_logprobs_mode()
 
         # Check token ID ranges
         if isinstance(self.model_engine.model, DecoderModelForCausalLM):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1899,8 +1899,6 @@ class PyExecutor:
                     f"Request beam width {sampling_config.beam_width} "
                     f"is not equal to max_beam_width {self.max_beam_width}. This is not supported!"
                 )
-        # Validate logprobs mode
-        request.validate_logprobs_mode()
 
         # Check token ID ranges
         if isinstance(self.model_engine.model, DecoderModelForCausalLM):

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -406,7 +406,7 @@ def _request_get_sampling_params(request: LlmRequest) -> UtilsSamplingParams:
 
 
 def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
-    if not hasattr(request, "py_sampling_strategy"):
+    if not hasattr(request, "py_sampling_strategy") or _get_max_beam_width(request) > 1:
         params = _request_get_sampling_params(request)
         request.py_sampling_strategy = resolve_sampling_strategy(params, vocab_size=vocab_size)
     return request.py_sampling_strategy

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2222,8 +2222,8 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
         #     Since read-caching is expected to help in typical cases, option (ii) is implemented here.
 
         # Track which logits require logit bias application
-        logits_bias_mask = torch.zeros((logits.size(0),), dtype=torch.bool, pin_memory=True)
-
+        request_steps_list = request_steps.tolist()
+        logits_bias_masks = [False] * logits.size(0)
         _next_bias_index = 0
 
         def provision_bias_index() -> int:
@@ -2243,11 +2243,11 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
 
         # Collect bias information
         req_bias = None
-        for i, (req, steps) in enumerate(zip(requests, request_steps)):
-            steps = int(steps.item())
+        for i, (req, steps) in enumerate(zip(requests, request_steps_list)):
             req_bias = req._py_embedding_bias_1d
             if req_bias is not None:
-                logits_bias_mask[i : (i + steps)] = True
+                for j in range(i, i + steps):
+                    logits_bias_masks[j] = True
                 req_bias_index = bias_to_index[req_bias]
                 bias_gather_indices.extend(repeat(req_bias_index, steps))
 
@@ -2258,7 +2258,9 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
         bias_gather_indices_cuda = torch.tensor(
             bias_gather_indices, pin_memory=True, dtype=torch.int32
         ).to(logits.device, non_blocking=True)
-        logits_bias_mask_cuda = logits_bias_mask.to(logits.device, non_blocking=True)
+        logits_bias_mask_cuda = torch.tensor(
+            logits_bias_masks, pin_memory=True, dtype=torch.bool
+        ).to(logits.device, non_blocking=True)
         biases_tensor = torch.empty((len(bias_to_index), *req_bias.shape), pin_memory=True)
         biases_tensor = torch.stack(
             tuple(bias_to_index.keys()),

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -960,15 +960,15 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
         finish_reasons = int_tensor(self.NEW_TOKENS_SHAPE)
 
         # Only used for logprobs processing or beam search
-        sampled_log_probs = torch.zeros(self.LOGPROBS_SHAPE, device="cuda", dtype=torch.float32)
+        sampled_log_probs = torch.empty(self.LOGPROBS_SHAPE, device="cuda", dtype=torch.float32)
         # Only used for logprobs processing
-        sampled_log_prob_indices = torch.zeros(
+        sampled_log_prob_indices = torch.empty(
             self.LOGPROBS_SHAPE, device="cuda", dtype=torch.int32
         )
-        sampled_log_prob_ranks = torch.zeros(self.LOGPROBS_SHAPE, device="cuda", dtype=torch.int32)
+        sampled_log_prob_ranks = torch.empty(self.LOGPROBS_SHAPE, device="cuda", dtype=torch.int32)
         # These are 0 sized tensors, if topk-logprobs are not used
-        topk_indices = torch.zeros(self.topk_logprobs_shape, device="cuda", dtype=torch.int32)
-        topk_vals = torch.zeros(self.topk_logprobs_shape, device="cuda", dtype=torch.float32)
+        topk_indices = torch.empty(self.topk_logprobs_shape, device="cuda", dtype=torch.int32)
+        topk_vals = torch.empty(self.topk_logprobs_shape, device="cuda", dtype=torch.float32)
 
         # Only used for beam search
         cache_indirection: torch.Tensor | None = None
@@ -978,11 +978,11 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
         original_tokens: torch.Tensor | None = None
         first_finish_reasons: torch.Tensor | None = None
         if self._use_beam_search:
-            cache_indirection = torch.zeros(
+            cache_indirection = torch.empty(
                 self.CACHE_INDIRECTION_SHAPE, device="cuda", dtype=torch.int
             )
             cache_indirection_buffer = int_tensor(self.CACHE_INDIRECTION_SHAPE)
-            cum_log_probs = torch.zeros(
+            cum_log_probs = torch.empty(
                 self.CACHE_INDIRECTION_SHAPE[:-1], device="cuda", dtype=torch.float32
             )
             predecessor_beams = int_tensor(self.CACHE_INDIRECTION_SHAPE[:-1])

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2423,7 +2423,7 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
 
             group_strategies_per_step = [  # convert from per-request to per-step
                 strat
-                for strat, steps in zip(group_strategies, req_num_steps[group_req_indices])
+                for strat, steps in zip(group_strategies, req_num_steps[group_req_indices].tolist())
                 for _ in range(steps)
             ]
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2773,11 +2773,11 @@ class TorchSampler(Sampler, AsyncWorkerMixin):
         sampled_rank_cuda = group_logprobs_cuda.sum(dim=-1).to(torch.int32)
 
         # Use a single D2H copy to reduce overheads
-        topk_vals = torch.empty_like(topk_vals_cuda, device="cpu", pin_memory=False)
-        topk_indices = torch.empty_like(topk_indices_cuda, device="cpu", pin_memory=False)
-        sampled_vals = torch.empty_like(sampled_vals_cuda, device="cpu", pin_memory=False)
-        sampled_indices = torch.empty_like(sampled_indices_cuda, device="cpu", pin_memory=False)
-        sampled_rank = torch.empty_like(sampled_rank_cuda, device="cpu", pin_memory=False)
+        topk_vals = torch.empty_like(topk_vals_cuda, device="cpu", pin_memory=True)
+        topk_indices = torch.empty_like(topk_indices_cuda, device="cpu", pin_memory=True)
+        sampled_vals = torch.empty_like(sampled_vals_cuda, device="cpu", pin_memory=True)
+        sampled_indices = torch.empty_like(sampled_indices_cuda, device="cpu", pin_memory=True)
+        sampled_rank = torch.empty_like(sampled_rank_cuda, device="cpu", pin_memory=True)
 
         topk_vals.copy_(topk_vals_cuda, non_blocking=True)
         topk_indices.copy_(topk_indices_cuda, non_blocking=True)

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -406,8 +406,10 @@ def _request_get_sampling_params(request: LlmRequest) -> UtilsSamplingParams:
 
 
 def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
-    params = _request_get_sampling_params(request)
-    return resolve_sampling_strategy(params, vocab_size=vocab_size)
+    if not hasattr(request, "py_sampling_strategy"):
+        params = _request_get_sampling_params(request)
+        request.py_sampling_strategy = resolve_sampling_strategy(params, vocab_size=vocab_size)
+    return request.py_sampling_strategy
 
 
 def _group_requests_by_strategy_key(

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -250,7 +250,7 @@ class RequestGroupKey(Generic[GenericStrategyKeyType]):
         return iter((self.strategy_key, self.needs_probs))
 
     def __len__(self):
-        return 3
+        return 2
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -472,10 +472,10 @@ def sample(
     strategy: Strategy,
     logits: torch.Tensor,
     *,
-    generator: Optional[torch.Generator] = None,
+    generator: torch.Generator | None = None,
     group_metadata: StrategyMetadata | None = None,
     return_probs: bool = True,
-) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[float]]:
+) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
     match strategy:
         case ("top_k", top_k, temperature):
             tokens, softmax = top_k_sampling_batch(
@@ -547,11 +547,11 @@ class GroupedStrategySampler(Generic[GenericStrategyKeyType], abc.ABC):
         strategies: list[Strategy],
         logits: torch.Tensor,
         *,
-        group_logit_indices: Optional[torch.Tensor] = None,
-        generator: Optional[torch.Generator] = None,
+        group_logit_indices: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
         return_probs: bool,
         group_metadata: StrategyMetadata | None = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor], float | torch.Tensor | None]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, float | torch.Tensor | None]:
         raise NotImplementedError
 
 
@@ -581,11 +581,11 @@ class SimpleGroupedStrategySampler(GroupedStrategySampler[Strategy]):
         strategies: list[Strategy],
         logits: torch.Tensor,
         *,
-        group_logit_indices: Optional[torch.Tensor] = None,
-        generator: Optional[torch.Generator] = None,
+        group_logit_indices: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
         return_probs: bool,
         group_metadata: StrategyMetadata | None = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor], float | None]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
         if group_key[0] == "beam_search":
             beam_width_in = group_key[1]
         else:

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -266,7 +266,8 @@ def greedy_search_sampling_batch(
     next_tokens = torch.argmax(logits, dim=-1)
     softmax: Optional[torch.Tensor] = None
     if return_probs:
-        softmax = torch.softmax(logits, dim=-1)
+        softmax = torch.zeros_like(logits)
+        softmax.scatter_(1, next_tokens.unsqueeze(-1), 1.0)
     return next_tokens, softmax
 
 
@@ -474,7 +475,7 @@ def sample(
     generator: Optional[torch.Generator] = None,
     group_metadata: StrategyMetadata | None = None,
     return_probs: bool = True,
-) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[float]]:
     match strategy:
         case ("top_k", top_k, temperature):
             tokens, softmax = top_k_sampling_batch(
@@ -506,6 +507,7 @@ def sample(
             )
         case ("greedy", None):
             tokens, softmax = greedy_search_sampling_batch(logits, return_probs=return_probs)
+            temperature = None
         case ("beam_search", beam_width_in, beam_width_out, temperature):
             assert group_metadata is not None and isinstance(group_metadata, BeamSearchMetadata), (
                 "BeamSearchMetadata is required for beam_search_sampling_batch"
@@ -519,7 +521,7 @@ def sample(
                 generator=generator,
                 return_probs=return_probs,
             )
-    return tokens, softmax
+    return tokens, softmax, temperature
 
 
 GenericStrategyKeyType = TypeVar("GenericStrategyKeyType")

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -551,7 +551,7 @@ class GroupedStrategySampler(Generic[GenericStrategyKeyType], abc.ABC):
         generator: Optional[torch.Generator] = None,
         return_probs: bool,
         group_metadata: StrategyMetadata | None = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], float | torch.Tensor | None]:
         raise NotImplementedError
 
 
@@ -585,7 +585,7 @@ class SimpleGroupedStrategySampler(GroupedStrategySampler[Strategy]):
         generator: Optional[torch.Generator] = None,
         return_probs: bool,
         group_metadata: StrategyMetadata | None = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], float | None]:
         if group_key[0] == "beam_search":
             beam_width_in = group_key[1]
         else:

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
@@ -141,8 +141,9 @@ class _StrategyImpls:
             *,
             group_logit_indices: Optional[torch.Tensor],
         ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-            probs = self._prepare_probs_with_temperature(logits, group_logit_indices, None)
-            new_tokens, _ = greedy_search_sampling_batch(probs, return_probs=False)
+            if group_logit_indices is not None:
+                logits = torch.index_select(logits, 0, group_logit_indices)  # ensures copy
+            new_tokens, probs = greedy_search_sampling_batch(logits, return_probs=True)
             return new_tokens, probs
 
         @classmethod
@@ -240,6 +241,9 @@ class _StrategyImpls:
             return True
 
     class GreedyWithProbs(StrategyImplWithProbs):
+        def __init__(self):
+            self._temperature = None
+
         @override
         @classmethod
         def from_strategies(
@@ -425,6 +429,9 @@ class _StrategyImpls:
             return False
 
     class GreedySampleOnly(StrategyImplSampleOnly):
+        def __init__(self):
+            self._temperature = None
+
         @override
         @classmethod
         def from_strategies(
@@ -722,7 +729,7 @@ class FlashInferGroupedStrategySampler(GroupedStrategySampler[Type[_StrategyImpl
         generator: Optional[torch.Generator] = None,
         return_probs: bool,
         group_metadata: StrategyMetadata | None = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
         if hasattr(group_key, "static_beam_width_in"):
             beam_width_in = group_key.static_beam_width_in
         else:
@@ -735,9 +742,16 @@ class FlashInferGroupedStrategySampler(GroupedStrategySampler[Type[_StrategyImpl
         assert return_probs == group_key.computes_probs()
 
         strategy_impl_cls = group_key
-        return strategy_impl_cls.from_strategies(strategies, cuda_device=logits.device).sample(
+        sampling_object = strategy_impl_cls.from_strategies(strategies, cuda_device=logits.device)
+        next_tokens, softmax = sampling_object.sample(
             logits,
             group_logit_indices=group_logit_indices,
             generator=generator,
             group_metadata=group_metadata,
         )
+        temperature = (
+            sampling_object._temperature.unsqueeze(-1)
+            if sampling_object._temperature is not None
+            else None
+        )
+        return next_tokens, softmax, temperature

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -215,7 +215,7 @@ class MTPSampler(TorchSampler):
 
     SampleState = SampleStateMTP
 
-    @dataclass(frozen=True, kw_only=True)
+    @dataclass(kw_only=True)
     class Store(TorchSampler.Store):
         new_tokens: torch.Tensor
         next_new_tokens: torch.Tensor

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -562,6 +562,7 @@ class BaseWorker(GenerationExecutor):
                 cache_salt_id=request.cache_salt_id)
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
+            executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode
 
             if self._is_pytorch_backend and request.multimodal_params is not None:
                 if request.multimodal_params.multimodal_data is not None:

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -221,7 +221,7 @@ class GenerationExecutor(ABC):
             self, request: GenerationRequest) -> Optional[LogprobParams]:
         """Store logprobs-related fields from request for the later logprob calculation."""
         logprob_params = None
-        if request.sampling_params.logprobs or request.sampling_params.prompt_logprobs:
+        if request.sampling_params.logprobs is not None or request.sampling_params.prompt_logprobs:
             logprob_params = LogprobParams(
                 logprobs=request.sampling_params.logprobs,
                 prompt_logprobs=request.sampling_params.prompt_logprobs,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -666,7 +666,7 @@ class BaseLLM:
             if sampling_params.prompt_logprobs and not sampling_params.return_context_logits:
                 sampling_params.return_context_logits = True
                 sampling_params._context_logits_auto_enabled = True
-            if sampling_params.logprobs and not sampling_params.return_generation_logits:
+            if sampling_params.logprobs is not None and not sampling_params.return_generation_logits:
                 sampling_params.return_generation_logits = True
                 sampling_params._generation_logits_auto_enabled = True
 
@@ -737,7 +737,7 @@ class BaseLLM:
                 f"Example: LLM(..., build_config=BuildConfig(gather_context_logits=True))."
             )
 
-        if sampling_params.logprobs and not self.args.gather_generation_logits:
+        if sampling_params.logprobs is not None and not self.args.gather_generation_logits:
             raise ValueError(
                 f"`sampling_params.logprobs={sampling_params.logprobs}` requires `gather_generation_logits=True` "
                 f"to be passed explicitly to the `LLM()` constructor.")

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -6,6 +6,7 @@ from typing import List, Literal, NamedTuple, Optional, Tuple, Union
 
 import torch
 from pydantic import BaseModel
+from strenum import StrEnum
 
 from tensorrt_llm.bindings import executor as tllme
 from tensorrt_llm.logger import logger
@@ -44,6 +45,11 @@ class LogprobParams(NamedTuple):
     drop_context_logits: bool = False
     # Drop the geneation_logits once the logprobs are computed
     drop_generation_logits: bool = False
+
+
+class LogprobMode(StrEnum):
+    RAW = "raw"
+    PROCESSED = "processed"
 
 
 class LogitsProcessor(ABC):
@@ -174,7 +180,7 @@ class SamplingParams:
 
         logprobs (int, optional): Number of log probabilities to return per output token. When set to 0, return only the sampled token's log probability.
                                   When set to K>0, return top-K log probabilities + the sampled token's log probability (last entry) if it's not in the Top-K. Defaults to None.
-        logprobs_mode (Literal["raw", "processed"]): The mode of log probabilities to return. Defaults to "raw".
+        logprobs_mode (Literal["raw", "processed"]): The mode of log probabilities to return. Valid modes are "raw" and "processed". Defaults to "raw".
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
         return_generation_logits (bool): Controls if Result should contain the generation logits. Defaults to False.
@@ -324,9 +330,10 @@ class SamplingParams:
                 f"under the greedy decoding."
             )
 
-        if self.logprobs_mode not in ["raw", "processed"]:
+        if self.logprobs_mode not in [LogprobMode.RAW, LogprobMode.PROCESSED]:
             raise ValueError(
-                f"logprobs_mode must be one of ['raw', 'processed'], got {self.logprobs_mode}"
+                f"logprobs_mode must be one of {LogprobMode.RAW.value}, {LogprobMode.PROCESSED.value}. "
+                f"Got {self.logprobs_mode} instead."
             )
 
         if self.truncate_prompt_tokens is not None and self.truncate_prompt_tokens < 1:

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -344,10 +344,11 @@ class SamplingParams:
         if self.guided_decoding is not None:
             self.guided_decoding._validate()
 
-        # correct types as users might pass in logprob=True for Top-1 logprobs and logprobs=False for no logprobs
+        # correct types as users might pass in logprob=True for Top-0 logprobs and logprobs=False for no logprobs
         if self.logprobs is False:
             self.logprobs = None
-        self.logprobs = self.logprobs and int(self.logprobs)
+        if self.logprobs is True:
+            self.logprobs = 0
         self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
 
     # NB: Static, because downstream code only holds instances of

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -187,7 +187,7 @@ class SamplingParams:
 
         logprobs (int, optional): Number of log probabilities to return per output token. When set to 0, return only the sampled token's log probability.
                                   When set to K>0, return top-K log probabilities + the sampled token's log probability (last entry) if it's not in the Top-K. Defaults to None.
-        logprobs_mode (LogprobMode, optional): The mode of log probabilities to return. Defaults to RAW.
+        logprobs_mode (LogprobMode): The mode of log probabilities to return. Defaults to LogprobMode.RAW.
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
         return_generation_logits (bool): Controls if Result should contain the generation logits. Defaults to False.

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -2,7 +2,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import List, NamedTuple, Optional, Tuple, Union
+from typing import List, Literal, NamedTuple, Optional, Tuple, Union
 
 import torch
 from pydantic import BaseModel
@@ -173,6 +173,7 @@ class SamplingParams:
         beam_width_array (List[int], optional): The array of beam width using in Variable-Beam-Width-Search. Defaults to None.
 
         logprobs (int, optional): Number of log probabilities to return per output token. Defaults to None.
+        logprobs_mode (Literal["raw", "processed"]): The mode of log probabilities to return. Defaults to "raw".
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
         return_generation_logits (bool): Controls if Result should contain the generation logits. Defaults to False.
@@ -219,6 +220,7 @@ class SamplingParams:
     n: int = 1
     best_of: Optional[int] = None
     use_beam_search: bool = False
+    logprobs_mode: Literal["raw", "processed"] = "raw"
 
     # Keep the below fields in sync with tllme.SamplingConfig or maintin the mapping table.
     top_k: Optional[int] = None
@@ -319,6 +321,11 @@ class SamplingParams:
                 f"Please set to best_of=1 or set an environment variable "
                 f"TLLM_ALLOW_N_GREEDY_DECODING=1 to allow best_of > 1 "
                 f"under the greedy decoding."
+            )
+
+        if self.logprobs_mode not in ["raw", "processed"]:
+            raise ValueError(
+                f"logprobs_mode must be one of ['raw', 'processed'], got {self.logprobs_mode}"
             )
 
         if self.truncate_prompt_tokens is not None and self.truncate_prompt_tokens < 1:

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -172,7 +172,8 @@ class SamplingParams:
         min_p (float, optional): scale the most likely token to determine the minimum token probability. None means using C++ runtime default 0.0. Defaults to None.
         beam_width_array (List[int], optional): The array of beam width using in Variable-Beam-Width-Search. Defaults to None.
 
-        logprobs (int, optional): Number of log probabilities to return per output token. Defaults to None.
+        logprobs (int, optional): Number of log probabilities to return per output token. When set to 0, return only the sampled token's log probability.
+                                  When set to K>0, return top-K log probabilities + the sampled token's log probability (last entry) if it's not in the Top-K. Defaults to None.
         logprobs_mode (Literal["raw", "processed"]): The mode of log probabilities to return. Defaults to "raw".
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
@@ -501,7 +502,7 @@ class SamplingParams:
         config_kwargs = {f: getattr(self, f) for f in fields}
 
         if is_pytorch_backend:
-            config_kwargs["return_log_probs"] = bool(self.logprobs)
+            config_kwargs["return_log_probs"] = self.logprobs is not None
             if self.prompt_logprobs and not self.return_context_logits:
                 logger.info(
                     "Since prompt_logprobs is requested but return_context_logits is False, "

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -337,7 +337,9 @@ class SamplingParams:
         if self.guided_decoding is not None:
             self.guided_decoding._validate()
 
-        # correct types as users might pass in logprob=True for Top-1 logprobs
+        # correct types as users might pass in logprob=True for Top-1 logprobs and logprobs=False for no logprobs
+        if self.logprobs is False:
+            self.logprobs = None
         self.logprobs = self.logprobs and int(self.logprobs)
         self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
 

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -22,7 +22,7 @@ l0_a30:
   - unittest/_torch/modeling -k "modeling_starcoder2"
   - unittest/_torch/auto_deploy/unit/singlegpu
   - unittest/_torch/sampler/test_beam_search.py
-  - unittest/_torch/sampler/test_return_logits.py
+  - unittest/_torch/sampler/test_logits_logprobs.py
   - test_e2e.py::test_openai_completions_with_logit_bias[torch_sampler]
   - test_e2e.py::test_openai_chat_with_logit_bias[torch_sampler]
   - test_e2e.py::test_openai_completions_with_logit_bias[trtllm_sampler]

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -306,6 +306,8 @@ unittest/_torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm
 triton_server/test_triton.py::test_gpt_speculative_decoding[gpt-speculative-decoding] SKIP (https://nvbugs/5762854)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8B_Instruct_RocketKV::test_auto_dtype SKIP (https://nvbugs/5762822)
 unittest/_torch/sampler/test_return_logits.py SKIP (https://nvbugs/5764627)
+unittest/_torch/sampler/test_logits_logprobs.py::test_generate_with_return_logits SKIP (https://nvbugs/5764627)
+unittest/_torch/sampler/test_logits_logprobs.py::test_generate_async_with_return_logits SKIP (https://nvbugs/5764627)
 examples/serve/test_serve.py::test_config_file_loading[--config] SKIP (https://nvbugs/5754977)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-tp2pp2-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] SKIP (https://nvbugspro.nvidia.com/bug/5794313)
 examples/test_ray.py::test_ray_disaggregated_serving[tp2] SKIP (https://nvbugs/5612502)

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -635,7 +635,11 @@ def test_create_beam_history():
     # set the logprobs in the request:
     token_logprobs = sampler._convert_logprobs_tensor_to_list(
         original_logprob_indices[:beam_width, :num_generated_tokens - 1],
-        original_logprobs[:beam_width, :num_generated_tokens - 1])
+        original_logprobs[:beam_width, :num_generated_tokens - 1],
+        None,
+        None,
+        None,
+    )
     request.py_result.set_log_probs(
         token_logprobs,
         cum_log_probs=torch.zeros_like(

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -125,7 +125,7 @@ def check_generation_logits(beam: CompletionOutput,
 def check_logprobs(beam: CompletionOutput, sampling_params: SamplingParams,
                    valid_tokens: int | None) -> None:
     """Check if the logprobs have the correct shape"""
-    if sampling_params.logprobs:
+    if sampling_params.logprobs is not None:
         generated_tokens = valid_tokens if valid_tokens is not None else sampling_params.max_tokens
         assert len(
             beam.logprobs
@@ -345,7 +345,7 @@ class GeneralTestParams:
     prompt_len = len(input_tokens)
     num_generated_tokens = 5
     seq_len = prompt_len + num_generated_tokens
-    num_logprobs = 1
+    num_logprobs = 0
     seq_slot = 4
     end_id = 99
     batch_size = 2
@@ -541,7 +541,7 @@ def create_default_request(test_params: GeneralTestParams) -> LlmRequest:
                       end_id=test_params.end_id,
                       sampling_config=SamplingConfig(
                           sampling_params._get_sampling_config()),
-                      return_log_probs=test_params.num_logprobs > 0,
+                      return_log_probs=test_params.num_logprobs >= 0,
                       num_logprobs=test_params.num_logprobs,
                       is_streaming=False)
 
@@ -590,7 +590,7 @@ def test_create_beam_history():
     num_generated_tokens = test_params.num_generated_tokens
     seq_slot = test_params.seq_slot
     vocab_size = test_params.vocab_size
-    num_logprobs = test_params.num_logprobs
+    num_logprobs = test_params.num_logprobs + 1
     cache_indirection = sampler.store.cache_indirection
     original_tokens = sampler.store.original_tokens
     original_logprobs = torch.zeros(
@@ -661,9 +661,10 @@ def test_create_beam_history():
         ) > 0, "Deterministic offsets must not only contain zeros. Otherwise change the seed."
 
     # set the new log probs and tokens for the beam search sampling
-    sampler.store.new_log_probs[
+    sampler.store.sampled_log_probs[
         seq_slot, :beam_width] = original_logprobs[:beam_width,
-                                                   num_generated_tokens - 1, 0]
+                                                   num_generated_tokens - 1,
+                                                   0:1]
     sampler.store.new_tokens[
         0,
         seq_slot, :beam_width] = original_logprob_indices[:beam_width,

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -7,10 +7,8 @@ from utils.llm_data import llm_models_root
 from utils.util import force_ampere
 
 from tensorrt_llm import LLM, SamplingParams
-from tensorrt_llm._torch.pyexecutor.sampling_utils import \
-    top_k_top_p_sampling_batch
-from tensorrt_llm._torch.pyexecutor.sampling_utils_flashinfer import \
-    _StrategyImpls
+from tensorrt_llm._torch.pyexecutor.sampling_utils import top_k_top_p_sampling_batch
+from tensorrt_llm._torch.pyexecutor.sampling_utils_flashinfer import _StrategyImpls
 from tensorrt_llm.llmapi.llm_utils import KvCacheConfig
 
 prompts = ["A B C"]
@@ -41,7 +39,6 @@ def sampler_type_fixture(request) -> str:
 
 
 class CacheSalter:
-
     _salt = 0
 
     @classmethod
@@ -74,12 +71,10 @@ def llm(
     disable_overlap_scheduler = disable_overlap_scheduler_fixture
 
     llm = LLM(
-        model=os.path.join(llm_models_root(), "llama-models-v2",
-                           "TinyLlama-1.1B-Chat-v1.0"),
+        model=os.path.join(llm_models_root(), "llama-models-v2", "TinyLlama-1.1B-Chat-v1.0"),
         kv_cache_config=global_kvcache_config,
         gather_generation_logits=gather_generation_logits,
-        max_batch_size=
-        128,  # reduce buffer sizes, specially for generation logits
+        max_batch_size=128,  # reduce buffer sizes, specially for generation logits
         sampler_type=sampler_type,
         disable_overlap_scheduler=disable_overlap_scheduler,
     )
@@ -88,15 +83,14 @@ def llm(
     #        Remove patch below once fixed.
     old_exit = LLM.__exit__
 
-    def _exit_with_xfail_on_timeout(self, exc_type, exc_value,
-                                    traceback) -> bool:
+    def _exit_with_xfail_on_timeout(self, exc_type, exc_value, traceback) -> bool:
         import _pytest.outcomes
+
         try:
             return old_exit(self, exc_type, exc_value, traceback)
         except _pytest.outcomes.Failed as e:
             if e.msg and "pytest-timeout" in e.msg.lower():
-                pytest.xfail(
-                    "Known LLM shutdown issue (https://nvbugs/5577178).")
+                pytest.xfail("Known LLM shutdown issue (https://nvbugs/5577178).")
             else:
                 raise
 
@@ -111,8 +105,7 @@ def llm(
 def simple_llm(request) -> LLM:
     disable_flashinfer_sampling = request.param
     llm = LLM(
-        model=os.path.join(llm_models_root(), "llama-models-v2",
-                           "TinyLlama-1.1B-Chat-v1.0"),
+        model=os.path.join(llm_models_root(), "llama-models-v2", "TinyLlama-1.1B-Chat-v1.0"),
         max_batch_size=8,
         disable_flashinfer_sampling=disable_flashinfer_sampling,
     )
@@ -136,8 +129,7 @@ def test_generate_with_return_logits(
     gather_context_logits = gather_context_logits_fixture
     gather_generation_logits = gather_generation_logits_fixture
 
-    if not (gather_context_logits or gather_generation_logits
-            or return_log_probs):  # prune space
+    if not (gather_context_logits or gather_generation_logits or return_log_probs):  # prune space
         pytest.skip("Nothing to test")
 
     sampling_params = SamplingParams(
@@ -148,9 +140,9 @@ def test_generate_with_return_logits(
     )
 
     for output in llm.generate(
-            prompts,
-            sampling_params=sampling_params,
-            cache_salt=[CacheSalter.get_salt(reuse_cache) for _ in prompts],
+        prompts,
+        sampling_params=sampling_params,
+        cache_salt=[CacheSalter.get_salt(reuse_cache) for _ in prompts],
     ):
         if gather_context_logits:
             assert output.context_logits is not None
@@ -174,8 +166,7 @@ def test_generate_with_return_logits(
                 assert gen_logits is not None
                 assert gen_logits.ndim == 2
                 assert gen_logits.shape[0] == sampling_params.max_tokens
-                assert torch.argmax(gen_logits,
-                                    dim=1).tolist() == sequence.token_ids
+                assert torch.argmax(gen_logits, dim=1).tolist() == sequence.token_ids
             else:
                 assert sequence.generation_logits is None
 
@@ -202,23 +193,24 @@ def test_generate_async_with_return_logits(
     gather_context_logits = gather_context_logits_fixture
     gather_generation_logits = gather_generation_logits_fixture
 
-    if not (gather_context_logits or gather_generation_logits
-            or return_log_probs):  # prune space
+    if not (gather_context_logits or gather_generation_logits or return_log_probs):  # prune space
         pytest.skip("Nothing to test")
 
     sampling_params = SamplingParams(
         max_tokens=8,
         return_context_logits=gather_context_logits,
         return_generation_logits=gather_generation_logits,
-        logprobs=return_log_probs)
+        logprobs=return_log_probs,
+    )
 
     for idx, output in enumerate(
-            llm.generate_async(
-                prompts[0],
-                sampling_params=sampling_params,
-                streaming=True,
-                cache_salt=CacheSalter.get_salt(reuse_cache),
-            )):
+        llm.generate_async(
+            prompts[0],
+            sampling_params=sampling_params,
+            streaming=True,
+            cache_salt=CacheSalter.get_salt(reuse_cache),
+        )
+    ):
         if gather_context_logits:
             assert output.context_logits is not None
             # NOTE: prompt_token_ids of "A B C" becomes [1, 319, 350, 315]
@@ -242,8 +234,7 @@ def test_generate_async_with_return_logits(
                 assert gen_logits.ndim == 2
                 assert gen_logits.shape[0] == 1
                 try:
-                    assert torch.argmax(
-                        gen_logits, dim=1).tolist()[0] == sequence.token_ids[-1]
+                    assert torch.argmax(gen_logits, dim=1).tolist()[0] == sequence.token_ids[-1]
                 except AssertionError:
                     # FIXME: Remove xfail once the bug is fixed
                     pytest.xfail("Known bug: https://nvbugs/5573238")
@@ -256,15 +247,13 @@ def test_generate_async_with_return_logits(
                 assert len(sequence.logprobs) == 0
 
 
-@pytest.mark.parametrize("logprobs_k", [0, 1, 3],
-                         ids=["top_0", "top_1", "top_3"])
+@pytest.mark.parametrize("logprobs_k", [0, 1, 3], ids=["top_0", "top_1", "top_3"])
 @pytest.mark.parametrize("logprobs_mode", ["raw", "processed"])
 @pytest.mark.threadleak(enabled=False)
-def test_sampled_token_always_in_logprobs(logprobs_k: int, logprobs_mode: str,
-                                          simple_llm: LLM):
+def test_sampled_token_always_in_logprobs(logprobs_k: int, logprobs_mode: str, simple_llm: LLM):
     """Two scenarios:
-        - logprobs=0: Returns only sampled token (1 element)
-        - logprobs=K (K>0): Returns top-K tokens + sampled token if not in top-K (up to K+1 elements)
+    - logprobs=0: Returns only sampled token (1 element)
+    - logprobs=K (K>0): Returns top-K tokens + sampled token if not in top-K (up to K+1 elements)
     """
 
     sampling_params = SamplingParams(
@@ -275,69 +264,75 @@ def test_sampled_token_always_in_logprobs(logprobs_k: int, logprobs_mode: str,
         logprobs_mode=logprobs_mode,
     )
 
-    for output in simple_llm.generate(["The future of AI is"],
-                                      sampling_params=sampling_params):
-        print(f"\n{'='*80}")
+    for output in simple_llm.generate(["The future of AI is"], sampling_params=sampling_params):
+        print(f"\n{'=' * 80}")
         print(f"Generated text: {output.outputs[0].text!r}")
         print(f"Generated token IDs: {output.outputs[0].token_ids}")
 
         logprobs = output.outputs[0].logprobs
         token_ids = output.outputs[0].token_ids
 
-        assert len(logprobs) == sampling_params.max_tokens, \
+        assert len(logprobs) == sampling_params.max_tokens, (
             f"Expected {sampling_params.max_tokens} logprob entries, got {len(logprobs)}"
+        )
 
-        for token_idx, (sampled_token_id,
-                        token_logprobs) in enumerate(zip(token_ids, logprobs)):
+        for token_idx, (sampled_token_id, token_logprobs) in enumerate(zip(token_ids, logprobs)):
             print(
-                f"\n  Token {token_idx}: ID={sampled_token_id}, Text={simple_llm.tokenizer.decode([sampled_token_id])!r}"
+                f"\n  Token {token_idx}: "
+                f"ID={sampled_token_id}, "
+                f"Text={simple_llm.tokenizer.decode([sampled_token_id])!r}"
             )
 
-            assert sampled_token_id in token_logprobs, \
+            assert sampled_token_id in token_logprobs, (
                 f"Token {token_idx}: Sampled token ID {sampled_token_id} not in logprobs dict: {token_logprobs.keys()}"
+            )
 
             if logprobs_k == 0:
-                assert len(token_logprobs) == 1, \
+                assert len(token_logprobs) == 1, (
                     f"Token {token_idx}: Expected 1 logprob (sampled only), got {len(token_logprobs)}"
+                )
             else:
-                assert len(token_logprobs) <= logprobs_k + 1, \
+                assert len(token_logprobs) <= logprobs_k + 1, (
                     f"Token {token_idx}: Expected at most {logprobs_k + 1} logprobs, got {len(token_logprobs)}"
+                )
                 assert len(token_logprobs) >= 1
 
-            sorted_tokens_by_prob = sorted(token_logprobs.items(),
-                                           key=lambda x: x[1].logprob,
-                                           reverse=True)
+            sorted_tokens_by_prob = sorted(
+                token_logprobs.items(), key=lambda x: x[1].logprob, reverse=True
+            )
 
             if logprobs_k > 0:
                 sampled_token_rank = token_logprobs[sampled_token_id].rank
                 sampled_in_topk = sampled_token_rank <= logprobs_k
 
                 if not sampled_in_topk:
-                    assert sorted_tokens_by_prob[-1][0] == sampled_token_id, \
-                        f"Token {token_idx}: Sampled token (ID={sampled_token_id}, rank={sampled_token_rank}) not in top-{logprobs_k}, " \
-                        f"should be last in sorted list, but last token is ID={sorted_tokens_by_prob[-1][0]}"
+                    assert sorted_tokens_by_prob[-1][0] == sampled_token_id, (
+                        f"Token {token_idx}: Sampled token (ID={sampled_token_id}, rank={sampled_token_rank}) "
+                        f"not in top-{logprobs_k}, should be last in sorted list, "
+                        f"but last token is ID={sorted_tokens_by_prob[-1][0]}"
+                    )
 
-            for rank_idx, (token_id,
-                           logprob_obj) in enumerate(sorted_tokens_by_prob,
-                                                     start=1):
+            for rank_idx, (token_id, logprob_obj) in enumerate(sorted_tokens_by_prob, start=1):
                 token_text = simple_llm.tokenizer.decode([token_id])
                 is_sampled = "← SAMPLED" if token_id == sampled_token_id else ""
-                print(f"    • Token {token_id:5d} ({token_text:15s}): "
-                      f"logprob={logprob_obj.logprob:8.4f}, "
-                      f"rank={logprob_obj.rank} {is_sampled}")
+                print(
+                    f"    • Token {token_id:5d} ({token_text:15s}): "
+                    f"logprob={logprob_obj.logprob:8.4f}, "
+                    f"rank={logprob_obj.rank} {is_sampled}"
+                )
 
                 if logprobs_k > 0 and sampled_in_topk:
-                    assert logprob_obj.rank == rank_idx, \
-                        f"Token {token_idx}: Token {token_id} rank mismatch. " \
+                    assert logprob_obj.rank == rank_idx, (
+                        f"Token {token_idx}: Token {token_id} rank mismatch. "
                         f"Expected rank {rank_idx} (by sorted position), got {logprob_obj.rank}"
+                    )
 
-        print(f"{'='*80}\n")
+        print(f"{'=' * 80}\n")
 
 
 @pytest.mark.parametrize("logprobs_k", [0, 2], ids=["top_0", "top_2"])
 @pytest.mark.threadleak(enabled=False)
-def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
-                                                    simple_llm: LLM):
+def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int, simple_llm: LLM):
     """Test logprobs when requests are reordered by sampling strategy grouping"""
 
     test_prompts = [
@@ -350,39 +345,43 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
 
     # Causes reordering: [0,1,2,3,4] → [0,2,3,1,4]
     sampling_params_list = [
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_k=50,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True),
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_p=0.9,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True),
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_k=50,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True),
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_k=50,
-                       logprobs=None,
-                       return_generation_logits=True),
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_p=0.9,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_k=50,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+        ),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_p=0.9,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+        ),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_k=50,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+        ),
+        SamplingParams(
+            max_tokens=6, temperature=0.8, top_k=50, logprobs=None, return_generation_logits=True
+        ),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_p=0.9,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+        ),
     ]
 
-    outputs = list(
-        simple_llm.generate(test_prompts, sampling_params=sampling_params_list))
+    outputs = list(simple_llm.generate(test_prompts, sampling_params=sampling_params_list))
 
     for req_idx, output in enumerate(outputs):
-        generation_logits = output.outputs[0].generation_logits.to(
-            device="cuda")
+        generation_logits = output.outputs[0].generation_logits.to(device="cuda")
         token_ids = output.outputs[0].token_ids
         logprobs = output.outputs[0].logprobs
         if sampling_params_list[req_idx].logprobs is None:
@@ -396,12 +395,14 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
         num_logits = len(generation_logits)
 
         for token_idx, (sampled_token_id, token_logprobs_dict) in enumerate(
-                zip(token_ids[:num_logits], logprobs[:num_logits])):
+            zip(token_ids[:num_logits], logprobs[:num_logits])
+        ):
             returned_logprob = token_logprobs_dict[sampled_token_id].logprob
 
             logits_for_token = generation_logits[token_idx]
-            expected_logprobs = torch.nn.functional.log_softmax(
-                logits_for_token, dim=-1).to(device="cpu")
+            expected_logprobs = torch.nn.functional.log_softmax(logits_for_token, dim=-1).to(
+                device="cpu"
+            )
             expected_logprob = expected_logprobs[sampled_token_id].item()
             print(
                 f"Req {req_idx}, Token {token_idx}: returned={returned_logprob:.6f}, expected={expected_logprob:.6f}"
@@ -424,54 +425,64 @@ def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
 
     sampling_params_list = [
         # greedy decoding
-        SamplingParams(max_tokens=6,
-                       temperature=0.0,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.0,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
         # temperature sampling
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
         # top-p sampling
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_p=0.9,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_p=0.9,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
         # top-k sampling
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_k=50,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_k=50,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
         # top-p sampling 2
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_p=0.9,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_p=0.9,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
         # top-p and top-k sampling
-        SamplingParams(max_tokens=6,
-                       temperature=0.8,
-                       top_p=0.9,
-                       top_k=50,
-                       logprobs=logprobs_k,
-                       return_generation_logits=True,
-                       logprobs_mode="processed"),
+        SamplingParams(
+            max_tokens=6,
+            temperature=0.8,
+            top_p=0.9,
+            top_k=50,
+            logprobs=logprobs_k,
+            return_generation_logits=True,
+            logprobs_mode="processed",
+        ),
     ]
 
-    outputs = list(
-        simple_llm.generate(test_prompts, sampling_params=sampling_params_list))
+    outputs = list(simple_llm.generate(test_prompts, sampling_params=sampling_params_list))
 
     for req_idx, output in enumerate(outputs):
-        generation_logits = output.outputs[0].generation_logits.to(
-            device="cuda")
+        generation_logits = output.outputs[0].generation_logits.to(device="cuda")
         token_ids = output.outputs[0].token_ids
         logprobs = output.outputs[0].logprobs
 
@@ -482,10 +493,9 @@ def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
         num_logits = len(generation_logits)
 
         for token_idx, token_logprobs_dict in enumerate(logprobs[:num_logits]):
-            assert token_ids[
-                token_idx] in token_logprobs_dict, "Sampled token not in logprobs"
+            assert token_ids[token_idx] in token_logprobs_dict, "Sampled token not in logprobs"
 
-            logits_for_token = generation_logits[token_idx:token_idx + 1]
+            logits_for_token = generation_logits[token_idx : token_idx + 1]
             topk = sampling_params_list[req_idx].top_k
             topp = sampling_params_list[req_idx].top_p
             temperature = sampling_params_list[req_idx].temperature
@@ -500,37 +510,30 @@ def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
                 # perform maksing top-k top-p
                 if simple_llm.args.disable_flashinfer_sampling:
                     _, probs = top_k_top_p_sampling_batch(
-                        logits_for_token,
-                        top_k=topk,
-                        top_p=topp,
-                        temperature=temperature)
+                        logits_for_token, top_k=topk, top_p=topp, temperature=temperature
+                    )
                 else:
                     _, probs = _StrategyImpls.StrategyImplWithProbs._sample_with_probs(
                         logits_for_token,
                         group_logit_indices=None,
-                        top_k=torch.tensor([topk],
-                                           dtype=torch.int32,
-                                           device="cuda"),
-                        top_p=torch.tensor([topp],
-                                           dtype=torch.float32,
-                                           device="cuda"),
-                        temperature=torch.tensor([temperature],
-                                                 dtype=torch.float32,
-                                                 device="cuda"),
-                        generator=None)
+                        top_k=torch.tensor([topk], dtype=torch.int32, device="cuda"),
+                        top_p=torch.tensor([topp], dtype=torch.float32, device="cuda"),
+                        temperature=torch.tensor([temperature], dtype=torch.float32, device="cuda"),
+                        generator=None,
+                    )
 
             if temperature != 0:
                 logits_for_token /= temperature
-            adjusted_logits_for_token = torch.where(probs != 0,
-                                                    logits_for_token,
-                                                    float("-inf"))[0]
+            adjusted_logits_for_token = torch.where(probs != 0, logits_for_token, float("-inf"))[0]
             expected_logprobs = torch.nn.functional.log_softmax(
-                adjusted_logits_for_token, dim=-1).to(device="cpu")
+                adjusted_logits_for_token, dim=-1
+            ).to(device="cpu")
             for logprob_token, logprob_values in token_logprobs_dict.items():
                 expected_logprob = expected_logprobs[logprob_token].item()
                 returned_logprob = logprob_values.logprob
                 print(
-                    f"Req {req_idx}, Token {token_idx}: returned={returned_logprob:.6f}, expected={expected_logprob:.6f}"
+                    f"Req {req_idx}, Token {token_idx}: "
+                    f"returned={returned_logprob:.6f}, expected={expected_logprob:.6f}"
                 )
                 torch.testing.assert_close(returned_logprob, expected_logprob)
 
@@ -538,8 +541,7 @@ def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
 @force_ampere
 @pytest.mark.gpu2
 def test_logprobs_match_hf_tp2():
-    model_path = os.path.join(llm_models_root(), "llama-models-v2",
-                              "TinyLlama-1.1B-Chat-v1.0")
+    model_path = os.path.join(llm_models_root(), "llama-models-v2", "TinyLlama-1.1B-Chat-v1.0")
     llm = LLM(
         model=model_path,
         tensor_parallel_size=2,
@@ -553,15 +555,17 @@ def test_logprobs_match_hf_tp2():
         logprobs=0,
     )
 
-    hf_model = AutoModelForCausalLM.from_pretrained(
-        model_path, torch_dtype=torch.bfloat16).to("cuda")
+    hf_model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch.bfloat16).to(
+        "cuda"
+    )
     hf_tokenizer = AutoTokenizer.from_pretrained(model_path)
 
     output = list(llm.generate(prompts, sampling_params=sampling_params))[0]
 
     trtllm_token_ids = output.outputs[0].token_ids
     trtllm_logprobs = torch.tensor(
-        [list(lp.values())[0].logprob for lp in output.outputs[0].logprobs])
+        [list(lp.values())[0].logprob for lp in output.outputs[0].logprobs]
+    )
 
     base_ids = hf_tokenizer.encode(prompts[0], return_tensors="pt").to("cuda")
     hf_logprobs = []

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -344,10 +344,11 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
         "The capital of France is",
         "The future of AI is",
         "Hello, my name is",
+        "Hello, my name is",
         "Write a short story about a cat",
     ]
 
-    # Causes reordering: [0,1,2,3] → [0,2,1,3]
+    # Causes reordering: [0,1,2,3,4] → [0,2,3,1,4]
     sampling_params_list = [
         SamplingParams(max_tokens=6,
                        temperature=0.8,
@@ -366,6 +367,11 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
                        return_generation_logits=True),
         SamplingParams(max_tokens=6,
                        temperature=0.8,
+                       top_k=50,
+                       logprobs=None,
+                       return_generation_logits=True),
+        SamplingParams(max_tokens=6,
+                       temperature=0.8,
                        top_p=0.9,
                        logprobs=logprobs_k,
                        return_generation_logits=True),
@@ -378,6 +384,9 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
         generation_logits = output.outputs[0].generation_logits
         token_ids = output.outputs[0].token_ids
         logprobs = output.outputs[0].logprobs
+        if sampling_params_list[req_idx].logprobs is None:
+            assert len(logprobs) == 0
+            continue
 
         assert generation_logits is not None
         assert len(logprobs) == len(token_ids), "Logprobs length mismatch"

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -419,10 +419,16 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int,
 @pytest.mark.threadleak(enabled=False)
 def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
     """Test logprobs when requests are reordered by sampling strategy grouping"""
+    if logprobs_k == 0 and simple_llm.args.disable_flashinfer_sampling:
+        pytest.skip(
+            "top_0 does currently not work without flashinfer sampling. Remove this skip once this is fixed."
+        )
 
     test_prompts = [
         "The capital of France is",
         "The future of AI is",
+        "Hello, my name is",
+        "Write a short story about a cat",
         "Hello, my name is",
         "Write a short story about a cat",
     ]

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
 from utils.llm_data import llm_models_root
 from utils.util import force_ampere
 
@@ -390,41 +391,52 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int):
                 f"the wrong token position."
 
 
-# def test_logprobs_match_hf_tp2():
-#     """Compare TensorRT-LLM logprobs against HuggingFace reference."""
-#     model_path = os.path.join(llm_models_root(), "llama-models-v2", "TinyLlama-1.1B-Chat-v1.0")
-#     llm = LLM(
-#             model=model_path,
-#             tensor_parallel_size=2,
-#         )
+@force_ampere
+@pytest.mark.gpu2
+def test_logprobs_match_hf_tp2():
+    model_path = os.path.join(llm_models_root(), "llama-models-v2",
+                              "TinyLlama-1.1B-Chat-v1.0")
+    llm = LLM(
+        model=model_path,
+        tensor_parallel_size=2,
+    )
 
-#     sampling_params = SamplingParams(
-#         max_tokens=10,
-#         temperature=0,
-#         logprobs=0,
-#     )
+    prompts = ["The future of the AI is"]
 
-#     hf_model = AutoModelForCausalLM.from_pretrained(modesl_path, torch_dtype=torch.bfloat16).to("cuda")
-#     hf_tokenizer = AutoTokenizer.from_pretrained(model_path)
+    sampling_params = SamplingParams(
+        max_tokens=10,
+        temperature=1.0,
+        logprobs=0,
+    )
 
-#     output = list(llm.generate(prompts, sampling_params=sampling_params))[0]
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        model_path, torch_dtype=torch.bfloat16).to("cuda")
+    hf_tokenizer = AutoTokenizer.from_pretrained(model_path)
 
-#     trtllm_token_ids = output.outputs[0].token_ids
-#     trtllm_logprobs = torch.tensor([list(lp.values())[0].logprob for lp in output.outputs[0].logprobs])
+    output = list(llm.generate(prompts, sampling_params=sampling_params))[0]
 
-#     base_ids = hf_tokenizer.encode(prompts[0], return_tensors="pt").to("cuda")
-#     hf_logprobs = []
+    trtllm_token_ids = output.outputs[0].token_ids
+    trtllm_logprobs = torch.tensor(
+        [list(lp.values())[0].logprob for lp in output.outputs[0].logprobs])
 
-#     for i, token_id in enumerate(trtllm_token_ids):
-#         input_ids = torch.cat([base_ids, torch.tensor(trtllm_token_ids[:i], device="cuda").unsqueeze(0)], dim=1) if i > 0 else base_ids
-#         with torch.no_grad():
-#             logits = hf_model(input_ids).logits[0, -1, :]
-#         hf_logprobs.append(torch.log_softmax(logits, dim=-1)[token_id].item())
+    base_ids = hf_tokenizer.encode(prompts[0], return_tensors="pt").to("cuda")
+    hf_logprobs = []
 
-#     hf_logprobs = torch.tensor(hf_logprobs)
+    for i, token_id in enumerate(trtllm_token_ids):
+        if i > 0:
+            prev_tokens = torch.tensor([trtllm_token_ids[:i]], device="cuda")
+            input_ids = torch.cat([base_ids, prev_tokens], dim=1)
+        else:
+            input_ids = base_ids
+        with torch.no_grad():
+            logits = hf_model(input_ids).logits[0, -1, :]
+        hf_logprobs.append(torch.log_softmax(logits, dim=-1)[token_id].item())
 
-#     print(f"\nTensorRT-LLM logprobs: {trtllm_logprobs}")
-#     print(f"HuggingFace logprobs:  {hf_logprobs}")
+    hf_logprobs = torch.tensor(hf_logprobs)
 
-#     max_diff = (trtllm_logprobs - hf_logprobs).abs().max().item()
-#     assert max_diff < 0.1, f"Max logprob diff {max_diff:.4f} exceeds threshold"
+    print(f"\nTensorRT-LLM logprobs: {trtllm_logprobs}")
+    print(f"HuggingFace logprobs:  {hf_logprobs}")
+    print(f"Diff: {(trtllm_logprobs - hf_logprobs).abs()}")
+
+    max_diff = (trtllm_logprobs - hf_logprobs).abs().max().item()
+    assert max_diff < 0.15, f"Max logprob diff {max_diff:.4f} exceeds threshold"

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -86,7 +86,7 @@ class TestStrategySelection:
         is_context_init_state: bool  # Torch sampler accesses this, but it does not affect this test
 
         def get_beam_width_by_iter(
-            self, for_next_iteration: bool
+            self, for_next_iteration: bool = False
         ) -> int:  # Torch sampler accesses this, but it does not affect this test
             return self.sampling_config.beam_width
 
@@ -445,11 +445,21 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
             def py_return_context_logits(self) -> bool:
                 return self._return_context_logits
 
+            def get_beam_width_by_iter(
+                self, for_next_iteration: bool = False
+            ) -> int:  # Torch sampler accesses this, but it does not affect this test
+                return self.sampling_config.beam_width
+
         class GenRequestMock:
             def __init__(self, draft_len: int):
                 self.is_context_init_state = False
                 self.py_draft_tokens = torch.empty(draft_len, dtype=torch.int32, device=device)
                 self.sampling_config = SamplingConfig(beam_width=1)
+
+            def get_beam_width_by_iter(
+                self, for_next_iteration: bool = False
+            ) -> int:  # Torch sampler accesses this, but it does not affect this test
+                return self.sampling_config.beam_width
 
         class ScheduledRequestsMock:
             @property

--- a/tests/unittest/api_stability/api_stability_core.py
+++ b/tests/unittest/api_stability/api_stability_core.py
@@ -31,6 +31,7 @@ from tensorrt_llm.llmapi import (CalibConfig, CompletionOutput,
 from tensorrt_llm.llmapi.llm_args import SamplerType
 from tensorrt_llm.llmapi.llm_utils import LlmArgs
 from tensorrt_llm.logger import Singleton
+from tensorrt_llm.sampling_params import LogprobMode
 
 
 def repr_annotation(field_type: type) -> str:

--- a/tests/unittest/api_stability/references/sampling_params.yaml
+++ b/tests/unittest/api_stability/references/sampling_params.yaml
@@ -16,7 +16,7 @@ methods:
         annotation: Optional[int]
         default: null
       logprobs_mode:
-        annotation: Literal["raw", "processed"]
-        default: "raw"
+        annotation: LogprobMode
+        default: LogprobMode.RAW
     return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/references/sampling_params.yaml
+++ b/tests/unittest/api_stability/references/sampling_params.yaml
@@ -15,5 +15,8 @@ methods:
       prompt_ignore_length:
         annotation: Optional[int]
         default: null
+      logprobs_mode:
+        annotation: Literal["raw", "processed"]
+        default: "raw"
     return_annotation: None
 properties: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable log probability modes ("raw" or "processed") to control logprob output format.
  * Enhanced per-token sampled log probability tracking with top-k support.
  * Improved sampling strategy handling with temperature state management.

* **Bug Fixes**
  * Fixed log probability parameter handling to respect explicit false values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Iintroduces a new optional parameter, logprobs_mode, to the SamplingParams and LlmRequest classes, allowing users to specify the mode of log probabilities to return.
- Create process_logprobs function to remove logprobs processing code from process_requests.
- add batching based on logprobs_mode to sample_batched_by_strategy
- additionally return processed logits from sampling

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
