### PR TITLE
[TRTLLM-9660][feat] Convert cuteDSL GEMM to opt-in feature

### DIFF
--- a/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
+++ b/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
@@ -578,7 +578,9 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
                 if not isinstance(backend_value, str):
                     return False
 
-                valid_backends = {'auto', 'cutlass', 'cublaslt', 'cutedsl'}
+                valid_backends = {
+                    'auto', 'auto_no_cutedsl', 'cutlass', 'cublaslt', 'cutedsl'
+                }
                 return backend_value in valid_backends
 
             register_replacement(

--- a/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
+++ b/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
@@ -526,7 +526,7 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
             alpha_key = KeywordArg('alpha')
             output_dtype_key = KeywordArg('output_dtype')
             to_userbuffers_key = KeywordArg('to_userbuffers')
-            backend_key = KeywordArg('backend')
+            allowed_backends_key = KeywordArg('allowed_backends')
             trtllm_nvfp4_gemm_default = CallFunction(
                 torch.ops.trtllm.nvfp4_gemm.default,
                 act_fp4_key,
@@ -536,7 +536,7 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
                 alpha_key,
                 output_dtype_key,
                 to_userbuffers=to_userbuffers_key,
-                backend=backend_key)
+                allowed_backends=allowed_backends_key)
             ub_copy = CallFunction(torch.ops.trtllm.copy_to_userbuffers,
                                    trtllm_nvfp4_gemm_default)
 
@@ -548,7 +548,7 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
                 alpha: torch.Tensor,
                 output_dtype: torch.dtype,
                 to_userbuffers: bool,
-                backend: str,
+                allowed_backends,
             ):
                 return
 
@@ -560,28 +560,28 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
                 alpha: torch.Tensor,
                 output_dtype: torch.dtype,
                 to_userbuffers: bool,
-                backend: str,
+                allowed_backends,
             ):
                 nvfp4_gemm_output = torch.ops.trtllm.nvfp4_gemm(
                     act_fp4, weight, act_sf, weight_scale, alpha, output_dtype,
-                    True, backend)
+                    True, allowed_backends)
                 return nvfp4_gemm_output
 
             def extra_check(match: Match) -> bool:
-                # Validate backend value
-                backend_value = match.kwargs.get('backend')
-                if backend_value is None:
-                    # No backend specified, use default - OK
-                    return True
+                # Validate allowed_backends if present
+                allowed_backends_value = match.kwargs.get('allowed_backends')
+                if allowed_backends_value is not None:
+                    # allowed_backends should be a list of strings
+                    if not isinstance(allowed_backends_value, list):
+                        return False
+                    valid_individual = {
+                        'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'
+                    }
+                    if not all(b in valid_individual
+                               for b in allowed_backends_value):
+                        return False
 
-                # backend should be a string literal
-                if not isinstance(backend_value, str):
-                    return False
-
-                valid_backends = {
-                    'auto', 'auto_no_cutedsl', 'cutlass', 'cublaslt', 'cutedsl'
-                }
-                return backend_value in valid_backends
+                return True
 
             register_replacement(
                 empty_nvfp4_gemm_prologue_pattern,

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -820,7 +820,9 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
             valid_tactics = self.get_valid_tactics(inputs,
                                                    OptimizationProfile())
             if valid_tactics:
-                tactic = valid_tactics[0]
+                # Prefer cutlass as fallback if available, otherwise use first valid tactic
+                tactic = "cutlass" if "cutlass" in valid_tactics else valid_tactics[
+                    0]
             else:
                 m, n, k = inputs[0].shape[0], inputs[1].shape[
                     0], inputs[0].shape[1] * 2

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -695,31 +695,36 @@ def _(
 class NVFP4GemmUnifiedRunner(TunableRunner):
     runner_dict = dict()
 
-    def __init__(self,
-                 to_userbuffers: bool,
-                 output_dtype: torch.dtype,
-                 backend: str = "auto",
-                 exclude_cutedsl: bool = False):
+    def __init__(self, to_userbuffers: bool, output_dtype: torch.dtype,
+                 allowed_backends: List[str]):
         super().__init__()
         self.to_userbuffers = to_userbuffers
         self.output_dtype = output_dtype
-        self.backend = backend
-        self.exclude_cutedsl = exclude_cutedsl
+        self.allowed_backends = allowed_backends
 
     def unique_id(self):
-        """Include backend and exclude_cutedsl in cache key to avoid sharing cache across backends."""
-        return (self.to_userbuffers, self.output_dtype, self.backend,
-                self.exclude_cutedsl)
+        """Include allowed_backends in cache key to avoid sharing cache across different backend configs."""
+        # Convert list to tuple for hashability
+        allowed_tuple = tuple(self.allowed_backends)
+        return (self.to_userbuffers, self.output_dtype, allowed_tuple)
+
+    def _is_backend_allowed(self, backend_name: str) -> bool:
+        """Check if a backend is allowed based on allowed_backends list."""
+        return backend_name in self.allowed_backends
+
+    def _is_only_backend(self, backend_name: str) -> bool:
+        """Check if this is the only backend in allowed_backends (explicitly forced)."""
+        return self.allowed_backends == [backend_name]
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,
                           **kwargs) -> List[Tuple]:
-        # return valid nvfp4 gemm implementations
+        # return valid nvfp4 gemm implementations from allowed_backends
         tactics = []
         act_fp4, weight, act_sf, weight_scale, alpha = inputs
-        backend = self.backend
 
-        if backend in ["auto", "cuda_core"]:
+        # Add CUDA Core backend if available
+        if self._is_backend_allowed("cuda_core"):
             is_cuda_core_supported = False
             m = act_fp4.shape[0]
             sm_version = None
@@ -735,41 +740,39 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
 
             if is_cuda_core_supported:
                 tactics.append("cuda_core")
-            elif backend == "cuda_core":
-                # Explicitly requested but conditions not met - raise error
+            elif self._is_only_backend("cuda_core"):
+                # Explicitly forced but conditions not met - raise error
                 error_msg = f"CUDA Core backend requires SM >= {CudaCoreNVFP4Runner.MIN_SM_VERSION} and M <= {CudaCoreNVFP4Runner.MAX_M_DIMENSION}. "
                 error_msg += f"Current: SM={sm_version if sm_version else 'N/A'}, M={m}. "
-                error_msg += "Please use backend='auto' or another backend."
+                error_msg += "Please add other backends to allowed_backends."
                 raise ValueError(error_msg)
 
         # Add CUTLASS runner (always available)
-        if backend in ["auto", "cutlass"]:
+        if self._is_backend_allowed("cutlass"):
             tactics.append("cutlass")
 
         # Add cuBLASLt runner if available
-        if backend in ["auto", "cublaslt"]:
+        if self._is_backend_allowed("cublaslt"):
             if IS_CUBLASLT_AVAILABLE:
                 tactics.append("cublaslt")
-            elif backend == "cublaslt":
+            elif self._is_only_backend("cublaslt"):
                 raise ValueError(
                     "cuBLASLt backend is not available. "
-                    "Please check cuBLASLt installation or use backend='auto'.")
+                    "Please check cuBLASLt installation or add other backends to allowed_backends."
+                )
 
         # Add CuteDSL runner if available
-        # Note: "auto_no_cutedsl" explicitly excludes cutedsl from auto selection
-        if backend in ["auto", "cutedsl"] and not self.exclude_cutedsl:
+        if self._is_backend_allowed("cutedsl"):
             if IS_CUTLASS_DSL_AVAILABLE:
                 # Check SM version first - CuteDSL NVFP4 only supports SM 100 (B200)
                 sm_version = get_sm_version()
                 if sm_version not in [100, 103]:
-                    if backend == "cutedsl":
-                        # Explicitly requested CuteDSL but SM version not supported
+                    if self._is_only_backend("cutedsl"):
+                        # Explicitly forced CuteDSL but SM version not supported
                         raise ValueError(
                             f"CuteDSL NVFP4 backend requires SM 100 (B200) or SM 103 (B300), but got SM {sm_version}. "
                             f"CuteDSL NVFP4 is not supported on this GPU architecture. "
-                            f"Please use backend='auto' to automatically select a compatible backend."
-                        )
-                    # else: backend='auto' → silently skip CuteDSL
+                            f"Please add other backends to allowed_backends.")
                 else:
                     # SM version OK, check if CuteDSL supports the current shape
                     from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import \
@@ -782,8 +785,8 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
                     if cutedsl_tactics:
                         # CuteDSL supports this shape
                         tactics.append("cutedsl")
-                    elif backend == "cutedsl":
-                        # Explicitly requested CuteDSL but it doesn't support this shape
+                    elif self._is_only_backend("cutedsl"):
+                        # Explicitly forced CuteDSL but it doesn't support this shape
                         m, n, k = inputs[0].shape[0], inputs[1].shape[
                             0], inputs[0].shape[1] * 2
                         raise ValueError(
@@ -792,13 +795,12 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
                             f"CuteDSL requires 16-byte alignment for major (contiguous) dimensions:\n"
                             f"  - K must be divisible by 32 (FP4 K-major layout): K%32={'0✓' if k % 32 == 0 else str(k%32)+'✗'}\n"
                             f"  - Or the combination of (M, N, K, tiling, cluster shape) is not supported\n"
-                            f"Please use backend='auto' to automatically select a compatible backend."
-                        )
-                    # else: backend='auto' and CuteDSL doesn't support shape → silently skip
-            elif backend == "cutedsl":
+                            f"Please add other backends to allowed_backends.")
+            elif self._is_only_backend("cutedsl"):
                 raise ValueError(
                     "CuteDSL backend is not available. "
-                    "Please check CuteDSL installation or use backend='auto'.")
+                    "Please check CuteDSL installation or add other backends to allowed_backends."
+                )
 
         return tactics
 
@@ -811,31 +813,21 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
     ) -> torch.Tensor:
         act_fp4, weight, act_sf, weight_scale, alpha = inputs
 
-        requested_backend = self.backend
-
-        # If a specific backend was requested (not 'auto') and we're using fallback tactic
-        # This can happen on cache miss, where AutoTuner uses tactic=-1 as default
-        if requested_backend != 'auto' and requested_backend != tactic and tactic == -1:
-            # User explicitly requested a backend, but we're falling back to default
-            # This might happen on cache miss. We should validate the requested backend supports this shape.
-
-            # Get valid tactics for the requested backend
+        # Handle fallback tactic (-1) on cache miss
+        if tactic == -1:
+            # Get valid tactics and use first available
             from tensorrt_llm._torch.autotuner import OptimizationProfile
             valid_tactics = self.get_valid_tactics(inputs,
                                                    OptimizationProfile())
-
-            if not valid_tactics or requested_backend not in valid_tactics:
-                # Requested backend doesn't support this shape
+            if valid_tactics:
+                tactic = valid_tactics[0]
+            else:
                 m, n, k = inputs[0].shape[0], inputs[1].shape[
                     0], inputs[0].shape[1] * 2
                 raise ValueError(
-                    f"Backend '{requested_backend}' was explicitly requested but does not support the current shape:\n"
+                    f"No valid backends available for the current shape:\n"
                     f"  M={m}, N={n}, K={k}\n"
-                    f"Please use backend='auto' to automatically select a compatible backend."
-                )
-
-            # Backend supports it, use the requested backend instead of fallback
-            tactic = requested_backend
+                    f"  Allowed backends: {self.allowed_backends}")
 
         if tactic == "cuda_core":
             # Unswizzle the activation scale factors
@@ -886,11 +878,11 @@ def nvfp4_gemm(
     alpha: torch.Tensor,
     output_dtype: torch.dtype,
     to_userbuffers: bool = False,
-    backend: str = "auto_no_cutedsl",
+    allowed_backends: Optional[List[str]] = None,
 ) -> torch.Tensor:
-    """Unified NVFP4 GEMM with automatic or manual backend selection.
+    """Unified NVFP4 GEMM with automatic backend selection.
 
-    This function can automatically choose the best backend or force a specific backend:
+    This function automatically chooses the best backend from the allowed list:
     - CUTLASS: Predefined CUTLASS configurations with auto-tuning
     - cuBLASLt: Heuristic-based algorithms from cuBLASLt library
     - CuteDSL: Blackwell-optimized persistent kernels (when available and inputs are valid)
@@ -898,8 +890,7 @@ def nvfp4_gemm(
 
     The AutoTuner profiles all available backends during the first run and caches
     the best choice for each input shape. Subsequent calls use the cached selection
-    with zero overhead. In 'auto' mode, backends are only considered if their
-    requirements are met (e.g., CUDA Core only participates when SM >= 100 and M <= 8).
+    with zero overhead.
 
     Args:
         act_fp4: Activation tensor [m, k] in FP4 format (packed in uint8)
@@ -909,13 +900,10 @@ def nvfp4_gemm(
         alpha: Scaling factor (as torch.Tensor for CUTLASS/cuBLASLt compatibility)
         output_dtype: Output data type
         to_userbuffers: Whether to use user buffers (CUTLASS/cuBLASLt only)
-        backend: Backend selection, one of:
-            - 'auto_no_cutedsl': Auto-select from cutlass/cublaslt/cuda_core (default, faster build)
-            - 'auto': Auto-select from all backends including cutedsl (slower build, extreme perf)
-            - 'cutlass': Force use CUTLASS (FP4GemmRunner)
-            - 'cublaslt': Force use cuBLASLt (CublasLtFP4GemmRunner)
-            - 'cutedsl': Force use CuteDSL (CuteDSLNVFP4Wrapper)
-            - 'cuda_core': Force use CUDA Core (CudaCoreNVFP4Runner, requires SM >= 100, M <= 8)
+        allowed_backends: List of backends to consider for auto-selection.
+            Default: ['cutlass', 'cublaslt', 'cuda_core'] (excludes cutedsl for faster build)
+            Add 'cutedsl' for extreme performance at the cost of longer build time.
+            Valid backends: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.
 
     Returns:
         Output tensor [m, n] with dtype=output_dtype
@@ -924,23 +912,26 @@ def nvfp4_gemm(
         ValueError: If backend is invalid/unavailable
     """
 
-    # Validate backend parameter
-    valid_backends = [
-        'auto', 'auto_no_cutedsl', 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'
-    ]
-    if backend not in valid_backends:
+    valid_individual_backends = {'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'}
+
+    # Use default if not specified
+    if allowed_backends is None:
+        allowed_backends = ['cutlass', 'cublaslt', 'cuda_core']
+
+    # Validate allowed_backends
+    invalid_backends = set(allowed_backends) - valid_individual_backends
+    if invalid_backends:
         raise ValueError(
-            f"Invalid backend '{backend}'. Must be one of {valid_backends}")
+            f"Invalid backends in allowed_backends: {invalid_backends}. "
+            f"Valid backends are: {sorted(valid_individual_backends)}.")
+    if not allowed_backends:
+        raise ValueError(
+            f"allowed_backends cannot be empty. "
+            f"Valid backends are: {sorted(valid_individual_backends)}.")
 
-    # Normalize auto_no_cutedsl to auto for the runner (cutedsl exclusion is handled in get_valid_tactics)
-    effective_backend = 'auto' if backend == 'auto_no_cutedsl' else backend
-
-    # Build list of runners based on backend parameter
-    runner = NVFP4GemmUnifiedRunner(
-        to_userbuffers,
-        output_dtype,
-        effective_backend,
-        exclude_cutedsl=(backend == 'auto_no_cutedsl'))
+    # Build runner with allowed backends
+    runner = NVFP4GemmUnifiedRunner(to_userbuffers, output_dtype,
+                                    list(allowed_backends))
 
     # Use AutoTuner to select best runner and tactic
     # - For 'auto' mode: compare across all backends, find global optimum
@@ -980,7 +971,7 @@ def _(
     alpha: torch.Tensor,
     output_dtype: torch.dtype,
     to_userbuffers: bool = False,
-    backend: str = "auto_no_cutedsl",
+    allowed_backends: Optional[List[str]] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.compile support."""
     return act_fp4.new_empty((act_fp4.size(0), weight.size(0)),

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -772,7 +772,7 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
                         raise ValueError(
                             f"CuteDSL NVFP4 backend requires SM 100 (B200) or SM 103 (B300), but got SM {sm_version}. "
                             f"CuteDSL NVFP4 is not supported on this GPU architecture. "
-                            f"Please add other backends to allowed_backends.")
+                            "Please add other backends to allowed_backends.")
                 else:
                     # SM version OK, check if CuteDSL supports the current shape
                     from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import \

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -102,6 +102,11 @@ class ModelConfig(Generic[TConfig]):
     # If true, use low precision combine in MoE operations (only for NVFP4 quantization)
     use_low_precision_moe_combine: bool = False
 
+    # NVFP4 GEMM backend configuration - list of backends to consider for auto-selection
+    # Default excludes 'cutedsl' for faster build time. Add 'cutedsl' for extreme perf.
+    nvfp4_gemm_allowed_backends: List[str] = field(
+        default_factory=lambda: ['cutlass', 'cublaslt', 'cuda_core'])
+
     allreduce_strategy: AllReduceStrategy = AllReduceStrategy.AUTO
 
     # If true, enable min-latency mode. Currently only used for Llama4.

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -28,7 +28,7 @@ from tensorrt_llm.quantization.utils.fp8_utils import (
 
 from ..._utils import get_sm_version, is_sm_100f
 from ...models.modeling_utils import QuantConfig
-from ..utils import Fp4QuantizedTensor, unswizzle_sf
+from ..utils import Fp4QuantizedTensor, get_model_extra_attrs, unswizzle_sf
 
 
 class WeightMode(str, enum.Enum):
@@ -937,14 +937,15 @@ class NVFP4LinearMethod(LinearMethodBase):
                 input, module.input_scale, module.scaling_vector_size, False)
 
         # Use unified interface - supports CUTLASS, cuBLASLt, CuteDSL
-        output = torch.ops.trtllm.nvfp4_gemm(act_fp4,
-                                             module.weight,
-                                             act_sf,
-                                             module.weight_scale,
-                                             module.alpha,
-                                             module.dtype,
-                                             to_userbuffers=False,
-                                             backend=module.nvfp4_backend)
+        output = torch.ops.trtllm.nvfp4_gemm(
+            act_fp4,
+            module.weight,
+            act_sf,
+            module.weight_scale,
+            module.alpha,
+            module.dtype,
+            to_userbuffers=False,
+            allowed_backends=module.nvfp4_allowed_backends)
         # Take the dim of out_features if padded. Make sure the output is contiguous
         if output.shape[-1] > module.out_features:
             output = output[..., :module.out_features].contiguous()
@@ -2054,18 +2055,15 @@ class Linear(nn.Module):
         use_cute_dsl_blockscaling_mm: bool = False,
         disable_deep_gemm: bool = False,
         fused_weight_shard_indices_mapping: Optional[dict] = None,
-        nvfp4_backend: str = "auto_no_cutedsl",
+        nvfp4_allowed_backends: Optional[List[str]] = None,
     ):
         """
         Args:
-            nvfp4_backend: Backend selection for NVFP4 GEMM operations.
-                Supported values: "auto", "auto_no_cutedsl", "cutlass", "cublaslt", "cutedsl".
-                - "auto": Automatically selects the best backend (may include cutedsl).
-                - "auto_no_cutedsl": Like auto, but excludes cutedsl from selection.
-                - "cutlass", "cublaslt", "cutedsl": Force specific backend.
-                Default is "auto_no_cutedsl" (excludes cutedsl to reduce build time).
-                Set to "auto" for extreme performance at the cost of longer build time.
-                Can be overridden via TRTLLM_NVFP4_GEMM_BACKEND environment variable.
+            nvfp4_allowed_backends: List of backends to consider for NVFP4 GEMM auto-selection.
+                Default (via config): ['cutlass', 'cublaslt', 'cuda_core'] - excludes cutedsl for faster build.
+                Add 'cutedsl' for extreme performance at the cost of longer build time.
+                Valid backends: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.
+                Configure via nvfp4_gemm_config.allowed_backends in extra_llm_api_options.yaml.
         """
         from ..distributed import AllReduce
 
@@ -2086,22 +2084,17 @@ class Linear(nn.Module):
         self.disable_deep_gemm = disable_deep_gemm
         self.fused_weight_shard_indices_mapping = fused_weight_shard_indices_mapping
 
-        # Support environment variable override for nvfp4_backend
-        nvfp4_backend_value = os.environ.get('TRTLLM_NVFP4_GEMM_BACKEND',
-                                             nvfp4_backend)
-
-        # Validate backend selection
-        valid_backends = {
-            'auto', 'auto_no_cutedsl', 'cutlass', 'cublaslt', 'cutedsl'
-        }
-        if nvfp4_backend_value not in valid_backends:
-            raise ValueError(
-                f"Invalid nvfp4_backend: '{nvfp4_backend_value}'. "
-                f"Supported values are: {', '.join(sorted(valid_backends))}. "
-                f"Set via constructor argument or TRTLLM_NVFP4_GEMM_BACKEND environment variable."
-            )
-
-        self.nvfp4_backend = nvfp4_backend_value
+        # Store NVFP4 GEMM allowed backends configuration
+        # Read from model_extra_attrs if not explicitly provided (allows config via llm_api_options)
+        if nvfp4_allowed_backends is None:
+            model_attrs = get_model_extra_attrs()
+            if model_attrs:
+                nvfp4_allowed_backends = model_attrs.get(
+                    'nvfp4_gemm_allowed_backends')
+        # Default: exclude cutedsl for faster build time
+        self.nvfp4_allowed_backends = nvfp4_allowed_backends or [
+            'cutlass', 'cublaslt', 'cuda_core'
+        ]
 
         local_in_features = in_features
         local_out_features = out_features

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2054,13 +2054,17 @@ class Linear(nn.Module):
         use_cute_dsl_blockscaling_mm: bool = False,
         disable_deep_gemm: bool = False,
         fused_weight_shard_indices_mapping: Optional[dict] = None,
-        nvfp4_backend: str = "auto",
+        nvfp4_backend: str = "auto_no_cutedsl",
     ):
         """
         Args:
             nvfp4_backend: Backend selection for NVFP4 GEMM operations.
-                Supported values: "auto", "cutlass", "cublaslt", "cutedsl".
-                Default is "auto" which automatically selects the best backend.
+                Supported values: "auto", "auto_no_cutedsl", "cutlass", "cublaslt", "cutedsl".
+                - "auto": Automatically selects the best backend (may include cutedsl).
+                - "auto_no_cutedsl": Like auto, but excludes cutedsl from selection.
+                - "cutlass", "cublaslt", "cutedsl": Force specific backend.
+                Default is "auto_no_cutedsl" (excludes cutedsl to reduce build time).
+                Set to "auto" for extreme performance at the cost of longer build time.
                 Can be overridden via TRTLLM_NVFP4_GEMM_BACKEND environment variable.
         """
         from ..distributed import AllReduce
@@ -2087,7 +2091,9 @@ class Linear(nn.Module):
                                              nvfp4_backend)
 
         # Validate backend selection
-        valid_backends = {'auto', 'cutlass', 'cublaslt', 'cutedsl'}
+        valid_backends = {
+            'auto', 'auto_no_cutedsl', 'cutlass', 'cublaslt', 'cutedsl'
+        }
         if nvfp4_backend_value not in valid_backends:
             raise ValueError(
                 f"Invalid nvfp4_backend: '{nvfp4_backend_value}'. "

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -937,6 +937,8 @@ class NVFP4LinearMethod(LinearMethodBase):
                 input, module.input_scale, module.scaling_vector_size, False)
 
         # Use unified interface - supports CUTLASS, cuBLASLt, CuteDSL
+        # Convert list to comma-separated string for torch.compile compatibility
+        allowed_backends_str = ','.join(module.nvfp4_allowed_backends)
         output = torch.ops.trtllm.nvfp4_gemm(
             act_fp4,
             module.weight,
@@ -945,7 +947,7 @@ class NVFP4LinearMethod(LinearMethodBase):
             module.alpha,
             module.dtype,
             to_userbuffers=False,
-            allowed_backends=module.nvfp4_allowed_backends)
+            allowed_backends=allowed_backends_str)
         # Take the dim of out_features if padded. Make sure the output is contiguous
         if output.shape[-1] > module.out_features:
             output = output[..., :module.out_features].contiguous()

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -357,7 +357,13 @@ class ModelLoader:
             moe_disable_finalize_fusion=self.llm_args.moe_config.
             disable_finalize_fusion,
             use_low_precision_moe_combine=self.llm_args.moe_config.
-            use_low_precision_moe_combine)
+            use_low_precision_moe_combine,
+            nvfp4_gemm_allowed_backends=self.llm_args.nvfp4_gemm_config.
+            allowed_backends)
+
+        # Store nvfp4 config in extra_attrs for Linear layer access
+        config.extra_attrs[
+            'nvfp4_gemm_allowed_backends'] = config.nvfp4_gemm_allowed_backends
 
         validate_and_set_kv_cache_quant(config,
                                         self.llm_args.kv_cache_config.dtype)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -412,6 +412,34 @@ class MoeConfig(StrictBaseModel):
         return cls(**data)
 
 
+class Nvfp4GemmConfig(StrictBaseModel):
+    """
+    Configuration for NVFP4 GEMM backend selection.
+    """
+    allowed_backends: List[str] = Field(
+        default=['cutlass', 'cublaslt', 'cuda_core'],
+        description="List of backends to consider for auto-selection. "
+        "Default excludes 'cutedsl' for faster build time. "
+        "Add 'cutedsl' for extreme performance at the cost of longer build time. "
+        "Valid values: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.")
+
+    @model_validator(mode="after")
+    def validate_allowed_backends(self) -> 'Nvfp4GemmConfig':
+        valid_backends = {'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'}
+        invalid = set(self.allowed_backends) - valid_backends
+        if invalid:
+            raise ValueError(
+                f"Invalid backends in allowed_backends: {invalid}. "
+                f"Valid backends are: {sorted(valid_backends)}")
+        if not self.allowed_backends:
+            raise ValueError("allowed_backends cannot be empty.")
+        return self
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+
 class AttentionDpConfig(StrictBaseModel):
     """
     Configuration for attention DP.
@@ -2566,6 +2594,11 @@ class TorchLlmArgs(BaseLlmArgs):
                                   description="MoE config.",
                                   status="beta")
 
+    nvfp4_gemm_config: Nvfp4GemmConfig = Field(
+        default_factory=Nvfp4GemmConfig,
+        description="NVFP4 GEMM backend config.",
+        status="beta")
+
     attn_backend: str = Field(default='TRTLLM',
                               description="Attention backend to use.",
                               status="beta")
@@ -3050,6 +3083,7 @@ def update_llm_args_with_extra_dict(
         "speculative_config": DecodingBaseConfig,
         "lora_config": LoraConfig,
         "moe_config": MoeConfig,
+        "nvfp4_gemm_config": Nvfp4GemmConfig,
         "attention_dp_config": AttentionDpConfig,
         "sparse_attention_config": BaseSparseAttentionConfig,
         "kv_cache_config": KvCacheConfig,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -420,7 +420,7 @@ class Nvfp4GemmConfig(StrictBaseModel):
         default=['cutlass', 'cublaslt', 'cuda_core'],
         description="List of backends to consider for auto-selection. "
         "Default excludes 'cutedsl' for faster build time. "
-        "Add 'cutedsl' for extreme performance at the cost of longer build time. "
+        "Add 'cutedsl' for extreme performance at the cost of longer server launch time. "
         "Valid values: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.")
 
     @model_validator(mode="after")

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -115,6 +115,10 @@ methods:
         annotation: tensorrt_llm.llmapi.llm_args.MoeConfig
         status: beta
         default: null
+      nvfp4_gemm_config:
+        annotation: tensorrt_llm.llmapi.llm_args.Nvfp4GemmConfig
+        status: beta
+        default: null
       attn_backend:
         annotation: str
         default: TRTLLM


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 GEMM backend configuration to model settings for more granular control over available optimization backends.

* **Refactor**
  * Updated NVFP4 backend specification to use a list of allowed backends instead of a single backend parameter, enabling flexible backend selection and fallback strategies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
