### PR TITLE
[#9460][feat] Add mxfp4 moe torch reference op for GPT-OSS in AutoDeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
@@ -1,5 +1,6 @@
 # Triton-kernels-based MXFP4 MoE ops (GPT-OSS style) with routing, swizzling, and fused activation
 
+import math
 from typing import Callable, Tuple
 
 import torch
@@ -34,6 +35,81 @@ except Exception as _e:
     FP4 = convert_layout = wrap_torch_tensor = None
     layout = StridedLayout = None
     TritonEPRouter = None
+
+
+# adapted from gpt-oss official implementation:
+# https://github.com/openai/gpt-oss/blob/main/gpt_oss/torch/weights.py#L68
+FP4_VALUES = [
+    +0.0,
+    +0.5,
+    +1.0,
+    +1.5,
+    +2.0,
+    +3.0,
+    +4.0,
+    +6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def _dequantize_mxfp4(
+    blocks: torch.Tensor,  # [..., G, B] in uint8
+    scales: torch.Tensor,  # [..., G] in uint8
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    rows_per_chunk: int = 16384 * 512,
+) -> torch.Tensor:
+    """
+    Dequantize MXFP4 format weights to bfloat16.
+    Based on the reference implementation in gpt-oss official repo.
+
+    Args:
+        blocks: Packed FP4 values (2 per byte) in uint8 format
+        scales: Exponent scales in uint8 format (offset by 127)
+        dtype: Target dtype for dequantized output
+        rows_per_chunk: Number of rows to process at once (for memory efficiency)
+
+    Returns:
+        Dequantized tensor in target dtype
+    """
+    scales_int = scales.to(torch.int32) - 127
+
+    assert blocks.shape[:-1] == scales.shape, f"{blocks.shape=} does not match {scales.shape=}"
+
+    lut = torch.tensor(FP4_VALUES, dtype=dtype, device=blocks.device)
+
+    *prefix_shape, G, B = blocks.shape
+    rows_total = math.prod(prefix_shape) * G
+
+    blocks_flat = blocks.reshape(rows_total, B)
+    scales_flat = scales_int.reshape(rows_total, 1)
+
+    out = torch.empty(rows_total, B * 2, dtype=dtype, device=blocks.device)
+
+    for r0 in range(0, rows_total, rows_per_chunk):
+        r1 = min(r0 + rows_per_chunk, rows_total)
+
+        blk = blocks_flat[r0:r1]
+        exp = scales_flat[r0:r1]
+
+        idx_lo = (blk & 0x0F).to(torch.long)  # Lower nibble
+        idx_hi = (blk >> 4).to(torch.long)  # Upper nibble
+
+        sub = out[r0:r1]
+        sub[:, 0::2] = lut[idx_lo]  # Even positions: lower nibble
+        sub[:, 1::2] = lut[idx_hi]  # Odd positions: upper nibble
+
+        torch.ldexp(sub, exp, out=sub)
+        del idx_lo, idx_hi, blk, exp
+
+    return out.reshape(*prefix_shape, G, B * 2).view(*prefix_shape, G * B * 2)
 
 
 # copied from transformers.integrations.mxfp4::swizzle_mxfp4 with minor modification
@@ -264,5 +340,113 @@ def _mxfp4_mlp_ep_fake(
     down_scales: torch.Tensor,
     ep_size: int,
     ep_rank: int,
+):
+    return torch.empty_like(hidden_states)
+
+
+@torch.library.custom_op("auto_deploy::torch_mxfp4_moe", mutates_args=())
+def torch_mxfp4_moe(
+    hidden_states: torch.Tensor,  # [B, S, H] or [B*S, H]
+    # router
+    router_weight: torch.Tensor,  # [E, H]
+    router_bias: torch.Tensor,  # [E]
+    top_k: int,
+    # gate_up path
+    gate_up_blocks: torch.Tensor,  # [E, 2I, H//32, 16] in unit8
+    gate_up_bias: torch.Tensor,  # [E, 2I]
+    gate_up_scales: torch.Tensor,  # [E, 2I, H//32] in unit8
+    alpha: float,
+    limit: float,
+    # down path
+    down_blocks: torch.Tensor,  # [E, H, I//32, 16] in uint8
+    down_bias: torch.Tensor,  # [E, H]
+    down_scales: torch.Tensor,  # [E, H, I//32] in uint8
+) -> torch.Tensor:
+    leading_shape = hidden_states.shape[:-1]
+    hidden_size = hidden_states.shape[-1]
+    x = hidden_states.reshape(-1, hidden_size)  # (num_tokens, hidden_size)
+    num_tokens = x.shape[0]
+    num_experts = gate_up_blocks.shape[0]
+    intermediate_size = gate_up_blocks.shape[1] // 2
+
+    # Dequantize gate_up weights
+    # gate_up_blocks: [E, 2I, KB, BS] where KB*BS*2 = H
+    # After dequant: [E, 2I, H]
+    gate_up_w = []
+    for e in range(num_experts):
+        w_dequant = _dequantize_mxfp4(
+            gate_up_blocks[e],  # [2I, KB, BS]
+            gate_up_scales[e],  # [2I, KB]
+            dtype=hidden_states.dtype,
+        )  # [2I, H]
+        gate_up_w.append(w_dequant)
+    gate_up_w = torch.stack(gate_up_w, dim=0)  # [E, 2I, H]
+    gate_up_w = gate_up_w.transpose(-2, -1)  # [E, H, 2I]
+
+    # Dequantize down weights
+    # down_blocks: [E, H, KB, BS] -> dequantize to get enough elements for [E, I, H]
+    # Note: Due to the complex MXFP4 layout, we dequantize and extract the needed portion
+    down_w = []
+    for e in range(num_experts):
+        # Dequantize: [H, KB, BS] -> [H, KB*BS*2] = [H, H] (since KB*BS*2 = H typically)
+        w_dequant = _dequantize_mxfp4(
+            down_blocks[e],
+            down_scales[e],
+            dtype=hidden_states.dtype,
+        )  # [H, H]
+
+        # Flatten and extract first I*H elements
+        w_flat = w_dequant.reshape(-1)
+        w_flat = w_flat[: intermediate_size * hidden_size]
+        w_dequant = w_flat.reshape(intermediate_size, hidden_size)
+        down_w.append(w_dequant)
+    down_w = torch.stack(down_w, dim=0)  # [E, I, H]
+
+    # Router: compute logits and select top-k experts per token
+    router_logits = F.linear(x, router_weight, router_bias)  # [num_tokens, E]
+    topk_weights, topk_indices = torch.topk(router_logits, top_k, dim=-1)  # [num_tokens, top_k]
+    topk_weights = F.softmax(topk_weights, dim=-1)  # Normalize only top-k weights
+
+    # Process experts in order (similar to triton's expert-grouped approach)
+    # Use float32 accumulation to reduce precision errors, then cast back to input dtype
+    output = torch.zeros((num_tokens, hidden_size), dtype=torch.float32, device=x.device)
+    for expert_idx in range(num_experts):
+        expert_mask = topk_indices == expert_idx  # [num_tokens, top_k]
+        if not expert_mask.any():
+            continue
+        token_indices, k_indices = torch.where(expert_mask)
+        expert_tokens = x[token_indices]  # [n_tokens_using_expert, H]
+        expert_weights = topk_weights[token_indices, k_indices]  # [n_tokens_using_expert]
+        gate_up = F.linear(
+            expert_tokens, gate_up_w[expert_idx].T, gate_up_bias[expert_idx]
+        )  # [n, 2I]
+        gate = gate_up[..., 0::2]  # [n, I]
+        up = gate_up[..., 1::2]  # [n, I]
+        gate = gate.clamp(min=None, max=limit)
+        up = up.clamp(min=-limit, max=limit)
+        glu = gate * torch.sigmoid(gate * alpha)
+        expert_out = F.linear((up + 1) * glu, down_w[expert_idx].T, down_bias[expert_idx])  # [n, H]
+        expert_out = (expert_out * expert_weights.unsqueeze(-1)).to(torch.float32)  # [n, H]
+        output.index_add_(0, token_indices, expert_out)
+
+    output = output.to(hidden_states.dtype)
+    output = output.reshape(*leading_shape, hidden_size)
+    return output
+
+
+@torch_mxfp4_moe.register_fake
+def _torch_mxfp4_moe_fake(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    router_bias: torch.Tensor,
+    top_k: int,
+    gate_up_blocks: torch.Tensor,
+    gate_up_bias: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    alpha: float,
+    limit: float,
+    down_blocks: torch.Tensor,
+    down_bias: torch.Tensor,
+    down_scales: torch.Tensor,
 ):
     return torch.empty_like(hidden_states)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mxfp4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mxfp4_moe.py
@@ -1,0 +1,99 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.mxfp4_moe import (
+    IS_TRITON_KERNELS_AVAILABLE,
+)
+
+
+@pytest.mark.skipif(
+    not IS_TRITON_KERNELS_AVAILABLE,
+    reason="triton_kernels unavailable",
+)
+@pytest.mark.parametrize("num_experts", [4, 8])
+@pytest.mark.parametrize("topk", [2, 4])
+@pytest.mark.parametrize(
+    "batch_size",
+    [
+        2,
+        4,
+    ],
+)
+@pytest.mark.parametrize("seq_len", [8, 16])
+@pytest.mark.parametrize("alpha,limit", [(1.0, 1.0), (1.702, 7.0)])
+def test_torch_mxfp4_moe_vs_triton(num_experts, topk, batch_size, seq_len, alpha, limit):
+    """
+    Test torch_mxfp4_moe reference implementation against triton_mxfp4_moe.
+    Tests with various combinations of parameters including different alpha and limit values.
+    """
+    if topk > num_experts:
+        pytest.skip("topk must be <= num_experts")
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    B, S = batch_size, seq_len
+    H = 32  # hidden size
+    In = 8  # intermediate size
+    TWO_I = 2 * In
+    KB, BS = 4, 4  # K-tiling such that KB * BS * 2 == H (FP4 packs 2 per byte)
+    assert KB * BS * 2 == H
+
+    dtype_x = torch.bfloat16
+    dtype_bf16 = torch.bfloat16
+    dtype_u8 = torch.uint8
+
+    atol = 0.0
+    rtol = 0.0
+
+    x = torch.randn((B, S, H), dtype=dtype_x, device="cuda") * 0.5
+    router_weight = torch.randn((num_experts, H), device="cuda").to(dtype_bf16) * 0.2
+    router_bias = torch.randn((num_experts,), device="cuda").to(dtype_bf16) * 0.1
+
+    def _rand_scales(shape):
+        return torch.randint(1, 16, shape, dtype=dtype_u8, device="cuda")
+
+    gate_up_blocks = torch.randint(
+        0, 256, (num_experts, TWO_I, KB, BS), dtype=dtype_u8, device="cuda"
+    )
+    gate_up_scales = _rand_scales((num_experts, TWO_I, KB))
+    gate_up_bias = (0.1 * torch.randn((num_experts, TWO_I), device="cuda")).to(dtype_bf16)
+    down_blocks = torch.randint(0, 256, (num_experts, H, KB, BS), dtype=dtype_u8, device="cuda")
+    down_scales = _rand_scales((num_experts, H, KB))
+    down_bias = (0.1 * torch.randn((num_experts, H), device="cuda")).to(dtype_bf16)
+
+    assert (gate_up_scales != 0).all() and (down_scales != 0).all(), (
+        "Zero scales would cause NaNs/inf."
+    )
+
+    triton_out = torch.ops.auto_deploy.triton_mxfp4_moe(
+        x,
+        router_weight,
+        router_bias,
+        topk,
+        gate_up_blocks,
+        gate_up_bias,
+        gate_up_scales,
+        alpha,
+        limit,
+        down_blocks,
+        down_bias,
+        down_scales,
+    )
+
+    torch_out = torch.ops.auto_deploy.torch_mxfp4_moe(
+        x,
+        router_weight,
+        router_bias,
+        topk,
+        gate_up_blocks,
+        gate_up_bias,
+        gate_up_scales,
+        alpha,
+        limit,
+        down_blocks,
+        down_bias,
+        down_scales,
+    )
+
+    torch.testing.assert_close(torch_out, triton_out, rtol=rtol, atol=atol, equal_nan=True)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
