### PR TITLE
[TRTLLM-9432][feat] Reduce synchronization and recompilation for qwen3-next

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -827,16 +827,13 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         conv_states,
         ssm_states,
         num_decodes,
+        query_start_loc_long,
         **kwargs,
     ):
         mixed_qkv = kwargs["mixed_qkv"]
         a = kwargs["a"]
         b = kwargs["b"]
         cache_indices = kwargs["cache_indices"]
-        query_start_loc = torch.arange(0,
-                                       num_decodes + 1,
-                                       dtype=torch.long,
-                                       device=mixed_qkv.device)
 
         mixed_qkv = causal_conv1d_update(
             mixed_qkv,
@@ -870,7 +867,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             b=b,
             initial_state_source=ssm_states,
             initial_state_indices=cache_indices,
-            cu_seqlens=query_start_loc,
+            cu_seqlens=query_start_loc_long,
             use_qk_l2norm_in_kernel=True,
             softplus_beta=1.0,
             softplus_threshold=20.0,

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -826,7 +826,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         self,
         conv_states,
         ssm_states,
-        num_decodes,
         query_start_loc_long,
         **kwargs,
     ):
@@ -1065,7 +1064,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             "state_indices_p": state_indices_p,
             "state_indices_d": state_indices_d,
             "num_prefill": num_prefills,
-            "num_decodes": num_decodes,
         }
         if num_prefills > 0:
             attn_out = self.forward_extend(conv_states, ssm_states, **kwargs)

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -827,7 +827,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         conv_states,
         ssm_states,
         num_decodes,
-        cu_seqlens,
         **kwargs,
     ):
         mixed_qkv = kwargs["mixed_qkv"]
@@ -836,7 +835,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         cache_indices = kwargs["cache_indices"]
         query_start_loc = torch.arange(0,
                                        num_decodes + 1,
-                                       device=cu_seqlens.device).to(torch.long)
+                                       dtype=torch.long,
+                                       device=mixed_qkv.device)
 
         mixed_qkv = causal_conv1d_update(
             mixed_qkv,
@@ -890,13 +890,13 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         batch_size = kwargs["batch_size"]
         has_initial_states = kwargs["has_initial_states"][:batch_size]
         cache_indices = kwargs["cache_indices"]
-        query_start_loc = kwargs["query_start_loc"][:batch_size + 1]
+        query_start_loc = kwargs["query_start_loc"]
+        query_start_loc_long = kwargs["query_start_loc_long"]
         num_prefill_tokens = kwargs["num_prefill_tokens"]
         num_decode_tokens = kwargs["num_decode_tokens"]
         state_indices_p = kwargs["state_indices_p"]
         state_indices_d = kwargs["state_indices_d"]
         num_prefill = kwargs["num_prefill"]
-        num_decode = kwargs["num_decode"]
 
         conv_states_to_use = conv_states
 
@@ -964,19 +964,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         recurrent_state = ssm_states[cache_indices]
 
-        if num_decode > 0:
-            # TODO set it in mambaCacheManager
-            decode_query_start_loc = torch.arange(
-                1, num_decode + 1,
-                device=query_start_loc.device)  # num_decode 个
-            decode_query_start_loc = decode_query_start_loc + query_start_loc[
-                num_prefill]
-            new_query_start_loc = torch.cat(
-                [query_start_loc[:num_prefill + 1], decode_query_start_loc])
-        else:
-            new_query_start_loc = query_start_loc
-
-        new_query_start_loc = new_query_start_loc.to(torch.long)
         core_attn_out, last_recurrent_state = chunk_gated_delta_rule(
             q=query,
             k=key,
@@ -985,7 +972,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             beta=beta,
             initial_state=recurrent_state,
             output_final_state=True,
-            cu_seqlens=new_query_start_loc,
+            cu_seqlens=query_start_loc_long,
             head_first=False,
             use_qk_l2norm_in_kernel=True,
         )
@@ -1030,8 +1017,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         ssm_states = attn_metadata.kv_cache_manager.get_ssm_states(
             self.layer_idx)
         if num_prefills > 0:
-            ssm_states[state_indices_p] = 0
-            # conv_states[state_indices_p] = 0 # not necessary
+            ssm_states[state_indices_p].zero_()
+            # conv_states[state_indices_p].zero_() # not necessary
 
         def _compute_projected_states_qkvz():
             return self.in_proj_qkvz(hidden_states)
@@ -1072,20 +1059,20 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             "z": z,
             "has_initial_states": has_initial_states,
             "cache_indices": state_indices,
-            "query_start_loc": mamba_metadata.cu_seqlens,
+            "query_start_loc": mamba_metadata.query_start_loc,
+            "query_start_loc_long": mamba_metadata.query_start_loc_long,
             "batch_size": attn_metadata.seq_lens.shape[0],
             "num_prefill_tokens": num_prefill_tokens,
             "num_decode_tokens": num_decode_tokens,
             "state_indices_p": state_indices_p,
             "state_indices_d": state_indices_d,
             "num_prefill": num_prefills,
-            "num_decode": num_decodes,
+            "num_decodes": num_decodes,
         }
         if num_prefills > 0:
             attn_out = self.forward_extend(conv_states, ssm_states, **kwargs)
         else:
-            attn_out = self.forward_decode(conv_states, ssm_states, num_decodes,
-                                           mamba_metadata.cu_seqlens, **kwargs)
+            attn_out = self.forward_decode(conv_states, ssm_states, **kwargs)
 
         z_shape_og = z.shape
         # reshape input data into 2D tensor

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1017,9 +1017,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             ssm_states[state_indices_p] = torch.zeros((),
                                                       dtype=ssm_states.dtype,
                                                       device=ssm_states.device)
-            # conv_states[state_indices_p] = torch.zeros(
-            #     (), dtype=conv_states.dtype,
-            #     device=conv_states.device)  # not necessary
 
         def _compute_projected_states_qkvz():
             return self.in_proj_qkvz(hidden_states)

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1017,8 +1017,12 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         ssm_states = attn_metadata.kv_cache_manager.get_ssm_states(
             self.layer_idx)
         if num_prefills > 0:
-            ssm_states[state_indices_p].zero_()
-            # conv_states[state_indices_p].zero_() # not necessary
+            ssm_states[state_indices_p] = torch.zeros((),
+                                                      dtype=ssm_states.dtype,
+                                                      device=ssm_states.device)
+            # conv_states[state_indices_p] = torch.zeros(
+            #     (), dtype=conv_states.dtype,
+            #     device=conv_states.device)  # not necessary
 
         def _compute_projected_states_qkvz():
             return self.in_proj_qkvz(hidden_states)

--- a/tensorrt_llm/_torch/modules/fla/l2norm.py
+++ b/tensorrt_llm/_torch/modules/fla/l2norm.py
@@ -56,8 +56,7 @@ def l2norm_fwd_kernel(
     x,
     y,
     eps,
-    NB: tl.constexpr,
-    T: tl.constexpr,
+    T,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
@@ -91,7 +90,6 @@ def l2norm_fwd(x: torch.Tensor,
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]), )
@@ -100,7 +98,6 @@ def l2norm_fwd(x: torch.Tensor,
             x,
             y,
             eps,
-            NB=NB,
             T=T,
             D=D,
             BD=BD,

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -146,3 +146,10 @@ class Mamba2Metadata:
             else:
                 self.chunk_indices = None
                 self.chunk_offsets = None
+        else:
+            self.query_start_loc = None
+            self.query_start_loc_long = torch.arange(
+                0,
+                batch_size + 1,
+                dtype=torch.long,
+                device=self.cu_seqlens.device)

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -108,6 +108,7 @@ class Mamba2Metadata:
         self.chunk_offsets: torch.Tensor = None
 
     def prepare(self, attn_metadata: AttentionMetadata):
+        batch_size = attn_metadata.seq_lens.shape[0]
         num_contexts = attn_metadata.num_contexts
         context_lens = attn_metadata.seq_lens_cuda[:num_contexts]
         num_ctx_tokens = attn_metadata.num_ctx_tokens
@@ -116,6 +117,16 @@ class Mamba2Metadata:
                          dim=0,
                          dtype=torch.int,
                          out=self.cu_seqlens[1:num_contexts + 1])
+            torch.add(self.cu_seqlens[num_contexts],
+                      torch.arange(1,
+                                   batch_size - num_contexts + 1,
+                                   dtype=self.cu_seqlens.dtype,
+                                   device=self.cu_seqlens.device),
+                      out=self.cu_seqlens[num_contexts + 1:batch_size + 1])
+            # Need both `query_start_loc` and `query_start_loc_long` because `causal_conv1d_fn`
+            # accepts only `int32` while `chunk_gated_delta_rule` accepts only `long`.
+            self.query_start_loc = self.cu_seqlens[:batch_size + 1]
+            self.query_start_loc_long = self.query_start_loc.to(torch.long)
             self.seq_idx = torch.repeat_interleave(
                 torch.arange(num_contexts,
                              dtype=torch.int,

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -123,8 +123,9 @@ class MambaCacheManager(BaseResourceManager):
                 block = self.mamba_cache_free_blocks.pop()
                 self.mamba_cache_index[r] = block
                 state_indices.append(block)
-        self.state_indices[:len(state_indices)] = torch.as_tensor(
-            state_indices, dtype=torch.int32, device=self.ssm_states.device)
+        self.state_indices[:len(state_indices)].copy_(torch.tensor(
+            state_indices, dtype=torch.int32, pin_memory=True),
+                                                      non_blocking=True)
 
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
         context_ids = [


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized attention sequence handling for improved model processing efficiency
  * Enhanced kernel computation parameters for better performance
  * Improved cache state management for memory efficiency
  * Streamlined metadata handling in model inference pipeline

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
