### PR TITLE
[None][fix] Fix MTP rewind corner case

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2909,6 +2909,18 @@ void KVCacheManager::removeToken(RequestIdType requestId)
 
 void KVCacheManager::rewindKVCache(RequestIdType requestId, SizeType32 rewindLengths)
 {
+    // Check if the sequence still exists before rewinding
+    // In overlap mode with MTP, the request may have been terminated and removed
+    // from mSequences before rewindKVCache is called
+    {
+        std::scoped_lock lck(mSequencesMtx);
+        if (mSequences.find(requestId) == mSequences.end())
+        {
+            TLLM_LOG_DEBUG("Request %lu has already been removed from KV cache manager, skipping rewind", requestId);
+            return;
+        }
+    }
+    
     for (SizeType32 si = 0; si < rewindLengths; ++si)
     {
         removeToken(requestId);


### PR DESCRIPTION
# Description
When using overlap scheduler with MTP, the request may have been terminated and removed from mSequences before rewindKVCache is called, we should avoid this.
