### PR TITLE
[https://nvbugs/5633340][fix] start disagg workers and servers on free ports

### DIFF
--- a/tests/integration/defs/disaggregated/test_auto_scaling.py
+++ b/tests/integration/defs/disaggregated/test_auto_scaling.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import traceback
 import uuid
 
 import openai
@@ -10,14 +11,32 @@ import pytest
 import requests
 import yaml
 
+from tensorrt_llm._utils import get_free_port
 from tensorrt_llm.logger import logger
 
-TEST_PORT = 8000
 HEARTBEAT_INTERVAL = 1
 INACTIVE_TIMEOUT = 2
-CHECK_STATUS_INTERVAL = 3  # check cluster status with a larger interval than inactive timeout to avoid flaky tests
+# check cluster status with a larger interval than inactive timeout to avoid flaky tests
+CHECK_STATUS_INTERVAL = 3
 
 ROUTER_TYPES = ["round_robin", "load_balancing", "kv_cache_aware"]
+USED_PORTS = set()
+
+
+# get_free_port doesn't guarantee that consecutive calls will return different ports
+# if no server is bound to the port immediately after the call
+def get_free_unused_port():
+    global USED_PORTS
+    max_attempts = 100
+    for _ in range(max_attempts):
+        port = get_free_port()
+        if port not in USED_PORTS:
+            USED_PORTS.add(port)
+            return port
+        else:
+            logger.info(f"Port {port} is already used, trying another one")
+    raise Exception(
+        f"Failed to find a free unused port after {max_attempts} attempts")
 
 
 @pytest.fixture
@@ -25,10 +44,20 @@ def model_name():
     return "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 
 
-@pytest.fixture(scope="function")
-def service_discovery(request):
+@pytest.fixture
+def disagg_port():
+    return get_free_unused_port()
+
+
+@pytest.fixture
+def work_dir():
+    return tempfile.mkdtemp()
+
+
+@pytest.fixture
+def service_discovery(request, disagg_port, work_dir):
     if request.param == "etcd":
-        data_dir = f"{tempfile.gettempdir()}/disagg_test-etcd-{uuid.uuid4()}"
+        data_dir = f"{work_dir}/disagg_test-etcd-{uuid.uuid4()}"
         etcd = subprocess.Popen(["etcd", "--data-dir", data_dir])
         yield etcd, f"etcd://localhost:2379"
         try:
@@ -38,7 +67,7 @@ def service_discovery(request):
         except Exception:
             pass
     else:
-        yield None, f"http://localhost:{TEST_PORT}"
+        yield None, f"http://localhost:{disagg_port}"
 
 
 @pytest.fixture
@@ -59,10 +88,10 @@ def router(request):
 
 
 @pytest.fixture
-def disagg_server_config(disagg_cluster_config, router):
+def disagg_server_config(disagg_cluster_config, router, disagg_port):
     return {
         "hostname": "localhost",
-        "port": TEST_PORT,
+        "port": disagg_port,
         "disagg_cluster": disagg_cluster_config,
         "context_servers": {
             "router": {
@@ -93,9 +122,20 @@ def worker_config(disagg_cluster_config):
     }
 
 
-def _run_worker(model_name, worker_config, role, port=8000, device=-1):
-    worker_config_path = tempfile.NamedTemporaryFile(delete=False)
-    with open(worker_config_path.name, "w+") as f:
+class ProcessWrapper:
+
+    def __init__(self, process, log_file=None, log_path=None, port=0):
+        self.process = process
+        self.log_file = log_file
+        self.log_path = log_path
+        self.port = port
+
+
+def _run_worker(model_name, worker_config, role, port, work_dir, device=-1):
+    if port == 0:
+        port = get_free_unused_port()
+    worker_config_path = os.path.join(work_dir, f"{role}_{port}_config.yaml")
+    with open(worker_config_path, "w+") as f:
         yaml.dump(worker_config, f)
         f.flush()
         cmd = [
@@ -107,40 +147,46 @@ def _run_worker(model_name, worker_config, role, port=8000, device=-1):
             "--port",
             str(port),
             "--extra_llm_api_options",
-            worker_config_path.name,
+            worker_config_path,
             "--server_role",
             "context" if role.startswith("ctx") else "generation",
         ]
         env = os.environ.copy()
         if device != -1:
             env["CUDA_VISIBLE_DEVICES"] = str(device)
-        f = open(f"output_{role}.log", "w+")
-        return subprocess.Popen(cmd, env=env, stdout=f, stderr=f)
+        log_path = os.path.join(work_dir, f"output_{role}.log")
+        log_file = open(log_path, "w+")
+        print(f"Running {role} on port {port}")
+        return ProcessWrapper(subprocess.Popen(cmd,
+                                               env=env,
+                                               stdout=log_file,
+                                               stderr=log_file),
+                              log_file=log_file,
+                              log_path=log_path,
+                              port=port)
 
 
-def run_ctx_worker(model_name,
-                   ctx_worker_config,
-                   port=TEST_PORT + 100,
-                   device=0):
-    return _run_worker(model_name, ctx_worker_config, "ctx", port, device)
+def run_ctx_worker(model_name, ctx_worker_config, work_dir, port=0, device=0):
+    return _run_worker(model_name, ctx_worker_config, "ctx", port, work_dir,
+                       device)
 
 
-def run_gen_worker(model_name,
-                   gen_worker_config,
-                   port=TEST_PORT + 200,
-                   device=1):
-    return _run_worker(model_name, gen_worker_config, "gen", port, device)
+def run_gen_worker(model_name, gen_worker_config, work_dir, port=0, device=1):
+    return _run_worker(model_name, gen_worker_config, "gen", port, work_dir,
+                       device)
 
 
-def run_disagg_server(disagg_cluster_config, port=TEST_PORT):
-    disagg_server_config_path = f"/tmp/disagg_server_{port}_config.yaml"
+def run_disagg_server(disagg_cluster_config, work_dir, port=0):
+    disagg_server_config_path = os.path.join(work_dir,
+                                             "disagg_server_config.yaml")
     disagg_cluster_config["port"] = port
     with open(disagg_server_config_path, "w+") as f:
         yaml.dump(disagg_cluster_config, f)
     cmds = ["trtllm-serve", "disaggregated", "-c", disagg_server_config_path]
-    f = open("disagg_server.log", "w+")
-    p = subprocess.Popen(cmds, stdout=f, stderr=f)
-    return p
+    log_path = os.path.join(work_dir, "disagg_server.log")
+    log_file = open(log_path, "w+")
+    p = subprocess.Popen(cmds, stdout=log_file, stderr=log_file)
+    return ProcessWrapper(p, log_file=log_file, log_path=log_path, port=port)
 
 
 async def wait_for_disagg_server_ready(port):
@@ -179,8 +225,9 @@ async def wait_for_worker_ready(port):
 def verify_cluster_info(ready,
                         ctx_workers=-1,
                         gen_workers=-1,
-                        port=TEST_PORT,
+                        port=0,
                         expected_code=200):
+    assert port > 0, "port must be positive"
     info_resp = requests.get(f"http://localhost:{port}/cluster_info")
     assert info_resp.status_code == expected_code
     info = info_resp.json()
@@ -192,17 +239,44 @@ def verify_cluster_info(ready,
         assert len(info["current_workers"]["generation_servers"]) == gen_workers
 
 
-def terminate(*args):
+def tail(f, n):
+    try:
+        proc = subprocess.Popen(['tail', '-n', str(n), f],
+                                stdout=subprocess.PIPE)
+        return proc.stdout.read().decode('utf-8')
+    except Exception as e:
+        print(f"Failed to tail {f}: {e}")
+        print(f"Traceback: {traceback.format_exc()}")
+        return ""
+
+
+def terminate(*args, show_log_lines=30, release_port=True):
     for arg in args:
-        if arg and isinstance(arg, subprocess.Popen):
+        if arg and isinstance(arg, ProcessWrapper):
             try:
-                arg.kill()
-                arg.wait(timeout=10)
-            except Exception:
-                print(f"Failed to terminate process {arg.pid}")
+                # tail the log file for better debugging on CI
+                if os.path.exists(arg.log_path):
+                    print(f"-------------{arg.log_path}---------------")
+                    print(tail(arg.log_path, show_log_lines))
+            except Exception as e:
+                print(f"Failed to tail {arg.log_path}: {e}")
+                print(f"Traceback: {traceback.format_exc()}")
+            if arg.process:
+                try:
+                    arg.process.kill()
+                    arg.process.wait(timeout=10)
+                    arg.process = None
+                    if arg.log_file:
+                        arg.log_file.close()
+                        arg.log_file = None
+                    if release_port:
+                        global USED_PORTS
+                        USED_PORTS.discard(arg.port)
+                except Exception:
+                    print(f"Failed to terminate process {arg.process.pid}")
 
 
-def request_completion(model_name, prompt, port=TEST_PORT):
+def request_completion(model_name, prompt, port):
     client = openai.OpenAI(api_key="tensorrt_llm",
                            base_url=f"http://localhost:{port}/v1")
     return client.completions.create(model=model_name,
@@ -217,20 +291,22 @@ def request_completion(model_name, prompt, port=TEST_PORT):
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize("service_discovery", ["etcd", "http"], indirect=True)
 async def test_service_discovery(model_name, disagg_server_config,
-                                 worker_config, router, service_discovery):
+                                 worker_config, router, service_discovery,
+                                 disagg_port, work_dir):
     ctx_worker1 = None
     gen_worker1 = None
     disagg_server = None
     try:
         # initial cluster, 1 ctx, 1 gen, request should succeed
-        ctx_worker1 = run_ctx_worker(model_name, worker_config, TEST_PORT + 100)
-        gen_worker1 = run_gen_worker(model_name, worker_config, TEST_PORT + 200)
-        disagg_server = run_disagg_server(disagg_server_config, TEST_PORT)
-        await wait_for_disagg_server_ready(TEST_PORT)
-        verify_cluster_info(True, 1, 1)
+        ctx_worker1 = run_ctx_worker(model_name, worker_config, work_dir)
+        gen_worker1 = run_gen_worker(model_name, worker_config, work_dir)
+        disagg_server = run_disagg_server(disagg_server_config, work_dir,
+                                          disagg_port)
+        await wait_for_disagg_server_ready(disagg_port)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
         response = request_completion(model_name,
                                       "Hello, my name is",
-                                      port=TEST_PORT)
+                                      port=disagg_port)
         print(response)
     finally:
         terminate(ctx_worker1, gen_worker1, disagg_server)
@@ -244,7 +320,8 @@ async def test_service_discovery(model_name, disagg_server_config,
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.timeout(600)
 async def test_minimal_instances(model_name, disagg_server_config,
-                                 worker_config, router, service_discovery):
+                                 worker_config, router, service_discovery,
+                                 disagg_port, work_dir):
     # the cluster should have at least 2 ctx and 2 gen workers
     minimal_instances = {
         "context_servers": 2,
@@ -254,36 +331,37 @@ async def test_minimal_instances(model_name, disagg_server_config,
         "minimal_instances"] = minimal_instances
     worker_config["disagg_cluster"]["minimal_instances"] = minimal_instances
 
-    processes = []
-
+    ctx_worker1 = None
+    gen_worker1 = None
+    ctx_worker2 = None
+    gen_worker2 = None
+    disagg_server = None
     try:
-        processes.append(
-            run_ctx_worker(model_name, worker_config, TEST_PORT + 100))
-        processes.append(
-            run_gen_worker(model_name, worker_config, TEST_PORT + 200))
-        processes.append(run_disagg_server(disagg_server_config, TEST_PORT))
-        await wait_for_worker_ready(TEST_PORT + 100)
-        await wait_for_worker_ready(TEST_PORT + 200)
-        verify_cluster_info(False, 1, 1)
+        ctx_worker1 = run_ctx_worker(model_name, worker_config, work_dir)
+        gen_worker1 = run_gen_worker(model_name, worker_config, work_dir)
+        disagg_server = run_disagg_server(disagg_server_config, work_dir,
+                                          disagg_port)
+        await wait_for_worker_ready(ctx_worker1.port)
+        await wait_for_worker_ready(gen_worker1.port)
+        verify_cluster_info(False, 1, 1, port=disagg_port)
         # with only 1 ctx and 1 gen worker, the request should fail
         with pytest.raises(Exception):
             response = request_completion(model_name,
                                           "Hello, my name is",
-                                          port=TEST_PORT)
+                                          port=disagg_port)
             print(response)
 
-        processes.append(
-            run_ctx_worker(model_name, worker_config, TEST_PORT + 101))
-        processes.append(
-            run_gen_worker(model_name, worker_config, TEST_PORT + 201))
-        await wait_for_disagg_server_ready(TEST_PORT)
-        verify_cluster_info(True, 2, 2)
+        ctx_worker2 = run_ctx_worker(model_name, worker_config, work_dir)
+        gen_worker2 = run_gen_worker(model_name, worker_config, work_dir)
+        await wait_for_disagg_server_ready(disagg_port)
+        verify_cluster_info(True, 2, 2, port=disagg_port)
         response = request_completion(model_name,
                                       "Hello, my name is",
-                                      port=TEST_PORT)
+                                      port=disagg_port)
         print(response)
     finally:
-        terminate(*processes)
+        terminate(ctx_worker1, ctx_worker2, gen_worker1, gen_worker2,
+                  disagg_server)
 
 
 @pytest.mark.skip_less_device(2)
@@ -292,7 +370,7 @@ async def test_minimal_instances(model_name, disagg_server_config,
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.timeout(600)
 async def test_worker_restart(model_name, disagg_server_config, worker_config,
-                              router, service_discovery):
+                              router, service_discovery, disagg_port, work_dir):
     ctx_worker1 = None
     ctx_worker2 = None
     gen_worker1 = None
@@ -303,74 +381,85 @@ async def test_worker_restart(model_name, disagg_server_config, worker_config,
         # initial cluster, 1 ctx, 1 gen, request should succeed
         ctx_worker1 = run_ctx_worker(model_name,
                                      worker_config,
-                                     TEST_PORT + 100,
+                                     work_dir,
                                      device=0)
         gen_worker1 = run_gen_worker(model_name,
                                      worker_config,
-                                     TEST_PORT + 200,
+                                     work_dir,
                                      device=1)
-        disagg_server = run_disagg_server(disagg_server_config, TEST_PORT)
-        await wait_for_disagg_server_ready(TEST_PORT)
-        verify_cluster_info(True, 1, 1)
+        disagg_server = run_disagg_server(disagg_server_config, work_dir,
+                                          disagg_port)
+        await wait_for_disagg_server_ready(disagg_port)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
         response = request_completion(model_name,
                                       "Hello, my name is",
-                                      port=TEST_PORT)
+                                      port=disagg_port)
         print(response)
         # kill gen1, the request should fail
-        terminate(gen_worker1)
+        terminate(gen_worker1, release_port=False)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
-        verify_cluster_info(False, 1, 0)
+        verify_cluster_info(False, 1, 0, port=disagg_port)
         with pytest.raises(Exception):
-            request_completion(model_name, "Hello, my name is", port=TEST_PORT)
+            request_completion(model_name,
+                               "Hello, my name is",
+                               port=disagg_port)
 
         test_prompt = "The capital of France is"
 
         # add gen2, the request should succeed
         gen_worker2 = run_gen_worker(model_name,
                                      worker_config,
-                                     TEST_PORT + 201,
+                                     work_dir,
+                                     port=0,
                                      device=2)
-        await wait_for_worker_ready(TEST_PORT + 201)
+        await wait_for_worker_ready(gen_worker2.port)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
-        verify_cluster_info(True, 1, 1)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
 
-        response = request_completion(model_name, test_prompt, port=TEST_PORT)
+        response = request_completion(model_name, test_prompt, port=disagg_port)
         print(response)
         response_text = response.choices[0].text
         assert len(response.choices[0].text) >= 1
 
         # kill ctx1, the request should fail
-        terminate(ctx_worker1)
+        terminate(ctx_worker1, release_port=False)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
-        verify_cluster_info(False, 0, 1)
+        verify_cluster_info(False, 0, 1, port=disagg_port)
         with pytest.raises(Exception):
-            request_completion(model_name, test_prompt, port=TEST_PORT)
+            request_completion(model_name, test_prompt, port=disagg_port)
 
         # add ctx2, the request should succeed
         ctx_worker2 = run_ctx_worker(model_name,
                                      worker_config,
-                                     TEST_PORT + 101,
+                                     work_dir,
+                                     port=0,
                                      device=3)
-        await wait_for_worker_ready(TEST_PORT + 101)
-        verify_cluster_info(True, 1, 1)
+        await wait_for_worker_ready(ctx_worker2.port)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
 
-        response = request_completion(model_name, test_prompt, port=TEST_PORT)
+        response = request_completion(model_name, test_prompt, port=disagg_port)
         response_text = response.choices[0].text
         assert len(response.choices[0].text) >= 1
 
         # restart ctx1 and gen1 with the same ports, we have 2 ctxs and 2 gens now
-        ctx_worker1 = run_ctx_worker(model_name, worker_config, TEST_PORT + 100)
-        gen_worker1 = run_gen_worker(model_name, worker_config, TEST_PORT + 200)
-        await wait_for_worker_ready(TEST_PORT + 100)
-        await wait_for_worker_ready(TEST_PORT + 200)
+        ctx_worker1 = run_ctx_worker(model_name,
+                                     worker_config,
+                                     work_dir,
+                                     port=ctx_worker1.port)
+        gen_worker1 = run_gen_worker(model_name,
+                                     worker_config,
+                                     work_dir,
+                                     port=gen_worker1.port)
+        await wait_for_worker_ready(ctx_worker1.port)
+        await wait_for_worker_ready(gen_worker1.port)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
-        verify_cluster_info(True, 2, 2)
+        verify_cluster_info(True, 2, 2, port=disagg_port)
 
         # send 10 requests, the responses will be generated by the different ctx/gen workers (but we can't verify it now)
         for _ in range(10):
             response = request_completion(model_name,
                                           test_prompt,
-                                          port=TEST_PORT)
+                                          port=disagg_port)
             assert response.choices[0].text == response_text
         print(response)
     finally:
@@ -384,20 +473,22 @@ async def test_worker_restart(model_name, disagg_server_config, worker_config,
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.timeout(300)
 async def test_disagg_server_restart(model_name, disagg_server_config,
-                                     worker_config, router, service_discovery):
+                                     worker_config, router, service_discovery,
+                                     disagg_port, work_dir):
     ctx_worker1 = None
     gen_worker1 = None
     disagg_server = None
     try:
         # initial cluster, 1 ctx, 1 gen, request should succeed
-        ctx_worker1 = run_ctx_worker(model_name, worker_config, TEST_PORT + 100)
-        gen_worker1 = run_gen_worker(model_name, worker_config, TEST_PORT + 200)
-        disagg_server = run_disagg_server(disagg_server_config, TEST_PORT)
-        await wait_for_disagg_server_ready(TEST_PORT)
-        verify_cluster_info(True, 1, 1)
+        ctx_worker1 = run_ctx_worker(model_name, worker_config, work_dir)
+        gen_worker1 = run_gen_worker(model_name, worker_config, work_dir)
+        disagg_server = run_disagg_server(disagg_server_config, work_dir,
+                                          disagg_port)
+        await wait_for_disagg_server_ready(disagg_port)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
         response = request_completion(model_name,
                                       "Hello, my name is",
-                                      port=TEST_PORT)
+                                      port=disagg_port)
         print(response)
         response_text = response.choices[0].text
 
@@ -408,12 +499,13 @@ async def test_disagg_server_restart(model_name, disagg_server_config,
             verify_cluster_info(False, 1, 1, expected_code=500)
 
         # restart disagg server, the request should succeed
-        disagg_server = run_disagg_server(disagg_server_config, TEST_PORT)
-        await wait_for_disagg_server_ready(TEST_PORT)
-        verify_cluster_info(True, 1, 1)
+        disagg_server = run_disagg_server(disagg_server_config, work_dir,
+                                          disagg_port)
+        await wait_for_disagg_server_ready(disagg_port)
+        verify_cluster_info(True, 1, 1, port=disagg_port)
         response = request_completion(model_name,
                                       "Hello, my name is",
-                                      port=TEST_PORT)
+                                      port=disagg_port)
         print(response)
         assert response.choices[0].text == response_text
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -369,8 +369,6 @@ accuracy/test_llm_api_pytorch_multimodal.py::TestNemotron_Nano_12B_V2_VL::test_a
 accuracy/test_llm_api_pytorch.py::TestLlama3_3_70BInstruct::test_fp8_eagle3_tp8[eagle3_one_model=True] SKIP (https://nvbugs/5673743)
 accuracy/test_llm_api_pytorch.py::TestLlama3_3_70BInstruct::test_fp8_eagle3_tp8[eagle3_one_model=False] SKIP (https://nvbugs/5673743)
 accuracy/test_llm_api_pytorch.py::TestNemotronNas::test_auto_dtype_tp8 SKIP (https://nvbugs/5673527)
-disaggregated/test_auto_scaling.py::test_disagg_server_restart[etcd-round_robin] SKIP (https://nvbugs/5633340)
-disaggregated/test_auto_scaling.py::test_disagg_server_restart[http-round_robin] SKIP (https://nvbugs/5633340)
 accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-4] SKIP (https://nvbugs/5680312, https://nvbugs/5636912)
 accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-2] SKIP (https://nvbugs/5680312, https://nvbugs/5636912)
 unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py::test_build_ad[meta-llama/Meta-Llama-3.1-8B-Instruct-llm_extra_args0-2] SKIP (https://nvbugs/5680755)


### PR DESCRIPTION
Also print logs at exit for better debugging experience of flaky CI failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure with dynamic port allocation and enhanced process lifecycle management for better test isolation and reliability.
  * Re-enabled previously skipped tests for disaggregated server restart scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
