### PR TITLE
[TRTLLM-7736][feat] Incrementally update the inputs of target and draft models

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -695,6 +695,7 @@ class ADEngine(ModelEngine):
         new_tensors_device: Optional[torch.Tensor] = None,
         gather_context_logits: bool = False,
         cache_indirection_buffer: Optional[torch.Tensor] = None,
+        num_accepted_tokens_device: Optional[torch.Tensor] = None,
     ):
         """Run forward from scheduled requests; main entrypoint that gets called by the executor."""
         # convert requests and store in sequence info object

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -305,6 +305,11 @@ class PyTorchModelEngine(ModelEngine):
             raise e
 
         self.is_warmup = False
+        self.previous_request_ids = []
+        self.has_previous_device_draft = False
+        self.previous_accepted_tokens_cuda = torch.empty((self.batch_size, ),
+                                                         dtype=torch.int,
+                                                         device='cuda')
 
         self.attn_backend = get_attention_backend(
             self.llm_args.attn_backend,
@@ -378,8 +383,18 @@ class PyTorchModelEngine(ModelEngine):
 
         # Pre-allocated buffers for draft model to avoid implicit synchronization
         # These are used to build index tensors without creating tensors from Python lists
-        if is_draft_model:
-            # Buffers for context and first_draft input_ids updates
+        max_first_draft_tokens = self.batch_size * (
+            self.original_max_draft_len + 1) if spec_config else self.batch_size
+        tokens_per_draft = self.original_max_draft_len + 1
+        self.idx_accepted_tokens_cache = None
+        self.draft_token_positions_cache = None
+        if spec_config:
+            # Cache for idx_accepted_tokens (pattern: 0,0,0...1,1,1...2,2,2...)
+            self.idx_accepted_tokens_cache = torch.arange(
+                max_first_draft_tokens, dtype=torch.long,
+                device='cuda') // tokens_per_draft
+
+        if self.is_draft_model:
             self.draft_ctx_token_indices_cuda = torch.empty((self.batch_size, ),
                                                             dtype=torch.long,
                                                             device='cuda')
@@ -387,9 +402,6 @@ class PyTorchModelEngine(ModelEngine):
                                                         dtype=torch.long,
                                                         device='cuda')
             # Buffers for first_draft requests (max_draft_len+1 tokens per request)
-            max_first_draft_tokens = self.batch_size * (
-                self.original_max_draft_len +
-                1) if spec_config else self.batch_size
             self.draft_first_draft_indices_cuda = torch.empty(
                 (max_first_draft_tokens, ), dtype=torch.long, device='cuda')
             self.draft_first_draft_seq_slots_cuda = torch.empty(
@@ -400,6 +412,12 @@ class PyTorchModelEngine(ModelEngine):
                                                            device='cuda')
             self.draft_request_indices_buffer_cuda = torch.empty(
                 (self.batch_size, ), dtype=torch.int, device='cuda')
+
+            # Pre-computed constant tensors for incremental update optimization
+            # Cache for token_positions (pattern: 0,1,2...N repeated)
+            self.draft_token_positions_cache = torch.arange(tokens_per_draft,
+                                                            dtype=torch.long,
+                                                            device='cuda')
 
         # We look up this key in resource_manager during forward to find the
         # kv cache manager. Can be changed to support multiple model engines
@@ -1328,6 +1346,481 @@ class PyTorchModelEngine(ModelEngine):
             input_ids, vocab_size=vocab_size, mm_token_ids=mm_token_ids)
         return text_token_indices, mm_token_indices
 
+    def _can_use_incremental_update(
+            self, scheduled_requests: ScheduledRequests,
+            new_tokens_device: Optional[torch.Tensor],
+            next_draft_tokens_device: Optional[torch.Tensor]) -> bool:
+        """
+        Check if we can use incremental update for the given scheduled requests and new tensors device.
+        """
+        # Not use this approach for non-speculative decoding
+        if self.spec_config is None:
+            return False
+
+        # Not allowed for one-model speculative decoding
+        if not self.spec_config.spec_dec_mode.has_draft_model():
+            return False
+
+        if not self.cuda_graph_runner.enabled:
+            return False
+
+        if self.use_mrope:
+            return False
+
+        # Not allowed for non-overlap scheduler
+        if new_tokens_device is None:
+            return False
+
+        # The changes between context and generation requests are not straightforward.
+        if len(scheduled_requests.context_requests) > 0:
+            return False
+
+        # Check if the request_ids changes
+        request_ids = [
+            request.py_request_id
+            for request in scheduled_requests.generation_requests
+        ]
+        if self.previous_request_ids != request_ids:
+            return False
+
+        has_current_device_draft = next_draft_tokens_device is not None
+        return (self.is_draft_model and self.model_is_wrapped) or (
+            has_current_device_draft and self.has_previous_device_draft)
+
+    @nvtx_range("_apply_incremental_update")
+    def _apply_incremental_update(
+            self,
+            scheduled_requests: ScheduledRequests,
+            kv_cache_manager: KVCacheManager,
+            attn_metadata: AttentionMetadata,
+            spec_metadata: Optional[SpecMetadata] = None,
+            new_tensors_device: Optional[SampleStateTensors] = None,
+            cache_indirection_buffer: Optional[torch.Tensor] = None,
+            num_accepted_tokens_device: Optional[torch.Tensor] = None,
+            req_id_to_old_request: Optional[Dict[int, LlmRequest]] = None,
+            resource_manager: Optional[ResourceManager] = None):
+        """
+        Apply incremental update for the given scheduled requests and new tensors device.
+        """
+
+        if self.is_draft_model:
+            return self._apply_incremental_update_draft(
+                scheduled_requests, kv_cache_manager, attn_metadata,
+                spec_metadata, new_tensors_device, num_accepted_tokens_device)
+        else:
+            return self._apply_incremental_update_target(
+                scheduled_requests, kv_cache_manager, attn_metadata,
+                spec_metadata, new_tensors_device, num_accepted_tokens_device)
+
+    @nvtx_range("_prepare_incremental_update_metadata")
+    def _prepare_incremental_update_metadata(
+            self,
+            scheduled_requests: ScheduledRequests,
+            kv_cache_manager: KVCacheManager,
+            attn_metadata: AttentionMetadata,
+            spec_metadata: Optional[SpecMetadata],
+            prompt_lengths: List[int],
+            num_cached_tokens_per_seq: List[int],
+            total_num_tokens: int,
+            num_generation_tokens: int,
+            request_accepted_path: Optional[Dict[int, Any]] = None,
+            num_extend_ctx_requests: int = 0):
+        """
+        Common metadata preparation logic for incremental updates.
+        """
+
+        enable_spec_decode = self.enable_spec_decode
+        enable_attention_dp = self.enable_attention_dp
+        spec_config = self.spec_config if enable_spec_decode else None
+
+        # Set up attention metadata - batch simple assignments
+        attn_metadata.beam_width = 1
+        attn_metadata.prompt_lens = prompt_lengths
+        attn_metadata.num_contexts = num_extend_ctx_requests if (
+            enable_spec_decode and spec_config.spec_dec_mode.extend_ctx(
+                self.attn_backend) and spec_config.is_linear_tree) else 0
+        attn_metadata.num_chunked_ctx_requests = attn_metadata.num_contexts
+
+        # Create KV cache params and prepare metadata
+        attn_metadata.kv_cache_params = KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            num_extra_kv_tokens=get_num_extra_kv_tokens(spec_config))
+        attn_metadata.kv_cache_manager = kv_cache_manager
+        attn_metadata.prepare()
+
+        # Get LoRA parameters
+        lora_params = self._get_lora_params_from_requests(
+            scheduled_requests, attn_metadata)
+
+        # Handle padding for piecewise CUDA graphs
+        attn_metadata.padded_num_tokens = None
+
+        # Handle attention DP
+        if enable_attention_dp:
+            attn_metadata.all_rank_num_tokens = self._get_all_rank_num_tokens(
+                attn_metadata)
+
+        # Prepare speculative metadata
+        if spec_metadata is not None:
+            # Set request_accepted_path if Eagle3
+            if isinstance(spec_metadata, Eagle3SpecMetadata):
+                spec_metadata.request_accepted_path = request_accepted_path
+
+            spec_metadata.prepare()
+
+            # Handle distributed spec metadata
+            if enable_attention_dp:
+                sequence_lengths = spec_metadata.seq_lens
+                all_rank_num_tokens = self.dist.tp_allgather(
+                    [spec_metadata.num_tokens,
+                     len(sequence_lengths)])
+                spec_metadata.all_rank_num_tokens = [
+                    item[0] for item in all_rank_num_tokens
+                ]
+                spec_metadata.all_rank_num_seqs = [
+                    item[1] for item in all_rank_num_tokens
+                ]
+
+        # Set iteration states - batch dictionary updates
+        self.iter_states.update({
+            'num_ctx_requests': 0,
+            'num_ctx_tokens': 0,
+            'num_generation_tokens': num_generation_tokens
+        })
+
+        return lora_params
+
+    @torch.compile(options={"max-autotune": True})
+    def _update_draft_input_tensors(self,
+                                    num_accepted_tokens_device: torch.Tensor,
+                                    new_tokens_device: torch.Tensor,
+                                    total_num_tokens: int,
+                                    num_first_draft_requests: int):
+        """
+        This function performs in-place updates on position_ids, num_accepted_draft_tokens,
+        gather_ids, and input_ids tensors for speculative decoding draft operations.
+        """
+        # Prepare position_ids
+        idx_accepted_tokens = self.idx_accepted_tokens_cache[:total_num_tokens]
+        self.position_ids_cuda[:total_num_tokens].add_(
+            self.num_accepted_draft_tokens_cuda[idx_accepted_tokens] + 1)
+
+        # Prepare gather_ids
+        old_accepted_tokens = self.num_accepted_draft_tokens_cuda[:
+                                                                  num_first_draft_requests].clone(
+                                                                  )
+        self.num_accepted_draft_tokens_cuda[:num_first_draft_requests].copy_(
+            num_accepted_tokens_device[
+                self.draft_seq_slots_buffer_cuda[:num_first_draft_requests]],
+            non_blocking=True)
+        self.gather_ids_cuda[:num_first_draft_requests].add_(
+            self.num_accepted_draft_tokens_cuda[:num_first_draft_requests] -
+            old_accepted_tokens)
+
+        # Prepare token_positions for input_ids update
+        tokens_per_first_draft = self.original_max_draft_len + 1
+        token_positions = self.draft_token_positions_cache[:tokens_per_first_draft].repeat(
+            num_first_draft_requests)
+
+        # Prepare input_ids
+        self.input_ids_cuda[
+            self.
+            draft_first_draft_indices_cuda[:total_num_tokens]] = new_tokens_device[
+                token_positions,
+                self.draft_first_draft_seq_slots_cuda[:total_num_tokens], 0]
+
+    def _apply_incremental_update_draft(
+            self,
+            scheduled_requests: ScheduledRequests,
+            kv_cache_manager: KVCacheManager,
+            attn_metadata: AttentionMetadata,
+            spec_metadata: Optional[SpecMetadata] = None,
+            new_tensors_device: Optional[SampleStateTensors] = None,
+            num_accepted_tokens_device: Optional[torch.Tensor] = None):
+        new_tokens_device = new_tensors_device.new_tokens
+
+        num_generation_tokens = len(scheduled_requests.generation_requests)
+        num_gen_requests = 0
+
+        tokens_per_first_draft = self.original_max_draft_len + 1
+        prompt_lengths = []  # per sequence
+        num_cached_tokens_per_seq = []  # per sequence
+
+        for request in scheduled_requests.generation_requests:
+            if request.is_dummy:
+                num_gen_requests += 1
+                past_seen_token_num = request.max_beam_num_tokens - 1
+                request.cached_tokens = past_seen_token_num
+            else:
+                assert request.py_is_first_draft
+                past_seen_token_num = request.max_beam_num_tokens - tokens_per_first_draft
+
+            num_cached_tokens_per_seq.append(past_seen_token_num)
+            prompt_lengths.append(request.py_prompt_len)
+            request.py_batch_idx = request.py_seq_slot
+
+        num_first_draft_requests = num_generation_tokens - num_gen_requests
+        total_num_tokens = num_first_draft_requests * tokens_per_first_draft
+
+        self._update_draft_input_tensors(
+            num_accepted_tokens_device=num_accepted_tokens_device,
+            new_tokens_device=new_tokens_device,
+            total_num_tokens=total_num_tokens,
+            num_first_draft_requests=num_first_draft_requests)
+
+        # Prepare spec_metadata
+        if spec_metadata is not None:
+            spec_metadata.draft_tokens = []
+            spec_metadata.gather_ids = self.gather_ids_cuda[:
+                                                            num_generation_tokens]
+            spec_metadata.num_accepted_draft_tokens = self.num_accepted_draft_tokens_cuda[:
+                                                                                          num_generation_tokens]
+
+        # Use common metadata preparation logic
+        lora_params = self._prepare_incremental_update_metadata(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata,
+            spec_metadata=spec_metadata,
+            prompt_lengths=prompt_lengths,
+            num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            total_num_tokens=total_num_tokens,
+            num_generation_tokens=num_generation_tokens,
+            num_extend_ctx_requests=0)
+
+        # No padding because there are only generation requests.
+        attn_metadata.padded_num_tokens = None
+        virtual_num_tokens = total_num_tokens + num_gen_requests
+        if self.enable_attention_dp:
+            attn_metadata.all_rank_num_tokens = self._get_all_rank_num_tokens(
+                attn_metadata)
+
+        final_position_ids = self.position_ids_cuda[:
+                                                    virtual_num_tokens].unsqueeze(
+                                                        0)
+
+        inputs = {
+            'attn_metadata': attn_metadata,
+            'input_ids': self.input_ids_cuda[:virtual_num_tokens],
+            'position_ids': final_position_ids,
+            'inputs_embeds': None,
+            "multimodal_params": [],
+        }
+
+        if bool(lora_params):
+            inputs['lora_params'] = lora_params
+
+        if spec_metadata is not None:
+            inputs['spec_metadata'] = spec_metadata
+
+        return inputs, self.gather_ids_cuda[:num_generation_tokens]
+
+    @torch.compile(options={"max-autotune": True})
+    def _update_target_input_tensors(
+            self, num_accepted_tokens_device: torch.Tensor,
+            new_tokens_device: torch.Tensor,
+            next_draft_tokens_device: torch.Tensor,
+            new_tokens_lens_device: torch.Tensor, previous_slots: torch.Tensor,
+            total_num_tokens: int, num_extend_reqeust_wo_dummy: int,
+            num_tokens_per_extend_request: int,
+            previous_batch_draft_tokens: int):
+        """
+        This function performs in-place updates on position_ids, num_accepted_draft_tokens,
+        input_ids, draft_tokens, and offset tensors for speculative decoding extend context operations.
+        """
+
+        # Prepare position_ids
+        idx_accepted_tokens = self.idx_accepted_tokens_cache[:total_num_tokens]
+        self.position_ids_cuda[:total_num_tokens].add_(
+            self.num_accepted_draft_tokens_cuda[idx_accepted_tokens] + 1)
+
+        self.num_accepted_draft_tokens_cuda[:num_extend_reqeust_wo_dummy].copy_(
+            num_accepted_tokens_device[:num_extend_reqeust_wo_dummy],
+            non_blocking=True)
+
+        # Initialize offset tensors to zeros
+        self.previous_pos_id_offsets_cuda.mul_(0)
+        self.previous_kv_lens_offsets_cuda.mul_(0)
+
+        # Prepare input_ids
+        new_tokens = new_tokens_device.transpose(
+            0, 1)[previous_slots, :].flatten()
+        self.input_ids_cuda[:total_num_tokens].copy_(new_tokens,
+                                                     non_blocking=True)
+
+        # Prepare draft tokens
+        self.draft_tokens_cuda[:previous_batch_draft_tokens].copy_(
+            next_draft_tokens_device[previous_slots, :].flatten(),
+            non_blocking=True)
+
+        # Compute kv_len_offsets and update offset tensors
+        previous_pos_indices = previous_slots.repeat_interleave(
+            num_tokens_per_extend_request)
+        self.previous_pos_indices_cuda[:total_num_tokens].copy_(
+            previous_pos_indices, non_blocking=True)
+        kv_len_offsets_device = new_tokens_lens_device - num_tokens_per_extend_request
+        self.previous_pos_id_offsets_cuda[:num_extend_reqeust_wo_dummy *
+                                          num_tokens_per_extend_request].copy_(
+                                              new_tokens_lens_device[
+                                                  self.
+                                                  previous_pos_indices_cuda[:
+                                                                            total_num_tokens]],
+                                              non_blocking=True)
+        self.previous_kv_lens_offsets_cuda[:num_extend_reqeust_wo_dummy].copy_(
+            kv_len_offsets_device[previous_slots], non_blocking=True)
+
+    def _apply_incremental_update_target(
+            self,
+            scheduled_requests: ScheduledRequests,
+            kv_cache_manager: KVCacheManager,
+            attn_metadata: AttentionMetadata,
+            spec_metadata: Optional[SpecMetadata] = None,
+            new_tensors_device: Optional[SampleStateTensors] = None,
+            num_accepted_tokens_device: Optional[torch.Tensor] = None):
+        # Extract tensors from new_tensors_device
+        new_tokens_device = new_tensors_device.new_tokens  # [batch, 1 + draft_len]
+        new_tokens_lens_device = new_tensors_device.new_tokens_lens  # [batch]
+        next_draft_tokens_device = new_tensors_device.next_draft_tokens  # [batch, draft_len]
+
+        # Pre-compute constants
+        extend_requests = scheduled_requests.generation_requests
+        num_extend_requests = len(extend_requests)
+        num_tokens_per_extend_request = self.original_max_draft_len + 1
+        spec_config = self.spec_config
+
+        prompt_lengths = torch.empty(num_extend_requests,
+                                     dtype=torch.int,
+                                     device='cpu',
+                                     pin_memory=True)
+        num_cached_tokens_per_seq = torch.empty(num_extend_requests,
+                                                dtype=torch.int,
+                                                device='cpu',
+                                                pin_memory=True)
+        previous_batch_indices = torch.empty(num_extend_requests,
+                                             dtype=torch.int,
+                                             device='cpu',
+                                             pin_memory=True)
+
+        request_accepted_path = {}
+        num_extend_dummy_requests = 0
+        num_previous_batch = 0
+
+        use_extend_ctx = (self.enable_spec_decode
+                          and spec_config.spec_dec_mode.extend_ctx(
+                              self.attn_backend) and spec_config.is_linear_tree)
+
+        for idx, request in enumerate(extend_requests):
+            request_accepted_path[request.py_request_id] = \
+                request.py_num_accepted_draft_tokens_indices
+
+            base_past_seen = request.max_beam_num_tokens - 1
+
+            if use_extend_ctx:
+                # We're treating the prompt lengths as context requests here, so
+                # the prompt lens should not include the cached tokens.
+                prompt_lengths[idx] = num_tokens_per_extend_request
+            else:
+                prompt_lengths[idx] = request.py_prompt_len
+
+            if request.is_dummy:
+                num_cached_tokens_per_seq[idx] = base_past_seen
+                request.cached_tokens = base_past_seen
+                num_extend_dummy_requests += 1
+            else:
+                # Request has previous tensor
+                previous_batch_indices[
+                    num_previous_batch] = request.py_batch_idx
+                num_previous_batch += 1
+
+                num_cached_tokens_per_seq[
+                    idx] = base_past_seen + num_tokens_per_extend_request
+                request.cached_tokens = num_cached_tokens_per_seq[idx].item()
+
+            request.py_batch_idx = request.py_seq_slot
+
+        num_extend_reqeust_wo_dummy = num_extend_requests - num_extend_dummy_requests
+        total_num_tokens = num_extend_reqeust_wo_dummy * num_tokens_per_extend_request
+
+        previous_slots = self.previous_batch_indices_cuda[:num_previous_batch]
+        previous_slots.copy_(previous_batch_indices[:num_previous_batch],
+                             non_blocking=True)
+
+        prompt_lengths = prompt_lengths.tolist()
+        num_cached_tokens_per_seq = num_cached_tokens_per_seq.tolist()
+
+        previous_batch_draft_tokens = num_extend_reqeust_wo_dummy * self.runtime_draft_len
+
+        self._update_target_input_tensors(
+            num_accepted_tokens_device=num_accepted_tokens_device,
+            new_tokens_device=new_tokens_device,
+            next_draft_tokens_device=next_draft_tokens_device,
+            new_tokens_lens_device=new_tokens_lens_device,
+            previous_slots=previous_slots,
+            total_num_tokens=total_num_tokens,
+            num_extend_reqeust_wo_dummy=num_extend_reqeust_wo_dummy,
+            num_tokens_per_extend_request=num_tokens_per_extend_request,
+            previous_batch_draft_tokens=previous_batch_draft_tokens)
+
+        # Prepare spec_metadata
+        num_generation_tokens = num_extend_requests * num_tokens_per_extend_request
+        if spec_metadata is not None:
+            total_draft_lens = self.max_total_draft_tokens * num_extend_requests
+            spec_metadata.draft_tokens = self.draft_tokens_cuda[:
+                                                                total_draft_lens]
+            spec_metadata.gather_ids = self.gather_ids_cuda[:total_num_tokens]
+            spec_metadata.num_accepted_draft_tokens = self.num_accepted_draft_tokens_cuda[:
+                                                                                          num_extend_requests]
+
+        # Determine if we're using extend_ctx mode for linear tree decoding
+        num_extend_ctx_requests = 0
+        if self.enable_spec_decode and spec_config.spec_dec_mode.extend_ctx(
+                self.attn_backend) and spec_config.is_linear_tree:
+            num_extend_ctx_requests = num_extend_requests
+
+        lora_params = self._prepare_incremental_update_metadata(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata,
+            spec_metadata=spec_metadata,
+            prompt_lengths=prompt_lengths,
+            num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            total_num_tokens=total_num_tokens,
+            num_generation_tokens=num_generation_tokens,
+            request_accepted_path=request_accepted_path,
+            num_extend_ctx_requests=num_extend_ctx_requests)
+
+        # No padding because there are only generation requests.
+        attn_metadata.padded_num_tokens = None
+        virtual_num_tokens = num_generation_tokens
+        if self.enable_attention_dp:
+            attn_metadata.all_rank_num_tokens = self._get_all_rank_num_tokens(
+                attn_metadata)
+
+        final_position_ids = self.position_ids_cuda[:
+                                                    virtual_num_tokens].unsqueeze(
+                                                        0)
+
+        # Prepare inputs
+        # Note: multimodal_params is always empty for incremental updates because:
+        # - This function only processes generation requests (no context requests)
+        # - Multimodal data (images/videos) is only needed during context/prefill phase
+        inputs = {
+            'attn_metadata': attn_metadata,
+            'input_ids': self.input_ids_cuda[:virtual_num_tokens],
+            'position_ids': final_position_ids,
+            'inputs_embeds': None,
+            "multimodal_params": [],
+        }
+
+        if bool(lora_params):
+            inputs['lora_params'] = lora_params
+
+        if spec_metadata is not None:
+            inputs['spec_metadata'] = spec_metadata
+
+        return inputs, self.gather_ids_cuda[:num_generation_tokens]
+
     def _prepare_tp_inputs(
             self,
             scheduled_requests: ScheduledRequests,
@@ -1357,6 +1850,15 @@ class PyTorchModelEngine(ModelEngine):
         if self.guided_decoder is not None:
             self.guided_decoder.add_batch(scheduled_requests,
                                           new_tokens=new_tokens_device)
+
+        if self._can_use_incremental_update(scheduled_requests,
+                                            new_tokens_device,
+                                            next_draft_tokens_device):
+            return self._apply_incremental_update(
+                scheduled_requests, kv_cache_manager, attn_metadata,
+                spec_metadata, new_tensors_device, cache_indirection_buffer,
+                num_accepted_tokens_device, req_id_to_old_request,
+                resource_manager)
 
         # if new_tensors_device exist, input_ids will only contain new context tokens
         input_ids = []  # per sequence
@@ -1564,7 +2066,8 @@ class PyTorchModelEngine(ModelEngine):
                 # overlap scheduler can only support the speculative decoding
                 # methods with a fixed number of draft tokens
                 sequence_lengths.append(1 + self.runtime_draft_len)
-                num_accepted_draft_tokens.append(self.runtime_draft_len)
+                num_accepted_draft_tokens.append(
+                    request.py_num_accepted_draft_tokens)
                 past_seen_token_num = request.max_beam_num_tokens - 1
                 draft_lens.append(self.runtime_draft_len)
                 gather_ids.extend(
@@ -2146,6 +2649,14 @@ class PyTorchModelEngine(ModelEngine):
         self.iter_states['num_ctx_requests'] = num_ctx_requests
         self.iter_states['num_ctx_tokens'] = num_ctx_tokens
         self.iter_states['num_generation_tokens'] = num_generation_tokens
+
+        if not self.is_warmup:
+            self.previous_request_ids = [
+                request.py_request_id
+                for request in scheduled_requests.generation_requests
+            ]
+            self.has_previous_device_draft = next_draft_tokens_device is not None
+
         return inputs, self.gather_ids_cuda[:len(
             gather_ids)] if self.enable_spec_decode else None
 

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -533,10 +533,13 @@ class ModelDrafter(Drafter):
 
         if has_draft_tokens:
             # We already updated the target state, so the new_tokens_lens should be all ones.
-            new_tokens_lens = torch.ones(batch_size, device=device)
+            new_tokens_lens = torch.ones(batch_size,
+                                         dtype=torch.int,
+                                         device=device)
             new_tokens_lens += num_accepted_tokens_device
             next_draft_tokens = torch.zeros(batch_size,
                                             self.max_draft_len,
+                                            dtype=torch.int,
                                             device=device)
         target_inputs.new_tokens_lens = new_tokens_lens
         target_inputs.next_draft_tokens = next_draft_tokens


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Preparing the inputs from beginning takes much time on host, and the host overhead becomes the bottleneck of two-model speculative decoding's perf, so the PR is using incremental update for the model engine.

The PR can reduce the cost of _prepare_tp_inputs for draft model in GPT-OSS on tp8 from ~710us to ~410us.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
