### PR TITLE
[TRTLLM-9468][chore] Update disagg benchmarking scripts to support context parallelism

### DIFF
--- a/examples/disaggregated/slurm/benchmark/README.md
+++ b/examples/disaggregated/slurm/benchmark/README.md
@@ -175,15 +175,16 @@ Results are automatically organized in the work directory:
 
 ### Benchmark Modes
 
-The system supports two primary benchmark modes:
+The system supports three primary benchmark modes:
 
 1. **End-to-End (e2e)**: Tests the complete disaggregated inference pipeline including both context processing and token generation phases
 2. **Generation Only (gen_only)**: Focuses solely on testing the generation phase with pre-cached KV data
+3. **Generation Only No Context (gen_only_no_context)**: Skips launching context workers entirely by setting `TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1`. This is useful when you only want to benchmark the generation phase without allocating resources for context workers.
 
 Configure the mode in the YAML file:
 ```yaml
 benchmark:
-  mode: "e2e"  # or "gen_only"
+  mode: "e2e"  # or "gen_only" or "gen_only_no_context"
 ```
 
 ### Metrics Collection

--- a/examples/disaggregated/slurm/benchmark/config.yaml
+++ b/examples/disaggregated/slurm/benchmark/config.yaml
@@ -11,7 +11,7 @@ slurm:
 
 # Benchmark Mode
 benchmark:
-  mode: "e2e"  # Options: e2e, gen_only
+  mode: "e2e"  # Options: e2e, gen_only, gen_only_no_context
   use_nv_sa_benchmark: false  # Whether to use NVIDIA SA benchmark script
   multi_round: 8  # Number of benchmark rounds
   benchmark_ratio: 0.8  # Benchmark ratio
@@ -34,6 +34,7 @@ environment:
   model_path: "<model_path>"
   trtllm_repo: "<trtllm_repo>"
   build_wheel: false  # Don't build the wheel when launching multiple jobs
+  cuda_architectures: ""  # Optional CUDA architectures to build for (e.g. "90-real;100-real"). If empty, builds for all architectures
   trtllm_wheel_path: ""  # Path to pre-built TensorRT-LLM wheel. If provided, install from this wheel instead
   work_dir: "<full_path_to_work_dir>"
   worker_env_var: "TLLM_LOG_LEVEL=INFO TRTLLM_SERVER_DISABLE_GC=1 TRTLLM_WORKER_DISABLE_GC=1 TRTLLM_ENABLE_PDL=1 ENROOT_ALLOW_DEV=yes"
@@ -59,6 +60,11 @@ worker_config:
     enable_attention_dp: true
     enable_lm_head_tp_in_adp: true
     pipeline_parallel_size: 1
+    context_parallel_size: 1
+    # Uncomment this section to enable context parallelism.
+    # cp_config:
+    #   cp_type: "HELIX"
+    #   tokens_per_block: 32  # must match kv_config.tokens_per_block.
     max_batch_size: 256
     max_num_tokens: 512
     max_seq_len: 2251
@@ -83,6 +89,7 @@ worker_config:
     trust_remote_code: true
     kv_cache_config:
       enable_block_reuse: false
+      tokens_per_block: 32
       free_gpu_memory_fraction: 0.8
       dtype: fp8
     moe_config:
@@ -103,6 +110,7 @@ worker_config:
     max_num_tokens: 4608
     max_seq_len: 1227
     tensor_parallel_size: 4
+    context_parallel_size: 1
     moe_expert_parallel_size: 4
     enable_attention_dp: true
     pipeline_parallel_size: 1

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -26,6 +26,7 @@ while [[ $# -gt 0 ]]; do
         --container-mount) container_mount="$2"; shift 2 ;;
         --container-image) container_image="$2"; shift 2 ;;
         --build-wheel) build_wheel="$2"; shift 2 ;;
+        --cuda-architectures) cuda_architectures="$2"; shift 2 ;;
         --trtllm-wheel-path) trtllm_wheel_path="$2"; shift 2 ;;
 
         # Accuracy evaluation
@@ -79,6 +80,14 @@ echo
 echo "Server Environment Variables:"
 echo "  server_env_var: ${server_env_var}"
 
+# Set TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1 for gen_only_no_context mode
+if [ "${benchmark_mode}" = "gen_only_no_context" ]; then
+    export TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1
+    worker_env_var="${worker_env_var} TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1"
+    server_env_var="${server_env_var} TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1"
+    echo "Setting TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1 for gen_only_no_context mode"
+fi
+
 container_name="disaggr-test"
 
 # Function to cleanup on failure
@@ -122,6 +131,9 @@ elif [ -d "${trtllm_repo}" ]; then
     if [ "${build_wheel}" = "true" ]; then
         echo "Building TensorRT-LLM wheel on one node..."
         build_command="python3 ./scripts/build_wheel.py --trt_root /usr/local/tensorrt --benchmarks --use_ccache --clean"
+        if [ -n "${cuda_architectures:-}" ]; then
+            build_command="${build_command} --cuda_architectures \"${cuda_architectures}\""
+        fi
         if ! srun --container-name=${container_name} \
             --container-mounts=${container_mount} \
             --mpi=pmix --overlap -N 1 --ntasks-per-node=1 \
@@ -160,8 +172,15 @@ for i in "${!node_array[@]}"; do
     echo "Replaced $placeholder with $current_val"
 done
 
+# start the workers (skip ctx workers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set).
 echo "Starting worker commands from ${start_worker_cmds_file}..."
 cat ${start_worker_cmds_file} | while read cmd; do
+    # Skip ctx worker commands if in gen-only mode
+    # CTX appears as argument to start_worker.sh and in log filename
+    if [ "${TRTLLM_DISAGG_BENCHMARK_GEN_ONLY:-0}" = "1" ] && [[ "$cmd" == *"start_worker.sh CTX"* ]]; then
+        echo "Skipping ctx worker command (TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set): ${cmd}"
+        continue
+    fi
     echo "Starting worker command: ${cmd}"
     eval "${cmd}"
 done

--- a/examples/disaggregated/slurm/benchmark/gen_server_config.py
+++ b/examples/disaggregated/slurm/benchmark/gen_server_config.py
@@ -35,12 +35,17 @@ if __name__ == "__main__":
         time.sleep(10)
         print(f"Waiting for hostnames folder {hostnames_folder} to be found")
     hostnames = os.listdir(hostnames_folder)
-    # check length of hostnames is equal to num_ctx_servers + num_gen_servers, if not, sleep 10 seconds and check again
-    while len(hostnames) != args.num_ctx_servers + args.num_gen_servers:
+
+    # Skip context servers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set
+    gen_only = os.getenv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY") == "1"
+    expected_hostnames = args.num_gen_servers if gen_only else args.num_ctx_servers + args.num_gen_servers
+
+    # check length of hostnames is equal to expected count, if not, sleep 10 seconds and check again
+    while len(hostnames) != expected_hostnames:
         time.sleep(10)
         hostnames = os.listdir(hostnames_folder)
         print(
-            f"Waiting for hostnames to be found in {hostnames_folder}, current length: {len(hostnames)}, expected length: {args.num_ctx_servers + args.num_gen_servers}"
+            f"Waiting for hostnames to be found in {hostnames_folder}, current length: {len(hostnames)}, expected length: {expected_hostnames}"
         )
     print(f"All hostnames found in {hostnames_folder}")
 
@@ -65,13 +70,18 @@ if __name__ == "__main__":
     hostname = socket.gethostname()
     print(f"Current hostname: {hostname}")
 
+    # Skip context servers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set
+    gen_only = os.getenv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY") == "1"
+
     server_config = {
         'hostname': hostname,
         'port': args.server_port,
         'backend': 'pytorch',
         'context_servers': {
-            'num_instances': args.num_ctx_servers,
-            'urls': ctx_urls
+            'num_instances':
+            0 if gen_only else args.num_ctx_servers,
+            'urls': [] if gen_only else
+            [f'{host}:{args.worker_port}' for host in ctx_hostnames]
         },
         'generation_servers': {
             'num_instances': args.num_gen_servers,

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -133,6 +133,7 @@ def submit_job(config, log_dir):
     # Set default environment configuration for backward compatibility
     env_config.setdefault('trtllm_repo', '')
     env_config.setdefault('build_wheel', False)
+    env_config.setdefault('cuda_architectures', '')
     env_config.setdefault('trtllm_wheel_path', '')
     env_config.setdefault('worker_env_var', '')
     env_config.setdefault('server_env_var', '')
@@ -154,12 +155,14 @@ def submit_job(config, log_dir):
 
     # Calculate nodes based on world sizes
     ctx_tp_size = config['worker_config']['ctx']['tensor_parallel_size']
+    ctx_cp_size = config['worker_config']['ctx']['context_parallel_size']
     ctx_pp_size = config['worker_config']['ctx']['pipeline_parallel_size']
-    ctx_world_size = ctx_tp_size * ctx_pp_size
+    ctx_world_size = ctx_tp_size * ctx_cp_size * ctx_pp_size
     ctx_nodes = calculate_nodes(ctx_world_size, ctx_num, gpus_per_node)
     gen_tp_size = config['worker_config']['gen']['tensor_parallel_size']
+    gen_cp_size = config['worker_config']['gen']['context_parallel_size']
     gen_pp_size = config['worker_config']['gen']['pipeline_parallel_size']
-    gen_world_size = gen_tp_size * gen_pp_size
+    gen_world_size = gen_tp_size * gen_cp_size * gen_pp_size
     gen_nodes = calculate_nodes(gen_world_size, gen_num, gpus_per_node)
     total_nodes = ctx_nodes + gen_nodes
     total_tasks = total_nodes * gpus_per_node
@@ -284,6 +287,7 @@ def submit_job(config, log_dir):
         *([] if not slurm_config['set_segment'] else [f'--segment={total_nodes}']),
         f'--output={log_dir}/slurm-%j.out',
         f'--error={log_dir}/slurm-%j.err',
+        f'--gpus-per-node={hw_config["gpus_per_node"]}',
         *([arg for arg in slurm_config['extra_args'].split() if arg]),
         slurm_config['script_file'],
 
@@ -309,6 +313,7 @@ def submit_job(config, log_dir):
         '--container-mount', env_config['container_mount'],
         '--container-image', env_config['container_image'],
         '--build-wheel', str(env_config['build_wheel']).lower(),
+        '--cuda-architectures', env_config['cuda_architectures'],
         '--trtllm-wheel-path', env_config['trtllm_wheel_path'],
 
         # Accuracy evaluation

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1878,16 +1878,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         assert metadata.kv_cache_manager is not None
         sink_token_length = 0
 
-        # Ensure helix_is_inactive_rank is on the same device as other tensors.
+        # Ensure helix_is_inactive_rank and position_ids are on the same device.
         if helix_is_inactive_rank is not None:
-            if isinstance(helix_is_inactive_rank, list):
-                helix_is_inactive_rank = torch.tensor(
-                    helix_is_inactive_rank,
-                    dtype=torch.bool,
-                    device=helix_position_offsets.device)
-            elif helix_is_inactive_rank.device.type != 'cuda':
-                helix_is_inactive_rank = helix_is_inactive_rank.to(
-                    helix_position_offsets.device)
+            assert helix_is_inactive_rank.device == helix_position_offsets.device, \
+                f"helix_is_inactive_rank must be on the same device as helix_position_offsets, " \
+                f"got {helix_is_inactive_rank.device} vs {helix_position_offsets.device}"
 
         mla_tensor_params = [helix_position_offsets, helix_is_inactive_rank]
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2015,6 +2015,11 @@ class PyTorchModelEngine(ModelEngine):
 
         attn_metadata.request_ids = request_ids
         attn_metadata.prompt_lens = prompt_lengths
+        if helix_is_inactive_rank is not None and len(
+                helix_is_inactive_rank) > 0:
+            helix_is_inactive_rank = torch.tensor(helix_is_inactive_rank,
+                                                  dtype=torch.bool,
+                                                  device='cuda')
         attn_metadata.helix_is_inactive_rank = helix_is_inactive_rank
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
         # Use num_chunked_ctx_requests to record the number of extend context requests,

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -863,7 +863,10 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             "disable_overlap_scheduler": True,
             "kv_cache_config": kv_cache_config,
             "enable_chunked_prefill": False,
-            "cuda_graph_config": None,
+            "cuda_graph_config": {
+                "enable_padding": True,
+                "batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128]
+            },
             "cache_transceiver_config": {
                 "backend": "UCX"
             },


### PR DESCRIPTION
## Description

This MR makes the following changes:
- adds changes to disagg benchmarking scripts to support context parallelism configs
- allows optionally building for specific cuda architectures to save time
- skips launching and waiting for ctx servers when `TRTLLM_DISAGG_BENCHMARK_GEN_ONLY` is enabled. This is needed in cases where ctx server can't handle as big an ISL as a gen server with helix parallelism can - so the benchmarking is blocked by ctx server dying
- fixes cuda graph capture issue with helix parallelism and update test for gatekeeping

## Test Coverage

Locally tested with [config_MR_9720.yaml](https://github.com/user-attachments/files/24044737/config_MR_9720.yaml).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for specifying custom CUDA architectures during build configuration
  - Introduced context parallelism with HELIX configuration support, including tokens-per-block specification
  - Enhanced Slurm batch job submission with explicit GPU-per-node resource allocation

* **Bug Fixes**
  - Added validation to ensure configuration consistency for HELIX parallelism settings across cache and context parallel configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->