### PR TITLE
[None][feat] Draft: Eagle + Medusa

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_medusa.py
+++ b/tensorrt_llm/_torch/models/modeling_medusa.py
@@ -1,0 +1,146 @@
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+from transformers import LlamaConfig
+
+from ..attention_backend import AttentionMetadata
+from ..model_config import ModelConfig
+from ..speculative import SpecMetadata
+from .checkpoints.base_weight_mapper import BaseWeightMapper
+from .modeling_llama import LlamaModel
+from .modeling_utils import DecoderModelForCausalLM, register_auto_model
+
+
+class MedusaModel(nn.Module):
+    """
+    Medusa model that combines a base LLM with a single Medusa head.
+
+    This model processes hidden states through the base model and then
+    through a Medusa head for draft token generation.
+    """
+
+    def __init__(self, model_config: ModelConfig[LlamaConfig], head_idx: int):
+        super().__init__()
+        self.model_config = model_config
+        self.head_idx = head_idx
+        self.hidden_size = model_config.pretrained_config.hidden_size
+        self.vocab_size = model_config.pretrained_config.vocab_size
+
+        # Get the number of layers from eagle_config
+        # (Medusa uses the same config structure for parallel draft heads)
+        self.num_layers = model_config.pretrained_config.eagle_config.get(
+            "parallel_draft_heads_num_layers", 0
+        )
+        assert self.num_layers > 0, "parallel_draft_heads_num_layers must be > 0"
+
+        # Create the Medusa layers
+        self.medusa_layers = nn.ModuleList(
+            [nn.Linear(self.hidden_size, self.hidden_size) for _ in range(self.num_layers)]
+        )
+        self.act = nn.SiLU()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Forward pass through the Medusa head.
+
+        Args:
+            hidden_states: Hidden states from the base model
+
+        Returns:
+            Processed hidden states after Medusa head
+        """
+        for layer in self.medusa_layers:
+            hidden_states = layer(hidden_states)
+            hidden_states = self.act(hidden_states) + hidden_states
+        return hidden_states
+
+
+@register_auto_model("MedusaForCausalLM")
+class MedusaForCausalLM(DecoderModelForCausalLM[LlamaModel, LlamaConfig]):
+    """
+    Medusa model for causal language modeling with speculative decoding.
+
+    This represents a single Medusa head with its own logits processor.
+    Multiple instances of this class should be created for parallel draft heads.
+    """
+
+    def __init__(
+        self,
+        model_config: ModelConfig[LlamaConfig],
+        head_idx: int = 0,
+    ):
+        # Initialize with the base model (shared or new)
+
+        super().__init__(
+            config=model_config,
+            hidden_size=model_config.pretrained_config.hidden_size,
+            vocab_size=model_config.pretrained_config.vocab_size,
+        )
+
+        self.head_idx = head_idx
+
+        # Initialize the Medusa head for this model
+        self.model = MedusaModel(model_config, head_idx)
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: torch.LongTensor = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        return_context_logits: bool = False,
+        spec_metadata: Optional[SpecMetadata] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Forward pass through the Medusa model.
+
+        Args:
+            attn_metadata: Attention metadata for the forward pass
+            input_ids: Input token IDs
+            position_ids: Position IDs for positional encoding
+            inputs_embeds: Pre-computed input embeddings (optional)
+            return_context_logits: Whether to return context logits
+            spec_metadata: Speculative decoding metadata
+            hidden_states: Pre-computed hidden states (optional, for reusing base model output)
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            Logits from the language model head after Medusa head processing
+        """
+
+        # Process through Medusa head
+        output = self.medusa_head(hidden_states)
+
+        # Process through logits processor (each head has its own)
+        return self.logits_processor.forward(
+            output,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )
+
+    def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
+        """
+        Load weights into the model.
+
+        Args:
+            weights: Dictionary mapping weight names to tensors
+            weight_mapper: Weight mapper for handling weight name conversions
+        """
+        # Prepend "model." to weight keys if not already present
+        # (except for lm_head and medusa_head)
+        new_weights = {}
+        for k, v in weights.items():
+            if "lm_head" not in k and "medusa_head" not in k:
+                new_k = "model." + k
+            else:
+                new_k = k
+            new_weights[new_k] = v
+
+        super().load_weights(weights=new_weights, weight_mapper=weight_mapper)

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -453,6 +453,18 @@ class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel,
         )
         self.load_lm_head_from_target = True
 
+        if model_config.pretrained_config.eagle_config.get(
+                "parallel_draft_step", 0) > 0:
+            from .modeling_medusa import MedusaForCausalLM
+            self.parallel_draft_heads = nn.ModuleList([
+                MedusaForCausalLM(model_config, start_layer_idx + i)
+                for i in range(
+                    model_config.pretrained_config.eagle_config.get(
+                        "parallel_draft_step", 0))
+            ])
+        else:
+            self.parallel_draft_heads = None
+
     def forward(
         self,
         attn_metadata: AttentionMetadata,

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Generic, List, Optional, Tuple
 
 import torch
@@ -452,18 +453,18 @@ class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel,
             vocab_size=config.draft_vocab_size,
         )
         self.load_lm_head_from_target = True
-
+        config = model_config.pretrained_config
         if model_config.pretrained_config.eagle_config.get(
-                "parallel_draft_step", 0) > 0:
+                "parallel_draft_step", 1) > 1:
             from .modeling_medusa import MedusaForCausalLM
             self.parallel_draft_heads = nn.ModuleList([
-                MedusaForCausalLM(model_config, start_layer_idx + i)
+                MedusaForCausalLM(model_config, start_layer_idx + config.num_hidden_layers, head_idx=i)
                 for i in range(
                     model_config.pretrained_config.eagle_config.get(
-                        "parallel_draft_step", 0))
+                        "parallel_draft_step", 1)-1)
             ])
         else:
-            self.parallel_draft_heads = None
+            self.parallel_draft_heads = nn.ModuleList([])
 
     def forward(
         self,
@@ -497,7 +498,18 @@ class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel,
 
         new_weights = {}
         for k, v in weights.items():
-            if 'lm_head' not in k:
+            if 'parallel_draft_heads' in k:
+                # parallel_draft_heads is a direct attribute of Eagle3ForCausalLM,
+                # not under self.model, so keep the key as-is but transform the format.
+                # Checkpoint format: parallel_draft_heads.{head_idx}.{layer_idx}.linear.{param}
+                # Model format: parallel_draft_heads.{head_idx}.model.medusa_layers.{layer_idx}.{param}
+                match = re.match(r'parallel_draft_heads\.(\d+)\.(\d+)\.linear\.(.+)', k)
+                if match:
+                    head_idx, layer_idx, param = match.groups()
+                    new_k = f'parallel_draft_heads.{head_idx}.model.medusa_layers.{layer_idx}.{param}'
+                else:
+                    new_k = k
+            elif 'lm_head' not in k:
                 new_k = "model." + k
             else:
                 self.load_lm_head_from_target = False

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -475,6 +475,13 @@ class Eagle3OneModelWorker(SpecWorkerBase):
                 "attn_metadata": attn_metadata,
                 "spec_metadata": spec_metadata,
             }
+        for layer in draft_model.parallel_draft_heads:
+            med_out = layer(hidden_states)
+            logits = layer.logits_processor(med_out, layer.lm_head,
+                                            attn_metadata, True)
+            new_draft_token = self.draft_decoder(logits, layer)
+            next_draft_tokens.append(new_draft_token)
+
         next_draft_tokens = torch.stack(next_draft_tokens, dim=1)
 
         # restore attn_metadata to support cuda graph


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Medusa model architecture support for speculative token generation
  * Implemented parallel drafting heads for concurrent draft token generation, enabling faster inference
  * Enhanced speculative decoding with multi-head parallel drafting capabilities for improved token generation performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
