### PR TITLE
[#9760][fix] Use RequestError for validation errors to prevent engine shutdown

### DIFF
--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -31,7 +31,7 @@ from ..executor import (DetokenizedGenerationResultBase, GenerationExecutor,
                         GenerationResult, IterationResult, LoRARequest,
                         PostprocWorkerConfig, PromptAdapterRequest)
 from ..executor.postproc_worker import PostprocParams
-from ..executor.utils import (create_mpi_comm_session,
+from ..executor.utils import (RequestError, create_mpi_comm_session,
                               get_spawn_proxy_process_env)
 from ..inputs import (PromptInputs, create_input_processor,
                       create_input_processor_with_hash, get_cache_salt_id,
@@ -686,7 +686,7 @@ class BaseLLM:
             if self.args.backend == "pytorch" and not self.args.enable_chunked_prefill and not is_gen_only:
                 max_num_tokens = self.args.max_num_tokens
                 if max_num_tokens and prompt_len / self.args.parallel_config.cp_size + query_len > max_num_tokens:
-                    raise ValueError(
+                    raise RequestError(
                         f"The sum of prompt length ({prompt_len/self.args.parallel_config.cp_size}), query length ({query_len}) should not exceed "
                         f"max_num_tokens ({max_num_tokens})")
             return

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2393,7 +2393,8 @@ def test_llm_chunked_prefill():
                   enable_chunked_prefill=False,
                   fast_build=True)
 
-        with pytest.raises(ValueError):
+        # max_num_tokens validation now raises RequestError consistently
+        with pytest.raises(RequestError):
             output = llm.generate_async(
                 "A " * build_config.max_num_tokens,
                 sampling_params=sampling_params,
@@ -2436,13 +2437,9 @@ def _test_llm_capture_request_error(pytorch_backend: bool, tp_size: int = 1):
     )
 
     prompt = 'A ' * 65  # the minimum max_num_tokens is 64
-    if pytorch_backend:
-        # pytorch backend will raise ValueError for max_num_tokens
-        with pytest.raises(ValueError):
-            llm.generate(prompt)
-    else:
-        with pytest.raises(RequestError):
-            llm.generate(prompt)
+    # Both backends now consistently raise RequestError for max_num_tokens validation
+    with pytest.raises(RequestError):
+        llm.generate(prompt)
 
 
 def test_llm_capture_request_error():

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -8,7 +8,7 @@ import pytest
 
 from tensorrt_llm import LLM
 from tensorrt_llm.disaggregated_params import DisaggregatedParams
-from tensorrt_llm.executor import GenerationExecutorWorker
+from tensorrt_llm.executor import GenerationExecutorWorker, RequestError
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
 from tensorrt_llm.llmapi import CacheTransceiverConfig, KvCacheConfig
 from tensorrt_llm.llmapi.llm_args import NGramDecodingConfig, PeftCacheConfig
@@ -830,10 +830,13 @@ class TestLlmError:
                   kv_cache_config=global_kvcache_config,
                   max_num_tokens=100)
 
-        with pytest.raises(ValueError,
-                           match="should not exceed max_num_tokens"):
-            ids = [random.randint(10, 100) for _ in range(101)]
-            llm.generate([ids])
+        try:
+            with pytest.raises(RequestError,
+                               match="should not exceed max_num_tokens"):
+                ids = [random.randint(10, 100) for _ in range(101)]
+                llm.generate([ids])
+        finally:
+            llm.shutdown()
 
 
 class FailingExecutorWorker(GenerationExecutorWorker):
@@ -962,10 +965,13 @@ class TestLlmError:
                   kv_cache_config=global_kvcache_config,
                   max_num_tokens=100)
 
-        with pytest.raises(ValueError,
-                           match="should not exceed max_num_tokens"):
-            ids = [random.randint(10, 100) for _ in range(101)]
-            llm.generate([ids])
+        try:
+            with pytest.raises(RequestError,
+                               match="should not exceed max_num_tokens"):
+                ids = [random.randint(10, 100) for _ in range(101)]
+                llm.generate([ids])
+        finally:
+            llm.shutdown()
 
 
 @skip_ray


### PR DESCRIPTION
## Background
Currently, validation errors in `_check_arguments()` raise `ValueError`, which causes the engine to shut down when caught by the Dynamo handler instead of returning a proper HTTP 400 error response to the client.


## Why This Fix is Needed
- `RequestError` is caught by the executor's error handling system and converted to proper error responses
- Prevents entire engine shutdown on invalid user input
- Maintains consistency with other validation errors (e.g., `default_max_tokens`) which already use `RequestError`
- Allows graceful error handling in production environments

## Testing
```
Build the image and run the container

./container/build.sh --framework trtllm
./container/run.sh -it --mount-workspace --gpus all --framework trtllm

agg.yaml

Change agg.yaml file
tensor_parallel_size: 1
moe_expert_parallel_size: 1
enable_attention_dp: false
max_num_tokens: 23
max_batch_size: 16
trust_remote_code: true
backend: pytorch
enable_chunked_prefill: false

kv_cache_config:
  free_gpu_memory_fraction: 0.85

Inside the container
Environment variables with defaults
exportMODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-0.6B"}
exportSERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen/Qwen3-0.6B"}
exportAGG_ENGINE_ARGS=${AGG_ENGINE_ARGS:-"examples/backends/trtllm/engine_configs/qwen3/agg.yaml"}
run frontend
python3 -m dynamo.frontend --router-mode kv --http-port 8080 >& tzuling_frontend.log &
run worker
python3 -m dynamo.trtllm
  --model-path "$MODEL_PATH"
  --served-model-name "$SERVED_MODEL_NAME"
  --extra-engine-args "$AGG_ENGINE_ARGS"
  --max-seq-len 20
  --publish-events-and-metrics >& tzuling_backend.log &

Send prompt > max_seq_len request
curl -s localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [
    {
      "role": "developer",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "Hello! It’s a wonderful day. How are you today? Have you had breakfast?"
    }
  ],
  "stream": false,
  "max_tokens": 300
}'
```
Now returns 
```
{"message":"The sum of prompt length (26.0), query length (0) should not exceed max_num_tokens (22)","type":"Internal Server Error","code":500}
```
without crashing the engine

Fixes #9760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling consistency by updating exception types in input validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->