### PR TITLE
[None][feat] AutoDeploy: prepare_metadata revisited

### DIFF
--- a/examples/auto_deploy/nano_v3.yaml
+++ b/examples/auto_deploy/nano_v3.yaml
@@ -6,6 +6,7 @@ enable_chunked_prefill: true
 attn_backend: flashinfer
 model_factory: AutoModelForCausalLM
 skip_loading_weights: false
+# TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/9884
 free_mem_ratio: 0.88
 cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 320, 384]
 kv_cache_config:

--- a/examples/auto_deploy/nano_v3.yaml
+++ b/examples/auto_deploy/nano_v3.yaml
@@ -6,7 +6,7 @@ enable_chunked_prefill: true
 attn_backend: flashinfer
 model_factory: AutoModelForCausalLM
 skip_loading_weights: false
-free_mem_ratio: 0.9
+free_mem_ratio: 0.88
 cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 320, 384]
 kv_cache_config:
   # disable kv_cache reuse since not supported for hybrid/ssm models

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -1,6 +1,6 @@
 """Compile backend with cudagraph."""
 
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -12,7 +12,7 @@ from tensorrt_llm._torch.autotuner import autotune
 
 from ...utils.cuda_graph import CudaGraphWarmUpPhase
 from ...utils.logger import ad_logger
-from ..compiler import CompileBackendRegistry, CompilerBackend
+from ..compiler import CompileBackendRegistry, CompilerBackend, GetArgsKwargsForBatchSize
 
 
 def _args_kwargs_flatten_spec(in_spec: TreeSpec, *args, **kwargs) -> List[Any]:
@@ -31,13 +31,10 @@ class CapturedGraph(nn.Module):
     def __init__(
         self,
         model: nn.Module,
-        cuda_graph_batch_sizes: List[int],
-        num_batched_inputs: int,  # number of batched, dynamic inputs...
+        num_batched_inputs: Optional[int] = None,  # number of batched, dynamic inputs...
     ):
         super().__init__()
         self.model = model
-        self.cuda_graph_max_batch_size = max(cuda_graph_batch_sizes)
-        ad_logger.info(f"Setting {self.cuda_graph_max_batch_size=}")
         self.num_batched_inputs = num_batched_inputs if num_batched_inputs is not None else 1
         self.cudagraphs: Dict[Tuple[int, ...], CUDAGraph] = {}
         self._input_buffers: List[torch.Tensor] = [
@@ -45,7 +42,6 @@ class CapturedGraph(nn.Module):
         ]
         self._out_buffer_flat: List[torch.Tensor] = None
         self._args_hash: Optional[Tuple[int, ...]] = None
-        self.cuda_graph_batch_sizes = sorted(cuda_graph_batch_sizes, reverse=True)
         self._cuda_graph_mem_pool = None
 
         # store the in_spec and out_spec during graph capture
@@ -54,17 +50,6 @@ class CapturedGraph(nn.Module):
 
     def _get_hash(self, flat_args: List[Any]) -> Tuple[int, ...]:
         return tuple(hash(a) for a in flat_args)
-
-    @staticmethod
-    def round_up_to_closest(batch_sizes: Iterable[int], bs: int) -> Optional[int]:
-        """Return closest batch size larger or equal to bs."""
-        if bs > max(batch_sizes, default=0):
-            return None
-        return min(batch_sizes, key=lambda x: (x < bs, abs(x - bs)), default=None)
-
-    def round_to_cuda_batch_size(self, bs: int) -> int:
-        """Round batch size to the nearest cuda batch size."""
-        return self.round_up_to_closest(self.cuda_graph_batch_sizes, bs)
 
     def _capture_one_graph(self, *args, **kwargs) -> torch.cuda.CUDAGraph:
         """Capture and return one cuda graph."""
@@ -87,10 +72,15 @@ class CapturedGraph(nn.Module):
         self._cuda_graph_mem_pool = self._cuda_graph_mem_pool or graph.pool()
         return graph
 
-    def capture_graph(self, *args, **kwargs):
-        """Capture and pre-fetch the graph for variable batch size."""
-        # check this is the first time we capture the graph
+    def capture_graph(self, get_args_kwargs: GetArgsKwargsForBatchSize, batch_sizes: List[int]):
+        """Capture and pre-fetch the graph for desired batch sizes."""
         assert not self.cudagraphs, "Graphs already captured."
+
+        # sort batch sizes in descending order
+        batch_sizes = sorted(batch_sizes, reverse=True)
+
+        # get args, kwargs for the first time for the largest batch size
+        args, kwargs = get_args_kwargs(batch_sizes[0])
 
         # flatten args, kwargs for the first time and record in_spec
         all_args_flat, self._in_spec = _args_kwargs_flatten(*args, **kwargs)
@@ -102,23 +92,8 @@ class CapturedGraph(nn.Module):
         # set the args hash --> this is used to compare the static inputs during graph replay
         self._args_hash = self._get_hash(args_static)
 
-        # sanity checks on the batched inputs
-        msg_bs = (
-            f"Input batch size exceeds maximum CUDA graph batch size. "
-            f"CUDA graph max batch size: {self.cuda_graph_max_batch_size}, "
-            f"but got input batch sizes: {[input.shape[0] for input in args_batched]}. "
-            f"Did you intentionally set the maximal value of cuda_graph_batch_sizes lower "
-            f"than the max_batch_size? It will fall back to non-CUDA graph forward pass for "
-            f"batch sizes exceeding the max_batch_size."
-        )
-        if any(self.cuda_graph_max_batch_size < input.shape[0] for input in args_batched):
-            ad_logger.info(msg_bs)
-
-        # repeat the batched input tensors to the cuda_graph_max_batch_size
-        self._input_buffers = [
-            input[:1].repeat_interleave(self.cuda_graph_max_batch_size, dim=0)
-            for input in args_batched
-        ]
+        # store the input buffers for the largest batch size
+        self._input_buffers = [a.clone() for a in args_batched]
 
         # create new args, kwargs with the input buffers and static args
         args, kwargs = self._in_spec.unflatten(self._input_buffers + args_static)
@@ -126,13 +101,30 @@ class CapturedGraph(nn.Module):
         # capture output once with cuda_graph_max_batch_size to capture output buffers
         # store the out_spec at this point
         with CudaGraphWarmUpPhase():
-            ad_logger.info(f"Warm up with {self.cuda_graph_max_batch_size=} before graph capture")
+            ad_logger.info(f"Warm up with max_batch_size={batch_sizes[0]} before graph capture")
             out = self.model(*args, **kwargs)
         self._out_buffer_flat, self._out_spec = tree_flatten(out)
 
         # capture graph now for a range of batch sizes
-        for bs in self.cuda_graph_batch_sizes:
+        for bs in batch_sizes:
             ad_logger.info(f"Capturing graph for batch size: {bs}")
+
+            # get new args, kwargs for the current batch size
+            args, kwargs = get_args_kwargs(bs)
+            all_args_flat = _args_kwargs_flatten_spec(self._in_spec, *args, **kwargs)
+            args_batched = all_args_flat[: self.num_batched_inputs]
+            args_static = all_args_flat[self.num_batched_inputs :]
+
+            # assert that static args match the stored hash
+            assert self._args_hash == self._get_hash(args_static), (
+                "Static args mismatch during capture"
+            )
+
+            # copy new inputs to input buffers
+            for i, input_tensor in enumerate(args_batched):
+                self._input_buffers[i][: input_tensor.shape[0]].copy_(
+                    input_tensor, non_blocking=True
+                )
 
             # setup args, kwargs
             inputs_truncated = [in_buffer[:bs] for in_buffer in self._input_buffers]
@@ -155,12 +147,8 @@ class CapturedGraph(nn.Module):
         if self._args_hash != self._get_hash(args_static):
             return self.model(*args, **kwargs)
 
-        # Calculate rounded-up shapes for each input
-        rounded_shapes = [
-            (self.round_to_cuda_batch_size(input.shape[0]),) + tuple(input.shape[1:])
-            for input in args_batched
-        ]
-        combined_shape = sum(rounded_shapes, start=())
+        # Calculate combined shape tuple as hash for cudagraph lookup
+        combined_shape = sum((arg.shape for arg in args_batched), start=())
 
         # regular forward for non-matching shapes
         if combined_shape not in self.cudagraphs:
@@ -188,72 +176,22 @@ class TorchCudagraphCompiler(CompilerBackend):
         *args_for_init,
         cuda_graph_batch_sizes: Optional[List[int]] = None,
         num_batched_inputs: int = 1,
-        max_batch_size: Optional[int] = None,
+        get_args_kwargs_for_compile: GetArgsKwargsForBatchSize = None,
         **kwargs_for_init,
     ):
         super().__init__(*args_for_init, **kwargs_for_init)
-
-        # heuristic to identify max batch size
-        assert max_batch_size or cuda_graph_batch_sizes, (
-            "At least one of max_batch_size or cuda_graph_batch_sizes must be provided."
-        )
-        self.max_batch_size = max_batch_size or max(cuda_graph_batch_sizes)
-
         self.num_batched_inputs = num_batched_inputs
-        if not cuda_graph_batch_sizes:
-            # Use heuristic which includes commonly-used sizes like 1 and max_bs
-            self.cuda_graph_batch_sizes = self._get_graph_batch_sizes(self.max_batch_size)
-            ad_logger.info(f"Using heuristic cuda_graph_batch_sizes: {self.cuda_graph_batch_sizes}")
-        else:
-            # Sanitize user-provided sizes: clamp to [1, max_batch_size], dedupe, sort desc
-            # No point capturing CUDA graphs for batch sizes larger than max_batch_size
-            effective = {
-                min(max(1, int(b)), int(self.max_batch_size))
-                for b in cuda_graph_batch_sizes
-                if isinstance(b, (int, float)) and b > 0
-            }
-            self.cuda_graph_batch_sizes = sorted(effective, reverse=True)
-
-            # Log if we clamped any values
-            original_values = [
-                int(b) for b in cuda_graph_batch_sizes if isinstance(b, (int, float)) and b > 0
-            ]
-            clamped_values = [v for v in original_values if v > self.max_batch_size]
-            if clamped_values:
-                ad_logger.info(
-                    f"Clamped CUDA graph batch sizes {clamped_values} to max_batch_size={self.max_batch_size}"
-                )
-
-            ad_logger.info(
-                f"Using explicit cuda_graph_batch_sizes: requested={cuda_graph_batch_sizes}"
-                f" -> effective={self.cuda_graph_batch_sizes}"
-                f" (clamped to [1, {self.max_batch_size}])"
-            )
+        self.cuda_graph_batch_sizes = cuda_graph_batch_sizes or []
+        self.get_args_kwargs_for_compile = get_args_kwargs_for_compile
 
     @torch.inference_mode()
     def compile(self) -> CapturedGraph:
-        captured_model = CapturedGraph(
-            self.model,
-            cuda_graph_batch_sizes=self.cuda_graph_batch_sizes,
-            num_batched_inputs=self.num_batched_inputs,
-        )
+        captured_model = CapturedGraph(self.model, num_batched_inputs=self.num_batched_inputs)
 
         # try capturing cudagraph
-        if self.args is not None or self.kwargs is not None:
-            captured_model.capture_graph(*self.args, **self.kwargs)
+        assert self.get_args_kwargs_for_compile is not None, (
+            "get_args_kwargs_for_compile must be provided"
+        )
+        captured_model.capture_graph(self.get_args_kwargs_for_compile, self.cuda_graph_batch_sizes)
 
         return captured_model
-
-    @staticmethod
-    def _get_graph_batch_sizes(
-        max_bs: int, extra: Optional[List[int]] = None, multiplier: int = 128
-    ) -> List[int]:
-        """Heuristic to set batch sizes for graph capture."""
-        # do 1, max_bs, and extra as special batch sizes
-        batch_sizes = {1, max_bs, *(extra or [])}
-
-        # add all multiples of multiplier up to max_bs
-        batch_sizes.update(range(multiplier, max_bs + 1, multiplier))
-
-        # return as sorted list
-        return sorted(batch_sizes, reverse=True)

--- a/tensorrt_llm/_torch/auto_deploy/compile/compiler.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/compiler.py
@@ -4,9 +4,12 @@ This is useful as final optimization step for in-framework deployment of our inf
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Tuple, Type
 
 import torch.nn as nn
+
+ArgsKwargs = Tuple[List[Any], Dict[str, Any]]
+GetArgsKwargsForBatchSize = Callable[[int], ArgsKwargs]
 
 
 class CompileBackendRegistry:
@@ -32,16 +35,8 @@ class CompileBackendRegistry:
 
 
 class CompilerBackend(ABC):
-    def __init__(
-        self,
-        model: nn.Module,
-        args: Tuple[Any, ...],
-        kwargs: Optional[Dict[str, Any]] = None,
-        **compiler_kwargs,
-    ):
+    def __init__(self, model: nn.Module, **compiler_kwargs):
         self.model = model
-        self.args = args
-        self.kwargs = kwargs or {}
 
     @abstractmethod
     def compile(self) -> nn.Module:

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -143,8 +143,6 @@ transforms:
   ############################################################################################
   # SWITCH TO CACHED+FLATTENED ATTENTION + INITIALIZE CACHES
   ############################################################################################
-  update_in_out_nodes:
-    stage: cache_init
   insert_cached_attention:
     stage: cache_init
     backend: flashinfer

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -423,6 +423,9 @@ class SequenceInfo:
         # see https://github.com/NVIDIA/TensorRT-LLM/issues/4504
         max_seq_len_adjusted = self.max_seq_len + 1
 
+        # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/9883 clean up this hack
+        self.max_state_slots = max_batch_size + 1
+
         # if the provided max_num_tokens is less than the max_batch_size * max_seq_len_adjusted,
         # we use the provided max_num_tokens. If max_num_tokens provided is more, we still use
         # max_batch_size * max_seq_len_adjusted since the extra tokens cannot be used.

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -24,6 +24,259 @@ from ..utils.logger import ad_logger
 Constant = Union[int, float, str, None]
 
 
+class InputBuffer:
+    """Manages contiguous memory buffers for efficient host-to-device transfers.
+
+    This class consolidates multiple tensors into a single contiguous buffer on both
+    host (pinned memory) and device. This enables efficient bulk transfers with a
+    single async H2D copy instead of multiple small copies.
+
+    The buffer layout places the truncatable tensor (typically cache_loc) last,
+    allowing partial copies when the full buffer isn't needed.
+
+    Usage:
+        1. Create InputBuffer with tensor specifications (name, max_numel, dtype)
+        2. Use store() to write data to the pinned host buffer
+        3. Call copy_to_device() to perform a single async H2D transfer
+        4. Access device tensors via get_view()
+    """
+
+    def __init__(self, tensor_specs: List[Tuple[str, int, torch.dtype]]):
+        """Initialize the InputBuffer.
+
+        Args:
+            tensor_specs: Ordered list of (name, max_numel, dtype) tuples.
+                         The last tensor is treated as truncatable during copy.
+        """
+        self._tensor_specs = {name: (numel, dtype) for name, numel, dtype in tensor_specs}
+        self._tensor_order = [name for name, _, _ in tensor_specs]
+
+        # Calculate offsets for each tensor (aligned to dtype's element size)
+        self._offsets: Dict[str, int] = {}
+        self._byte_sizes: Dict[str, int] = {}
+
+        current_offset = 0
+        for name, numel, dtype in tensor_specs:
+            # Align to the tensor's element size for proper memory access
+            alignment = dtype.itemsize
+            aligned_offset = (current_offset + alignment - 1) // alignment * alignment
+            byte_size = numel * dtype.itemsize
+            self._offsets[name] = aligned_offset
+            self._byte_sizes[name] = byte_size
+            current_offset = aligned_offset + byte_size
+
+        # Total buffer size
+        self._total_bytes = current_offset
+
+        # Allocate contiguous buffers (device buffer starts on default device, use to() to move)
+        self._device_buffer = torch.empty(self._total_bytes, dtype=torch.uint8)
+        self._host_buffer = torch.empty(
+            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=True
+        )
+
+        # Create persistent views into device and host buffers
+        # Persistent views help us identify the arguments as static during graph capture.
+        self._device_views = self._create_views(self._device_buffer)
+        self._host_views = self._create_views(self._host_buffer)
+
+        # Track current lengths for each tensor (for truncation optimization)
+        self._current_lengths: Dict[str, int] = {name: 0 for name in self._tensor_order}
+
+    def _create_views(self, buffer: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Create views into the given buffer for each tensor."""
+        views = {}
+        for name in self._tensor_order:
+            offset = self._offsets[name]
+            byte_size = self._byte_sizes[name]
+            _, dtype = self._tensor_specs[name]
+            views[name] = buffer[offset : offset + byte_size].view(dtype)
+        return views
+
+    @property
+    def tensor_names(self) -> List[str]:
+        """Return the list of tensor names in buffer order."""
+        return self._tensor_order.copy()
+
+    @property
+    def _truncatable_name(self) -> str:
+        """Return the name of the truncatable tensor."""
+        return self._tensor_order[-1]
+
+    @property
+    def total_bytes(self) -> int:
+        """Total size of the buffer in bytes."""
+        return self._total_bytes
+
+    @property
+    def device(self) -> torch.device:
+        """Return the device of the device buffer."""
+        return self._device_buffer.device
+
+    def get_view(self, name: str) -> torch.Tensor:
+        """Get the device tensor view for the specified name.
+
+        Args:
+            name: Name of the tensor.
+
+        Returns:
+            A view into the device buffer for the specified tensor.
+        """
+        return self._device_views[name]
+
+    def get_view_at_current_length(self, name: str) -> torch.Tensor:
+        """Get the device tensor view for the specified name at the current length.
+
+        Args:
+            name: Name of the tensor.
+
+        Returns:
+            A view into the device buffer for the specified tensor at the current length.
+        """
+        return self._device_views[name][: self._current_lengths[name]]
+
+    def get_host_view(self, name: str) -> torch.Tensor:
+        """Get the host tensor view for the specified name.
+
+        Args:
+            name: Name of the tensor.
+
+        Returns:
+            A view into the pinned host buffer for the specified tensor.
+        """
+        return self._host_views[name]
+
+    def get_capacity(self, name: str) -> int:
+        """Get the maximum number of elements for the specified tensor.
+
+        Args:
+            name: Name of the tensor.
+
+        Returns:
+            Maximum number of elements that can be stored.
+        """
+        numel, _ = self._tensor_specs[name]
+        return numel
+
+    def get_current_length(self, name: str) -> int:
+        """Get the current stored length for the specified tensor.
+
+        Args:
+            name: Name of the tensor.
+
+        Returns:
+            Number of elements currently stored in the tensor.
+        """
+        return self._current_lengths[name]
+
+    def store(
+        self,
+        name: str,
+        data: List[Number],
+        fill_value: Optional[Number] = None,
+    ) -> int:
+        """Store data into the host buffer.
+
+        Args:
+            name: Name of the tensor to store to.
+            data: List of values to store.
+            fill_value: Optional value to fill the entire tensor with before storing.
+                       If None, only the provided data is written.
+
+        Returns:
+            Number of elements stored.
+        """
+        numel, dtype = self._tensor_specs[name]
+        host_view = self.get_host_view(name)
+
+        # Fill with default value if specified
+        if fill_value is not None:
+            host_view.fill_(fill_value)
+
+        # Convert list to tensor and copy to host buffer
+        length = len(data)
+        assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
+
+        temp_tensor = torch.tensor(data, dtype=dtype)
+        host_view[:length].copy_(temp_tensor)
+
+        self._current_lengths[name] = length
+        return length
+
+    def copy_to_device(self) -> None:
+        """Copy from host buffer to device buffer.
+
+        Uses the current length of the truncatable tensor (last in spec) to minimize
+        transfer size. All tensors before the truncatable one are fully copied.
+        """
+        # Calculate bytes to copy based on truncatable tensor's current length
+        truncatable_len = self._current_lengths[self._truncatable_name]
+        truncatable_offset = self._offsets[self._truncatable_name]
+        truncatable_dtype = self._tensor_specs[self._truncatable_name][1]
+        copy_bytes = truncatable_offset + truncatable_len * truncatable_dtype.itemsize
+
+        # Single async copy
+        with nvtx_range("ad_input_buffer_h2d_copy"):
+            self._device_buffer[:copy_bytes].copy_(
+                self._host_buffer[:copy_bytes], non_blocking=True
+            )
+
+    def resize(self, name: str, new_capacity: int) -> None:
+        """Resize a tensor's capacity.
+
+        This operation is only supported for the last tensor in the buffer to avoid
+        complex offset recalculations.
+
+        Args:
+            name: Name of the tensor to resize.
+            new_capacity: New maximum number of elements for the tensor.
+        """
+        assert name == self._truncatable_name, (
+            f"Can only resize the last tensor in the buffer ('{self._truncatable_name}'). "
+            f"Attempted to resize '{name}'."
+        )
+
+        old_numel, dtype = self._tensor_specs[name]
+        if new_capacity <= old_numel:
+            return  # No need to resize if new capacity is smaller or equal
+
+        # Update tensor specs
+        self._tensor_specs[name] = (new_capacity, dtype)
+
+        # Calculate new byte size for this tensor
+        new_byte_size = new_capacity * dtype.itemsize
+        self._byte_sizes[name] = new_byte_size
+
+        # Update total bytes (offset stays the same since it's the last tensor)
+        self._total_bytes = self._offsets[name] + new_byte_size
+
+        # Resize device buffer in-place
+        self._device_buffer.resize_(self._total_bytes)
+
+        # Host buffer must be re-allocated to ensure we have pinned memory
+        old_host_buffer = self._host_buffer
+        self._host_buffer = torch.empty(
+            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=True
+        )
+        self._host_buffer[: old_host_buffer.numel()].copy_(old_host_buffer)
+        del old_host_buffer
+
+        # Recreate views after the update
+        self._device_views = self._create_views(self._device_buffer)
+        self._host_views = self._create_views(self._host_buffer)
+
+    def to(self, *args, **kwargs) -> None:
+        """Move the device buffer to a new device/dtype.
+
+        Note: This recreates the device views after moving.
+        """
+        old_device = self._device_buffer.device
+        self._device_buffer = self._device_buffer.to(*args, **kwargs)
+
+        # Recreate views if device changed
+        if old_device != self._device_buffer.device:
+            self._device_views = self._create_views(self._device_buffer)
+
+
 class CacheConfig(BaseModel):
     """Cache configuration for attention-related dtypes."""
 
@@ -83,21 +336,41 @@ class SequenceInfo:
     Those are extra arguments that can be provided to the interface and they are stored as follows:
     - _extra_args: dictionary of extra arguments with currently active values.
 
-    ### CACHE ARGUMENTS NEEDED FOR ATTENTION OPERATORS FOR FLATTENED SEQUENCES + CACHES ############
+    ### AVAILABLE ARGUMENTS TO BE ADDED BY THE TRANSFORMS IF NEEDED ################################
     - seq_len: [s_0, s_1, ..., s_{b-1}] such that s_total = sum(s_i)
       Describes how long each sequence is. For example,
       input_ids[:s_0] will correspond to sequence 0 in the batch and input_ids[s_0:s_1] will
       correspond to sequence 1 in the batch.
+    - cu_seqlen: [0, s_0, s_0+s_1, ..., s_total]
+      Cumulative sequence lengths of shape [b+1]. cu_seqlen[i+1] - cu_seqlen[i] gives the length
+      of sequence i.
     - input_pos: [pos_0, ..., pos_{b-1}]
-      Corresponds to the total number of tokens that has been already been cached for each sequence
-      in the batch.
-    - cache_loc: [c0, ...., c_{np-1}] where np is total number of pages allocated to describe all
-      sequences in the batch.
+      Corresponds to the total number of tokens that have already been cached for each sequence
+      in the batch (i.e., the starting position in the cache for new tokens).
     - pages_per_seq: [ps_0, ps_1, ..., ps_{b-1}] where ps_i is the number of pages allocated for
-      sequence i. Note that, for example, cache_loc[p_0:p_1] will correspond to the pages associated
-      with sequence 1 in the batch.
-    - slot_idx: [s_0, s_1, ..., s_{b-1}]
+      sequence i. Note that, for example, cache_loc[sum(ps_0:ps_{i-1}):sum(ps_0:ps_i)] will
+      correspond to the pages associated with sequence i in the batch.
+    - cu_num_pages: [0, ps_0, ps_0+ps_1, ..., sum(ps_i)]
+      Cumulative number of pages of shape [b+1]. cu_num_pages[i+1] - cu_num_pages[i] gives the
+      number of pages for sequence i.
+    - seq_len_with_cache: [pos_0+s_0, pos_1+s_1, ..., pos_{b-1}+s_{b-1}]
+      Total sequence length including cached tokens for each sequence (input_pos + seq_len).
+    - last_page_len: [lpl_0, lpl_1, ..., lpl_{b-1}]
+      Number of valid tokens in the last page for each sequence. Computed as
+      (seq_len_with_cache - 1) % page_size + 1.
+    - slot_idx: [slot_0, slot_1, ..., slot_{b-1}]
       Corresponds to the slot index of each sequence in the batch.
+    - use_initial_states: [bool_0, bool_1, ..., bool_{b-1}]
+      Per-sequence boolean indicating whether initial states should be used (True if input_pos > 0).
+    - batch_info: [num_prefill, num_prefill_tokens, num_decode]
+      Batch metadata containing the number of prefill sequences, total prefill tokens, and number
+      of decode sequences.
+    - cache_loc: [c_0, c_1, ..., c_{np-1}] where np is total number of pages allocated to describe
+      all sequences in the batch. Each value is a page index in the cache.
+    - _gather_idx: [g_0, g_1, ..., g_{s_total-1}]
+      Gather indices used by the overlap scheduler to reorder input tokens.
+    - _mask_scatter_indices: [m_0, m_1, ..., m_{s_total-1}]
+      Mask scatter indices used by the overlap scheduler to scatter results back.
 
     ################################################################################################
 
@@ -119,7 +392,6 @@ class SequenceInfo:
         page_size: int = 0,
         max_num_tokens: Optional[int] = None,
         vocab_size_padded: Optional[int] = None,
-        chunk_size: Optional[int] = None,
     ):
         """Initialize the SequenceInfo object.
 
@@ -146,10 +418,6 @@ class SequenceInfo:
         self.max_batch_size = max_batch_size
         self.page_size = page_size if page_size > 0 else max_seq_len
         self.vocab_size_padded = vocab_size_padded
-        self.chunk_size = chunk_size
-        # Chunk size is an input to a custom op, so we need to set a default value if it is not provided.
-        if self.chunk_size is None:
-            self.chunk_size = 128
         # NOTE (lucaslie): WAR to address issue when using flashinfer attention with
         # (max_batch_size, max_seq_len) input in trtllm runtime.
         # see https://github.com/NVIDIA/TensorRT-LLM/issues/4504
@@ -188,31 +456,47 @@ class SequenceInfo:
         )
 
         # indicator if extra args are activated that are needed for cached attention backends
-        self._is_cached_attn = False
+        self._use_flattened_layout = False
 
         # TENSOR FIELDS ############################################################################
-        self._args_device: Dict[str, torch.Tensor] = {
+        # Define tensor specifications for the InputBuffer
+        # Order matters: cache_loc is placed LAST for truncation optimization during H2D copy
+        # Format: (name, max_numel, dtype)
+        tensor_specs: List[Tuple[str, int, torch.dtype]] = [
             # TENSOR FIELDS FOR UNCACHED ATTENTION
-            "input_ids": torch.ones(self.max_num_tokens, dtype=torch.int),
-            "position_ids": torch.zeros(self.max_num_tokens, dtype=torch.long),
+            ("input_ids", self.max_num_tokens, torch.int),
+            ("position_ids", self.max_num_tokens, torch.long),
             # TENSOR FIELDS FOR CACHED ATTENTION
-            "seq_len": torch.empty(self.max_batch_size, dtype=torch.int),
-            "input_pos": torch.empty(self.max_batch_size, dtype=torch.int),
-            "cache_loc": torch.empty(max_num_cache_loc_assignments, dtype=torch.int),
-            "pages_per_seq": torch.empty(self.max_batch_size, dtype=torch.int),
-            "slot_idx": torch.empty(self.max_batch_size, dtype=torch.long),
+            ("seq_len", self.max_batch_size, torch.int),
+            ("cu_seqlen", self.max_batch_size + 1, torch.int),
+            ("input_pos", self.max_batch_size, torch.int),
+            ("pages_per_seq", self.max_batch_size, torch.int),
+            ("cu_num_pages", self.max_batch_size + 1, torch.int),
+            ("seq_len_with_cache", self.max_batch_size, torch.int),
+            ("last_page_len", self.max_batch_size, torch.int),
+            ("slot_idx", self.max_batch_size, torch.long),
+            ("use_initial_states", self.max_batch_size, torch.bool),
+            ("batch_info", 3, torch.int),
             # OTHER FIELDS WHERE WE NEED EFFICIENT HOST<>DEVICE TRANSFER
-            "_gather_idx": torch.empty(self.max_num_tokens, dtype=torch.int),
+            ("_gather_idx", self.max_num_tokens, torch.int),
+            ("_mask_scatter_indices", self.max_num_tokens, torch.int),
+            # cache_loc is LAST for truncation optimization (it's the largest tensor)
+            ("cache_loc", max_num_cache_loc_assignments, torch.int),
+        ]
+
+        # Create the InputBuffer that manages contiguous host and device memory
+        # Starts on default device; use to() to move to target device
+        self._input_buffer = InputBuffer(tensor_specs)
+
+        # Initialize args_list from tensor specs
+        self._args_list: Dict[str, List[int]] = {
+            name: [0] * numel for name, numel, _ in tensor_specs
         }
-        self._args_host: Dict[str, List[int]] = {
-            k: v.tolist() for k, v in self._args_device.items()
-        }
-        # NOTE: order of keys is relevant here!
-        self._uncached_arg_names = ("input_ids", "position_ids")
-        self._cached_arg_names = ("seq_len", "input_pos", "cache_loc", "pages_per_seq", "slot_idx")
-        # page_size is the size of attentionkv-cache pages.
-        # chunk_size is used in mamba prefill kernels to split the context into chunks.
-        self._cached_constants = ("page_size", "chunk_size")
+
+        self._active_args = ("input_ids", "position_ids")
+        self._shapeable_args = ("input_ids", "position_ids")
+        # Args that should be returned from host (pinned memory) instead of device in _named_args
+        self._host_return_args = ("batch_info",)
         ############################################################################################
 
         # EXTRA TENSOR FIELDS ######################################################################
@@ -224,7 +508,7 @@ class SequenceInfo:
 
     @property
     def device(self) -> torch.device:
-        return self._args_device["input_ids"].device
+        return self._input_buffer.device
 
     def _shape_for_forward(self, tnsr: torch.Tensor) -> torch.Tensor:
         """Shape the tensor for the forward pass based on the current attention mode.
@@ -238,7 +522,7 @@ class SequenceInfo:
         # check if we are still running uncached attention in which case we are also still
         # operate on unflattened tensors with explicit [batch_size, seq_len, ...] shape
         # generate-only batches are also formatted like this (i.e. [b, 1])
-        if not self._is_cached_attn or self.is_generate:
+        if not self._use_flattened_layout or self.is_generate:
             bs = len(self.seq_len)
             sl = self.seq_len[0]
         # use [1,total_len] shape to indicate non-generate-only batch for cached attention
@@ -248,20 +532,26 @@ class SequenceInfo:
         # truncate to total tokens now, reshape, and return
         return tnsr[: self.total_num_tokens].view(bs, sl, *tnsr.shape[1:])
 
-    def _named_args(
-        self, include_extra_args: bool = True, include_cached_args: bool = True
-    ) -> Dict[str, torch.Tensor]:
-        # start with uncached args and shape them along the way
-        args = {k: self._shape_for_forward(self._args_device[k]) for k in self._uncached_arg_names}
+    def _named_args(self, include_extra_args: bool = True) -> Dict[str, torch.Tensor]:
+        # Build args dict, using host views for _host_return_args, device views otherwise
+        args = {}
+        for name in self._active_args:
+            if name in self._host_return_args:
+                view = self._input_buffer.get_host_view(name)
+            else:
+                view = self._input_buffer.get_view(name)
+            args[name] = self._shape_for_forward(view) if name in self._shapeable_args else view
 
         # check other args to include
         if include_extra_args:
             args.update(self._extra_args)
 
-        if include_cached_args:
-            args.update({k: self._args_device[k] for k in self._cached_arg_names})
-
         return args
+
+    @property
+    def available_args(self) -> Set[str]:
+        """Return a list of available arguments."""
+        return set(self._input_buffer.tensor_names)
 
     @property
     def named_args(self) -> Dict[str, torch.Tensor]:
@@ -273,19 +563,7 @@ class SequenceInfo:
         Cached arguments are only included if the attention mode is cached to reflect that after
         switching to cached attention, the cached arguments are required for a forward pass.
         """
-        return self._named_args(include_extra_args=True, include_cached_args=self._is_cached_attn)
-
-    @property
-    def named_standard_args(self) -> Dict[str, torch.Tensor]:
-        """Return a dictionary of named standard arguments.
-
-        We define standard arguments as the arguments that are part of the model's forward function
-        by default (i.e., without the extra arguments).
-
-        Just liked ``named_args``, this property includes cached attention arguments if the
-        attention mode is cached.
-        """
-        return self._named_args(include_extra_args=False, include_cached_args=self._is_cached_attn)
+        return self._named_args(include_extra_args=True)
 
     @property
     def args(self) -> Tuple[torch.Tensor, ...]:
@@ -293,56 +571,20 @@ class SequenceInfo:
         return tuple(self.named_args.values())
 
     @property
-    def args_for_prepare_metadata(self) -> Tuple[str, ...]:
-        """Return a tuple of node/tensor arguments for the prepare_metadata op.
-
-        The ``prepare_metadata`` interface expects the following arguments:
-
-        1. ``args_for_prepare_metadata`` as nodes, i.e., as input-dependent tensors.
-        2. ``const_args_for_prepare_metadata`` as constants that can directly by passed in as args
-           to the corresponding ``prepare_metadata`` node/op.
-
-        This interface handles the tensor/node arguments part and can be used by compiler passes
-        like ``insert_cached_attention`` to extract the constant arguments and add them to the
-        ``prepare_metadata`` node/op.
-        """
-        # NOTE: for now we do _not_ include input_ids since we are not guaranteed that input_ids
-        # is part of the graph, e.g., in situations where the graph is a submodule of the overall
-        # model. In such instances, the graph usually sees inputs_embeds. However, we assume for
-        # now that position_ids is always part of the graph.
-        return ("position_ids",) + self._cached_arg_names
-
-    @property
-    def const_args_for_prepare_metadata(self) -> Tuple[Constant, ...]:
-        """Return a tuple of extra (const, non-tensor) arguments for the prepare_metadata op.
-
-        The ``prepare_metadata`` interface expects the following arguments:
-
-        1. ``args_for_prepare_metadata`` as nodes, i.e., as input-dependent tensors.
-        2. ``const_args_for_prepare_metadata`` as constants that can directly by passed in as args
-           to the corresponding ``prepare_metadata`` node/op.
-
-        This interface handles the constant arguments part and can be used by compiler passes like
-        ``insert_cached_attention`` to extract the constant arguments and add them to the
-        ``prepare_metadata`` node/op.
-        """
-        return tuple(getattr(self, k) for k in self._cached_constants)
-
-    @property
     def seq_len(self) -> List[int]:
-        return self._args_host["seq_len"].copy()
+        return self._args_list["seq_len"].copy()
 
     @property
     def input_pos(self) -> List[int]:
-        return self._args_host["input_pos"].copy()
+        return self._args_list["input_pos"].copy()
 
     @property
     def cache_loc(self) -> List[int]:
-        return self._args_host["cache_loc"].copy()
+        return self._args_list["cache_loc"].copy()
 
     @property
     def pages_per_seq(self) -> List[int]:
-        return self._args_host["pages_per_seq"].copy()
+        return self._args_list["pages_per_seq"].copy()
 
     @property
     def num_sequences(self) -> int:
@@ -363,9 +605,18 @@ class SequenceInfo:
     @num_pages.setter
     def num_pages(self, value):
         self._num_pages = value
-        # update the cache_loc tensor
-        if self._args_device["cache_loc"].numel() < value:
-            self._args_device["cache_loc"].resize_(value)
+        # Check if we need to resize cache_loc (it's the last tensor in the buffer)
+        cache_loc_capacity = self._input_buffer.get_capacity("cache_loc")
+        if value > cache_loc_capacity:
+            ad_logger.info(
+                f"Resizing cache_loc capacity from {cache_loc_capacity} to {value} "
+                f"to accommodate num_pages={value}"
+            )
+            # Resize the input buffer (cache_loc is the last tensor, so this is supported)
+            self._input_buffer.resize("cache_loc", value)
+            # Also resize the args_list to match
+            old_size = len(self._args_list["cache_loc"])
+            self._args_list["cache_loc"].extend([0] * (value - old_size))
 
     @property
     def is_paged(self) -> bool:
@@ -420,6 +671,7 @@ class SequenceInfo:
         pages_per_seq = [len(p) for p in page_assignments]
         return cache_loc_flat, pages_per_seq
 
+    # TODO: remove after updating all cached backends
     @classmethod
     def _get_sanitized_seq_len(
         cls, input_or_position_ids: torch.Tensor, seq_len: torch.Tensor
@@ -459,7 +711,7 @@ class SequenceInfo:
         _, s = input_or_position_ids.shape[:2]
         num_seq = cls._get_sanitized_num_sequences(input_or_position_ids, seq_len)
         if s > 1:
-            return seq_len[:num_seq].detach().clone()
+            return seq_len[:num_seq].clone()
         else:
             return torch.ones(num_seq, dtype=seq_len.dtype, device=seq_len.device)
 
@@ -481,31 +733,29 @@ class SequenceInfo:
             num_seq = b
         return num_seq
 
-    def switch_to_cached_attn_inputs(self) -> List[str]:
-        """Switch to inputs for cached+flattened attention operators.
+    def activate_arg(self, arg_name: str) -> bool:
+        """Activate a desired argument.
+
+        The first time this function is called we will also switch to the flattened input layout.
 
         Returns:
-            List[str]: List of new argument names that are now activated.
-
-        This function will change the inputs provided by the interface from the arguments expected
-        by regular attention in PyTorch (SDPA-style) to the arguments needed once we use attention
-        operators with cache support and flattened sequences.
-
-        NOTE: The graph inference optimizer is responsible for ensuring the the new inputs are
-        correctly reflected in the graph after this function is called.
+            True if the argument was activated, False if already activated.
         """
-        assert not self._is_cached_attn, "Cached+flattened attention already activated"
-        self._is_cached_attn = True
-        return list(self._cached_arg_names)
+        assert arg_name in self.available_args, f"{arg_name=} not found in {self.available_args}"
+        self._use_flattened_layout = True
+        if arg_name not in self._active_args:
+            self._active_args += (arg_name,)
+            return True
+        return False
 
     def to(self, *args, **kwargs) -> None:
-        def _move_dict(d: Dict[str, torch.Tensor]) -> None:
-            for k, v in d.items():
-                if v is not None:
-                    d[k] = v.to(*args, **kwargs)
+        # Move the InputBuffer (which recreates views automatically)
+        self._input_buffer.to(*args, **kwargs)
 
-        _move_dict(self._args_device)
-        _move_dict(self._extra_args)
+        # Move extra args
+        for k, v in self._extra_args.items():
+            if v is not None:
+                self._extra_args[k] = v.to(*args, **kwargs)
 
     def set_example_sequence(
         self,
@@ -525,7 +775,6 @@ class SequenceInfo:
             for ids_one_seq in input_ids
         ]
         cache_loc = list(range(sum(pages_per_seq)))
-        page_assignments = self._get_page_assignments(cache_loc, pages_per_seq)
 
         # vanilla slot indices
         slot_idx = list(range(len(input_ids)))
@@ -534,7 +783,8 @@ class SequenceInfo:
             input_ids,
             position_ids,  # will be auto-inferred if None
             input_pos=0,  # no cache history
-            page_assignments=page_assignments,  # vanilla page assignments
+            cache_loc=cache_loc,  # vanilla page assignments
+            pages_per_seq=pages_per_seq,  # vanilla page assignments
             slot_idx=slot_idx,  # vanilla slot indices
             **extra_args,
         )
@@ -546,9 +796,9 @@ class SequenceInfo:
         input_ids = torch.ones(self.max_batch_size, seq_len, dtype=torch.int).tolist()
         self.set_example_sequence(input_ids)
 
-    def set_generate_only_batch(self) -> None:
+    def set_generate_only_batch(self, batch_size: Optional[int] = None) -> None:
         """Set an example sequence for generate-only batch."""
-        self.set_example_sequence([[1]] * self.max_batch_size)
+        self.set_example_sequence([[1]] * (batch_size or self.max_batch_size))
 
     def reset(self) -> None:
         """Reset the sequence information.
@@ -571,33 +821,29 @@ class SequenceInfo:
         name: str,
         tnsr_like: List[Number],
         reset_val: Optional[Number] = None,
+        force_copy: bool = False,
     ) -> None:
-        """Store the argument on the host and copy to the device in a non-blocking fashion.
+        """Store the argument into the pinned host buffer for later batch transfer to device.
+
+        The data is stored in the host-side pinned memory buffer managed by InputBuffer.
+        The actual H2D transfer happens in a single batch at the end of nest_sequences().
 
         Args:
             name: Name of the argument to store.
             tnsr_like: List of values to store.
-            reset_val: Value to reset/fill the full tensor on the device to before writing to it.
+            reset_val: Value to reset/fill the tensor with before writing data.
+            force_copy: Whether to force immediate copy to device (for use outside nest_sequences).
         """
-        with nvtx_range(f"ad_store_seq_info_arg_{name}"):
-            tnsr_device = self._args_device[name]
+        with nvtx_range(f"ad_store_on_host_seq_info_arg_{name}"):
+            # Always store list object for Python access
+            self._args_list[name] = tnsr_like.copy()
 
-            # store list object on the host
-            self._args_host[name] = tnsr_like.copy()
+            # Only store to buffer when the argument is active or force_copy is True
+            if not (name in self._active_args or force_copy):
+                return
 
-            # pin the memory on the host
-            tnsr_host = torch.tensor(tnsr_like, dtype=tnsr_device.dtype, pin_memory=True)
-
-            # check for available space
-            assert tnsr_device.numel() >= tnsr_host.numel(), (
-                f"device tensor {name} is too small, available: {tnsr_device.numel()}, "
-                f"required: {tnsr_host.numel()}"
-            )
-
-            # reset/copy to the device in a non-blocking fashion
-            if reset_val is not None:
-                tnsr_device.fill_(reset_val)
-            tnsr_device[: len(tnsr_like)].copy_(tnsr_host, non_blocking=True)
+            # Store to the InputBuffer's pinned host memory
+            self._input_buffer.store(name, tnsr_like, fill_value=reset_val)
 
     def _store_extra_arg(
         self, name: str, tnsr_like: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]]
@@ -627,53 +873,66 @@ class SequenceInfo:
         self,
         input_ids: Sequence[Sequence[int]],
         position_ids: Optional[Sequence[Sequence[int]]] = None,
+        seq_len: Optional[Sequence[int]] = None,
         input_pos: Optional[Union[Sequence[int], int]] = None,
-        page_assignments: Optional[Sequence[Sequence[int]]] = None,
+        batch_info: Optional[Sequence[int]] = None,
+        cu_seqlen: Optional[Sequence[int]] = None,
+        cache_loc: Optional[Sequence[int]] = None,
+        pages_per_seq: Optional[Sequence[int]] = None,
+        cu_num_pages: Optional[Sequence[int]] = None,
+        seq_len_with_cache: Optional[Sequence[int]] = None,
+        last_page_len: Optional[Sequence[int]] = None,
         slot_idx: Optional[Sequence[int]] = None,
+        use_initial_states: Optional[Sequence[bool]] = None,
+        _gather_idx: Optional[Sequence[int]] = None,
+        _mask_scatter_indices: Optional[Sequence[int]] = None,
         **extra_args: Dict[str, Union[torch.Tensor, Sequence[torch.Tensor]]],
     ) -> None:
         """Create and store sequence information for the next forward pass.
 
         Args:
             input_ids: List of sequences of input_ids.
-            position_ids: List of sequences of position_ids for each token.
-            input_pos: Absolute starting position in the cache for each sequence.
-            page_assignments: List of sequences of page assignments for each sequence.
-            slot_idx: List of slot indices for each sequence.
+            position_ids: List of sequences of position_ids for each token. If None, auto-inferred
+                from input_pos and seq_len.
+            seq_len: List of sequence lengths for each sequence. If None, inferred from input_ids.
+            input_pos: Absolute starting position in the cache for each sequence. Can be a single
+                int (applied to all sequences) or a list of ints.
+            batch_info: Batch metadata as [num_prefill, num_prefill_tokens, num_decode]. If None,
+                auto-computed from seq_len.
+            cu_seqlen: Cumulative sequence lengths of shape [b+1]. If None, auto-computed from
+                seq_len.
+            cache_loc: Flat list of page indices for all sequences. Must be provided together with
+                pages_per_seq.
+            pages_per_seq: Number of pages allocated per sequence. Must be provided together with
+                cache_loc.
+            cu_num_pages: Cumulative number of pages of shape [b+1]. If None, auto-computed from
+                pages_per_seq.
+            seq_len_with_cache: Total sequence length including cached tokens (input_pos + seq_len)
+                for each sequence. If None, auto-computed.
+            last_page_len: Number of valid tokens in the last page for each sequence. If None,
+                auto-computed from seq_len_with_cache.
+            slot_idx: Slot index for each sequence in the batch.
+            use_initial_states: Per-sequence boolean indicating if the initial states should be
+                used. If None, auto-computed as (input_pos > 0).
+            _gather_idx: Gather indices for the overlap scheduler to reorder input tokens.
+            _mask_scatter_indices: Mask scatter indices for the overlap scheduler.
             extra_args: Extra arguments to be stored in the interface.
 
         This i/f will ensure that all sequence info args are updated accordingly. Reset values are
         chosen as "neutral" values so that for cases like rounding up batch sizes for cudagraph we
         only write to unused buffers/caches.
         """
-        ### UPDATE METADATA ########################################################################
-        # update metadata first since it's useful for other updates to have up-to-date information
-
-        # set new sequence lengths --> resetting the remaining entries to zero is important to help
-        # us discern the actual number of sequences in the batch.
-        self._store_arg("seq_len", [len(ids) for ids in input_ids], reset_val=0)
+        ### UPDATE SEQUENCE LENGTH AND INPUT POSITION FIRST SINCE IT'S USED FOR OTHER UPDATES ######
+        if seq_len is None:
+            seq_len = [len(ids) for ids in input_ids]
+        self._store_arg("seq_len", seq_len)
 
         # check for updated input_pos (i.e. cache start position)
         if input_pos is not None:
             self._store_arg(
                 "input_pos",
                 [input_pos] * self.num_sequences if isinstance(input_pos, int) else input_pos,
-                reset_val=0,
             )
-
-        # check for updated page_assignments
-        if page_assignments is not None:
-            cache_loc, pages_per_seq = self._get_cache_locations_and_pages_per_sequence(
-                page_assignments
-            )
-            free_cache_loc = self._get_unique_value(set(cache_loc), self.num_pages)
-            self._store_arg("cache_loc", cache_loc, reset_val=free_cache_loc)
-            self._store_arg("pages_per_seq", pages_per_seq, reset_val=1)
-
-        # check for updated slot_idx
-        if slot_idx is not None:
-            free_slot_idx = self._get_unique_value(set(slot_idx), self.max_batch_size)
-            self._store_arg("slot_idx", slot_idx, reset_val=free_slot_idx)
 
         ### UPDATE MAIN INPUTS #####################################################################
         # set new input_ids and make sure to flatten it
@@ -687,37 +946,98 @@ class SequenceInfo:
             ]
         self._store_arg("position_ids", self._flatten(position_ids))
 
+        ### UPDATE OTHER (DERIVATIVE) METADATA #####################################################
+        # check for updated batch_info_tensor
+        if batch_info is None:
+            num_prefill = sum(s_l > 1 for s_l in seq_len)
+            num_prefill_tokens = sum(s_l for s_l in seq_len if s_l > 1)
+            num_decode = len(seq_len) - num_prefill
+            batch_info = [num_prefill, num_prefill_tokens, num_decode]
+        self._store_arg("batch_info", batch_info)
+
+        if cu_seqlen is None:
+            cu_seqlen = torch.zeros(len(seq_len) + 1, dtype=torch.int)
+            cu_seqlen[1:] = torch.cumsum(torch.tensor(seq_len), dim=0)
+            cu_seqlen = cu_seqlen.tolist()
+        self._store_arg("cu_seqlen", cu_seqlen)
+
+        # check for updated page_assignments
+        assert (cache_loc is None) == (pages_per_seq is None), (
+            "cache_loc and pages_per_seq must beeither both None or both set"
+        )
+        if cache_loc is not None and pages_per_seq is not None:
+            self._store_arg("cache_loc", cache_loc)
+            self._store_arg("pages_per_seq", pages_per_seq)
+
+        # update cumulative number of pages
+        if cu_num_pages is None:
+            pages_per_seq = self.pages_per_seq
+            cu_num_pages = torch.zeros(len(pages_per_seq) + 1, dtype=torch.int)
+            cu_num_pages[1:] = torch.cumsum(torch.tensor(pages_per_seq), dim=0)
+            cu_num_pages = cu_num_pages.tolist()
+        self._store_arg("cu_num_pages", cu_num_pages)
+
+        # update sequence length with cache
+        if seq_len_with_cache is None:
+            seq_len_with_cache = [i_p + s_l for i_p, s_l in zip(self.input_pos, self.seq_len)]
+        self._store_arg("seq_len_with_cache", seq_len_with_cache)
+
+        # update last page length
+        if last_page_len is None:
+            last_page_len = [(slwc - 1) % self.page_size + 1 for slwc in seq_len_with_cache]
+        self._store_arg("last_page_len", last_page_len)
+
+        # check for updated slot_idx
+        if slot_idx is not None:
+            self._store_arg("slot_idx", slot_idx)
+
+        # check for updated use_initial_states
+        if use_initial_states is None:
+            use_initial_states = [i_p > 0 for i_p in self.input_pos]
+        self._store_arg("use_initial_states", use_initial_states)
+
+        ### UPDATE OVERLAP SCHEDULER METADATA ######################################################
+        # check for updated _gather_idx
+        if _gather_idx is not None:
+            self._store_arg("_gather_idx", _gather_idx, force_copy=True)
+
+        # check for updated _mask_scatter_indices
+        if _mask_scatter_indices is not None:
+            self._store_arg("_mask_scatter_indices", _mask_scatter_indices, force_copy=True)
+
         ### UPDATE EXTRA INPUTS ####################################################################
         self._extra_args = {}
         for key, value in extra_args.items():
             self._store_extra_arg(key, value)
 
+        ### BATCH COPY TO DEVICE ###################################################################
+        # Perform a single async H2D copy for all device tensors
+        # The copy is truncated at the end of cache_loc to minimize transfer size
+        self._input_buffer.copy_to_device()
+
     @nvtx_range("ad_rescatter_input_ids")
-    def rescatter_input_ids(
-        self, ungathered_input_ids: torch.Tensor, gather_idx: List[int], scatter_ref: int
-    ):
+    def rescatter_input_ids(self, ungathered_input_ids: torch.Tensor):
         """Re-scatter the provided ungathered input ids into the input_ids tensor.
 
         Args:
-            ungathered_input_ids: The input ids on the device from which to gather.
-            gather_idx: The list of indices to gather from the ungathered_input_ids.
-            scatter_ref: The reference index to scatter to in input_ids via masked scatter.
+            ungathered_input_ids: The input ids on the device from which to gather using the stored
+                gather and mask scatter indices.
 
         Returns:
             None
 
         This function will assume that we are in a generate-only batch.
         """
-        # store the new gather indices
-        self._store_arg("_gather_idx", gather_idx)
+        # retrieve input_ids and gather_ids on device
+        input_ids_device = self._input_buffer.get_view_at_current_length("input_ids")
+        gather_ids_device = self._input_buffer.get_view_at_current_length("_gather_idx")
+        mask_scatter_indices_device = self._input_buffer.get_view_at_current_length(
+            "_mask_scatter_indices"
+        )
 
-        # gather the provided input ids in a streaming fashion
-        gather_ids_device = self._args_device["_gather_idx"][: len(gather_idx)]
-        packed_input_ids = ungathered_input_ids[gather_ids_device]
-
-        # re-scatter the provided input ids into the input_ids tensor
-        input_ids_device = self._args_device["input_ids"]
-        input_ids_device.masked_scatter_(input_ids_device == scatter_ref, packed_input_ids)
+        torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+            ungathered_input_ids, gather_ids_device, mask_scatter_indices_device, input_ids_device
+        )
 
     @nvtx_range("ad_unnest_sequences")
     def unnest_sequences(self, t_nested: torch.Tensor) -> List[torch.Tensor]:
@@ -796,7 +1116,8 @@ class AttentionDescriptor(ABC):
         ```
         def attention_op(
             *qkv,       # list of tensors corresponding to Q, K, V as in source attention op
-            *metadata,  # global info about the sequences as returned by the prepare_metadata op
+            *meta_std,  # standard metadata fields identified by matching arg names!
+            *meta_extra,# metadata about the sequences as returned by the prepare_metadata op
             *caches,    # contains layer-specific caches per provided cache initializers
             *buffers,   # global buffers used by the attention op as provided by buffer initializers
             *constants, # basic arguments (int, float, str, None) added as CONSTANTS in the graph
@@ -814,31 +1135,42 @@ class AttentionDescriptor(ABC):
 
     @classmethod
     @abstractmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+    def get_standard_metadata_args(cls) -> List[str]:
+        """Get the list of standard metadata arguments that are expected by the attention op."""
+        raise NotImplementedError
+
+    @classmethod
+    def get_prepare_extra_metadata_info(
+        cls, any_source_attn_node: Node
+    ) -> Tuple[Optional[PrepareMetadataCallable], int, List[Constant]]:
         """Get the prepare_metadata op.
 
         The prepare_metadata op should follow the below signature:
 
         ```
-        def prepare_metadata(
-            position_ids: torch.Tensor,
-            seq_len: torch.Tensor,
-            input_pos: torch.Tensor,
-            cache_loc: torch.Tensor,
-            pages_per_seq: torch.Tensor,
-            slot_idx: torch.Tensor,
-            page_size: int,
+        def prepare_extra_metadata(
+            *desired_graph_inputs,  # matched by arg names in the signature of the prepare_metadata op
+            *constant_inputs, # as returned by this function
         ) -> List[torch.Tensor]: ...
         ```
-        The metadata should contain all necessary global information required for the underlying
-        attention op to process the input sequence and the returned list of tensors will be passed
-        on to each invocation of the attention op in the graph.
+        The metadata should contain all necessary extra global information required for the
+        underlying attention op to process the input sequence and the returned list of tensors will
+        be passed as additional arguments to each invocation of the attention op in the graph.
 
-        prepare_metadata is called once at the beginning of the forward pass.
+        This may not be needed for all attention ops if the standard metadata is sufficient.
+
+        prepare_metadata is called once at the beginning of the forward pass for each attention op
+        detected in the graph.
 
         **Note that the prepare_metadata op should be a valid torch custom op, which comes with
         restrictions on the supported types in the signature.**
+
+        Returns:
+            - prepare_metadata_op: The prepare_metadata op callable.
+            - num_meta_out: The number of extra metadata tensors to return.
+            - const_args: A list of constant arguments to pass to the prepare_metadata op.
         """
+        return None, 0, []
 
     @classmethod
     @abstractmethod
@@ -878,15 +1210,16 @@ class AttentionDescriptor(ABC):
         If the buffer initializer requires information about the attention op, it can retrieve
         the necessary information from the source attention node.
         """
+        return {}
 
     @classmethod
-    @abstractmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         """Provide a list of constant arguments to be passed to the attention op.
 
         The constant arguments are passed to the attention op as additional arguments after the
         caches and buffers. The constants are expected to be of type int, float, str, or None.
         """
+        return []
 
 
 class AttentionRegistry:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
@@ -175,7 +175,7 @@ class FlaDeltaBackend(AttentionDescriptor):
 
         def _get_delta_cache(si: SequenceInfo):
             return torch.empty(
-                si.max_batch_size,
+                si.max_state_slots,
                 num_heads,
                 key_dim,
                 value_dim,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
@@ -5,7 +5,7 @@ Delta Rule is based on this paper: https://arxiv.org/abs/2406.06484
 Kernels are based on this repo: https://github.com/fla-org/flash-linear-attention
 """
 
-from typing import List, Tuple
+from typing import List
 
 import torch
 from torch._ops import OpOverloadPacket
@@ -21,80 +21,10 @@ from ..attention_interface import (
     CacheInitializerDict,
     Constant,
     MHACallable,
-    PrepareMetadataCallable,
     SequenceInfo,
 )
 from .delta_rule.chunk import chunk_delta_rule_fwd
 from .delta_rule.fused_recurrent import fused_recurrent_delta_rule_fwd
-
-
-@torch.library.custom_op("auto_deploy::fla_delta_prepare_metadata", mutates_args=())
-def fla_delta_prepare_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
-) -> List[torch.Tensor]:
-    """Prepare metadata for cached chunked delta rule.
-
-    Returns a tuple of (cu_seq_lens, slot_idx_sanitized, use_initial_states, batch_info_tensor).
-    """
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-    cu_seqlens = torch.zeros(num_seq + 2, dtype=torch.int32, device=seq_len_sanitized.device)
-
-    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
-    use_initial_states = input_pos[:num_seq] > 0
-
-    _, s = position_ids.shape[:2]
-    if s > 1:
-        prefill_mask = seq_len_sanitized > 1
-        num_prefill = int(prefill_mask.sum().item())
-        num_prefill_tokens = int(seq_len_sanitized[:num_prefill].sum().item())
-        num_decode = num_seq - num_prefill
-
-        # compute cu_seq_lens for the prefill sequences first
-        cu_seqlens[1 : num_prefill + 1] = torch.cumsum(seq_len_sanitized[:num_prefill], 0)
-    else:
-        num_prefill = 0
-        num_prefill_tokens = 0
-        num_decode = num_seq
-
-    # decode is just arange...
-    cu_seqlens[num_prefill + 1 :] = torch.arange(
-        num_decode + 1, device=cu_seqlens.device, dtype=cu_seqlens.dtype
-    )
-    batch_info_tensor = torch.tensor(
-        [num_prefill, num_prefill_tokens, num_decode], dtype=torch.int32
-    )
-
-    return cu_seqlens, slot_idx_sanitized, use_initial_states, batch_info_tensor
-
-
-@fla_delta_prepare_metadata.register_fake
-def fla_delta_prepare_metadata_fake(
-    position_ids,
-    seq_len,
-    input_pos,
-    cache_loc,
-    pages_per_seq,
-    slot_idx,
-    page_size,
-    chunk_size,
-):
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-    cu_seq_lens = torch.empty(num_seq + 2, dtype=torch.int32, device=seq_len_sanitized.device)
-    return (
-        cu_seq_lens,
-        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
-        torch.empty(num_seq, dtype=torch.bool, device=slot_idx.device),
-        torch.empty(3, dtype=torch.int32),  # host tensor
-    )
 
 
 @torch.library.custom_op("auto_deploy::fla_cached_delta_rule", mutates_args=())
@@ -104,11 +34,13 @@ def fla_cached_delta_rule(
     k: torch.Tensor,
     v: torch.Tensor,
     beta: torch.Tensor,
-    # METADATA
-    cu_seqlens: torch.Tensor,  # [num_seq + 1]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
-    batch_info_tensor: torch.Tensor,  # [3]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     delta_cache: torch.Tensor,  # [max_batch_size, H, K, V]
     # CONSTANTS
@@ -117,16 +49,22 @@ def fla_cached_delta_rule(
     b, s, num_heads, _ = q.shape
 
     # flatten it
-    q_flat = q.view(1, b * s, num_heads, -1)
-    k_flat = k.view(1, b * s, num_heads, -1)
-    v_flat = v.view(1, b * s, num_heads, -1)
-    beta_flat = beta.view(1, b * s, num_heads)
+    q_flat = q.view(b * s, num_heads, -1)
+    k_flat = k.view(b * s, num_heads, -1)
+    v_flat = v.view(b * s, num_heads, -1)
+    beta_flat = beta.view(b * s, num_heads)
 
     # pre-allocate output
     y = torch.empty_like(v, memory_format=torch.contiguous_format)
-    y_flat = y.view(1, b * s, num_heads, -1)
+    y_flat = y.view(b * s, num_heads, -1)
 
-    num_prefill, num_prefill_tokens, num_decode = batch_info_tensor.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+
+    # clean up metadata
+    cu_seqlen_prefill = cu_seqlen[: num_prefill + 1]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
 
     if num_prefill > 0:
         initial_states = None
@@ -138,17 +76,17 @@ def fla_cached_delta_rule(
             )
 
         y_prefill, _, final_state = chunk_delta_rule_fwd(
-            q=q_flat[:, :num_prefill_tokens],
-            k=k_flat[:, :num_prefill_tokens],
-            v=v_flat[:, :num_prefill_tokens],
-            beta=beta_flat[:, :num_prefill_tokens],
+            q=q_flat[None, :num_prefill_tokens],
+            k=k_flat[None, :num_prefill_tokens],
+            v=v_flat[None, :num_prefill_tokens],
+            beta=beta_flat[None, :num_prefill_tokens],
             scale=scale,
             initial_state=initial_states,
             output_final_state=True,
-            cu_seqlens=cu_seqlens[: num_prefill + 1],
+            cu_seqlens=cu_seqlen_prefill,
         )
 
-        y_flat[:, :num_prefill_tokens] = y_prefill.to(y_flat.dtype)
+        y_flat[None, :num_prefill_tokens] = y_prefill.to(y_flat.dtype)
         delta_cache.index_copy_(0, slot_idx[:num_prefill], final_state.to(delta_cache.dtype))
 
         del y_prefill, initial_states, final_state
@@ -157,17 +95,16 @@ def fla_cached_delta_rule(
         # NOTE: avoiding state clone here and adopting the kernel to handle
         # indexed initial states would give a boost
         y_decode, _, final_state = fused_recurrent_delta_rule_fwd(
-            q=q_flat[:, num_prefill_tokens:],
-            k=k_flat[:, num_prefill_tokens:],
-            v=v_flat[:, num_prefill_tokens:],
-            beta=beta_flat[:, num_prefill_tokens:],
+            q=q_flat[num_prefill_tokens:, None],
+            k=k_flat[num_prefill_tokens:, None],
+            v=v_flat[num_prefill_tokens:, None],
+            beta=beta_flat[num_prefill_tokens:, None],
             scale=scale,
             initial_state=delta_cache[slot_idx[num_prefill:]].clone(),
             output_final_state=True,
-            cu_seqlens=cu_seqlens[num_prefill + 1 :],
         )
 
-        y_flat[:, num_prefill_tokens:] = y_decode.to(y_flat.dtype)
+        y_flat[num_prefill_tokens:, None] = y_decode.to(y_flat.dtype)
         delta_cache.index_copy_(0, slot_idx[num_prefill:], final_state.to(delta_cache.dtype))
 
         del y_decode, final_state
@@ -182,11 +119,13 @@ def fla_cached_delta_rule_fake(
     k: torch.Tensor,
     v: torch.Tensor,
     beta: torch.Tensor,
-    # METADATA
-    cu_seqlens: torch.Tensor,  # [num_seq + 1]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
-    batch_info_tensor: torch.Tensor,  # [3]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     delta_cache: torch.Tensor,  # [max_batch_size, H, K, V]
     # CONSTANTS
@@ -217,12 +156,11 @@ class FlaDeltaBackend(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.fla_cached_delta_rule
+        return torch.ops.auto_deploy.fla_cached_delta_rule.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        # Returns (cu_seq_lens, slot_idx, use_initial_states, batch_info_tensor)
-        return torch.ops.auto_deploy.fla_delta_prepare_metadata, 4
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -156,14 +156,7 @@ _GlobalFlashInferPlanner = _FlashInferPlanner()
 
 @torch.library.custom_op("auto_deploy::flashinfer_attention_prepare_metadata", mutates_args=())
 def prepare_flashinfer_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
+    batch_info: torch.Tensor, cu_seqlen: torch.Tensor, seq_len_with_cache: torch.Tensor
 ) -> List[torch.Tensor]:
     """Prepare metadata for flashinfer attention.
 
@@ -174,58 +167,31 @@ def prepare_flashinfer_metadata(
     # reset the planner
     _GlobalFlashInferPlanner.reset()
 
-    # retrieve sanitzed metadata
-    seq_len = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len)
+    # retrieve host-side metadata
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+    num_tokens = num_prefill_tokens + num_decode
 
-    # prepare flashinfer-style metadata
-    offsets = input_pos[:num_seq].clone()
-
-    qo_indptr = torch.zeros(num_seq + 1, dtype=torch.int, device=seq_len.device)
-    qo_indptr[1:] = torch.cumsum(seq_len, 0)
-
-    paged_kv_indptr = torch.zeros_like(qo_indptr)
-    paged_kv_indptr[1:] = torch.cumsum(pages_per_seq[:num_seq], 0)
-
-    # NOTE: it is okay to clone cache_loc here without truncation. paged_kv_indptr is already
-    # truncated and will point to the correct sub range of cache_loc.
-    paged_kv_indices = cache_loc.clone()
-
-    paged_kv_last_page_len = ((offsets + seq_len - 1) % page_size) + 1
+    qo_indptr = cu_seqlen[: num_seq + 1]
 
     # Compute batch_indices and positions so that they can be reused for kv cache appends
     # for all the layers
     batch_indices, positions = flashinfer.get_batch_indices_positions(
-        qo_indptr,
-        flashinfer.get_seq_lens(paged_kv_indptr, paged_kv_last_page_len, page_size),
-        position_ids.numel(),
+        qo_indptr, seq_len_with_cache[:num_seq], num_tokens
     )
-    # return metadata
-    return (
-        qo_indptr,
-        paged_kv_indptr,
-        paged_kv_indices,
-        paged_kv_last_page_len,
-        batch_indices,
-        positions,
-    )
+    # return extrametadata
+    return batch_indices, positions
 
 
-# TODO: Move the truncation of seq_len out of this custom op
-# As SequenceInfo._get_sanitized_num_sequences could break in fake mode
 @prepare_flashinfer_metadata.register_fake
 def prepare_flashinfer_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
+    batch_info: torch.Tensor, cu_seqlen: torch.Tensor, seq_len_with_cache: torch.Tensor
 ):
-    seq_len = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    qo_indptr = torch.empty(len(seq_len) + 1, dtype=seq_len.dtype, device=seq_len.device)
+    num_prefill, _, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
     return (
-        qo_indptr,  # qo_indptr
-        torch.empty_like(qo_indptr),  # paged_kv_indptr
-        torch.empty_like(cache_loc),  # paged_kv_indices
-        torch.empty_like(seq_len),  # paged_kv_last_page_len
-        torch.empty_like(seq_len),  # batch_indices
-        torch.empty_like(seq_len),  # positions
+        torch.empty(num_seq, dtype=cu_seqlen.dtype, device=cu_seqlen.device),  # batch_indices
+        torch.empty(num_seq, dtype=cu_seqlen.dtype, device=cu_seqlen.device),  # positions
     )
 
 
@@ -235,13 +201,15 @@ def flashinfer_mha_with_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    # METADATA
-    qo_indptr: torch.Tensor,
-    paged_kv_indptr: torch.Tensor,
-    paged_kv_indices: torch.Tensor,
-    paged_kv_last_page_len: torch.Tensor,
-    batch_indices: torch.Tensor,
-    positions: torch.Tensor,
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    # EXTRA METADATA
+    flashinfer_batch_indices: torch.Tensor,
+    flashinfer_positions: torch.Tensor,
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -260,6 +228,18 @@ def flashinfer_mha_with_cache(
     q = q.reshape(b * s, -1, head_dim)
     k = k.reshape(b * s, -1, head_dim)
     v = v.reshape(b * s, -1, head_dim)
+
+    # convert to flashinfer-style metadata
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+
+    qo_indptr = cu_seqlen[: num_seq + 1]
+    paged_kv_indptr = cu_num_pages[: num_seq + 1]
+
+    # NOTE: it is okay to have cache_loc here without truncation. paged_kv_indptr will be
+    # truncated and will point to the correct sub range of cache_loc.
+    paged_kv_indices = cache_loc
+    paged_kv_last_page_len = last_page_len[:num_seq]
 
     n_heads = q.shape[1]
     n_kv_heads = k.shape[1]
@@ -286,8 +266,8 @@ def flashinfer_mha_with_cache(
     flashinfer.page.append_paged_kv_cache(
         k,
         v,
-        batch_indices,
-        positions,
+        flashinfer_batch_indices,
+        flashinfer_positions,
         (k_cache, v_cache),
         paged_kv_indices,
         paged_kv_indptr,
@@ -316,13 +296,15 @@ def flashinfer_mha_with_cache_fake(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    # METADATA
-    qo_indptr: torch.Tensor,
-    paged_kv_indptr: torch.Tensor,
-    paged_kv_indices: torch.Tensor,
-    paged_kv_last_page_len: torch.Tensor,
-    batch_indices: torch.Tensor,
-    positions: torch.Tensor,
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    # EXTRA METADATA
+    flashinfer_batch_indices: torch.Tensor,
+    flashinfer_positions: torch.Tensor,
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -364,11 +346,17 @@ class FlashInferAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.flashinfer_attention_mha_with_cache
+        return torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.auto_deploy.flashinfer_attention_prepare_metadata, 6
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "cu_seqlen", "cu_num_pages", "cache_loc", "last_page_len"]
+
+    @classmethod
+    def get_prepare_extra_metadata_info(
+        cls, any_source_attn_node: Node
+    ) -> Tuple[Optional[PrepareMetadataCallable], int, List[Constant]]:
+        return torch.ops.auto_deploy.flashinfer_attention_prepare_metadata.default, 2, []
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
@@ -24,7 +24,7 @@ The flattened cached op integrates with the auto_deploy attention interface
 and updates a slot-indexed convolution state cache internally.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 from torch._ops import OpOverloadPacket
@@ -38,75 +38,12 @@ from ..attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
     AttentionRegistry,
-    BufferInitializerDict,
     CacheConfig,
     CacheInitializerDict,
     Constant,
     MHACallable,
-    PrepareMetadataCallable,
     SequenceInfo,
 )
-
-
-def _build_conv_state_from_sequence(input_bt_c: torch.Tensor, kernel_size: int) -> torch.Tensor:
-    """Builds a convolution state of fixed window `kernel_size` from a sequence.
-
-    input_bt_c: [B, T, C]
-    Returns: [B, C, K]
-    """
-    # [B, T, C] -> [B, C, T]
-    input_b_c_t = input_bt_c.transpose(1, 2)
-    seq_len = input_b_c_t.shape[-1]
-    if seq_len >= kernel_size:
-        return input_b_c_t[..., -kernel_size:]
-    pad_amount = kernel_size - seq_len
-    # F.pad last dim (time) with (pad_left, pad_right)
-    return torch.nn.functional.pad(input_b_c_t, (pad_amount, 0))
-
-
-# ---------------------------------------------------------------
-# Metadata + flattened cached op that integrates with the AD i/f
-# ---------------------------------------------------------------
-@torch.library.custom_op("auto_deploy::cuda_causal_conv_prepare_metadata", mutates_args=())
-def cuda_causal_conv_prepare_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
-) -> List[torch.Tensor]:
-    """Prepare metadata for cached causal conv (CUDA backend).
-
-    Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
-    """
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-
-    seq_start = torch.zeros_like(seq_len_sanitized)
-    if num_seq > 1:
-        seq_start[1:] = torch.cumsum(seq_len_sanitized[:-1], 0)
-
-    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
-    # This is only used during prefill to determine if we should use the initial states from the cache.
-    use_initial_states = input_pos[:num_seq] > 0
-    return (seq_len_sanitized, seq_start, slot_idx_sanitized, use_initial_states)
-
-
-@cuda_causal_conv_prepare_metadata.register_fake
-def cuda_causal_conv_prepare_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
-):
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-    return (
-        torch.empty_like(seq_len_sanitized),
-        torch.empty_like(seq_len_sanitized),
-        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
-        torch.empty(num_seq, dtype=torch.bool, device=slot_idx.device),
-    )
 
 
 @torch.library.custom_op("auto_deploy::cuda_cached_causal_conv1d", mutates_args={"input"})
@@ -115,11 +52,13 @@ def _cuda_cached_causal_conv1d(
     input: torch.Tensor,  # [b, s, c_in]
     weight: torch.Tensor,  # [c_out, c_in/groups, k] but we expect depthwise use: [c_in, k]
     bias: Optional[torch.Tensor],
-    # METADATA
-    seq_len: torch.Tensor,  # [num_seq]
-    seq_start: torch.Tensor,  # [num_seq]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     conv_state_cache: torch.Tensor,  # [max_batch_size, c_in, k-1]
     # CONSTANTS
@@ -140,16 +79,10 @@ def _cuda_cached_causal_conv1d(
     NOTE: This op modifies `input` in-place.
     """
     b, s = input.shape[:2]
-    num_seq = seq_len.shape[0]
 
-    # Split by lengths: assume prefills first, decodes after
-    if s == 1:
-        num_prefill = 0
-        num_decode = num_seq
-    else:
-        prefill_mask = seq_len > 1
-        num_prefill = int(prefill_mask.sum().item())
-        num_decode = num_seq - num_prefill
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+    num_total_tokens = num_prefill_tokens + num_decode
 
     # Flatten tokens
     bs = b * s
@@ -162,47 +95,29 @@ def _cuda_cached_causal_conv1d(
     else:
         w2d = weight
 
-    total_prefill_tokens = 0
-
     # PREFILL: concatenate all prefill tokens and run one varlen forward
     if num_prefill > 0:
-        seq_len_prefill = seq_len[:num_prefill].to(torch.int32)
-        total_prefill_tokens = int(seq_len_prefill.sum().item())
-
         # x_varlen: (dim, cu_seq_len)
-        x_varlen = inp_flat[:total_prefill_tokens].transpose(0, 1).contiguous()
-
-        # Metadata
-        cu_seqlens = torch.cat(
-            [
-                torch.zeros(1, dtype=torch.int32, device=input.device),
-                torch.cumsum(seq_len_prefill, dim=0, dtype=torch.int32),
-            ],
-            dim=0,
-        ).contiguous()
-        cache_indices = slot_idx[:num_prefill].to(torch.int32).contiguous()
-        has_initial_state = use_initial_states[:num_prefill].to(torch.bool)
+        x_varlen = inp_flat[:num_prefill_tokens].transpose(0, 1).contiguous()
 
         # Run varlen conv; updates conv_state_cache in-place per cache_indices
         y_varlen = causal_conv1d_fn(
             x_varlen,
             w2d,
             bias,
-            query_start_loc=cu_seqlens,
-            cache_indices=cache_indices,
-            has_initial_state=has_initial_state,
+            query_start_loc=cu_seqlen[: num_prefill + 1],
+            cache_indices=slot_idx[:num_prefill].to(torch.int32),
+            has_initial_state=use_initial_states[:num_prefill],
             conv_states=conv_state_cache,
             activation=activation,
             pad_slot_id=PAD_SLOT_ID,
         )  # (dim, total_prefill_tokens)
         # Scatter outputs back to input buffer
-        inp_flat[:total_prefill_tokens] = y_varlen.transpose(0, 1)
+        inp_flat[:num_prefill_tokens] = y_varlen.transpose(0, 1)
 
     # DECODE: batch update for single-token sequences
     if num_decode > 0:
-        x_decode = inp_flat[
-            total_prefill_tokens : total_prefill_tokens + num_decode
-        ]  # [num_decode, C_in]
+        x_decode = inp_flat[num_prefill_tokens:num_total_tokens]  # [num_decode, C_in]
 
         causal_conv1d_update(
             x_decode,  # [batch, dim]
@@ -211,26 +126,26 @@ def _cuda_cached_causal_conv1d(
             bias,
             activation=activation,
             cache_seqlens=None,
-            conv_state_indices=slot_idx[num_prefill:].to(torch.int32),
+            conv_state_indices=slot_idx[num_prefill:num_seq].to(torch.int32),
             pad_slot_id=PAD_SLOT_ID,
         )
-
-    return
 
 
 @_cuda_cached_causal_conv1d.register_fake
 def _cuda_cached_causal_conv1d_fake(
-    # INPUTS
-    input: torch.Tensor,
-    weight: torch.Tensor,
+    # INPUTS (dense but may be flattened across sequences)
+    input: torch.Tensor,  # [b, s, c_in]
+    weight: torch.Tensor,  # [c_out, c_in/groups, k] but we expect depthwise use: [c_in, k]
     bias: Optional[torch.Tensor],
-    # METADATA
-    seq_len: torch.Tensor,
-    seq_start: torch.Tensor,
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
-    use_initial_states: torch.Tensor,  # [num_seq]
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
-    conv_state_cache: torch.Tensor,
+    conv_state_cache: torch.Tensor,  # [max_batch_size, c_in, k-1]
     # CONSTANTS
     stride: int,
     padding: int,
@@ -238,11 +153,11 @@ def _cuda_cached_causal_conv1d_fake(
     groups: int,
     padding_mode: str,
     activation: Optional[str],
-):
-    return
+) -> None:
+    pass
 
 
-def cuda_cached_causal_conv1d_wrapper(input, *args, **kwargs):
+def cuda_cached_causal_conv1d_wrapper(input: torch.Tensor, *args, **kwargs) -> torch.Tensor:
     torch.ops.auto_deploy.cuda_cached_causal_conv1d(input, *args, **kwargs)
     return input
 
@@ -266,16 +181,15 @@ class CudaBackendCausalConv(AttentionDescriptor):
 
     @classmethod
     def get_source_attention_op(cls) -> OpOverloadPacket:
-        return torch.ops.auto_deploy.torch_causal_conv1d
+        return torch.ops.auto_deploy.torch_causal_conv1d.default
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
         return cuda_cached_causal_conv1d_wrapper
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        # Returns (seq_len, seq_start, slot_idx, use_initial_states)
-        return torch.ops.auto_deploy.cuda_causal_conv_prepare_metadata, 4
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(
@@ -297,10 +211,6 @@ class CudaBackendCausalConv(AttentionDescriptor):
             )
 
         return {"conv_state_cache": _get_conv_cache}
-
-    @classmethod
-    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
-        return {}
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
@@ -203,7 +203,7 @@ class CudaBackendCausalConv(AttentionDescriptor):
 
         def _get_conv_cache(si: SequenceInfo):
             return torch.empty(
-                si.max_batch_size,
+                si.max_state_slots,
                 in_channels,
                 max(1, kernel_size - 1),
                 device=si.device,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
@@ -310,7 +310,7 @@ class TorchBackendCausalConv(AttentionDescriptor):
 
         def _get_conv_cache(si: SequenceInfo):
             return torch.empty(
-                si.max_batch_size,
+                si.max_state_slots,
                 in_channels,
                 kernel_size,
                 device=si.device,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -319,7 +319,7 @@ class TorchBackendSSM(AttentionDescriptor):
 
         def _get_ssm_cache(si: SequenceInfo):
             return torch.empty(
-                si.max_batch_size,
+                si.max_state_slots,
                 num_heads,
                 head_dim,
                 ssm_state_size,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -22,7 +22,6 @@ from ..attention_interface import (
     CacheInitializerDict,
     Constant,
     MHACallable,
-    PrepareMetadataCallable,
     SequenceInfo,
 )
 from .torch_mamba import _torch_ssm_prefill
@@ -111,52 +110,6 @@ def _update_ssm_state_cache(ssm_cache: torch.Tensor, ssm_state: torch.Tensor) ->
 # ---------------------------------------------------------------
 
 
-@torch.library.custom_op("auto_deploy::torch_ssm_prepare_metadata", mutates_args=())
-def _torch_ssm_prepare_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
-) -> List[torch.Tensor]:
-    """Prepare metadata for cached SSM transform.
-
-    Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
-    """
-    # Determine number of active sequences and compute seq_start boundaries
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-
-    seq_start = torch.zeros_like(seq_len_sanitized)
-    if num_seq > 1:
-        seq_start[1:] = torch.cumsum(seq_len_sanitized[:-1], 0)
-
-    # Truncate slot indices to match active sequences
-    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
-    # TODO(https://github.com/NVIDIA/TensorRT-LLM/issues/8170): update torch
-    # reference implementation to support chunked prefill.
-    use_initial_states = input_pos > 0
-    return (seq_len_sanitized, seq_start, slot_idx_sanitized, use_initial_states)
-
-
-@_torch_ssm_prepare_metadata.register_fake
-def _torch_ssm_prepare_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
-):
-    # Use the same sanitization logic to determine sizes in fake mode
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-    return (
-        torch.empty_like(seq_len_sanitized),
-        torch.empty_like(seq_len_sanitized),
-        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
-        torch.empty(num_seq, dtype=torch.bool, device=slot_idx.device),
-    )
-
-
 @torch.library.custom_op("auto_deploy::torch_cached_ssm", mutates_args={})
 def _torch_cached_ssm(
     # INPUTS (dense but may be flattened across sequences)
@@ -167,11 +120,14 @@ def _torch_cached_ssm(
     D: torch.Tensor,  # [num_heads]
     dt: torch.Tensor,  # [b, s, num_heads]
     dt_bias: torch.Tensor,  # [num_heads]
-    # METADATA
-    seq_len: torch.Tensor,  # [num_seq]
-    seq_start: torch.Tensor,  # [num_seq]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    seq_len: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
     # CONSTANTS
@@ -187,6 +143,14 @@ def _torch_cached_ssm(
     """
     b, s = hidden_states.shape[:2]
     num_seq = seq_len.shape[0]
+
+    # get cleaned up metadata
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+    seq_len = seq_len[:num_seq]
+    seq_start = cu_seqlen[:num_seq]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
 
     if s == 1:
         # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
@@ -273,21 +237,24 @@ def _torch_cached_ssm(
 
 @_torch_cached_ssm.register_fake
 def _torch_cached_ssm_fake(
-    # INPUTS
-    hidden_states: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    D: torch.Tensor,
-    dt: torch.Tensor,
-    dt_bias: torch.Tensor,
-    # METADATA
+    # INPUTS (dense but may be flattened across sequences)
+    hidden_states: torch.Tensor,  # [b, s, num_heads, head_dim]
+    A: torch.Tensor,  # [num_heads]
+    B: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    C: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    D: torch.Tensor,  # [num_heads]
+    dt: torch.Tensor,  # [b, s, num_heads]
+    dt_bias: torch.Tensor,  # [num_heads]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
-    seq_start: torch.Tensor,
+    cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
     use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
-    ssm_state_cache: torch.Tensor,
+    ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
     # CONSTANTS
     time_step_limit: List[float],
     chunk_size: int,
@@ -322,12 +289,11 @@ class TorchBackendSSM(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.torch_cached_ssm
+        return torch.ops.auto_deploy.torch_cached_ssm.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        # Returns (seq_len, seq_start, slot_idx)
-        return torch.ops.auto_deploy.torch_ssm_prepare_metadata, 4
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "seq_len", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_mamba.py
@@ -327,7 +327,7 @@ class TritonBackendSSM(AttentionDescriptor):
 
         def _get_ssm_cache(si: SequenceInfo):
             return torch.empty(
-                si.max_batch_size,
+                si.max_state_slots,
                 num_heads,
                 head_dim,
                 ssm_state_size,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_mamba.py
@@ -29,7 +29,6 @@ from ..attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
     AttentionRegistry,
-    BufferInitializerDict,
     CacheConfig,
     CacheInitializerDict,
     Constant,
@@ -41,124 +40,63 @@ from ..attention_interface import (
 
 @torch.library.custom_op("auto_deploy::triton_ssm_prepare_metadata", mutates_args=())
 def _triton_ssm_prepare_metadata(
+    # INPUTS
     position_ids: torch.Tensor,
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA PROVIDED BY THE DESCRIPTOR
     chunk_size: int,
 ) -> List[torch.Tensor]:
     """Prepare metadata for cached SSM transform.
 
     Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
     """
-    # Determine number of active sequences and compute seq_start boundaries
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
+    device = cu_seqlen.device
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
 
-    # Truncate slot indices to match active sequences
-    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
-    # TODO(https://github.com/NVIDIA/TensorRT-LLM/issues/8170): update torch
-    # reference implementation to support chunked prefill.
-    use_initial_states = input_pos[:num_seq] > 0
-
-    device = position_ids.device
-
-    chunk_indices = torch.zeros(num_seq, dtype=torch.int32, device=device)
-    chunk_offsets = torch.zeros(num_seq, dtype=torch.int32, device=device)
-    cu_seqlens = torch.zeros(num_seq + 1, dtype=torch.int32, device=device)
-    _, s = position_ids.shape[:2]
-    if s > 1:
-        # only compute chunk indices and offsets for prefill.
-        prefill_mask = seq_len_sanitized > 1
-        num_prefill = int(prefill_mask.sum().item())
-        num_prefill_tokens = int(seq_len_sanitized[:num_prefill].sum().item())
-        num_decode = num_seq - num_prefill
-        cu_seqlens = torch.cat(
-            [
-                torch.zeros(1, dtype=torch.int32, device=device),
-                torch.cumsum(seq_len_sanitized[:num_prefill].to(torch.int32), dim=0),
-            ],
-            dim=0,
+    if num_prefill > 0:
+        chunk_indices, chunk_offsets = cu_seqlens_to_chunk_indices_offsets(
+            cu_seqlen[: num_prefill + 1], chunk_size
         )
-        chunk_indices, chunk_offsets = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
         seq_idx_prefill = torch.repeat_interleave(
-            torch.arange(num_prefill, device=device, dtype=torch.int32),
-            seq_len_sanitized[:num_prefill],
+            torch.arange(num_prefill, device=device, dtype=torch.int32), seq_len[:num_prefill]
         ).view(1, -1)
     else:
-        num_prefill = 0
-        num_prefill_tokens = 0
-        num_decode = num_seq
+        chunk_indices = torch.empty(0, dtype=torch.int32, device=device)
+        chunk_offsets = torch.empty(0, dtype=torch.int32, device=device)
         seq_idx_prefill = torch.empty(1, 0, dtype=torch.int32, device=device)
-    batch_info_tensor = torch.tensor(
-        [num_prefill, num_prefill_tokens, num_decode], dtype=torch.int32
-    )  # host tensor
 
-    return (
-        seq_len_sanitized,
-        slot_idx_sanitized,
-        use_initial_states,
-        cu_seqlens,
-        chunk_indices,
-        chunk_offsets,
-        seq_idx_prefill,
-        batch_info_tensor,
-    )
+    return (chunk_indices, chunk_offsets, seq_idx_prefill)
 
 
 @_triton_ssm_prepare_metadata.register_fake
 def _triton_ssm_prepare_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
+    # INPUTS
+    position_ids: torch.Tensor,
+    batch_info: torch.Tensor,
+    seq_len: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA PROVIDED BY THE DESCRIPTOR
+    chunk_size: int,
 ):
-    # Use the same sanitization logic to determine sizes in fake mode
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
-    num_seq = len(seq_len_sanitized)
-    device = slot_idx.device
-    # Always-correct shapes
-    seq_len_fake = torch.empty_like(seq_len_sanitized)
-    slot_idx_fake = torch.empty(num_seq, dtype=torch.long, device=device)
-    use_initial_states_fake = torch.empty(num_seq, dtype=torch.bool, device=device)
-    cu_seqlens_fake = torch.empty(num_seq + 1, dtype=torch.int32, device=device)
-
-    # Token-dependent shapes (prefill vs decode)
-    _, s = position_ids.shape[:2]
+    b, s = position_ids.shape[:2]
+    num_tokens = b * s
+    device = cu_seqlen.device
+    dtype = torch.int32
     if s > 1:
-        prefill_mask = seq_len_sanitized > 1
-        num_prefill = int(prefill_mask.sum().item())
-        num_prefill_tokens = int(seq_len_sanitized[:num_prefill].sum().item())
-        cu_seqlens_runtime = torch.cat(
-            [
-                torch.zeros(1, dtype=torch.int32, device=device),
-                torch.cumsum(seq_len_sanitized[:num_prefill].to(torch.int32), dim=0),
-            ],
-            dim=0,
+        # NOTE: this is only an upper bound for the shape in this case...
+        return (
+            torch.empty(num_tokens, dtype=dtype, device=device),  # chunk_indices
+            torch.empty(num_tokens, dtype=dtype, device=device),  # chunk_offsets
+            torch.empty(1, num_tokens, dtype=dtype, device=device),  # seq_idx_prefill
         )
-        chunk_indices_rt, chunk_offsets_rt = cu_seqlens_to_chunk_indices_offsets(
-            cu_seqlens_runtime, chunk_size
-        )
-        chunk_indices_fake = torch.empty_like(chunk_indices_rt)
-        chunk_offsets_fake = torch.empty_like(chunk_offsets_rt)
-        seq_idx_prefill_fake = torch.empty(1, num_prefill_tokens, dtype=torch.int32, device=device)
     else:
-        chunk_indices_fake = torch.empty(0, dtype=torch.int32, device=device)
-        chunk_offsets_fake = torch.empty(0, dtype=torch.int32, device=device)
-        seq_idx_prefill_fake = torch.empty(1, 0, dtype=torch.int32, device=device)
-
-    batch_info_tensor_fake = torch.empty(3, dtype=torch.int32)
-
-    return (
-        seq_len_fake,
-        slot_idx_fake,
-        use_initial_states_fake,
-        cu_seqlens_fake,
-        chunk_indices_fake,
-        chunk_offsets_fake,
-        seq_idx_prefill_fake,
-        batch_info_tensor_fake,
-    )
+        return (
+            torch.empty(0, dtype=dtype, device=device),  # chunk_indices
+            torch.empty(0, dtype=dtype, device=device),  # chunk_offsets
+            torch.empty(1, 0, dtype=dtype, device=device),  # seq_idx_prefill
+        )
 
 
 @torch.library.custom_op("auto_deploy::triton_cached_ssm", mutates_args={})
@@ -171,15 +109,15 @@ def _triton_cached_ssm(
     D: torch.Tensor,  # [num_heads]
     dt: torch.Tensor,  # [b, s, num_heads]
     dt_bias: torch.Tensor,  # [num_heads]
-    # METADATA
-    seq_len: torch.Tensor,  # [num_seq]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
-    cu_seqlens: torch.Tensor,  # [num_seq + 1]
-    chunk_indices: torch.Tensor,  # [num_seq + 1]
-    chunk_offsets: torch.Tensor,  # [num_seq + 1]
-    seq_idx_prefill: torch.Tensor,  # [1, num_prefill]
-    batch_info_tensor: torch.Tensor,  # [3]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    chunk_indices: torch.Tensor,  # [num_logical_chunks]
+    chunk_offsets: torch.Tensor,  # [num_logical_chunks]
+    seq_idx_prefill: torch.Tensor,  # [1, num_prefill_tokens]
     # CACHES
     ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
     # CONSTANTS
@@ -202,7 +140,9 @@ def _triton_cached_ssm(
 
     ssm_state_size = B.shape[3]
 
-    num_prefill, num_prefill_tokens, num_decode = batch_info_tensor.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+    num_total_tokens = num_prefill_tokens + num_decode
 
     y_prefill = None
     y_decode = None
@@ -239,7 +179,7 @@ def _triton_cached_ssm(
             seq_idx=seq_idx_prefill,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
-            cu_seqlens=cu_seqlens,
+            cu_seqlens=cu_seqlen[: num_prefill + 1],
             dt_softplus=True,
             dt_limit=(time_step_limit[0], time_step_limit[1]),
             return_final_states=False,
@@ -253,12 +193,12 @@ def _triton_cached_ssm(
 
     # Decode: batch single-token updates via selective_state_update
     if num_decode > 0:
-        slot_idx_decode = slot_idx[num_prefill:]
+        slot_idx_decode = slot_idx[num_prefill:num_seq]
 
-        x_decode = hs_flat[num_prefill_tokens : num_prefill_tokens + num_decode]  # [nd, H, D]
-        B_decode = B_flat[num_prefill_tokens : num_prefill_tokens + num_decode]  # [nd, G, N]
-        C_decode = C_flat[num_prefill_tokens : num_prefill_tokens + num_decode]  # [nd, G, N]
-        dt_decode = dt_flat[num_prefill_tokens : num_prefill_tokens + num_decode]  # [nd, H]
+        x_decode = hs_flat[num_prefill_tokens:num_total_tokens]  # [nd, H, D]
+        B_decode = B_flat[num_prefill_tokens:num_total_tokens]  # [nd, G, N]
+        C_decode = C_flat[num_prefill_tokens:num_total_tokens]  # [nd, G, N]
+        dt_decode = dt_flat[num_prefill_tokens:num_total_tokens]  # [nd, H]
 
         dt_hp = dt_decode[:, :, None].expand(-1, num_heads, head_dim)
         dt_bias_hp = dt_bias[..., None].expand(num_heads, head_dim)
@@ -284,7 +224,7 @@ def _triton_cached_ssm(
         y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
         y_flat = y.view(bs, *y.shape[2:])
         y_flat[:num_prefill_tokens].copy_(y_prefill[0])
-        y_flat[num_prefill_tokens : num_prefill_tokens + num_decode].copy_(y_decode)
+        y_flat[num_prefill_tokens:num_total_tokens].copy_(y_decode)
         return y
     elif num_prefill > 0:
         return y_prefill[0].view(b, s, num_heads, head_dim).to(hidden_states.dtype)
@@ -304,15 +244,15 @@ def _triton_cached_ssm_fake(
     D: torch.Tensor,  # [num_heads]
     dt: torch.Tensor,  # [b, s, num_heads]
     dt_bias: torch.Tensor,  # [num_heads]
-    # METADATA
-    seq_len: torch.Tensor,  # [num_seq]
-    slot_idx: torch.Tensor,  # [num_seq]
-    use_initial_states: torch.Tensor,  # [num_seq]
-    cu_seqlens: torch.Tensor,  # [num_seq + 1]
-    chunk_indices: torch.Tensor,  # [num_seq + 1]
-    chunk_offsets: torch.Tensor,  # [num_seq + 1]
-    seq_idx_prefill: torch.Tensor,  # [1, num_prefill]
-    batch_info_tensor: torch.Tensor,  # [3]
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    chunk_indices: torch.Tensor,  # [num_logical_chunks]
+    chunk_offsets: torch.Tensor,  # [num_logical_chunks]
+    seq_idx_prefill: torch.Tensor,  # [1, num_prefill_tokens]
     # CACHES
     ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
     # CONSTANTS
@@ -327,7 +267,6 @@ def _triton_cached_ssm_fake(
     )
 
 
-# TODO: consider inheriting from TorchBackendSSM instead of redefining everything
 @AttentionRegistry.register("triton_ssm")
 class TritonBackendSSM(AttentionDescriptor):
     @classmethod
@@ -351,13 +290,21 @@ class TritonBackendSSM(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.triton_cached_ssm
+        return torch.ops.auto_deploy.triton_cached_ssm.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        # Returns: seq_len, slot_idx, use_initial_states,
-        # cu_seqlens, chunk_indices, chunk_offsets, seq_idx_prefill, batch_info_tensor
-        return torch.ops.auto_deploy.triton_ssm_prepare_metadata, 8
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "cu_seqlen", "slot_idx", "use_initial_states"]
+
+    @classmethod
+    def get_prepare_extra_metadata_info(
+        cls, any_source_attn_node: Node
+    ) -> Tuple[PrepareMetadataCallable, int, List[Constant]]:
+        return (
+            torch.ops.auto_deploy.triton_ssm_prepare_metadata.default,
+            3,  # chunk_indices, chunk_offsets, seq_idx_prefill
+            extract_op_args(any_source_attn_node, "chunk_size"),
+        )
 
     @classmethod
     def get_cache_initializers(
@@ -389,10 +336,6 @@ class TritonBackendSSM(AttentionDescriptor):
             )
 
         return {"ssm_state_cache": _get_ssm_cache}
-
-    @classmethod
-    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
-        return {}
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
@@ -1,7 +1,7 @@
 """Torch backend attention using pure PyTorch reference implementations."""
 
 import math
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 from torch._ops import OpOverloadPacket
@@ -19,7 +19,6 @@ from .attention_interface import (
     CacheInitializerDict,
     Constant,
     MHACallable,
-    PrepareMetadataCallable,
     SequenceInfo,
 )
 from .torch_attention import repeat_kv, update_kv_cache
@@ -253,11 +252,14 @@ def torch_backend_mha_with_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    # METADATA
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
-    seq_start: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -274,6 +276,14 @@ def torch_backend_mha_with_cache(
     num_kv_heads, qk_head_dim = k_cache.shape[-2:]
     v_head_dim = v_cache.shape[-1]
     b, s = q.shape[:2]
+
+    # get cleaned up metadata
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+    seq_len = seq_len[:num_seq]
+    input_pos = input_pos[:num_seq]
+    cache_loc = cache_loc[:num_seq]
+    seq_start = cu_seqlen[:num_seq]
 
     # check for num_heads
     num_heads = q.shape[2] // qk_head_dim if q.ndim == 3 else q.shape[2]
@@ -337,57 +347,30 @@ def torch_backend_mha_with_cache(
 
 @torch_backend_mha_with_cache.register_fake
 def torch_backend_mha_with_cache_fake(
+    # Q, K, V
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
-    seq_start: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA
+    #
+    # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    # BUFFERS
+    # <none>
+    # CONSTANTS
     scale: Optional[float],
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
 ):
     return q.new_empty(*q.shape[:-1], v.shape[-1]).contiguous()
-
-
-@torch.library.custom_op("auto_deploy::torch_cached_attention_prepare_metadata", mutates_args=())
-def torch_backend_prepare_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
-) -> List[torch.Tensor]:
-    """Prepare metadata for torch backend attention (similar to triton backend)."""
-    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
-    seq_start = torch.zeros_like(seq_len[:num_seq])
-    seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
-    return (
-        seq_len[:num_seq].clone(),
-        input_pos[:num_seq].clone(),
-        cache_loc[:num_seq].clone(),
-        seq_start,
-    )
-
-
-@torch_backend_prepare_metadata.register_fake
-def torch_backend_prepare_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
-):
-    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
-    return (
-        torch.empty_like(seq_len[:num_seq]),
-        torch.empty_like(input_pos[:num_seq]),
-        torch.empty_like(cache_loc[:num_seq]),
-        torch.empty_like(seq_len[:num_seq]),
-    )
 
 
 @AttentionRegistry.register("torch")
@@ -413,11 +396,11 @@ class TorchBackendAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.torch_cached_attention_with_cache
+        return torch.ops.auto_deploy.torch_cached_attention_with_cache.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.auto_deploy.torch_cached_attention_prepare_metadata, 4
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -1,7 +1,7 @@
 """Custom ops for MHA/XQA attention."""
 
 import math
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 import triton
@@ -20,7 +20,6 @@ from .attention_interface import (
     CacheInitializerDict,
     Constant,
     MHACallable,
-    PrepareMetadataCallable,
     SequenceInfo,
 )
 from .triton_kernels.attention_with_kv_cache import (
@@ -188,11 +187,14 @@ def flattened_mha_with_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    # METADATA
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
-    seq_start: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA
+    #
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -207,6 +209,15 @@ def flattened_mha_with_cache(
 
     NOTE: this op can also handle seq_len==0, which might be useful for CUDAGRAPH.
     """
+    # check for sequence info and truncate metadata
+    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_seq = num_prefill + num_decode
+
+    seq_len = seq_len[:num_seq]
+    input_pos = input_pos[:num_seq]
+    cache_loc = cache_loc[:num_seq]
+    seq_start = cu_seqlen[:num_seq]
+
     # b, s info
     # NOTE: b, s are just the shapes of the input tensor q; not necessarily the number of sequences.
     # Generally speaking, we expect one of two cases here:
@@ -239,7 +250,17 @@ def flattened_mha_with_cache(
     if s == 1:
         # generate-only phase
         _generate_mha(
-            q, k, v, k_cache, v_cache, cache_loc, input_pos, scale, y, sinks, sliding_window
+            q,
+            k,
+            v,
+            k_cache,
+            v_cache,
+            cache_loc,
+            input_pos,
+            scale,
+            y,
+            sinks,
+            sliding_window,
         )
     else:
         # mixed context + generate phase
@@ -264,60 +285,29 @@ def flattened_mha_with_cache(
 
 @flattened_mha_with_cache.register_fake
 def flattened_mha_fake(
+    # Q, K, V
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    # STANDARD METADATA
+    batch_info: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
-    seq_start: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # EXTRA METADATA
+    #
+    # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    # BUFFERS
+    # <none>
+    # CONSTANTS
     scale: Optional[float],
     sinks: Optional[torch.Tensor] = None,
     sliding_window: Optional[int] = None,
 ):
     return q.new_empty(*q.shape[:-1], v.shape[-1]).contiguous()
-
-
-@torch.library.custom_op(
-    "auto_deploy::triton_attention_prepare_fused_mha_metadata", mutates_args=()
-)
-def prepare_fused_mha_metadata(
-    position_ids: torch.Tensor,
-    seq_len: torch.Tensor,
-    input_pos: torch.Tensor,
-    cache_loc: torch.Tensor,
-    pages_per_seq: torch.Tensor,
-    slot_idx: torch.Tensor,
-    page_size: int,
-    chunk_size: int,
-) -> List[torch.Tensor]:
-    # TODO: maybe use slot_idx instead of pages_per_seq??
-    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
-    seq_start = torch.zeros_like(seq_len[:num_seq])
-    seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
-    return (
-        seq_len[:num_seq].clone(),
-        input_pos[:num_seq].clone(),
-        cache_loc[:num_seq].clone(),
-        seq_start,
-    )
-
-
-# TODO: Move the truncation of inputs out of this custom op
-# SequenceInfo._get_sanitized_num_sequences could break in fake mode
-@prepare_fused_mha_metadata.register_fake
-def prepare_fused_mha_metadata_fake(
-    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
-):
-    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
-    return (
-        torch.empty_like(seq_len[:num_seq]),
-        torch.empty_like(input_pos[:num_seq]),
-        torch.empty_like(cache_loc[:num_seq]),
-        torch.empty_like(seq_len[:num_seq]),
-    )
 
 
 @AttentionRegistry.register("triton")
@@ -343,11 +333,11 @@ class TritonAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache
+        return torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache.default
 
     @classmethod
-    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.auto_deploy.triton_attention_prepare_fused_mha_metadata, 4
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_utils.py
@@ -1,0 +1,86 @@
+"""Triton utility operations for auto_deploy."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_gather_scatter_kernel(
+    ungathered_ptr,  # *T
+    gather_ids_ptr,  # *int64
+    mask_indices_ptr,  # *int64
+    out_ptr,  # *T
+    n_elements,  # int32
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Triton kernel for fused gather and scatter operation.
+
+    This kernel gathers values from `ungathered_ptr` using indices from `gather_ids_ptr`
+    and scatters them to `out_ptr` at positions specified by `mask_indices_ptr`.
+    """
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # load source indices
+    src_idx = tl.load(gather_ids_ptr + offs, mask=mask, other=0)
+    # load values from ungathered
+    vals = tl.load(ungathered_ptr + src_idx, mask=mask, other=0)
+
+    # load destination indices (into flattened output)
+    dst_idx = tl.load(mask_indices_ptr + offs, mask=mask, other=0)
+
+    # scatter values to output
+    tl.store(out_ptr + dst_idx, vals, mask=mask)
+
+
+@torch.library.custom_op("auto_deploy::triton_utils_fused_gather_scatter", mutates_args=("out",))
+def fused_gather_scatter(
+    ungathered_input: torch.Tensor,
+    gather_ids: torch.Tensor,
+    mask_indices: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    """Fused gather and scatter operation using Triton.
+
+    This operation gathers values from `ungathered_input` at indices specified by
+    `gather_ids` and scatters the gathered values to `out` at positions specified
+    by `mask_indices`.
+
+    This is useful for efficiently rearranging input_ids in overlap scheduling
+    scenarios where tokens need to be reordered based on scheduling decisions.
+
+    Args:
+        ungathered_input: Source tensor from which to gather values.
+        gather_ids: Indices into `ungathered_input` specifying which values to gather.
+        mask_indices: Destination indices in `out` where gathered values should be scattered.
+        out: Output tensor where gathered values will be scattered.
+
+    Note:
+        This operation mutates `out` in-place.
+    """
+    n = gather_ids.numel()
+
+    BLOCK_SIZE = 256
+    grid = ((n + BLOCK_SIZE - 1) // BLOCK_SIZE,)
+
+    _fused_gather_scatter_kernel[grid](
+        ungathered_input,  # ungathered_ptr
+        gather_ids,  # gather_ids_ptr
+        mask_indices,  # mask_indices_ptr
+        out,  # out_ptr
+        n,  # n_elements
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+@fused_gather_scatter.register_fake
+def fused_gather_scatter_fake(
+    ungathered_input: torch.Tensor,
+    gather_ids: torch.Tensor,
+    mask_indices: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    """Fake implementation for torch.compile / graph tracing."""
+    pass

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -268,6 +268,22 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
 
         return self
 
+    @model_validator(mode="after")
+    def update_cuda_graph_batch_sizes(self):
+        # if not set, use heuristic
+        if self.cuda_graph_batch_sizes is None:
+            cg_bs = {1, self.max_batch_size}
+            cg_bs.update(range(1, 128 + 1, 16))
+            cg_bs.update(range(128, self.max_batch_size + 1, 128))
+        else:
+            cg_bs = [b for b in self.cuda_graph_batch_sizes if b <= self.max_batch_size]
+        self.cuda_graph_batch_sizes = sorted(cg_bs, reverse=True)
+        ad_logger.info(f"Using cuda_graph_batch_sizes: {self.cuda_graph_batch_sizes}")
+
+        # ensure that the cuda_graph_batch_sizes are updated in the shortcut and transform config
+        self.update_transforms_with_shortcuts()
+        return self
+
     @field_validator("kv_cache_config", mode="after")
     @classmethod
     def validate_kv_cache_config(cls, kv_cache_config: KvCacheConfig) -> KvCacheConfig:
@@ -307,6 +323,9 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
         if "yaml_default" not in self.model_fields_set:
             kwargs.pop("yaml_default")
         return kwargs
+
+    def is_cuda_graph_enabled(self) -> bool:
+        return self.compile_backend in ["torch-cudagraph", "torch-opt"]
 
     ### PRIVATE METHODS ############################################################################
     @classmethod

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -194,11 +194,6 @@ class ModelFactory(ABC):
         """Returns the sharding config for this model."""
         return self._sharding_config
 
-    @property
-    def chunk_size(self) -> Optional[int]:
-        """Returns the chunk size for this model."""
-        return None
-
     def get_cache_config(self) -> CacheConfig:
         """Return the cache configuration for the model.
 

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -141,13 +141,6 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
         model_config, _ = self._get_model_config()
         return getattr(model_config, "vocab_size", None)
 
-    @property
-    def chunk_size(self) -> Optional[int]:
-        """Returns the chunk size for this model."""
-        model_config, _ = self._get_model_config()
-        # chunk_size is an input to a custom op, so it can not be none. We set it to a default value of 128.
-        return getattr(model_config, "chunk_size", 128)
-
     def _recursive_update_config(
         self, config: PretrainedConfig, update_dict: Dict[str, Any]
     ) -> Tuple[PretrainedConfig, Dict[str, Any]]:

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -25,8 +25,9 @@ from tensorrt_llm._torch.pyexecutor._util import (
     get_decoding_mode,
     get_kv_cache_manager_cls,
 )
+from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
 from tensorrt_llm._torch.pyexecutor.guided_decoder import GuidedDecoder
-from tensorrt_llm._torch.pyexecutor.llm_request import get_draft_token_length
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, get_draft_token_length
 from tensorrt_llm._torch.pyexecutor.py_executor_creator import get_guided_decoding_config
 from tensorrt_llm._torch.pyexecutor.seq_slot_manager import SeqSlotManager
 from tensorrt_llm._torch.speculative import get_spec_drafter
@@ -35,7 +36,6 @@ from tensorrt_llm.llmapi.llm_args import (
     ContextChunkingPolicy,
     LoadFormat,
     SamplerType,
-    SpeculativeConfig,
     TorchLlmArgs,
 )
 from tensorrt_llm.llmapi.tokenizer import TokenizerBase
@@ -203,6 +203,106 @@ def create_draft_kv_cache_manager_maybe(
     )
 
 
+def _round_up_to_closest(batch_sizes: List[int], bs: int) -> Optional[int]:
+    """Return closest batch size larger or equal to bs."""
+    if bs > max(batch_sizes, default=0):
+        return None
+    return min(batch_sizes, key=lambda x: (x < bs, abs(x - bs)), default=None)
+
+
+def maybe_pad_for_cuda_graph(func):
+    def wrapper(
+        self: "ADEngine",
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        *args,
+        **kwargs,
+    ):
+        def _call_func():
+            return func(self, scheduled_requests, resource_manager, *args, **kwargs)
+
+        if not (self.cuda_graph_used and scheduled_requests.can_run_cuda_graph):
+            return _call_func()
+
+        # check if it's generate-only batch
+        is_generate_only = len(scheduled_requests.context_requests) == 0
+
+        if not is_generate_only:
+            return _call_func()
+
+        # check closest cuda graph batch size
+        closest_cg_bs = _round_up_to_closest(
+            self.cuda_graph_batch_sizes, scheduled_requests.batch_size
+        )
+
+        # check if we need to pad
+        num_padding = closest_cg_bs - scheduled_requests.batch_size
+
+        if num_padding <= 0:
+            return _call_func()
+
+        # create a dummy request if it doesn't already exist
+        kv_cache_manager = resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER
+        )
+        if self.padding_dummy_request is None and kv_cache_manager.get_num_free_blocks() > 0:
+            self.padding_dummy_request = kv_cache_manager.add_dummy_requests(
+                request_ids=[CUDA_GRAPH_DUMMY_REQUEST_ID],
+                is_gen=True,
+                max_num_draft_tokens=self.max_total_draft_tokens,
+                use_mrope=False,
+                max_beam_width=self.max_beam_width,
+            )[0]
+            self.padding_dummy_request.is_cuda_graph_dummy = True
+            spec_res_mgr = resource_manager.get_resource_manager(
+                ResourceManagerType.SPEC_RESOURCE_MANAGER
+            )
+            if spec_res_mgr:
+                spec_res_mgr.add_dummy_requests([CUDA_GRAPH_DUMMY_REQUEST_ID])
+
+        if self.padding_dummy_request is None:
+            return _call_func()
+
+        # now call slot manager to add the dummy request
+        slot_manager: SeqSlotManager = resource_manager.get_resource_manager(
+            ResourceManagerType.SEQ_SLOT_MANAGER
+        )
+
+        # check if we have a free slot available
+        if not slot_manager.slot_manager.free_slots:
+            # NOTE: this should never happen, but we'll check just in case and emit an error
+            ad_logger.error("No free slots available for CUDA graph padding")
+            return _call_func()
+
+        seq_slot = slot_manager.slot_manager.add_slot(self.padding_dummy_request.request_id)
+        self.padding_dummy_request.seq_slot = seq_slot
+        self.padding_dummy_request.py_seq_slot = seq_slot
+
+        # pad the scheduled requests with the dummy request
+        scheduled_requests.generation_requests.extend([self.padding_dummy_request] * num_padding)
+
+        ret = _call_func()
+
+        # free the slot for the dummy request
+        # NOTE: unlike the occupied page, we do free the slot here because slots are limited by the
+        # max batch size, so we need them to be available for the next batch.
+        slot_manager.free_resources(self.padding_dummy_request)
+
+        # NOTE: C++ interface forbids setting this back to None - so we will use an illegal value
+        # instead
+        self.padding_dummy_request.seq_slot = slot_manager.get_max_resource_count()
+        self.padding_dummy_request.py_seq_slot = slot_manager.get_max_resource_count()
+
+        # truncate requests
+        scheduled_requests.generation_requests = scheduled_requests.generation_requests[
+            :-num_padding
+        ]
+
+        return ret
+
+    return wrapper
+
+
 class ADEngine(ModelEngine):
     """The AutoDeploy Engine (ADEngine) is the main engine interface to execute AutoDeploy models.
 
@@ -223,7 +323,6 @@ class ADEngine(ModelEngine):
         max_seq_len = ad_config.max_seq_len
         attn_page_size = ad_config.attn_page_size
         max_num_tokens = ad_config.max_num_tokens
-        max_beam_width = ad_config.max_beam_width
 
         # update device to contain the current default device if it's in cuda
         device = torch.device(ad_config.device)
@@ -240,7 +339,6 @@ class ADEngine(ModelEngine):
             page_size=attn_page_size,
             max_num_tokens=max_num_tokens,
             vocab_size_padded=factory.vocab_size_padded,
-            chunk_size=factory.chunk_size,
         )
         reporting_info = ReportingInfo(
             print_log=False,
@@ -258,10 +356,8 @@ class ADEngine(ModelEngine):
             build_and_optimize,
             seq_info,
             device,
-            max_beam_width,
-            ad_config.speculative_config,
-            ad_config.disable_overlap_scheduler,
-            reporting_info,
+            ad_config=ad_config,
+            reporting_info=reporting_info,
         )
 
     @torch.inference_mode()
@@ -270,9 +366,7 @@ class ADEngine(ModelEngine):
         get_inference_model: GetInferenceModel,
         seq_info: SequenceInfo,
         device: DeviceLikeType,
-        max_beam_width: int = 1,
-        spec_config: Optional[SpeculativeConfig] = None,
-        disable_overlap_scheduler: bool = False,
+        ad_config: Optional[LlmArgs] = None,
         reporting_info: ReportingInfo = ReportingInfo(),
     ) -> None:
         """Initialize the engine with model and sequence information."""
@@ -293,11 +387,22 @@ class ADEngine(ModelEngine):
         self.iter_states = {}
 
         # NOTE (lucaslie): not a declared base member in the base class; required by PyExecutor...
-        self.max_beam_width = max_beam_width
         self.enable_attention_dp = False
-        self._disable_overlap_scheduler = disable_overlap_scheduler
 
-        self.spec_config = spec_config
+        if ad_config is not None:
+            self.max_beam_width = ad_config.max_beam_width
+            self.spec_config = ad_config.speculative_config
+            self._disable_overlap_scheduler = ad_config.disable_overlap_scheduler
+        else:
+            self.max_beam_width = 1
+            self.spec_config = None
+            self._disable_overlap_scheduler = False
+
+        # check for max total draft tokens
+        if self.spec_config is not None:
+            self.max_total_draft_tokens = self.spec_config.max_total_draft_tokens
+        else:
+            self.max_total_draft_tokens = 0
 
         # TODO(govind): Enable overlap scheduler for speculation.
         assert self.spec_config is None or self._disable_overlap_scheduler, (
@@ -318,6 +423,18 @@ class ADEngine(ModelEngine):
         self.model = get_inference_model(self.cache_seq_interface)
         # start fresh with fixed seed
         torch.manual_seed(42)
+
+        # check cuda graph padding...
+        # TODO: better mechanism to retrieve this information when we refactor LlmArgs
+        if ad_config is None:
+            self.cuda_graph_used = False
+            self.cuda_graph_batch_sizes = []
+        else:
+            self.cuda_graph_used = ad_config.is_cuda_graph_enabled()
+            self.cuda_graph_batch_sizes = ad_config.cuda_graph_batch_sizes
+
+        # keep a reference for one dummy request around
+        self.padding_dummy_request: Optional[LlmRequest] = None
 
     @nvtx_range("ad_prepare_inputs")
     def _prepare_inputs(
@@ -343,15 +460,25 @@ class ADEngine(ModelEngine):
         gen_requests = extend_requests + generation_requests
         # info to be extracted
         input_ids: List[List[int]] = []
+        position_ids: List[List[int]] = []
         input_pos: List[int] = []
+        seq_len: List[int] = []
+        cu_seqlen: List[int] = [0]
         last_logit_only: List[bool] = []
-        page_assignments: List[List[int]] = []
+        cache_loc: List[int] = []
+        pages_per_seq: List[int] = []
+        cu_num_pages: List[int] = [0]
+        seq_len_with_cache: List[int] = []
+        last_page_len: List[int] = []
         slot_idx: List[int] = []
+        use_initial_states: List[bool] = []
 
         # gather indices are used to gather tokens in new_tokens into input_ids
-        flat_gather_indices: List[List[int]] = []
+        flat_gather_indices: List[int] = []
+        mask_scatter_indices: List[int] = []
         extra_args: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
+        page_size = self.cache_seq_interface.info.page_size
         dummy_token = -1
         num_ctx_requests = len(context_requests)
         num_ctx_tokens = 0
@@ -371,16 +498,26 @@ class ADEngine(ModelEngine):
             input_ids.append(prompt_tokens)
             input_pos.append(begin_compute)
 
+            seq_len.append(len(input_ids[-1]))
+            cu_seqlen.append(cu_seqlen[-1] + seq_len[-1])
+
             request.py_batch_idx = request.seq_slot
             last_logit_only.append(True)
 
             # get cache indices and truncate the number of blocks according to end_compute
             cache_indices = kv_cache_manager.get_cache_indices(request)
             num_active_blocks = kv_cache_manager.get_num_kv_blocks(end_compute)
-            page_assignments.append(cache_indices[:num_active_blocks])
+            cache_loc.extend(cache_indices[:num_active_blocks])
+            pages_per_seq.append(num_active_blocks)
+            cu_num_pages.append(cu_num_pages[-1] + pages_per_seq[-1])
+            seq_len_with_cache.append(input_pos[-1] + seq_len[-1])
+            last_page_len.append((seq_len_with_cache[-1] - 1) % page_size + 1)
+
+            position_ids.append(list(range(input_pos[-1], seq_len_with_cache[-1])))
 
             # store seq slot idx
             slot_idx.append(request.seq_slot)
+            use_initial_states.append(input_pos[-1] > 0)
 
             # store extra arguments
             if request.py_multimodal_data is not None:
@@ -414,7 +551,7 @@ class ADEngine(ModelEngine):
                 else:
                     return request.max_beam_num_tokens - 1
 
-        def _build_input_ids(request) -> Tuple[List[int], List[int]]:
+        def _build_input_ids(request) -> Tuple[List[int], List[int], bool]:
             """Build input_ids and gather indices for a request.
             Gather indices are used to gather tokens from new_tokens into input_ids when we run the overlap scheduler.
             """
@@ -446,11 +583,11 @@ class ADEngine(ModelEngine):
                     gather_indices = [request.py_batch_idx]
                     input_ids = [dummy_token]
 
-            return input_ids, gather_indices
+            return input_ids, gather_indices, use_overlap
 
         for request in gen_requests:
             num_tokens_seen = _compute_num_tokens_seen(request)
-            input_ids_for_request, gather_indices_to_append = _build_input_ids(request)
+            input_ids_for_request, gather_indices_to_append, use_overlap = _build_input_ids(request)
 
             input_ids.append(input_ids_for_request)
             input_pos.append(num_tokens_seen)
@@ -459,27 +596,46 @@ class ADEngine(ModelEngine):
             num_generation_tokens += 1 + get_draft_token_length(request)
             request.py_batch_idx = request.seq_slot
             slot_idx.append(request.seq_slot)
+            use_initial_states.append(input_pos[-1] > 0)
             last_logit_only.append(False)
+
+            seq_len.append(len(input_ids[-1]))
+            cu_seqlen.append(cu_seqlen[-1] + seq_len[-1])
+
+            if use_overlap:
+                mask_scatter_indices.extend(list(range(cu_seqlen[-2], cu_seqlen[-1])))
 
             # get cache indices
             cache_indices = kv_cache_manager.get_cache_indices(request)
-            page_assignments.append(cache_indices)
+            cache_loc.extend(cache_indices)
+            pages_per_seq.append(len(cache_indices))
+            cu_num_pages.append(cu_num_pages[-1] + pages_per_seq[-1])
+            seq_len_with_cache.append(input_pos[-1] + seq_len[-1])
+            last_page_len.append((seq_len_with_cache[-1] - 1) % page_size + 1)
+
+            position_ids.append(list(range(input_pos[-1], seq_len_with_cache[-1])))
 
         # update the sequence info object now
         self.cache_seq_interface.info.nest_sequences(
             input_ids,
+            position_ids=position_ids,
+            seq_len=seq_len,
             input_pos=input_pos,
-            page_assignments=page_assignments,
+            cu_seqlen=cu_seqlen,
+            cache_loc=cache_loc,
+            pages_per_seq=pages_per_seq,
+            cu_num_pages=cu_num_pages,
+            seq_len_with_cache=seq_len_with_cache,
+            last_page_len=last_page_len,
             slot_idx=slot_idx,
+            use_initial_states=use_initial_states,
+            _gather_idx=None if new_tokens is None else flat_gather_indices,
+            _mask_scatter_indices=None if new_tokens is None else mask_scatter_indices,
             **extra_args,
         )
         # scatter the new tokens into the input_ids tensor if provided
         if new_tokens is not None:
-            self.cache_seq_interface.info.rescatter_input_ids(
-                ungathered_input_ids=new_tokens.flatten(),  # ensure it's flattened
-                gather_idx=flat_gather_indices,
-                scatter_ref=dummy_token,
-            )
+            self.cache_seq_interface.info.rescatter_input_ids(new_tokens.flatten())
 
         self.iter_states["num_ctx_requests"] = num_ctx_requests
         self.iter_states["num_ctx_tokens"] = num_ctx_tokens
@@ -503,6 +659,7 @@ class ADEngine(ModelEngine):
         return self.cache_seq_interface.info.max_batch_size
 
     @torch.inference_mode()
+    @maybe_pad_for_cuda_graph
     def forward(
         self,
         scheduled_requests: ScheduledRequests,

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -110,10 +110,15 @@ class DemoEngine(ADEngine):
                     extra_args[k].append(v)
 
         sequence_info.reset()
+        page_assignments = self._assign_pages(total_lens)
+        cache_loc, pages_per_seq = sequence_info._get_cache_locations_and_pages_per_sequence(
+            page_assignments
+        )
         sequence_info.nest_sequences(
             input_ids=input_ids,
             input_pos=0,
-            page_assignments=self._assign_pages(total_lens),
+            cache_loc=cache_loc,
+            pages_per_seq=pages_per_seq,
             slot_idx=list(range(len(input_ids))),
             **extra_args,
         )
@@ -142,10 +147,15 @@ class DemoEngine(ADEngine):
             seq_lens_current = sequence_info.seq_len
             input_pos_next = [ip + sl for ip, sl in zip(input_pos_next, seq_lens_current)]
             total_lens_next = [ip + len(t_ids) for ip, t_ids in zip(input_pos_next, token_ids)]
+            page_assignments = self._assign_pages(total_lens_next)
+            cache_loc, pages_per_seq = sequence_info._get_cache_locations_and_pages_per_sequence(
+                page_assignments
+            )
             sequence_info.nest_sequences(
                 token_ids,
                 input_pos=input_pos_next,
-                page_assignments=self._assign_pages(total_lens_next),
+                cache_loc=cache_loc,
+                pages_per_seq=pages_per_seq,
             )
 
             # nest new tokens and run stop check

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -19,7 +19,7 @@ from ...distributed.common import is_initialized as is_distributed_initialized
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils._graph import add_graph_input
-from ...utils.node_utils import get_all_input_output_nodes, is_op
+from ...utils.node_utils import is_op
 from ..interface import (
     BaseTransform,
     SharedConfig,
@@ -27,44 +27,6 @@ from ..interface import (
     TransformInfo,
     TransformRegistry,
 )
-
-
-@TransformRegistry.register("update_in_out_nodes")
-class UpdateInOutNodes(BaseTransform):
-    """Modify the graph module by adding new input nodes.
-
-    The new input nodes correspond to the extra arguments needed for cached and flattened attention.
-
-    Args:
-        egm: The graph module to analyze and modify.
-        cm: Cached sequence interface containing extra argument information.
-    """
-
-    def _apply(
-        self,
-        gm: GraphModule,
-        cm: CachedSequenceInterface,
-        factory: ModelFactory,
-        shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
-        # loop through nodes to get input, output, and get_attr nodes
-        input_nodes, output_nodes = get_all_input_output_nodes(gm.graph)
-
-        # NOTE: for now, we wanna make sure we *only* return the final output and no hidden states.
-        # Later on, we can revisit how to support returning hidden states.
-        assert len(output_nodes) == 1, "Expected exactly one output node!"
-        assert len(output_nodes[0].all_input_nodes) == 1, (
-            "Expected to only return final tensor output!"
-        )
-
-        # Activate and add extra argument nodes
-        new_args = cm.info.switch_to_cached_attn_inputs()
-        for name in new_args:
-            input_nodes.append(add_graph_input(gm, name))
-
-        info = TransformInfo(skipped=False, num_matches=1, is_clean=False, has_valid_shapes=False)
-
-        return gm, info
 
 
 class InsertCachedAttentionConfig(TransformConfig):
@@ -91,26 +53,57 @@ class InsertCachedAttention(BaseTransform):
     def attn_descriptor(self) -> Type[AttentionDescriptor]:
         return AttentionRegistry.get(self.config.backend)
 
-    def _process_get_metadata(
-        self, gm: GraphModule, m_args: List[str], const_args: List[Constant]
+    def _add_or_retrieve_input(
+        self, gm: GraphModule, cm: CachedSequenceInterface, name: str
+    ) -> Node:
+        """Add or retrieve an input node from the graph."""
+        input_nodes = gm.graph.find_nodes(op="placeholder", target=name)
+        if len(input_nodes) == 0:
+            cm.info.activate_arg(name)
+            return add_graph_input(gm, name)
+        elif len(input_nodes) == 1:
+            return input_nodes[0]
+        else:
+            raise ValueError(f"Expected exactly one input node for {name=}, got {input_nodes=}")
+
+    def _process_metadata_std(self, gm: GraphModule, cm: CachedSequenceInterface) -> List[Node]:
+        """Process the standard metadata nodes."""
+        return [
+            self._add_or_retrieve_input(gm, cm, arg_name)
+            for arg_name in self.attn_descriptor.get_standard_metadata_args()
+        ]
+
+    def _process_metadata_extra(
+        self, gm: GraphModule, cm: CachedSequenceInterface, any_source_attn_node: Node
     ) -> List[Node]:
         """Process the get_metadata function into an op and return node references."""
-        # retrieve input nodes
-        input_nodes, _ = get_all_input_output_nodes(gm.graph)
-        input_nodes_mapping = {n.target: n for n in input_nodes}
+        # get the metadata op for extra metadata and number of return values
+        prep_meta_op, num_meta_out, const_args = (
+            self.attn_descriptor.get_prepare_extra_metadata_info(any_source_attn_node)
+        )
 
-        # filtered and sorted for SequenceInfo arguments + constants (input_ids, position_ids, etc.)
-        inputs_from_info = [input_nodes_mapping[k] for k in m_args]
+        # if there is no extra metadata op or no return values, we can return early
+        if prep_meta_op is None or num_meta_out == 0:
+            return []
 
-        # insert metadata computation and extract each argument as a node
-        get_metadata, num_metadata = self.attn_descriptor.get_prepare_metadata_op()
-        with gm.graph.inserting_before(input_nodes[-1].next):
-            ret_node = gm.graph.call_function(get_metadata, args=(*inputs_from_info, *const_args))
-            metadata_nodes = [
-                gm.graph.call_function(operator.getitem, args=(ret_node, idx))
-                for idx in range(num_metadata)
-            ]
-        return metadata_nodes
+        # check what inputs the extra metadata op expects
+        inputs_for_prep_meta = [
+            self._add_or_retrieve_input(gm, cm, arg.name)
+            for arg in prep_meta_op._schema.arguments
+            if arg.name in cm.info.available_args
+        ]
+        inputs_for_prep_meta.extend(const_args)
+
+        # add the computed extra metadata nodes to the graph and add to meta for cached attention op
+        meta_nodes_extra = []
+        node_last_input = gm.graph.find_nodes(op="placeholder", sort=True)[-1]
+        with gm.graph.inserting_before(node_last_input.next):
+            ret_node = gm.graph.call_function(prep_meta_op, args=tuple(inputs_for_prep_meta))
+            for idx in range(num_meta_out):
+                meta_extra_node = gm.graph.call_function(operator.getitem, args=(ret_node, idx))
+                meta_nodes_extra.append(meta_extra_node)
+
+        return meta_nodes_extra
 
     def _process_cache_node(self, gm: GraphModule, cache_name: str) -> Node:
         """Process the cache nodes by inserting a cached attention replacement op."""
@@ -121,7 +114,8 @@ class InsertCachedAttention(BaseTransform):
         gm: GraphModule,
         attn_node: Node,
         qkv_nodes: List[Node],
-        meta_nodes: List[Node],
+        meta_nodes_std: List[Node],
+        meta_nodes_extra: List[Node],
         cache_nodes: List[Node],
         buffer_nodes: List[Node],
         constants: List[Constant],
@@ -130,7 +124,14 @@ class InsertCachedAttention(BaseTransform):
         with gm.graph.inserting_before(attn_node):
             cached_attn_node = gm.graph.call_function(
                 self.attn_descriptor.get_cached_attention_op(),
-                args=(*qkv_nodes, *meta_nodes, *cache_nodes, *buffer_nodes, *constants),
+                args=(
+                    *qkv_nodes,
+                    *meta_nodes_std,
+                    *meta_nodes_extra,
+                    *cache_nodes,
+                    *buffer_nodes,
+                    *constants,
+                ),
             )
         attn_node.replace_all_uses_with(cached_attn_node)
         gm.graph.erase_node(attn_node)
@@ -165,10 +166,11 @@ class InsertCachedAttention(BaseTransform):
         if cm.info.is_paged:
             assert attn_descriptor.is_paged(), "Paged sequence info requires paged attention op."
 
+        # get standard metadata nodes for all source attention nodes
+        meta_nodes_std = self._process_metadata_std(gm, cm)
+
         # insert metadata computation and extract each argument as a node
-        metadata_nodes = self._process_get_metadata(
-            gm, cm.info.args_for_prepare_metadata, cm.info.const_args_for_prepare_metadata
-        )
+        meta_nodes_extra = self._process_metadata_extra(gm, cm, source_attn_nodes[0])
 
         buffer_in_lookup: Dict[str, Node] = {}
 
@@ -201,7 +203,14 @@ class InsertCachedAttention(BaseTransform):
 
             # insert cached attention replacement op
             self._insert_cached_attn_node(
-                gm, attn_node, qkv, metadata_nodes, cache_in_nodes, buffer_in_nodes, constants
+                gm,
+                attn_node,
+                qkv,
+                meta_nodes_std,
+                meta_nodes_extra,
+                cache_in_nodes,
+                buffer_in_nodes,
+                constants,
             )
             num_cached_attn_replacements += 1
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -87,8 +87,7 @@ class InsertCachedAttention(BaseTransform):
         node_last_input = gm.graph.find_nodes(op="placeholder", sort=True)[-1]
         with gm.graph.inserting_before(node_last_input.next):
             ret_node = gm.graph.call_function(
-                prep_meta_op,
-                args=tuple(*inputs_for_prep_meta, *const_args),
+                prep_meta_op, args=(*inputs_for_prep_meta, *const_args)
             )
             for idx in range(num_meta_out):
                 meta_extra_node = gm.graph.call_function(operator.getitem, args=(ret_node, idx))

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -6,7 +6,7 @@ from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import torch
 from torch._ops import OpOverload, OpOverloadPacket
-from torch.fx import Graph, GraphModule, Node
+from torch.fx import GraphModule, Node
 
 from .logger import ad_logger
 
@@ -346,12 +346,6 @@ def is_dist_op(node: Node) -> bool:
         torch.ops.auto_deploy.trtllm_dist_all_reduce,
     }
     return is_op(node, dist_ops)
-
-
-def get_all_input_output_nodes(graph: Graph) -> Tuple[List[Node], List[Node]]:
-    input_nodes: List[Node] = graph.find_nodes(op="placeholder")
-    output_nodes: List[Node] = graph.find_nodes(op="output")
-    return (input_nodes, output_nodes)
 
 
 def get_user_if_pattern_match(node, ops, numusers, user_idx: int = 0):

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -67,7 +67,7 @@ class SequenceEmbeddingInfo(SequenceInfo):
         self.hidden_size = hidden_size
         self.dtype = dtype
         self._args_device["input_ids"] = self._add_hidden_dim(self._args_device["input_ids"])
-        self._args_host["input_ids"] = self._args_device["input_ids"].cpu()
+        self._args_list["input_ids"] = self._args_device["input_ids"].cpu()
         self._initialized = True
         self.reset()
 

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -8,7 +8,6 @@ from _torch_test_utils import all_close, reset_parameters
 from torch.export import export
 from torch.fx import GraphModule
 
-from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.factory import (
     FullModelExportInfo,
@@ -43,47 +42,6 @@ class FakeFactory(ModelFactory):
 
     def get_export_infos(self, model: nn.Module) -> List[SubModuleExportInfo]:
         return [FullModelExportInfo()]
-
-
-class SequenceEmbeddingInfo(SequenceInfo):
-    """A sequence info object for testing that replaces the input_ids with an embedding tensor.
-
-    This is useful to run tests without the tokenizer in the loop.
-    """
-
-    def _add_hidden_dim(self, input_ids: Sequence[Sequence[Any]]) -> torch.Tensor:
-        return torch.rand(
-            *input_ids.shape,
-            self.hidden_size,
-            device=self.device,
-            dtype=self.dtype,
-        )
-
-    def __init__(self, *args, hidden_size: int, dtype: torch.dtype, **kwargs):
-        self._initialized = False
-        super().__init__(*args, **kwargs)
-
-        # overwrite input_ids with an embedding tensor and run reset again
-        self.hidden_size = hidden_size
-        self.dtype = dtype
-        self._args_device["input_ids"] = self._add_hidden_dim(self._args_device["input_ids"])
-        self._args_list["input_ids"] = self._args_device["input_ids"].cpu()
-        self._initialized = True
-        self.reset()
-
-    def nest_sequences(self, input_ids: Sequence[Sequence[Any]], *args, **kwargs) -> None:
-        # convert input_ids to an embedding tensor if needed
-        if not (isinstance(input_ids, torch.Tensor) and input_ids.ndim == 3) and self._initialized:
-            # first convert to a list of tensors
-            input_embeds = [
-                torch.tensor(ids, device=self.device, dtype=self.dtype) for ids in input_ids
-            ]
-            # then add the hidden dimension to every tensor
-            input_embeds = [self._add_hidden_dim(ids) for ids in input_embeds]
-        else:
-            input_embeds = input_ids
-
-        super().nest_sequences(input_embeds, *args, **kwargs)
 
 
 def count_parameters(model: torch.nn.Module):

--- a/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
@@ -40,6 +40,16 @@ class TorchAttentionReference:
             0, batch_size * seq_len, seq_len, device=q.device, dtype=torch.int32
         )
 
+        # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+        # For context phase (seq_len > 1): [batch_size, batch_size * seq_len, 0]
+        # For generate phase (seq_len == 1): [0, 0, batch_size]
+        if seq_len == 1:
+            batch_info = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
+        else:
+            batch_info = torch.tensor(
+                [batch_size, batch_size * seq_len, 0], device=q.device, dtype=torch.int32
+            )
+
         # Flatten inputs to [1, total_seq_len, ...] format
         q_flat = q.view(1, batch_size * seq_len, -1)
         k_flat = k.view(1, batch_size * seq_len, -1)
@@ -50,6 +60,7 @@ class TorchAttentionReference:
             q_flat,
             k_flat,
             v_flat,
+            batch_info,
             seq_len_tensor,
             input_positions,
             cache_loc,
@@ -70,14 +81,34 @@ class TorchAttentionReference:
 
     @staticmethod
     def flattened_mha_with_cache(
-        q, k, v, seq_len, input_positions, cache_loc, seq_start, k_cache, v_cache, scale=None
+        q,
+        k,
+        v,
+        batch_info,
+        seq_len,
+        input_positions,
+        cache_loc,
+        seq_start,
+        k_cache,
+        v_cache,
+        scale=None,
     ):
         """Reference implementation following triton flattened MHA pattern.
 
         This function directly calls the torch backend implementation via custom op registry.
         """
         return torch.ops.auto_deploy.torch_cached_attention_with_cache(
-            q, k, v, seq_len, input_positions, cache_loc, seq_start, k_cache, v_cache, scale
+            q,
+            k,
+            v,
+            batch_info,
+            seq_len,
+            input_positions,
+            cache_loc,
+            seq_start,
+            k_cache,
+            v_cache,
+            scale,
         )
 
     @staticmethod
@@ -113,11 +144,15 @@ class TorchAttentionReference:
         k_flat = k_new.view(1, batch_size, -1)
         v_flat = v_new.view(1, batch_size, -1)
 
+        # Create batch_info for decode phase: [num_prefill, num_prefill_tokens, num_decode]
+        batch_info = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
+
         # Call torch backend via custom op registry
         output_flat = torch.ops.auto_deploy.torch_cached_attention_with_cache(
             q_flat,
             k_flat,
             v_flat,
+            batch_info,
             seq_len,
             input_positions,
             cache_loc,
@@ -135,6 +170,7 @@ class TorchAttentionReference:
         q,
         k,
         v,
+        batch_info,
         seq_len,
         input_positions,
         cache_loc,
@@ -153,6 +189,7 @@ class TorchAttentionReference:
             q,
             k,
             v,
+            batch_info,
             seq_len,
             input_positions,
             cache_loc,

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -14,7 +14,9 @@ from build_and_run_ad import ExperimentConfig, main
             {
                 "transforms": {
                     "insert_cached_attention": {"backend": "flashinfer"},
-                    "compile_model": {"backend": "torch-opt"},
+                    # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/9878
+                    # "compile_model": {"backend": "torch-opt"},
+                    "compile_model": {"backend": "torch-cudagraph"},
                 },
             },
         ),

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
@@ -11,6 +11,7 @@ from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import (
     _args_kwargs_flatten_spec,
 )
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.shim.ad_executor import _round_up_to_closest
 
 
 class ModelWithMultipleInputs(torch.nn.Module):
@@ -44,7 +45,7 @@ class ModelWithMultipleInputs(torch.nn.Module):
     ],
 )
 def test_round_up_to_closest(lst, value, expected):
-    assert CapturedGraph.round_up_to_closest(lst, value) == expected
+    assert _round_up_to_closest(lst, value) == expected
 
 
 @pytest.mark.parametrize("num_inputs", [1, 2, 3])

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
@@ -150,7 +150,7 @@ def test_flat_gqa_op(
 
     # Use torch backend as clean reference
     ref_flat = TorchAttentionReference.flattened_mha_with_cache(
-        q, k, v, seq_len, input_positions, cache_loc, seq_start, k_cache, v_cache
+        q, k, v, batch_info, seq_len, input_positions, cache_loc, seq_start, k_cache, v_cache
     )
 
     assert torch.allclose(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
@@ -125,22 +125,25 @@ def test_flat_gqa_op(
     k = torch.randn(1, seq_len.sum(), n_kv_heads * D_HEAD, **dtype_kwargs)
     v = torch.randn(1, seq_len.sum(), n_kv_heads * D_HEAD, **dtype_kwargs)
 
+    # create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    num_prefill_tokens = seq_len[:num_context].sum()
+    batch_info = torch.tensor([num_context, num_prefill_tokens, num_generate], **int_kwargs)
+
     # run op
     output = torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         seq_len,
         input_positions,
         cache_loc,
-        seq_start,
+        seq_start,  # cu_seqlen
         # CACHES
         k_cache,
         v_cache,
-        # BUFFERS
-        # <none>
         # CONSTANTS
         scale=None,
     )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
@@ -57,9 +57,11 @@ def test_generate_only_with_slot_mapping_cuda(conv_env):
     )
 
     # Metadata (not used in generate-only op entry, but required by the interface)
-    seq_len = torch.ones(batch, device=device, dtype=torch.int32)
-    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+    cu_seqlen = torch.zeros(batch, device=device, dtype=torch.int32)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
+    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # For generate-only: num_decode = batch, num_prefill = 0
+    batch_info = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
     # Snapshot caches for reference before running op (op mutates caches)
     gathered_before = conv_state_cache.clone().index_select(0, slot_idx)
     x_ref = x.clone()
@@ -69,9 +71,9 @@ def test_generate_only_with_slot_mapping_cuda(conv_env):
         x,
         w,
         b,
-        # METADATA
-        seq_len,
-        seq_start,
+        # STANDARD METADATA
+        batch_info,
+        cu_seqlen,
         slot_idx,
         use_initial_states,
         # CACHES
@@ -173,25 +175,3 @@ def test_context_flattened_and_state_writeback_cuda(conv_env):
         )
 
     assert torch.allclose(y, y_ref.to(y.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"])
-
-
-def test_prepare_metadata_cuda(conv_env):
-    device = conv_env["device"]
-
-    b, s = 4, 6
-    # input_ids = torch.randint(0, 1000, (b, s), device=device)
-    position_ids = torch.arange(s, device=device).expand(b, -1)
-    seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
-    input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
-    cache_loc = torch.arange(b, device=device, dtype=torch.int32)
-    pages_per_seq = torch.ones(b, device=device, dtype=torch.int32)
-    slot_idx = torch.tensor([2, 0, 1, 3], device=device, dtype=torch.int32)
-    page_size = 128
-    chunk_size = 128
-    out = torch.ops.auto_deploy.cuda_causal_conv_prepare_metadata(
-        position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
-    )
-    assert len(out) == 4
-    seq_len_s, seq_start, slot_s, use_initial_states = out
-    assert seq_len_s.numel() == 2 and slot_s.numel() == 2
-    assert torch.all(seq_start == torch.tensor([0, 2], device=device, dtype=seq_start.dtype))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -89,16 +89,22 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         ),
         BATCH_SIZE * SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor(
+        [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
+    )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -219,16 +225,21 @@ def test_flashinfer_attention_op_decode(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # For decode phase: num_decode = BATCH_SIZE, num_prefill = 0
+    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -338,16 +349,22 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * PREFILL_SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor(
+        [BATCH_SIZE, BATCH_SIZE * PREFILL_SEQ_LEN, 0], dtype=torch.int32, device=device
+    )
     flashinfer_output_1 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_1,
         k_1,
         v_1,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -413,16 +430,20 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * 1,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output_3 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_3,
         k_3,
         v_3,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -522,16 +543,22 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         ),
         BATCH_SIZE * SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor(
+        [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
+    )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -669,16 +696,22 @@ def test_flashinfer_attention_with_fp8_cache(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor(
+        [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
+    )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -766,16 +799,20 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         BATCH_SIZE * SEQ_LEN,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor([BATCH_SIZE, SEQ_LEN, 0], dtype=torch.int32, device=device)
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
         paged_kv_last_page_len,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES
@@ -849,16 +886,20 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         BATCH_SIZE * 1,
     )
+    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output_gen = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_gen,
         k_gen,
         v_gen,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         qo_indptr2,
         paged_kv_indptr2,
         paged_kv_indices2,
         paged_kv_last_page_len2,
+        # EXTRA METADATA
         batch_indices,
         positions,
         # CACHES

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
@@ -55,19 +55,23 @@ def test_generate_only_with_slot_mapping(conv_env):
 
     # Metadata (not used in generate-only op entry, but required by the interface)
     seq_len = torch.ones(batch, device=device, dtype=torch.int32)
-    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+    cu_seqlen = torch.zeros(batch, device=device, dtype=torch.int32)
     # Snapshot caches for reference before running op (op mutates caches)
     gathered_before = conv_state_cache.clone().index_select(0, slot_idx)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
+    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # For generate-only: num_decode = batch, num_prefill = 0
+    batch_info = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
     # Run cached op
     y = torch.ops.auto_deploy.torch_cached_causal_conv1d(
         # INPUTS
         x,
         w,
         b,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         seq_len,
-        seq_start,
+        cu_seqlen,
         slot_idx,
         use_initial_states,
         # CACHES
@@ -118,16 +122,22 @@ def test_context_flattened_and_state_writeback(conv_env):
     )
 
     seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
-    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
+    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # For context/prefill phase: num_prefill = len(lens), num_decode = 0
+    num_seqs = len(lens)
+    num_prefill_tokens = sum(lens)
+    batch_info = torch.tensor([num_seqs, num_prefill_tokens, 0], device=device, dtype=torch.int32)
     y = torch.ops.auto_deploy.torch_cached_causal_conv1d(
         # INPUTS
         x,
         w,
         b,
-        # METADATA
+        # STANDARD METADATA
+        batch_info,
         seq_len,
-        seq_start,
+        cu_seqlen,
         slot_idx,
         use_initial_states,
         # CACHES
@@ -163,26 +173,3 @@ def test_context_flattened_and_state_writeback(conv_env):
         )
 
     assert torch.allclose(y, y_ref.to(y.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"])
-
-
-def test_prepare_metadata(conv_env):
-    device = conv_env["device"]
-
-    b, s = 4, 6
-    # input_ids = torch.randint(0, 1000, (b, s), device=device)
-    position_ids = torch.arange(s, device=device).expand(b, -1)
-    seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
-    input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
-    cache_loc = torch.arange(b, device=device, dtype=torch.int32)
-    pages_per_seq = torch.ones(b, device=device, dtype=torch.int32)
-    slot_idx = torch.tensor([2, 0, 1, 3], device=device, dtype=torch.int32)
-    page_size = 128
-    chunk_size = 128
-
-    out = torch.ops.auto_deploy.torch_causal_conv_prepare_metadata(
-        position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size, chunk_size
-    )
-    assert len(out) == 4
-    seq_len_s, seq_start, slot_s, use_initial_states = out
-    assert seq_len_s.numel() == 2 and slot_s.numel() == 2
-    assert torch.all(seq_start == torch.tensor([0, 2], device=device, dtype=seq_start.dtype))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
@@ -121,7 +121,7 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
     ssm_state_cache_triton = ssm_state_cache_torch.clone()
 
     seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
-    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
     use_initial_states = torch.tensor([0] * batch, device=device).to(torch.bool)
     cu_seqlens = torch.cat(
         [
@@ -134,7 +134,8 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         torch.arange(len(lens), device=device, dtype=torch.int32),
         seq_len,
     ).view(1, -1)
-    batch_info_tensor = torch.tensor([len(lens), sum(lens), 0], dtype=torch.int32)
+    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_tensor = torch.tensor([len(lens), sum(lens), 0], dtype=torch.int32, device=device)
     # Torch reference
     y_torch = torch.ops.auto_deploy.torch_cached_ssm(
         hidden_states,
@@ -144,11 +145,15 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         D,
         dt,
         dt_bias,
+        # STANDARD METADATA
+        batch_info_tensor,
         seq_len,
-        seq_start,
+        cu_seqlen,
         slot_idx,
         use_initial_states,
+        # CACHES
         ssm_state_cache_torch,
+        # CONSTANTS
         time_step_limit,
         chunk_size,
     )
@@ -162,15 +167,18 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         D,
         dt,
         dt_bias,
-        seq_len,
+        # STANDARD METADATA
+        batch_info_tensor,
+        cu_seqlens,
         slot_idx,
         use_initial_states,
-        cu_seqlens,
+        # EXTRA METADATA
         None,  # chunk indices
         None,  # chunk offsets
         seq_idx_prefill,
-        batch_info_tensor,
+        # CACHES
         ssm_state_cache_triton,
+        # CONSTANTS
         time_step_limit,
         chunk_size,
     )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_triton_utils.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_triton_utils.py
@@ -1,0 +1,162 @@
+"""Unit tests for triton utility custom ops."""
+
+import pytest
+import torch
+
+# Import to register the custom op
+from tensorrt_llm._torch.auto_deploy.custom_ops import triton_utils  # noqa: F401
+
+
+def _reference_gather_scatter(
+    ungathered_input: torch.Tensor,
+    gather_ids: torch.Tensor,
+    mask_indices: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Reference implementation using pure PyTorch."""
+    out_ref = out.clone()
+    gathered_values = ungathered_input[gather_ids]
+    out_ref[mask_indices] = gathered_values
+    return out_ref
+
+
+@pytest.mark.parametrize("n_elements", [1, 16, 128, 256, 1024, 4096])
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64, torch.float16, torch.float32])
+def test_fused_gather_scatter_basic(n_elements, dtype):
+    """Test basic gather-scatter functionality with various sizes and dtypes."""
+    device = "cuda"
+
+    # Create source tensor with unique values for easy verification
+    ungathered_input = torch.arange(n_elements * 2, device=device, dtype=dtype)
+
+    # Create gather indices (gather from various positions in ungathered_input)
+    gather_ids = torch.randint(0, n_elements * 2, (n_elements,), device=device, dtype=torch.int32)
+
+    # Create scatter indices (scatter to various positions in output)
+    mask_indices = torch.randperm(n_elements, device=device, dtype=torch.int32)
+
+    # Create output tensors
+    out = torch.zeros(n_elements, device=device, dtype=dtype)
+    out_ref = out.clone()
+
+    # Compute reference
+    out_ref = _reference_gather_scatter(ungathered_input, gather_ids, mask_indices, out_ref)
+
+    # Call the custom op
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input, gather_ids, mask_indices, out
+    )
+
+    # Verify
+    torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 32, 64])
+def test_fused_gather_scatter_for_input_ids(batch_size):
+    """Test the typical use case: rescattering input_ids for overlap scheduler."""
+    device = "cuda"
+
+    # Simulate ungathered input_ids from a sampler
+    vocab_size = 32000
+    ungathered_input_ids = torch.randint(
+        0, vocab_size, (batch_size,), device=device, dtype=torch.int32
+    )
+
+    # Gather indices specify which tokens to pick from ungathered_input_ids
+    gather_ids = torch.randperm(batch_size, device=device, dtype=torch.int32)
+
+    # Mask indices specify where to place them in the output
+    mask_indices = torch.arange(batch_size, device=device, dtype=torch.int32)
+
+    # Output buffer
+    input_ids_out = torch.zeros(batch_size, device=device, dtype=torch.int32)
+
+    # Reference implementation
+    ref_out = _reference_gather_scatter(
+        ungathered_input_ids, gather_ids, mask_indices, input_ids_out.clone()
+    )
+
+    # Custom op
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input_ids, gather_ids, mask_indices, input_ids_out
+    )
+
+    torch.testing.assert_close(input_ids_out, ref_out, rtol=0, atol=0)
+
+
+def test_fused_gather_scatter_identity():
+    """Test identity gather-scatter (indices are identity permutation)."""
+    device = "cuda"
+    n_elements = 64
+
+    ungathered_input = torch.arange(n_elements, device=device, dtype=torch.int32)
+    gather_ids = torch.arange(n_elements, device=device, dtype=torch.int32)
+    mask_indices = torch.arange(n_elements, device=device, dtype=torch.int32)
+
+    out = torch.zeros(n_elements, device=device, dtype=torch.int32)
+
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input, gather_ids, mask_indices, out
+    )
+
+    # Should be identity
+    torch.testing.assert_close(out, ungathered_input, rtol=0, atol=0)
+
+
+def test_fused_gather_scatter_reverse():
+    """Test reverse gather-scatter."""
+    device = "cuda"
+    n_elements = 64
+
+    ungathered_input = torch.arange(n_elements, device=device, dtype=torch.int32)
+    # Gather in order but scatter in reverse
+    gather_ids = torch.arange(n_elements, device=device, dtype=torch.int32)
+    mask_indices = torch.arange(n_elements - 1, -1, -1, device=device, dtype=torch.int32)
+
+    out = torch.zeros(n_elements, device=device, dtype=torch.int32)
+
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input, gather_ids, mask_indices, out
+    )
+
+    # Output should be reversed
+    expected = torch.arange(n_elements - 1, -1, -1, device=device, dtype=torch.int32)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_fused_gather_scatter_duplicate_gather():
+    """Test that gathering same index multiple times works correctly."""
+    device = "cuda"
+    n_elements = 16
+
+    ungathered_input = torch.arange(100, 100 + n_elements, device=device, dtype=torch.int32)
+    # Gather the same index (0) for all positions
+    gather_ids = torch.zeros(n_elements, device=device, dtype=torch.int32)
+    mask_indices = torch.arange(n_elements, device=device, dtype=torch.int32)
+
+    out = torch.zeros(n_elements, device=device, dtype=torch.int32)
+
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input, gather_ids, mask_indices, out
+    )
+
+    # All values should be the first element of ungathered_input (100)
+    expected = torch.full((n_elements,), 100, device=device, dtype=torch.int32)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_fused_gather_scatter_single_element():
+    """Test with a single element."""
+    device = "cuda"
+
+    ungathered_input = torch.tensor([42], device=device, dtype=torch.int32)
+    gather_ids = torch.tensor([0], device=device, dtype=torch.int32)
+    mask_indices = torch.tensor([0], device=device, dtype=torch.int32)
+
+    out = torch.zeros(1, device=device, dtype=torch.int32)
+
+    torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
+        ungathered_input, gather_ids, mask_indices, out
+    )
+
+    torch.testing.assert_close(out, ungathered_input, rtol=0, atol=0)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -47,7 +47,9 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
                 "transforms": {
                     "resize_kv_cache": {"free_mem_ratio": 0.0001},
                     "insert_cached_attention": {"backend": "flashinfer"},
-                    "compile_model": {"backend": "torch-opt"},
+                    # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/9878
+                    # "compile_model": {"backend": "torch-opt"},
+                    "compile_model": {"backend": "torch-cudagraph"},
                 },
             },
         ),

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -193,6 +193,8 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
             {
                 "transforms": {
                     "multi_stream_moe": {"stage": "compile", "enabled": True},
+                    # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/9878
+                    "compile_model": {"backend": "torch-cudagraph"},
                 },
             },
         ),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CUDA graph padding support with automatic batch size computation and request padding for improved kernel execution efficiency.
  * Introduced standardized metadata handling across attention and SSM operations for simplified and more flexible model compilation.

* **Improvements**
  * Enhanced memory management with unified input buffer consolidation for more efficient device transfers.
  * Optimized CUDA graph batch size configuration with heuristic-based defaults and explicit control.
  * Simplified compiler backend architecture by removing per-instance argument storage and delegating to compile-time callbacks.

* **Refactor**
  * Restructured metadata preparation from dedicated operations to standard argument passing across custom ops.
  * Consolidated buffer handling in attention operations for cleaner memory management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

* revisits metadata approach in AutoDeploy and removes many small kernels with low GPU utilization
* updates cudagraph padding with valid dummy request to ensure better tracking of padding
* improves TPOT for latency scenarios due to reduced GPU idle time for small kernels

### Perf numbers for nano v3:

#### ISL/OSL 1000/1000 at concurrency 1:

main (3156f2e852)
```
Inter Token Latency: 3.52ms
Output Token Throughput Per User (tokens/sec/user): 285.03
Output Token Throughput (tokens/sec) 277.81
```

vs this branch
```
Inter Token Latency: 3.41
Output Token Throughput Per User (tokens/sec/user): 294.82
Output Token Throughput (tokens/sec): 287.71
```

#### ISL/OSL 1000/1000 at concurrency 384:
main (3156f2e852)
```
Inter Token Latency: 33.80ms
Output Token Throughput Per User (tokens/sec/user): 29.67
Output Token Throughput (tokens/sec) 10823.09
```

vs this branch
```
Inter Token Latency: 33.41ms
Output Token Throughput Per User (tokens/sec/user): 30.00
Output Token Throughput (tokens/sec) 10715.14
```

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
