### PR TITLE
[None][refactor] Refactor logits selection in TorchSampler

### DIFF
--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -435,7 +435,6 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
         class ContextRequestMock:
             def __init__(self, is_last_context_chunk: bool, return_context_logits: bool):
-                self.is_context_init_state = True
                 self.is_last_context_chunk = is_last_context_chunk
                 self.py_draft_tokens = torch.tensor([], dtype=torch.int32, device=device)
                 self.sampling_config = SamplingConfig(beam_width=1)
@@ -447,7 +446,6 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
         class GenRequestMock:
             def __init__(self, draft_len: int):
-                self.is_context_init_state = False
                 self.py_draft_tokens = torch.empty(draft_len, dtype=torch.int32, device=device)
                 self.sampling_config = SamplingConfig(beam_width=1)
 
@@ -468,6 +466,13 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                             LlmRequest,
                             ContextRequestMock(
                                 is_last_context_chunk=True, return_context_logits=False
+                            ),
+                        ),
+                        # This request is expected to be skipped
+                        cast(
+                            LlmRequest,
+                            ContextRequestMock(
+                                is_last_context_chunk=False, return_context_logits=False
                             ),
                         ),
                         cast(
@@ -494,11 +499,8 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                     else []
                 )
 
-            def all_requests(self) -> list[LlmRequest]:
-                return self.context_requests + self.generation_requests
-
         expected_num_requests = with_ctx * 3 + with_gen * 2
-        expected_req_num_beams = torch.tensor([1] * expected_num_requests, dtype=torch.int32)
+        expected_num_beams = torch.tensor([1] * expected_num_requests, dtype=torch.int32)
 
         num_context_logits_prefix_sum = [
             0,
@@ -506,18 +508,22 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 [
                     100 + 1,  # context req. 1 (assume context len. 100)
                     (100 + 1) + (0 + 1),  # context req. 2 (not returning context)
-                    (100 + 1) + (0 + 1) + (50 + 1),  # context req. 3 (assume context len. 50)
+                    (100 + 1) + (0 + 1) + (0 + 1),  # context req. 3 (not returning context)
+                    (100 + 1)
+                    + (0 + 1)
+                    + (0 + 1)
+                    + (50 + 1),  # context req. 4 (assume context len. 50)
                 ]
                 if with_ctx
                 else []
             ),
         ]
-        expected_req_num_generation_steps = [
+        expected_num_sampling_logits = [
             *(
                 [
                     1,  # context req. 1
                     1,  # context req. 2
-                    1,  # context req. 3
+                    1,  # context req. 4
                 ]
                 if with_ctx
                 else []
@@ -531,22 +537,22 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 else []
             ),
         ]
-        expected_req_num_generation_steps_tensor = torch.tensor(
-            expected_req_num_generation_steps, dtype=torch.int32
+        expected_num_sampling_logits_tensor = torch.tensor(
+            expected_num_sampling_logits, dtype=torch.int32
         )
 
-        expected_req_offsets = torch.cumsum(expected_req_num_generation_steps_tensor, dim=0).roll(1)
-        expected_req_offsets[0] = 0
+        expected_logits_offsets = torch.cumsum(expected_num_sampling_logits_tensor, dim=0).roll(1)
+        expected_logits_offsets[0] = 0
 
         # num_logits_to_keep = cast(int, req_num_generation_steps_tensor.sum().item())
-        generation_requests_total_steps = (draft_len_req1 + 1) + (
+        generation_requests_total_logits = (draft_len_req1 + 1) + (
             draft_len_req2 + 1
         )  # cf. req_num_generation_steps
 
         vocab_size = 12
 
-        num_total_steps = num_context_logits_prefix_sum[-1] + generation_requests_total_steps
-        all_logits = torch.empty((num_total_steps, vocab_size))
+        num_total_logits = num_context_logits_prefix_sum[-1] + generation_requests_total_logits
+        all_logits = torch.empty((num_total_logits, vocab_size))
 
         for i in range(all_logits.size(0)):
             all_logits[i, :] = torch.arange(i, i + vocab_size)
@@ -558,7 +564,8 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
             expected_logit_indices += [
                 100,  # gen logits from context req. 1
                 101,  # gen logits from context req. 2
-                152,  # gen logits from context req. 3
+                # 102,  # skipped gen logits from context req. 3
+                153,  # gen logits from context req. 4
             ]
         if with_gen:
             gen_logit_offset = num_context_logits_prefix_sum[-1]
@@ -568,7 +575,7 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 ),  # gen logits from gen. req. 1
                 *range(
                     gen_logit_offset + draft_len_req1 + 1,
-                    gen_logit_offset + generation_requests_total_steps,
+                    gen_logit_offset + generation_requests_total_logits,
                 ),  # gen logits from gen. req. 2
             ]
 
@@ -576,10 +583,10 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
         @dataclass
         class UutResult:
-            req_num_generated_tokens: torch.Tensor
-            req_num_beams: torch.Tensor
-            req_num_steps: torch.Tensor
-            req_offsets: torch.Tensor
+            selected_requests: list[LlmRequest]
+            logits_offsets: torch.Tensor
+            num_sampling_logits: torch.Tensor
+            num_beams: torch.Tensor
             selected_logits: torch.Tensor
 
         @dataclass
@@ -590,6 +597,7 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
 
         def _uut(res=res):
             (
+                selected_requests,
                 sampling_requests_metadata,
                 selected_logits,
             ) = TorchSampler._select_generated_logits(
@@ -598,10 +606,10 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
                 num_context_logits_prefix_sum=num_context_logits_prefix_sum,
             )
             res.result = UutResult(
-                req_num_generated_tokens=sampling_requests_metadata.req_num_generated_tokens,
-                req_num_beams=sampling_requests_metadata.req_num_beams,
-                req_num_steps=sampling_requests_metadata.req_num_steps,
-                req_offsets=sampling_requests_metadata.req_offsets,
+                selected_requests=selected_requests,
+                logits_offsets=sampling_requests_metadata.logits_offsets,
+                num_sampling_logits=sampling_requests_metadata.num_sampling_logits,
+                num_beams=sampling_requests_metadata.num_beams,
                 selected_logits=selected_logits,
             )
 
@@ -610,14 +618,12 @@ def test_select_generated_logits(draft_len: int, with_ctx: bool, with_gen: bool)
         # Check results
         assert res.result is not None
 
+        assert len(res.result.selected_requests) == expected_num_requests
+        torch.testing.assert_close(res.result.logits_offsets.to("cpu"), expected_logits_offsets)
         torch.testing.assert_close(
-            res.result.req_num_generated_tokens.to("cpu"), expected_req_num_generation_steps_tensor
+            res.result.num_sampling_logits.to("cpu"), expected_num_sampling_logits_tensor
         )
-        torch.testing.assert_close(res.result.req_num_beams.to("cpu"), expected_req_num_beams)
-        torch.testing.assert_close(
-            res.result.req_num_steps.to("cpu"), expected_req_num_generation_steps_tensor
-        )
-        torch.testing.assert_close(res.result.req_offsets.to("cpu"), expected_req_offsets)
+        torch.testing.assert_close(res.result.num_beams.to("cpu"), expected_num_beams)
         torch.testing.assert_close(res.result.selected_logits.to("cpu"), expected_logits)
 
     _run_test_with_warmup(_test_runner, max_sync_s=0.3)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
