### PR TITLE
[https://nvbugs/5726962][feat] Apply fusion for W4AFP8_AWQ MoE

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -813,13 +813,13 @@ private:
     bool mayHaveFinalizeFused() const
     {
         return moe_gemm_runner_.supportsTmaWarpSpecialized() && moe_gemm_runner_.getSM() >= 90 && use_fused_finalize_
-            && !use_w4_groupwise;
+            && !use_wfp4a16;
     }
 
     static bool mayHaveFinalizeFused(int sm)
     {
         using RunnerType = decltype(moe_gemm_runner_);
-        return RunnerType::supportsTmaWarpSpecialized(sm) && sm >= 90 && !use_w4_groupwise;
+        return RunnerType::supportsTmaWarpSpecialized(sm) && sm >= 90 && !use_wfp4a16;
     }
 
     // TODO: This should eventually take the quant params to give more flexibility

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/launchers/moe_gemm_tma_ws_mixed_input_launcher.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/launchers/moe_gemm_tma_ws_mixed_input_launcher.h
@@ -28,8 +28,9 @@ namespace cutlass_kernels_oss
 {
 using tensorrt_llm::kernels::cutlass_kernels::GroupedGemmInput;
 using tensorrt_llm::kernels::cutlass_kernels::TmaWarpSpecializedGroupedGemmInput;
-template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, typename CTAShape,
-    typename ClusterShape, typename MainloopScheduleType, typename EpilogueScheduleType,
+using EpilogueFusion = TmaWarpSpecializedGroupedGemmInput::EpilogueFusion;
+template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, EpilogueFusion FUSION,
+    typename CTAShape, typename ClusterShape, typename MainloopScheduleType, typename EpilogueScheduleType,
     cutlass::WeightOnlyQuantOp QuantOp>
 void sm90_generic_mixed_moe_gemm_kernelLauncher(
     tensorrt_llm::kernels::cutlass_kernels::GroupedGemmInput<T, WeightType, GemmOutputType, GemmOutputType> inputs,

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -794,18 +794,51 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
             // EpilogueTag is ignored
             if (inputs.k % 512 == 0)
             {
-                cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                    cutlass_extensions::EpilogueOpDefault, 4>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault,
+                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 4>(
+                        inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
+                else
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
+                        4>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
             }
             else if (inputs.k % 256 == 0)
             {
-                cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                    cutlass_extensions::EpilogueOpDefault, 2>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault,
+                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 2>(
+                        inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
+                else
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
+                        2>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
             }
             else if (inputs.k % 128 == 0)
             {
-                cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                    cutlass_extensions::EpilogueOpDefault, 1>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault,
+                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 1>(
+                        inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
+                else
+                {
+                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
+                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
+                        1>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                }
             }
             else
             {
@@ -820,7 +853,8 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
                 inputs.gemm_config.is_tma_warp_specialized, "wfp4a16 is only supported for TMA warp specialization");
             // EpilogueTag is ignored
             cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                cutlass_extensions::EpilogueOpDefault, 1>(inputs, hopper_inputs, multi_processor_count_, nullptr);
+                cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE, 1>(
+                inputs, hopper_inputs, multi_processor_count_, nullptr);
             return;
         }
 #endif

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch.h
@@ -792,58 +792,37 @@ void MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>::dispatchToArch(
             TLLM_CHECK_WITH_INFO(
                 inputs.gemm_config.is_tma_warp_specialized, "w4afp8 is only supported for TMA warp specialization");
             // EpilogueTag is ignored
+#define SM90_DISPATCH_MOE_MIXED_GEMM_TO_CUTLASS_SELECT_FINALIZE(SCALE_FACTOR)                                          \
+    if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)                          \
+    {                                                                                                                  \
+        cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,               \
+            cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE,       \
+            SCALE_FACTOR>(inputs, hopper_inputs, multi_processor_count_, nullptr);                                     \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,               \
+            cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,           \
+            SCALE_FACTOR>(inputs, hopper_inputs, multi_processor_count_, nullptr);                                     \
+    }
+
             if (inputs.k % 512 == 0)
             {
-                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault,
-                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 4>(
-                        inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
-                else
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
-                        4>(inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
+                SM90_DISPATCH_MOE_MIXED_GEMM_TO_CUTLASS_SELECT_FINALIZE(4)
             }
             else if (inputs.k % 256 == 0)
             {
-                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault,
-                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 2>(
-                        inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
-                else
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
-                        2>(inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
+                SM90_DISPATCH_MOE_MIXED_GEMM_TO_CUTLASS_SELECT_FINALIZE(2)
             }
             else if (inputs.k % 128 == 0)
             {
-                if (hopper_inputs.fusion == TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE)
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault,
-                        TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE, 1>(
-                        inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
-                else
-                {
-                    cutlass_kernels_oss::sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass<T, WeightType, ScaleBiasType,
-                        cutlass_extensions::EpilogueOpDefault, TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE,
-                        1>(inputs, hopper_inputs, multi_processor_count_, nullptr);
-                }
+                SM90_DISPATCH_MOE_MIXED_GEMM_TO_CUTLASS_SELECT_FINALIZE(1)
             }
             else
             {
                 TLLM_THROW("Invalid GEMM K size %d", (int) inputs.k);
             }
+#undef SM90_DISPATCH_MOE_MIXED_GEMM_TO_CUTLASS_SELECT_FINALIZE
             return;
         }
 

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws_mixed_dtype.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws_mixed_dtype.h
@@ -37,6 +37,7 @@
 #include "cutlass/tensor_ref.h"
 
 #include "cutlass_extensions/compute_occupancy.h"
+#include "cutlass_extensions/detail/collective/mixed_input_utils.hpp"
 #include "cutlass_extensions/epilogue_helpers.h"
 #include "cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h"
 #include "cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h"
@@ -67,11 +68,12 @@ using tensorrt_llm::kernels::cutlass_kernels::GroupedGemmInput;
 using tensorrt_llm::kernels::cutlass_kernels::TmaWarpSpecializedGroupedGemmInput;
 namespace tk = tensorrt_llm::common;
 namespace tkc = tensorrt_llm::cutlass_extensions;
+using EpilogueFusion = TmaWarpSpecializedGroupedGemmInput::EpilogueFusion;
 
 using namespace cute;
 
-template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, typename CTAShape,
-    typename ClusterShape>
+template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, EpilogueFusion FUSION,
+    typename CTAShape, typename ClusterShape>
 void sm90_dispatch_mainloop_schedules(GroupedGemmInput<T, WeightType, GemmOutputType, GemmOutputType> inputs,
     TmaWarpSpecializedGroupedGemmInput hopper_inputs, int sm_count_, size_t* workspace_size)
 {
@@ -88,7 +90,7 @@ void sm90_dispatch_mainloop_schedules(GroupedGemmInput<T, WeightType, GemmOutput
         {
             if constexpr ((get<0>(CTAShape{}) == 128) && get<1>(CTAShape{}) == 128)
             {
-                sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, CTAShape,
+                sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
                     ClusterShape, cutlass::gemm::KernelTmaWarpSpecializedPingpong,
                     cutlass::epilogue::TmaWarpSpecializedCooperative,
                     cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
@@ -96,7 +98,7 @@ void sm90_dispatch_mainloop_schedules(GroupedGemmInput<T, WeightType, GemmOutput
             }
             else
             {
-                sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, CTAShape,
+                sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
                     ClusterShape, cutlass::gemm::KernelTmaWarpSpecializedCooperative,
                     cutlass::epilogue::TmaWarpSpecializedCooperative,
                     cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
@@ -106,9 +108,10 @@ void sm90_dispatch_mainloop_schedules(GroupedGemmInput<T, WeightType, GemmOutput
 
         break;
     case tkc::MainloopScheduleType::PINGPONG:
-        sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, CTAShape, ClusterShape,
-            cutlass::gemm::KernelTmaWarpSpecializedPingpong, cutlass::epilogue::TmaWarpSpecializedCooperative,
-            cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
+            ClusterShape, cutlass::gemm::KernelTmaWarpSpecializedPingpong,
+            cutlass::epilogue::TmaWarpSpecializedCooperative, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
+            inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     default:
         TLLM_THROW(
@@ -122,7 +125,8 @@ void sm90_dispatch_mainloop_schedules(GroupedGemmInput<T, WeightType, GemmOutput
 #endif
 }
 
-template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, typename CTAShape>
+template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, EpilogueFusion FUSION,
+    typename CTAShape>
 void sm90_dispatch_moe_mixed_dtype_gemm_config(GroupedGemmInput<T, WeightType, GemmOutputType, GemmOutputType> inputs,
     TmaWarpSpecializedGroupedGemmInput hopper_inputs, int sm_count_, size_t* workspace_size)
 {
@@ -130,26 +134,27 @@ void sm90_dispatch_moe_mixed_dtype_gemm_config(GroupedGemmInput<T, WeightType, G
     switch (inputs.gemm_config.cluster_shape)
     {
     case tkc::ClusterShape::ClusterShape_1x1x1:
-        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, CTAShape, Shape<_1, _1, _1>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
+            Shape<_1, _1, _1>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::ClusterShape::ClusterShape_2x1x1:
-        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, CTAShape, Shape<_2, _1, _1>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
+            Shape<_2, _1, _1>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::ClusterShape::ClusterShape_1x2x1:
-        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, CTAShape, Shape<_1, _2, _1>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
+            Shape<_1, _2, _1>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::ClusterShape::ClusterShape_2x2x1:
-        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, CTAShape, Shape<_2, _2, _1>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_mainloop_schedules<T, WeightType, GemmOutputType, EpilogueTag, FUSION, CTAShape,
+            Shape<_2, _2, _1>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     default: TLLM_THROW("[Mixed dtype MoE GEMM][dispatch_CGA_config] Config is invalid for mixed type GEMM."); break;
     }
 }
 
-template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, int PackedScalesNum>
+template <typename T, typename WeightType, typename GemmOutputType, typename EpilogueTag, EpilogueFusion FUSION,
+    int PackedScalesNum>
 void sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass(
     GroupedGemmInput<T, WeightType, GemmOutputType, GemmOutputType> inputs,
     TmaWarpSpecializedGroupedGemmInput hopper_inputs, int sm_count_, size_t* workspace_size)
@@ -168,49 +173,49 @@ void sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass(
     switch (inputs.gemm_config.tile_config_sm90)
     {
     case tkc::CutlassTileConfigSM90::CtaShape64x16x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_64, _16, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_64, _16, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape64x32x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_64, _32, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_64, _32, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape64x64x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_64, _64, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_64, _64, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape64x128x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag,
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
             Shape<_64, _Ntile, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     // case tkc::CutlassTileConfigSM90::CtaShape64x256x128B:
     //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_64, _256,
     //     _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
     case tkc::CutlassTileConfigSM90::CtaShape128x16x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_128, _16, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_128, _16, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape128x32x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_128, _32, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_128, _32, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape128x64x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_128, _64, _Ktile>>(
-            inputs, hopper_inputs, sm_count_, workspace_size);
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
+            Shape<_128, _64, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     case tkc::CutlassTileConfigSM90::CtaShape128x128x128B:
-        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag,
+        sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION,
             Shape<_128, _128, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size);
         break;
     // case tkc::CutlassTileConfigSM90::CtaShape128x256x128B:
-    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_128, _256,
-    //     _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
+    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION, Shape<_128,
+    //     _256, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
     // case tkc::CutlassTileConfigSM90::CtaShape256x128x128B:
-    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_128, _256,
-    //     _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
+    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION, Shape<_128,
+    //     _256, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
     // case tkc::CutlassTileConfigSM90::CtaShape256x256x128B:
-    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, Shape<_256, _256,
-    //     _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
+    //     sm90_dispatch_moe_mixed_dtype_gemm_config<T, WeightType, GemmOutputType, EpilogueTag, FUSION, Shape<_256,
+    //     _256, _Ktile>>(inputs, hopper_inputs, sm_count_, workspace_size); break;
     case tkc::CutlassTileConfigSM90::Undefined:
         TLLM_THROW("[Mixed dtype MoE GEMM][sm90_dispatch_moe_mixed_dtype_gemm_to_cutlass] gemm config undefined.");
         break;
@@ -236,12 +241,15 @@ size_t calcMaxWorkspaceSizeTmaWarpSpecializedMixedInput(int num_experts, int sm_
     using _Ktile = Int<Ktile>;
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
-    GroupedGemmInput<T, WeightType, OutputType, OutputType> inputs{};
+    constexpr bool use_wfp4a16 = std::is_same_v<WeightType, cutlass::float_e2m1_t>;
+    constexpr int group_size = use_wfp4a16 ? cutlass::gemm::collective::detail::mxfp4_group_size
+                                           : cutlass::gemm::collective::detail::int4_group_size;
+    GroupedGemmInput<T, WeightType, OutputType, OutputType> inputs{.groupwise_quant_group_size = group_size};
     inputs.num_experts = num_experts;
     sm90_generic_mixed_moe_gemm_kernelLauncher<T, WeightType, OutputType,
-        tensorrt_llm::cutlass_extensions::EpilogueOpDefault, Shape<_128, _64, _Ktile>, Shape<_1, _1, _1>,
-        cutlass::gemm::KernelTmaWarpSpecializedCooperative, cutlass::epilogue::TmaWarpSpecializedCooperative,
-        cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
+        tensorrt_llm::cutlass_extensions::EpilogueOpDefault, EpilogueFusion::NONE, Shape<_128, _64, _Ktile>,
+        Shape<_1, _1, _1>, cutlass::gemm::KernelTmaWarpSpecializedCooperative,
+        cutlass::epilogue::TmaWarpSpecializedCooperative, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
         inputs, TmaWarpSpecializedGroupedGemmInput{}, sm_count_, &count);
 #endif
     return count;

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
@@ -2095,7 +2095,7 @@ __global__ void doActivationKernel(T* output, GemmOutputType const* gemm_result,
 
     // 2D grid: blockIdx.x for tokens in groups of kProcessRows, blockIdx.y for columns
     int64_t const row_offset = blockIdx.x * kProcessRows;
-    int64_t const col_offset = blockIdx.y * blockDim.x + threadIdx.x;
+    int64_t const col_offset = blockIdx.y * blockDim.y + threadIdx.y;
 
     assert(inter_size % ACTIVATION_ELEM_PER_THREAD == 0);
     int64_t const num_elems_in_col = inter_size / ACTIVATION_ELEM_PER_THREAD;
@@ -2439,7 +2439,7 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
 
         cudaLaunchConfig_t config;
         config.gridDim = dim3(grid_x, grid_y, 1);
-        config.blockDim = threads;
+        config.blockDim = dim3(1, threads, 1);
         config.dynamicSmemBytes = 0;
         config.stream = stream;
         cudaLaunchAttribute attrs[1];

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/python/generate_kernels.py
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/python/generate_kernels.py
@@ -41,9 +41,9 @@ EpiTag = {
 
 EpiFusion = {
     TrtLlm_EpilogueFusion.epilogue_fusion_none:
-    "tensorrt_llm::TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE",
+    "tensorrt_llm::kernels::cutlass_kernels::TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::NONE",
     TrtLlm_EpilogueFusion.epilogue_fusion_finalize:
-    "tensorrt_llm::TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE",
+    "tensorrt_llm::kernels::cutlass_kernels::TmaWarpSpecializedGroupedGemmInput::EpilogueFusion::FINALIZE",
 }
 
 EpiFusionSuffixes = {
@@ -227,9 +227,11 @@ const {act_tag}*, const {weight_tag}*, const {scale_zero_tag}*, const {scale_zer
                 or operation.weight_type != e2m1):
             # Mixed MoE GEMM
             weight_tag = CudaTypeName[operation.weight_type]
+            assert operation.epi_fusion is not None
+            epi_fusion = EpiFusion[operation.epi_fusion]
             instantiation = f"""
 template void sm90_generic_mixed_moe_gemm_kernelLauncher<{act_tag}, {weight_tag}, {out_tag},
-{epi_tag}, {cute_cta_shape}, {cute_cga_shape}, {kernel_sched}, {epi_sched}, {quant_op}> (
+{epi_tag}, {epi_fusion}, {cute_cta_shape}, {cute_cga_shape}, {kernel_sched}, {epi_sched}, {quant_op}> (
 GroupedGemmInput<{act_tag}, {weight_tag}, {out_tag}, {out_tag}>inputs, TmaWarpSpecializedGroupedGemmInput hopper_inputs, int sm_count_, size_t* workspace_size);
 """
         else:
@@ -588,6 +590,11 @@ def generate_sm90_mixed_type_grouped_gemm_operations(is_arch_enabled):
 
     epi_tags = [TrtLlm_EpilogueTag.epilogue_op_default]
 
+    epi_fusions = [
+        TrtLlm_EpilogueFusion.epilogue_fusion_none,
+        TrtLlm_EpilogueFusion.epilogue_fusion_finalize
+    ]
+
     M_TILES = [64, 128]  # Currently M tile must be 128 for Grouped GEMM
     N_TILES = [16, 32, 64, 128]
     K_TILES = [128, 256, 512]
@@ -605,13 +612,13 @@ def generate_sm90_mixed_type_grouped_gemm_operations(is_arch_enabled):
     cga_shapes = list(product([1, 2], [1, 2], [1]))
 
     partial_args_int4 = product(supported_dtypes_int4, quant_ops, epi_tags,
-                                cta_shapes_mnk_int4, cga_shapes)
+                                epi_fusions, cta_shapes_mnk_int4, cga_shapes)
     partial_args_fp4 = product(supported_dtypes_fp4, quant_ops, epi_tags,
-                               cta_shapes_mnk_fp4, cga_shapes)
+                               epi_fusions, cta_shapes_mnk_fp4, cga_shapes)
     partial_args = chain(partial_args_int4, partial_args_fp4)
 
     operations = list()
-    for dtype_combo, quant_op, epi_tag, cta_shape_mnk, cga_shape in partial_args:
+    for dtype_combo, quant_op, epi_tag, epi_fusion, cta_shape_mnk, cga_shape in partial_args:
         use_coop = cta_shape_mnk[0] >= 128
         mainloop_schedules = [
             KernelScheduleType.TmaWarpSpecializedCooperative,
@@ -624,7 +631,7 @@ def generate_sm90_mixed_type_grouped_gemm_operations(is_arch_enabled):
                     == KernelScheduleType.TmaWarpSpecializedCooperative):
                 continue
             moe_gemm_operation = TrtLlm_GemmLauncher(GemmKind.Grouped, arch, *dtype_combo, quant_op, epi_tag, cta_shape_mnk, \
-                                                    warp_shape, stages, cga_shape, mainloop_schedule, epi_schedule)
+                                                    warp_shape, stages, cga_shape, mainloop_schedule, epi_schedule, epi_fusion)
             operations.append(moe_gemm_operation)
     return operations
 

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -1124,6 +1124,9 @@ private:
                 auto& fc1_alpha = quant_scales.value()[6];
                 auto& fc2_alpha = quant_scales.value()[7];
                 int group_size = TmaWarpSpecializedGroupedGemmInput::INT4GroupwiseParams::int4_group_size;
+                // Whether it is per-expert activation scale
+                bool fc1_use_per_expert_act_scale = fc1_act_scales.numel() > hidden_size;
+                bool fc2_use_per_expert_act_scale = fc2_act_scales.numel() > inter_size;
                 return kernels::QuantParams::GroupWise(group_size,
                     static_cast<void const*>(fc1_weight_scales.data_ptr()),
                     static_cast<void const*>(fc2_weight_scales.data_ptr()),
@@ -1132,7 +1135,8 @@ private:
                     static_cast<void const*>(fc1_weight_zeros.numel() > 0 ? fc1_weight_zeros.data_ptr() : nullptr),
                     static_cast<void const*>(fc2_weight_zeros.numel() > 0 ? fc2_weight_zeros.data_ptr() : nullptr),
                     static_cast<float const*>(fc1_alpha.numel() > 0 ? fc1_alpha.data_ptr() : nullptr),
-                    static_cast<float const*>(fc2_alpha.numel() > 0 ? fc2_alpha.data_ptr() : nullptr));
+                    static_cast<float const*>(fc2_alpha.numel() > 0 ? fc2_alpha.data_ptr() : nullptr),
+                    fc1_use_per_expert_act_scale, fc2_use_per_expert_act_scale);
             }
             else
             {

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -168,7 +168,10 @@ protected:
     constexpr static bool ANY_FP4 = WEIGHT_FP4 || ACT_FP4;
     constexpr static bool ANY_FPX = ANY_FP4 || FP8;
 
-    constexpr static bool INT_QUANT = !std::is_same_v<GemmDataType, WeightType> && std::is_integral_v<WeightType>;
+    constexpr static bool W4A8_AWQ
+        = std::is_same_v<GemmDataType, SafeFP8> && std::is_same_v<WeightType, cutlass::uint4b_t>;
+    constexpr static bool INT_QUANT
+        = !std::is_same_v<GemmDataType, WeightType> && std::is_integral_v<WeightType> && !W4A8_AWQ;
     constexpr static int64_t WEIGHT_ELEM_PER_BYTE = (INT4 || WEIGHT_FP4) ? 2 : 1;
     using InputType = std::conditional_t<NVFP4 || MXFP8_MXFP4, OutputType, GemmDataType>;
     using WeightStorage = std::conditional_t<WEIGHT_ELEM_PER_BYTE == 2, uint8_t, WeightType>;
@@ -184,7 +187,7 @@ protected:
     using DataType = std::conditional_t<NVFP4 || MXFP8_MXFP4, OutputType, GemmDataType>;
 
     // FP8_MXFP4 quantizes just the weights on the fly
-    using WeightRawType = std::conditional_t<FP8_MXFP4, OutputType, DataType>;
+    using WeightRawType = std::conditional_t<FP8_MXFP4 || W4A8_AWQ, OutputType, DataType>;
 
     static BufferManager::CudaStreamPtr mStream;
     static std::unique_ptr<BufferManager> mBufferManager;
@@ -321,8 +324,9 @@ protected:
     float* mSwigluBeta{};
     float* mSwigluLimit{};
 
-    DataType* mExpertIntScale1{};
-    DataType* mExpertIntScale2{};
+    using scale_type = std::conditional_t<W4A8_AWQ, WeightScale, DataType>;
+    scale_type* mExpertIntScale1{};
+    scale_type* mExpertIntScale2{};
 
     float mFP8WeightScalar1{1.f};
     float mFP8WeightScalar2{1.f};
@@ -375,7 +379,7 @@ protected:
 
     bool mIsGated = false;
     int64_t mGatedMultiplier = 1;
-    int64_t mGroupSize = -1;
+    int64_t mGroupSize = W4A8_AWQ ? 128 : -1;
 
     ActivationType mActType = ActivationType::Relu;
 
@@ -453,7 +457,7 @@ protected:
             total_size += weight_size / 2;
         }
         // Quantized data types use a second scratch buffer for the weights before quantizing
-        if (ANY_FPX || INT_QUANT)
+        if (ANY_FPX || INT_QUANT || W4A8_AWQ)
         {
             total_size += weight_elems * sizeof(DataType);
         }
@@ -534,6 +538,14 @@ protected:
 
             mExpertIntScale1 = allocBuffer<DataType>(mNumExperts * gated_inter);
             mExpertIntScale2 = allocBuffer<DataType>(mNumExperts * mHiddenSize);
+        }
+        else if constexpr (W4A8_AWQ)
+        {
+            mExpertWeight1 = allocBuffer<WeightStorage>(expert_matrix_size * mGatedMultiplier / WEIGHT_ELEM_PER_BYTE);
+            mExpertWeight2 = allocBuffer<WeightStorage>(expert_matrix_size / WEIGHT_ELEM_PER_BYTE);
+
+            mExpertIntScale1 = allocBuffer<WeightScale>(expert_matrix_size * mGatedMultiplier / mGroupSize);
+            mExpertIntScale2 = allocBuffer<WeightScale>(expert_matrix_size / mGroupSize);
         }
         else if constexpr (ANY_FP4)
         {
@@ -638,12 +650,22 @@ protected:
             doIntQuant(quant_type, shape1, mRawExpertWeight1, mExpertIntScale1, mExpertWeight1);
             doIntQuant(quant_type, shape2, mRawExpertWeight2, mExpertIntScale2, mExpertWeight2);
         }
+        else if constexpr (W4A8_AWQ)
+        {
+            cutlass_kernels::QuantType quant_type = cutlass_kernels::QuantType::W4_AFP8;
+
+            std::vector<size_t> shape1{(size_t) mNumExperts, (size_t) mHiddenSize, (size_t) gated_inter};
+            std::vector<size_t> shape2{(size_t) mNumExperts, (size_t) mInterSize, (size_t) mHiddenSize};
+
+            doIntQuant(quant_type, shape1, mRawExpertWeight1, mExpertIntScale1, mExpertWeight1);
+            doIntQuant(quant_type, shape2, mRawExpertWeight2, mExpertIntScale2, mExpertWeight2);
+        }
 
         check_cuda_error(cudaStreamSynchronize(stream));
     }
 
-    void doIntQuant(cutlass_kernels::QuantType quant_type, std::vector<size_t> shape, DataType* inputs,
-        DataType* scales, uint8_t* outputs)
+    void doIntQuant(cutlass_kernels::QuantType quant_type, std::vector<size_t> shape, WeightRawType* inputs,
+        scale_type* scales, uint8_t* outputs)
     {
         // Runs on the CPU, must be after stream sync
         if constexpr (INT_QUANT)
@@ -652,17 +674,119 @@ protected:
 
             size_t elems = std::reduce(shape.begin(), shape.end(), 1, std::multiplies{});
             std::vector<int8_t> h_out(elems);
-            std::vector<DataType> h_input(elems);
-            std::vector<DataType> h_scales(shape[0] * shape[2]);
+            std::vector<WeightRawType> h_input(elems);
+            std::vector<scale_type> h_scales(shape[0] * shape[2]);
 
-            check_cuda_error(cudaMemcpy(h_input.data(), inputs, elems * sizeof(DataType), cudaMemcpyDeviceToHost));
+            check_cuda_error(cudaMemcpy(h_input.data(), inputs, elems * sizeof(WeightRawType), cudaMemcpyDeviceToHost));
 
             cutlass_kernels::symmetric_quantize(h_out.data(), h_scales.data(), h_input.data(), shape, quant_type, true);
 
             check_cuda_error(cudaMemcpy(
                 outputs, h_out.data(), elems * sizeof(int8_t) / WEIGHT_ELEM_PER_BYTE, cudaMemcpyHostToDevice));
             check_cuda_error(
-                cudaMemcpy(scales, h_scales.data(), h_scales.size() * sizeof(DataType), cudaMemcpyHostToDevice));
+                cudaMemcpy(scales, h_scales.data(), h_scales.size() * sizeof(scale_type), cudaMemcpyHostToDevice));
+        }
+        else if constexpr (W4A8_AWQ)
+        {
+            check_cuda_error(cudaStreamSynchronize(mStream->get()));
+            assert(shape[1] % mGroupSize == 0);
+
+            size_t elems = std::reduce(shape.begin(), shape.end(), 1, std::multiplies{});
+            std::vector<int8_t> h_out(elems * sizeof(int8_t) / WEIGHT_ELEM_PER_BYTE);
+            std::vector<WeightRawType> h_input(elems);
+            std::vector<scale_type> h_scales(elems / mGroupSize);
+            check_cuda_error(cudaMemcpy(h_input.data(), inputs, elems * sizeof(WeightRawType), cudaMemcpyDeviceToHost));
+
+            const size_t num_experts = shape[0];
+            int const input_mat_size = shape[1] * shape[2];
+            int const bits_per_weigtht_element = 4;
+
+            int const quantized_mat_size = input_mat_size * bits_per_weigtht_element / 8;
+            float const quant_range_scale = 1.f / float(1 << (bits_per_weigtht_element - 1));
+
+            for (int expert = 0; expert < num_experts; ++expert)
+            {
+                WeightRawType const* current_weight = h_input.data() + expert * input_mat_size;
+                int8_t* current_quantized_weight = h_out.data() + expert * quantized_mat_size;
+                scale_type* current_scales = h_scales.data() + expert * input_mat_size / mGroupSize;
+
+                for (int ii = 0; ii < input_mat_size / mGroupSize; ++ii)
+                {
+                    float scale = 0.f;
+                    WeightRawType const* current_weight_group = current_weight + ii * mGroupSize;
+                    for (int jj = 0; jj < mGroupSize; ++jj)
+                    {
+                        scale = std::max(scale, std::abs(float(current_weight_group[jj])));
+                    }
+                    scale *= quant_range_scale;
+                    current_scales[ii] = scale_type(scale);
+                }
+
+                for (int ii = 0; ii < input_mat_size / mGroupSize; ++ii)
+                {
+                    WeightRawType const* current_weight_group = current_weight + ii * mGroupSize;
+                    int8_t* current_quantized_weight_group
+                        = current_quantized_weight + ii * mGroupSize * bits_per_weigtht_element / 8;
+                    float const scale = float(current_scales[ii]);
+                    for (int jj = 0; jj < mGroupSize / 2; ++jj)
+                    {
+                        // We will pack two int4 elements per iteration of the inner loop.
+                        float const weight_elt0 = float(current_weight_group[jj * 2]);
+                        float const weight_elt1 = float(current_weight_group[jj * 2 + 1]);
+                        float const scaled_weight0 = (scale != 0.0f) ? round(weight_elt0 / scale) : 0.0f;
+                        float const scaled_weight1 = (scale != 0.0f) ? round(weight_elt1 / scale) : 0.0f;
+                        int int_weight0 = int(scaled_weight0);
+                        int int_weight1 = int(scaled_weight1);
+                        const int8_t clipped_weight0 = std::max(-8, std::min(7, int_weight0));
+                        const int8_t clipped_weight1 = std::max(-8, std::min(7, int_weight1));
+                        // Kill the sign extension bits (hence 0x0F mask) then shift to upper bits
+                        // if packing the second int4 and or the bits into the final result.
+                        current_quantized_weight_group[jj] = clipped_weight0 | (clipped_weight1 << 4);
+                    }
+                }
+                // WAR: For a diagonal matrix in which each column has only one nonzero element, the scale value is
+                // calculated based on it being quantized to 8. However, after quantization, the nonzero value is
+                // clipped to 7. Adjust the scale value to fix the error.
+                for (int ii = 0; ii < input_mat_size / mGroupSize; ++ii)
+                {
+                    current_scales[ii] = scale_type(float(current_scales[ii]) * 8 / 7);
+                }
+
+                int interleave = 1;
+                int const sm = getSMVersion();
+                if (sm == 90)
+                {
+                    interleave = shape[1] % 512 == 0 ? 4 : shape[1] % 256 == 0 ? 2 : 1;
+                }
+
+                // Permute scales: from [N, K/mGroupSize/interleave, interleave] to [K/mGroupSize/interleave, N,
+                // interleave]
+                int const dim0 = shape[2];                           // N
+                int const dim1 = shape[1] / mGroupSize / interleave; // K/mGroupSize/interleave
+                int const dim2 = interleave;
+
+                std::vector<scale_type> temp_scales(input_mat_size / mGroupSize);
+                for (int n = 0; n < dim0; ++n)
+                {
+                    for (int k = 0; k < dim1; ++k)
+                    {
+                        for (int i = 0; i < dim2; ++i)
+                        {
+                            // src index: [n, k, i] in layout [N, K/mGroupSize/interleave, interleave]
+                            int src_idx = n * (dim1 * dim2) + k * dim2 + i;
+                            // dst index: [k, n, i] in layout [K/mGroupSize/interleave, N, interleave]
+                            int dst_idx = k * (dim0 * dim2) + n * dim2 + i;
+                            temp_scales[dst_idx] = current_scales[src_idx];
+                        }
+                    }
+                }
+                std::copy(temp_scales.begin(), temp_scales.end(), current_scales);
+            }
+
+            check_cuda_error(cudaMemcpy(
+                outputs, h_out.data(), elems * sizeof(int8_t) / WEIGHT_ELEM_PER_BYTE, cudaMemcpyHostToDevice));
+            check_cuda_error(
+                cudaMemcpy(scales, h_scales.data(), h_scales.size() * sizeof(scale_type), cudaMemcpyHostToDevice));
         }
     }
 
@@ -1229,6 +1353,31 @@ protected:
             ASSERT_TRUE(scale1_ptr && scale2_ptr);
             quant_params = QuantParams::Int(scale1_ptr, scale2_ptr);
         }
+        else if constexpr (W4A8_AWQ)
+        {
+            auto input_scale1 = allocBuffer<scale_type>(mNumExperts * mHiddenSize * mGatedMultiplier);
+            auto input_scale2 = allocBuffer<scale_type>(mNumExperts * mInterSize);
+            std::vector<scale_type> h_input_scale1(mNumExperts * mHiddenSize * mGatedMultiplier, 1.0f);
+            std::vector<scale_type> h_input_scale2(mNumExperts * mInterSize, 1.0f);
+            check_cuda_error(cudaMemcpy(input_scale1, h_input_scale1.data(),
+                mNumExperts * mHiddenSize * mGatedMultiplier * sizeof(scale_type), cudaMemcpyHostToDevice));
+            check_cuda_error(cudaMemcpy(input_scale2, h_input_scale2.data(),
+                mNumExperts * mInterSize * sizeof(scale_type), cudaMemcpyHostToDevice));
+
+            auto alpha1_ptrs = allocBuffer<float>(mNumExperts);
+            auto alpha2_ptrs = allocBuffer<float>(mNumExperts);
+            for (int i = 0; i < mNumExperts; i++)
+            {
+                float alpha1_value = 1.0f;
+                float alpha2_value = 1.0f;
+                check_cuda_error(cudaMemcpy(alpha1_ptrs + i, &alpha1_value, sizeof(float), cudaMemcpyHostToDevice));
+                check_cuda_error(cudaMemcpy(alpha2_ptrs + i, &alpha2_value, sizeof(float), cudaMemcpyHostToDevice));
+            }
+
+            ASSERT_TRUE(scale1_ptr && scale2_ptr);
+            quant_params = QuantParams::GroupWise(mGroupSize, scale1_ptr, scale2_ptr, input_scale1, input_scale2,
+                nullptr, nullptr, alpha1_ptrs, alpha2_ptrs);
+        }
         else if (FP8)
         {
             ASSERT_TRUE(scale1_ptr && scale2_ptr && scale3_ptr);
@@ -1628,6 +1777,11 @@ using Types = ::testing::Types<
 #endif
 #endif
 
+#ifdef ENABLE_BF16
+#ifdef ENABLE_FP8
+    WeightParams<SafeFP8, cutlass::uint4b_t, __nv_bfloat16, void, __nv_bfloat16>,
+#endif
+#endif
     WeightParams<half>, WeightParams<float>
 
     //  , WeightParams<half, uint8_t>, WeightParams<half, cutlass::uint4b_t>

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -224,7 +224,7 @@ protected:
         static_assert(!FP8, "FP8 Tests enabled on unsupported CUDA version");
 #endif
         bool should_skip_no_device = mDeviceCount <= 0;
-        bool should_skip_unsupported_fp8 = getSMVersion() < 89 && FP8;
+        bool should_skip_unsupported_fp8 = getSMVersion() < 89 && (FP8 || W4A8_AWQ);
         bool should_skip_unsupported_fp4 = (getSMVersion() < 100) && ANY_FP4;
         return should_skip_no_device || should_skip_unsupported_fp8 || should_skip_unsupported_fp4;
     }

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -1829,6 +1829,12 @@ void MixtureOfExpertsTest<TypeParam_>::BasicPermuteTest(
 
     initLocals(hidden_size, num_experts, k, num_tokens);
 
+    if (mGroupSize > 0 && (mHiddenSize % mGroupSize != 0 || mInterSize % mGroupSize != 0))
+    {
+        GTEST_SKIP() << "Skipping due to unsupported groupwise configuration";
+        return;
+    }
+
     auto test_archs = getAllTileConfigsToTest();
     for (auto [gemm1, gemm2] : test_archs)
     {
@@ -2057,6 +2063,13 @@ TYPED_TEST(MixtureOfExpertsTest, PermuteDeepSeekV3)
     size_t inter_size = 2048;
     this->mInterSizeFraction = float(inter_size) / hidden_size;
 
+    if (this->W4A8_AWQ)
+    {
+        // TODO: Implement W4A8_AWQ for PermuteDeepSeekV3
+        GTEST_SKIP() << "W4A8_AWQ is not implemented for PermuteDeepSeekV3";
+        return;
+    }
+
     if (!this->checkSufficientTestMemory(100, hidden_size, 256, 8))
     {
         GTEST_SKIP() << "Insufficient free memory for test";
@@ -2108,6 +2121,13 @@ void MixtureOfExpertsTest<TypeParam_>::ParallelismTest(
             GTEST_SKIP();
             return;
         }
+    }
+
+    if (W4A8_AWQ)
+    {
+        // TODO: Implement W4A8_AWQ for ParallelismTest
+        GTEST_SKIP() << "W4A8_AWQ is not implemented for ParallelismTest";
+        return;
     }
 
     ASSERT_LE(ep_size, num_experts);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized MOE GEMM kernel dispatch logic to improve epilogue fusion handling and quantization mode selection
  * Enhanced kernel template parameters for better specialization of mixed-input and mixed-dtype GEMM operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
According to nsys trace analyzing, both prologue fusion and epilogue fusion could enhance performance. However, prologue and epilogue fusion cannot be applied to W4AFP8_AWQ MoE currently.

This PR applies prologue and epilogue fusion for W4AFP8_AWQ MoE, implements CUDA unit test for W4AFP8_AQW MoE.
Cherry-pick [5b5c3b](https://github.com/rosenrodt/TensorRT-LLM/commit/5b5c3b1cca9877ba6e3ddd2aa847603aa2bedc53) to fuse prequant scale into preceding activation kernel.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
pytest tests/unittest/_torch/modules/test_fused_moe.py -k w4afp8 -s

cmake --build ./build_Debug -t mixtureOfExpertsTest
./build_Debug/tests/unit_tests/kernels/mixtureOfExpertsTest --gtest_filter=*.Permute

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
