### PR TITLE
[None][fix] Fix iteration stats for spec-dec

### DIFF
--- a/docs/source/features/speculative-decoding.md
+++ b/docs/source/features/speculative-decoding.md
@@ -38,7 +38,7 @@ Draft/target is the simplest form of speculative decoding. In this approach, an 
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig
 
 speculative_config = DraftTargetDecodingConfig(
-    max_draft_len=3, speculative_model="/path/to/draft_model")
+    max_draft_len=3, speculative_model_dir="/path/to/draft_model")
 
 llm = LLM("/path/to/target_model", speculative_config=speculative_config, disable_overlap_scheduler=True)
 ```
@@ -59,7 +59,7 @@ from tensorrt_llm.llmapi import EagleDecodingConfig
 eagle3_one_model = False
 
 speculative_config = EagleDecodingConfig(
-    max_draft_len=3, speculative_model="/path/to/draft_model", eagle3_one_model=eagle3_one_model)
+    max_draft_len=3, speculative_model_dir="/path/to/draft_model", eagle3_one_model=eagle3_one_model)
 
 # Only need to disable overlap scheduler if eagle3_one_model is False.
 llm = LLM("/path/to/target_model", speculative_config=speculative_config, disable_overlap_scheduler=True)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -659,6 +659,11 @@ class PyExecutor:
 
         if spec_resource_manager is not None or has_spec_config:
             stats.specdec_stats = SpecDecodingStats()
+            # Reset draft latency at the start of each iteration to prevent stale values
+            # from previous iterations when speculation is disabled
+            if self.drafter is not None and hasattr(self.drafter,
+                                                    'last_draft_latency_ms'):
+                self.drafter.last_draft_latency_ms = 0.0
 
         return stats
 
@@ -800,9 +805,10 @@ class PyExecutor:
                 stats.specdec_stats.acceptance_length = 0.0
 
             # Get draft latency from drafter if available (only for two-model mode)
+            # Only use draft latency if there were actually draft tokens in this iteration
             draft_latency_ms = 0.0
-            if self.drafter is not None and hasattr(self.drafter,
-                                                    'last_draft_latency_ms'):
+            if total_draft_tokens > 0 and self.drafter is not None and hasattr(
+                    self.drafter, 'last_draft_latency_ms'):
                 draft_latency_ms = getattr(self.drafter,
                                            'last_draft_latency_ms', 0.0)
 

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -99,6 +99,9 @@ class ModelDrafter(Drafter):
 
         # Create accumulator for draft tokens in non-CDL mode
         self.draft_tokens_accumulator: Dict[int, List[int]] = {}
+
+        # Initialize draft latency tracking for specDecodingStats
+        self.last_draft_latency_ms = 0.0
         # Track previous draft batch for overlap scheduling
         self.previous_draft_batch: Optional[ScheduledRequests] = None
         self.previous_draft_outputs: Optional[Any] = None
@@ -809,6 +812,8 @@ class ModelDrafter(Drafter):
                 - Updated target inputs or None
                 - Draft sample state or None
         """
+        import time
+        draft_start_time = time.time()
 
         self.disable_overlap_scheduler = False
         if target_inputs is None:
@@ -896,6 +901,10 @@ class ModelDrafter(Drafter):
         self.previous_draft_outputs = previous_draft_state
         self.previous_scheduled_batch = scheduled_batch
 
+        # Record draft latency for stats
+        draft_end_time = time.time()
+        self.last_draft_latency_ms = (draft_end_time - draft_start_time) * 1e3
+
     @nvtx_range("prepare_draft_tokens")
     def prepare_draft_tokens(
         self,
@@ -909,6 +918,9 @@ class ModelDrafter(Drafter):
             scheduled_requests: The scheduled requests for this iteration
             resource_manager: The resource manager for this iteration
         """
+        import time
+        draft_start_time = time.time()
+
         self.disable_overlap_scheduler = True
         if not self.draft_model_engine:
             raise ValueError("Draft model engine is not set")
@@ -936,6 +948,10 @@ class ModelDrafter(Drafter):
                 # Clean up draft_seq_slot_manager resources
                 for req in draft_batch.all_requests():
                     self.draft_seq_slot_manager.free_resources(req)
+                # Record draft latency before returning
+                draft_end_time = time.time()
+                self.last_draft_latency_ms = (draft_end_time -
+                                              draft_start_time) * 1e3
                 return
 
             if self.guided_decoder is not None:
@@ -958,6 +974,11 @@ class ModelDrafter(Drafter):
             for req_id, tokens in self.draft_tokens_accumulator.items():
                 target_model_req = self.req_id_to_old_request[req_id]
                 target_model_req.py_draft_tokens = tokens
+
+            # Record draft latency for stats
+            draft_end_time = time.time()
+            self.last_draft_latency_ms = (draft_end_time -
+                                          draft_start_time) * 1e3
         except Exception as e:
             traceback.print_exc()
             error_msg = str(e)

--- a/tests/integration/defs/examples/serve/test_spec_decoding_metrics.py
+++ b/tests/integration/defs/examples/serve/test_spec_decoding_metrics.py
@@ -1,0 +1,240 @@
+import os
+import time
+
+import pytest
+import requests
+from defs.conftest import llm_models_root
+from defs.trt_test_alternative import popen, print_error, print_info
+
+
+def check_spec_decoding_metrics(http_port="8000", expect_draft_latency=False, min_draft_tokens=1):
+    print_info("Checking specDecodingStats in /metrics endpoint...")
+
+    try:
+        url = f"http://localhost:{http_port}/metrics"
+        response = requests.get(url, timeout=5)
+
+        if response.status_code != 200:
+            print_error(f"Failed to get metrics: HTTP {response.status_code}")
+            return False
+
+        metrics_list = response.json()
+        if not metrics_list or len(metrics_list) == 0:
+            print_error("No metrics returned")
+            return False
+
+        print_info(f"Retrieved {len(metrics_list)} iteration stats")
+
+        # Find iterations with speculative decoding
+        iterations_with_spec = []
+        for metric in metrics_list:
+            spec_stats = metric.get("specDecodingStats")
+            if spec_stats and spec_stats.get("numDraftTokens", 0) > 0:
+                iterations_with_spec.append((metric["iter"], spec_stats))
+
+        if not iterations_with_spec:
+            print_error("No iterations with specDecodingStats found")
+            print_info("This might happen if all requests are in context phase")
+            return False
+
+        print_info(f"Found {len(iterations_with_spec)} iterations with spec decoding")
+
+        # Validate specDecodingStats structure and values
+        for iter_num, spec_stats in iterations_with_spec[:3]:  # Check first 3
+            # Validate field types and constraints
+            assert isinstance(spec_stats["numDraftTokens"], int)
+            assert isinstance(spec_stats["numAcceptedTokens"], int)
+            assert isinstance(spec_stats["numRequestsWithDraftTokens"], int)
+            assert isinstance(spec_stats["acceptanceLength"], (int, float))
+            assert isinstance(spec_stats["iterLatencyMS"], (int, float))
+            assert isinstance(spec_stats["draftOverhead"], (int, float))
+
+            # Validate value constraints
+            assert spec_stats["numDraftTokens"] >= min_draft_tokens
+            assert spec_stats["numAcceptedTokens"] >= 0
+            assert spec_stats["numAcceptedTokens"] <= spec_stats["numDraftTokens"]
+            assert spec_stats["numRequestsWithDraftTokens"] > 0
+            assert spec_stats["acceptanceLength"] >= 1.0  # At least 1 token per request
+            assert spec_stats["iterLatencyMS"] >= 0.0
+            assert spec_stats["draftOverhead"] >= 0.0
+            assert spec_stats["draftOverhead"] <= 1.0  # Can't exceed 100%
+
+            # For 2-model mode, verify draft latency is tracked
+            if expect_draft_latency:
+                assert spec_stats["iterLatencyMS"] > 0.0, (
+                    "Two-model mode should have non-zero draft latency"
+                )
+                assert spec_stats["draftOverhead"] > 0.0, (
+                    "Two-model mode should have non-zero draft overhead"
+                )
+
+        return True
+
+    except Exception as e:
+        print_error(f"Error checking spec decoding metrics: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_spec_decoding_metrics_eagle3_one_model():
+    model_path = f"{llm_models_root()}/Qwen3/Qwen3-8B"
+    eagle3_path = f"{llm_models_root()}/Qwen3/qwen3_8b_eagle3"
+
+    # Skip if models don't exist
+    if not os.path.exists(model_path) or not os.path.exists(eagle3_path):
+        pytest.skip(f"Required models not found: {model_path}, {eagle3_path}")
+
+    extra_config = {
+        "enable_iter_perf_stats": True,
+        "disable_overlap_scheduler": True,
+        "trust_remote_code": True,
+        "speculative_config": {
+            "decoding_type": "Eagle",
+            "max_draft_len": 4,
+            "speculative_model_dir": eagle3_path,
+            "eagle3_one_model": True,
+        },
+    }
+
+    import tempfile
+
+    import yaml
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
+        yaml.dump(extra_config, f)
+        config_file = f.name
+
+    port = 8010
+    cmd = [
+        "trtllm-serve",
+        model_path,
+        "--backend",
+        "pytorch",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--max_batch_size",
+        "8",
+        "--trust_remote_code",
+        "--config",
+        config_file,
+    ]
+
+    try:
+        print_info("Starting trtllm-serve with Eagle3 one-model mode...")
+        with popen(cmd):
+            # Wait for server
+            from test_serve import check_server_ready
+
+            check_server_ready(http_port=str(port), timeout_timer=600)
+
+            # Send test requests
+            print_info("Sending test requests...")
+            for i in range(5):
+                requests.post(
+                    f"http://localhost:{port}/v1/chat/completions",
+                    json={
+                        "model": "Qwen3-8B",
+                        "messages": [{"role": "user", "content": f"Count to {i + 3}"}],
+                        "max_tokens": 30,
+                    },
+                    timeout=30,
+                )
+                time.sleep(0.3)
+
+            # Wait for metrics to accumulate
+            time.sleep(1)
+
+            # Check metrics (one-model mode has iterLatencyMS=0)
+            assert check_spec_decoding_metrics(
+                http_port=str(port),
+                expect_draft_latency=False,  # One-model mode
+                min_draft_tokens=1,
+            )
+    finally:
+        if os.path.exists(config_file):
+            os.remove(config_file)
+
+
+def test_spec_decoding_metrics_eagle3_two_model():
+    model_path = f"{llm_models_root()}/Qwen3/Qwen3-8B"
+    eagle3_path = f"{llm_models_root()}/Qwen3/qwen3_8b_eagle3"
+
+    # Skip if models don't exist
+    if not os.path.exists(model_path) or not os.path.exists(eagle3_path):
+        pytest.skip(f"Required models not found: {model_path}, {eagle3_path}")
+
+    extra_config = {
+        "enable_iter_perf_stats": True,
+        "disable_overlap_scheduler": True,
+        "trust_remote_code": True,
+        "speculative_config": {
+            "decoding_type": "Eagle",
+            "max_draft_len": 4,
+            "speculative_model_dir": eagle3_path,
+            "eagle3_one_model": False,  # Two-model mode
+        },
+    }
+
+    import tempfile
+
+    import yaml
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
+        yaml.dump(extra_config, f)
+        config_file = f.name
+
+    port = 8011
+    cmd = [
+        "trtllm-serve",
+        model_path,
+        "--backend",
+        "pytorch",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--max_batch_size",
+        "8",
+        "--trust_remote_code",
+        "--config",
+        config_file,
+    ]
+
+    try:
+        print_info("Starting trtllm-serve with Eagle3 two-model mode...")
+        with popen(cmd):
+            # Wait for server
+            from test_serve import check_server_ready
+
+            check_server_ready(http_port=str(port), timeout_timer=600)
+
+            # Send test requests
+            print_info("Sending test requests...")
+            for i in range(5):
+                requests.post(
+                    f"http://localhost:{port}/v1/chat/completions",
+                    json={
+                        "model": "Qwen3-8B",
+                        "messages": [{"role": "user", "content": f"Count to {i + 3}"}],
+                        "max_tokens": 30,
+                    },
+                    timeout=30,
+                )
+                time.sleep(0.3)
+
+            # Wait for metrics to accumulate
+            time.sleep(1)
+
+            # Check metrics (two-model mode should have iterLatencyMS > 0)
+            assert check_spec_decoding_metrics(
+                http_port=str(port),
+                expect_draft_latency=True,  # Two-model mode
+                min_draft_tokens=1,
+            )
+    finally:
+        if os.path.exists(config_file):
+            os.remove(config_file)

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -225,6 +225,88 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
         assert text_spec == text_ref
 
 
+@pytest.mark.parametrize("eagle3_one_model", [True, False])
+def test_eagle3_spec_decoding_stats(eagle3_one_model):
+    """Test that specDecodingStats are correctly populated in metrics endpoint"""
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
+    target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
+
+    # Skip if models don't exist
+    if not os.path.exists(target_model_dir) or not os.path.exists(
+            eagle_model_dir):
+        pytest.skip(f"Required models not found")
+
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False,
+                                    free_gpu_memory_fraction=0.6)
+    spec_config = EagleDecodingConfig(
+        max_draft_len=3,
+        speculative_model_dir=eagle_model_dir,
+        eagle3_one_model=eagle3_one_model,
+    )
+
+    with LLM(
+            model=target_model_dir,
+            speculative_config=spec_config,
+            kv_cache_config=kv_cache_config,
+            disable_overlap_scheduler=not eagle3_one_model,
+            enable_iter_perf_stats=True,
+            max_batch_size=4,
+    ) as llm:
+        # Generate some output to collect stats
+        prompts = [
+            "The capital of France is",
+            "The president of the United States is",
+        ]
+        sampling_params = SamplingParams(max_tokens=20, temperature=0)
+        llm.generate(prompts, sampling_params)
+
+        # Get iteration stats
+        stats = llm.get_stats(timeout=2)
+        assert len(stats) > 0, "Should have iteration stats"
+
+        # Find iterations with speculation (generation phase)
+        iterations_with_spec = []
+        for stat in stats:
+            if 'specDecodingStats' in stat:
+                spec_stats = stat['specDecodingStats']
+                if spec_stats.get('numDraftTokens', 0) > 0:
+                    iterations_with_spec.append(spec_stats)
+
+        # Should have at least some iterations with spec decoding
+        assert len(iterations_with_spec) > 0, \
+            f"Should have iterations with specDecodingStats (found {len(iterations_with_spec)})"
+
+        # Validate specDecodingStats structure and values
+        for spec_stats in iterations_with_spec:
+            # Check all fields are present
+            assert 'numDraftTokens' in spec_stats
+            assert 'numAcceptedTokens' in spec_stats
+            assert 'numRequestsWithDraftTokens' in spec_stats
+            assert 'acceptanceLength' in spec_stats
+            assert 'iterLatencyMS' in spec_stats
+            assert 'draftOverhead' in spec_stats
+
+            # Validate value constraints
+            assert spec_stats['numDraftTokens'] > 0
+            assert 0 <= spec_stats['numAcceptedTokens'] <= spec_stats[
+                'numDraftTokens']
+            assert spec_stats['numRequestsWithDraftTokens'] > 0
+            assert spec_stats['acceptanceLength'] >= 1.0
+            assert spec_stats['iterLatencyMS'] >= 0.0
+            assert 0.0 <= spec_stats['draftOverhead'] <= 1.0
+
+        # Calculate overall acceptance rate
+        total_draft = sum(s['numDraftTokens'] for s in iterations_with_spec)
+        total_accepted = sum(s['numAcceptedTokens']
+                             for s in iterations_with_spec)
+        acceptance_rate = (total_accepted / total_draft *
+                           100) if total_draft > 0 else 0
+
+        # Should have reasonable acceptance rate for Eagle3
+        assert acceptance_rate > 5.0, f"Acceptance rate too low: {acceptance_rate:.1f}%"
+
+
 @pytest.mark.parametrize("use_cuda_graph", [True, False])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3_long_prompt(use_cuda_graph):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added speculative decoding metrics including draft token counts, accepted token counts, draft latency, and acceptance rate to enhance observability of speculative decoding performance.

* **Documentation**
  * Updated configuration parameter names for improved clarity in speculative decoding setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fill the spec-dec stats per iter in the py_executor
Update draft latency in the model_drafter for two-model path
Fix documentation for using EAGLE3 speculative decoding
Add tests for stats

## Test Coverage

tests/integration/defs/examples/serve/test_spec_decoding_metrics.py
tests/unittest/_torch/speculative/test_eagle3.py


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
