### PR TITLE
[https://nvbugs/5556998][fix] init_hf_modules in worker_main for models with trust_remote=true

### DIFF
--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -39,7 +39,30 @@ from .utils import (ErrorResponse, IntraProcessQueue, RequestError,
 
 __all__ = [
     "BaseWorker",
+    "_init_hf_modules",
 ]
+
+
+def _init_hf_modules():
+    """Initialize cached HuggingFace modules for models with trust_remote_code=True.
+
+    This is safe to call multiple times (idempotent) and should be called:
+    1. At module import time (for main process and spawned subprocesses)
+    2. At worker_main entry (for forked processes or external MPI ranks)
+
+    References: https://github.com/vllm-project/vllm/pull/871
+    """
+    try:
+        from transformers.dynamic_module_utils import init_hf_modules
+        init_hf_modules()
+        logger.debug("HF modules initialized")
+    except ImportError as e:
+        logger.warning(f"ImportError initializing HF modules: {e}")
+    except Exception as e:
+        logger.error(f"Exception initializing HF modules: {e}")
+
+
+_init_hf_modules()
 
 
 class BaseWorker(GenerationExecutor):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -288,8 +288,6 @@ def worker_main(
     if llm_args is not None and llm_args.trust_remote_code:
         _init_hf_modules()
 
-    logger_debug(f"Worker {mpi_rank()} entering worker_main...\n", "green")
-
     result_queue: Optional[IpcQueue] = None
     result_queues: Optional[List[IpcQueue]] = None
 

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -23,7 +23,7 @@ from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
                             print_traceback_on_error)
 from ..lora_helper import LoraConfig
 from ..sampling_params import BatchedLogitsProcessor
-from .base_worker import BaseWorker
+from .base_worker import BaseWorker, _init_hf_modules
 from .executor import IterationResultQueue
 from .ipc import FusedIpcQueue, IpcQueue
 from .postproc_worker import (PostprocWorker, PostprocWorkerConfig,
@@ -284,6 +284,11 @@ def worker_main(
             "performance.", )
         logger.warning(f"Will clear the cpu affinity")
         clear_sched_affinity(pid)
+
+    if llm_args is not None and llm_args.trust_remote_code:
+        _init_hf_modules()
+
+    logger_debug(f"Worker {mpi_rank()} entering worker_main...\n", "green")
 
     result_queue: Optional[IpcQueue] = None
     result_queues: Optional[List[IpcQueue]] = None


### PR DESCRIPTION
cherry pick https://github.com/NVIDIA/TensorRT-LLM/pull/8931/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced initialization of HuggingFace module caching in worker processes to ensure reliable remote code handling across execution contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->