### PR TITLE
[None][feat] Add more optimization options for MOE CuteDSL finalized kernel

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -7,20 +7,13 @@ from tensorrt_llm.logger import logger
 
 from ..._utils import get_sm_version
 from ...math_utils import pad_up
-from ..autotuner import (
-    AutoTuner,
-    ConstraintSpec,
-    DynamicTensorSpec,
-    OptimizationProfile,
-    TunableRunner,
-    TuningConfig,
-)
+from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
+                         DynamicTensorSpec, OptimizationProfile, TunableRunner,
+                         TuningConfig)
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
-from ..utils import (
-    fp4_scale_infer_shape,
-    get_last_power_of_2_num_tokens_buckets,
-    last_positive_power_of_2,
-)
+from ..utils import (fp4_scale_infer_shape,
+                     get_last_power_of_2_num_tokens_buckets,
+                     last_positive_power_of_2)
 
 try:
     from cuda.bindings import driver as cuda
@@ -29,15 +22,17 @@ except ImportError:
 
 
 class GroupedGemmInputsHelper:
+    """Base helper class for grouped GEMM input preparation and tuning.
 
-    def __init__(
-        self,
-        num_experts: int,
-        top_k: int,
-        num_local_experts: int,
-        local_expert_offset: int,
-        tile_size: int,
-    ):
+    Subclasses should override IDX_SHAPE_INFER to specify which input tensor
+    to use for shape inference in tuning.
+    """
+    # Input tensor index for shape inference - subclass can override
+    IDX_A = 0
+    IDX_SHAPE_INFER = IDX_A  # Default: use a tensor for shape inference
+
+    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
+                 local_expert_offset: int, tile_size: int):
         self.num_experts = num_experts
         self.top_k = top_k
         self.num_local_experts = num_local_experts
@@ -51,43 +46,40 @@ class GroupedGemmInputsHelper:
         num_expanded_tokens = num_tokens * self.top_k
         if num_expanded_tokens <= self.num_local_experts:
             return num_expanded_tokens
-        return (
-            num_expanded_tokens + (self.tile_size - 1) * self.num_local_experts
-        ) // self.tile_size
+        return (num_expanded_tokens +
+                (self.tile_size - 1) * self.num_local_experts) // self.tile_size
 
     def get_max_num_permuted_tokens(self, num_tokens: int) -> int:
         return self.get_max_num_tiles(num_tokens) * self.tile_size
 
     def infer_num_tokens(self, max_num_permuted_tokens: int) -> int:
-        """Infer the maximum possible number of tokens given the max_num_permuted_tokens."""
+        """Infer the maximum possible number of tokens given the max_num_permuted_tokens.
+        """
         max_num_tiles = max_num_permuted_tokens // self.tile_size
         if max_num_tiles >= self.num_local_experts:
-            return (
-                max_num_permuted_tokens
-                - (self.tile_size - 1) * (self.num_local_experts - 1)
-            ) // self.top_k
+            return (max_num_permuted_tokens - (self.tile_size - 1) *
+                    (self.num_local_experts - 1)) // self.top_k
         return max_num_tiles // self.top_k
 
     def gen_tuning_buckets(self, max_num_tokens: int) -> List[int]:
         buckets = get_last_power_of_2_num_tokens_buckets(
-            self.infer_num_tokens(max_num_tokens)
-        )
-        return sorted(list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
+            self.infer_num_tokens(max_num_tokens))
+        return sorted(
+            list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
 
     def map_to_tuning_buckets(self, x: int) -> int:
         return self.get_max_num_permuted_tokens(
-            last_positive_power_of_2(self.infer_num_tokens(x))
-        )
+            last_positive_power_of_2(self.infer_num_tokens(x)))
 
     def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
-        return self.infer_num_tokens(input_shapes[0][0])
+        return self.infer_num_tokens(input_shapes[self.IDX_SHAPE_INFER][0])
 
     def infer_shape_max_num_tiles(self, input_shapes: List[torch.Size]) -> int:
-        return input_shapes[0][0] // self.tile_size
+        """Infer max_num_tiles from the shape inference tensor (IDX_SHAPE_INFER)."""
+        return input_shapes[self.IDX_SHAPE_INFER][0] // self.tile_size
 
     def infer_shape_max_num_permuted_tokens(
-        self, input_shapes: List[torch.Size]
-    ) -> int:
+            self, input_shapes: List[torch.Size]) -> int:
         return self.infer_shape_max_num_tiles(input_shapes) * self.tile_size
 
     def generate_num_tokens_per_expert(self, num_tokens: int) -> List[int]:
@@ -104,34 +96,34 @@ class GroupedGemmInputsHelper:
         return num_tokens_per_expert
 
     def generate_tile_idx_to_group_idx(
-        self, num_tokens_per_expert: List[int]
-    ) -> List[int]:
+            self, num_tokens_per_expert: List[int]) -> List[int]:
         tile_idx_to_group_idx = []
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
             tile_idx_to_group_idx.extend([i] * curr_num_tiles)
         return tile_idx_to_group_idx
 
     def generate_tile_idx_to_mn_limit(
-        self, num_tokens_per_expert: List[int]
-    ) -> List[int]:
+            self, num_tokens_per_expert: List[int]) -> List[int]:
         tile_idx_to_mn_limit = []
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
             prev_mn_limit = len(tile_idx_to_mn_limit) * self.tile_size
             for j in range(curr_num_tiles):
-                tile_idx_to_mn_limit.append(
-                    prev_mn_limit + min((j + 1) * self.tile_size, curr_num_tokens)
-                )
+                tile_idx_to_mn_limit.append(prev_mn_limit + min(
+                    (j + 1) * self.tile_size, curr_num_tokens))
         return tile_idx_to_mn_limit
 
     def generate_permuted_idx_to_expanded_idx(
-        self, num_tokens: int, num_tokens_per_expert: List[int]
-    ) -> List[int]:
+            self, num_tokens: int,
+            num_tokens_per_expert: List[int]) -> List[int]:
         permuted_idx_to_expanded_idx = []
         colmajor_expanded_idx = 0
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
             for j in range(curr_num_tiles * self.tile_size):
                 if j < curr_num_tokens:
                     token_idx = colmajor_expanded_idx % num_tokens
@@ -144,133 +136,188 @@ class GroupedGemmInputsHelper:
         return permuted_idx_to_expanded_idx
 
     def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-        (
-            a,
-            b,
-            a_sf,
-            b_sf,
-            alpha,
-            tile_idx_to_group_idx,
-            num_non_exiting_tiles,
-            *others,
-        ) = inputs
+        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others = inputs
         num_tokens = self.infer_num_tokens(a.size(0))
         num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
         tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-            num_tokens_per_expert
-        )
+            num_tokens_per_expert)
         num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-        num_padding_tiles_val = (
-            tile_idx_to_group_idx.size(0) - num_non_exiting_tiles_val
-        )
+        num_padding_tiles_val = tile_idx_to_group_idx.size(
+            0) - num_non_exiting_tiles_val
         assert num_non_exiting_tiles_val > 0
         assert num_padding_tiles_val >= 0
 
         tile_idx_to_group_idx = torch.tensor(
             tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_group_idx.dtype,
-            device=tile_idx_to_group_idx.device,
-        )
+            device=tile_idx_to_group_idx.device)
         num_non_exiting_tiles = torch.tensor(
             [num_non_exiting_tiles_val],
             dtype=num_non_exiting_tiles.dtype,
-            device=num_non_exiting_tiles.device,
-        )
-        return (
-            a,
-            b,
-            a_sf,
-            b_sf,
-            alpha,
-            tile_idx_to_group_idx,
-            num_non_exiting_tiles,
-            *others,
-        )
+            device=num_non_exiting_tiles.device)
+        return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others
 
     def inputs_pre_hook_finalize_fusion(
-        self, inputs: List[torch.Tensor]
-    ) -> List[torch.Tensor]:
-        (
-            a,
-            b,
-            a_sf,
-            b_sf,
-            alpha,
-            output,
-            tile_idx_to_group_idx,
-            tile_idx_to_mn_limit,
-            permuted_idx_to_expanded_idx,
-            num_non_exiting_tiles,
-            token_final_scales,
-        ) = inputs
+            self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        a, b, a_sf, b_sf, alpha, output, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
         num_tokens = self.infer_num_tokens(a.size(0))
         num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
         tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-            num_tokens_per_expert
-        )
+            num_tokens_per_expert)
         tile_idx_to_mn_limit_list = self.generate_tile_idx_to_mn_limit(
-            num_tokens_per_expert
-        )
+            num_tokens_per_expert)
         permuted_idx_to_expanded_idx_list = self.generate_permuted_idx_to_expanded_idx(
-            num_tokens, num_tokens_per_expert
-        )
+            num_tokens, num_tokens_per_expert)
         num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-        num_padding_tiles_val = (
-            tile_idx_to_group_idx.size(0) - num_non_exiting_tiles_val
-        )
+        num_padding_tiles_val = tile_idx_to_group_idx.size(
+            0) - num_non_exiting_tiles_val
         assert num_non_exiting_tiles_val > 0
         assert num_padding_tiles_val >= 0
         assert len(tile_idx_to_mn_limit_list) == num_non_exiting_tiles_val
-        assert (
-            len(permuted_idx_to_expanded_idx_list)
-            == num_non_exiting_tiles_val * self.tile_size
-        )
+        assert len(permuted_idx_to_expanded_idx_list
+                   ) == num_non_exiting_tiles_val * self.tile_size
 
         tile_idx_to_group_idx = torch.tensor(
             tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_group_idx.dtype,
-            device=tile_idx_to_group_idx.device,
-        )
+            device=tile_idx_to_group_idx.device)
         tile_idx_to_mn_limit = torch.tensor(
             tile_idx_to_mn_limit_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_mn_limit.dtype,
-            device=tile_idx_to_mn_limit.device,
-        )
+            device=tile_idx_to_mn_limit.device)
         permuted_idx_to_expanded_idx = torch.tensor(
-            permuted_idx_to_expanded_idx_list
-            + [self.pad_val] * (num_padding_tiles_val * self.tile_size),
+            permuted_idx_to_expanded_idx_list + [self.pad_val] *
+            (num_padding_tiles_val * self.tile_size),
             dtype=permuted_idx_to_expanded_idx.dtype,
-            device=permuted_idx_to_expanded_idx.device,
-        )
+            device=permuted_idx_to_expanded_idx.device)
         num_non_exiting_tiles = torch.tensor(
             [num_non_exiting_tiles_val],
             dtype=num_non_exiting_tiles.dtype,
-            device=num_non_exiting_tiles.device,
-        )
-        return (
-            a,
-            b,
-            a_sf,
-            b_sf,
-            alpha,
-            output,
-            tile_idx_to_group_idx,
-            tile_idx_to_mn_limit,
-            permuted_idx_to_expanded_idx,
-            num_non_exiting_tiles,
-            token_final_scales,
-        )
+            device=num_non_exiting_tiles.device)
+        return a, b, a_sf, b_sf, alpha, output, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales
+
+
+class GatherGroupedGemmInputsHelper(GroupedGemmInputsHelper):
+    """Helper class for gather-based grouped GEMM input preparation.
+
+    This subclass handles inputs where:
+    - a tensor contains original (non-permuted) activations
+    - permuted_idx_to_expanded_idx specifies the gather pattern
+    - Shape inference uses permuted_idx_to_expanded_idx size instead of a size
+
+    Input tensor layout:
+        0: a                       - Original input activation (not permuted)
+        1: b                       - Weight tensor
+        2: a_sf                    - Scale factor for a
+        3: b_sf                    - Scale factor for b
+        4: alpha                   - Per-expert scaling factor
+        5: tile_idx_to_group_idx   - Tile to expert mapping
+        6: tile_idx_to_mn_limit    - Tile M/N limits
+        7: permuted_idx_to_expanded_idx        - Token permutation mapping
+        8: num_non_exiting_tiles   - Number of valid tiles
+        9: global_sf               - Global scale factor
+    """
+    # Override: use permuted_idx_to_expanded_idx for shape inference
+    IDX_PERMUTED_IDX_TO_EXPANDED_IDX = 7
+    IDX_SHAPE_INFER = IDX_PERMUTED_IDX_TO_EXPANDED_IDX
+
+    def generate_permuted_idx_to_expanded_idx(
+            self, num_tokens: int, num_tokens_per_expert: List[int],
+            max_num_permuted_tokens: int) -> List[int]:
+        """Generate permuted_idx_to_expanded_idx for gather operation.
+
+        Maps permuted index to expanded index (token_idx * top_k + topk_idx).
+
+        Args:
+            num_tokens: Total number of input tokens
+            num_tokens_per_expert: List of token counts per expert
+            max_num_permuted_tokens: Target size of the output list
+
+        Returns:
+            List of expanded IDs with length = max_num_permuted_tokens,
+            where permuted_idx_to_expanded_idx[permuted_idx] = expanded_idx
+            Padding tokens are marked with pad_val
+            Note: In kernel, use expanded_idx // top_k to get original token_idx
+        """
+        permuted_idx_to_expanded_idx = []
+        colmajor_expanded_idx = 0
+        for i, curr_num_tokens in enumerate(num_tokens_per_expert):
+            curr_num_tiles = (curr_num_tokens + self.tile_size -
+                              1) // self.tile_size
+            for j in range(curr_num_tiles * self.tile_size):
+                if j < curr_num_tokens:
+                    token_idx = colmajor_expanded_idx % num_tokens
+                    topk_idx = colmajor_expanded_idx // num_tokens
+                    expanded_idx = token_idx * self.top_k + topk_idx
+                    permuted_idx_to_expanded_idx.append(expanded_idx)
+                    colmajor_expanded_idx += 1
+                else:
+                    permuted_idx_to_expanded_idx.append(
+                        self.pad_val)  # Padding token
+        # Pad to max_num_permuted_tokens
+        while len(permuted_idx_to_expanded_idx) < max_num_permuted_tokens:
+            permuted_idx_to_expanded_idx.append(self.pad_val)
+        return permuted_idx_to_expanded_idx
+
+    def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        """Pre-hook for gather-based SwiGLU fusion kernel.
+
+        Generates:
+            - tile_idx_to_group_idx
+            - tile_idx_to_mn_limit
+            - permuted_idx_to_expanded_idx (for gather operation)
+            - num_non_exiting_tiles
+        """
+        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, \
+            permuted_idx_to_expanded_idx, num_non_exiting_tiles, global_sf = inputs
+        # Verify permuted_idx_to_expanded_idx index matches the class constant
+        assert inputs[
+            self.
+            IDX_PERMUTED_IDX_TO_EXPANDED_IDX] is permuted_idx_to_expanded_idx
+
+        max_num_permuted_tokens = permuted_idx_to_expanded_idx.size(0)
+        max_num_tiles = max_num_permuted_tokens // self.tile_size
+
+        num_tokens = self.infer_num_tokens(max_num_permuted_tokens)
+        num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
+        tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
+            num_tokens_per_expert)
+        tile_idx_to_mn_limit_list = self.generate_tile_idx_to_mn_limit(
+            num_tokens_per_expert)
+        permuted_idx_to_expanded_idx_list = self.generate_permuted_idx_to_expanded_idx(
+            num_tokens, num_tokens_per_expert, max_num_permuted_tokens)
+        num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
+        num_padding_tiles_val = max_num_tiles - num_non_exiting_tiles_val
+        assert num_non_exiting_tiles_val > 0
+        assert num_padding_tiles_val >= 0
+        assert len(tile_idx_to_mn_limit_list) == num_non_exiting_tiles_val
+        assert len(permuted_idx_to_expanded_idx_list) == max_num_permuted_tokens
+
+        tile_idx_to_group_idx = torch.tensor(
+            tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
+            dtype=tile_idx_to_group_idx.dtype,
+            device=tile_idx_to_group_idx.device)
+        tile_idx_to_mn_limit = torch.tensor(
+            tile_idx_to_mn_limit_list + [self.pad_val] * num_padding_tiles_val,
+            dtype=tile_idx_to_mn_limit.dtype,
+            device=tile_idx_to_mn_limit.device)
+        permuted_idx_to_expanded_idx = torch.tensor(
+            permuted_idx_to_expanded_idx_list,
+            dtype=permuted_idx_to_expanded_idx.dtype,
+            device=permuted_idx_to_expanded_idx.device)
+        num_non_exiting_tiles = torch.tensor(
+            [num_non_exiting_tiles_val],
+            dtype=num_non_exiting_tiles.dtype,
+            device=num_non_exiting_tiles.device)
+        return (a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx,
+                tile_idx_to_mn_limit, permuted_idx_to_expanded_idx,
+                num_non_exiting_tiles, global_sf)
 
 
 class FusedMoEInputsHelper:
 
-    def __init__(
-        self,
-        num_experts: int,
-        top_k: int,
-        num_local_experts: int,
-        local_expert_offset: int,
-    ):
+    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
+                 local_expert_offset: int):
         self.num_experts = num_experts
         self.top_k = top_k
         self.num_local_experts = num_local_experts
@@ -283,14 +330,12 @@ class FusedMoEInputsHelper:
         x, x_sf, token_selected_experts, token_final_scales, *others = inputs
         num_tokens = token_selected_experts.size(0)
         new_token_final_scales, new_token_selected_experts = torch.randn(
-            num_tokens, self.num_experts, device=token_selected_experts.device
-        ).topk(self.top_k, dim=-1)
+            num_tokens, self.num_experts,
+            device=token_selected_experts.device).topk(self.top_k, dim=-1)
         new_token_selected_experts = new_token_selected_experts.to(
-            token_selected_experts.dtype
-        )
+            token_selected_experts.dtype)
         new_token_final_scales = new_token_final_scales.softmax(dim=-1).to(
-            token_final_scales.dtype
-        )
+            token_final_scales.dtype)
         return x, x_sf, new_token_selected_experts, new_token_final_scales, *others
 
 
@@ -299,42 +344,34 @@ if IS_CUTLASS_DSL_AVAILABLE:
     import cutlass
     import cutlass.cute as cute
 
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm import (
-        Sm100BlockScaledContiguousGroupedGemmKernel,
-    )
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
-        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
-    )
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_swiglu_fusion import (
-        Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel,
-    )
-    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import (
-        Sm100BlockScaledPersistentDenseGemmKernel,
-    )
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import \
+        BlockScaledContiguousGatherGroupedGemmKernel
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm import \
+        Sm100BlockScaledContiguousGroupedGemmKernel
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import \
+        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_swiglu_fusion import \
+        Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel
+    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
+        Sm100BlockScaledPersistentDenseGemmKernel
     from ..cute_dsl_kernels.blackwell.utils import make_ptr
 
     class CuteDSLNVFP4BlackwellLinear(TunableRunner):
         kernel_class = Sm100BlockScaledPersistentDenseGemmKernel
         kernel_cache = dict()
         tuning_config = TuningConfig(
-            dynamic_tensor_specs=(
-                DynamicTensorSpec(
-                    0,
-                    0,
-                    get_last_power_of_2_num_tokens_buckets,
-                    last_positive_power_of_2,
-                ),
-            ),
-            constraint_specs=(ConstraintSpec(2, 0, fp4_scale_infer_shape),),
+            dynamic_tensor_specs=(DynamicTensorSpec(
+                0, 0, get_last_power_of_2_num_tokens_buckets,
+                last_positive_power_of_2), ),
+            constraint_specs=(ConstraintSpec(2, 0, fp4_scale_infer_shape), ),
             use_cold_l2_cache=True,
+            distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
         )
 
-        def __init__(
-            self,
-            output_dtype: torch.dtype,
-            to_userbuffers: bool = False,
-            use_tvm_ffi: bool = True,
-        ):
+        def __init__(self,
+                     output_dtype: torch.dtype,
+                     to_userbuffers: bool = False,
+                     use_tvm_ffi: bool = True):
             super().__init__()
 
             if output_dtype != torch.bfloat16:
@@ -349,16 +386,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return (self.output_dtype, self.to_userbuffers, self.use_tvm_ffi)
 
         def __hash__(self):
-            return hash((self.output_dtype, self.to_userbuffers, self.use_tvm_ffi))
+            return hash(
+                (self.output_dtype, self.to_userbuffers, self.use_tvm_ffi))
 
         def __eq__(self, other):
             if not isinstance(other, self.__class__):
                 return False
-            return (
-                self.output_dtype == other.output_dtype
-                and self.to_userbuffers == other.to_userbuffers
-                and self.use_tvm_ffi == other.use_tvm_ffi
-            )
+            return self.output_dtype == other.output_dtype and self.to_userbuffers == other.to_userbuffers and self.use_tvm_ffi == other.use_tvm_ffi
 
         def get_valid_tactics(
             self,
@@ -395,15 +429,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if real_k % 32 != 0:
                 logger.debug(
                     f"CuteDSL: K={real_k} does not meet 16-byte alignment requirement "
-                    f"(K%32={real_k%32}, expected 0). Skipping all tactics."
-                )
+                    f"(K%32={real_k%32}, expected 0). Skipping all tactics.")
                 return []
 
             # Optimize swap_ab candidates based on M and N alignment
             # swap_ab=False → C is N-major → requires N%8==0 (BF16: 128 bits / 16 bits = 8)
             # swap_ab=True  → C is M-major → requires M%8==0
-            m_aligned = m % 8 == 0
-            n_aligned = n % 8 == 0
+            m_aligned = (m % 8 == 0)
+            n_aligned = (n % 8 == 0)
 
             if not m_aligned and not n_aligned:
                 logger.debug(
@@ -421,8 +454,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             logger.debug(
                 f"CuteDSL: M={m}(aligned={m_aligned}), N={n}(aligned={n_aligned}), K={real_k}(aligned=True). "
-                f"Testing swap_ab={swap_ab_candidates}"
-            )
+                f"Testing swap_ab={swap_ab_candidates}")
 
             # full shamoo
             mma_tiler_mn_candidates = [
@@ -450,17 +482,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             use_prefetch_candidates = [True, False]
 
             valid_tactics = []
-            for (
-                mma_tiler_mn,
-                cluster_shape_mn,
-                swap_ab,
-                use_prefetch,
-            ) in itertools.product(
-                mma_tiler_mn_candidates,
-                cluster_shape_mn_candidates,
-                swap_ab_candidates,
-                use_prefetch_candidates,
-            ):
+            for mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch in itertools.product(
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates,
+                    swap_ab_candidates, use_prefetch_candidates):
                 if swap_ab:
                     c_major = "m"
                     kernel_m = n
@@ -471,32 +495,30 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     kernel_n = n
 
                 if self.__class__.kernel_class.can_implement(
-                    cutlass.Float4E2M1FN,  # ab_dtype,
-                    cutlass.Float8E4M3FN,  # sf_dtype
-                    sf_vec_size,  # sf_vec_size,
-                    cutlass.BFloat16,  # c_dtype,
-                    mma_tiler_mn,
-                    cluster_shape_mn,
-                    kernel_m,
-                    kernel_n,
-                    real_k,
-                    batch_size,
-                    a_major,
-                    b_major,
-                    c_major,
+                        cutlass.Float4E2M1FN,  # ab_dtype,
+                        cutlass.Float8E4M3FN,  # sf_dtype
+                        sf_vec_size,  # sf_vec_size,
+                        cutlass.BFloat16,  # c_dtype,
+                        mma_tiler_mn,
+                        cluster_shape_mn,
+                        kernel_m,
+                        kernel_n,
+                        real_k,
+                        batch_size,
+                        a_major,
+                        b_major,
+                        c_major,
                 ):
                     valid_tactics.append(
-                        (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch)
-                    )
+                        (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch))
 
             logger.debug(
                 f"CuteDSL: Found {len(valid_tactics)} valid tactics for M={m}, N={n}, K={real_k}"
             )
             return valid_tactics
 
-        def make_cute_dsl_global_pointer(
-            self, tensor: torch.Tensor, dtype, assumed_align: int
-        ):
+        def make_cute_dsl_global_pointer(self, tensor: torch.Tensor, dtype,
+                                         assumed_align: int):
             return make_ptr(
                 dtype,
                 tensor.data_ptr(),
@@ -544,10 +566,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             # Allocate output tensor from UserBuffers or regular CUDA memory
             if self.to_userbuffers:
                 c_tensor = torch.ops.trtllm.create_userbuffers_tensor(
-                    [m, n], self.output_dtype
-                )
+                    [m, n], self.output_dtype)
             else:
-                c_tensor = torch.empty(*(m, n), dtype=self.output_dtype, device="cuda")
+                c_tensor = torch.empty(*(m, n),
+                                       dtype=self.output_dtype,
+                                       device="cuda")
 
             if swap_ab:
                 c_tensor = c_tensor.permute(1, 0)
@@ -568,19 +591,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 raise ValueError(
                     f"CuteDSL: act scale factor size mismatch. "
                     f"Expected {expected_a_sf_size} (sf_m={sf_m} * sf_k={sf_k}), "
-                    f"got {a_sf_tensor.numel()} for shape M={m}, K={real_k}"
-                )
+                    f"got {a_sf_tensor.numel()} for shape M={m}, K={real_k}")
             if b_sf_tensor.numel() != expected_b_sf_size:
                 raise ValueError(
                     f"CuteDSL: weight scale factor size mismatch. "
                     f"Expected {expected_b_sf_size} (sf_n={sf_n} * sf_k={sf_k}), "
-                    f"got {b_sf_tensor.numel()} for shape N={n}, K={real_k}"
-                )
+                    f"got {b_sf_tensor.numel()} for shape N={n}, K={real_k}")
             if alpha_tensor.numel() != 1:
-                raise ValueError(
-                    f"CuteDSL: alpha size mismatch. "
-                    f"Expected 1, got {alpha_tensor.numel()}"
-                )
+                raise ValueError(f"CuteDSL: alpha size mismatch. "
+                                 f"Expected 1, got {alpha_tensor.numel()}")
 
             # Reshape to CuteDSL's expected format (just a view, no copy)
             a_sf_tensor = a_sf_tensor.reshape(sf_m * sf_k)
@@ -588,33 +607,23 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             if not self.use_tvm_ffi:
                 a_ptr = self.make_cute_dsl_global_pointer(
-                    a_tensor, cutlass.Float4E2M1FN, 32
-                )
+                    a_tensor, cutlass.Float4E2M1FN, 32)
                 b_ptr = self.make_cute_dsl_global_pointer(
-                    b_tensor, cutlass.Float4E2M1FN, 32
-                )
+                    b_tensor, cutlass.Float4E2M1FN, 32)
                 a_sf_ptr = self.make_cute_dsl_global_pointer(
-                    a_sf_tensor, cutlass.Float8E4M3FN, 16
-                )
+                    a_sf_tensor, cutlass.Float8E4M3FN, 16)
                 b_sf_ptr = self.make_cute_dsl_global_pointer(
-                    b_sf_tensor, cutlass.Float8E4M3FN, 16
-                )
+                    b_sf_tensor, cutlass.Float8E4M3FN, 16)
                 c_ptr = self.make_cute_dsl_global_pointer(
-                    c_tensor, cutlass.BFloat16, 16
-                )
+                    c_tensor, cutlass.BFloat16, 16)
                 alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
 
                 # get stream
                 torch_stream = torch.cuda.current_stream()
                 stream = cuda.CUstream(torch_stream.cuda_stream)
 
-            cache_key = (
-                sf_vec_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-                swap_ab,
-                use_prefetch,
-            )
+            cache_key = (sf_vec_size, mma_tiler_mn, cluster_shape_mn, swap_ab,
+                         use_prefetch)
             if swap_ab:
                 kernel_m = n
                 kernel_n = m
@@ -651,23 +660,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if cache_key not in self.__class__.kernel_cache:
                 if self.use_tvm_ffi:
                     a_ptr = self.make_cute_dsl_global_pointer(
-                        a_tensor, cutlass.Float4E2M1FN, 32
-                    )
+                        a_tensor, cutlass.Float4E2M1FN, 32)
                     b_ptr = self.make_cute_dsl_global_pointer(
-                        b_tensor, cutlass.Float4E2M1FN, 32
-                    )
+                        b_tensor, cutlass.Float4E2M1FN, 32)
                     a_sf_ptr = self.make_cute_dsl_global_pointer(
-                        a_sf_tensor, cutlass.Float8E4M3FN, 16
-                    )
+                        a_sf_tensor, cutlass.Float8E4M3FN, 16)
                     b_sf_ptr = self.make_cute_dsl_global_pointer(
-                        b_sf_tensor, cutlass.Float8E4M3FN, 16
-                    )
+                        b_sf_tensor, cutlass.Float8E4M3FN, 16)
                     c_ptr = self.make_cute_dsl_global_pointer(
-                        c_tensor, cutlass.BFloat16, 16
-                    )
+                        c_tensor, cutlass.BFloat16, 16)
                     alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
                     # make faked stream
-                    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+                    stream = cute.runtime.make_fake_stream(
+                        use_tvm_ffi_env_stream=True)
 
                     if swap_ab:
                         kernel_a_ptr = b_ptr
@@ -689,8 +694,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1]
-                )
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
 
                 # Note: when tvm_ffi fake stream is used, at least one parameter shoube be tensor type,
                 # so we make alpha as the cute.Tensor type in the jit func.
@@ -712,11 +716,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     max_active_clusters,
                     stream,
                     swap_ab,
-                    options=(
-                        f"--opt-level 2 --enable-tvm-ffi"
-                        if self.use_tvm_ffi
-                        else "--opt-level 2"
-                    ),
+                    options=f"--opt-level 2 --enable-tvm-ffi"
+                    if self.use_tvm_ffi else "--opt-level 2",
                 )
 
                 self.__class__.kernel_cache[cache_key] = compiled_gemm
@@ -763,9 +764,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return c_tensor
 
     # a/b: fp4, scale: fp8, output: bf16
-    @torch.library.custom_op(
-        "trtllm::cute_dsl_nvfp4_gemm_blackwell", mutates_args=(), device_types="cuda"
-    )
+    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_gemm_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
     def cute_dsl_nvfp4_gemm_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -802,7 +803,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
         tuner = AutoTuner.get()
 
-        runner = CuteDSLNVFP4BlackwellLinear(output_dtype, to_userbuffers, use_tvm_ffi)
+        runner = CuteDSLNVFP4BlackwellLinear(output_dtype, to_userbuffers,
+                                             use_tvm_ffi)
         inputs = [input, weight, input_scale, weight_scale, alpha]
         _, best_tactic = tuner.choose_one(
             "trtllm::cute_dsl_nvfp4_gemm_blackwell",
@@ -838,16 +840,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(
-            self,
-            num_experts: int,
-            top_k: int,
-            num_local_experts: int,
-            local_expert_offset: int,
-            tile_size: int,
-            output_dtype: torch.dtype,
-            scaling_vector_size: int = 16,
-        ):
+        def __init__(self,
+                     num_experts: int,
+                     top_k: int,
+                     num_local_experts: int,
+                     local_expert_offset: int,
+                     tile_size: int,
+                     output_dtype: torch.dtype,
+                     scaling_vector_size: int = 16):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -891,25 +891,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                mma_tiler_mn_candidates, cluster_shape_mn_candidates
-            ):
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
                 if self.__class__.kernel_class.can_implement(
-                    ab_dtype=cutlass.Float4E2M1FN,
-                    sf_dtype=cutlass.Float8E4M3FN,
-                    sf_vec_size=self.scaling_vector_size,
-                    acc_dtype=cutlass.Float32,
-                    c_dtype=cutlass.BFloat16,
-                    use_2cta_instrs=False,
-                    mma_tiler_mn=mma_tiler_mn,
-                    cluster_shape_mn=cluster_shape_mn,
-                    m=m,
-                    n=n,
-                    k=k,
-                    l=l,
-                    a_major="k",
-                    b_major="k",
-                    c_major="n",
-                    m_aligned=self.tile_size,
+                        ab_dtype=cutlass.Float4E2M1FN,
+                        sf_dtype=cutlass.Float8E4M3FN,
+                        sf_vec_size=self.scaling_vector_size,
+                        acc_dtype=cutlass.Float32,
+                        c_dtype=cutlass.BFloat16,
+                        use_2cta_instrs=False,
+                        mma_tiler_mn=mma_tiler_mn,
+                        cluster_shape_mn=cluster_shape_mn,
+                        m=m,
+                        n=n,
+                        k=k,
+                        l=l,
+                        a_major="k",
+                        b_major="k",
+                        c_major="n",
+                        m_aligned=self.tile_size,
                 ):
                     valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
 
@@ -918,37 +917,27 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(
-                    self.num_experts,
-                    self.top_k,
-                    self.num_local_experts,
-                    self.local_expert_offset,
-                    self.tile_size,
-                )
+                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
+                                                 self.num_local_experts,
+                                                 self.local_expert_offset,
+                                                 self.tile_size)
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(
-                        DynamicTensorSpec(
-                            0,
-                            0,
-                            helper.gen_tuning_buckets,
-                            helper.map_to_tuning_buckets,
-                        ),
-                    ),
-                    constraint_specs=(
-                        ConstraintSpec(2, 0, fp4_scale_infer_shape),
-                        ConstraintSpec(5, 0, helper.infer_shape_max_num_tiles),
-                    ),
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, helper.gen_tuning_buckets,
+                        helper.map_to_tuning_buckets), ),
+                    constraint_specs=(ConstraintSpec(2, 0,
+                                                     fp4_scale_infer_shape),
+                                      ConstraintSpec(
+                                          5, 0,
+                                          helper.infer_shape_max_num_tiles)),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(
-            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
-        ) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles = (
-                inputs
-            )
+        def forward(self, inputs: List[torch.Tensor],
+                    tactic: Optional[tuple]) -> torch.Tensor:
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -974,48 +963,40 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles,)
+            assert tile_idx_to_group_idx.size() == (num_tiles, )
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
 
             c = torch.empty(m, n, dtype=self.output_dtype, device=a.device)
 
-            a_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                a.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            b_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                b.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            a_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                a_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            b_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                b_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            alpha_ptr = make_ptr(
-                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
-            )
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
+                                 cute.AddressSpace.gmem)
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
-            )
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
+                cute.AddressSpace.gmem)
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
-            )
-            c_ptr = make_ptr(
-                cutlass.BFloat16, c.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
-            )
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
+                cute.AddressSpace.gmem)
+            c_ptr = make_ptr(cutlass.BFloat16,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=16)
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -1025,12 +1006,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
-            cache_key = (
-                self.scaling_vector_size,
-                self.tile_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-            )
+            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
+                         cluster_shape_mn)
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
@@ -1042,8 +1019,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1]
-                )
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -1085,11 +1061,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             return c
 
-    @torch.library.custom_op(
-        "trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell",
-        mutates_args=(),
-        device_types="cuda",
-    )
+    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
     def cute_dsl_nvfp4_grouped_gemm_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1109,22 +1083,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmRunner(
-            num_experts,
-            top_k,
-            num_local_experts,
-            local_expert_offset,
-            tile_size,
-            output_dtype,
-            scaling_vector_size,
-        )
+            num_experts, top_k, num_local_experts, local_expert_offset,
+            tile_size, output_dtype, scaling_vector_size)
         inputs = [
-            input,
-            weight,
-            input_scale,
-            weight_scale,
-            alpha,
-            tile_idx_to_group_idx,
-            num_non_exiting_tiles,
+            input, weight, input_scale, weight_scale, alpha,
+            tile_idx_to_group_idx, num_non_exiting_tiles
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -1136,7 +1099,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         output = runner(inputs, tactic=best_tactic)
         return output
 
-    @torch.library.register_fake("trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell")
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell")
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1157,21 +1121,20 @@ if IS_CUTLASS_DSL_AVAILABLE:
         n = weight.size(1)
         return torch.empty(m, n, dtype=output_dtype, device=input.device)
 
-    class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(TunableRunner):
+    class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(
+            TunableRunner):
         kernel_class = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(
-            self,
-            num_experts: int,
-            top_k: int,
-            num_local_experts: int,
-            local_expert_offset: int,
-            tile_size: int,
-            output_dtype: torch.dtype,
-            scaling_vector_size: int = 16,
-        ):
+        def __init__(self,
+                     num_experts: int,
+                     top_k: int,
+                     num_local_experts: int,
+                     local_expert_offset: int,
+                     tile_size: int,
+                     output_dtype: torch.dtype,
+                     scaling_vector_size: int = 16):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1210,82 +1173,62 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l, n = b.size(0), b.size(1)
 
             # TODO: Add full shmoo
-            mma_tiler_mn_candidates = [(128, 128), (128, 256), (256, 128), (256, 256)]
+            mma_tiler_mn_candidates = [(128, 128), (128, 256), (256, 128),
+                                       (256, 256)]
             cluster_shape_mn_candidates = [(1, 1), (1, 2), (2, 1), (2, 2)]
+            raster_along_m_candidates = [True, False]
 
             valid_tactics = []
-            for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                mma_tiler_mn_candidates, cluster_shape_mn_candidates
-            ):
+            for mma_tiler_mn, cluster_shape_mn, raster_along_m in itertools.product(
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates,
+                    raster_along_m_candidates):
                 if self.__class__.kernel_class.can_implement(
-                    ab_dtype=cutlass.Float4E2M1FN,
-                    sf_dtype=cutlass.Float8E4M3FN,
-                    sf_vec_size=self.scaling_vector_size,
-                    out_dtype=cutlass.BFloat16,
-                    mma_tiler_mn=mma_tiler_mn,
-                    cluster_shape_mn=cluster_shape_mn,
-                    m=m,
-                    n=n,
-                    k=k,
-                    l=l,
-                    a_major="k",
-                    b_major="k",
-                    out_major="n",
+                        ab_dtype=cutlass.Float4E2M1FN,
+                        sf_dtype=cutlass.Float8E4M3FN,
+                        sf_vec_size=self.scaling_vector_size,
+                        out_dtype=cutlass.BFloat16,
+                        mma_tiler_mn=mma_tiler_mn,
+                        cluster_shape_mn=cluster_shape_mn,
+                        m=m,
+                        n=n,
+                        k=k,
+                        l=l,
+                        a_major="k",
+                        b_major="k",
+                        out_major="n",
                 ):
-                    valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
+                    valid_tactics.append(
+                        (mma_tiler_mn, cluster_shape_mn, raster_along_m))
 
             return valid_tactics
 
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(
-                    self.num_experts,
-                    self.top_k,
-                    self.num_local_experts,
-                    self.local_expert_offset,
-                    self.tile_size,
-                )
+                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
+                                                 self.num_local_experts,
+                                                 self.local_expert_offset,
+                                                 self.tile_size)
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(
-                        DynamicTensorSpec(
-                            0,
-                            0,
-                            helper.gen_tuning_buckets,
-                            helper.map_to_tuning_buckets,
-                        ),
-                    ),
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, helper.gen_tuning_buckets,
+                        helper.map_to_tuning_buckets), ),
                     constraint_specs=(
                         ConstraintSpec(2, 0, fp4_scale_infer_shape),
                         ConstraintSpec(5, 0, helper.infer_shape_num_tokens),
                         ConstraintSpec(6, 0, helper.infer_shape_max_num_tiles),
                         ConstraintSpec(7, 0, helper.infer_shape_max_num_tiles),
                         ConstraintSpec(
-                            8, 0, helper.infer_shape_max_num_permuted_tokens
-                        ),
-                        ConstraintSpec(10, 0, helper.infer_shape_num_tokens),
-                    ),
+                            8, 0, helper.infer_shape_max_num_permuted_tokens),
+                        ConstraintSpec(10, 0, helper.infer_shape_num_tokens)),
                     inputs_pre_hook=helper.inputs_pre_hook_finalize_fusion,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(
-            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
-        ) -> torch.Tensor:
-            (
-                a,
-                b,
-                a_sf,
-                b_sf,
-                alpha,
-                c,
-                tile_idx_to_group_idx,
-                tile_idx_to_mn_limit,
-                permuted_idx_to_expanded_idx,
-                num_non_exiting_tiles,
-                token_final_scales,
-            ) = inputs
+        def forward(self, inputs: List[torch.Tensor],
+                    tactic: Optional[tuple]) -> torch.Tensor:
+            a, b, a_sf, b_sf, alpha, c, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -1316,94 +1259,81 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles,)
+            assert tile_idx_to_group_idx.size() == (num_tiles, )
             assert tile_idx_to_mn_limit.dtype == torch.int32
-            assert tile_idx_to_mn_limit.size() == (num_tiles,)
+            assert tile_idx_to_mn_limit.size() == (num_tiles, )
             assert permuted_idx_to_expanded_idx.dtype == torch.int32
-            assert permuted_idx_to_expanded_idx.size() == (m,)
+            assert permuted_idx_to_expanded_idx.size() == (m, )
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
             assert token_final_scales.dtype == torch.float32
             assert token_final_scales.dim() == 2
             assert token_final_scales.size() == (num_tokens, self.top_k)
 
-            a_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                a.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            b_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                b.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            a_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                a_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            b_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                b_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            alpha_ptr = make_ptr(
-                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
-            )
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
+                                 cute.AddressSpace.gmem)
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
-            )
-            tile_idx_to_mn_limit_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_mn_limit.data_ptr(), cute.AddressSpace.gmem
-            )
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
+                cute.AddressSpace.gmem)
+            tile_idx_to_mn_limit_ptr = make_ptr(cutlass.Int32,
+                                                tile_idx_to_mn_limit.data_ptr(),
+                                                cute.AddressSpace.gmem)
             permuted_idx_to_expanded_idx_ptr = make_ptr(
-                cutlass.Int32,
-                permuted_idx_to_expanded_idx.data_ptr(),
-                cute.AddressSpace.gmem,
-            )
+                cutlass.Int32, permuted_idx_to_expanded_idx.data_ptr(),
+                cute.AddressSpace.gmem)
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
-            )
-            token_final_scales_ptr = make_ptr(
-                cutlass.Float32, token_final_scales.data_ptr(), cute.AddressSpace.gmem
-            )
-            c_ptr = make_ptr(
-                cutlass.BFloat16, c.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
-            )
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
+                cute.AddressSpace.gmem)
+            token_final_scales_ptr = make_ptr(cutlass.Float32,
+                                              token_final_scales.data_ptr(),
+                                              cute.AddressSpace.gmem)
+            c_ptr = make_ptr(cutlass.BFloat16,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=16)
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
 
             if isinstance(tactic, tuple):
-                mma_tiler_mn, cluster_shape_mn = tactic
+                mma_tiler_mn, cluster_shape_mn, raster_along_m = tactic
             else:
                 if self.tile_size == 256:
-                    mma_tiler_mn, cluster_shape_mn = (256, 128), (2, 1)
+                    mma_tiler_mn, cluster_shape_mn, raster_along_m = (
+                        256, 128), (2, 1), False
                 else:
-                    mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+                    mma_tiler_mn, cluster_shape_mn, raster_along_m = (
+                        128, 128), (1, 1), False
 
-            cache_key = (
-                self.scaling_vector_size,
-                self.tile_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-            )
+            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
+                         cluster_shape_mn)
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
                     mma_tiler_mn=mma_tiler_mn,
                     cluster_shape_mn=cluster_shape_mn,
-                    use_prefetch=False,
+                    raster_along_m=raster_along_m,
                 )
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1]
-                )
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -1457,9 +1387,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell",
-        mutates_args=("output",),
-        device_types="cuda",
-    )
+        mutates_args=("output", ),
+        device_types="cuda")
     def cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1483,27 +1412,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(
-            num_experts,
-            top_k,
-            num_local_experts,
-            local_expert_offset,
-            tile_size,
-            output_dtype,
-            scaling_vector_size,
-        )
+            num_experts, top_k, num_local_experts, local_expert_offset,
+            tile_size, output_dtype, scaling_vector_size)
 
         inputs = [
-            input,
-            weight,
-            input_scale,
-            weight_scale,
-            alpha,
-            output,
-            tile_idx_to_group_idx,
-            tile_idx_to_mn_limit,
-            permuted_idx_to_expanded_idx,
-            num_non_exiting_tiles,
-            token_final_scales,
+            input, weight, input_scale, weight_scale, alpha, output,
+            tile_idx_to_group_idx, tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx, num_non_exiting_tiles,
+            token_final_scales
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -1517,8 +1433,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell",
         mutates_args=(),
-        device_types="cuda",
-    )
+        device_types="cuda")
     def cute_dsl_nvfp4_grouped_gemm_finalize_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1540,7 +1455,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> torch.Tensor:
         num_tokens = token_final_scales.size(0)
         n = weight.size(1)
-        output = torch.zeros(num_tokens, n, dtype=output_dtype, device=input.device)
+        output = torch.zeros(num_tokens,
+                             n,
+                             dtype=output_dtype,
+                             device=input.device)
         torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell(
             input=input,
             weight=weight,
@@ -1564,8 +1482,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         return output
 
     @torch.library.register_fake(
-        "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell"
-    )
+        "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell")
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1587,22 +1504,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> torch.Tensor:
         num_tokens = token_final_scales.size(0)
         n = weight.size(1)
-        return torch.empty(num_tokens, n, dtype=output_dtype, device=input.device)
+        return torch.empty(num_tokens,
+                           n,
+                           dtype=output_dtype,
+                           device=input.device)
 
-    class Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(TunableRunner):
+    class Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(
+            TunableRunner):
         kernel_class = Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(
-            self,
-            num_experts: int,
-            top_k: int,
-            num_local_experts: int,
-            local_expert_offset: int,
-            tile_size: int,
-            scaling_vector_size: int = 16,
-        ):
+        def __init__(self,
+                     num_experts: int,
+                     top_k: int,
+                     num_local_experts: int,
+                     local_expert_offset: int,
+                     tile_size: int,
+                     scaling_vector_size: int = 16):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1642,25 +1561,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                mma_tiler_mn_candidates, cluster_shape_mn_candidates
-            ):
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
                 if self.__class__.kernel_class.can_implement(
-                    ab_dtype=cutlass.Float4E2M1FN,
-                    sf_dtype=cutlass.Float8E4M3FN,
-                    sf_vec_size=self.scaling_vector_size,
-                    acc_dtype=cutlass.Float32,
-                    c_dtype=cutlass.Float4E2M1FN,
-                    use_2cta_instrs=False,
-                    mma_tiler_mn=mma_tiler_mn,
-                    cluster_shape_mn=cluster_shape_mn,
-                    m=m,
-                    n=n,
-                    k=k,
-                    l=l,
-                    a_major="k",
-                    b_major="k",
-                    c_major="n",
-                    m_aligned=self.tile_size,
+                        ab_dtype=cutlass.Float4E2M1FN,
+                        sf_dtype=cutlass.Float8E4M3FN,
+                        sf_vec_size=self.scaling_vector_size,
+                        acc_dtype=cutlass.Float32,
+                        c_dtype=cutlass.Float4E2M1FN,
+                        use_2cta_instrs=False,
+                        mma_tiler_mn=mma_tiler_mn,
+                        cluster_shape_mn=cluster_shape_mn,
+                        m=m,
+                        n=n,
+                        k=k,
+                        l=l,
+                        a_major="k",
+                        b_major="k",
+                        c_major="n",
+                        m_aligned=self.tile_size,
                 ):
                     valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
 
@@ -1669,44 +1587,27 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(
-                    self.num_experts,
-                    self.top_k,
-                    self.num_local_experts,
-                    self.local_expert_offset,
-                    self.tile_size,
-                )
+                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
+                                                 self.num_local_experts,
+                                                 self.local_expert_offset,
+                                                 self.tile_size)
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(
-                        DynamicTensorSpec(
-                            0,
-                            0,
-                            helper.gen_tuning_buckets,
-                            helper.map_to_tuning_buckets,
-                        ),
-                    ),
-                    constraint_specs=(
-                        ConstraintSpec(2, 0, fp4_scale_infer_shape),
-                        ConstraintSpec(5, 0, helper.infer_shape_max_num_tiles),
-                    ),
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, helper.gen_tuning_buckets,
+                        helper.map_to_tuning_buckets), ),
+                    constraint_specs=(ConstraintSpec(2, 0,
+                                                     fp4_scale_infer_shape),
+                                      ConstraintSpec(
+                                          5, 0,
+                                          helper.infer_shape_max_num_tiles)),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(
-            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
-        ) -> torch.Tensor:
-            (
-                a,
-                b,
-                a_sf,
-                b_sf,
-                alpha,
-                tile_idx_to_group_idx,
-                num_non_exiting_tiles,
-                global_sf,
-            ) = inputs
+        def forward(self, inputs: List[torch.Tensor],
+                    tactic: Optional[tuple]) -> torch.Tensor:
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, global_sf = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -1734,67 +1635,51 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles,)
+            assert tile_idx_to_group_idx.size() == (num_tiles, )
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
             assert global_sf.dtype == torch.float32
             assert global_sf.numel() == 1
 
             c = torch.empty(m, interm_size // 2, dtype=a.dtype, device=a.device)
-            c_sf = torch.empty(
-                m * interm_size // self.scaling_vector_size,
-                dtype=a_sf.dtype,
-                device=a_sf.device,
-            )
+            c_sf = torch.empty(m * interm_size // self.scaling_vector_size,
+                               dtype=a_sf.dtype,
+                               device=a_sf.device)
 
-            a_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                a.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            b_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                b.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            a_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                a_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            b_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                b_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            alpha_ptr = make_ptr(
-                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
-            )
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
+                                 cute.AddressSpace.gmem)
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
-            )
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
+                cute.AddressSpace.gmem)
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
-            )
-            global_sf_ptr = make_ptr(
-                cutlass.Float32, global_sf.data_ptr(), cute.AddressSpace.gmem
-            )
-            c_ptr = make_ptr(
-                cutlass.Float4E2M1FN,
-                c.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=32,
-            )
-            c_sf_ptr = make_ptr(
-                cutlass.Float8E4M3FN,
-                c_sf.data_ptr(),
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
+                cute.AddressSpace.gmem)
+            global_sf_ptr = make_ptr(cutlass.Float32, global_sf.data_ptr(),
+                                     cute.AddressSpace.gmem)
+            c_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                c_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -1804,12 +1689,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
-            cache_key = (
-                self.scaling_vector_size,
-                self.tile_size,
-                mma_tiler_mn,
-                cluster_shape_mn,
-            )
+            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
+                         cluster_shape_mn)
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
@@ -1822,8 +1703,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1]
-                )
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -1872,8 +1752,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell",
         mutates_args=(),
-        device_types="cuda",
-    )
+        device_types="cuda")
     def cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1893,22 +1772,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(
-            num_experts,
-            top_k,
-            num_local_experts,
-            local_expert_offset,
-            tile_size,
-            scaling_vector_size,
-        )
+            num_experts, top_k, num_local_experts, local_expert_offset,
+            tile_size, scaling_vector_size)
         inputs = [
-            input,
-            weight,
-            input_scale,
-            weight_scale,
-            alpha,
-            tile_idx_to_group_idx,
-            num_non_exiting_tiles,
-            global_sf,
+            input, weight, input_scale, weight_scale, alpha,
+            tile_idx_to_group_idx, num_non_exiting_tiles, global_sf
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -1920,7 +1788,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         output = runner(inputs, tactic=best_tactic)
         return output
 
-    @torch.library.register_fake("trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell")
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell")
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1940,28 +1809,409 @@ if IS_CUTLASS_DSL_AVAILABLE:
         m = input.size(0)
         n = weight.size(1)
         interm_size = n // 2
-        output = torch.empty(
-            m, interm_size // 2, dtype=input.dtype, device=input.device
-        )
-        output_scale = torch.empty(
-            m * interm_size // scaling_vector_size,
-            dtype=input_scale.dtype,
-            device=input_scale.device,
-        )
+        output = torch.empty(m,
+                             interm_size // 2,
+                             dtype=input.dtype,
+                             device=input.device)
+        output_scale = torch.empty(m * interm_size // scaling_vector_size,
+                                   dtype=input_scale.dtype,
+                                   device=input_scale.device)
         return output, output_scale
+
+    class Sm100BlockScaledContiguousGatherGroupedGemmSwigluFusionRunner(
+            TunableRunner):
+        kernel_class = BlockScaledContiguousGatherGroupedGemmKernel
+        kernel_cache = dict()
+        tuning_config_cache = dict()
+
+        def __init__(self,
+                     num_experts: int,
+                     top_k: int,
+                     num_local_experts: int,
+                     local_expert_offset: int,
+                     tile_size: int,
+                     scaling_vector_size: int = 16):
+            super().__init__()
+            self.num_experts = num_experts
+            self.top_k = top_k
+            self.num_local_experts = num_local_experts
+            self.local_expert_offset = local_expert_offset
+            if tile_size not in [128, 256]:
+                raise ValueError(
+                    f"Tile size {tile_size} is not supported, it only supports 128 and 256."
+                )
+            self.tile_size = tile_size
+            self.scaling_vector_size = scaling_vector_size
+
+            if get_sm_version() != 100 and get_sm_version() != 103:
+                raise ValueError(
+                    f"SM version {get_sm_version()} is not supported for {self.__class__.__name__}, it only supports SM 100 and SM 103"
+                )
+
+        def unique_id(self):
+            return (
+                self.num_experts,
+                self.top_k,
+                self.num_local_experts,
+                self.local_expert_offset,
+                self.tile_size,
+                self.scaling_vector_size,
+            )
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+            **kwargs,
+        ) -> List[Tuple[int, int]]:
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, *_ = inputs
+            # m is the permuted size from permuted_idx_to_expanded_idx, not from a
+            m = permuted_idx_to_expanded_idx.size(0)
+            k = a.size(1) * 2
+            l, n = b.size(0), b.size(1)
+
+            if self.tile_size == 128:
+                mma_tiler_mn_candidates = [(128, 128), (128, 256)]
+                cluster_shape_mn_candidates = [(1, 1)]
+            elif self.tile_size == 256:
+                mma_tiler_mn_candidates = [(256, 128), (256, 256)]
+                cluster_shape_mn_candidates = [(2, 1)]
+            else:
+                raise ValueError(f"Tile size {self.tile_size} is not supported")
+
+            valid_tactics = []
+            for mma_tiler_mn, cluster_shape_mn in itertools.product(
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                if self.__class__.kernel_class.can_implement(
+                        ab_dtype=cutlass.Float4E2M1FN,
+                        sf_dtype=cutlass.Float8E4M3FN,
+                        sf_vec_size=self.scaling_vector_size,
+                        acc_dtype=cutlass.Float32,
+                        c_dtype=cutlass.Float4E2M1FN,
+                        mma_tiler_mn=mma_tiler_mn,
+                        cluster_shape_mn=cluster_shape_mn,
+                        m=m,
+                        n=n,
+                        k=k,
+                        l=l,
+                        a_major="k",
+                        b_major="k",
+                        c_major="n",
+                        m_aligned=self.tile_size,
+                ):
+                    valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
+
+            return valid_tactics
+
+        def get_tuning_config(self) -> TuningConfig:
+            key = self.unique_id()
+            if key not in self.__class__.tuning_config_cache:
+                helper = GatherGroupedGemmInputsHelper(self.num_experts,
+                                                       self.top_k,
+                                                       self.num_local_experts,
+                                                       self.local_expert_offset,
+                                                       self.tile_size)
+                self.__class__.tuning_config_cache[key] = TuningConfig(
+                    # Use permuted_idx_to_expanded_idx (IDX_SHAPE_INFER) for tuning
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        GatherGroupedGemmInputsHelper.IDX_SHAPE_INFER, 0,
+                        helper.gen_tuning_buckets,
+                        helper.map_to_tuning_buckets), ),
+                    constraint_specs=(ConstraintSpec(
+                        0, 0, helper.infer_shape_num_tokens),
+                                      ConstraintSpec(
+                                          2, 0, helper.infer_shape_num_tokens),
+                                      ConstraintSpec(
+                                          5, 0,
+                                          helper.infer_shape_max_num_tiles),
+                                      ConstraintSpec(
+                                          6, 0,
+                                          helper.infer_shape_max_num_tiles)),
+                    inputs_pre_hook=helper.inputs_pre_hook,
+                    use_cuda_graph=True,
+                )
+            return self.__class__.tuning_config_cache[key]
+
+        def forward(self, inputs: List[torch.Tensor],
+                    tactic: Optional[tuple]) -> torch.Tensor:
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, global_sf = inputs
+            # Verify permuted_idx_to_expanded_idx index matches the class constant
+            assert inputs[
+                GatherGroupedGemmInputsHelper.
+                IDX_PERMUTED_IDX_TO_EXPANDED_IDX] is permuted_idx_to_expanded_idx
+            assert a.dtype == torch.float4_e2m1fn_x2
+            assert a.dim() == 2
+            assert b.dtype == torch.float4_e2m1fn_x2
+            assert b.dim() == 3
+            assert a_sf.dtype == torch.uint8
+            assert a_sf.dim() == 2
+            assert b_sf.dtype == torch.uint8
+            assert b_sf.dim() == 3
+            assert alpha.dtype == torch.float32
+            assert alpha.dim() == 1
+
+            # a.size(0) is orig_m (original input size before gather)
+            # permuted_idx_to_expanded_idx.size(0) is m (permuted size after gather)
+            orig_m, k = a.size(0), a.size(1) * 2
+            m = permuted_idx_to_expanded_idx.size(0)
+            l, n = b.size(0), b.size(1)
+            scale_k = k // self.scaling_vector_size
+            interm_size = n // 2
+            assert m % self.tile_size == 0
+            assert k % (self.scaling_vector_size * 4) == 0
+            assert n % (self.scaling_vector_size * 4 * 2) == 0
+            assert b.size(2) * 2 == k
+            assert a_sf.size(0) == orig_m
+            assert a_sf.size(1) == scale_k
+            assert b_sf.size(0) == l
+            assert b_sf.size(1) == n
+            assert b_sf.size(2) == scale_k
+            assert alpha.size(0) == l
+
+            num_tiles = m // self.tile_size
+            assert tile_idx_to_group_idx.dtype == torch.int32
+            assert tile_idx_to_group_idx.size() == (num_tiles, )
+            assert tile_idx_to_mn_limit.dtype == torch.int32
+            assert tile_idx_to_mn_limit.size() == (num_tiles, )
+            assert permuted_idx_to_expanded_idx.dtype == torch.int32
+            assert permuted_idx_to_expanded_idx.size() == (m, )
+            assert num_non_exiting_tiles.dtype == torch.int32
+            assert num_non_exiting_tiles.numel() == 1
+            assert global_sf.dtype == torch.float32
+            assert global_sf.numel() == 1
+
+            c = torch.empty(m, interm_size // 2, dtype=a.dtype, device=a.device)
+            c_sf = torch.empty(m * interm_size // self.scaling_vector_size,
+                               dtype=a_sf.dtype,
+                               device=a_sf.device)
+
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
+                                 cute.AddressSpace.gmem)
+            tile_idx_to_group_idx_ptr = make_ptr(
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
+                cute.AddressSpace.gmem)
+            tile_idx_to_mn_limit_ptr = make_ptr(cutlass.Int32,
+                                                tile_idx_to_mn_limit.data_ptr(),
+                                                cute.AddressSpace.gmem)
+            permuted_idx_to_expanded_idx_ptr = make_ptr(
+                cutlass.Int32, permuted_idx_to_expanded_idx.data_ptr(),
+                cute.AddressSpace.gmem)
+            num_non_exiting_tiles_ptr = make_ptr(
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
+                cute.AddressSpace.gmem)
+            global_sf_ptr = make_ptr(cutlass.Float32, global_sf.data_ptr(),
+                                     cute.AddressSpace.gmem)
+            c_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                c_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+
+            torch_stream = torch.cuda.current_stream()
+            stream = cuda.CUstream(torch_stream.cuda_stream)
+
+            if isinstance(tactic, tuple):
+                mma_tiler_mn, cluster_shape_mn = tactic
+            else:
+                mma_tiler_mn, cluster_shape_mn = (self.tile_size,
+                                                  128), (self.tile_size // 128,
+                                                         1)
+
+            cache_key = (self.scaling_vector_size, self.tile_size, self.top_k,
+                         mma_tiler_mn, cluster_shape_mn)
+            if cache_key not in self.__class__.kernel_cache:
+                gemm = self.__class__.kernel_class(
+                    sf_vec_size=self.scaling_vector_size,
+                    acc_dtype=cutlass.Float32,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    vectorized_f32=True,
+                    topk=self.top_k,
+                )
+                # Compute max active clusters on current device
+                hardware_info = cutlass.utils.HardwareInfo()
+                max_active_clusters = hardware_info.get_max_active_clusters(
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
+
+                compiled_gemm = cute.compile(
+                    gemm.wrapper,
+                    a_ptr,
+                    b_ptr,
+                    a_sf_ptr,
+                    b_sf_ptr,
+                    c_ptr,
+                    c_sf_ptr,
+                    alpha_ptr,
+                    tile_idx_to_group_idx_ptr,
+                    tile_idx_to_mn_limit_ptr,
+                    permuted_idx_to_expanded_idx_ptr,
+                    num_non_exiting_tiles_ptr,
+                    global_sf_ptr,
+                    orig_m,
+                    m,
+                    n,
+                    k,
+                    l,
+                    tile_size=self.tile_size,
+                    scaling_vector_size=self.scaling_vector_size,
+                    max_active_clusters=max_active_clusters,
+                    stream=stream,
+                )
+                self.__class__.kernel_cache[cache_key] = compiled_gemm
+            else:
+                compiled_gemm = self.__class__.kernel_cache[cache_key]
+
+            compiled_gemm(
+                a_ptr,
+                b_ptr,
+                a_sf_ptr,
+                b_sf_ptr,
+                c_ptr,
+                c_sf_ptr,
+                alpha_ptr,
+                tile_idx_to_group_idx_ptr,
+                tile_idx_to_mn_limit_ptr,
+                permuted_idx_to_expanded_idx_ptr,
+                num_non_exiting_tiles_ptr,
+                global_sf_ptr,
+                orig_m,
+                m,
+                n,
+                k,
+                l,
+                stream=stream,
+            )
+            return c, c_sf
+
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell",
+        mutates_args=(),
+        device_types="cuda")
+    def cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        tile_idx_to_group_idx: torch.Tensor,
+        tile_idx_to_mn_limit: torch.Tensor,
+        permuted_idx_to_expanded_idx: torch.Tensor,
+        num_non_exiting_tiles: torch.Tensor,
+        global_sf: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        num_local_experts: int,
+        local_expert_offset: int,
+        tile_size: int,
+        scaling_vector_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tuner = AutoTuner.get()
+
+        runner = Sm100BlockScaledContiguousGatherGroupedGemmSwigluFusionRunner(
+            num_experts, top_k, num_local_experts, local_expert_offset,
+            tile_size, scaling_vector_size)
+        inputs = [
+            input, weight, input_scale, weight_scale, alpha,
+            tile_idx_to_group_idx, tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx, num_non_exiting_tiles, global_sf
+        ]
+
+        _, best_tactic = tuner.choose_one(
+            "trtllm::cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell",
+            [runner],
+            runner.get_tuning_config(),
+            inputs,
+        )
+        output = runner(inputs, tactic=best_tactic)
+        return output
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell")
+    def _(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        tile_idx_to_group_idx: torch.Tensor,
+        tile_idx_to_mn_limit: torch.Tensor,
+        permuted_idx_to_expanded_idx: torch.Tensor,
+        num_non_exiting_tiles: torch.Tensor,
+        global_sf: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        num_local_experts: int,
+        local_expert_offset: int,
+        tile_size: int,
+        scaling_vector_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        m = permuted_idx_to_expanded_idx.size(0)
+        n = weight.size(1)
+        interm_size = n // 2
+        output = torch.empty(m,
+                             interm_size // 2,
+                             dtype=input.dtype,
+                             device=input.device)
+        output_scale = torch.empty(m * interm_size // scaling_vector_size,
+                                   dtype=input_scale.dtype,
+                                   device=input_scale.device)
+        return output, output_scale
+
+    class FusedMoEInputsHelper:
+
+        def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
+                     local_expert_offset: int):
+            self.num_experts = num_experts
+            self.top_k = top_k
+            self.num_local_experts = num_local_experts
+            self.local_expert_offset = local_expert_offset
+
+        def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
+            return input_shapes[0][0]
+
+        def inputs_pre_hook(self,
+                            inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+            x, x_sf, token_selected_experts, token_final_scales, *others = inputs
+            num_tokens = token_selected_experts.size(0)
+            new_token_final_scales, new_token_selected_experts = torch.randn(
+                num_tokens,
+                self.num_experts,
+                device=token_selected_experts.device).topk(self.top_k, dim=-1)
+            new_token_selected_experts = new_token_selected_experts.to(
+                token_selected_experts.dtype)
+            new_token_final_scales = new_token_final_scales.softmax(dim=-1).to(
+                token_final_scales.dtype)
+            return x, x_sf, new_token_selected_experts, new_token_final_scales, *others
 
     class Sm100BlockScaledFusedMoERunner(TunableRunner):
         tuning_config_cache = dict()
 
-        def __init__(
-            self,
-            num_experts: int,
-            top_k: int,
-            num_local_experts: int,
-            local_expert_offset: int,
-            output_dtype: torch.dtype,
-            scaling_vector_size: int = 16,
-        ):
+        def __init__(self,
+                     num_experts: int,
+                     top_k: int,
+                     num_local_experts: int,
+                     local_expert_offset: int,
+                     output_dtype: torch.dtype,
+                     scaling_vector_size: int = 16):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1993,60 +2243,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = FusedMoEInputsHelper(
-                    self.num_experts,
-                    self.top_k,
-                    self.num_local_experts,
-                    self.local_expert_offset,
-                )
+                helper = FusedMoEInputsHelper(self.num_experts, self.top_k,
+                                              self.num_local_experts,
+                                              self.local_expert_offset)
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(
-                        DynamicTensorSpec(
-                            0,
-                            0,
-                            get_last_power_of_2_num_tokens_buckets,
-                            last_positive_power_of_2,
-                        ),
-                    ),
-                    constraint_specs=(
-                        ConstraintSpec(1, 0, fp4_scale_infer_shape),
-                        ConstraintSpec(2, 0, helper.infer_shape_num_tokens),
-                        ConstraintSpec(3, 0, helper.infer_shape_num_tokens),
-                    ),
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, get_last_power_of_2_num_tokens_buckets,
+                        last_positive_power_of_2), ),
+                    constraint_specs=(ConstraintSpec(1, 0,
+                                                     fp4_scale_infer_shape),
+                                      ConstraintSpec(
+                                          2, 0, helper.infer_shape_num_tokens),
+                                      ConstraintSpec(
+                                          3, 0, helper.infer_shape_num_tokens)),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(
-            self, inputs: List[torch.Tensor], tactic: Optional[int]
-        ) -> torch.Tensor:
+        def forward(self, inputs: List[torch.Tensor],
+                    tactic: Optional[int]) -> torch.Tensor:
             if isinstance(tactic, int):
                 tile_size = tactic
             else:
                 tile_size = 128
 
-            (
-                x,
-                x_sf,
-                token_selected_experts,
-                token_final_scales,
-                gemm1_weight,
-                gemm1_weight_scale,
-                gemm1_alpha,
-                gemm2_input_global_scale,
-                gemm2_weight,
-                gemm2_weight_scale,
-                gemm2_alpha,
-            ) = inputs
-            (
-                tile_idx_to_expert_idx,
-                tile_idx_to_mn_limit,
-                expanded_idx_to_permuted_idx,
-                permuted_idx_to_expanded_idx,
-                total_num_padded_tokens,
-                num_non_exiting_tiles,
-            ) = torch.ops.trtllm.moe_sort(
+            x, x_sf, token_selected_experts, token_final_scales, gemm1_weight, gemm1_weight_scale, gemm1_alpha, gemm2_input_global_scale, gemm2_weight, gemm2_weight_scale, gemm2_alpha = inputs
+            tile_idx_to_expert_idx, tile_idx_to_mn_limit, expanded_idx_to_permuted_idx, permuted_idx_to_expanded_idx, total_num_padded_tokens, num_non_exiting_tiles = torch.ops.trtllm.moe_sort(
                 token_selected_experts=token_selected_experts,
                 token_final_scales=token_final_scales,
                 num_experts=self.num_experts,
@@ -2108,11 +2331,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             return x
 
-    @torch.library.custom_op(
-        "trtllm::cute_dsl_nvfp4_fused_moe_blackwell",
-        mutates_args=(),
-        device_types="cuda",
-    )
+    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_fused_moe_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
     def cute_dsl_nvfp4_fused_moe_blackwell(
         input: torch.Tensor,
         input_scale: torch.Tensor,
@@ -2133,26 +2354,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
         scaling_vector_size: int = 16,
     ) -> torch.Tensor:
         tuner = AutoTuner.get()
-        runner = Sm100BlockScaledFusedMoERunner(
-            num_experts,
-            top_k,
-            num_local_experts,
-            local_expert_offset,
-            output_dtype,
-            scaling_vector_size,
-        )
+        runner = Sm100BlockScaledFusedMoERunner(num_experts, top_k,
+                                                num_local_experts,
+                                                local_expert_offset,
+                                                output_dtype,
+                                                scaling_vector_size)
         inputs = [
-            input,
-            input_scale,
-            token_selected_experts,
-            token_final_scales,
-            gemm1_weight,
-            gemm1_weight_scale,
-            gemm1_alpha,
-            gemm2_input_global_scale,
-            gemm2_weight,
-            gemm2_weight_scale,
-            gemm2_alpha,
+            input, input_scale, token_selected_experts, token_final_scales,
+            gemm1_weight, gemm1_weight_scale, gemm1_alpha,
+            gemm2_input_global_scale, gemm2_weight, gemm2_weight_scale,
+            gemm2_alpha
         ]
 
         _, best_tactic = tuner.choose_one(

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -1381,7 +1381,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if isinstance(tactic, tuple):
                 mma_tiler_mn, cluster_shape_mn = tactic
             else:
-                mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+                if self.tile_size == 256:
+                    mma_tiler_mn, cluster_shape_mn = (256, 128), (2, 1)
+                else:
+                    mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
             cache_key = (
                 self.scaling_vector_size,

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -7,12 +7,20 @@ from tensorrt_llm.logger import logger
 
 from ..._utils import get_sm_version
 from ...math_utils import pad_up
-from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
-                         OptimizationProfile, TunableRunner, TuningConfig)
+from ..autotuner import (
+    AutoTuner,
+    ConstraintSpec,
+    DynamicTensorSpec,
+    OptimizationProfile,
+    TunableRunner,
+    TuningConfig,
+)
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
-from ..utils import (fp4_scale_infer_shape,
-                     get_last_power_of_2_num_tokens_buckets,
-                     last_positive_power_of_2)
+from ..utils import (
+    fp4_scale_infer_shape,
+    get_last_power_of_2_num_tokens_buckets,
+    last_positive_power_of_2,
+)
 
 try:
     from cuda.bindings import driver as cuda
@@ -22,8 +30,14 @@ except ImportError:
 
 class GroupedGemmInputsHelper:
 
-    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
-                 local_expert_offset: int, tile_size: int):
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        num_local_experts: int,
+        local_expert_offset: int,
+        tile_size: int,
+    ):
         self.num_experts = num_experts
         self.top_k = top_k
         self.num_local_experts = num_local_experts
@@ -37,30 +51,33 @@ class GroupedGemmInputsHelper:
         num_expanded_tokens = num_tokens * self.top_k
         if num_expanded_tokens <= self.num_local_experts:
             return num_expanded_tokens
-        return (num_expanded_tokens +
-                (self.tile_size - 1) * self.num_local_experts) // self.tile_size
+        return (
+            num_expanded_tokens + (self.tile_size - 1) * self.num_local_experts
+        ) // self.tile_size
 
     def get_max_num_permuted_tokens(self, num_tokens: int) -> int:
         return self.get_max_num_tiles(num_tokens) * self.tile_size
 
     def infer_num_tokens(self, max_num_permuted_tokens: int) -> int:
-        """Infer the maximum possible number of tokens given the max_num_permuted_tokens.
-        """
+        """Infer the maximum possible number of tokens given the max_num_permuted_tokens."""
         max_num_tiles = max_num_permuted_tokens // self.tile_size
         if max_num_tiles >= self.num_local_experts:
-            return (max_num_permuted_tokens - (self.tile_size - 1) *
-                    (self.num_local_experts - 1)) // self.top_k
+            return (
+                max_num_permuted_tokens
+                - (self.tile_size - 1) * (self.num_local_experts - 1)
+            ) // self.top_k
         return max_num_tiles // self.top_k
 
     def gen_tuning_buckets(self, max_num_tokens: int) -> List[int]:
         buckets = get_last_power_of_2_num_tokens_buckets(
-            self.infer_num_tokens(max_num_tokens))
-        return sorted(
-            list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
+            self.infer_num_tokens(max_num_tokens)
+        )
+        return sorted(list(set(self.get_max_num_permuted_tokens(x) for x in buckets)))
 
     def map_to_tuning_buckets(self, x: int) -> int:
         return self.get_max_num_permuted_tokens(
-            last_positive_power_of_2(self.infer_num_tokens(x)))
+            last_positive_power_of_2(self.infer_num_tokens(x))
+        )
 
     def infer_shape_num_tokens(self, input_shapes: List[torch.Size]) -> int:
         return self.infer_num_tokens(input_shapes[0][0])
@@ -69,7 +86,8 @@ class GroupedGemmInputsHelper:
         return input_shapes[0][0] // self.tile_size
 
     def infer_shape_max_num_permuted_tokens(
-            self, input_shapes: List[torch.Size]) -> int:
+        self, input_shapes: List[torch.Size]
+    ) -> int:
         return self.infer_shape_max_num_tiles(input_shapes) * self.tile_size
 
     def generate_num_tokens_per_expert(self, num_tokens: int) -> List[int]:
@@ -86,34 +104,34 @@ class GroupedGemmInputsHelper:
         return num_tokens_per_expert
 
     def generate_tile_idx_to_group_idx(
-            self, num_tokens_per_expert: List[int]) -> List[int]:
+        self, num_tokens_per_expert: List[int]
+    ) -> List[int]:
         tile_idx_to_group_idx = []
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size -
-                              1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
             tile_idx_to_group_idx.extend([i] * curr_num_tiles)
         return tile_idx_to_group_idx
 
     def generate_tile_idx_to_mn_limit(
-            self, num_tokens_per_expert: List[int]) -> List[int]:
+        self, num_tokens_per_expert: List[int]
+    ) -> List[int]:
         tile_idx_to_mn_limit = []
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size -
-                              1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
             prev_mn_limit = len(tile_idx_to_mn_limit) * self.tile_size
             for j in range(curr_num_tiles):
-                tile_idx_to_mn_limit.append(prev_mn_limit + min(
-                    (j + 1) * self.tile_size, curr_num_tokens))
+                tile_idx_to_mn_limit.append(
+                    prev_mn_limit + min((j + 1) * self.tile_size, curr_num_tokens)
+                )
         return tile_idx_to_mn_limit
 
     def generate_permuted_idx_to_expanded_idx(
-            self, num_tokens: int,
-            num_tokens_per_expert: List[int]) -> List[int]:
+        self, num_tokens: int, num_tokens_per_expert: List[int]
+    ) -> List[int]:
         permuted_idx_to_expanded_idx = []
         colmajor_expanded_idx = 0
         for i, curr_num_tokens in enumerate(num_tokens_per_expert):
-            curr_num_tiles = (curr_num_tokens + self.tile_size -
-                              1) // self.tile_size
+            curr_num_tiles = (curr_num_tokens + self.tile_size - 1) // self.tile_size
             for j in range(curr_num_tiles * self.tile_size):
                 if j < curr_num_tokens:
                     token_idx = colmajor_expanded_idx % num_tokens
@@ -126,71 +144,133 @@ class GroupedGemmInputsHelper:
         return permuted_idx_to_expanded_idx
 
     def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others = inputs
+        (
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
+            *others,
+        ) = inputs
         num_tokens = self.infer_num_tokens(a.size(0))
         num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
         tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-            num_tokens_per_expert)
+            num_tokens_per_expert
+        )
         num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-        num_padding_tiles_val = tile_idx_to_group_idx.size(
-            0) - num_non_exiting_tiles_val
+        num_padding_tiles_val = (
+            tile_idx_to_group_idx.size(0) - num_non_exiting_tiles_val
+        )
         assert num_non_exiting_tiles_val > 0
         assert num_padding_tiles_val >= 0
 
         tile_idx_to_group_idx = torch.tensor(
             tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_group_idx.dtype,
-            device=tile_idx_to_group_idx.device)
+            device=tile_idx_to_group_idx.device,
+        )
         num_non_exiting_tiles = torch.tensor(
             [num_non_exiting_tiles_val],
             dtype=num_non_exiting_tiles.dtype,
-            device=num_non_exiting_tiles.device)
-        return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others
+            device=num_non_exiting_tiles.device,
+        )
+        return (
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
+            *others,
+        )
 
     def inputs_pre_hook_finalize_fusion(
-            self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
-        a, b, a_sf, b_sf, alpha, output, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
+        self, inputs: List[torch.Tensor]
+    ) -> List[torch.Tensor]:
+        (
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha,
+            output,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx,
+            num_non_exiting_tiles,
+            token_final_scales,
+        ) = inputs
         num_tokens = self.infer_num_tokens(a.size(0))
         num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
         tile_idx_to_group_idx_list = self.generate_tile_idx_to_group_idx(
-            num_tokens_per_expert)
+            num_tokens_per_expert
+        )
         tile_idx_to_mn_limit_list = self.generate_tile_idx_to_mn_limit(
-            num_tokens_per_expert)
+            num_tokens_per_expert
+        )
         permuted_idx_to_expanded_idx_list = self.generate_permuted_idx_to_expanded_idx(
-            num_tokens, num_tokens_per_expert)
+            num_tokens, num_tokens_per_expert
+        )
         num_non_exiting_tiles_val = len(tile_idx_to_group_idx_list)
-        num_padding_tiles_val = tile_idx_to_group_idx.size(
-            0) - num_non_exiting_tiles_val
+        num_padding_tiles_val = (
+            tile_idx_to_group_idx.size(0) - num_non_exiting_tiles_val
+        )
         assert num_non_exiting_tiles_val > 0
         assert num_padding_tiles_val >= 0
         assert len(tile_idx_to_mn_limit_list) == num_non_exiting_tiles_val
-        assert len(permuted_idx_to_expanded_idx_list
-                   ) == num_non_exiting_tiles_val * self.tile_size
+        assert (
+            len(permuted_idx_to_expanded_idx_list)
+            == num_non_exiting_tiles_val * self.tile_size
+        )
 
         tile_idx_to_group_idx = torch.tensor(
             tile_idx_to_group_idx_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_group_idx.dtype,
-            device=tile_idx_to_group_idx.device)
+            device=tile_idx_to_group_idx.device,
+        )
         tile_idx_to_mn_limit = torch.tensor(
             tile_idx_to_mn_limit_list + [self.pad_val] * num_padding_tiles_val,
             dtype=tile_idx_to_mn_limit.dtype,
-            device=tile_idx_to_mn_limit.device)
+            device=tile_idx_to_mn_limit.device,
+        )
         permuted_idx_to_expanded_idx = torch.tensor(
-            permuted_idx_to_expanded_idx_list + [self.pad_val] *
-            (num_padding_tiles_val * self.tile_size),
+            permuted_idx_to_expanded_idx_list
+            + [self.pad_val] * (num_padding_tiles_val * self.tile_size),
             dtype=permuted_idx_to_expanded_idx.dtype,
-            device=permuted_idx_to_expanded_idx.device)
+            device=permuted_idx_to_expanded_idx.device,
+        )
         num_non_exiting_tiles = torch.tensor(
             [num_non_exiting_tiles_val],
             dtype=num_non_exiting_tiles.dtype,
-            device=num_non_exiting_tiles.device)
-        return a, b, a_sf, b_sf, alpha, output, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales
+            device=num_non_exiting_tiles.device,
+        )
+        return (
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha,
+            output,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx,
+            num_non_exiting_tiles,
+            token_final_scales,
+        )
 
 
 class FusedMoEInputsHelper:
 
-    def __init__(self, num_experts: int, top_k: int, num_local_experts: int,
-                 local_expert_offset: int):
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        num_local_experts: int,
+        local_expert_offset: int,
+    ):
         self.num_experts = num_experts
         self.top_k = top_k
         self.num_local_experts = num_local_experts
@@ -203,12 +283,14 @@ class FusedMoEInputsHelper:
         x, x_sf, token_selected_experts, token_final_scales, *others = inputs
         num_tokens = token_selected_experts.size(0)
         new_token_final_scales, new_token_selected_experts = torch.randn(
-            num_tokens, self.num_experts,
-            device=token_selected_experts.device).topk(self.top_k, dim=-1)
+            num_tokens, self.num_experts, device=token_selected_experts.device
+        ).topk(self.top_k, dim=-1)
         new_token_selected_experts = new_token_selected_experts.to(
-            token_selected_experts.dtype)
+            token_selected_experts.dtype
+        )
         new_token_final_scales = new_token_final_scales.softmax(dim=-1).to(
-            token_final_scales.dtype)
+            token_final_scales.dtype
+        )
         return x, x_sf, new_token_selected_experts, new_token_final_scales, *others
 
 
@@ -217,31 +299,42 @@ if IS_CUTLASS_DSL_AVAILABLE:
     import cutlass
     import cutlass.cute as cute
 
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm import \
-        Sm100BlockScaledContiguousGroupedGemmKernel
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import \
-        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
-    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_swiglu_fusion import \
-        Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel
-    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
-        Sm100BlockScaledPersistentDenseGemmKernel
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm import (
+        Sm100BlockScaledContiguousGroupedGemmKernel,
+    )
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
+    )
+    from ..cute_dsl_kernels.blackwell.blockscaled_contiguous_grouped_gemm_swiglu_fusion import (
+        Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel,
+    )
+    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import (
+        Sm100BlockScaledPersistentDenseGemmKernel,
+    )
     from ..cute_dsl_kernels.blackwell.utils import make_ptr
 
     class CuteDSLNVFP4BlackwellLinear(TunableRunner):
         kernel_class = Sm100BlockScaledPersistentDenseGemmKernel
         kernel_cache = dict()
         tuning_config = TuningConfig(
-            dynamic_tensor_specs=(DynamicTensorSpec(
-                0, 0, get_last_power_of_2_num_tokens_buckets,
-                last_positive_power_of_2), ),
-            constraint_specs=(ConstraintSpec(2, 0, fp4_scale_infer_shape), ),
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    0,
+                    0,
+                    get_last_power_of_2_num_tokens_buckets,
+                    last_positive_power_of_2,
+                ),
+            ),
+            constraint_specs=(ConstraintSpec(2, 0, fp4_scale_infer_shape),),
             use_cold_l2_cache=True,
         )
 
-        def __init__(self,
-                     output_dtype: torch.dtype,
-                     to_userbuffers: bool = False,
-                     use_tvm_ffi: bool = True):
+        def __init__(
+            self,
+            output_dtype: torch.dtype,
+            to_userbuffers: bool = False,
+            use_tvm_ffi: bool = True,
+        ):
             super().__init__()
 
             if output_dtype != torch.bfloat16:
@@ -256,13 +349,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return (self.output_dtype, self.to_userbuffers, self.use_tvm_ffi)
 
         def __hash__(self):
-            return hash(
-                (self.output_dtype, self.to_userbuffers, self.use_tvm_ffi))
+            return hash((self.output_dtype, self.to_userbuffers, self.use_tvm_ffi))
 
         def __eq__(self, other):
             if not isinstance(other, self.__class__):
                 return False
-            return self.output_dtype == other.output_dtype and self.to_userbuffers == other.to_userbuffers and self.use_tvm_ffi == other.use_tvm_ffi
+            return (
+                self.output_dtype == other.output_dtype
+                and self.to_userbuffers == other.to_userbuffers
+                and self.use_tvm_ffi == other.use_tvm_ffi
+            )
 
         def get_valid_tactics(
             self,
@@ -299,14 +395,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if real_k % 32 != 0:
                 logger.debug(
                     f"CuteDSL: K={real_k} does not meet 16-byte alignment requirement "
-                    f"(K%32={real_k%32}, expected 0). Skipping all tactics.")
+                    f"(K%32={real_k%32}, expected 0). Skipping all tactics."
+                )
                 return []
 
             # Optimize swap_ab candidates based on M and N alignment
             # swap_ab=False → C is N-major → requires N%8==0 (BF16: 128 bits / 16 bits = 8)
             # swap_ab=True  → C is M-major → requires M%8==0
-            m_aligned = (m % 8 == 0)
-            n_aligned = (n % 8 == 0)
+            m_aligned = m % 8 == 0
+            n_aligned = n % 8 == 0
 
             if not m_aligned and not n_aligned:
                 logger.debug(
@@ -324,7 +421,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             logger.debug(
                 f"CuteDSL: M={m}(aligned={m_aligned}), N={n}(aligned={n_aligned}), K={real_k}(aligned=True). "
-                f"Testing swap_ab={swap_ab_candidates}")
+                f"Testing swap_ab={swap_ab_candidates}"
+            )
 
             # full shamoo
             mma_tiler_mn_candidates = [
@@ -352,9 +450,17 @@ if IS_CUTLASS_DSL_AVAILABLE:
             use_prefetch_candidates = [True, False]
 
             valid_tactics = []
-            for mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch in itertools.product(
-                    mma_tiler_mn_candidates, cluster_shape_mn_candidates,
-                    swap_ab_candidates, use_prefetch_candidates):
+            for (
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+            ) in itertools.product(
+                mma_tiler_mn_candidates,
+                cluster_shape_mn_candidates,
+                swap_ab_candidates,
+                use_prefetch_candidates,
+            ):
                 if swap_ab:
                     c_major = "m"
                     kernel_m = n
@@ -365,30 +471,32 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     kernel_n = n
 
                 if self.__class__.kernel_class.can_implement(
-                        cutlass.Float4E2M1FN,  # ab_dtype,
-                        cutlass.Float8E4M3FN,  # sf_dtype
-                        sf_vec_size,  # sf_vec_size,
-                        cutlass.BFloat16,  # c_dtype,
-                        mma_tiler_mn,
-                        cluster_shape_mn,
-                        kernel_m,
-                        kernel_n,
-                        real_k,
-                        batch_size,
-                        a_major,
-                        b_major,
-                        c_major,
+                    cutlass.Float4E2M1FN,  # ab_dtype,
+                    cutlass.Float8E4M3FN,  # sf_dtype
+                    sf_vec_size,  # sf_vec_size,
+                    cutlass.BFloat16,  # c_dtype,
+                    mma_tiler_mn,
+                    cluster_shape_mn,
+                    kernel_m,
+                    kernel_n,
+                    real_k,
+                    batch_size,
+                    a_major,
+                    b_major,
+                    c_major,
                 ):
                     valid_tactics.append(
-                        (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch))
+                        (mma_tiler_mn, cluster_shape_mn, swap_ab, use_prefetch)
+                    )
 
             logger.debug(
                 f"CuteDSL: Found {len(valid_tactics)} valid tactics for M={m}, N={n}, K={real_k}"
             )
             return valid_tactics
 
-        def make_cute_dsl_global_pointer(self, tensor: torch.Tensor, dtype,
-                                         assumed_align: int):
+        def make_cute_dsl_global_pointer(
+            self, tensor: torch.Tensor, dtype, assumed_align: int
+        ):
             return make_ptr(
                 dtype,
                 tensor.data_ptr(),
@@ -436,11 +544,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             # Allocate output tensor from UserBuffers or regular CUDA memory
             if self.to_userbuffers:
                 c_tensor = torch.ops.trtllm.create_userbuffers_tensor(
-                    [m, n], self.output_dtype)
+                    [m, n], self.output_dtype
+                )
             else:
-                c_tensor = torch.empty(*(m, n),
-                                       dtype=self.output_dtype,
-                                       device="cuda")
+                c_tensor = torch.empty(*(m, n), dtype=self.output_dtype, device="cuda")
 
             if swap_ab:
                 c_tensor = c_tensor.permute(1, 0)
@@ -461,15 +568,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 raise ValueError(
                     f"CuteDSL: act scale factor size mismatch. "
                     f"Expected {expected_a_sf_size} (sf_m={sf_m} * sf_k={sf_k}), "
-                    f"got {a_sf_tensor.numel()} for shape M={m}, K={real_k}")
+                    f"got {a_sf_tensor.numel()} for shape M={m}, K={real_k}"
+                )
             if b_sf_tensor.numel() != expected_b_sf_size:
                 raise ValueError(
                     f"CuteDSL: weight scale factor size mismatch. "
                     f"Expected {expected_b_sf_size} (sf_n={sf_n} * sf_k={sf_k}), "
-                    f"got {b_sf_tensor.numel()} for shape N={n}, K={real_k}")
+                    f"got {b_sf_tensor.numel()} for shape N={n}, K={real_k}"
+                )
             if alpha_tensor.numel() != 1:
-                raise ValueError(f"CuteDSL: alpha size mismatch. "
-                                 f"Expected 1, got {alpha_tensor.numel()}")
+                raise ValueError(
+                    f"CuteDSL: alpha size mismatch. "
+                    f"Expected 1, got {alpha_tensor.numel()}"
+                )
 
             # Reshape to CuteDSL's expected format (just a view, no copy)
             a_sf_tensor = a_sf_tensor.reshape(sf_m * sf_k)
@@ -477,23 +588,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             if not self.use_tvm_ffi:
                 a_ptr = self.make_cute_dsl_global_pointer(
-                    a_tensor, cutlass.Float4E2M1FN, 32)
+                    a_tensor, cutlass.Float4E2M1FN, 32
+                )
                 b_ptr = self.make_cute_dsl_global_pointer(
-                    b_tensor, cutlass.Float4E2M1FN, 32)
+                    b_tensor, cutlass.Float4E2M1FN, 32
+                )
                 a_sf_ptr = self.make_cute_dsl_global_pointer(
-                    a_sf_tensor, cutlass.Float8E4M3FN, 16)
+                    a_sf_tensor, cutlass.Float8E4M3FN, 16
+                )
                 b_sf_ptr = self.make_cute_dsl_global_pointer(
-                    b_sf_tensor, cutlass.Float8E4M3FN, 16)
+                    b_sf_tensor, cutlass.Float8E4M3FN, 16
+                )
                 c_ptr = self.make_cute_dsl_global_pointer(
-                    c_tensor, cutlass.BFloat16, 16)
+                    c_tensor, cutlass.BFloat16, 16
+                )
                 alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
 
                 # get stream
                 torch_stream = torch.cuda.current_stream()
                 stream = cuda.CUstream(torch_stream.cuda_stream)
 
-            cache_key = (sf_vec_size, mma_tiler_mn, cluster_shape_mn, swap_ab,
-                         use_prefetch)
+            cache_key = (
+                sf_vec_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                swap_ab,
+                use_prefetch,
+            )
             if swap_ab:
                 kernel_m = n
                 kernel_n = m
@@ -530,19 +651,23 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if cache_key not in self.__class__.kernel_cache:
                 if self.use_tvm_ffi:
                     a_ptr = self.make_cute_dsl_global_pointer(
-                        a_tensor, cutlass.Float4E2M1FN, 32)
+                        a_tensor, cutlass.Float4E2M1FN, 32
+                    )
                     b_ptr = self.make_cute_dsl_global_pointer(
-                        b_tensor, cutlass.Float4E2M1FN, 32)
+                        b_tensor, cutlass.Float4E2M1FN, 32
+                    )
                     a_sf_ptr = self.make_cute_dsl_global_pointer(
-                        a_sf_tensor, cutlass.Float8E4M3FN, 16)
+                        a_sf_tensor, cutlass.Float8E4M3FN, 16
+                    )
                     b_sf_ptr = self.make_cute_dsl_global_pointer(
-                        b_sf_tensor, cutlass.Float8E4M3FN, 16)
+                        b_sf_tensor, cutlass.Float8E4M3FN, 16
+                    )
                     c_ptr = self.make_cute_dsl_global_pointer(
-                        c_tensor, cutlass.BFloat16, 16)
+                        c_tensor, cutlass.BFloat16, 16
+                    )
                     alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
                     # make faked stream
-                    stream = cute.runtime.make_fake_stream(
-                        use_tvm_ffi_env_stream=True)
+                    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
                     if swap_ab:
                         kernel_a_ptr = b_ptr
@@ -564,7 +689,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1])
+                    cluster_shape_mn[0] * cluster_shape_mn[1]
+                )
 
                 # Note: when tvm_ffi fake stream is used, at least one parameter shoube be tensor type,
                 # so we make alpha as the cute.Tensor type in the jit func.
@@ -586,8 +712,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     max_active_clusters,
                     stream,
                     swap_ab,
-                    options=f"--opt-level 2 --enable-tvm-ffi"
-                    if self.use_tvm_ffi else "--opt-level 2",
+                    options=(
+                        f"--opt-level 2 --enable-tvm-ffi"
+                        if self.use_tvm_ffi
+                        else "--opt-level 2"
+                    ),
                 )
 
                 self.__class__.kernel_cache[cache_key] = compiled_gemm
@@ -634,9 +763,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return c_tensor
 
     # a/b: fp4, scale: fp8, output: bf16
-    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_gemm_blackwell",
-                             mutates_args=(),
-                             device_types="cuda")
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_gemm_blackwell", mutates_args=(), device_types="cuda"
+    )
     def cute_dsl_nvfp4_gemm_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -673,8 +802,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
         tuner = AutoTuner.get()
 
-        runner = CuteDSLNVFP4BlackwellLinear(output_dtype, to_userbuffers,
-                                             use_tvm_ffi)
+        runner = CuteDSLNVFP4BlackwellLinear(output_dtype, to_userbuffers, use_tvm_ffi)
         inputs = [input, weight, input_scale, weight_scale, alpha]
         _, best_tactic = tuner.choose_one(
             "trtllm::cute_dsl_nvfp4_gemm_blackwell",
@@ -710,14 +838,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(self,
-                     num_experts: int,
-                     top_k: int,
-                     num_local_experts: int,
-                     local_expert_offset: int,
-                     tile_size: int,
-                     output_dtype: torch.dtype,
-                     scaling_vector_size: int = 16):
+        def __init__(
+            self,
+            num_experts: int,
+            top_k: int,
+            num_local_experts: int,
+            local_expert_offset: int,
+            tile_size: int,
+            output_dtype: torch.dtype,
+            scaling_vector_size: int = 16,
+        ):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -761,24 +891,25 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                mma_tiler_mn_candidates, cluster_shape_mn_candidates
+            ):
                 if self.__class__.kernel_class.can_implement(
-                        ab_dtype=cutlass.Float4E2M1FN,
-                        sf_dtype=cutlass.Float8E4M3FN,
-                        sf_vec_size=self.scaling_vector_size,
-                        acc_dtype=cutlass.Float32,
-                        c_dtype=cutlass.BFloat16,
-                        use_2cta_instrs=False,
-                        mma_tiler_mn=mma_tiler_mn,
-                        cluster_shape_mn=cluster_shape_mn,
-                        m=m,
-                        n=n,
-                        k=k,
-                        l=l,
-                        a_major="k",
-                        b_major="k",
-                        c_major="n",
-                        m_aligned=self.tile_size,
+                    ab_dtype=cutlass.Float4E2M1FN,
+                    sf_dtype=cutlass.Float8E4M3FN,
+                    sf_vec_size=self.scaling_vector_size,
+                    acc_dtype=cutlass.Float32,
+                    c_dtype=cutlass.BFloat16,
+                    use_2cta_instrs=False,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    m=m,
+                    n=n,
+                    k=k,
+                    l=l,
+                    a_major="k",
+                    b_major="k",
+                    c_major="n",
+                    m_aligned=self.tile_size,
                 ):
                     valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
 
@@ -787,27 +918,37 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
-                                                 self.num_local_experts,
-                                                 self.local_expert_offset,
-                                                 self.tile_size)
+                helper = GroupedGemmInputsHelper(
+                    self.num_experts,
+                    self.top_k,
+                    self.num_local_experts,
+                    self.local_expert_offset,
+                    self.tile_size,
+                )
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, helper.gen_tuning_buckets,
-                        helper.map_to_tuning_buckets), ),
-                    constraint_specs=(ConstraintSpec(2, 0,
-                                                     fp4_scale_infer_shape),
-                                      ConstraintSpec(
-                                          5, 0,
-                                          helper.infer_shape_max_num_tiles)),
+                    dynamic_tensor_specs=(
+                        DynamicTensorSpec(
+                            0,
+                            0,
+                            helper.gen_tuning_buckets,
+                            helper.map_to_tuning_buckets,
+                        ),
+                    ),
+                    constraint_specs=(
+                        ConstraintSpec(2, 0, fp4_scale_infer_shape),
+                        ConstraintSpec(5, 0, helper.infer_shape_max_num_tiles),
+                    ),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(self, inputs: List[torch.Tensor],
-                    tactic: Optional[tuple]) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles = inputs
+        def forward(
+            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
+        ) -> torch.Tensor:
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles = (
+                inputs
+            )
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -833,40 +974,48 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles, )
+            assert tile_idx_to_group_idx.size() == (num_tiles,)
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
 
             c = torch.empty(m, n, dtype=self.output_dtype, device=a.device)
 
-            a_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             a.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            b_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             b.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                a_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                b_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
-                                 cute.AddressSpace.gmem)
+            a_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                a.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            b_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                b.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            a_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                a_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            b_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                b_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            alpha_ptr = make_ptr(
+                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
+            )
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
-                cute.AddressSpace.gmem)
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
+            )
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
-                cute.AddressSpace.gmem)
-            c_ptr = make_ptr(cutlass.BFloat16,
-                             c.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=16)
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
+            )
+            c_ptr = make_ptr(
+                cutlass.BFloat16, c.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+            )
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -876,8 +1025,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
-            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
-                         cluster_shape_mn)
+            cache_key = (
+                self.scaling_vector_size,
+                self.tile_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+            )
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
@@ -889,7 +1042,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1])
+                    cluster_shape_mn[0] * cluster_shape_mn[1]
+                )
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -931,9 +1085,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             return c
 
-    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell",
-                             mutates_args=(),
-                             device_types="cuda")
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell",
+        mutates_args=(),
+        device_types="cuda",
+    )
     def cute_dsl_nvfp4_grouped_gemm_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -953,11 +1109,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmRunner(
-            num_experts, top_k, num_local_experts, local_expert_offset,
-            tile_size, output_dtype, scaling_vector_size)
+            num_experts,
+            top_k,
+            num_local_experts,
+            local_expert_offset,
+            tile_size,
+            output_dtype,
+            scaling_vector_size,
+        )
         inputs = [
-            input, weight, input_scale, weight_scale, alpha,
-            tile_idx_to_group_idx, num_non_exiting_tiles
+            input,
+            weight,
+            input_scale,
+            weight_scale,
+            alpha,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -969,8 +1136,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         output = runner(inputs, tactic=best_tactic)
         return output
 
-    @torch.library.register_fake(
-        "trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell")
+    @torch.library.register_fake("trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell")
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -991,20 +1157,21 @@ if IS_CUTLASS_DSL_AVAILABLE:
         n = weight.size(1)
         return torch.empty(m, n, dtype=output_dtype, device=input.device)
 
-    class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(
-            TunableRunner):
+    class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(TunableRunner):
         kernel_class = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(self,
-                     num_experts: int,
-                     top_k: int,
-                     num_local_experts: int,
-                     local_expert_offset: int,
-                     tile_size: int,
-                     output_dtype: torch.dtype,
-                     scaling_vector_size: int = 16):
+        def __init__(
+            self,
+            num_experts: int,
+            top_k: int,
+            num_local_experts: int,
+            local_expert_offset: int,
+            tile_size: int,
+            output_dtype: torch.dtype,
+            scaling_vector_size: int = 16,
+        ):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1043,29 +1210,27 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l, n = b.size(0), b.size(1)
 
             # TODO: Add full shmoo
-            mma_tiler_mn_candidates = [(128, 128), (128, 256)]
-            cluster_shape_mn_candidates = [(1, 1), (1, 2)]
+            mma_tiler_mn_candidates = [(128, 128), (128, 256), (256, 128), (256, 256)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (2, 1), (2, 2)]
 
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                mma_tiler_mn_candidates, cluster_shape_mn_candidates
+            ):
                 if self.__class__.kernel_class.can_implement(
-                        ab_dtype=cutlass.Float4E2M1FN,
-                        sf_dtype=cutlass.Float8E4M3FN,
-                        sf_vec_size=self.scaling_vector_size,
-                        acc_dtype=cutlass.Float32,
-                        out_dtype=cutlass.BFloat16,
-                        use_2cta_instrs=False,
-                        mma_tiler_mn=mma_tiler_mn,
-                        cluster_shape_mn=cluster_shape_mn,
-                        m=m,
-                        n=n,
-                        k=k,
-                        l=l,
-                        a_major="k",
-                        b_major="k",
-                        c_major="n",
-                        m_aligned=self.tile_size,
+                    ab_dtype=cutlass.Float4E2M1FN,
+                    sf_dtype=cutlass.Float8E4M3FN,
+                    sf_vec_size=self.scaling_vector_size,
+                    out_dtype=cutlass.BFloat16,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    m=m,
+                    n=n,
+                    k=k,
+                    l=l,
+                    a_major="k",
+                    b_major="k",
+                    out_major="n",
                 ):
                     valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
 
@@ -1074,30 +1239,53 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
-                                                 self.num_local_experts,
-                                                 self.local_expert_offset,
-                                                 self.tile_size)
+                helper = GroupedGemmInputsHelper(
+                    self.num_experts,
+                    self.top_k,
+                    self.num_local_experts,
+                    self.local_expert_offset,
+                    self.tile_size,
+                )
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, helper.gen_tuning_buckets,
-                        helper.map_to_tuning_buckets), ),
+                    dynamic_tensor_specs=(
+                        DynamicTensorSpec(
+                            0,
+                            0,
+                            helper.gen_tuning_buckets,
+                            helper.map_to_tuning_buckets,
+                        ),
+                    ),
                     constraint_specs=(
                         ConstraintSpec(2, 0, fp4_scale_infer_shape),
                         ConstraintSpec(5, 0, helper.infer_shape_num_tokens),
                         ConstraintSpec(6, 0, helper.infer_shape_max_num_tiles),
                         ConstraintSpec(7, 0, helper.infer_shape_max_num_tiles),
                         ConstraintSpec(
-                            8, 0, helper.infer_shape_max_num_permuted_tokens),
-                        ConstraintSpec(10, 0, helper.infer_shape_num_tokens)),
+                            8, 0, helper.infer_shape_max_num_permuted_tokens
+                        ),
+                        ConstraintSpec(10, 0, helper.infer_shape_num_tokens),
+                    ),
                     inputs_pre_hook=helper.inputs_pre_hook_finalize_fusion,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(self, inputs: List[torch.Tensor],
-                    tactic: Optional[tuple]) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, c, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
+        def forward(
+            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
+        ) -> torch.Tensor:
+            (
+                a,
+                b,
+                a_sf,
+                b_sf,
+                alpha,
+                c,
+                tile_idx_to_group_idx,
+                tile_idx_to_mn_limit,
+                permuted_idx_to_expanded_idx,
+                num_non_exiting_tiles,
+                token_final_scales,
+            ) = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -1128,54 +1316,64 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles, )
+            assert tile_idx_to_group_idx.size() == (num_tiles,)
             assert tile_idx_to_mn_limit.dtype == torch.int32
-            assert tile_idx_to_mn_limit.size() == (num_tiles, )
+            assert tile_idx_to_mn_limit.size() == (num_tiles,)
             assert permuted_idx_to_expanded_idx.dtype == torch.int32
-            assert permuted_idx_to_expanded_idx.size() == (m, )
+            assert permuted_idx_to_expanded_idx.size() == (m,)
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
             assert token_final_scales.dtype == torch.float32
             assert token_final_scales.dim() == 2
             assert token_final_scales.size() == (num_tokens, self.top_k)
 
-            a_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             a.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            b_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             b.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                a_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                b_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
-                                 cute.AddressSpace.gmem)
+            a_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                a.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            b_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                b.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            a_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                a_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            b_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                b_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            alpha_ptr = make_ptr(
+                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
+            )
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
-                cute.AddressSpace.gmem)
-            tile_idx_to_mn_limit_ptr = make_ptr(cutlass.Int32,
-                                                tile_idx_to_mn_limit.data_ptr(),
-                                                cute.AddressSpace.gmem)
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
+            )
+            tile_idx_to_mn_limit_ptr = make_ptr(
+                cutlass.Int32, tile_idx_to_mn_limit.data_ptr(), cute.AddressSpace.gmem
+            )
             permuted_idx_to_expanded_idx_ptr = make_ptr(
-                cutlass.Int32, permuted_idx_to_expanded_idx.data_ptr(),
-                cute.AddressSpace.gmem)
+                cutlass.Int32,
+                permuted_idx_to_expanded_idx.data_ptr(),
+                cute.AddressSpace.gmem,
+            )
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
-                cute.AddressSpace.gmem)
-            token_final_scales_ptr = make_ptr(cutlass.Float32,
-                                              token_final_scales.data_ptr(),
-                                              cute.AddressSpace.gmem)
-            c_ptr = make_ptr(cutlass.BFloat16,
-                             c.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=16)
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
+            )
+            token_final_scales_ptr = make_ptr(
+                cutlass.Float32, token_final_scales.data_ptr(), cute.AddressSpace.gmem
+            )
+            c_ptr = make_ptr(
+                cutlass.BFloat16, c.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+            )
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -1185,20 +1383,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
-            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
-                         cluster_shape_mn)
+            cache_key = (
+                self.scaling_vector_size,
+                self.tile_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+            )
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
-                    acc_dtype=cutlass.Float32,
-                    use_2cta_instrs=False,
                     mma_tiler_mn=mma_tiler_mn,
                     cluster_shape_mn=cluster_shape_mn,
+                    use_prefetch=False,
                 )
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1])
+                    cluster_shape_mn[0] * cluster_shape_mn[1]
+                )
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -1252,8 +1454,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell",
-        mutates_args=("output", ),
-        device_types="cuda")
+        mutates_args=("output",),
+        device_types="cuda",
+    )
     def cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1277,14 +1480,27 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(
-            num_experts, top_k, num_local_experts, local_expert_offset,
-            tile_size, output_dtype, scaling_vector_size)
+            num_experts,
+            top_k,
+            num_local_experts,
+            local_expert_offset,
+            tile_size,
+            output_dtype,
+            scaling_vector_size,
+        )
 
         inputs = [
-            input, weight, input_scale, weight_scale, alpha, output,
-            tile_idx_to_group_idx, tile_idx_to_mn_limit,
-            permuted_idx_to_expanded_idx, num_non_exiting_tiles,
-            token_final_scales
+            input,
+            weight,
+            input_scale,
+            weight_scale,
+            alpha,
+            output,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx,
+            num_non_exiting_tiles,
+            token_final_scales,
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -1298,7 +1514,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell",
         mutates_args=(),
-        device_types="cuda")
+        device_types="cuda",
+    )
     def cute_dsl_nvfp4_grouped_gemm_finalize_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1320,10 +1537,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> torch.Tensor:
         num_tokens = token_final_scales.size(0)
         n = weight.size(1)
-        output = torch.zeros(num_tokens,
-                             n,
-                             dtype=output_dtype,
-                             device=input.device)
+        output = torch.zeros(num_tokens, n, dtype=output_dtype, device=input.device)
         torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell(
             input=input,
             weight=weight,
@@ -1347,7 +1561,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         return output
 
     @torch.library.register_fake(
-        "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell")
+        "trtllm::cute_dsl_nvfp4_grouped_gemm_finalize_blackwell"
+    )
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1369,24 +1584,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> torch.Tensor:
         num_tokens = token_final_scales.size(0)
         n = weight.size(1)
-        return torch.empty(num_tokens,
-                           n,
-                           dtype=output_dtype,
-                           device=input.device)
+        return torch.empty(num_tokens, n, dtype=output_dtype, device=input.device)
 
-    class Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(
-            TunableRunner):
+    class Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(TunableRunner):
         kernel_class = Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel
         kernel_cache = dict()
         tuning_config_cache = dict()
 
-        def __init__(self,
-                     num_experts: int,
-                     top_k: int,
-                     num_local_experts: int,
-                     local_expert_offset: int,
-                     tile_size: int,
-                     scaling_vector_size: int = 16):
+        def __init__(
+            self,
+            num_experts: int,
+            top_k: int,
+            num_local_experts: int,
+            local_expert_offset: int,
+            tile_size: int,
+            scaling_vector_size: int = 16,
+        ):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1426,24 +1639,25 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
-                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                mma_tiler_mn_candidates, cluster_shape_mn_candidates
+            ):
                 if self.__class__.kernel_class.can_implement(
-                        ab_dtype=cutlass.Float4E2M1FN,
-                        sf_dtype=cutlass.Float8E4M3FN,
-                        sf_vec_size=self.scaling_vector_size,
-                        acc_dtype=cutlass.Float32,
-                        c_dtype=cutlass.Float4E2M1FN,
-                        use_2cta_instrs=False,
-                        mma_tiler_mn=mma_tiler_mn,
-                        cluster_shape_mn=cluster_shape_mn,
-                        m=m,
-                        n=n,
-                        k=k,
-                        l=l,
-                        a_major="k",
-                        b_major="k",
-                        c_major="n",
-                        m_aligned=self.tile_size,
+                    ab_dtype=cutlass.Float4E2M1FN,
+                    sf_dtype=cutlass.Float8E4M3FN,
+                    sf_vec_size=self.scaling_vector_size,
+                    acc_dtype=cutlass.Float32,
+                    c_dtype=cutlass.Float4E2M1FN,
+                    use_2cta_instrs=False,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    m=m,
+                    n=n,
+                    k=k,
+                    l=l,
+                    a_major="k",
+                    b_major="k",
+                    c_major="n",
+                    m_aligned=self.tile_size,
                 ):
                     valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
 
@@ -1452,27 +1666,44 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = GroupedGemmInputsHelper(self.num_experts, self.top_k,
-                                                 self.num_local_experts,
-                                                 self.local_expert_offset,
-                                                 self.tile_size)
+                helper = GroupedGemmInputsHelper(
+                    self.num_experts,
+                    self.top_k,
+                    self.num_local_experts,
+                    self.local_expert_offset,
+                    self.tile_size,
+                )
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, helper.gen_tuning_buckets,
-                        helper.map_to_tuning_buckets), ),
-                    constraint_specs=(ConstraintSpec(2, 0,
-                                                     fp4_scale_infer_shape),
-                                      ConstraintSpec(
-                                          5, 0,
-                                          helper.infer_shape_max_num_tiles)),
+                    dynamic_tensor_specs=(
+                        DynamicTensorSpec(
+                            0,
+                            0,
+                            helper.gen_tuning_buckets,
+                            helper.map_to_tuning_buckets,
+                        ),
+                    ),
+                    constraint_specs=(
+                        ConstraintSpec(2, 0, fp4_scale_infer_shape),
+                        ConstraintSpec(5, 0, helper.infer_shape_max_num_tiles),
+                    ),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(self, inputs: List[torch.Tensor],
-                    tactic: Optional[tuple]) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, global_sf = inputs
+        def forward(
+            self, inputs: List[torch.Tensor], tactic: Optional[tuple]
+        ) -> torch.Tensor:
+            (
+                a,
+                b,
+                a_sf,
+                b_sf,
+                alpha,
+                tile_idx_to_group_idx,
+                num_non_exiting_tiles,
+                global_sf,
+            ) = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -1500,51 +1731,67 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
-            assert tile_idx_to_group_idx.size() == (num_tiles, )
+            assert tile_idx_to_group_idx.size() == (num_tiles,)
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
             assert global_sf.dtype == torch.float32
             assert global_sf.numel() == 1
 
             c = torch.empty(m, interm_size // 2, dtype=a.dtype, device=a.device)
-            c_sf = torch.empty(m * interm_size // self.scaling_vector_size,
-                               dtype=a_sf.dtype,
-                               device=a_sf.device)
+            c_sf = torch.empty(
+                m * interm_size // self.scaling_vector_size,
+                dtype=a_sf.dtype,
+                device=a_sf.device,
+            )
 
-            a_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             a.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            b_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             b.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                a_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                b_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
-            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
-                                 cute.AddressSpace.gmem)
+            a_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                a.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            b_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                b.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            a_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                a_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            b_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                b_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            alpha_ptr = make_ptr(
+                cutlass.Float32, alpha.data_ptr(), cute.AddressSpace.gmem
+            )
             tile_idx_to_group_idx_ptr = make_ptr(
-                cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
-                cute.AddressSpace.gmem)
+                cutlass.Int32, tile_idx_to_group_idx.data_ptr(), cute.AddressSpace.gmem
+            )
             num_non_exiting_tiles_ptr = make_ptr(
-                cutlass.Int32, num_non_exiting_tiles.data_ptr(),
-                cute.AddressSpace.gmem)
-            global_sf_ptr = make_ptr(cutlass.Float32, global_sf.data_ptr(),
-                                     cute.AddressSpace.gmem)
-            c_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             c.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                c_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
+                cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
+            )
+            global_sf_ptr = make_ptr(
+                cutlass.Float32, global_sf.data_ptr(), cute.AddressSpace.gmem
+            )
+            c_ptr = make_ptr(
+                cutlass.Float4E2M1FN,
+                c.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            c_sf_ptr = make_ptr(
+                cutlass.Float8E4M3FN,
+                c_sf.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -1554,8 +1801,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
 
-            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
-                         cluster_shape_mn)
+            cache_key = (
+                self.scaling_vector_size,
+                self.tile_size,
+                mma_tiler_mn,
+                cluster_shape_mn,
+            )
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
@@ -1568,7 +1819,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
-                    cluster_shape_mn[0] * cluster_shape_mn[1])
+                    cluster_shape_mn[0] * cluster_shape_mn[1]
+                )
 
                 compiled_gemm = cute.compile(
                     gemm.wrapper,
@@ -1617,7 +1869,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
     @torch.library.custom_op(
         "trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell",
         mutates_args=(),
-        device_types="cuda")
+        device_types="cuda",
+    )
     def cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1637,11 +1890,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tuner = AutoTuner.get()
 
         runner = Sm100BlockScaledContiguousGroupedGemmSwigluFusionRunner(
-            num_experts, top_k, num_local_experts, local_expert_offset,
-            tile_size, scaling_vector_size)
+            num_experts,
+            top_k,
+            num_local_experts,
+            local_expert_offset,
+            tile_size,
+            scaling_vector_size,
+        )
         inputs = [
-            input, weight, input_scale, weight_scale, alpha,
-            tile_idx_to_group_idx, num_non_exiting_tiles, global_sf
+            input,
+            weight,
+            input_scale,
+            weight_scale,
+            alpha,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
+            global_sf,
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -1653,8 +1917,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         output = runner(inputs, tactic=best_tactic)
         return output
 
-    @torch.library.register_fake(
-        "trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell")
+    @torch.library.register_fake("trtllm::cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell")
     def _(
         input: torch.Tensor,
         weight: torch.Tensor,
@@ -1674,25 +1937,28 @@ if IS_CUTLASS_DSL_AVAILABLE:
         m = input.size(0)
         n = weight.size(1)
         interm_size = n // 2
-        output = torch.empty(m,
-                             interm_size // 2,
-                             dtype=input.dtype,
-                             device=input.device)
-        output_scale = torch.empty(m * interm_size // scaling_vector_size,
-                                   dtype=input_scale.dtype,
-                                   device=input_scale.device)
+        output = torch.empty(
+            m, interm_size // 2, dtype=input.dtype, device=input.device
+        )
+        output_scale = torch.empty(
+            m * interm_size // scaling_vector_size,
+            dtype=input_scale.dtype,
+            device=input_scale.device,
+        )
         return output, output_scale
 
     class Sm100BlockScaledFusedMoERunner(TunableRunner):
         tuning_config_cache = dict()
 
-        def __init__(self,
-                     num_experts: int,
-                     top_k: int,
-                     num_local_experts: int,
-                     local_expert_offset: int,
-                     output_dtype: torch.dtype,
-                     scaling_vector_size: int = 16):
+        def __init__(
+            self,
+            num_experts: int,
+            top_k: int,
+            num_local_experts: int,
+            local_expert_offset: int,
+            output_dtype: torch.dtype,
+            scaling_vector_size: int = 16,
+        ):
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1724,33 +1990,60 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def get_tuning_config(self) -> TuningConfig:
             key = self.unique_id()
             if key not in self.__class__.tuning_config_cache:
-                helper = FusedMoEInputsHelper(self.num_experts, self.top_k,
-                                              self.num_local_experts,
-                                              self.local_expert_offset)
+                helper = FusedMoEInputsHelper(
+                    self.num_experts,
+                    self.top_k,
+                    self.num_local_experts,
+                    self.local_expert_offset,
+                )
                 self.__class__.tuning_config_cache[key] = TuningConfig(
-                    dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, get_last_power_of_2_num_tokens_buckets,
-                        last_positive_power_of_2), ),
-                    constraint_specs=(ConstraintSpec(1, 0,
-                                                     fp4_scale_infer_shape),
-                                      ConstraintSpec(
-                                          2, 0, helper.infer_shape_num_tokens),
-                                      ConstraintSpec(
-                                          3, 0, helper.infer_shape_num_tokens)),
+                    dynamic_tensor_specs=(
+                        DynamicTensorSpec(
+                            0,
+                            0,
+                            get_last_power_of_2_num_tokens_buckets,
+                            last_positive_power_of_2,
+                        ),
+                    ),
+                    constraint_specs=(
+                        ConstraintSpec(1, 0, fp4_scale_infer_shape),
+                        ConstraintSpec(2, 0, helper.infer_shape_num_tokens),
+                        ConstraintSpec(3, 0, helper.infer_shape_num_tokens),
+                    ),
                     inputs_pre_hook=helper.inputs_pre_hook,
                     use_cuda_graph=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(self, inputs: List[torch.Tensor],
-                    tactic: Optional[int]) -> torch.Tensor:
+        def forward(
+            self, inputs: List[torch.Tensor], tactic: Optional[int]
+        ) -> torch.Tensor:
             if isinstance(tactic, int):
                 tile_size = tactic
             else:
                 tile_size = 128
 
-            x, x_sf, token_selected_experts, token_final_scales, gemm1_weight, gemm1_weight_scale, gemm1_alpha, gemm2_input_global_scale, gemm2_weight, gemm2_weight_scale, gemm2_alpha = inputs
-            tile_idx_to_expert_idx, tile_idx_to_mn_limit, expanded_idx_to_permuted_idx, permuted_idx_to_expanded_idx, total_num_padded_tokens, num_non_exiting_tiles = torch.ops.trtllm.moe_sort(
+            (
+                x,
+                x_sf,
+                token_selected_experts,
+                token_final_scales,
+                gemm1_weight,
+                gemm1_weight_scale,
+                gemm1_alpha,
+                gemm2_input_global_scale,
+                gemm2_weight,
+                gemm2_weight_scale,
+                gemm2_alpha,
+            ) = inputs
+            (
+                tile_idx_to_expert_idx,
+                tile_idx_to_mn_limit,
+                expanded_idx_to_permuted_idx,
+                permuted_idx_to_expanded_idx,
+                total_num_padded_tokens,
+                num_non_exiting_tiles,
+            ) = torch.ops.trtllm.moe_sort(
                 token_selected_experts=token_selected_experts,
                 token_final_scales=token_final_scales,
                 num_experts=self.num_experts,
@@ -1812,9 +2105,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             return x
 
-    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_fused_moe_blackwell",
-                             mutates_args=(),
-                             device_types="cuda")
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_fused_moe_blackwell",
+        mutates_args=(),
+        device_types="cuda",
+    )
     def cute_dsl_nvfp4_fused_moe_blackwell(
         input: torch.Tensor,
         input_scale: torch.Tensor,
@@ -1835,16 +2130,26 @@ if IS_CUTLASS_DSL_AVAILABLE:
         scaling_vector_size: int = 16,
     ) -> torch.Tensor:
         tuner = AutoTuner.get()
-        runner = Sm100BlockScaledFusedMoERunner(num_experts, top_k,
-                                                num_local_experts,
-                                                local_expert_offset,
-                                                output_dtype,
-                                                scaling_vector_size)
+        runner = Sm100BlockScaledFusedMoERunner(
+            num_experts,
+            top_k,
+            num_local_experts,
+            local_expert_offset,
+            output_dtype,
+            scaling_vector_size,
+        )
         inputs = [
-            input, input_scale, token_selected_experts, token_final_scales,
-            gemm1_weight, gemm1_weight_scale, gemm1_alpha,
-            gemm2_input_global_scale, gemm2_weight, gemm2_weight_scale,
-            gemm2_alpha
+            input,
+            input_scale,
+            token_selected_experts,
+            token_final_scales,
+            gemm1_weight,
+            gemm1_weight_scale,
+            gemm1_alpha,
+            gemm2_input_global_scale,
+            gemm2_weight,
+            gemm2_weight_scale,
+            gemm2_alpha,
         ]
 
         _, best_tactic = tuner.choose_one(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -2242,7 +2242,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         use_2cta_instrs = mma_tiler_mn[0] == 256 and cluster_shape_mn[0] % 2 == 0
 
         # Skip invalid mma tile shape
-        if not (mma_tiler_mn[0] in [64, 128, 256]):
+        if mma_tiler_mn[0] not in (64, 128, 256):
             is_valid = False
         # Skip invalid mma tile n
         if mma_tiler_mn[1] not in (64, 128, 192, 256):
@@ -2477,7 +2477,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             c,
             a_sf,
             b_sf,
-            "n",
             tile_idx_to_group_idx,
             num_non_exiting_tiles,
             tile_idx_to_mn_limit,

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1,0 +1,1087 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# TODO(zhichenj): This file is copied and modified from cutlass example
+
+"""Example usage of the kernel.
+
+python cutlass_ir/compiler/python/examples/blackwell/contiguous_blockscaled_grouped_gemm_finalize_fusion.py \
+        --ab_dtype Float4E2M1FN --out_dtype Float32 \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 256,256 --cluster_shape_mn 1,1 --seq_len 4096 \
+        --benchmark 128x7168x2048x8 --iterations 1
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+try:
+    from tensorrt_llm._torch.cute_dsl_kernels.blackwell import (
+        blockscaled_contiguous_grouped_gemm_finalize_fusion as kernel_module,
+    )
+except (ModuleNotFoundError, ImportError):
+    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    from blackwell import blockscaled_contiguous_grouped_gemm_finalize_fusion as kernel_module
+
+Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel = (
+    kernel_module.Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
+)
+cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
+
+try:
+    from .testing import benchmark
+except ImportError:
+    from testing import benchmark
+
+
+def create_mask(group_m_list, cta_tile_mn, permuted_m=None):
+    """Create mask and group mapping for contiguous grouped GEMM.
+
+    :param group_m_list: List of M values for each group (will be aligned to cta_tile_mn[0])
+    :param cta_tile_m: CTA tile size in M dimension (from mma_tiler_mn[0])
+    :param permuted_m: Optional padded M dimension for cuda_graph support. If provided,
+                     tile_idx_to_expert_idx will be padded to this size.
+                     When tile_idx >= num_non_exiting_tiles, the kernel exits.
+
+    Note: For cuda_graph support, set permuted_m to the pre-calculated padded size:
+          permuted_m = m * topK + num_local_experts * (256 - 1)
+          Example: 4096*8 + (256/32)*255 = 34808
+          Only the actual valid rows (aligned_groupm[0]+aligned_groupm[1]+...) contain
+          valid data. The kernel will exit when tile_idx >= num_non_exiting_tiles.
+
+    :return: Tuple of (valid_m, aligned_group_m_list, tile_idx_to_expert_idx, num_non_exiting_tiles)
+             - tile_idx_to_expert_idx: shape (permuted_m/cta_tile_m,) if permuted_m provided, else (valid_m/cta_tile_m,)
+             - num_non_exiting_tiles: scalar value = valid_m/cta_tile_m
+    """
+    m_aligned = cta_tile_mn[0]
+    valid_m = 0
+    aligned_group_m_list = []
+    tile_idx_to_expert_idx = []
+    tile_idx_to_mn_limit = []
+
+    for i, group_m in enumerate(group_m_list):
+        aligned_group_m = ((group_m + m_aligned - 1) // m_aligned) * m_aligned
+        aligned_group_m_list.append(aligned_group_m)
+
+        # Calculate number of tiles for this group based on CTA tile M size
+        # Each tile covers cta_tile_m rows in M dimension
+        num_tiles_in_group = aligned_group_m // cta_tile_mn[0]
+        # Add expert_idx for each tile in this group
+        tile_idx_to_expert_idx.extend([i] * num_tiles_in_group)
+
+        tile_idx_to_mn_limit.extend([group_m + valid_m] * num_tiles_in_group)
+        valid_m += aligned_group_m
+
+    # Compute num_non_exiting_tiles (number of valid tiles in M dimension)
+    num_non_exiting_tiles = len(tile_idx_to_expert_idx)
+
+    # Apply padding if requested (for cuda_graph support)
+    if permuted_m is not None:
+        if permuted_m < valid_m:
+            raise ValueError(
+                f"permuted_m ({permuted_m}) must be >= valid_m ({valid_m}). "
+                f"Cannot pad to a smaller size."
+            )
+        if permuted_m > valid_m:
+            # Calculate how many padding tiles are needed based on CTA tile M size
+            num_padding_tiles = (permuted_m - valid_m) // cta_tile_mn[0]
+            # Pad with 0 (these tiles won't be accessed due to num_non_exiting_tiles check)
+            tile_idx_to_expert_idx.extend([0] * num_padding_tiles)
+
+    # Final shape of tile_idx_to_expert_idx: (permuted_m/cta_tile_m,) if permuted_m provided, else (valid_m/cta_tile_m,)
+    tile_idx_to_expert_idx = torch.tensor(tile_idx_to_expert_idx, device="cuda", dtype=torch.int32)
+    num_non_exiting_tiles_tensor = torch.tensor(
+        [num_non_exiting_tiles], device="cuda", dtype=torch.int32
+    )
+
+    tile_idx_to_mn_limit_tensor = torch.tensor(
+        tile_idx_to_mn_limit, device="cuda", dtype=torch.int32
+    )
+
+    return (
+        valid_m,
+        aligned_group_m_list,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles_tensor,
+        tile_idx_to_mn_limit_tensor,
+    )
+
+
+def create_fused_finalize_tensors(
+    seq_len, topK, permuted_m, group_m_list, mma_tiler_mn, final_scale_dtype
+):
+    m_aligned = mma_tiler_mn[0]
+    permuted_idx_to_expanded_idx_tensor = torch.empty(
+        (permuted_m,), dtype=torch.int32, device="cuda"
+    ).fill_(-1)
+    # # normalized token final scales
+    token_final_scales = (
+        torch.rand(seq_len, topK).to(dtype=cutlass_torch.dtype(final_scale_dtype)).cuda()
+    )
+    token_final_scales = token_final_scales / token_final_scales.sum(dim=1, keepdim=True)
+
+    start_idx = 0
+    for group_idx in range(len(group_m_list)):
+        m_per_group = group_m_list[group_idx]
+
+        if m_per_group > 0:
+            # Sequential/Blocked assignment for better atomic add memory access (Friendly Layout)
+            # Experts are grouped into sets of size topK.
+            # Expert Set S (experts S*topK ... S*topK+topK-1) serves a contiguous block of tokens.
+            # This ensures that within an expert, we process tokens T, T+1, T+2... sequentially.
+
+            expert_set_idx = group_idx // topK
+            k_in_set = group_idx % topK
+
+            # Start token index for this expert set
+            start_token = expert_set_idx * m_per_group
+
+            # Generate sequential token indices for this expert
+            token_indices = torch.arange(
+                start_token, start_token + m_per_group, dtype=torch.int32, device="cuda"
+            )
+            token_indices = token_indices % seq_len
+
+            # expanded_idx = token_idx * topK + k
+            expanded_idx = token_indices * topK + k_in_set
+
+            permuted_idx_to_expanded_idx_tensor[start_idx : (start_idx + m_per_group)] = (
+                expanded_idx
+            )
+        # Move to next aligned group
+        m_aligned_per_group = ((m_per_group + m_aligned - 1) // m_aligned) * m_aligned
+        start_idx += m_aligned_per_group
+
+    return (
+        permuted_idx_to_expanded_idx_tensor,
+        token_final_scales,
+        from_dlpack(permuted_idx_to_expanded_idx_tensor).mark_layout_dynamic(),
+        from_dlpack(token_final_scales).mark_layout_dynamic(),
+    )
+
+
+def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
+    def ceil_div(a, b):
+        return (a + b - 1) // b
+
+    sf_k = ceil_div(k, sf_vec_size)
+    ref_shape = (l, mn, sf_k)
+
+    atom_m = (32, 4)
+    atom_k = 4
+    mma_shape = (
+        l,
+        ceil_div(mn, atom_m[0] * atom_m[1]),
+        ceil_div(sf_k, atom_k),
+        atom_m[0],
+        atom_m[1],
+        atom_k,
+    )
+
+    ref_permute_order = (1, 2, 0)
+    mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+    # Create f32 ref torch tensor (cpu)
+    ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        ref_shape,
+        torch.float32,
+        permute_order=ref_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=1,
+            max_val=3,
+        ),
+    )
+
+    # Create f32 cute torch tensor (cpu)
+    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape,
+        torch.float32,
+        permute_order=mma_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=0,
+            max_val=1,
+        ),
+    )
+
+    # convert ref f32 tensor to cute f32 tensor
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+        from_dlpack(ref_f32_torch_tensor_cpu),
+        from_dlpack(cute_f32_torch_tensor_cpu),
+    )
+
+    cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+    # reshape makes memory contiguous
+    ref_f32_torch_tensor_cpu = (
+        ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+        .unsqueeze(-1)
+        .expand(l, mn, sf_k, sf_vec_size)
+        .reshape(l, mn, sf_k * sf_vec_size)
+        .permute(*ref_permute_order)
+    )
+    # prune to mkl for reference check.
+    ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+    # Create dtype cute torch tensor (cpu)
+    cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+        cute_f32_torch_tensor_cpu,
+        dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    # Convert f32 cute tensor to dtype cute tensor
+    cute_tensor = cutlass_torch.convert_cute_tensor(
+        cute_f32_torch_tensor,
+        cute_tensor,
+        dtype,
+        is_dynamic_layout=True,
+    )
+
+    return ref_f32_torch_tensor_cpu, cute_tensor, cute_torch_tensor
+
+
+def create_tensors(
+    l,  # noqa: E741
+    group_m_list,
+    n,
+    k,
+    a_major,
+    b_major,
+    cd_major,
+    ab_dtype,
+    out_dtype,
+    sf_dtype,
+    sf_vec_size,
+    mma_tiler_mn,
+    permuted_m=None,
+    seq_len=None,
+):
+    """Create tensors for contiguous grouped GEMM.
+
+    :param permuted_m: Optional padded M dimension for cuda_graph support. If provided,
+                     A matrix, C matrix, and scale factor A will be padded to this size.
+                     The kernel exits when tile_idx >= num_non_exiting_tiles.
+    :param topK: Number of experts per token (for MoE with fused finalize)
+    :return: Tuple of (a_tensor, b_tensor, out_tensor, sfa_tensor, sfb_tensor,
+                      tile_idx_to_expert_idx, num_non_exiting_tiles, alpha,
+                      a_torch_cpu, b_torch_cpu, out_torch_cpu, sfa_torch_cpu, sfb_torch_cpu,
+                      alpha_torch_cpu, a_torch_gpu, b_torch_gpu, sfa_torch_gpu, sfb_torch_gpu,
+                      out_torch_gpu, aligned_group_m_list, valid_m
+
+    Example with CUDA graph padding:
+        # For MoE: m=4096, topK=8, num_local_experts=256, experts_per_rank=8
+        permuted_m = 4096 * 8 + 8 * 255  # = 34808
+        tensors = create_tensors(
+            l=8,  # num_local_experts
+            group_m_list=[512, 1024, ...],  # actual group sizes
+            n=4096, k=7168,
+            a_major="k", b_major="k", cd_major="n",
+            ab_dtype=cutlass.Float4E2M1FN,
+            out_dtype=cutlass.BFloat16,
+            sf_dtype=cutlass.Float8E4M3FN,
+            sf_vec_size=16,
+            cta_tile_m=128,  # CTA tile size in M dimension
+            permuted_m=34808,  # Enable padding for cuda_graph
+        )
+        # Returns tensors with A, C, and SFA padded to permuted_m rows,
+        # kernel exits early when tile_idx >= num_non_exiting_tiles
+        # Also returns permuted_idx_to_expanded_idx and token_final_scales for fusion
+    """
+    torch.manual_seed(1111)
+
+    alpha_torch_cpu = torch.ones((l,), dtype=torch.float32) * 0.1
+
+    (
+        valid_m,
+        aligned_group_m_list,
+        _tile_idx_to_expert_idx,
+        _num_non_exiting_tiles,
+        _tile_idx_to_mn_limit,
+    ) = create_mask(group_m_list, mma_tiler_mn, permuted_m)
+
+    # Use permuted_m for A/C tensors if provided (for cuda_graph support)
+    tensor_m = permuted_m if permuted_m is not None else valid_m
+
+    a_torch_cpu = cutlass_torch.matrix(1, tensor_m, k, a_major == "m", cutlass.Float32)
+    b_torch_cpu = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    out_torch_cpu = cutlass_torch.matrix(1, seq_len, n, cd_major == "m", cutlass.Float32)
+
+    out_torch_cpu.fill_(0)
+
+    a_tensor, a_torch_gpu = cutlass_torch.cute_tensor_like(
+        a_torch_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch_gpu = cutlass_torch.cute_tensor_like(
+        b_torch_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    out_tensor, out_torch_gpu = cutlass_torch.cute_tensor_like(
+        out_torch_cpu, out_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor with element divisibility for 16B alignment
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    out_tensor.mark_compact_shape_dynamic(
+        mode=1 if cd_major == "n" else 0,
+        stride_order=(2, 0, 1) if cd_major == "n" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    # Use tensor_m (permuted_m if provided) for scale factor A
+    sfa_torch_cpu, sfa_tensor, sfa_torch_gpu = create_scale_factor_tensor(
+        1, tensor_m, k, sf_vec_size, sf_dtype
+    )
+    sfb_torch_cpu, sfb_tensor, sfb_torch_gpu = create_scale_factor_tensor(
+        l, n, k, sf_vec_size, sf_dtype
+    )
+
+    tile_idx_to_expert_idx = from_dlpack(_tile_idx_to_expert_idx).mark_layout_dynamic()
+    num_non_exiting_tiles = from_dlpack(_num_non_exiting_tiles).mark_layout_dynamic()
+    tile_idx_to_mn_limit = from_dlpack(_tile_idx_to_mn_limit).mark_layout_dynamic()
+
+    alpha = from_dlpack(alpha_torch_cpu.cuda()).mark_layout_dynamic()
+
+    out_torch_gpu.fill_(0)
+
+    return (
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        a_torch_cpu,
+        b_torch_cpu,
+        out_torch_cpu,
+        sfa_torch_cpu,
+        sfb_torch_cpu,
+        alpha_torch_cpu,
+        a_torch_gpu,
+        b_torch_gpu,
+        sfa_torch_gpu,
+        sfb_torch_gpu,
+        out_torch_gpu,
+        aligned_group_m_list,
+        valid_m,
+    )
+
+
+def verify_reference_result(
+    a_torch_cpu: torch.Tensor,
+    b_torch_cpu: torch.Tensor,
+    sfa_torch_cpu: torch.Tensor,
+    sfb_torch_cpu: torch.Tensor,
+    alpha_torch_cpu: torch.Tensor,
+    permuted_idx_to_expanded_idx_torch: torch.Tensor,
+    token_final_scales_torch: torch.Tensor,
+    group_m_list: List[int],
+    aligned_group_m_list: List[int],
+    out_dtype: torch.dtype,
+    valid_m: int,
+    n: int,
+    topK: int,
+    seq_len: int,
+) -> torch.Tensor:
+    gemm_output = torch.empty((1, valid_m, n), dtype=torch.float32)
+    valid_mask = torch.zeros((valid_m,), dtype=torch.bool, device="cuda")
+    #########  gemm caculcation #########
+    start = 0
+    for i, group_m in enumerate(aligned_group_m_list):
+        end = start + group_m
+        res_a = torch.einsum(
+            "mk,mk->mk",
+            a_torch_cpu[start:end, :, 0],
+            sfa_torch_cpu[start:end, :, 0],
+        )
+        res_b = torch.einsum("nk,nk->nk", b_torch_cpu[:, :, i], sfb_torch_cpu[:, :, i])
+        gemm_output[0, start:end, :] = torch.einsum("mk,nk->mn", res_a, res_b) * alpha_torch_cpu[i]
+        valid_mask[start : start + group_m_list[i]] = 1
+        start = end
+
+    #########  finalize caculcation#########
+    # Considering BF16 accumulator gpu accuracy error, we used gpu to verify the result
+    gemm_output = gemm_output.permute((1, 2, 0)).cuda()
+
+    final_output = torch.zeros((seq_len, n), dtype=out_dtype).cuda()
+
+    gemm_output = gemm_output[:valid_m, :, 0].clone()  # (valid_m, n)
+    expanded_idx_all = permuted_idx_to_expanded_idx_torch[:valid_m]  # (valid_m,
+
+    # Step 3: Filter valid rows (expanded_idx >= 0)
+    expanded_idx_valid = expanded_idx_all[valid_mask]  # (num_valid,)
+    gemm_output_valid = gemm_output[valid_mask]  # (num_valid, n)
+
+    token_idx = expanded_idx_valid // topK  # (num_valid,)
+    topk_idx = expanded_idx_valid % topK  # (num_valid,)
+
+    scales = token_final_scales_torch[token_idx, topk_idx]  # (num_valid,)
+    scaled_output = gemm_output_valid * scales.unsqueeze(1)  # (num_valid, n)
+    scaled_output = scaled_output.to(out_dtype)
+
+    for i in range(len(token_idx)):
+        final_output[token_idx[i]] += scaled_output[i]
+
+    return final_output
+
+
+def run(
+    nkl: Tuple[int, int, int],
+    group_m_list: Tuple[int, ...],
+    ab_dtype: Type[cutlass.Numeric],
+    out_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    final_scale_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    out_major: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    tolerance: float,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    permuted_m: int = None,
+    topK: int = 8,
+    seq_len: int = 4096,
+    raster_along_m: bool = False,
+    use_cupti: bool = False,
+    **kwargs,
+):
+    """Prepare A/B/C tensors, launch GPU kernel, and reference checking.
+
+    :param nkl: Tuple of (N, K, L) dimensions of the GEMM problem.
+    :param group_m_list: List of M values for each group.
+    :param ab_dtype: Data type for input tensors A and B.
+    :param out_dtype: Data type for the output tensor C.
+    :param sf_dtype: Data type for the scale factor tensors.
+    :param sf_vec_size: Vector size for the scale factor tensors.
+    :param final_scale_dtype: Data type for the final scale factor tensors.
+    :param a_major: The major axis of the A tensor.
+    :param b_major: The major axis of the B tensor.
+    :param out_major: The major axis of the C tensor.
+    :param mma_tiler_mn: The shape of the MMA tile.
+    :param cluster_shape_mn: The shape of the CTA cluster.
+    :param tolerance: Tolerance for result validation.
+    :param warmup_iterations: Number of warmup runs.
+    :param iterations: Number of benchmark iterations.
+    :param skip_ref_check: If True, skips reference checking.
+    :param use_cold_l2: If True, uses a circular buffer to ensure a cold L2 cache.
+    :param permuted_m: Optional padded M dimension for CUDA graph support. If provided,
+                    A/C matrices and scale factor A will be padded to this size.
+    :param topK: Number of experts per token (for MoE with fused finalize)
+    :param seq_len: Sequence length for MoE, used by fused finalize,
+            need to know the sequence length to do finalize correctly.
+    :param raster_along_m: If True, raster along M dimensionfor tile scheduler.
+    :param use_cupti (bool, optional): If True, uses CUPTI to measure execution time.
+            Defaults to False.
+    """
+    m_aligned = mma_tiler_mn[0]
+    use_2cta_instrs = mma_tiler_mn[0] == 256 and cluster_shape_mn[0] % 2 == 0
+
+    print("Running Blackwell Persistent Dense Contiguous Grouped GEMM test with:")
+    print(f"nkl: {nkl}")
+    print(f"group_m_list: {group_m_list}")
+    print(
+        f"AB dtype: {ab_dtype}, C dtype: {out_dtype}, Scale factor dtype: {sf_dtype}, SF Vec size: {sf_vec_size}"
+    )
+    print(f"Group M alignment: {m_aligned}")
+    if permuted_m is not None:
+        print(f"Padded M (CUDA graph support): {permuted_m}")
+    print(f"Fused finalize enabled with topK={topK}")
+    print(f"Sequence length: {seq_len}")
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, Out: {out_major}")
+    print(f"Mma Tiler (M, N): {mma_tiler_mn}, Cluster Shape (M, N): {cluster_shape_mn}")
+    print(f"2CTA MMA instructions: {'True' if use_2cta_instrs else 'False'}")
+    print(f"Use TMA Store: {'True'}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use TMA prefetch: {'True'}")
+    print(f"Raster along M: {raster_along_m}")
+    print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+
+    # Unpack parameters
+    n, k, l = nkl  # noqa: E741
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    # Skip unsupported testcase
+    if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        out_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        m_aligned,
+        n,
+        k,
+        l,
+        a_major,
+        b_major,
+        out_major,
+    ):
+        raise TypeError(
+            f"Unsupported testcase {ab_dtype}, {sf_dtype}, {sf_vec_size}, {out_dtype}, "
+            f"{use_2cta_instrs}, {mma_tiler_mn}, {cluster_shape_mn}, {n}, {k}, {l}, "
+            f"{a_major}, {b_major}, {out_major}, {m_aligned}"
+        )
+
+    (
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        a_torch_cpu,
+        b_torch_cpu,
+        out_torch_cpu,
+        sfa_torch_cpu,
+        sfb_torch_cpu,
+        alpha_torch_cpu,
+        a_torch_gpu,
+        b_torch_gpu,
+        sfa_torch_gpu,
+        sfb_torch_gpu,
+        out_torch_gpu,
+        aligned_group_m_list,
+        valid_m,
+    ) = create_tensors(
+        l,
+        group_m_list,
+        n,
+        k,
+        a_major,
+        b_major,
+        out_major,
+        ab_dtype,
+        out_dtype,
+        sf_dtype,
+        sf_vec_size,
+        mma_tiler_mn,  # cta_tile_m
+        permuted_m,
+        seq_len,  # Pass seq_len as num_tokens for C tensor shape
+    )
+
+    # Calculate actual tensor_m used (with padding if permuted_m provided)
+    tensor_m = permuted_m if permuted_m is not None else valid_m
+
+    (
+        permuted_idx_to_expanded_idx_torch,
+        token_final_scales_torch,
+        permuted_idx_to_expanded_idx,
+        token_final_scales,
+    ) = create_fused_finalize_tensors(
+        seq_len,
+        topK,
+        tensor_m,
+        group_m_list,
+        mma_tiler_mn,
+        final_scale_dtype,
+    )
+
+    # Configure gemm kernel
+    gemm = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel(
+        sf_vec_size,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        raster_along_m,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+
+    # Initialize Stream
+    current_stream = cutlass_torch.default_stream()
+
+    # Compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        max_active_clusters,
+        current_stream,
+        permuted_idx_to_expanded_idx,
+        token_final_scales,
+        options="--opt-level 2",
+    )
+
+    # Compute reference result
+    if not skip_ref_check:
+        print("Verifying results...")
+        # Execution
+        compiled_gemm(
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            current_stream,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        )
+
+        torch.cuda.synchronize()
+        ref_result = verify_reference_result(
+            a_torch_cpu,
+            b_torch_cpu,
+            sfa_torch_cpu,
+            sfb_torch_cpu,
+            alpha_torch_cpu,
+            permuted_idx_to_expanded_idx_torch,
+            token_final_scales_torch,
+            group_m_list,
+            aligned_group_m_list,
+            out_torch_gpu.dtype,
+            valid_m,
+            n,
+            topK,
+            seq_len,
+        )
+
+        # Convert c back to f32 for comparison.
+        actual_result = out_torch_gpu[:, :, 0]
+        if out_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(actual_result, ref_result, atol=tolerance, rtol=1e-02)
+        elif out_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(1, valid_m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f8.element_type = out_dtype
+            ref_device = ref_result.cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            torch.testing.assert_close(
+                actual_result.cpu(), ref_device.cpu(), atol=tolerance, rtol=1e-02
+            )
+        # {$nv-internal-release begin}
+        elif out_dtype is cutlass.Float4E2M1FN:
+            # Convert ref : f32 -> f4 -> f32
+            ref_f4_ = torch.empty(*(1, valid_m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f4 = from_dlpack(ref_f4_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f4.element_type = out_dtype
+            ref_device = ref_result.cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f4)
+            cute.testing.convert(ref_f4, ref_tensor)
+            torch.testing.assert_close(
+                actual_result.cpu(), ref_device.cpu(), atol=tolerance, rtol=1e-02
+            )
+        # {$nv-internal-release end}
+
+    def generate_tensors():
+        (
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            a_torch_cpu,
+            b_torch_cpu,
+            out_torch_cpu,
+            sfa_torch_cpu,
+            sfb_torch_cpu,
+            alpha_torch_cpu,
+            a_torch_gpu,
+            b_torch_gpu,
+            sfa_torch_gpu,
+            sfb_torch_gpu,
+            out_torch_gpu,
+            aligned_group_m_list,
+            valid_m,
+        ) = create_tensors(
+            l,
+            group_m_list,
+            n,
+            k,
+            a_major,
+            b_major,
+            out_major,
+            ab_dtype,
+            out_dtype,
+            sf_dtype,
+            sf_vec_size,
+            mma_tiler_mn,  # cta_tile_m
+            permuted_m,
+            seq_len,  # Pass seq_len as num_tokens for C tensor shape
+        )
+
+        (
+            permuted_idx_to_expanded_idx_torch,
+            token_final_scales_torch,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        ) = create_fused_finalize_tensors(
+            seq_len,
+            topK,
+            tensor_m,
+            group_m_list,
+            mma_tiler_mn,
+            final_scale_dtype,
+        )
+
+        return cute.testing.JitArguments(
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            current_stream,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_torch_gpu.numel() * a_torch_gpu.element_size()
+            + b_torch_gpu.numel() * b_torch_gpu.element_size()
+            + out_torch_gpu.numel() * out_torch_gpu.element_size()
+            + sfa_torch_gpu.numel() * sfa_torch_gpu.element_size()
+            + sfb_torch_gpu.numel() * sfb_torch_gpu.element_size()
+            + (tensor_m // mma_tiler_mn[0])
+            * 4  # tile_idx_to_expert_idx length (tiles) * sizeof(int32)
+            + 1 * 4  # num_non_exiting_tiles (1 element) * sizeof(int32)
+            + alpha_torch_cpu.numel() * alpha_torch_cpu.element_size()
+        )
+        workspace_count = cute.testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        use_cupti=use_cupti,
+    )
+
+    return exec_time  # Return execution time in microseconds
+
+
+if __name__ == "__main__":
+
+    def parse_comma_separated_ints(s: str) -> Tuple[int, ...]:
+        try:
+            return tuple(int(x.strip()) for x in s.split(","))
+        except ValueError:
+            raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.")
+
+    def read_benchmark_file(
+        filepath: str,
+    ) -> Tuple[Tuple[int, int, int], Tuple[int, ...]]:
+        """Read benchmark file and return nkl and group_m_list.
+
+        File format:
+            0 256x512x128
+            1 512x512x512
+            2 1024x256x128
+            ...
+
+        Returns:
+            Tuple of ((n, k, l), (m0, m1, m2, ...)) where:
+            - n, k are from the first problem
+            - l is the total number of problems (groups)
+            - (m0, m1, m2, ...) are the M values for each group
+        """
+        problems = []
+        try:
+            with open(filepath, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+
+                    parts = line.split()
+                    if len(parts) < 2:
+                        continue
+
+                    # Parse index and dimensions (e.g., "256x512x128")
+                    dims = parts[1].split("x")
+                    if len(dims) == 3:
+                        m, n, k = int(dims[0]), int(dims[1]), int(dims[2])
+                        problems.append((m, n, k))
+
+            if not problems:
+                raise ValueError(f"No valid problems found in benchmark file: {filepath}")
+
+            # Use first problem's N, K dimensions
+            m_first, n, k = problems[0]
+            l = len(problems)  # noqa: E741
+
+            # Extract M values for each group
+            m_values = tuple(m for m, _, _ in problems)
+
+            print(f"Loaded {l} problems from benchmark file")
+            print(f"Using N={n}, K={k}, L={l}")
+            print(f"M values per group: {m_values}")
+
+            return ((n, k, l), m_values)
+
+        except FileNotFoundError:
+            raise argparse.ArgumentTypeError(f"Benchmark file not found: {filepath}")
+        except Exception as e:
+            raise argparse.ArgumentTypeError(f"Error reading benchmark file: {e}")
+
+    def parse_benchmark_arg(
+        arg: str,
+    ) -> Tuple[Tuple[int, int, int], Tuple[int, ...]]:
+        """Parse benchmark argument string.
+
+        Supported formats:
+        1. 'MxNxKxL': 128x512x1024x4 -> n=512, k=1024, l=4, m_values=(128, 128, 128, 128)
+        2. '[m0,m1,...]xNxK': [128,256]x512x1024 -> n=512, k=1024, l=2, m_values=(128, 256)
+        """
+        # Try matching [m0, m1, ...]xNxK format
+        match_list = re.match(r"\[([\d,\s]+)\]\s*x\s*(\d+)\s*x\s*(\d+)", arg)
+        if match_list:
+            m_str = match_list.group(1)
+            n = int(match_list.group(2))
+            k = int(match_list.group(3))
+            try:
+                m_values = tuple(int(x.strip()) for x in m_str.split(","))
+                l = len(m_values)  # noqa: E741
+                print(f"Parsed benchmark arg: N={n}, K={k}, L={l}")
+                print(f"M values per group: {m_values}")
+                return ((n, k, l), m_values)
+            except ValueError:
+                raise argparse.ArgumentTypeError(
+                    f"Invalid integer list in benchmark argument: {arg}"
+                )
+
+        # Try matching MxNxKxL format
+        parts = arg.split("x")
+        if len(parts) == 4:
+            try:
+                m, n, k, l = [int(x.strip()) for x in parts]  # noqa: E741
+                m_values = tuple([m] * l)
+                print(f"Parsed benchmark arg: M={m}, N={n}, K={k}, L={l}")
+                return ((n, k, l), m_values)
+            except ValueError:
+                pass
+
+        raise argparse.ArgumentTypeError(
+            f"Invalid benchmark argument format. Expected file path, 'MxNxKxL', or '[m0,m1,...]xNxK'. Got: {arg}"
+        )
+
+    parser = argparse.ArgumentParser(description="Example of Dense Persistent GEMM on Blackwell.")
+
+    parser.add_argument(
+        "--nkl",
+        type=parse_comma_separated_ints,
+        default=(256, 512, 1),
+        help="nkl dimensions: N, K, L (number of groups) (comma-separated)",
+    )
+
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        default=None,
+        help="Path to benchmark file with problem sizes (format: 'index MxNxK' per line),"
+        "or 'MxNxKxL' format or '[m0,m1,...]xNxK' format",
+    )
+
+    parser.add_argument(
+        "--permuted_m",
+        type=int,
+        default=None,
+        help="Optional padded M dimension for CUDA graph support. If specified,"
+        "A/C matrices and scale factor A will be padded to this size."
+        "Example: For MoE with m=4096, topK=8, experts_per_rank=8: permuted_m = 4096*8 + 8*255 = 34808",
+    )
+
+    parser.add_argument(
+        "--seq_len",
+        type=int,
+        default=4096,
+        help="Sequence length for MoE, used by fused finalize, need to know"
+        "the sequence length to do finalize correctly",
+    )
+
+    parser.add_argument(
+        "--topk",
+        type=int,
+        default=8,
+        help="Top-K experts per token (used for fused finalize)",
+    )
+
+    parser.add_argument(
+        "--mma_tiler_mn",
+        type=parse_comma_separated_ints,
+        default=(128, 128),
+        help="Mma tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=parse_comma_separated_ints,
+        default=(1, 1),
+        help="Cluster shape (comma-separated)",
+    )
+    parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float8E4M3FN)
+    parser.add_argument("--out_dtype", type=cutlass.dtype, default=cutlass.BFloat16)
+    parser.add_argument("--final_scale_dtype", type=cutlass.dtype, default=cutlass.Float32)
+    parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float32)
+    parser.add_argument("--sf_vec_size", type=int, default=16)
+    parser.add_argument("--a_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--out_major", choices=["n", "m"], type=str, default="n")
+    parser.add_argument("--tolerance", type=float, default=1e-01, help="Tolerance for validation")
+    parser.add_argument("--warmup_iterations", type=int, default=0, help="Warmup iterations")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
+    parser.add_argument("--use_cold_l2", action="store_true", default=False, help="Use cold L2")
+
+    parser.add_argument(
+        "--raster_along_m",
+        action="store_true",
+        dest="raster_along_m",
+        default=False,
+        help="Enable raster along M (default: True)",
+    )
+
+    parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=False,
+        help="Use CUPTI to measure execution time",
+    )
+
+    args = parser.parse_args()
+
+    # Process arguments to generate nkl and group_m_list
+    if args.benchmark:
+        # Read from benchmark file or parse string
+        if os.path.isfile(args.benchmark):
+            nkl, group_m_list = read_benchmark_file(args.benchmark)
+        else:
+            nkl, group_m_list = parse_benchmark_arg(args.benchmark)
+    else:
+        parser.error("No benchmark file or benchmark argument provided")
+    if len(args.mma_tiler_mn) != 2:
+        parser.error("--mma_tiler_mn must contain exactly 2 values")
+
+    if len(args.cluster_shape_mn) != 2:
+        parser.error("--cluster_shape_mn must contain exactly 2 values")
+
+    exec_time = run(
+        nkl,
+        group_m_list,
+        args.ab_dtype,
+        args.out_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.final_scale_dtype,
+        args.a_major,
+        args.b_major,
+        args.out_major,
+        args.mma_tiler_mn,
+        args.cluster_shape_mn,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+        args.permuted_m,
+        args.topk,
+        args.seq_len,
+        args.raster_along_m,
+        args.use_cupti,
+    )
+    print("exec_time: ", exec_time)
+    print("PASS")

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -2,12 +2,8 @@ import pytest
 import torch
 
 from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
-from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import (
-    cute_dsl_nvfp4_grouped_gemm_ref,
-)
-from tensorrt_llm._torch.modules.fused_moe.quantization import (
-    interleave_linear_and_gate,
-)
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import cute_dsl_nvfp4_grouped_gemm_ref
+from tensorrt_llm._torch.modules.fused_moe.quantization import interleave_linear_and_gate
 from tensorrt_llm._torch.utils import swizzle_sf, unswizzle_sf
 from tensorrt_llm._utils import get_sm_version
 
@@ -24,17 +20,11 @@ def test_grouped_gemm_inputs_helper(top_k: int, ep_size: int, tile_size: int):
     num_experts = 256
     num_local_experts = num_experts // ep_size
 
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tokens = 8192
     num_tokens_list = list(range(1, max_num_tokens + 1))
-    max_num_permuted_tokens_list = [
-        helper.get_max_num_permuted_tokens(x) for x in num_tokens_list
-    ]
-    num_inferred_tokens_list = [
-        helper.infer_num_tokens(x) for x in max_num_permuted_tokens_list
-    ]
+    max_num_permuted_tokens_list = [helper.get_max_num_permuted_tokens(x) for x in num_tokens_list]
+    num_inferred_tokens_list = [helper.infer_num_tokens(x) for x in max_num_permuted_tokens_list]
 
     for i in range(max_num_tokens):
         assert num_inferred_tokens_list[i] >= num_tokens_list[i]
@@ -43,9 +33,9 @@ def test_grouped_gemm_inputs_helper(top_k: int, ep_size: int, tile_size: int):
             assert num_inferred_tokens_list[i] >= num_inferred_tokens_list[i - 1]
 
     buckets = helper.gen_tuning_buckets(max_num_permuted_tokens_list[-1])
-    assert set(
-        [helper.map_to_tuning_buckets(x) for x in max_num_permuted_tokens_list]
-    ) == set(buckets)
+    assert set([helper.map_to_tuning_buckets(x) for x in max_num_permuted_tokens_list]) == set(
+        buckets
+    )
 
 
 @pytest.mark.parametrize("tile_size", [128, 256])
@@ -78,17 +68,13 @@ def test_moe_sort(num_tokens: int, top_k: int, ep_size: int, tile_size: int):
         tile_tokens_dim=tile_size,
     )
 
-    num_tokens_per_expert = torch.bincount(
-        token_selected_experts.flatten(), minlength=num_experts
-    )
+    num_tokens_per_expert = torch.bincount(token_selected_experts.flatten(), minlength=num_experts)
     num_tokens_per_expert = num_tokens_per_expert[:num_local_experts]
     num_tiles_per_expert = (num_tokens_per_expert + tile_size - 1) // tile_size
     num_tokens_per_expert = num_tokens_per_expert.cpu()
     num_tiles_per_expert = num_tiles_per_expert.cpu()
 
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
     num_valid_tiles = num_tiles_per_expert.sum().item()
@@ -157,9 +143,7 @@ def test_moe_permute(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     hidden_size = 4096
     num_experts = 256
     num_local_experts = num_experts // 32
-    x = torch.randint(
-        -100, 100, (num_tokens, hidden_size), dtype=torch.int32, device="cuda"
-    )
+    x = torch.randint(-100, 100, (num_tokens, hidden_size), dtype=torch.int32, device="cuda")
     x_sf = None
     if dtype == "float4":
         x = x[:, : hidden_size // 2].to(torch.int8).view(torch.float4_e2m1fn_x2)
@@ -176,9 +160,7 @@ def test_moe_permute(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     else:
         x = x.to(getattr(torch, dtype))
 
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
     tile_idx_to_mn_limit = (
@@ -206,9 +188,7 @@ def test_moe_permute(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     )
     if dtype == "float4":
         assert permuted_sf is not None
-        permuted_sf = unswizzle_sf(
-            permuted_sf, max_num_permuted_tokens, hidden_size, sf_vec_size
-        )
+        permuted_sf = unswizzle_sf(permuted_sf, max_num_permuted_tokens, hidden_size, sf_vec_size)
     else:
         assert permuted_sf is None
 
@@ -237,9 +217,7 @@ def test_moe_unpermute(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     hidden_size = 4096
     num_experts = 256
     num_local_experts = num_experts // 32
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
     permuted_x = torch.randint(
         -100,
@@ -256,17 +234,11 @@ def test_moe_unpermute(dtype: str, num_tokens: int, top_k: int, tile_size: int):
         dtype=torch.int32,
         device="cuda",
     )
-    topk_scales = torch.randn(
-        num_tokens, top_k, dtype=torch.float32, device="cuda"
-    ).softmax(dim=-1)
-    x = torch.ops.trtllm.moe_unpermute(
-        permuted_x, expanded_idx_to_permuted_idx, topk_scales
-    )
+    topk_scales = torch.randn(num_tokens, top_k, dtype=torch.float32, device="cuda").softmax(dim=-1)
+    x = torch.ops.trtllm.moe_unpermute(permuted_x, expanded_idx_to_permuted_idx, topk_scales)
 
     x_ref = (
-        (permuted_x[expanded_idx_to_permuted_idx] * topk_scales.unsqueeze(-1))
-        .sum(dim=1)
-        .to(dtype)
+        (permuted_x[expanded_idx_to_permuted_idx] * topk_scales.unsqueeze(-1)).sum(dim=1).to(dtype)
     )
     torch.testing.assert_close(x, x_ref)
 
@@ -334,9 +306,7 @@ def test_moe_swiglu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     interm_size = 4096
     num_experts = 256
     num_local_experts = num_experts // 32
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
 
@@ -356,9 +326,7 @@ def test_moe_swiglu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     )
     num_permuted_tokens = num_non_exiting_tiles_val * tile_size
 
-    y = torch.ops.trtllm.moe_swiglu(
-        x, tile_idx_to_mn_limit, num_non_exiting_tiles, tile_size
-    )
+    y = torch.ops.trtllm.moe_swiglu(x, tile_idx_to_mn_limit, num_non_exiting_tiles, tile_size)
     y_ref = swiglu_ref(x)
     torch.testing.assert_close(y[:num_permuted_tokens], y_ref[:num_permuted_tokens])
 
@@ -371,17 +339,13 @@ def test_moe_swiglu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
 @pytest.mark.parametrize("top_k", [1, 2, 8])
 @pytest.mark.parametrize("num_tokens", [128, 515, 1024])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float16"])
-def test_moe_swiglu_nvfp4_quantize(
-    dtype: str, num_tokens: int, top_k: int, tile_size: int
-):
+def test_moe_swiglu_nvfp4_quantize(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     dtype = getattr(torch, dtype)
     sf_vec_size = 16
     interm_size = 4096
     num_experts = 256
     num_local_experts = num_experts // 32
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
 
@@ -406,9 +370,7 @@ def test_moe_swiglu_nvfp4_quantize(
     y, y_sf = torch.ops.trtllm.moe_swiglu_nvfp4_quantize(
         x, global_sf, tile_idx_to_mn_limit, num_non_exiting_tiles, tile_size
     )
-    y_ref, y_sf_ref = torch.ops.trtllm.fp4_quantize(
-        swiglu_ref(x), global_sf, sf_vec_size, False
-    )
+    y_ref, y_sf_ref = torch.ops.trtllm.fp4_quantize(swiglu_ref(x), global_sf, sf_vec_size, False)
     match_ratio = (
         y[:num_permuted_tokens].view(torch.uint8) == y_ref[:num_permuted_tokens]
     ).sum().item() / y[:num_permuted_tokens].numel()
@@ -430,9 +392,7 @@ def test_moe_gelu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     interm_size = 4096
     num_experts = 256
     num_local_experts = num_experts // 32
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
 
@@ -452,9 +412,7 @@ def test_moe_gelu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
     )
     num_permuted_tokens = num_non_exiting_tiles_val * tile_size
 
-    y = torch.ops.trtllm.moe_gelu(
-        x, tile_idx_to_mn_limit, num_non_exiting_tiles, tile_size
-    )
+    y = torch.ops.trtllm.moe_gelu(x, tile_idx_to_mn_limit, num_non_exiting_tiles, tile_size)
     y_ref = torch.nn.functional.gelu(x)
     torch.testing.assert_close(y[:num_permuted_tokens], y_ref[:num_permuted_tokens])
 
@@ -467,26 +425,20 @@ def test_moe_gelu(dtype: str, num_tokens: int, top_k: int, tile_size: int):
 @pytest.mark.parametrize("ep_size", [1, 8, 32])
 @pytest.mark.parametrize("top_k", [1, 2, 8])
 @pytest.mark.parametrize("num_tokens", [128, 515, 1024, 8192])
-def test_nvfp4_grouped_gemm_blackwell(
-    num_tokens: int, top_k: int, ep_size: int, tile_size: int
-):
+def test_nvfp4_grouped_gemm_blackwell(num_tokens: int, top_k: int, ep_size: int, tile_size: int):
     sf_vec_size = 16
     hidden_size = 4096
     interm_size = 8192
     num_experts = 256
     num_local_experts = num_experts // ep_size
 
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
     routing_logits = torch.randn(num_tokens, num_experts, device="cuda")
     _, token_selected_experts = routing_logits.topk(top_k, dim=-1)
     token_selected_experts = token_selected_experts.to(torch.int32)
-    num_tokens_per_expert = torch.bincount(
-        token_selected_experts.flatten(), minlength=num_experts
-    )
+    num_tokens_per_expert = torch.bincount(token_selected_experts.flatten(), minlength=num_experts)
     num_tokens_per_expert = num_tokens_per_expert[:num_local_experts]
     # Ensure at least one valid token
     if num_tokens_per_expert.sum().item() == 0:
@@ -499,9 +451,7 @@ def test_nvfp4_grouped_gemm_blackwell(
     assert 0 <= num_valid_tiles <= max_num_tiles
     assert 0 <= num_valid_permuted_tokens <= max_num_permuted_tokens
 
-    num_non_exiting_tiles = torch.tensor(
-        [num_valid_tiles], dtype=torch.int32, device="cuda"
-    )
+    num_non_exiting_tiles = torch.tensor([num_valid_tiles], dtype=torch.int32, device="cuda")
     tile_idx_to_group_idx = torch.empty(max_num_tiles, dtype=torch.int32)
     # Note: Fill -2e9 for invalid tiles.
     tile_idx_to_group_idx.fill_(-2e9)
@@ -560,9 +510,7 @@ def test_nvfp4_grouped_gemm_blackwell(
         output_dtype=torch.bfloat16,
         scaling_vector_size=sf_vec_size,
     )
-    torch.testing.assert_close(
-        c[:num_valid_permuted_tokens], c_ref[:num_valid_permuted_tokens]
-    )
+    torch.testing.assert_close(c[:num_valid_permuted_tokens], c_ref[:num_valid_permuted_tokens])
 
 
 @pytest.mark.skipif(
@@ -662,9 +610,7 @@ def test_nvfp4_grouped_gemm_finalize_blackwell(
         expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
         topk_scales=token_final_scales,
     )
-    match_ratio = (
-        torch.isclose(c, c_ref, rtol=1.6e-2, atol=1e-5).sum().item() / c.numel()
-    )
+    match_ratio = torch.isclose(c, c_ref, rtol=1.6e-2, atol=1e-5).sum().item() / c.numel()
     assert match_ratio > 0.99
 
 
@@ -685,17 +631,13 @@ def test_nvfp4_grouped_gemm_swiglu_blackwell(
     num_experts = 256
     num_local_experts = num_experts // ep_size
 
-    helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, 0, tile_size
-    )
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
     max_num_tiles = helper.get_max_num_tiles(num_tokens)
     max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
     routing_logits = torch.randn(num_tokens, num_experts, device="cuda")
     _, token_selected_experts = routing_logits.topk(top_k, dim=-1)
     token_selected_experts = token_selected_experts.to(torch.int32)
-    num_tokens_per_expert = torch.bincount(
-        token_selected_experts.flatten(), minlength=num_experts
-    )
+    num_tokens_per_expert = torch.bincount(token_selected_experts.flatten(), minlength=num_experts)
     num_tokens_per_expert = num_tokens_per_expert[:num_local_experts]
     # Ensure at least one valid token
     if num_tokens_per_expert.sum().item() == 0:
@@ -708,9 +650,7 @@ def test_nvfp4_grouped_gemm_swiglu_blackwell(
     assert 0 <= num_valid_tiles <= max_num_tiles
     assert 0 <= num_valid_permuted_tokens <= max_num_permuted_tokens
 
-    num_non_exiting_tiles = torch.tensor(
-        [num_valid_tiles], dtype=torch.int32, device="cuda"
-    )
+    num_non_exiting_tiles = torch.tensor([num_valid_tiles], dtype=torch.int32, device="cuda")
     tile_idx_to_group_idx = torch.empty(max_num_tiles, dtype=torch.int32)
     # Note: Fill -2e9 for invalid tiles.
     tile_idx_to_group_idx.fill_(-2e9)
@@ -741,18 +681,16 @@ def test_nvfp4_grouped_gemm_swiglu_blackwell(
     b_sf = b_sf.view(num_local_experts, interm_size * 2, hidden_size // sf_vec_size)
     alpha = a_global_sf * b_global_sf
 
-    b_interleaved = interleave_linear_and_gate(
-        b.view(torch.uint8), group_size=64, dim=1
-    ).view(torch.float4_e2m1fn_x2)
+    b_interleaved = interleave_linear_and_gate(b.view(torch.uint8), group_size=64, dim=1).view(
+        torch.float4_e2m1fn_x2
+    )
     b_sf_unswizzled = unswizzle_sf(b_sf, interm_size * 2, hidden_size).view(
         num_local_experts, interm_size * 2, hidden_size // sf_vec_size
     )
-    b_sf_unswizzled_interleaved = interleave_linear_and_gate(
-        b_sf_unswizzled, group_size=64, dim=1
+    b_sf_unswizzled_interleaved = interleave_linear_and_gate(b_sf_unswizzled, group_size=64, dim=1)
+    b_sf_interleaved = swizzle_sf(b_sf_unswizzled_interleaved, interm_size * 2, hidden_size).view(
+        num_local_experts, interm_size * 2, hidden_size // sf_vec_size
     )
-    b_sf_interleaved = swizzle_sf(
-        b_sf_unswizzled_interleaved, interm_size * 2, hidden_size
-    ).view(num_local_experts, interm_size * 2, hidden_size // sf_vec_size)
 
     c_ref = cute_dsl_nvfp4_grouped_gemm_ref(
         a,
@@ -768,9 +706,7 @@ def test_nvfp4_grouped_gemm_swiglu_blackwell(
     )
     c_ref = swiglu_ref(c_ref)
     global_sf = c_ref[:num_valid_permuted_tokens].abs().max().float() / (448 * 6)
-    c_ref, c_sf_ref = torch.ops.trtllm.fp4_quantize(
-        c_ref, 1 / global_sf, sf_vec_size, False
-    )
+    c_ref, c_sf_ref = torch.ops.trtllm.fp4_quantize(c_ref, 1 / global_sf, sf_vec_size, False)
 
     c, c_sf = torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_swiglu_blackwell(
         a,
@@ -790,8 +726,7 @@ def test_nvfp4_grouped_gemm_swiglu_blackwell(
     )
 
     match_ratio = (
-        c[:num_valid_permuted_tokens].view(torch.uint8)
-        == c_ref[:num_valid_permuted_tokens]
+        c[:num_valid_permuted_tokens].view(torch.uint8) == c_ref[:num_valid_permuted_tokens]
     ).sum().item() / c[:num_valid_permuted_tokens].numel()
     assert match_ratio > 0.95
 


### PR DESCRIPTION
## Description

Enabled more optimization features for contiguous groupedgemm: 2CTA, tmem overlapping and tma prefetch:

- 2CTA is suitable for larger tokens. 

- TMEM overlap helps alleviate TMA load pressure and thus improves MATH SOL. 

- Rasterizing the tile scheduler from the M dimension to the N dimension provides improvements for small EPs.

Added `mma_tiler_mn` , `cluster_shape_mn`  and  `raster_along_m`candidates to help get best tactic for different problem sizes.

For example: 1024x7168x2048x8 (MxNxKxL) 's best tactic is `mma_tiler_mn: (256,256)` and `cluster_shape_mn: (2,2)` 

In addition, some redundant parameters in the previous code have been cleaned up. The M dimension is aligned according to `tile M`; when `tile M ` is 256 and `cluster_m` is divisible by 2, 2CTA is enabled by default. 

## Test Coverage
`tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py` added 2CTA test.
`tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py` added finalized kernel's example test.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved import resilience for CUDA environments with fallback mechanisms
  * Simplified kernel configuration interface by removing deprecated parameters
  
* **New Features**
  * Added prefetch capability support for kernel optimization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->