### PR TITLE
[None][infra] Add workflow to auto-label 'waiting for feedback' on team comments

### DIFF
--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -1,0 +1,59 @@
+name: Add Waiting for Feedback Label
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-waiting-for-feedback:
+    runs-on: ubuntu-latest
+    if: github.repository == 'NVIDIA/TensorRT-LLM'
+    steps:
+      - name: Check membership and add label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const issueNumber = context.issue.number;
+
+            console.log(`Comment by ${commenter} on #${issueNumber}`);
+
+            // Check if commenter is NVIDIA org member
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: 'NVIDIA',
+                username: commenter
+              });
+
+              // If we reach here, user is a member (204 response)
+              console.log(`${commenter} is an NVIDIA member. Adding 'waiting for feedback' label.`);
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['waiting for feedback']
+              });
+
+              console.log(`Successfully added 'waiting for feedback' label to #${issueNumber}`);
+
+            } catch (error) {
+              if (error.status === 404) {
+                // User is not a member - this is expected for community users
+                console.log(`${commenter} is not an NVIDIA member. No label added.`);
+              } else if (error.status === 302) {
+                // Token doesn't have org membership privileges
+                console.log(`Cannot determine membership for ${commenter} (insufficient token permissions)`);
+              } else {
+                // Unexpected error
+                console.error(`Error checking membership: ${error.message}`);
+                throw error;
+              }
+            }
+

--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -1,4 +1,4 @@
-name: Add Waiting for Feedback Label
+name: Manage Waiting for Feedback Label
 
 on:
   issue_comment:
@@ -11,48 +11,100 @@ permissions:
   pull-requests: write
 
 jobs:
-  add-waiting-for-feedback:
+  manage-waiting-for-feedback:
     runs-on: ubuntu-latest
     if: github.repository == 'NVIDIA/TensorRT-LLM'
     steps:
-      - name: Check membership and add label
+      - name: Check membership and manage label
         uses: actions/github-script@v7
         with:
           script: |
             const commenter = context.payload.comment.user.login;
             const issueNumber = context.issue.number;
+            const label = 'waiting for feedback';
 
-            console.log(`Comment by ${commenter} on #${issueNumber}`);
+            // Get the author of the issue/PR
+            const issue = context.payload.issue || context.payload.pull_request;
+            const author = issue?.user?.login;
+            const isAuthor = (commenter === author);
+
+            console.log(`Comment by ${commenter} on #${issueNumber} (author: ${author})`);
 
             // Check if commenter is NVIDIA org member
+            let isMember = false;
             try {
               await github.rest.orgs.checkMembershipForUser({
                 org: 'NVIDIA',
                 username: commenter
               });
+              isMember = true;
+            } catch (error) {
+              if (error.status === 404) {
+                isMember = false;
+              } else if (error.status === 302) {
+                console.log(`Cannot determine membership for ${commenter} (insufficient token permissions)`);
+                return;
+              } else {
+                console.error(`Error checking membership: ${error.message}`);
+                throw error;
+              }
+            }
 
-              // If we reach here, user is a member (204 response)
-              console.log(`${commenter} is an NVIDIA member. Adding 'waiting for feedback' label.`);
+            // Logic:
+            // - Author responds → remove label (feedback provided)
+            // - NVIDIA non-author comments → add label (team is waiting for response)
+            // - External non-author comments → remove label (someone provided feedback)
+
+            if (isAuthor) {
+              // Author responded - remove 'waiting for feedback' label
+              console.log(`${commenter} is the author. Removing '${label}' label if present.`);
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+                console.log(`Successfully removed '${label}' label from #${issueNumber}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`Label '${label}' was not present on #${issueNumber}. No action needed.`);
+                } else {
+                  throw error;
+                }
+              }
+
+            } else if (isMember) {
+              // NVIDIA non-author commented - add 'waiting for feedback' label
+              console.log(`${commenter} is an NVIDIA member (not author). Adding '${label}' label.`);
 
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                labels: ['waiting for feedback']
+                labels: [label]
               });
 
-              console.log(`Successfully added 'waiting for feedback' label to #${issueNumber}`);
+              console.log(`Successfully added '${label}' label to #${issueNumber}`);
 
-            } catch (error) {
-              if (error.status === 404) {
-                // User is not a member - this is expected for community users
-                console.log(`${commenter} is not an NVIDIA member. No label added.`);
-              } else if (error.status === 302) {
-                // Token doesn't have org membership privileges
-                console.log(`Cannot determine membership for ${commenter} (insufficient token permissions)`);
-              } else {
-                // Unexpected error
-                console.error(`Error checking membership: ${error.message}`);
-                throw error;
+            } else {
+              // External non-author commented - remove 'waiting for feedback' label
+              console.log(`${commenter} is external (not author). Removing '${label}' label if present.`);
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+                console.log(`Successfully removed '${label}' label from #${issueNumber}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`Label '${label}' was not present on #${issueNumber}. No action needed.`);
+                } else {
+                  throw error;
+                }
               }
             }

--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -35,12 +35,15 @@ jobs:
             }
 
             console.log(`Comment by ${commenter} on #${issueNumber} (author: ${author})`);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-            // Check if commenter is NVIDIA org member
+            // Check if commenter is repository member
             let isMember = false;
             try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'NVIDIA',
+              await github.rest.repos.checkCollaborator({({
+                owner,
+                repo,
                 username: commenter
               });
               isMember = true;

--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -56,4 +56,3 @@ jobs:
                 throw error;
               }
             }
-

--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -16,17 +16,23 @@ jobs:
     if: github.repository == 'NVIDIA/TensorRT-LLM'
     steps:
       - name: Check membership and manage label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const commenter = context.payload.comment.user.login;
-            const issueNumber = context.issue.number;
             const label = 'waiting for feedback';
 
-            // Get the author of the issue/PR
+            // Handle both issue_comment and pull_request_review_comment events
+            // context.issue.number is only available for issue_comment events
+            const issueNumber = context.issue?.number || context.payload.pull_request?.number;
             const issue = context.payload.issue || context.payload.pull_request;
             const author = issue?.user?.login;
             const isAuthor = (commenter === author);
+
+            if (!issueNumber) {
+              console.log('Could not determine issue/PR number. Skipping.');
+              return;
+            }
 
             console.log(`Comment by ${commenter} on #${issueNumber} (author: ${author})`);
 

--- a/.github/workflows/waiting_for_feedback.yml
+++ b/.github/workflows/waiting_for_feedback.yml
@@ -41,7 +41,7 @@ jobs:
             // Check if commenter is repository member
             let isMember = false;
             try {
-              await github.rest.repos.checkCollaborator({({
+              await github.rest.repos.checkCollaborator({
                 owner,
                 repo,
                 username: commenter


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to apply the "waiting for feedback" label to issues and pull requests based on team member interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds a GitHub Actions workflow that automatically adds the `waiting for feedback` label when an NVIDIA team member comments on an issue or PR.

**Without this automation**, the `waiting for feedback` label must be added manually, which:
- Is easily forgotten
- Causes stale issues to remain open indefinitely
- Creates inconsistent issue tracking


<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
