### PR TITLE
[https://nvbugs/5720482][fix] Fix test rpc streaming

### DIFF
--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -59,6 +59,7 @@ class ZeroMqQueue:
         self._setup_done = False
         self.name = name
         self.socket = self.context.socket(socket_type)
+        self.socket.set_hwm(0)
 
         # For ROUTER sockets, track the last identity to enable replies. For now we assume there is only one client in our case.
         self._last_identity = None

--- a/tensorrt_llm/executor/rpc/rpc_common.py
+++ b/tensorrt_llm/executor/rpc/rpc_common.py
@@ -75,6 +75,7 @@ class RPCRequest:
     is_streaming: bool = False
     creation_timestamp: Optional[
         float] = None  # Unix timestamp when request was created
+    routing_id: Optional[bytes] = None
 
     def __post_init__(self):
         """Initialize creation_timestamp if not provided."""

--- a/tensorrt_llm/executor/rpc/rpc_server.py
+++ b/tensorrt_llm/executor/rpc/rpc_server.py
@@ -228,8 +228,10 @@ class RPCServer:
 
         while asyncio.get_event_loop().time() < end_time:
             try:
-                req: RPCRequest = await asyncio.wait_for(
-                    self._client_socket.get_async_noblock(), timeout=2)
+                req, routing_id = await asyncio.wait_for(
+                    self._client_socket.get_async_noblock(return_identity=True),
+                    timeout=2)
+                req.routing_id = routing_id
                 drained_count += 1
                 logger_debug(f"[server] Draining request after shutdown: {req}")
 
@@ -299,13 +301,16 @@ class RPCServer:
                     error=error,
                     is_streaming=
                     True,  # Important: mark as streaming so it gets routed correctly
-                    stream_status='error'))
+                    stream_status='error'),
+                routing_id=req.routing_id)
             logger_debug(
                 f"[server] Sent error response for request {req.request_id}",
                 color="green")
         else:
-            await self._client_socket.put_async(
-                RPCResponse(req.request_id, result=None, error=error))
+            await self._client_socket.put_async(RPCResponse(req.request_id,
+                                                            result=None,
+                                                            error=error),
+                                                routing_id=req.routing_id)
             logger_debug(
                 f"[server] Sent error response for request {req.request_id}",
                 color="green")
@@ -335,8 +340,10 @@ class RPCServer:
             try:
                 #logger_debug(f"[server] Worker waiting for request", color="green")
                 # Read request directly from socket with timeout
-                req: RPCRequest = await asyncio.wait_for(
-                    self._client_socket.get_async_noblock(), timeout=2)
+                req, routing_id = await asyncio.wait_for(
+                    self._client_socket.get_async_noblock(return_identity=True),
+                    timeout=2)
+                req.routing_id = routing_id
                 logger_debug(f"[server] Worker got request: {req}",
                              color="green")
             except asyncio.TimeoutError:
@@ -492,15 +499,15 @@ class RPCServer:
         func = self._functions[req.method_name]
 
         if not inspect.isasyncgenfunction(func):
-            await self._client_socket.put_async(
-                RPCResponse(
-                    req.request_id,
-                    result=None,
-                    error=RPCStreamingError(
-                        f"Method '{req.method_name}' is not an async generator.",
-                        traceback=traceback.format_exc()),
-                    is_streaming=True,
-                    stream_status='error'))
+            await self._client_socket.put_async(RPCResponse(
+                req.request_id,
+                result=None,
+                error=RPCStreamingError(
+                    f"Method '{req.method_name}' is not an async generator.",
+                    traceback=traceback.format_exc()),
+                is_streaming=True,
+                stream_status='error'),
+                                                routing_id=req.routing_id)
             return
 
         chunk_index = 0
@@ -512,13 +519,14 @@ class RPCServer:
             logger_debug(
                 f"[server] RPC Server running streaming task {req.method_name}")
             # Send start signal
-            await self._client_socket.put_async(
-                RPCResponse(req.request_id,
-                            result=None,
-                            error=None,
-                            is_streaming=True,
-                            chunk_index=chunk_index,
-                            stream_status='start'))
+            await self._client_socket.put_async(RPCResponse(
+                req.request_id,
+                result=None,
+                error=None,
+                is_streaming=True,
+                chunk_index=chunk_index,
+                stream_status='start'),
+                                                routing_id=req.routing_id)
             logger_debug(
                 f"[server] Sent start signal for request {req.request_id}",
                 color="green")
@@ -584,39 +592,41 @@ class RPCServer:
                     chunk_index += 1
 
             # Send end signal
-            await self._client_socket.put_async(
-                RPCResponse(req.request_id,
-                            result=None,
-                            error=None,
-                            is_streaming=True,
-                            chunk_index=chunk_index,
-                            stream_status='end'))
+            await self._client_socket.put_async(RPCResponse(
+                req.request_id,
+                result=None,
+                error=None,
+                is_streaming=True,
+                chunk_index=chunk_index,
+                stream_status='end'),
+                                                routing_id=req.routing_id)
             logger_debug(
                 f"[server] Sent end signal for request {req.request_id}",
                 color="green")
         except RPCCancelled as e:
             # Server is shutting down, send cancelled error
-            await self._client_socket.put_async(
-                RPCResponse(req.request_id,
-                            result=None,
-                            error=e,
-                            is_streaming=True,
-                            chunk_index=chunk_index,
-                            stream_status='error'))
+            await self._client_socket.put_async(RPCResponse(
+                req.request_id,
+                result=None,
+                error=e,
+                is_streaming=True,
+                chunk_index=chunk_index,
+                stream_status='error'),
+                                                routing_id=req.routing_id)
             logger_debug(
                 f"[server] Sent error signal for request {req.request_id}",
                 color="green")
         except asyncio.TimeoutError:
-            await self._client_socket.put_async(
-                RPCResponse(
-                    req.request_id,
-                    result=None,
-                    error=RPCTimeout(
-                        f"Streaming method '{req.method_name}' timed out",
-                        traceback=traceback.format_exc()),
-                    is_streaming=True,
-                    chunk_index=chunk_index,
-                    stream_status='error'))
+            await self._client_socket.put_async(RPCResponse(
+                req.request_id,
+                result=None,
+                error=RPCTimeout(
+                    f"Streaming method '{req.method_name}' timed out",
+                    traceback=traceback.format_exc()),
+                is_streaming=True,
+                chunk_index=chunk_index,
+                stream_status='error'),
+                                                routing_id=req.routing_id)
 
         except Exception as e:
             response = RPCResponse(
@@ -633,7 +643,8 @@ class RPCServer:
                              response: RPCResponse) -> bool:
         """Safely sends a response, handling pickle errors."""
         try:
-            await self._client_socket.put_async(response)
+            await self._client_socket.put_async(response,
+                                                routing_id=req.routing_id)
             logger_debug(f"[server] Sent response for request {req.request_id}",
                          color="green")
             return True
@@ -661,7 +672,8 @@ class RPCServer:
                                     traceback=traceback.format_exc()))
 
             try:
-                await self._client_socket.put_async(error_response)
+                await self._client_socket.put_async(error_response,
+                                                    routing_id=req.routing_id)
                 logger_debug(
                     f"[server] Sent error response for request {req.request_id}",
                     color="green")

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -426,7 +426,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[moe_backend=CUT
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-two_model-overlap_scheduler] SKIP (https://nvbugs/5702826)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[cutlass-two_model-overlap_scheduler] SKIP (https://nvbugs/5702826)
 disaggregated/test_auto_scaling.py::test_worker_restart[etcd-round_robin] SKIP (https://nvbugs/5726118)
-unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_streaming SKIP (https://nvbugs/5720482)
 unittest/llmapi/test_llm_pytorch.py::test_llm_reward_model SKIP (https://nvbugs/5670458)
 perf/test_perf.py::test_perf[perf_sanity_upload-l0_gb200_multi_gpus-r1_fp4_v2_tep4_mtp3_1k1k] SKIP (https://nvbugs/5727481)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[enable_configurable_moe-moe_backend=TRTLLM-mtp_nextn=0-ep4-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=True] SKIP (https://nvbugs/5727475)

--- a/tests/unittest/executor/test_rpc.py
+++ b/tests/unittest/executor/test_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import threading
 import time
 
@@ -219,6 +220,30 @@ class TestRpcCorrectness:
                     ], f"results {results} != {[i for i in range(10000)]}"
 
                 asyncio.run(test_streaming_task())
+
+    def test_multi_client_to_single_server(self):
+        """Test that multiple RPC clients can concurrently connect to a single RPC server and execute tasks."""
+
+        class App:
+
+            def echo(self, msg: str) -> str:
+                return msg
+
+        with RpcServerWrapper(App()) as server:
+            # Create multiple clients
+            num_clients = 10
+            clients = [RPCClient(server.addr) for _ in range(num_clients)]
+
+            try:
+                # Perform requests from all clients
+                for i, client in enumerate(clients):
+                    msg = f"hello from client {i}"
+                    ret = client.echo(msg).remote()
+                    assert ret == msg, f"Client {i} failed: expected '{msg}', got '{ret}'"
+            finally:
+                # Clean up clients
+                for client in clients:
+                    client.close()
 
 
 class TestRpcError:
@@ -1008,3 +1033,93 @@ class TestRpcRobustness:
                             f"Iteration {i}/{num_calls} completed successfully")
 
         print(f"All {num_calls} iterations completed successfully")
+
+    @pytest.mark.parametrize("concurrency", [10, 50, 100])
+    def test_many_client_to_single_server(self, concurrency):
+        """
+        Pressure test where many clients connect to a single server.
+        Controls concurrency via parameter and ensures each client performs multiple operations.
+        """
+
+        class App:
+
+            def echo(self, msg: str) -> str:
+                return msg
+
+        total_clients = max(200, concurrency * 2)
+        requests_per_client = 100
+
+        with RpcServerWrapper(App(), async_run_task=True) as server:
+            errors = []
+
+            def run_client_session(client_id):
+                try:
+                    with RPCClient(server.addr) as client:
+                        for i in range(requests_per_client):
+                            msg = f"c{client_id}-req{i}"
+                            ret = client.echo(msg).remote()
+                            assert ret == msg
+                except Exception as e:
+                    errors.append(f"Client {client_id} error: {e}")
+                    raise
+
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=concurrency) as executor:
+                futures = [
+                    executor.submit(run_client_session, i)
+                    for i in range(total_clients)
+                ]
+                concurrent.futures.wait(futures)
+
+                # Check for exceptions in futures
+                for f in futures:
+                    if f.exception():
+                        errors.append(str(f.exception()))
+
+            assert not errors, f"Encountered errors: {errors[:5]}..."
+
+    @pytest.mark.parametrize("concurrency", [10, 50, 100])
+    def test_many_client_to_single_server_threaded(self, concurrency):
+        """
+        Pressure test where clients are created and used in different threads.
+        """
+        import concurrent.futures
+
+        class App:
+
+            def echo(self, msg: str) -> str:
+                return msg
+
+        # Scale total clients to be more than concurrency to force queueing/reuse
+        total_clients = max(200, concurrency * 2)
+        requests_per_client = 100
+
+        with RpcServerWrapper(App(), async_run_task=True) as server:
+            errors = []
+
+            def run_client_session(client_id):
+                try:
+                    # Client creation and usage happens strictly within this thread
+                    with RPCClient(server.addr) as client:
+                        for i in range(requests_per_client):
+                            msg = f"c{client_id}-req{i}"
+                            ret = client.echo(msg).remote()
+                            assert ret == msg
+                except Exception as e:
+                    errors.append(f"Client {client_id} error: {e}")
+                    raise
+
+            # Use ThreadPoolExecutor to simulate concurrent threads
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=concurrency) as executor:
+                futures = [
+                    executor.submit(run_client_session, i)
+                    for i in range(total_clients)
+                ]
+                concurrent.futures.wait(futures)
+
+                for f in futures:
+                    if f.exception():
+                        errors.append(str(f.exception()))
+
+            assert not errors, f"Encountered errors: {errors[:5]}..."

--- a/tests/unittest/executor/test_rpc.py
+++ b/tests/unittest/executor/test_rpc.py
@@ -200,7 +200,9 @@ class TestRpcCorrectness:
                         ) == no + 1, f"result {future.result()} != {no + 1}"
 
     def test_incremental_task_streaming(self):
-        with RpcServerWrapper(TestRpcCorrectness.App()) as server:
+        with RpcServerWrapper(TestRpcCorrectness.App(),
+                              async_run_task=True) as server:
+
             with RPCClient(server.addr) as client:
 
                 async def test_streaming_task():


### PR DESCRIPTION
## Changes
1. Add route_id to enhance the ZMQ ROUTER/DEALER in multiple RPCClient cases
2. Disable ZMQ HWM to avoid dropping messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added routing identifier support for RPC requests to enable improved tracking and proper routing of requests across distributed components.

* **Improvements**
  * Enhanced inter-process communication with identity-aware messaging capabilities for more reliable request/response handling in multi-process executor scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
