### PR TITLE
[TRTLLM-7906][feat] Support multiple post process for Responses API

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -51,20 +51,22 @@ from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 MemoryUpdateRequest, ModelCard,
                                                 ModelList, PromptTokensDetails,
                                                 ResponsesRequest,
+                                                ResponsesResponse,
                                                 UpdateWeightsRequest, UsageInfo,
                                                 to_llm_disaggregated_params)
 from tensorrt_llm.serve.postprocess_handlers import (
     ChatCompletionPostprocArgs, ChatPostprocArgs, CompletionPostprocArgs,
-    chat_harmony_post_processor, chat_harmony_streaming_post_processor,
-    chat_response_post_processor, chat_stream_post_processor,
-    completion_response_post_processor, completion_stream_post_processor)
+    ResponsesAPIPostprocArgs, chat_harmony_post_processor,
+    chat_harmony_streaming_post_processor, chat_response_post_processor,
+    chat_stream_post_processor, completion_response_post_processor,
+    completion_stream_post_processor, responses_api_post_processor,
+    responses_api_streaming_post_processor)
 from tensorrt_llm.serve.responses_utils import (ConversationHistoryStore,
+                                                ResponsesStreamingProcessor,
                                                 ServerArrivalTimeMiddleware)
 from tensorrt_llm.serve.responses_utils import \
     create_response as responses_api_create_response
 from tensorrt_llm.serve.responses_utils import get_steady_clock_now_in_seconds
-from tensorrt_llm.serve.responses_utils import \
-    process_streaming_events as responses_api_process_streaming_events
 from tensorrt_llm.serve.responses_utils import \
     request_preprocess as responses_api_request_preprocess
 from tensorrt_llm.version import __version__ as VERSION
@@ -119,9 +121,8 @@ class OpenAIServer:
             self.model_config = None
 
         # Enable response storage for Responses API
-        self.enable_store = True
-        if len(os.getenv("TRTLLM_RESPONSES_API_DISABLE_STORE", "")) > 0:
-            self.enable_store = False
+        self.enable_store = (len(os.getenv("TRTLLM_RESPONSES_API_DISABLE_STORE", "")) < 1) and not self.postproc_worker_enabled
+
         self.conversation_store = ConversationHistoryStore()
 
         model_dir = Path(model)
@@ -942,19 +943,39 @@ class OpenAIServer:
             return self.create_error_response(message=str(e), err_type="internal_error")
 
     async def openai_responses(self, request: ResponsesRequest, raw_request: Request) -> Response:
-        async def create_stream_response(generator, request: ResponsesRequest, sampling_params) -> AsyncGenerator[str, None]:
-            async for event_data in responses_api_process_streaming_events(
-                request=request,
-                sampling_params=sampling_params,
-                generator=generator,
-                model_name=self.model,
-                conversation_store=self.conversation_store,
-                use_harmony=self.use_harmony,
-                reasoning_parser=self.llm.args.reasoning_parser,
-                tool_parser=self.tool_parser,
-                enable_store=self.enable_store
-            ):
-                yield event_data
+        async def create_response(
+                promise: RequestOutput, postproc_params: PostprocParams) -> ResponsesResponse:
+            await promise.aresult()
+            if self.postproc_worker_enabled:
+                response = promise.outputs[0]._postprocess_result
+            else:
+                args = postproc_params.postproc_args
+                response = await responses_api_create_response(
+                    generator=promise,
+                    request=request,
+                    sampling_params=args.sampling_params,
+                    model_name=self.model,
+                    conversation_store=self.conversation_store,
+                    generation_result=None,
+                    enable_store=self.enable_store and request.store,
+                    use_harmony=self.use_harmony,
+                    reasoning_parser=args.reasoning_parser,
+                    tool_parser=args.tool_parser,
+                )
+
+            return response
+
+        async def create_streaming_generator(promise: RequestOutput, postproc_params: PostprocParams):
+            post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
+            streaming_processor = args.streaming_processor
+            initial_responses = streaming_processor.get_initial_responses()
+            for initial_response in initial_responses:
+                yield initial_response
+
+            async for res in promise:
+                pp_results = res.outputs[0]._postprocess_result if self.postproc_worker_enabled else post_processor(res, args)
+                for pp_res in pp_results:
+                    yield pp_res
 
         try:
             if request.background:
@@ -977,38 +998,61 @@ class OpenAIServer:
                 request=request,
                 prev_response=prev_response,
                 conversation_store=self.conversation_store,
-                enable_store=self.enable_store,
+                enable_store=self.enable_store and request.store,
                 use_harmony=self.use_harmony,
                 tokenizer=self.tokenizer if not self.use_harmony else None,
                 model_config=self.model_config if not self.use_harmony else None,
                 processor=self.processor if not self.use_harmony else None,
             )
 
+            streaming_processor = None
+            if request.stream:
+                # Per-request streaming processor
+                streaming_processor = ResponsesStreamingProcessor(
+                    request=request,
+                    sampling_params=sampling_params,
+                    model_name=self.model,
+                    conversation_store=self.conversation_store,
+                    enable_store=self.enable_store and request.store,
+                    use_harmony=self.use_harmony,
+                    reasoning_parser=self.llm.args.reasoning_parser,
+                    tool_parser=self.tool_parser,
+                )
+
+            postproc_args = ResponsesAPIPostprocArgs(
+                model=self.model,
+                request=request,
+                sampling_params=sampling_params,
+                use_harmony=self.use_harmony,
+                reasoning_parser=self.llm.args.reasoning_parser,
+                tool_parser=self.tool_parser,
+                streaming_processor=streaming_processor,
+            )
+            postproc_params = PostprocParams(
+                post_processor=responses_api_streaming_post_processor
+                if request.stream else responses_api_post_processor,
+                postproc_args=postproc_args,
+            )
             promise = self.llm.generate_async(
                 inputs=input_tokens,
                 sampling_params=sampling_params,
                 streaming=request.stream,
+                _postproc_params=postproc_params if self.postproc_worker_enabled else None,
             )
+
+            if self.postproc_worker_enabled and request.store:
+                logger.warning("Postproc workers are enabled, request will not be stored!")
 
             asyncio.create_task(self.await_disconnected(raw_request, promise))
 
             if request.stream:
                 return StreamingResponse(
-                    create_stream_response(promise, request, sampling_params),
+                    content=create_streaming_generator(promise, postproc_params),
                     media_type="text/event-stream"
                 )
             else:
-                return await responses_api_create_response(
-                    generator=promise,
-                    request=request,
-                    sampling_params=sampling_params,
-                    model_name=self.model,
-                    conversation_store=self.conversation_store,
-                    generation_result=None,
-                    enable_store=self.enable_store,
-                    use_harmony=self.use_harmony,
-                    reasoning_parser=self.llm.args.reasoning_parser,
-                    tool_parser=self.tool_parser)
+                response = await create_response(promise, postproc_params)
+                return JSONResponse(content=response.model_dump())
         except CppExecutorError:
             logger.error(traceback.format_exc())
             # If internal executor error is raised, shutdown the server

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -1,11 +1,16 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Literal, Optional, Tuple, Union
 
+from tensorrt_llm.serve.responses_utils import ResponsesStreamingProcessor
+from tensorrt_llm.serve.responses_utils import \
+    create_response_non_store as responses_api_create_response_non_store
+
 from .._utils import nvtx_range_debug
 from ..executor import (DetokenizedGenerationResultBase, GenerationResult,
                         GenerationResultBase)
 from ..executor.postproc_worker import PostprocArgs
 from ..executor.result import Logprob, TokenLogprobs
+from ..llmapi import SamplingParams
 from ..llmapi.reasoning_parser import (BaseReasoningParser,
                                        ReasoningParserFactory)
 from ..llmapi.tokenizer import TransformersTokenizer
@@ -26,7 +31,8 @@ from .openai_protocol import (ChatCompletionLogProbs,
                               CompletionResponseStreamChoice,
                               CompletionStreamResponse, DeltaFunctionCall,
                               DeltaMessage, DeltaToolCall, FunctionCall,
-                              PromptTokensDetails, StreamOptions, ToolCall,
+                              PromptTokensDetails, ResponsesRequest,
+                              ResponsesResponse, StreamOptions, ToolCall,
                               UsageInfo, to_disaggregated_params)
 from .tool_parser.base_tool_parser import BaseToolParser
 from .tool_parser.core_types import ToolCallItem
@@ -543,3 +549,42 @@ def chat_harmony_streaming_post_processor(
         num_prompt_tokens=args.num_prompt_tokens,
     )
     return response
+
+
+@dataclass(kw_only=True)
+class ResponsesAPIPostprocArgs(PostprocArgs):
+    model: str
+    request: ResponsesRequest
+    sampling_params: SamplingParams
+    use_harmony: bool
+    reasoning_parser: Optional[str] = None
+    tool_parser: Optional[str] = None
+    streaming_processor: Optional[ResponsesStreamingProcessor] = None
+
+
+@nvtx_range_debug("responses_api_post_processor")
+def responses_api_post_processor(
+        rsp: GenerationResult,
+        args: ResponsesAPIPostprocArgs) -> ResponsesResponse:
+    return responses_api_create_response_non_store(
+        generation_result=rsp,
+        request=args.request,
+        sampling_params=args.sampling_params,
+        model_name=args.model,
+        use_harmony=args.use_harmony,
+        reasoning_parser=args.reasoning_parser,
+        tool_parser=args.tool_parser,
+    )
+
+
+@nvtx_range_debug("responses_api_streaming_post_processor")
+def responses_api_streaming_post_processor(
+        rsp: GenerationResult, args: ResponsesAPIPostprocArgs) -> List[str]:
+    if args.streaming_processor is None:
+        raise ValueError(
+            "streaming_processor is required for streaming post-processing")
+    outputs = args.streaming_processor.process_single_output(rsp)
+    if rsp._done:
+        outputs.append(
+            args.streaming_processor.get_final_response_non_store(rsp))
+    return outputs

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -10,7 +10,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from copy import copy
-from typing import Any, Literal, Optional, OrderedDict, Tuple, Union
+from typing import Any, List, Literal, Optional, OrderedDict, Tuple, Union
 
 from openai.types.responses import (ResponseCompletedEvent,
                                     ResponseContentPartAddedEvent,
@@ -41,6 +41,7 @@ from openai_harmony import (Author, Conversation, DeveloperContent,
 from transformers import AutoProcessor, PretrainedConfig
 
 from tensorrt_llm.bindings import steady_clock_now
+from tensorrt_llm.executor import GenerationResult
 from tensorrt_llm.inputs.utils import apply_chat_template
 from tensorrt_llm.llmapi import SamplingParams
 from tensorrt_llm.llmapi.llm import RequestOutput
@@ -962,7 +963,7 @@ def _apply_tool_parser(
     return normal_text, calls
 
 
-async def _create_output_content(
+def _create_output_content(
     final_res: RequestOutput,
     reasoning_parser: Optional[str] = None,
     tool_parser: Optional[str] = None,
@@ -1040,7 +1041,7 @@ async def _create_output_content(
     return output_items, output_messages
 
 
-async def _create_output_content_harmony(
+def _create_output_content_harmony(
         final_res: RequestOutput
 ) -> Tuple[list[ResponseOutputItem], list[Message]]:
     output_messages = _parse_output_tokens(final_res.outputs[0].token_ids)
@@ -1057,12 +1058,53 @@ async def _create_output_content_harmony(
     return output_content, output_messages
 
 
+def _create_response(
+    final_res: GenerationResult,
+    use_harmony: bool,
+    request: ResponsesRequest,
+    model_name: str,
+    response_creation_time: int,
+    sampling_params: SamplingParams,
+    reasoning_parser: Optional[str] = None,
+    tool_parser: Optional[str] = None,
+) -> tuple[ResponsesResponse, list[Message | ChatCompletionMessageParam]]:
+    _responses_debug_log("================================================")
+    _responses_debug_log("RAW MODEL OUTPUT:")
+    _responses_debug_log(final_res.outputs)
+    _responses_debug_log("================================================")
+
+    # prepare responses output
+    output_content = []
+    if use_harmony:
+        output_content, output_messages = _create_output_content_harmony(
+            final_res)
+    else:
+        output_content, output_messages = _create_output_content(
+            final_res, reasoning_parser, tool_parser, request.tools)
+
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name=model_name,
+        created_time=response_creation_time,
+        output=output_content,
+        status=finish_reason_mapping(final_res.outputs[0].finish_reason),
+    )
+
+    _responses_debug_log("========== Response ===========")
+    _responses_debug_log(response)
+    _responses_debug_log("===============================")
+
+    # return output_messages for store_response
+    return response, output_messages
+
+
 async def create_response(
-    generator,
     request: ResponsesRequest,
     sampling_params: SamplingParams,
     model_name: str,
     conversation_store: ConversationHistoryStore,
+    generator: Optional[AsyncGenerator[RequestOutput, None]] = None,
     generation_result: Optional[RequestOutput] = None,
     enable_store: bool = False,
     use_harmony: bool = True,
@@ -1078,33 +1120,22 @@ async def create_response(
 
     if generation_result is not None:
         final_res = generation_result
-    else:
+    elif generator is not None:
         final_res = await generator
 
     if final_res is None:
         raise RuntimeError("No output generated or provided")
 
-    _responses_debug_log("================================================")
-    _responses_debug_log("RAW MODEL OUTPUT:")
-    _responses_debug_log(final_res.outputs)
-    _responses_debug_log("================================================")
-
     # prepare responses output
-    output_content = []
-    if use_harmony:
-        output_content, output_messages = await _create_output_content_harmony(
-            final_res)
-    else:
-        output_content, output_messages = await _create_output_content(
-            final_res, reasoning_parser, tool_parser, request.tools)
-
-    response = ResponsesResponse.from_request(
+    response, output_messages = _create_response(
+        final_res=final_res,
+        use_harmony=use_harmony,
         request=request,
-        sampling_params=sampling_params,
         model_name=model_name,
-        created_time=response_creation_time,
-        output=output_content,
-        status=finish_reason_mapping(final_res.outputs[0].finish_reason),
+        response_creation_time=response_creation_time,
+        sampling_params=sampling_params,
+        reasoning_parser=reasoning_parser,
+        tool_parser=tool_parser,
     )
 
     if enable_store and request.store:
@@ -1112,9 +1143,34 @@ async def create_response(
                                                 resp_msgs=output_messages,
                                                 prev_resp_id=prev_response_id)
 
-    _responses_debug_log("========== Response ===========")
-    _responses_debug_log(response)
-    _responses_debug_log("===============================")
+    return response
+
+
+def create_response_non_store(
+    generation_result: RequestOutput,
+    request: ResponsesRequest,
+    sampling_params: SamplingParams,
+    model_name: str,
+    use_harmony: bool = True,
+    create_time: Optional[int] = None,
+    reasoning_parser: Optional[str] = None,
+    tool_parser: Optional[str] = None,
+) -> ResponsesResponse:
+    response_creation_time = create_time if create_time is not None else int(
+        time.time())
+
+    # prepare responses output
+    response, _ = _create_response(
+        final_res=generation_result,
+        use_harmony=use_harmony,
+        request=request,
+        model_name=model_name,
+        response_creation_time=response_creation_time,
+        sampling_params=sampling_params,
+        reasoning_parser=reasoning_parser,
+        tool_parser=tool_parser,
+    )
+
     return response
 
 
@@ -1649,6 +1705,143 @@ def _generate_streaming_event_harmony(
                 parser.last_content_delta)
 
 
+class ResponsesStreamingProcessor:
+
+    def __init__(
+        self,
+        request: ResponsesRequest,
+        sampling_params: SamplingParams,
+        model_name: str,
+        create_time: Optional[int] = None,
+        conversation_store: Optional[ConversationHistoryStore] = None,
+        enable_store: bool = False,
+        use_harmony: bool = True,
+        reasoning_parser: Optional[str] = None,
+        tool_parser: Optional[str] = None,
+    ):
+        self.model_name = model_name
+        self.request = request
+        self.sampling_params = sampling_params
+        self.sequence_number = 0
+        self.streaming_events_helper = ResponsesStreamingEventsHelper()
+        self.response_creation_time = create_time if create_time is not None else int(
+            time.time())
+        self.final_res: Optional[RequestOutput] = None
+        self.reasoning_parser_dict: dict[int, BaseReasoningParser] = {}
+        self.tool_parser_dict: dict[int, BaseToolParser] = {}
+        self.stream_request_id = f"responses-api-{request.request_id}"
+        self.conversation_store = conversation_store
+        self.enable_store = enable_store
+        self.use_harmony = use_harmony
+        self.reasoning_parser = reasoning_parser
+        self.tool_parser = tool_parser
+
+    def _send_event(self, event: OpenAIBaseModel):
+        # Set sequence_number if the event has this attribute
+        if hasattr(event, 'sequence_number'):
+            event.sequence_number = self.sequence_number
+        self.sequence_number += 1
+        # Get event type from the event's type field if it exists
+        event_type = getattr(event, 'type', 'unknown')
+        return (f"event: {event_type}\n"
+                f"data: {event.model_dump_json(indent=None)}\n\n")
+
+    def get_initial_responses(self) -> List[str]:
+        initial_response = ResponsesResponse.from_request(
+            request=self.request,
+            sampling_params=self.sampling_params,
+            model_name=self.model_name,
+            created_time=self.response_creation_time,
+            output=[],
+            status="in_progress",
+            usage=None,
+        ).model_dump()
+
+        resp_created = self._send_event(
+            self.streaming_events_helper.get_response_created_event(
+                initial_response))
+        resp_in_progress = self._send_event(
+            self.streaming_events_helper.get_response_in_progress_event(
+                initial_response))
+        return [resp_created, resp_in_progress]
+
+    async def get_final_response(
+        self,
+        final_res: RequestOutput,
+    ) -> str:
+        final_response = await create_response(
+            generator=None,
+            request=self.request,
+            sampling_params=self.sampling_params,
+            model_name=self.model_name,
+            conversation_store=self.conversation_store,
+            generation_result=final_res,
+            enable_store=self.enable_store,
+            use_harmony=self.use_harmony,
+            create_time=self.response_creation_time,
+            reasoning_parser=self.reasoning_parser,
+            tool_parser=self.tool_parser,
+        )
+
+        return self._send_event(
+            ResponseCompletedEvent(
+                type="response.completed",
+                sequence_number=-1,
+                response=final_response.model_dump(),
+            ))
+
+    def get_final_response_non_store(
+        self,
+        final_res: RequestOutput,
+    ) -> str:
+        final_response = create_response_non_store(
+            generation_result=final_res,
+            request=self.request,
+            sampling_params=self.sampling_params,
+            model_name=self.model_name,
+            use_harmony=self.use_harmony,
+            create_time=self.response_creation_time,
+            reasoning_parser=self.reasoning_parser,
+            tool_parser=self.tool_parser,
+        )
+
+        return self._send_event(
+            ResponseCompletedEvent(
+                type="response.completed",
+                sequence_number=-1,
+                response=final_response.model_dump(),
+            ))
+
+    def process_single_output(self, res: GenerationResult) -> list[str]:
+        event_generator = None
+        output = res.outputs[0]
+        if self.use_harmony:
+            event_generator = _generate_streaming_event_harmony(
+                harmony_adapter=get_harmony_adapter(),
+                stream_request_id=self.stream_request_id,
+                output=output,
+                request=self.request,
+                streaming_events_helper=self.streaming_events_helper,
+            )
+
+        else:
+            event_generator = _generate_streaming_event(
+                output=output,
+                request=self.request,
+                finished_generation=res._done,
+                streaming_events_helper=self.streaming_events_helper,
+                reasoning_parser_id=self.reasoning_parser,
+                tool_parser_id=self.tool_parser,
+                reasoning_parser_dict=self.reasoning_parser_dict,
+                tool_parser_dict=self.tool_parser_dict,
+            )
+
+        if event_generator is None:
+            raise RuntimeError("Failed to generate streaming events")
+
+        return [self._send_event(event) for event in event_generator]
+
+
 async def process_streaming_events(
     generator,
     request: ResponsesRequest,
@@ -1661,97 +1854,31 @@ async def process_streaming_events(
     reasoning_parser: Optional[str] = None,
     tool_parser: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
-    sequence_number = 0
-    response_creation_time = create_time if create_time is not None else int(
-        time.time())
-    final_res: Optional[RequestOutput] = None
-    reasoning_parser_dict: dict[int, BaseReasoningParser] = {}
-    tool_parser_dict: dict[int, BaseToolParser] = {}
-
-    def _send_event(event: OpenAIBaseModel):
-        nonlocal sequence_number
-        # Set sequence_number if the event has this attribute
-        if hasattr(event, 'sequence_number'):
-            event.sequence_number = sequence_number
-        sequence_number += 1
-        # Get event type from the event's type field if it exists
-        event_type = getattr(event, 'type', 'unknown')
-        return (f"event: {event_type}\n"
-                f"data: {event.model_dump_json(indent=None)}\n\n")
-
-    streaming_events_helper = ResponsesStreamingEventsHelper()
-
-    initial_response = ResponsesResponse.from_request(
-        request,
-        sampling_params,
-        model_name=model_name,
-        created_time=response_creation_time,
-        output=[],
-        status="in_progress",
-        usage=None,
-    ).model_dump()
-
-    yield _send_event(
-        streaming_events_helper.get_response_created_event(initial_response))
-    yield _send_event(
-        streaming_events_helper.get_response_in_progress_event(
-            initial_response))
-
-    stream_request_id = f"responses-api-{request.request_id}"
-    harmony_adapter = get_harmony_adapter()
-    async for res in generator:
-        final_res = res
-        # TODO(JunyiXu-nv): handle multiple outputs
-        output = res.outputs[0]
-
-        event_generator = None
-        if use_harmony:
-            event_generator = _generate_streaming_event_harmony(
-                harmony_adapter=harmony_adapter,
-                stream_request_id=stream_request_id,
-                output=output,
-                request=request,
-                streaming_events_helper=streaming_events_helper,
-            )
-
-        else:
-            event_generator = _generate_streaming_event(
-                output=output,
-                request=request,
-                finished_generation=res.finished,
-                streaming_events_helper=streaming_events_helper,
-                reasoning_parser_id=reasoning_parser,
-                tool_parser_id=tool_parser,
-                reasoning_parser_dict=reasoning_parser_dict,
-                tool_parser_dict=tool_parser_dict,
-            )
-
-        if event_generator is None:
-            raise RuntimeError("Failed to generate streaming events")
-
-        for event in event_generator:
-            yield _send_event(event)
-
-    final_response = await create_response(
-        generator=generator,
+    streaming_processor = ResponsesStreamingProcessor(
         request=request,
         sampling_params=sampling_params,
         model_name=model_name,
+        create_time=create_time,
         conversation_store=conversation_store,
-        generation_result=final_res,
         enable_store=enable_store,
         use_harmony=use_harmony,
-        create_time=response_creation_time,
         reasoning_parser=reasoning_parser,
         tool_parser=tool_parser,
     )
 
-    yield _send_event(
-        ResponseCompletedEvent(
-            type="response.completed",
-            sequence_number=-1,
-            response=final_response.model_dump(),
-        ))
+    initial_responses = streaming_processor.get_initial_responses()
+    for initial_response in initial_responses:
+        yield initial_response
+
+    async for res in generator:
+        final_res = res
+        events = streaming_processor.process_single_output(res)
+        for event in events:
+            yield event
+
+    final_response = await streaming_processor.get_final_response(final_res)
+
+    yield final_response
 
 
 class ServerArrivalTimeMiddleware:

--- a/tests/unittest/llmapi/apps/_test_openai_responses.py
+++ b/tests/unittest/llmapi/apps/_test_openai_responses.py
@@ -21,11 +21,18 @@ def model(request):
     return request.param
 
 
+@pytest.fixture(scope="module",
+                params=[0, 2],
+                ids=["disable_processpool", "enable_processpool"])
+def num_postprocess_workers(request):
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def server(model: str):
+def server(model: str, num_postprocess_workers: int):
     model_path = get_model_path(model)
 
-    args = []
+    args = ["--num_postprocess_workers", f"{num_postprocess_workers}"]
     if model.startswith("Qwen3"):
         args.extend(["--reasoning_parser", "qwen3"])
     elif model.startswith("DeepSeek-R1"):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming and post-processing support for Responses API with per-request orchestration.
  * Introduced streaming processor for handling response generation and buffering.
  * Added support for per-request post-processor selection and configuration options.
  * Enhanced storage logic with conditional enablement based on post-processing worker usage.

* **Tests**
  * Added configuration parameters for post-processing worker counts in test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Feature:
- Responses API multi-postproc support for both streaming and non-streaming.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- tests/unittest/llmapi/apps/_test_openai_responses.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
