### PR TITLE
[None][feat] Add Suffix Decoding Speculative Decoding Support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,3 +35,4 @@ opentelemetry-sdk>=1.26.0
 opentelemetry-api>=1.26.0
 opentelemetry-exporter-otlp>=1.26.0
 opentelemetry-semantic-conventions-ai>=0.4.1
+arctic-inference==0.1.1 # Required for suffix decoding test

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -5,6 +5,7 @@ from .mtp import MTPEagleWorker, MTPSpecMetadata, MTPWorker
 from .ngram import NGramDrafter, NGramPoolManager
 from .save_hidden_state import SaveHiddenStatesDrafter
 from .spec_tree_manager import SpecTreeManager
+from .suffix import SuffixDrafter, SuffixResourceManager
 from .utils import (get_num_extra_kv_tokens, get_num_spec_layers,
                     get_spec_decoder, get_spec_drafter, get_spec_metadata,
                     get_spec_resource_manager, get_spec_worker,
@@ -17,6 +18,8 @@ __all__ = [
     "MTPWorker",
     "NGramDrafter",
     "NGramPoolManager",
+    "SuffixDrafter",
+    "SuffixResourceManager",
     "SaveHiddenStatesDrafter",
     "SpecMetadata",
     "get_num_extra_kv_tokens",

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -40,6 +40,7 @@ class SpeculativeDecodingMode(IntEnum):
     EAGLE3 = auto()
     EAGLE3_ONE_MODEL = auto()
     NGRAM = auto()
+    SUFFIX = auto()
     DRAFT_TARGET = auto()
     USER_PROVIDED = auto()
     SAVE_HIDDEN_STATES = auto()
@@ -70,6 +71,9 @@ class SpeculativeDecodingMode(IntEnum):
     def is_ngram(self):
         return self == SpeculativeDecodingMode.NGRAM
 
+    def is_suffix(self):
+        return self == SpeculativeDecodingMode.SUFFIX
+
     def is_user_provided(self):
         return self == SpeculativeDecodingMode.USER_PROVIDED
 
@@ -91,7 +95,7 @@ class SpeculativeDecodingMode(IntEnum):
 
     def support_overlap_scheduler(self):
         return self.is_mtp_one_model() or self.is_eagle3_one_model(
-        ) or self.has_draft_model()
+        ) or self.has_draft_model() or self.is_suffix()
 
     def support_guided_decoder(self):
         return self.is_none() or self.has_spec_drafter()
@@ -122,9 +126,9 @@ class SpeculativeDecodingMode(IntEnum):
         ) or self.is_eagle3_one_model()
 
     def has_spec_drafter(self):
-        return self.is_eagle3(
-        ) or self.is_draft_target() or self.is_ngram() or self.is_user_provided(
-        ) or self.is_mtp_eagle() or self.is_save_hidden_states()
+        return self.is_eagle3() or self.is_draft_target() or self.is_ngram(
+        ) or self.is_suffix() or self.is_user_provided() or self.is_mtp_eagle(
+        ) or self.is_save_hidden_states()
 
     def extend_ctx(self, attention_backend: Type[AttentionBackend]):
         """

--- a/tensorrt_llm/_torch/speculative/suffix.py
+++ b/tensorrt_llm/_torch/speculative/suffix.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Dict, Optional
+
+from tensorrt_llm.logger import logger
+
+from ..pyexecutor.llm_request import LlmRequest
+from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
+from ..pyexecutor.scheduler import ScheduledRequests
+from .drafter import Drafter
+
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.llm_args import SuffixDecodingConfig
+
+
+class SuffixResourceManager(BaseResourceManager):
+    """
+    Resource manager for Suffix Decoding. This class maintains the SuffixDecodingCache
+    for managing request outputs, evicting old requests, and managing per-prompt suffix trees.
+    Based on Suffix Decoding (https://arxiv.org/pdf/2411.04975).
+    """
+
+    def __init__(self, spec_config: "SuffixDecodingConfig", max_num_requests: int):
+        self.spec_config = spec_config
+        self.max_num_requests = max_num_requests
+        self.max_tree_depth = spec_config.max_tree_depth
+
+        # Lazy import to avoid error when Suffix Decoding is not used.
+        try:
+            from arctic_inference.suffix_decoding import SuffixDecodingCache
+        except ImportError:
+            raise ImportError(
+                "arctic_inference package is required for Suffix Decoding. "
+                "Please install it with: pip install arctic-inference"
+            )
+
+        # Initialize and empty cache. This object will take care of caching request
+        # outputs, evicting old requests, and manages the per-prompt suffix trees.
+        self.suffix_cache = SuffixDecodingCache(
+            max_tree_depth=spec_config.max_tree_depth,
+            max_cached_requests=spec_config.max_cached_requests,
+        )
+        # Track the last token count for each request to determine newly sampled tokens
+        self.last_token_counts: Dict[int, int] = {}
+
+    def get_max_resource_count(self) -> int:
+        return self.max_num_requests
+
+    def get_needed_resource_to_completion(self, request: LlmRequest) -> int:
+        return 0
+
+    def prepare_resources(self, scheduled_batch: ScheduledRequests):
+        """
+        Prepare resources for Suffix Decoding for requests in the scheduled batch.
+        """
+        for req in scheduled_batch.generation_requests:
+            req_id = req.request_id
+            token_ids = list(req.get_tokens(0))
+            num_prompt_tokens = req.py_orig_prompt_len
+            num_tokens = len(token_ids)
+
+            if req_id not in self.suffix_cache.active_requests:
+                # TODO: Check if we need to evict cache response when the same req_id is reused,
+                # e.g., when a request is interrupted and then restarted with different content.
+                # Not sure if this case can actually happen.
+                if req_id in self.suffix_cache.cached_requests:
+                    self.suffix_cache.evict_cached_response(req_id)
+
+                # Get prompt tokens for initialization
+                prompt_token_ids = token_ids[:num_prompt_tokens]
+
+                # Start a new request, which will build a suffix tree for this prompt
+                self.suffix_cache.start_request(req_id, prompt_token_ids)
+
+                # Initialize the token count for new requests
+                # If there are already generated tokens, they will be added in the unified logic below
+                self.last_token_counts[req_id] = num_prompt_tokens
+
+            # update the suffix cache with newly sampled tokens
+            last_token_count = self.last_token_counts.get(req_id, num_prompt_tokens)
+            if num_tokens > last_token_count:
+                # Get the newly sampled token(s) (tokens added since last call)
+                newly_sampled_ids = token_ids[last_token_count:num_tokens]
+                # Append the newly sampled ids to the suffix cache for this request
+                self.suffix_cache.add_active_response(req_id, newly_sampled_ids)
+                # Update the last token count
+                self.last_token_counts[req_id] = num_tokens
+            elif num_tokens == last_token_count:
+                # No new tokens were sampled (might happen in edge cases)
+                pass
+            else:
+                # This shouldn't happen, but handle gracefully
+                logger.warning(
+                    f"Request {req_id}: token count decreased from {last_token_count} "
+                    f"to {num_tokens}. Resetting token count."
+                )
+                self.last_token_counts[req_id] = num_tokens
+
+    def update_resources(self, scheduled_batch: ScheduledRequests):
+        pass
+
+    def free_resources(self, request: LlmRequest):
+        """
+        Free resources occupied by the specified request.
+        """
+        req_id = request.request_id
+        if req_id in self.suffix_cache.active_requests:
+            self.suffix_cache.stop_request(req_id)
+        # Clean up last_token_counts for completed requests
+        if req_id in self.last_token_counts:
+            del self.last_token_counts[req_id]
+
+
+class SuffixDrafter(Drafter):
+    """
+    Drafter for Suffix Decoding. This class uses SuffixCache to propose
+    speculative tokens for each request.
+    """
+
+    def __init__(
+        self,
+        spec_config,
+        suffix_cache_manager: SuffixResourceManager = None,
+    ):
+        super().__init__(
+            max_draft_len=spec_config.max_draft_len,
+            max_total_draft_tokens=spec_config.max_draft_len,
+            max_concurrency=spec_config.max_concurrency,
+            draft_len_schedule=spec_config.draft_len_schedule,
+        )
+        assert suffix_cache_manager is not None, (
+            "SuffixDecoding needs a resource manager to maintain the suffix cache."
+        )
+        self.spec_resource_manager = suffix_cache_manager
+        self.spec_config = spec_config
+        self.max_draft_len = spec_config.max_draft_len
+        self.max_total_draft_tokens = spec_config.max_draft_len
+        self.max_tree_depth = spec_config.max_tree_depth
+        self.max_spec_factor = spec_config.max_spec_factor
+        self.min_token_prob = spec_config.min_token_prob
+
+    def prepare_draft_tokens(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
+        """
+        Prepare draft tokens for the scheduled requests using Suffix Decoding.
+        Suffix Decoding will speculate a dynamic number of tokens for each request
+        every decoding step, so each entry may have different lengths.
+        """
+        # Sort by request_id when py_batch_idx is None as a fallback.
+        # This happens in the disagg case: for a set of new requests, we draft
+        # before forward_step, so py_batch_idx is not assigned.
+        for request in sorted(
+            scheduled_requests.generation_requests,
+            key=lambda r: (r.py_batch_idx is None, r.py_batch_idx or r.request_id),
+        ):
+            req_id = request.request_id
+
+            # Skip requests that have already reached the max sequence length.
+            num_tokens = len(request.get_tokens(0))
+            max_sequence_length = request.py_orig_prompt_len + request.py_max_new_tokens
+            if num_tokens >= max_sequence_length:
+                request.py_draft_tokens = []
+                continue
+
+            # Get the current token sequence
+            token_ids = list(request.get_tokens(0))
+
+            # Suffix decoding only uses the most recent tokens up to max_tree_depth, so
+            # we extract the pattern from the end of the input.
+            start = max(0, num_tokens - self.max_tree_depth)
+            pattern = token_ids[start:num_tokens]
+
+            # Speculate draft tokens
+            draft = self.spec_resource_manager.suffix_cache.speculate(
+                req_id,
+                pattern,
+                max_spec_tokens=min(self.max_draft_len, max_sequence_length - num_tokens - 1),
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+            )
+
+            draft_token_ids = draft.token_ids if draft else []
+            request.py_draft_tokens = draft_token_ids
+
+    def update_max_total_draft_tokens(self, new_max_total_draft_tokens: int) -> None:
+        """Override to propagate to SuffixResourceManager."""
+        super().update_max_total_draft_tokens(new_max_total_draft_tokens)
+        # Suffix Decoding uses dynamic draft lengths, so we don't need to update
+        # the resource manager's max_total_draft_tokens

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -15,6 +15,7 @@ from .mtp import (MTPEagleWorker, MTPHiddenStatesManager, MTPSampler,
                   MTPSpecMetadata, MTPWorker)
 from .ngram import NGramDrafter, NGramPoolManager
 from .save_hidden_state import SaveHiddenStatesDrafter
+from .suffix import SuffixDrafter, SuffixResourceManager
 
 
 def get_spec_metadata(spec_config,
@@ -98,6 +99,7 @@ def get_spec_metadata(spec_config,
         )
     if  spec_config.spec_dec_mode.is_draft_target() or \
         spec_config.spec_dec_mode.is_ngram() or \
+        spec_config.spec_dec_mode.is_suffix() or \
         spec_config.spec_dec_mode.is_user_provided():
         return SpecMetadata(
             max_draft_len=spec_config.max_draft_len,
@@ -155,6 +157,8 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
         )
     if spec_dec_mode.is_ngram():
         return NGramPoolManager(spec_config, max_num_requests)
+    if spec_dec_mode.is_suffix():
+        return SuffixResourceManager(spec_config, max_num_requests)
     if spec_dec_mode.is_user_provided():
         return spec_config.resource_manager
     return None
@@ -202,6 +206,9 @@ def get_spec_drafter(model_engine,
 
     if spec_config.spec_dec_mode.is_ngram():
         return NGramDrafter(spec_config, spec_resource_manager)
+
+    if spec_config.spec_dec_mode.is_suffix():
+        return SuffixDrafter(spec_config, spec_resource_manager)
 
     if spec_config.spec_dec_mode.is_save_hidden_states():
         return SaveHiddenStatesDrafter(spec_config, spec_resource_manager)

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -14,8 +14,8 @@ from .llm_args import (AttentionDpConfig, AutoDecodingConfig, BatchingType,
                        MedusaDecodingConfig, MoeConfig, MTPDecodingConfig,
                        NGramDecodingConfig, RocketSparseAttentionConfig,
                        SaveHiddenStatesDecodingConfig, SchedulerConfig,
-                       TorchCompileConfig, TorchLlmArgs, TrtLlmArgs,
-                       UserProvidedDecodingConfig)
+                       SuffixDecodingConfig, TorchCompileConfig, TorchLlmArgs,
+                       TrtLlmArgs, UserProvidedDecodingConfig)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
 from .mm_encoder import MultimodalEncoder
@@ -52,6 +52,7 @@ __all__ = [
     'DynamicBatchConfig',
     'CacheTransceiverConfig',
     'NGramDecodingConfig',
+    'SuffixDecodingConfig',
     'UserProvidedDecodingConfig',
     'TorchCompileConfig',
     'DraftTargetDecodingConfig',

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -695,6 +695,7 @@ class DecodingBaseConfig(StrictBaseModel):
             "Eagle": EagleDecodingConfig,
             "Lookahead": LookaheadDecodingConfig,
             "NGram": NGramDecodingConfig,
+            "Suffix": SuffixDecodingConfig,
             "DraftTarget": DraftTargetDecodingConfig,
             "SaveState": SaveHiddenStatesDecodingConfig,
             "UserProvided": UserProvidedDecodingConfig,
@@ -987,6 +988,40 @@ class NGramDecodingConfig(DecodingBaseConfig):
         return cls(**data)
 
     decoding_type: ClassVar[str] = "NGram"
+
+    def supports_backend(self, backend: str) -> bool:
+        return backend == "pytorch"
+
+
+class SuffixDecodingConfig(DecodingBaseConfig):
+    """
+    Configuration for Suffix Decoding drafter speculative decoding.
+    Arguments:
+        max_draft_len: int
+            The maximum number of speculative tokens to generate per step.
+        max_tree_depth: int
+            Maximum depth of the suffix tree.
+        max_spec_factor: float
+            Maximum speculation factor for dynamic draft length.
+        min_token_prob: float
+            Minimum token probability threshold for speculation.
+        max_cached_requests: int
+            Maximum number of cached requests in the suffix cache.
+    """
+    max_tree_depth: int = 24
+    max_spec_factor: float = 1.0
+    min_token_prob: float = 0.1
+    max_cached_requests: int = 10000
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.max_total_draft_tokens = self.max_draft_len  # Suffix Decoding uses dynamic draft lengths
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+    decoding_type: ClassVar[str] = "Suffix"
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -1448,6 +1483,7 @@ SpeculativeConfig: TypeAlias = Optional[Union[
     MedusaDecodingConfig,
     MTPDecodingConfig,
     NGramDecodingConfig,
+    SuffixDecodingConfig,
     UserProvidedDecodingConfig,
     SaveHiddenStatesDecodingConfig,
     AutoDecodingConfig,
@@ -2832,6 +2868,8 @@ class TorchLlmArgs(BaseLlmArgs):
                 assert self.speculative_config.speculative_model_dir is not None, "Path to EAGLE3 weights must be specified."
             elif isinstance(self.speculative_config, NGramDecodingConfig):
                 assert self.speculative_config.max_draft_len > 0 and self.speculative_config.max_matching_ngram_size > 0
+            elif isinstance(self.speculative_config, SuffixDecodingConfig):
+                assert self.speculative_config.max_draft_len > 0
             elif isinstance(self.speculative_config, DraftTargetDecodingConfig):
                 assert self.speculative_config.max_draft_len > 0
                 assert self.speculative_config.speculative_model_dir is not None, "Path to draft model must be specified."

--- a/tests/unittest/_torch/speculative/test_suffix.py
+++ b/tests/unittest/_torch/speculative/test_suffix.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import pytest
+import torch
+
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig, SuffixDecodingConfig
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from utils.llm_data import llm_models_root
+
+
+# TODO: add disable_overlap_scheduler=False
+@pytest.mark.parametrize(
+    "disable_overlap_scheduler,use_cuda_graph,attn_backend",
+    [[True, False, "TRTLLM"], [True, True, "TRTLLM"], [True, False, "FLASHINFER"]]
+)
+@pytest.mark.high_cuda_memory
+def test_llama_suffix(
+    disable_overlap_scheduler: bool, use_cuda_graph: bool, attn_backend: str
+) -> None:
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 20:
+        pytest.skip("Not enough memory to load target model")
+
+    max_batch_size = 2
+    max_draft_len = 4
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False, max_tokens=8192)
+    cuda_graph_config = CudaGraphConfig(batch_sizes=[1]) if use_cuda_graph else None
+
+    llm_common_config = dict(
+        model=llm_models_root() / "llama-3.1-model" / "Meta-Llama-3.1-8B",
+        backend="pytorch",
+        attn_backend=attn_backend,
+        disable_overlap_scheduler=disable_overlap_scheduler,
+        cuda_graph_config=cuda_graph_config,
+        max_batch_size=max_batch_size,
+        kv_cache_config=kv_cache_config,
+        max_num_tokens=2048,
+    )
+
+    spec_config = SuffixDecodingConfig(
+        max_draft_len=max_draft_len,
+        max_tree_depth=24,
+        max_spec_factor=1.0,
+        min_token_prob=0.1,
+        max_cached_requests=10000,
+    )
+
+    prompts = [
+        "The capital of France is",
+        "The president of the United States is",
+    ]
+    sampling_params = SamplingParams(max_tokens=32, ignore_eos=True, temperature=0)
+
+    llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
+    results_spec = llm_spec.generate(prompts, sampling_params)
+    generated_text_spec = [result.outputs[0].text for result in results_spec]
+    llm_spec.shutdown()
+
+    llm_ref = LLM(**llm_common_config)
+    results_ref = llm_ref.generate(prompts, sampling_params)
+    generated_text_ref = [result.outputs[0].text for result in results_ref]
+    llm_ref.shutdown()
+
+    for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
+        # The spec decode algorithm currently guarantees identical results
+        assert text_spec == text_ref
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/speculative/test_suffix.py
+++ b/tests/unittest/_torch/speculative/test_suffix.py
@@ -30,7 +30,7 @@ from utils.llm_data import llm_models_root
 # TODO: add disable_overlap_scheduler=False
 @pytest.mark.parametrize(
     "disable_overlap_scheduler,use_cuda_graph,attn_backend",
-    [[True, False, "TRTLLM"], [True, True, "TRTLLM"], [True, False, "FLASHINFER"]]
+    [[True, False, "TRTLLM"], [True, True, "TRTLLM"], [True, False, "FLASHINFER"]],
 )
 @pytest.mark.high_cuda_memory
 def test_llama_suffix(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added suffix-based speculative decoding mode to accelerate text generation through advanced token prediction
  * Introduced SuffixDecodingConfig configuration option with customizable decoding parameters

* **Tests**
  * Added test coverage for suffix decoding functionality across multiple hardware and configuration scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
This PR adds **Suffix Decoding** speculative decoding support to TensorRT-LLM. Suffix Decoding is a speculative decoding algorithm based on suffix trees that dynamically generates speculative tokens by maintaining suffix trees for each prompt, thereby accelerating the inference speed of large language models.

The implementation is based on the paper: **Suffix Decoding** (https://arxiv.org/pdf/2411.04975)

### Key Components

1. **SuffixResourceManager** (`tensorrt_llm/_torch/speculative/suffix.py`): Resource manager that maintains `SuffixDecodingCache` for managing request outputs, evicting old requests, and managing per-prompt suffix trees. Uses `arctic_inference.suffix_decoding.SuffixDecodingCache` as the underlying cache implementation.

2. **SuffixDrafter** (`tensorrt_llm/_torch/speculative/suffix.py`): Drafter class that uses SuffixCache to generate speculative tokens for each request. Supports dynamic draft token lengths where each request may generate speculative tokens of different lengths at each decoding step.

3. **SuffixDecodingConfig** (`tensorrt_llm/llmapi/llm_args.py`): Configuration class with parameters:
   - `max_tree_depth` (default: 24): Maximum depth of the suffix tree
   - `max_spec_factor` (default: 1.0): Maximum speculation factor for dynamic draft length
   - `min_token_prob` (default: 0.1): Minimum token probability threshold for speculation
   - `max_cached_requests` (default: 10000): Maximum number of cached requests in the suffix cache

4. **Integration**: Added Suffix mode support in `SpeculativeDecodingMode` enum and integrated with the existing speculative decoding framework through `utils.py`.

### Features

- Dynamic draft token length generation per request per decoding step
- Suffix tree-based pattern matching for efficient token sequence retrieval
- Request-level cache management with automatic resource cleanup
- Full integration with TensorRT-LLM's speculative decoding framework

### Dependencies

Requires `arctic-inference` package:
```bash
pip install arctic-inference
```

### Backend Support

Currently supports PyTorch backend only. TensorRT backend support is not included in this PR.

## Test Coverage

The following tests have been added to verify the functionality:

### Unit Tests
- **`tests/unittest/_torch/speculative/test_suffix.py`**: Comprehensive unit tests covering:
  - Different scheduler configurations (`disable_overlap_scheduler=True/False`)
  - CUDA Graph support (`use_cuda_graph=True/False`)
  - Different attention backends (TRTLLM, FLASHINFER)
  - Result consistency verification: Ensures speculative decoding results exactly match standard decoding results
  - Memory management: Verifies correct resource release after request completion
  - Edge case handling: Sequence length limits, empty requests

### Test Scenarios
- Basic Suffix Decoding functionality with LLaMA-3.1-8B model
- Multiple requests in batch processing
- Integration with different attention backends
- CUDA Graph compatibility
- Result correctness validation against standard decoding

### Test Command
```bash
pytest tests/unittest/_torch/speculative/test_suffix.py -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
