### PR TITLE
[TRTLLM-9493][noop] Refactor fusedMoeCommKernels to enable code sharing

### DIFF
--- a/cpp/tensorrt_llm/kernels/cudaAsyncOps.cuh
+++ b/cpp/tensorrt_llm/kernels/cudaAsyncOps.cuh
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "tensorrt_llm/kernels/moeCommKernelsCommon.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// ============================================================================
+// Address Conversion Utilities
+// ============================================================================
+
+static __device__ __forceinline__ uint32_t __as_ptr_smem(void const* __ptr)
+{
+    // Consider adding debug asserts here.
+    return static_cast<uint32_t>(__cvta_generic_to_shared(__ptr));
+}
+
+static __device__ __forceinline__ uint64_t __as_ptr_gmem(void const* __ptr)
+{
+    // Consider adding debug asserts here.
+    return static_cast<uint64_t>(__cvta_generic_to_global(__ptr));
+}
+
+// ============================================================================
+// Memory Fence Operations
+// ============================================================================
+
+__device__ __forceinline__ void fence_release_sys()
+{
+    asm volatile("fence.release.sys;" : : : "memory");
+}
+
+// ============================================================================
+// Memory Barrier Operations (mbarrier)
+// ============================================================================
+
+__device__ __forceinline__ void mbarrier_init(uint64_t* addr, uint32_t const& count)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm("mbarrier.init.shared.b64 [%0], %1;" : : "r"(__as_ptr_smem(addr)), "r"(count) : "memory");
+#endif
+}
+
+__device__ __forceinline__ void mbarrier_expect_tx(uint64_t* addr, const uint32_t txCount)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("mbarrier.expect_tx.relaxed.cta.shared::cta.b64 [%0], %1;"
+        :
+        : "r"(__as_ptr_smem(addr)), "r"(txCount)
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ uint64_t mbarrier_arrive(uint64_t* addr)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    uint64_t state;
+    asm("mbarrier.arrive.shared.b64 %0, [%1];" : "=l"(state) : "r"(__as_ptr_smem(addr)) : "memory");
+    return state;
+#else
+    return 0;
+#endif
+}
+
+__device__ __forceinline__ uint64_t mbarrier_arrive_expect_tx(uint64_t* addr, const uint32_t txCount)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    uint64_t state;
+    asm("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 %0, [%1], %2;"
+        : "=l"(state)
+        : "r"(__as_ptr_smem(addr)), "r"(txCount)
+        : "memory");
+    return state;
+#else
+    return 0;
+#endif
+}
+
+__device__ __forceinline__ bool mbarrier_try_wait_parity(uint64_t* addr, uint32_t const& phaseParity)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    uint32_t waitComplete;
+    asm("{\n\t .reg .pred P_OUT; \n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64  P_OUT, [%1], %2;\n\t"
+        "selp.b32 %0, 1, 0, P_OUT; \n"
+        "}"
+        : "=r"(waitComplete)
+        : "r"(__as_ptr_smem(addr)), "r"(phaseParity)
+        : "memory");
+    return static_cast<bool>(waitComplete);
+#else
+    return false;
+#endif
+}
+
+// ============================================================================
+// Async Copy Operations (cp.async for SM80+)
+// ============================================================================
+
+template <int COPY_SIZE = 4>
+__device__ __forceinline__ void ldgsts(int* dstShm, int const* srcMem, bool predGuard)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile(
+        "{\n"
+        "  .reg .pred p;\n"
+        "  setp.ne.b32 p, %0, 0;\n"
+        "  @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+        "}\n" ::"r"((int) predGuard),
+        "r"(__as_ptr_smem(dstShm)), "l"(__as_ptr_gmem(srcMem)), "n"(COPY_SIZE));
+#endif
+}
+
+__device__ __forceinline__ void cp_async_commit_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.commit_group;" : : :);
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_wait_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.wait_group %0;" : : "n"(N) : "memory");
+#endif
+}
+
+// ============================================================================
+// Bulk Async Copy Operations (cp.async.bulk for SM90+)
+// ============================================================================
+
+__device__ __forceinline__ void cp_async_bulk_g2s(void* dstMem, void const* srcMem, int copySize, uint64_t* smemBar)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+        :
+        : "r"(__as_ptr_smem(dstMem)), "l"(__as_ptr_gmem(srcMem)), "r"(copySize), "r"(__as_ptr_smem(smemBar))
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ void cp_async_bulk_s2g(void* dstMem, void const* srcMem, int copySize)
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm("cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;"
+        :
+        : "l"(__as_ptr_gmem(dstMem)), "r"(__as_ptr_smem(srcMem)), "r"(copySize)
+        : "memory");
+#endif
+}
+
+__device__ __forceinline__ void cp_async_bulk_commit_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.commit_group;" : : :);
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_bulk_wait_group()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.wait_group %0;" : : "n"(N) : "memory");
+#endif
+}
+
+template <int N = 0>
+__device__ __forceinline__ void cp_async_bulk_wait_group_read()
+{
+#if defined(__CUDACC__) && __CUDA_ARCH__ >= 900
+    asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(N) : "memory");
+#endif
+}
+
+// ============================================================================
+// Shared Memory Barrier Helpers
+// ============================================================================
+
+__device__ __forceinline__ void initSmemBar(uint64_t* smemBar, int laneId)
+{
+    if (laneId == 0)
+    {
+        mbarrier_init(smemBar, WARP_SIZE);
+    }
+    __syncwarp();
+}
+
+__device__ __forceinline__ void smemBarWait(uint64_t* smemBar, uint32_t* phaseParity)
+{
+    while (!mbarrier_try_wait_parity(smemBar, *phaseParity))
+    {
+    }
+    *phaseParity = 1 - *phaseParity;
+}
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.h
+++ b/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.h
@@ -83,11 +83,11 @@ struct MoeCommFieldInfo
     static constexpr uint64_t kAlign16BytePtrMask = (1ULL << 4) - 1;
     static constexpr uint32_t kAligned16BMask = (1 << 4) - 1;
 
-    // Constants for memory alignment and access
-    static constexpr int BYTES_PER_128B_BLOCK = 128;
-    static constexpr int INTS_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(int);
-    static constexpr int UINT64_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(uint64_t);
-    static constexpr int BYTES_PER_16B_BLOCK = 16;
+    // Constants for memory alignment and access (reference common constants for consistency)
+    static constexpr int BYTES_PER_128B_BLOCK = tensorrt_llm::kernels::BYTES_PER_128B_BLOCK;
+    static constexpr int INTS_PER_128B_BLOCK = tensorrt_llm::kernels::INTS_PER_128B_BLOCK;
+    static constexpr int UINT64_PER_128B_BLOCK = tensorrt_llm::kernels::UINT64_PER_128B_BLOCK;
+    static constexpr int BYTES_PER_16B_BLOCK = tensorrt_llm::kernels::BYTES_PER_16B_BLOCK;
     // Will pad one 16 byte for each unaligned field, then head and tail 16 byte might not be aligned
 
     // Fill single field info, the fields that need global info is not filled here.
@@ -253,9 +253,11 @@ public:
     static constexpr int FIFO_ENTRY_128_BYTE_COUNT = FIFO_ENTRY_BYTES / 128;
     static constexpr int FIFO_TOTAL_BYTES = FIFO_ENTRY_BYTES * FIFO_DEPTH;
     static constexpr int FIFO_TOTAL_U64 = FIFO_TOTAL_BYTES / sizeof(uint64_t);
-    static constexpr int MAX_GROUP_COUNT_PER_BLOCK = 8;
+    // Reference common constant for consistency
+    static constexpr int MAX_GROUP_COUNT_PER_BLOCK = tensorrt_llm::kernels::MAX_GROUP_COUNT_PER_BLOCK;
 
-    static constexpr int WARP_SIZE = 32;
+    // Reference common constant for consistency
+    static constexpr int WARP_SIZE = tensorrt_llm::kernels::WARP_SIZE;
 
     static int maxSmCount;
     static bool maxSmCountUsed;

--- a/cpp/tensorrt_llm/kernels/ll128Proto.cuh
+++ b/cpp/tensorrt_llm/kernels/ll128Proto.cuh
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "tensorrt_llm/kernels/moeCommKernelsCommon.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+class LL128Proto
+{
+public:
+    static constexpr uint32_t INITIALIZED_VALUE = 0xFFFFFFFFU;
+
+    template <bool USE_FINISH>
+    static __device__ __forceinline__ int checkDataReceivedInShm(uint8_t* sharedMemoryBase, uint64_t step,
+        int countIn128Bytes, int fifoEntry128ByteIndexBase, int loaded128ByteCount, int laneId)
+    {
+        // return value should be how many package already been received.
+        // 0 means no data received, -1 means has received finish package(should be the very first 128 Byte).
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int totalValidCount = 0;
+        for (int idxBase = loaded128ByteCount; idxBase < countIn128Bytes; idxBase += WARP_SIZE)
+        {
+            int idx = idxBase + laneId;
+            bool valid = false;
+            bool finish = false;
+            if (idx < countIn128Bytes)
+            {
+                int indexInFifoEntry = fifoEntry128ByteIndexBase + idx;
+                uint64_t value
+                    = aligned128BytesShm[idx * UINT64_PER_128B_BLOCK + indexInFifoEntry % UINT64_PER_128B_BLOCK];
+                if (USE_FINISH)
+                {
+                    finish = (value == (step & (1ULL << 63ULL)));
+                    valid = (value == step) || finish;
+                }
+                else
+                {
+                    valid = (value == step);
+                }
+            }
+            __syncwarp();
+            unsigned validMask = __ballot_sync(WARP_MASK, valid);
+            // here we check valid in order, if previous valid is not true, we ignore the current valid.
+            int validCount = (validMask == WARP_MASK) ? WARP_SIZE : (__ffs(~validMask) - 1);
+            if (USE_FINISH)
+            {
+                unsigned finishedMask = __ballot_sync(WARP_MASK, finish);
+                // finish should be the very first 128 Byte.
+                if (finishedMask & 0x1)
+                {
+                    return -1;
+                }
+            }
+            totalValidCount += validCount;
+
+            if (validCount != WARP_SIZE)
+            {
+                break;
+            }
+        }
+        return totalValidCount;
+    }
+
+    static __device__ __forceinline__ void protoPack(
+        uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes, int fifoEntry128ByteIndexBase, int laneId)
+    {
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int halfLaneId = laneId % 16;
+        int halfIndex = laneId / 16;
+        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
+        // for LL128 15 * 128 Bytes will be packed to 16 * 128 Bytes, each 16 threads is used for one 15 * 128 bytes.
+        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
+        {
+            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
+            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % UINT64_PER_128B_BLOCK;
+            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
+            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
+            uint64_t tailValue = step;
+            uint64_t tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
+            if (halfLaneId == 15)
+            {
+                tailInnerIndex = tailFlagInnerIndex;
+            }
+            int targetTailIndex = tailOffsetIn128Bytes * UINT64_PER_128B_BLOCK + tailInnerIndex;
+            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
+            {
+                int flagIndex = idxIn128Bytes * UINT64_PER_128B_BLOCK + idxFromFifoEntry % UINT64_PER_128B_BLOCK;
+                tailValue = aligned128BytesShm[flagIndex];
+                aligned128BytesShm[flagIndex] = step;
+            }
+            aligned128BytesShm[targetTailIndex] = tailValue;
+            tailOffsetIn128Bytes += 2;
+        }
+        __syncwarp();
+    }
+
+    static __device__ __forceinline__ void protoUnpack(uint8_t* sharedMemoryBase, uint64_t step, int countIn128Bytes,
+        int fifoEntry128ByteIndexBase, int loaded128ByteCount, int laneId)
+    {
+        uint64_t* aligned128BytesShm = reinterpret_cast<uint64_t*>(sharedMemoryBase);
+        int halfLaneId = laneId % 16;
+        int halfIndex = laneId / 16;
+        int tailOffsetIn128Bytes = countIn128Bytes + halfIndex;
+        for (int idxIn128BytesBase = halfIndex * 15; idxIn128BytesBase < countIn128Bytes; idxIn128BytesBase += 30)
+        {
+            int tailFlagIndexFromFifoEntry = fifoEntry128ByteIndexBase + tailOffsetIn128Bytes;
+            int tailFlagInnerIndex = tailFlagIndexFromFifoEntry % UINT64_PER_128B_BLOCK;
+            int idxIn128Bytes = idxIn128BytesBase + halfLaneId;
+            int idxFromFifoEntry = fifoEntry128ByteIndexBase + idxIn128Bytes;
+            uint64_t tailValue = 0;
+            int tailInnerIndex = (halfLaneId >= tailFlagInnerIndex) ? halfLaneId + 1 : halfLaneId;
+            int targetTailIndex = tailOffsetIn128Bytes * UINT64_PER_128B_BLOCK + tailInnerIndex;
+            if (halfLaneId < 15)
+            {
+                tailValue = aligned128BytesShm[targetTailIndex];
+            }
+            if (idxIn128Bytes < countIn128Bytes && halfLaneId < 15)
+            {
+                int flagIndex = idxIn128Bytes * UINT64_PER_128B_BLOCK + idxFromFifoEntry % UINT64_PER_128B_BLOCK;
+                aligned128BytesShm[flagIndex] = tailValue;
+            }
+            tailOffsetIn128Bytes += 2;
+        }
+        __syncwarp();
+    }
+
+    static __device__ __forceinline__ void rearm(
+        uint32_t* u32FifoPtr, uint64_t step, int countIn128Bytes, int fifoEntry128ByteIndexBase, int laneId)
+    {
+        // LL128 don't need rearm
+    }
+
+    static __device__ __host__ __forceinline__ int computeProtoTransfer128ByteAlignedSize(
+        int compact128ByteSizeBeforeProto)
+    {
+        // each 15 * 128 byte need one tail 128 byte
+        int tail128ByteSize = (compact128ByteSizeBeforeProto + 15 * 128 - 1) / (15 * 128) * 128;
+        return compact128ByteSizeBeforeProto + tail128ByteSize;
+    }
+};
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/moeCommKernelsCommon.h
+++ b/cpp/tensorrt_llm/kernels/moeCommKernelsCommon.h
@@ -23,14 +23,71 @@ TRTLLM_NAMESPACE_BEGIN
 namespace kernels
 {
 
+// ============================================================================
+// Alignment Macro
+// ============================================================================
+
 #ifdef __CUDACC__
 #define ALIGN_256 __align__(256)
 #else
 #define ALIGN_256 alignas(256)
 #endif
 
+// ============================================================================
+// Warp Constants
+// ============================================================================
+
 constexpr int WARP_SIZE = 32;
 constexpr uint32_t WARP_MASK = 0xffffffff;
+
+// ============================================================================
+// Memory Block Constants
+// ============================================================================
+
+// Size of a 128-byte aligned block (used for bulk async copies)
+constexpr int BYTES_PER_128B_BLOCK = 128;
+
+// Size of a 16-byte aligned block (used for field alignment)
+constexpr int BYTES_PER_16B_BLOCK = 16;
+
+// Number of int elements per 128-byte block
+constexpr int INTS_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(int);
+
+// Number of uint64_t elements per 128-byte block
+constexpr int UINT64_PER_128B_BLOCK = BYTES_PER_128B_BLOCK / sizeof(uint64_t);
+
+// ============================================================================
+// Block Organization Constants
+// ============================================================================
+
+// Maximum number of groups (warps) per CTA for MoE communication kernels
+constexpr int MAX_GROUP_COUNT_PER_BLOCK = 8;
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Ceiling division: compute ceil(a / b) for integers
+ */
+template <typename T>
+inline constexpr T ceil_div(T a, T b)
+{
+    return (a + b - 1) / b;
+}
+
+/**
+ * Align value up to nearest multiple of alignment
+ */
+template <typename T>
+inline constexpr T align_up(T value, T alignment)
+{
+    return ceil_div(value, alignment) * alignment;
+}
+
+// ============================================================================
+// MoE Parallel Info Structures
+// ============================================================================
 
 struct MoeEpWorldInfo
 {


### PR DESCRIPTION
## Description
This is in preparation for https://github.com/NVIDIA/TensorRT-LLM/pull/9573 where we're adding an alltoall for helix parallelism which closely follows FusedMoeComms.

This is purely a refactor. No functional changes are intended.
- `cudaAsyncOps.cuh` has functionality moved from `fusedMoeCommKernels.cu`. No change in functionality intended.
- `ll128Proto.cuh` has functionality moved from `fusedMoeCommKernels.cu`. No change in functionality intended.

## Test Coverage
```
$ .cpp/build/tests/unit_tests/kernels/fusedMoeCommKernelTest
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CUDA kernel infrastructure for fused operations including synchronization utilities, memory operations, and abstraction layers for improved maintainability.
  * Consolidated common kernel constants and helper functions into shared utility modules to reduce duplication and ensure consistency across related components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->