### PR TITLE
[None][fix] Autodeploy: fix some legacy flashinfer attention test errors

### DIFF
--- a/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
@@ -41,9 +41,9 @@ class TorchAttentionReference:
         )
 
         # Flatten inputs to [1, total_seq_len, ...] format
-        q_flat = q.view(1, batch_size * seq_len, -1)
-        k_flat = k.view(1, batch_size * seq_len, -1)
-        v_flat = v.view(1, batch_size * seq_len, -1)
+        q_flat = q.reshape(1, batch_size * seq_len, -1)
+        k_flat = k.reshape(1, batch_size * seq_len, -1)
+        v_flat = v.reshape(1, batch_size * seq_len, -1)
 
         # Call torch backend via custom op registry
         output_flat = torch.ops.auto_deploy.torch_cached_attention_with_cache(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -38,7 +38,6 @@ def _attention_with_fp8_kv_cache(
     return ref.transpose(1, 2)
 
 
-@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5095416")
 @pytest.mark.parametrize("seq_length", [8, 32, 2048])
 @pytest.mark.parametrize("n_heads", [8])
 @pytest.mark.parametrize("batch_size", [1, 16, 32])
@@ -285,7 +284,6 @@ def test_flashinfer_attention_op_decode(
     )
 
 
-@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5095416")
 @pytest.mark.parametrize("prefill_seq_length", [4, 10, 2047])
 @pytest.mark.parametrize("n_heads", [8])
 @pytest.mark.parametrize("batch_size", [1, 16, 32])
@@ -369,13 +367,15 @@ def test_flashinfer_attention_context_and_generate(
     # Use torch backend as clean reference
     ref = TorchAttentionReference.basic_mha_with_cache(
         q_ref.view(BATCH_SIZE, PREFILL_SEQ_LEN, N_HEADS, D_HEAD),
-        k_ref.transpose(1, 2).transpose(2, 3),  # Convert [B,N,S,D] to [B,S,N,D]
-        v_ref.transpose(1, 2).transpose(2, 3),  # Convert [B,N,S,D] to [B,S,N,D]
+        k_ref,  # Already [B, S, N, D]
+        v_ref,  # Already [B, S, N, D]
         k_cache,
         v_cache,
         torch.zeros(BATCH_SIZE, device=device, dtype=torch.int),
     )
-    flashinfer_output_1 = flashinfer_output_1.view(BATCH_SIZE, -1, N_HEADS, D_HEAD)
+    # Reshape both to same format for comparison
+    flashinfer_output_1 = flashinfer_output_1.view(BATCH_SIZE, -1, N_HEADS * D_HEAD)
+    ref = ref.view(BATCH_SIZE, -1, N_HEADS * D_HEAD)
 
     assert torch.allclose(
         flashinfer_output_1.cpu().to(torch.float32),
@@ -707,7 +707,6 @@ def test_flashinfer_attention_with_fp8_cache(
     )
 
 
-@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5095416")
 @pytest.mark.parametrize("seq_lengths", [[8, 14], [11, 19, 22, 49]])
 @pytest.mark.parametrize("n_heads", [8])
 @pytest.mark.parametrize("dtype", [torch.float16])
@@ -764,7 +763,7 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         flashinfer.get_seq_lens(
             paged_kv_indptr, paged_kv_last_page_len, page_size=k_cache.shape[1]
         ),
-        BATCH_SIZE * SEQ_LEN,
+        SEQ_LEN,
     )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V


### PR DESCRIPTION
Looks like these tests have been waived for a long time. Fix the test and re-enable them. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled previously skipped unit tests for attention operations.
  * Improved test validation logic to ensure accurate comparisons between different implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


