### PR TITLE
[TRTLLM-8462][feat] Support GET/DELETE v1/responses/{response_id}

### DIFF
--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -198,7 +198,7 @@ class ConversationHistoryStore:
         # Map from conversation id to response id, which is the latest response in the conversation.
         self.conversation_to_response: dict[str, str] = {}
 
-    async def load_response(self, resp_id: str) -> ResponsesResponse:
+    async def load_response(self, resp_id: str) -> ResponsesResponse | None:
         _responses_debug_log(
             f"ConversationHistoryStore loading resp: {resp_id}")
         async with self.responses_lock:

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -202,6 +202,9 @@ class ConversationHistoryStore:
         _responses_debug_log(
             f"ConversationHistoryStore loading resp: {resp_id}")
         async with self.responses_lock:
+            if resp_id not in self.responses:
+                return None
+
             self.responses.move_to_end(resp_id)
             return self.responses.get(resp_id)
 
@@ -262,6 +265,10 @@ class ConversationHistoryStore:
             self.response_to_conversation[resp_id] = conversation_id
             self.conversation_to_response[conversation_id] = resp_id
             self._update_visited_conversation(conversation_id)
+
+    async def pop_response(self, resp_id: Optional[str] = None) -> bool:
+        async with self.responses_lock:
+            return self._pop_response(resp_id)
 
     async def store_messages(self, resp_id: str,
                              msgs: Union[list[Message],
@@ -398,11 +405,23 @@ class ConversationHistoryStore:
 
         del conversation[start_index:end_index + 1]
 
-    def _pop_response(self) -> None:
-        _responses_debug_log(f"responses type: {type(self.responses)}")
-        resp_id, _ = self.responses.popitem(last=False)
+    def _pop_response(self, resp_id: Optional[str] = None) -> bool:
+        _responses_debug_log(f"pop response {resp_id}")
+
+        if not self.responses:
+            return False
+
+        if resp_id is not None:
+            if resp_id not in self.responses:
+                return False
+            self.responses.pop(resp_id)
+        else:
+            resp_id, _ = self.responses.popitem(last=False)
+
         if resp_id in self.response_to_conversation:
             self.response_to_conversation.pop(resp_id)
+
+        return True
 
 
 def _get_system_message(

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1653,6 +1653,14 @@ def test_openai_responses(llm_root, llm_venv):
          str(test_root / "_test_openai_responses.py")])
 
 
+def test_openai_responses_entrypoint(llm_root, llm_venv):
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd([
+        "-m", "pytest",
+        str(test_root / "_test_openai_responses_entrypoint.py")
+    ])
+
+
 def test_openai_health(llm_root, llm_venv):
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd([

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -66,6 +66,7 @@ l0_a10:
   - test_e2e.py::test_openai_misc_example[pytorch]
   - test_e2e.py::test_openai_reasoning[pytorch]
   - test_e2e.py::test_openai_tool_call
+  - test_e2e.py::test_openai_responses_entrypoint
   - test_e2e.py::test_openai_completions_example[pytorch]
   - test_e2e.py::test_openai_chat_example[pytorch] TIMEOUT (90)
   - test_e2e.py::test_trtllm_bench_request_rate_and_concurrency[enable_concurrency-]

--- a/tests/unittest/llmapi/apps/_test_openai_responses_entrypoint.py
+++ b/tests/unittest/llmapi/apps/_test_openai_responses_entrypoint.py
@@ -1,0 +1,80 @@
+import openai
+import pytest
+
+from ..test_llm import get_model_path
+from .openai_server import RemoteOpenAIServer
+
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+
+@pytest.fixture(scope="module", params=["Qwen3/Qwen3-0.6B"])
+def model(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def server(model: str):
+    model_path = get_model_path(model)
+
+    args = []
+    if model.startswith("Qwen3"):
+        args.extend(["--reasoning_parser", "qwen3"])
+    elif model.startswith("DeepSeek-R1"):
+        args.extend(["--reasoning_parser", "deepseek-r1"])
+
+    if not model.startswith("gpt_oss"):
+        args.extend(["--tool_parser", "qwen3"])
+
+    with RemoteOpenAIServer(model_path, args) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def client(server: RemoteOpenAIServer):
+    return server.get_async_client()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_get(client: openai.AsyncOpenAI, model: str):
+    response = await client.responses.create(
+        model=model, input="Which one is larger as numeric, 9.9 or 9.11?", max_output_tokens=1024
+    )
+
+    response_get = await client.responses.retrieve(response.id)
+    assert response_get.id == response.id
+    assert response_get.model_dump() == response.model_dump()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_get_invalid_response_id(client: openai.AsyncOpenAI):
+    with pytest.raises(openai.BadRequestError):
+        await client.responses.retrieve("invalid_response_id")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_get_non_existent_response_id(client: openai.AsyncOpenAI):
+    with pytest.raises(openai.NotFoundError):
+        await client.responses.retrieve("resp_non_existent_response_id")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_delete(client: openai.AsyncOpenAI, model: str):
+    response = await client.responses.create(
+        model=model, input="Which one is larger as numeric, 9.9 or 9.11?", max_output_tokens=1024
+    )
+
+    await client.responses.delete(response.id)
+    with pytest.raises(openai.NotFoundError):
+        await client.responses.retrieve(response.id)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_delete_invalid_response_id(client: openai.AsyncOpenAI):
+    with pytest.raises(openai.BadRequestError):
+        await client.responses.delete("invalid_response_id")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_delete_non_existent_response_id(client: openai.AsyncOpenAI):
+    with pytest.raises(openai.NotFoundError):
+        await client.responses.delete("resp_non_existent_response_id")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET endpoint to retrieve individual stored responses with validation
  * Added DELETE endpoint to remove stored responses with validation
  * Enhanced response management with targeted removal capabilities

* **Tests**
  * Added comprehensive tests for response retrieval and deletion operations
  * Added error case tests for invalid and non-existent response IDs
  * Extended test coverage for robust response handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Support openai described entrypoints. Ref: https://platform.openai.com/docs/api-reference/responses

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- test_e2e.py::test_openai_responses_entrypoint

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
