### PR TITLE
[#9907][infra] Add Python builds tests to CI pre-merge pipeline

### DIFF
--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -242,9 +242,7 @@ def test_python_builds(args):
     print(f"Repository root: {repo_root}")
 
     # Uninstall existing tensorrt_llm to test fresh editable install
-    subprocess.run("pip3 uninstall -y tensorrt_llm || true",
-                   shell=True,
-                   check=False)
+    subprocess.run("pip3 uninstall -y tensorrt_llm", shell=True, check=False)
 
     print("##########  Install with TRTLLM_PRECOMPILED_LOCATION  ##########")
     env = os.environ.copy()
@@ -260,9 +258,7 @@ def test_python_builds(args):
 
     # Clean up: uninstall editable install to leave env in clean state
     print("##########  Clean up editable install  ##########")
-    subprocess.run("pip3 uninstall -y tensorrt_llm || true",
-                   shell=True,
-                   check=False)
+    subprocess.run("pip3 uninstall -y tensorrt_llm", shell=True, check=False)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -177,6 +177,23 @@ def create_link_for_models():
             os.symlink(src, dst, target_is_directory=True)
 
 
+def run_sanity_check(examples_path="../../examples"):
+    """Run sanity checks after installation."""
+    print("##########  Test import tensorrt_llm  ##########")
+    subprocess.check_call(
+        'python3 -c "import tensorrt_llm; print(tensorrt_llm.__version__)"',
+        shell=True)
+    print("##########  Verify license files  ##########")
+    verify_license_files()
+
+    print("##########  Create link for models  ##########")
+    create_link_for_models()
+
+    print("##########  Test quickstart example  ##########")
+    subprocess.check_call(
+        f"python3 {examples_path}/llm-api/quickstart_example.py", shell=True)
+
+
 def test_pip_install(args):
     print("##########  Install required system libs  ##########")
     if not os.path.exists("/usr/local/mpi/bin/mpicc"):
@@ -194,19 +211,7 @@ def test_pip_install(args):
     download_wheel(args)
     install_tensorrt_llm()
 
-    print("##########  Test import tensorrt_llm  ##########")
-    subprocess.check_call(
-        'python3 -c "import tensorrt_llm; print(tensorrt_llm.__version__)"',
-        shell=True)
-    print("##########  Verify license files  ##########")
-    verify_license_files()
-
-    print("##########  Create link for models  ##########")
-    create_link_for_models()
-
-    print("##########  Test quickstart example  ##########")
-    subprocess.check_call(
-        "python3 ../../examples/llm-api/quickstart_example.py", shell=True)
+    run_sanity_check()
 
 
 def test_python_builds(args):
@@ -239,34 +244,14 @@ def test_python_builds(args):
     subprocess.check_call(["pip3", "install", "-e", ".", "-v"],
                           cwd=repo_root,
                           env=env)
-
-    print("##########  Verify installation  ##########")
-    subprocess.check_call(
-        'python3 -c "import tensorrt_llm; print(tensorrt_llm.__version__)"',
-        shell=True)
-
-    print("##########  Verify C++ extension files  ##########")
-    subprocess.check_call([
-        "python3", "-m", "pytest", "-v",
-        "tests/unittest/utils/test_prebuilt_whl_cpp_extensions.py"
-    ],
-                          cwd=repo_root)
-
-    print("##########  Create link for models  ##########")
-    create_link_for_models()
-
-    print("##########  Test quickstart example  ##########")
-    subprocess.check_call(
-        f"python3 {repo_root}/examples/llm-api/quickstart_example.py",
-        shell=True)
+    run_sanity_check(examples_path=f"{repo_root}/examples")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check Pip Install")
     parser.add_argument("--wheel_path",
                         type=str,
-                        required=False,
-                        default="Default",
+                        required=True,
                         help="The wheel path")
     args = parser.parse_args()
 

--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -255,5 +255,6 @@ if __name__ == "__main__":
                         help="The wheel path")
     args = parser.parse_args()
 
-    test_pip_install(args)
+    # Run python_builds first (sanity check), then pip_install last
     test_python_builds(args)
+    test_pip_install(args)

--- a/tests/unittest/test_pip_install.py
+++ b/tests/unittest/test_pip_install.py
@@ -225,7 +225,7 @@ def test_python_builds(args):
     This test verifies the TRTLLM_PRECOMPILED_LOCATION workflow:
     1. Install required system libs
     2. Use precompiled wheel URL to extract C++ bindings
-    3. Build Python-only wheel (editable install)
+    3. Build Python-only wheel (editable install with --no-deps)
     4. Verify installation works correctly
     5. Run quickstart example
     6. Clean up editable install to leave env in clean state
@@ -250,7 +250,8 @@ def test_python_builds(args):
     env = os.environ.copy()
     env["TRTLLM_PRECOMPILED_LOCATION"] = wheel_url
 
-    subprocess.check_call(["pip3", "install", "-e", ".", "-v"],
+    # Use --no-deps to avoid changing torch/torchvision versions.
+    subprocess.check_call(["pip3", "install", "-e", ".", "--no-deps", "-v"],
                           cwd=repo_root,
                           env=env)
     run_sanity_check(examples_path=f"{repo_root}/examples")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation for building and installing from precompiled wheels, including environment configuration and installation verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
Adds Python builds tests to validate the `TRTLLM_PRECOMPILED_LOCATION` workflow in CI. 
QA Team found python builds failed in release/1.1.0rc3 as #9907 mentioned, we add python builds tests to CI pipeline as Infra team suggested.

## Changes

### `tests/unittest/test_pip_install.py`
- Extract `get_wheel_url()` from `download_wheel()` to avoid code duplication
- Add `test_python_builds()` to test TRTLLM_PRECOMPILED_LOCATION workflow
- Run both `test_pip_install()` and `test_python_builds()` in main

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
