### PR TITLE
[None][fix] [Gemma3] Fix RoPE for local attention for Gemma3

### DIFF
--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -702,22 +702,17 @@ class Attention(Module):
                           is_buffer=True))
         else:
 
-            def register_rope_params(rotary_base,
-                                     names_to_register,
-                                     is_local=False):
+            def register_rope_params(rotary_base, scale, scale_type, scaling,
+                                     names_to_register):
                 # Rotary const weights.
                 embed_positions = RopeEmbeddingUtils.create_sinusoidal_positions(
                     max_position_embeddings,
                     rotary_embedding_dim,
                 )
-                # For local attention, use no scaling (consistent with forward pass)
-                local_scale = 1.0 if is_local else rotary_embedding_scale
-                local_scale_type = RotaryScalingType.none if is_local else rotary_embedding_scale_type
-                local_scaling = None if is_local else rotary_embedding_scaling
 
                 rotary_inv_freq, embed_positions_for_gpt_attention = RopeEmbeddingUtils.create_sinusoidal_positions_for_attention_plugin(
                     max_position_embeddings, rotary_embedding_dim, rotary_base,
-                    local_scale, local_scale_type, local_scaling)
+                    scale, scale_type, scaling)
                 model_cls.register_parameter(
                     names_to_register[0],
                     Parameter(embed_positions, dtype='float32', is_buffer=True))
@@ -731,6 +726,9 @@ class Attention(Module):
                               is_buffer=True))
 
             register_rope_params(rotary_base=rotary_embedding_base,
+                                 scale=rotary_embedding_scale,
+                                 scale_type=rotary_embedding_scale_type,
+                                 scaling=rotary_embedding_scaling,
                                  names_to_register=[
                                      'embed_positions', 'rotary_inv_freq',
                                      'embed_positions_for_gpt_attention'
@@ -742,11 +740,13 @@ class Attention(Module):
             if rotary_embedding_base_local is not None:
                 register_rope_params(
                     rotary_base=rotary_embedding_base_local,
+                    scale=1.0,
+                    scale_type=RotaryScalingType.none,
+                    scaling=None,
                     names_to_register=[
                         'embed_positions_local', 'rotary_inv_freq_local',
                         'embed_positions_for_gpt_attention_local'
-                    ],
-                    is_local=True)
+                    ])
 
     @staticmethod
     def fill_attention_params(model_cls, attention_params):

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -702,7 +702,9 @@ class Attention(Module):
                           is_buffer=True))
         else:
 
-            def register_rope_params(rotary_base, names_to_register, is_local=False):
+            def register_rope_params(rotary_base,
+                                     names_to_register,
+                                     is_local=False):
                 # Rotary const weights.
                 embed_positions = RopeEmbeddingUtils.create_sinusoidal_positions(
                     max_position_embeddings,
@@ -1146,10 +1148,12 @@ class Attention(Module):
                 rotary_embedding_dim=self.rotary_embedding_dim,
                 rotary_embedding_base=self.rotary_embedding_base
                 if not self.is_local else self.rotary_embedding_base_local,
-                rotary_embedding_scale_type=self.rotary_embedding_scale_type if not self.is_local else RotaryScalingType.none,
+                rotary_embedding_scale_type=self.rotary_embedding_scale_type
+                if not self.is_local else RotaryScalingType.none,
                 rotary_embedding_short_m_scale=attention_params.short_mscale,
                 rotary_embedding_long_m_scale=attention_params.long_mscale,
-                rotary_embedding_scale=self.rotary_embedding_scale if not self.is_local else 1.0,
+                rotary_embedding_scale=self.rotary_embedding_scale
+                if not self.is_local else 1.0,
                 rotary_embedding_max_positions=self.max_position_embeddings,
                 rotary_embedding_original_max_positions=self.
                 original_max_position_embeddings,

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -702,7 +702,9 @@ class Attention(Module):
                           is_buffer=True))
         else:
 
-            def register_rope_params(rotary_base, scale, scale_type, scaling,
+            def register_rope_params(rotary_base, rotary_embedding_scale,
+                                     rotary_embedding_scale_type,
+                                     rotary_embedding_scaling,
                                      names_to_register):
                 # Rotary const weights.
                 embed_positions = RopeEmbeddingUtils.create_sinusoidal_positions(
@@ -712,7 +714,8 @@ class Attention(Module):
 
                 rotary_inv_freq, embed_positions_for_gpt_attention = RopeEmbeddingUtils.create_sinusoidal_positions_for_attention_plugin(
                     max_position_embeddings, rotary_embedding_dim, rotary_base,
-                    scale, scale_type, scaling)
+                    rotary_embedding_scale, rotary_embedding_scale_type,
+                    rotary_embedding_scaling)
                 model_cls.register_parameter(
                     names_to_register[0],
                     Parameter(embed_positions, dtype='float32', is_buffer=True))
@@ -725,14 +728,15 @@ class Attention(Module):
                               dtype='float32',
                               is_buffer=True))
 
-            register_rope_params(rotary_base=rotary_embedding_base,
-                                 scale=rotary_embedding_scale,
-                                 scale_type=rotary_embedding_scale_type,
-                                 scaling=rotary_embedding_scaling,
-                                 names_to_register=[
-                                     'embed_positions', 'rotary_inv_freq',
-                                     'embed_positions_for_gpt_attention'
-                                 ])
+            register_rope_params(
+                rotary_base=rotary_embedding_base,
+                rotary_embedding_scale=rotary_embedding_scale,
+                rotary_embedding_scale_type=rotary_embedding_scale_type,
+                rotary_embedding_scaling=rotary_embedding_scaling,
+                names_to_register=[
+                    'embed_positions', 'rotary_inv_freq',
+                    'embed_positions_for_gpt_attention'
+                ])
 
             # For models with non-homegeneous attention layers requiring a second set of rope params. e.g. Gemma3.
             rotary_embedding_base_local = getattr(config,
@@ -740,9 +744,9 @@ class Attention(Module):
             if rotary_embedding_base_local is not None:
                 register_rope_params(
                     rotary_base=rotary_embedding_base_local,
-                    scale=1.0,
-                    scale_type=RotaryScalingType.none,
-                    scaling=None,
+                    rotary_embedding_scale=1.0,
+                    rotary_embedding_scale_type=RotaryScalingType.none,
+                    rotary_embedding_scaling=None,
                     names_to_register=[
                         'embed_positions_local', 'rotary_inv_freq_local',
                         'embed_positions_for_gpt_attention_local'

--- a/tests/unittest/others/test_layer.py
+++ b/tests/unittest/others/test_layer.py
@@ -2115,7 +2115,6 @@ class TestLayer(unittest.TestCase):
                                    atol=atol,
                                    rtol=rtol)
 
-
     def test_gemma3_local_attention_rope_scaling(self):
         """
         Test that local attention layers in Gemma3 do NOT apply rope scaling,
@@ -2126,8 +2125,7 @@ class TestLayer(unittest.TestCase):
         ensures that local attention layers get scale=1.0 and scale_type=none,
         while global layers get the configured scaling.
         """
-        from tensorrt_llm.functional import (PositionEmbeddingType,
-                                             RotaryScalingType)
+        from tensorrt_llm.functional import PositionEmbeddingType
         from tensorrt_llm.layers.attention import Attention
 
         # Create a mock config similar to Gemma3 27B with rope_scaling
@@ -2138,10 +2136,7 @@ class TestLayer(unittest.TestCase):
             max_position_embeddings = 32768
             position_embedding_type = PositionEmbeddingType.rope_gpt_neox
             rotary_base = 1000000.0
-            rotary_scaling = {
-                "factor": 8.0,
-                "rope_type": "linear"
-            }
+            rotary_scaling = {"factor": 8.0, "rope_type": "linear"}
             rotary_pct = 1.0
             # Local attention uses a different base frequency
             rope_local_base_freq = 10000.0
@@ -2202,8 +2197,8 @@ class TestLayer(unittest.TestCase):
         # For local attention with scale=1.0 and base=10000:
         # inv_freq = 1.0 / (10000 ** (arange(0, dim, 2) / dim))
         dim = config.head_size  # rotary_embedding_dim = head_size * rotary_pct = 128
-        expected_local_inv_freq = 1.0 / (config.rope_local_base_freq**(
-            np.arange(0, dim, 2) / dim))
+        expected_local_inv_freq = 1.0 / (config.rope_local_base_freq
+                                         **(np.arange(0, dim, 2) / dim))
 
         np.testing.assert_allclose(
             local_inv_freq,
@@ -2214,14 +2209,15 @@ class TestLayer(unittest.TestCase):
         # For global attention with linear scaling (factor=8.0):
         # scale = 1.0 / 8.0 = 0.125
         # inv_freq = 0.125 / (1000000 ** (arange(0, dim, 2) / dim))
-        expected_global_inv_freq = (1.0 / 8.0) / (config.rotary_base**(
-            np.arange(0, dim, 2) / dim))
+        expected_global_inv_freq = (1.0 / 8.0) / (config.rotary_base**
+                                                  (np.arange(0, dim, 2) / dim))
 
         np.testing.assert_allclose(
             global_inv_freq,
             expected_global_inv_freq,
             rtol=1e-5,
-            err_msg="Global rotary_inv_freq should be computed WITH linear scaling")
+            err_msg=
+            "Global rotary_inv_freq should be computed WITH linear scaling")
 
 
 if __name__ == '__main__':

--- a/tests/unittest/others/test_layer.py
+++ b/tests/unittest/others/test_layer.py
@@ -2116,5 +2116,113 @@ class TestLayer(unittest.TestCase):
                                    rtol=rtol)
 
 
+    def test_gemma3_local_attention_rope_scaling(self):
+        """
+        Test that local attention layers in Gemma3 do NOT apply rope scaling,
+        even when the config has rope_scaling defined.
+
+        This is important for Gemma3 which uses different RoPE parameters for
+        local (sliding window) attention vs global attention layers. The fix
+        ensures that local attention layers get scale=1.0 and scale_type=none,
+        while global layers get the configured scaling.
+        """
+        from tensorrt_llm.functional import (PositionEmbeddingType,
+                                             RotaryScalingType)
+        from tensorrt_llm.layers.attention import Attention
+
+        # Create a mock config similar to Gemma3 27B with rope_scaling
+        class MockGemma3Config:
+            hidden_size = 5376
+            num_attention_heads = 32
+            head_size = 128
+            max_position_embeddings = 32768
+            position_embedding_type = PositionEmbeddingType.rope_gpt_neox
+            rotary_base = 1000000.0
+            rotary_scaling = {
+                "factor": 8.0,
+                "rope_type": "linear"
+            }
+            rotary_pct = 1.0
+            # Local attention uses a different base frequency
+            rope_local_base_freq = 10000.0
+
+        # Create a mock model class to receive registered parameters
+        class MockModelCls:
+            position_embedding_type = PositionEmbeddingType.rope_gpt_neox
+
+            @classmethod
+            def register_parameter(cls, name, param):
+                setattr(cls, name, param)
+
+        config = MockGemma3Config()
+
+        # Call the method that creates attention const params
+        Attention.create_attention_const_params(MockModelCls, config)
+
+        # Verify that global rope parameters are registered
+        self.assertTrue(hasattr(MockModelCls, 'embed_positions'),
+                        "Global embed_positions should be registered")
+        self.assertTrue(hasattr(MockModelCls, 'rotary_inv_freq'),
+                        "Global rotary_inv_freq should be registered")
+        self.assertTrue(
+            hasattr(MockModelCls, 'embed_positions_for_gpt_attention'),
+            "Global embed_positions_for_gpt_attention should be registered")
+
+        # Verify that local rope parameters are registered (since rope_local_base_freq is set)
+        self.assertTrue(hasattr(MockModelCls, 'embed_positions_local'),
+                        "Local embed_positions should be registered")
+        self.assertTrue(hasattr(MockModelCls, 'rotary_inv_freq_local'),
+                        "Local rotary_inv_freq should be registered")
+        self.assertTrue(
+            hasattr(MockModelCls, 'embed_positions_for_gpt_attention_local'),
+            "Local embed_positions_for_gpt_attention should be registered")
+
+        # Get the parameter values
+        global_inv_freq = MockModelCls.rotary_inv_freq.raw_value
+        local_inv_freq = MockModelCls.rotary_inv_freq_local.raw_value
+        global_cos_sin = MockModelCls.embed_positions_for_gpt_attention.raw_value
+        local_cos_sin = MockModelCls.embed_positions_for_gpt_attention_local.raw_value
+
+        # The global and local inv_freq should be different because:
+        # 1. Global uses rope_scaling with factor=8.0 (linear scaling applies 1/8 to inv_freq)
+        # 2. Local uses scale=1.0 (no scaling)
+        # Also they use different base frequencies (1000000 vs 10000)
+        self.assertFalse(
+            np.allclose(global_inv_freq, local_inv_freq),
+            "Global and local rotary_inv_freq should be different "
+            "(global has scaling, local does not)")
+
+        # The cos/sin embeddings should also be different
+        self.assertFalse(
+            np.allclose(global_cos_sin, local_cos_sin),
+            "Global and local embed_positions_for_gpt_attention should be different "
+            "(global has scaling, local does not)")
+
+        # Additional verification: Check that local inv_freq matches unscaled calculation
+        # For local attention with scale=1.0 and base=10000:
+        # inv_freq = 1.0 / (10000 ** (arange(0, dim, 2) / dim))
+        dim = config.head_size  # rotary_embedding_dim = head_size * rotary_pct = 128
+        expected_local_inv_freq = 1.0 / (config.rope_local_base_freq**(
+            np.arange(0, dim, 2) / dim))
+
+        np.testing.assert_allclose(
+            local_inv_freq,
+            expected_local_inv_freq,
+            rtol=1e-5,
+            err_msg="Local rotary_inv_freq should be computed WITHOUT scaling")
+
+        # For global attention with linear scaling (factor=8.0):
+        # scale = 1.0 / 8.0 = 0.125
+        # inv_freq = 0.125 / (1000000 ** (arange(0, dim, 2) / dim))
+        expected_global_inv_freq = (1.0 / 8.0) / (config.rotary_base**(
+            np.arange(0, dim, 2) / dim))
+
+        np.testing.assert_allclose(
+            global_inv_freq,
+            expected_global_inv_freq,
+            rtol=1e-5,
+            err_msg="Global rotary_inv_freq should be computed WITH linear scaling")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittest/others/test_layer.py
+++ b/tests/unittest/others/test_layer.py
@@ -2184,7 +2184,6 @@ class TestLayer(unittest.TestCase):
         # The global and local inv_freq should be different because:
         # 1. Global uses rope_scaling with factor=8.0 (linear scaling applies 1/8 to inv_freq)
         # 2. Local uses scale=1.0 (no scaling)
-        # Also they use different base frequencies (1000000 vs 10000)
         self.assertFalse(
             np.allclose(global_inv_freq, local_inv_freq),
             "Global and local rotary_inv_freq should be different "
@@ -2197,8 +2196,8 @@ class TestLayer(unittest.TestCase):
             "(global has scaling, local does not)")
 
         # Additional verification: Check that local inv_freq matches unscaled calculation
-        # For local attention with scale=1.0 and base=10000:
-        # inv_freq = 1.0 / (10000 ** (arange(0, dim, 2) / dim))
+        # For local attention with scale=1.0 and base=10:
+        # inv_freq = 1.0 / (10 ** (arange(0, dim, 2) / dim))
         dim = config.head_size  # rotary_embedding_dim = head_size * rotary_pct = 128
         expected_local_inv_freq = 1.0 / (config.rope_local_base_freq
                                          **(np.arange(0, dim, 2) / dim))
@@ -2211,7 +2210,7 @@ class TestLayer(unittest.TestCase):
 
         # For global attention with linear scaling (factor=8.0):
         # scale = 1.0 / 8.0 = 0.125
-        # inv_freq = 0.125 / (1000000 ** (arange(0, dim, 2) / dim))
+        # inv_freq = 0.125 / (100 ** (arange(0, dim, 2) / dim))
         expected_global_inv_freq = (1.0 / 8.0) / (config.rotary_base**
                                                   (np.arange(0, dim, 2) / dim))
 

--- a/tests/unittest/others/test_layer.py
+++ b/tests/unittest/others/test_layer.py
@@ -2135,11 +2135,14 @@ class TestLayer(unittest.TestCase):
             head_size = 128
             max_position_embeddings = 32768
             position_embedding_type = PositionEmbeddingType.rope_gpt_neox
-            rotary_base = 1000000.0
+            # Use small rotary base values to avoid numerical instability in tests.
+            # Large bases (e.g. 1000000) get exponentiated, causing potential flakiness
+            # when comparing floating point results.
+            rotary_base = 100.0
             rotary_scaling = {"factor": 8.0, "rope_type": "linear"}
             rotary_pct = 1.0
             # Local attention uses a different base frequency
-            rope_local_base_freq = 10000.0
+            rope_local_base_freq = 10.0
 
         # Create a mock model class to receive registered parameters
         class MockModelCls:


### PR DESCRIPTION
## Description

Gemma3 has local and global attention layers. Right now, RoPE is incorrectly applied for local layers, this PR fixes that. The issue is not apparent when dealing with shorter sequences - but once the sequence is long enough (longer than 1024 tokens minimum, for a 1024 token local window attention), the outputs are garbled a little. I've already applied this to my own version of TensorRT-LLM and my Gemma3 is now working as expected.


## Test Coverage

Added `tests/unittest/others/test_layer.py::TestLayer::test_gemma3_local_attention_rope_scaling.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
