### PR TITLE
[None][refactor] simplify get_stats and get_kvcache_events with rpc

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -143,8 +143,6 @@ class GenerationExecutorProxy(GenerationExecutor):
             request_queue_addr=self.request_queue.address,
             worker_init_status_queue_addr=self.worker_init_status_queue.address,
             result_queue_addr=self.result_queue.address,
-            stats_queue_addr=None,
-            kv_cache_events_queue_addr=None,
         )
 
     def abort_request(self, request_id: int) -> None:

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -117,7 +117,12 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
             return empty_async_iterable()
 
         # Fetch stats via RPC and populate the result
-        stats = self.get_stats(timeout)
+        try:
+            stats = self.rpc_client.fetch_stats_wait_async(
+                timeout=timeout).remote()
+        except Exception:
+            stats = []
+
         for stat in stats:
             self._iter_stats_result.queue.put(stat)
 
@@ -159,7 +164,12 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
             return empty_async_iterable()
 
         # Fetch kv events via RPC and populate the result
-        events = self.get_kv_events(timeout)
+        try:
+            events = self.rpc_client.fetch_kv_cache_events_wait_async(
+                timeout=timeout).remote()
+        except Exception:
+            events = []
+
         for event in events:
             self._iter_kv_events_result.queue.put(event)
 

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from ..llmapi.mpi_session import MpiPoolSession, MpiSession
 from ..llmapi.utils import logger_debug, print_colored
 from ..logger import logger
-from .base_worker import BaseWorker
 from .executor import GenerationExecutor
 from .postproc_worker import PostprocWorkerConfig
 from .result import IterationResult
@@ -92,8 +91,9 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
             List[dict]: A list of runtime stats as dict.
         """
         try:
+            # Stats are already serialized by the worker's fetch_stats_async()
             stats = self.rpc_client.fetch_stats_async().remote(timeout=timeout)
-            return [BaseWorker._stats_serializer(s) for s in stats]
+            return stats
         except Exception as e:
             logger.debug(f"Error fetching stats via RPC: {e}")
             return []
@@ -134,9 +134,10 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
             List[dict]: A list of runtime events as dict.
         """
         try:
+            # Events are already serialized by the worker's fetch_kv_cache_events_async()
             events = self.rpc_client.fetch_kv_cache_events_async().remote(
                 timeout=timeout)
-            return [BaseWorker._kv_cache_events_serializer(e) for e in events]
+            return events
         except Exception as e:
             logger.debug(f"Error fetching kv events via RPC: {e}")
             return []

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -1,11 +1,13 @@
 import threading
-from typing import Optional
+from typing import List, Optional
 
 from ..llmapi.mpi_session import MpiPoolSession, MpiSession
-from ..llmapi.utils import logger_debug
+from ..llmapi.utils import logger_debug, print_colored
 from ..logger import logger
+from .base_worker import BaseWorker
 from .executor import GenerationExecutor
 from .postproc_worker import PostprocWorkerConfig
+from .result import IterationResult
 from .rpc_proxy_mixin import RpcExecutorMixin
 from .rpc_worker import RpcWorker
 from .utils import create_mpi_comm_session, get_spawn_proxy_process_env
@@ -69,20 +71,99 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
                                 **self.worker_kwargs)
 
     def _setup_mainloop_with_tasks(self):
-        """Setup mainloop with all tasks needed for RpcProxy."""
+        """Setup mainloop with tasks needed for RpcProxy.
+
+        Note: Stats and kv_events are now fetched on-demand via direct RPC calls
+        (get_stats, aget_stats, get_kv_events, aget_kv_events), not via streaming loops.
+        """
         tasks = [
             self._fetch_responses_loop_async,
-            self._fetch_stats_loop_async,
         ]
-        # Only add kv_cache_events loop if it's enabled
-        if self._iter_kv_events_result:
-            tasks.append(self._fetch_kv_cache_events_loop_async)
-
         # Call mixin's setup_mainloop with custom tasks
         self.setup_mainloop(tasks=tasks, thread_name="rpc_proxy_main_loop")
 
-    def fetch_stats_remote(self):
-        return self.rpc_client.fetch_stats().remote()
+    def get_stats(self, timeout: float) -> List[dict]:
+        """Get iteration statistics from the runtime via RPC.
+
+        Args:
+            timeout (float): Max wait time in seconds for the RPC call.
+
+        Returns:
+            List[dict]: A list of runtime stats as dict.
+        """
+        try:
+            stats = self.rpc_client.fetch_stats_async().remote(timeout=timeout)
+            return [BaseWorker._stats_serializer(s) for s in stats]
+        except Exception as e:
+            logger.debug(f"Error fetching stats via RPC: {e}")
+            return []
+
+    def aget_stats(self, timeout: float) -> IterationResult:
+        """Get iteration statistics from the runtime via RPC (async).
+
+        Args:
+            timeout (float): Max wait time in seconds for the RPC call.
+
+        Returns:
+            IterationResult: An async iterable object containing runtime stats.
+        """
+        # Initialize iteration result if needed
+        self._maybe_initialize_iteration_results()
+
+        if self._iter_stats_result is None:
+            print_colored("Iteration statistics are not available yet.\n",
+                          "yellow")
+            from .executor import empty_async_iterable
+            return empty_async_iterable()
+
+        # Fetch stats via RPC and populate the result
+        stats = self.get_stats(timeout)
+        for stat in stats:
+            self._iter_stats_result.queue.put(stat)
+
+        self._iter_stats_result.set_timeout(timeout)
+        return self._iter_stats_result
+
+    def get_kv_events(self, timeout: float) -> List[dict]:
+        """Get iteration KV events from the runtime via RPC.
+
+        Args:
+            timeout (float): Max wait time in seconds for the RPC call.
+
+        Returns:
+            List[dict]: A list of runtime events as dict.
+        """
+        try:
+            events = self.rpc_client.fetch_kv_cache_events_async().remote(
+                timeout=timeout)
+            return [BaseWorker._kv_cache_events_serializer(e) for e in events]
+        except Exception as e:
+            logger.debug(f"Error fetching kv events via RPC: {e}")
+            return []
+
+    def aget_kv_events(self, timeout: float) -> IterationResult:
+        """Get iteration KV events from the runtime via RPC (async).
+
+        Args:
+            timeout (float): Max wait time in seconds for the RPC call.
+
+        Returns:
+            IterationResult: An async iterable object containing runtime events.
+        """
+        # Initialize iteration result if needed
+        self._maybe_initialize_iteration_results()
+
+        if self._iter_kv_events_result is None:
+            from .executor import empty_async_iterable
+            return empty_async_iterable()
+
+        # Fetch kv events via RPC and populate the result
+        events = self.get_kv_events(timeout)
+        for event in events:
+            self._iter_kv_events_result.queue.put(event)
+
+        self._iter_kv_events_result.set_timeout(timeout)
+        return self._iter_kv_events_result
 
     def setup_engine_remote(self):
         return self.rpc_client.setup_engine().remote(need_response=True)

--- a/tensorrt_llm/executor/rpc_worker_mixin.py
+++ b/tensorrt_llm/executor/rpc_worker_mixin.py
@@ -103,15 +103,21 @@ class RpcWorkerMixin:
         """Async version of fetch_stats using asyncio.to_thread.
 
         This method is exposed via RPC and can be called directly by the proxy.
+        Returns serialized stats (JSON strings) that can be sent over RPC.
         """
-        return await asyncio.to_thread(self.fetch_stats)
+        stats = await asyncio.to_thread(self.fetch_stats)
+        # Serialize stats before sending over RPC (IterationStats objects are not picklable)
+        return [self._stats_serializer(s) for s in stats]
 
     async def fetch_kv_cache_events_async(self, timeout: Optional[float] = None) -> list:
         """Async version of fetch_kv_cache_events using asyncio.to_thread.
 
         This method is exposed via RPC and can be called directly by the proxy.
+        Returns serialized events (JSON strings) that can be sent over RPC.
         """
-        return await asyncio.to_thread(self.fetch_kv_cache_events)
+        events = await asyncio.to_thread(self.fetch_kv_cache_events)
+        # Serialize events before sending over RPC
+        return [self._kv_cache_events_serializer(e) for e in events]
 
     # NOTE: fetch_stats_loop_async, fetch_kv_cache_events_loop_async, and _generic_fetch_loop_async
     # have been removed. Stats and kv_events are now fetched on-demand via direct RPC calls

--- a/tensorrt_llm/executor/rpc_worker_mixin.py
+++ b/tensorrt_llm/executor/rpc_worker_mixin.py
@@ -50,8 +50,9 @@ class RpcWorkerMixin:
         """Submits a request to the worker."""
         with nvtx_range_debug("RpcWorker.submit", color="blue", category="Worker"):
             logger_debug(f"[worker] Submitting request {request.id}", color="green")
-            super().submit(request)
+            result = super().submit(request)
             logger_debug(f"[worker] Submitted request {request.id}", color="green")
+            return result
 
     def fetch_responses(self, timeout: Optional[float] = None) -> list:
         """Fetch responses from the response queue (blocking)."""

--- a/tensorrt_llm/executor/rpc_worker_mixin.py
+++ b/tensorrt_llm/executor/rpc_worker_mixin.py
@@ -118,7 +118,3 @@ class RpcWorkerMixin:
         events = await asyncio.to_thread(self.fetch_kv_cache_events)
         # Serialize events before sending over RPC
         return [self._kv_cache_events_serializer(e) for e in events]
-
-    # NOTE: fetch_stats_loop_async, fetch_kv_cache_events_loop_async, and _generic_fetch_loop_async
-    # have been removed. Stats and kv_events are now fetched on-demand via direct RPC calls
-    # to fetch_stats_async and fetch_kv_cache_events_async instead of continuous loops.

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -142,8 +142,6 @@ class WorkerCommIpcAddrs(NamedTuple):
     request_queue_addr: tuple[str, Optional[bytes]]
     worker_init_status_queue_addr: tuple[str, Optional[bytes]]
     result_queue_addr: tuple[str, Optional[bytes]]
-    stats_queue_addr: tuple[str, Optional[bytes]]
-    kv_cache_events_queue_addr: tuple[str, Optional[bytes]]
 
 
 def is_llm_response(instance):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -1,11 +1,9 @@
 import gc
 import os
-import time
 import traceback
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from queue import Queue
-from typing import Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 import zmq
 
@@ -18,19 +16,15 @@ from ..llmapi.llm_args import BaseLlmArgs
 from ..llmapi.mpi_session import set_mpi_session_cpp
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import VizTracer, set_global_tracer
-from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue, logger_debug,
-                            print_traceback_on_error)
+from ..llmapi.utils import ManagedThread, logger_debug, print_traceback_on_error
 from ..sampling_params import BatchedLogitsProcessor
 from .base_worker import BaseWorker, _init_hf_modules
-from .executor import IterationResultQueue
 from .ipc import FusedIpcQueue, IpcQueue
 from .postproc_worker import (PostprocWorker, PostprocWorkerConfig,
                               postproc_worker_main)
 from .request import CancellingRequest, GenerationRequest
-from .result import IterationResult
 from .rpc_worker_mixin import RpcWorkerMixin
-from .utils import (ErrorResponse, RequestError, WorkerCommIpcAddrs,
-                    has_event_loop)
+from .utils import ErrorResponse, RequestError, WorkerCommIpcAddrs
 
 __all__ = [
     "GenerationExecutorWorker",
@@ -77,30 +71,6 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
             error_queue=self._error_queue,
             name="await_response_thread")
 
-        self.dispatch_stats_thread = ManagedThread(
-            self.dispatch_stats_task,
-            error_queue=self._error_queue,
-            name="dispatch_stats_thread")
-
-        self.dispatch_kv_cache_events_thread = ManagedThread(
-            self.dispatch_kv_cache_events_task,
-            error_queue=self._error_queue,
-            name="dispatch_kv_cache_events_thread")
-
-    def _create_iteration_result_queue(self,
-                                       it_result_queue: IterationResultQueue):
-        if not it_result_queue.is_initialized:
-            # not yet initialized
-            it_result_queue.is_initialized = True
-            if has_event_loop():
-                _queue = AsyncQueue()
-                it_result_queue.queue = _queue.sync_q
-                it_result_queue.aqueue = _queue
-            else:
-                _queue = Queue()
-                it_result_queue.queue = _queue
-                it_result_queue.aqueue = None
-
     def start_thread(self, thread: ManagedThread):
         if self.engine.can_enqueue_requests() and not thread.is_alive():
             thread.start()
@@ -108,74 +78,10 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
     def await_response_task(self) -> bool:
         return self._await_response_helper()
 
-    def _iteration_result_task(self, it_result_queue: IterationResultQueue,
-                               engine_get_result_api: Callable,
-                               result_singleton: IterationResult,
-                               result_serializer: Callable) -> bool:
-        time.sleep(0.2)
-        async_queues = []
-        queue = result_singleton.queue if self._is_llm_executor and result_singleton else it_result_queue.queue
-        try:
-            for results in engine_get_result_api():
-                res = result_serializer(results)
-                if self._is_llm_executor and result_singleton:
-                    # In this case, there's no ExecutorBindingProxy.
-                    # Worker needs to take care of putting to result queue.
-                    while queue.full():
-                        queue.get()
-                    if isinstance(queue, _SyncQueue):
-                        queue.put_nowait(res)
-                        async_queues.append(queue)
-                    else:
-                        queue.put(res)
-                else:
-                    # Send to ExecutorBindingProxy via IPC
-                    queue.put(res)
-
-            if async_queues:
-                _SyncQueue.notify_many(queue.loop, async_queues)
-        except AsyncQueue.EventLoopShutdownError:
-            # This happens in the last results loop while the generate workflow is stopped.
-            logger.debug("worker.py: EventLoopShutdownError")
-        except Exception as e:
-            logger.error(f"worker.py: Error in _iteration_result_task: {e}")
-            raise e
-
-        return True  # success
-
-    def dispatch_stats_task(self) -> bool:
-        return self._iteration_result_task(self.stats_queues, self.fetch_stats,
-                                           self._iter_stats_result,
-                                           self._stats_serializer)
-
-    def dispatch_kv_cache_events_task(self) -> bool:
-        if isinstance(self.engine, tllm.Executor):
-            # Check if the engine has a kv cache event manager
-            # If not, return an empty list for the events which will cause the thread to exit early.
-            event_manager = self.engine.get_kv_cache_event_manager()
-            if event_manager is None:
-                events_api = lambda: [None]
-            else:
-                events_api = event_manager.get_latest_events
-            return self._iteration_result_task(self.kv_events_queues,
-                                               events_api,
-                                               self._iter_kv_events_result,
-                                               self._kv_cache_events_serializer)
-        else:
-            return self._iteration_result_task(
-                self.kv_events_queues, self.engine.get_latest_kv_cache_events,
-                self._iter_kv_events_result, self._kv_cache_events_serializer)
-
     def start(self):
-        # create iteration result queues
-        self._create_iteration_result_queue(self.stats_queues)
-        self._create_iteration_result_queue(self.kv_events_queues)
-
-        # start threads
+        # Stats and KV events are now fetched on-demand via RPC,
+        # so we only need to start the response thread
         self.start_thread(self.await_response_thread)
-        self.start_thread(self.dispatch_kv_cache_events_thread)
-        if mpi_rank() == 0:
-            self.start_thread(self.dispatch_stats_thread)
 
     def shutdown(self):
 
@@ -188,16 +94,9 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
 
         if self.engine is not None:
             if self.engine.can_enqueue_requests():
-
                 if self.await_response_thread.is_alive():
                     self.await_response_thread.stop()
                     self.await_response_thread.join()
-                if self.dispatch_stats_thread.is_alive():
-                    self.dispatch_stats_thread.stop()
-                    self.dispatch_stats_thread.join()
-                if self.dispatch_kv_cache_events_thread.is_alive():
-                    self.dispatch_kv_cache_events_thread.stop()
-                    self.dispatch_kv_cache_events_thread.join()
 
             self.engine.shutdown()
             self.engine = None
@@ -299,20 +198,6 @@ def worker_main(
             is_server=False,
             socket_type=zmq.DEALER,
             name="worker_init_status_queue")
-        # Stats and kv_cache_events are now fetched via RPC, IPC queues are optional
-        mp_stats_queue = None
-        if worker_queues.stats_queue_addr is not None:
-            mp_stats_queue = FusedIpcQueue(worker_queues.stats_queue_addr,
-                                           is_server=False,
-                                           fuse_message=True,
-                                           name="worker_stats_queue")
-        kv_cache_events_queue = None
-        if worker_queues.kv_cache_events_queue_addr is not None:
-            kv_cache_events_queue = FusedIpcQueue(
-                worker_queues.kv_cache_events_queue_addr,
-                is_server=False,
-                fuse_message=False,
-                name="worker_kv_cache_events_queue")
 
         if postproc_worker_config.enabled:
             # IPC queues for sending inputs to the postprocess parallel
@@ -339,11 +224,6 @@ def worker_main(
             assert result_queues is not None
             for q in result_queues:
                 q.put(None)
-        # Signal the stats/kv_cache_events threads in the proxy to quit (if using IPC)
-        if mp_stats_queue is not None:
-            mp_stats_queue.put(None)
-        if kv_cache_events_queue is not None:
-            kv_cache_events_queue.put(None)
 
     postprocess_worker_futures = []
     if is_leader and postproc_worker_config.enabled:
@@ -417,13 +297,6 @@ def worker_main(
                 else:
                     worker.set_result_queue(result_queue)
 
-                # initialize the iteration result queues (only if using IPC, not RPC)
-                if mp_stats_queue is not None:
-                    worker._set_iteration_result_queue(worker.stats_queues,
-                                                       mp_stats_queue)
-                if kv_cache_events_queue is not None:
-                    worker._set_iteration_result_queue(worker.kv_events_queues,
-                                                       kv_cache_events_queue)
                 # Send ready signal with confirmation
                 ready_msg = (ready_signal, None)
                 if not worker_init_status_queue.notify_with_retry(ready_msg):

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -4,6 +4,7 @@ import gc
 import json
 import os
 import sys
+import time
 
 # Required for test_generate_with_seed to pass.
 # See the discussion in https://github.com/NVIDIA/TensorRT-LLM/pull/4264#issuecomment-2943269891
@@ -2175,21 +2176,6 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     if not pytorch_backend:
         llm_args_extra["fast_build"] = True
 
-    def get_stats_with_wait(llm: LLM, timeout: float = 2) -> List[dict]:
-        """Poll for stats with timeout since RPC calls return immediately."""
-        import json
-        import time
-        start = time.time()
-        while time.time() - start < timeout:
-            results = llm.get_stats(timeout=0.1)
-            if results:
-                # Parse JSON strings to dicts if needed
-                return [
-                    json.loads(r) if isinstance(r, str) else r for r in results
-                ]
-            time.sleep(0.1)
-        return []
-
     with LLM_CLASS(model=llama_model_path,
                    kv_cache_config=global_kvcache_config,
                    tensor_parallel_size=tp_size,
@@ -2208,7 +2194,8 @@ def llm_get_stats_test_harness(tp_size: int = 1,
                                    sampling_params=sampling_params):
             print(output)
 
-        results = get_stats_with_wait(llm, 2)
+        time.sleep(2)
+        results = llm.get_stats(2)
 
         validate_stats(results=results,
                        pp_size=pp_size,
@@ -2218,11 +2205,11 @@ def llm_get_stats_test_harness(tp_size: int = 1,
                        enable_chunked_prefill=enable_chunked_prefill,
                        enable_iter_req_stats=enable_iter_req_stats)
 
-        assert not get_stats_with_wait(llm, 0.5)
+        assert not llm.get_stats(0.5)
 
         # test that IterationResult()._done is properly set
         _ = llm.generate(prompts, sampling_params=sampling_params)
-        assert get_stats_with_wait(llm, 2)
+        assert llm.get_stats(2)
 
 
 @pytest.mark.parametrize("return_context_logits", [True, False])
@@ -2264,21 +2251,6 @@ def test_llm_get_queued_stats():
     max_tries = 10
     has_queue_requests = False
 
-    def get_stats_with_wait(llm, timeout: float = 2):
-        """Poll for stats with timeout since RPC calls return immediately."""
-        import json
-        import time
-        start = time.time()
-        while time.time() - start < timeout:
-            results = llm.get_stats(timeout=0.1)
-            if results:
-                # Parse JSON strings to dicts if needed
-                return [
-                    json.loads(r) if isinstance(r, str) else r for r in results
-                ]
-            time.sleep(0.1)
-        return []
-
     while not has_queue_requests and max_tries > 0:
         max_tries -= 1
         # Generate outputs, which will queue requests
@@ -2286,7 +2258,7 @@ def test_llm_get_queued_stats():
                                    sampling_params=sampling_params):
             print(output)
 
-        results = get_stats_with_wait(llm, 2)
+        results = llm.get_stats(2)
 
         for index, result in enumerate(results):
             if "requestStats" in result:
@@ -2372,7 +2344,7 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
             await asyncio.sleep(
                 4)  # ensure there's stats to collect for the assertion
             async for stats in llm.get_stats_async(
-            ):  # it will return immediately
+                    10):  # it will return immediately
                 results.append(stats)
 
             assert results

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2370,8 +2370,9 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
         async def task1(repetition_index: int):
             results = []
             await asyncio.sleep(
-                3)  # ensure there's stats to collect for the assertion
-            async for stats in llm.get_stats_async(timeout=2):
+                4)  # ensure there's stats to collect for the assertion
+            async for stats in llm.get_stats_async(
+            ):  # it will return immediately
                 results.append(stats)
 
             assert results

--- a/tests/unittest/llmapi/test_llm_multi_gpu.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu.py
@@ -487,11 +487,12 @@ def test_llm_get_kv_cache_events_tp2():
     # created + stored events
     assert events and len(events) >= 2
     for event in events:
+        print(f"event: {event}")
         if event:
-            if event[0]["event_id"] == 0:
-                assert event[0]["data"]["type"] == "created"
-            elif event[0]["event_id"] == 1:
-                assert event[0]["data"]["type"] == "stored"
+            if event["event_id"] == 0:
+                assert event["data"]["type"] == "created"
+            elif event["event_id"] == 1:
+                assert event["data"]["type"] == "stored"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RPC-based retrieval methods for execution statistics and KV cache events with synchronous (`get_stats`, `get_kv_events`) and asynchronous (`aget_stats`, `aget_kv_events`) interfaces.

* **Refactor**
  * Improved internal statistics and KV cache event handling through RPC-based communication for better performance and scalability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
