### PR TITLE
[https://nvbugs/5741060][fix] Fix pg op test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -441,6 +441,5 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[tp2pp2
 unittest/_torch/modeling/test_modeling_out_of_tree.py::TestOutOfTree::test_llm_api[False] SKIP (https://nvbugs/5739981)
 unittest/_torch/modeling/test_modeling_out_of_tree.py::TestOutOfTree::test_llm_api[True] SKIP (https://nvbugs/5739981)
 unittest/_torch/modeling/test_modeling_out_of_tree.py::TestOutOfTree::test_serve[True] SKIP (https://nvbugs/5739981)
-unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py SKIP (https://nvbugs/5741060)
 full:sm89/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[MMLU-gen_tp=2-ctx_pp=2] SKIP (https://nvbugs/5596337)
 full:sm89/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_tp_pp_symmetric[MMLU-tp2pp2] SKIP (https://nvbugs/5596337)

--- a/tests/unittest/_torch/ray_orchestrator/conftest.py
+++ b/tests/unittest/_torch/ray_orchestrator/conftest.py
@@ -2,7 +2,11 @@ import os
 import sys
 
 import pytest
-import ray
+
+try:
+    import ray
+except ModuleNotFoundError:
+    from tensorrt_llm import ray_stub as ray
 
 from tensorrt_llm._utils import mpi_disabled
 
@@ -33,7 +37,7 @@ def setup_ray_cluster():
     }
     ray_init_args = {
         "include_dashboard": False,
-        "namespace": "test_allreduce_pg_op",
+        "namespace": "test",
         "ignore_reinit_error": True,
         "runtime_env": runtime_env
     }

--- a/tests/unittest/_torch/ray_orchestrator/conftest.py
+++ b/tests/unittest/_torch/ray_orchestrator/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+import ray
 
 from tensorrt_llm._utils import mpi_disabled
 
@@ -21,3 +22,24 @@ if not mpi_disabled():
     pytest.skip(
         "Ray tests are only tested in Ray CI stage or with --run-ray flag",
         allow_module_level=True)
+
+
+@pytest.fixture(scope="function")
+def setup_ray_cluster():
+    runtime_env = {
+        "env_vars": {
+            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"
+        }
+    }
+    ray_init_args = {
+        "include_dashboard": False,
+        "namespace": "test_allreduce_pg_op",
+        "ignore_reinit_error": True,
+        "runtime_env": runtime_env
+    }
+    try:
+        ray.init(address="local", **ray_init_args)
+        yield
+    finally:
+        if ray.is_initialized():
+            ray.shutdown()

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
@@ -258,12 +258,11 @@ def test_allgather_pg_op(seq_len, hidden_size, var_len):
                                                         expected_result, sizes)
                 for remotePGTest in remotePGTests
             ])
+        for r in results:
+            assert r is True
     finally:
         if ray.is_initialized():
             ray.shutdown()
-
-    for r in results:
-        assert r is True
 
 
 @pytest.mark.gpu2
@@ -343,12 +342,11 @@ def test_reducescatter_pg_op(seq_len, hidden_size, var_len):
                 for remotePGTest, expected_result in zip(
                     remotePGTests, expected_result_list)
             ])
+        for r in results:
+            assert r is True
     finally:
         if ray.is_initialized():
             ray.shutdown()
-
-    for r in results:
-        assert r is True
 
 
 @pytest.mark.gpu2
@@ -402,9 +400,8 @@ def test_allreduce_pg_op(seq_len, hidden_size):
                                                     expected_result)
             for remotePGTest in remotePGTests
         ])
+        for r in results:
+            assert r is True
     finally:
         if ray.is_initialized():
             ray.shutdown()
-
-    for r in results:
-        assert r is True

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
@@ -29,7 +29,6 @@ class AllgatherPGTest:
         self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
 
         torch.cuda.set_device(self.local_gpu)
-        self.local_device = torch.device(f"cuda:{self.local_gpu}")
 
         torch.distributed.init_process_group(
             backend="cuda:nccl,cpu:gloo",
@@ -39,8 +38,8 @@ class AllgatherPGTest:
 
     @torch.inference_mode()
     def run_allgather_pg_op(self, test_tensor, expected_result, sizes):
-        test_tensor = test_tensor.to(self.local_device)
-        expected_result = expected_result.to(self.local_device)
+        test_tensor = test_tensor.cuda()
+        expected_result = expected_result.cuda()
 
         mapping = Mapping(world_size=self.world_size,
                           gpus_per_node=self.world_size,
@@ -83,7 +82,6 @@ class ReducescatterPGTest:
         self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
 
         torch.cuda.set_device(self.local_gpu)
-        self.local_device = torch.device(f"cuda:{self.local_gpu}")
 
         torch.distributed.init_process_group(
             backend="cuda:nccl,cpu:gloo",
@@ -93,8 +91,8 @@ class ReducescatterPGTest:
 
     @torch.inference_mode()
     def run_reducescatter_pg_op(self, test_tensor, expected_result, sizes):
-        test_tensor = test_tensor.to(self.local_device)
-        expected_result = expected_result.to(self.local_device)
+        test_tensor = test_tensor.cuda()
+        expected_result = expected_result.cuda()
 
         mapping = Mapping(world_size=self.world_size,
                           gpus_per_node=self.world_size,
@@ -137,7 +135,6 @@ class AllreducePGTest:
         self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
 
         torch.cuda.set_device(self.local_gpu)
-        self.local_device = torch.device(f"cuda:{self.local_gpu}")
 
         torch.distributed.init_process_group(
             backend="cuda:nccl,cpu:gloo",
@@ -147,8 +144,8 @@ class AllreducePGTest:
 
     @torch.inference_mode()
     def run_allreduce_pg_op(self, test_tensor, expected_result):
-        test_tensor = test_tensor.to(self.local_device)
-        expected_result = expected_result.to(self.local_device)
+        test_tensor = test_tensor.cuda()
+        expected_result = expected_result.cuda()
 
         mapping = Mapping(world_size=self.world_size,
                           gpus_per_node=self.world_size,

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py
@@ -16,19 +16,19 @@ from tensorrt_llm.mapping import Mapping
 
 
 @ray.remote(num_gpus=1)
-class AllgatherPGTest:
+class PgOpTest:
 
     def __init__(self, rank, world_size):
         self.rank = rank
         self.world_size = world_size
         self.master_address = os.environ["MASTER_ADDR"]
         self.master_port = os.environ["MASTER_PORT"]
+
         assert len(ray.get_gpu_ids()) == 1
         self.gpu = int(ray.get_gpu_ids()[0])
         from tensorrt_llm.executor.ray_gpu_worker import RayWorkerWrapper
-        self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
-
-        torch.cuda.set_device(self.local_gpu)
+        local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
+        torch.cuda.set_device(local_gpu)
 
         torch.distributed.init_process_group(
             backend="cuda:nccl,cpu:gloo",
@@ -36,147 +36,30 @@ class AllgatherPGTest:
             world_size=world_size,
             rank=rank)
 
-    @torch.inference_mode()
-    def run_allgather_pg_op(self, test_tensor, expected_result, sizes):
+        self.mapping = Mapping(world_size=self.world_size,
+                               gpus_per_node=self.world_size,
+                               tp_size=self.world_size,
+                               rank=self.rank)
+        TorchDist(self.mapping)
+
+    def run(self, pg_op_name: str, test_tensor: torch.Tensor,
+            expected_result: torch.Tensor, **additional_kwargs):
+        additional_kwargs.update({
+            "group": self.mapping.tp_group,
+        })
+        if pg_op_name == "allreduce_pg":
+            additional_kwargs.update({"pg": self.mapping.tp_group_pg.boxed()})
+        else:
+            additional_kwargs.update(
+                {"process_group": self.mapping.tp_group_pg.boxed()})
         test_tensor = test_tensor.cuda()
         expected_result = expected_result.cuda()
-
-        mapping = Mapping(world_size=self.world_size,
-                          gpus_per_node=self.world_size,
-                          tp_size=self.world_size,
-                          rank=self.rank)
-        if torch.distributed.is_initialized():
-            TorchDist(mapping)
-        else:
-            raise RuntimeError("torch.distributed is not initialized")
-
-        allgather_pg_op = attrgetter('ops.trtllm.allgather_pg')(torch)
-        output = allgather_pg_op(test_tensor, sizes, mapping.tp_group,
-                                 mapping.tp_group_pg.boxed())
-
+        pg_op_func = attrgetter(f'ops.trtllm.{pg_op_name}')(torch)
+        output = pg_op_func(test_tensor, **additional_kwargs)
         if isinstance(output, (list, tuple)):
             result_tensor = output[0]
         else:
             result_tensor = output
-
-        rtol, atol = 0.05, 0.15
-        torch.testing.assert_close(result_tensor,
-                                   expected_result,
-                                   rtol=rtol,
-                                   atol=atol)
-
-        return True
-
-
-@ray.remote(num_gpus=1)
-class ReducescatterPGTest:
-
-    def __init__(self, rank, world_size):
-        self.rank = rank
-        self.world_size = world_size
-        self.master_address = os.environ["MASTER_ADDR"]
-        self.master_port = os.environ["MASTER_PORT"]
-        assert len(ray.get_gpu_ids()) == 1
-        self.gpu = int(ray.get_gpu_ids()[0])
-        from tensorrt_llm.executor.ray_gpu_worker import RayWorkerWrapper
-        self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
-
-        torch.cuda.set_device(self.local_gpu)
-
-        torch.distributed.init_process_group(
-            backend="cuda:nccl,cpu:gloo",
-            init_method=f"tcp://{self.master_address}:{self.master_port}",
-            world_size=world_size,
-            rank=rank)
-
-    @torch.inference_mode()
-    def run_reducescatter_pg_op(self, test_tensor, expected_result, sizes):
-        test_tensor = test_tensor.cuda()
-        expected_result = expected_result.cuda()
-
-        mapping = Mapping(world_size=self.world_size,
-                          gpus_per_node=self.world_size,
-                          tp_size=self.world_size,
-                          rank=self.rank)
-        if torch.distributed.is_initialized():
-            TorchDist(mapping)
-        else:
-            raise RuntimeError("torch.distributed is not initialized")
-
-        reducescatter_pg_op = attrgetter('ops.trtllm.reducescatter_pg')(torch)
-        output = reducescatter_pg_op(test_tensor, sizes, mapping.tp_group,
-                                     mapping.tp_group_pg.boxed())
-
-        if isinstance(output, (list, tuple)):
-            result_tensor = output[0]
-        else:
-            result_tensor = output
-
-        rtol, atol = 0.05, 0.15
-        torch.testing.assert_close(result_tensor,
-                                   expected_result,
-                                   rtol=rtol,
-                                   atol=atol)
-
-        return True
-
-
-@ray.remote(num_gpus=1)
-class AllreducePGTest:
-
-    def __init__(self, rank, world_size):
-        self.rank = rank
-        self.world_size = world_size
-        self.master_address = os.environ["MASTER_ADDR"]
-        self.master_port = os.environ["MASTER_PORT"]
-        assert len(ray.get_gpu_ids()) == 1
-        self.gpu = int(ray.get_gpu_ids()[0])
-        from tensorrt_llm.executor.ray_gpu_worker import RayWorkerWrapper
-        self.local_gpu = RayWorkerWrapper.physical_to_local_id(self.gpu)
-
-        torch.cuda.set_device(self.local_gpu)
-
-        torch.distributed.init_process_group(
-            backend="cuda:nccl,cpu:gloo",
-            init_method=f"tcp://{self.master_address}:{self.master_port}",
-            world_size=world_size,
-            rank=rank)
-
-    @torch.inference_mode()
-    def run_allreduce_pg_op(self, test_tensor, expected_result):
-        test_tensor = test_tensor.cuda()
-        expected_result = expected_result.cuda()
-
-        mapping = Mapping(world_size=self.world_size,
-                          gpus_per_node=self.world_size,
-                          tp_size=self.world_size,
-                          rank=self.rank)
-        if torch.distributed.is_initialized():
-            TorchDist(mapping)
-        else:
-            raise RuntimeError("torch.distributed is not initialized")
-
-        allreduce_pg_op = attrgetter('ops.trtllm.allreduce_pg')(torch)
-        output = allreduce_pg_op(
-            input=test_tensor,
-            residual=None,
-            norm_weight=None,
-            scale=None,
-            bias=None,
-            workspace=None,
-            group=mapping.tp_group,
-            strategy=AllReduceStrategy.NCCL,
-            op=AllReduceFusionOp.NONE,  # Pure allreduce, no fusion
-            eps=1e-5,
-            trigger_completion_at_end=True,
-            rank=self.rank,
-            pg=mapping.tp_group_pg.boxed())
-
-        if isinstance(output, (list, tuple)):
-            result_tensor = output[0]
-        else:
-            result_tensor = output
-
         rtol, atol = 0.05, 0.15
         torch.testing.assert_close(result_tensor,
                                    expected_result,
@@ -191,7 +74,7 @@ class AllreducePGTest:
                          ids=lambda x: f"hidden:{x}")
 @pytest.mark.parametrize("seq_len", [16, 64], ids=lambda x: f"seqlen:{x}")
 @pytest.mark.parametrize("var_len", [True, False], ids=lambda x: f"var_len:{x}")
-def test_allgather_pg_op(seq_len, hidden_size, var_len):
+def test_allgather_pg_op(setup_ray_cluster, seq_len, hidden_size, var_len):
     torch.manual_seed(42)
     dtype = torch.bfloat16
     world_size = 2
@@ -207,59 +90,41 @@ def test_allgather_pg_op(seq_len, hidden_size, var_len):
         expected_result = test_tensor.repeat(world_size, 1)
         sizes = None
 
-    runtime_env = {
-        "env_vars": {
-            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"
-        }
-    }
-    ray_init_args = {
-        "include_dashboard": False,
-        "namespace": "test_allgather_pg_op",
-        "ignore_reinit_error": True,
-        "runtime_env": runtime_env
-    }
+    remotePGTests = []
+    master_port = get_free_port()
+    runtime_env = ray.runtime_env.RuntimeEnv()
+    runtime_env["env_vars"] = os.environ.copy()
+    runtime_env["env_vars"].update({
+        "TLLM_DISABLE_MPI": "1",
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": str(master_port)
+    })
 
-    try:
-        ray.init(address="local", **ray_init_args)
+    for rank in range(world_size):
+        remotePGTests.append(
+            PgOpTest.options(runtime_env=runtime_env).remote(rank, world_size))
 
-        master_port = get_free_port()
-        runtime_env = ray.runtime_env.RuntimeEnv()
-        runtime_env["env_vars"] = os.environ.copy()
-        runtime_env["env_vars"].update({
-            "TLLM_DISABLE_MPI": "1",
-            "MASTER_ADDR": "127.0.0.1",
-            "MASTER_PORT": str(master_port)
-        })
+    ray.get(
+        [remotePGTest.__ray_ready__.remote() for remotePGTest in remotePGTests])
 
-        remotePGTests = []
-        for rank in range(world_size):
-            remotePGTests.append(
-                AllgatherPGTest.options(runtime_env=runtime_env).remote(
-                    rank, world_size))
-
-        ray.get([
-            remotePGTest.__ray_ready__.remote()
+    if var_len:
+        results = ray.get([
+            remotePGTest.run.remote("allgather_pg",
+                                    test_tensor,
+                                    expected_result,
+                                    sizes=sizes) for remotePGTest, test_tensor
+            in zip(remotePGTests, test_tensor_list)
+        ])
+    else:
+        results = ray.get([
+            remotePGTest.run.remote("allgather_pg",
+                                    test_tensor,
+                                    expected_result,
+                                    sizes=sizes)
             for remotePGTest in remotePGTests
         ])
-
-        if var_len:
-            results = ray.get([
-                remotePGTest.run_allgather_pg_op.remote(test_tensor,
-                                                        expected_result, sizes)
-                for remotePGTest, test_tensor in zip(remotePGTests,
-                                                     test_tensor_list)
-            ])
-        else:
-            results = ray.get([
-                remotePGTest.run_allgather_pg_op.remote(test_tensor,
-                                                        expected_result, sizes)
-                for remotePGTest in remotePGTests
-            ])
-        for r in results:
-            assert r is True
-    finally:
-        if ray.is_initialized():
-            ray.shutdown()
+    for r in results:
+        assert r is True
 
 
 @pytest.mark.gpu2
@@ -267,7 +132,7 @@ def test_allgather_pg_op(seq_len, hidden_size, var_len):
                          ids=lambda x: f"hidden:{x}")
 @pytest.mark.parametrize("seq_len", [16, 64], ids=lambda x: f"seqlen:{x}")
 @pytest.mark.parametrize("var_len", [True, False], ids=lambda x: f"var_len:{x}")
-def test_reducescatter_pg_op(seq_len, hidden_size, var_len):
+def test_reducescatter_pg_op(setup_ray_cluster, seq_len, hidden_size, var_len):
     torch.manual_seed(42)
     dtype = torch.bfloat16
     world_size = 2
@@ -290,115 +155,77 @@ def test_reducescatter_pg_op(seq_len, hidden_size, var_len):
         ]
         sizes = None
 
-    runtime_env = {
-        "env_vars": {
-            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"
-        }
-    }
-    ray_init_args = {
-        "include_dashboard": False,
-        "namespace": "test_reducescatter_pg_op",
-        "ignore_reinit_error": True,
-        "runtime_env": runtime_env
-    }
+    master_port = get_free_port()
+    runtime_env = ray.runtime_env.RuntimeEnv()
+    runtime_env["env_vars"] = os.environ.copy()
+    runtime_env["env_vars"].update({
+        "TLLM_DISABLE_MPI": "1",
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": str(master_port)
+    })
 
-    try:
-        ray.init(address="local", **ray_init_args)
+    remotePGTests = []
+    for rank in range(world_size):
+        remotePGTests.append(
+            PgOpTest.options(runtime_env=runtime_env).remote(rank, world_size))
 
-        master_port = get_free_port()
-        runtime_env = ray.runtime_env.RuntimeEnv()
-        runtime_env["env_vars"] = os.environ.copy()
-        runtime_env["env_vars"].update({
-            "TLLM_DISABLE_MPI": "1",
-            "MASTER_ADDR": "127.0.0.1",
-            "MASTER_PORT": str(master_port)
-        })
+    ray.get(
+        [remotePGTest.__ray_ready__.remote() for remotePGTest in remotePGTests])
 
-        remotePGTests = []
-        for rank in range(world_size):
-            remotePGTests.append(
-                ReducescatterPGTest.options(runtime_env=runtime_env).remote(
-                    rank, world_size))
-
-        ray.get([
-            remotePGTest.__ray_ready__.remote()
-            for remotePGTest in remotePGTests
-        ])
-
-        if var_len:
-            results = ray.get([
-                remotePGTest.run_reducescatter_pg_op.remote(
-                    test_tensor, expected_result, sizes)
-                for remotePGTest, expected_result in zip(
-                    remotePGTests, expected_result_list)
-            ])
-        else:
-            results = ray.get([
-                remotePGTest.run_reducescatter_pg_op.remote(
-                    test_tensor, expected_result, sizes)
-                for remotePGTest, expected_result in zip(
-                    remotePGTests, expected_result_list)
-            ])
-        for r in results:
-            assert r is True
-    finally:
-        if ray.is_initialized():
-            ray.shutdown()
+    results = ray.get([
+        remotePGTest.run.remote("reducescatter_pg",
+                                test_tensor,
+                                expected_result,
+                                sizes=sizes) for remotePGTest, expected_result
+        in zip(remotePGTests, expected_result_list)
+    ])
+    for r in results:
+        assert r is True
 
 
 @pytest.mark.gpu2
 @pytest.mark.parametrize("hidden_size", [128, 1024],
                          ids=lambda x: f"hidden:{x}")
 @pytest.mark.parametrize("seq_len", [16, 64], ids=lambda x: f"seqlen:{x}")
-def test_allreduce_pg_op(seq_len, hidden_size):
+def test_allreduce_pg_op(setup_ray_cluster, seq_len, hidden_size):
     torch.manual_seed(42)
     dtype = torch.bfloat16
     world_size = 2
     test_tensor = torch.randn((seq_len, hidden_size), dtype=dtype)
     expected_result = test_tensor * world_size
 
-    runtime_env = {
-        "env_vars": {
-            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"
-        }
-    }
-    ray_init_args = {
-        "include_dashboard": False,
-        "namespace": "test_allreduce_pg_op",
-        "ignore_reinit_error": True,
-        "runtime_env": runtime_env
-    }
+    master_port = get_free_port()
+    runtime_env = ray.runtime_env.RuntimeEnv()
+    runtime_env["env_vars"] = os.environ.copy()
+    runtime_env["env_vars"].update({
+        "TLLM_DISABLE_MPI": "1",
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": str(master_port)
+    })
 
-    try:
-        ray.init(address="local", **ray_init_args)
+    remotePGTests = []
+    for rank in range(world_size):
+        remotePGTests.append(
+            PgOpTest.options(runtime_env=runtime_env).remote(rank, world_size))
 
-        master_port = get_free_port()
-        runtime_env = ray.runtime_env.RuntimeEnv()
-        runtime_env["env_vars"] = os.environ.copy()
-        runtime_env["env_vars"].update({
-            "TLLM_DISABLE_MPI": "1",
-            "MASTER_ADDR": "127.0.0.1",
-            "MASTER_PORT": str(master_port)
-        })
+    ray.get(
+        [remotePGTest.__ray_ready__.remote() for remotePGTest in remotePGTests])
 
-        remotePGTests = []
-        for rank in range(world_size):
-            remotePGTests.append(
-                AllreducePGTest.options(runtime_env=runtime_env).remote(
-                    rank, world_size))
-
-        ray.get([
-            remotePGTest.__ray_ready__.remote()
-            for remotePGTest in remotePGTests
-        ])
-
-        results = ray.get([
-            remotePGTest.run_allreduce_pg_op.remote(test_tensor,
-                                                    expected_result)
-            for remotePGTest in remotePGTests
-        ])
-        for r in results:
-            assert r is True
-    finally:
-        if ray.is_initialized():
-            ray.shutdown()
+    results = ray.get([
+        remotePGTest.run.remote("allreduce_pg",
+                                test_tensor,
+                                expected_result,
+                                residual=None,
+                                norm_weight=None,
+                                scale=None,
+                                bias=None,
+                                workspace=None,
+                                strategy=AllReduceStrategy.NCCL,
+                                op=AllReduceFusionOp.NONE,
+                                eps=1e-5,
+                                trigger_completion_at_end=True,
+                                rank=i)
+        for i, remotePGTest in enumerate(remotePGTests)
+    ])
+    for r in results:
+        assert r is True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixed pg operator tests by manual control over Ray actor device visibility instead of automatic management by Ray.
  * Enabled previously skipped pg operator tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
