### PR TITLE
Don't review: Fix moe bug

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -20,6 +20,7 @@ from .interface import MoE, MoEWeightLoadingMode
 from .moe_load_balancer import get_moe_load_balancer
 from .routing import BaseMoeRoutingMethod
 
+
 def get_moe_cls(
         model_config: ModelConfig,
         override_quant_config: Optional[QuantConfig] = None) -> Type[MoE]:
@@ -341,7 +342,8 @@ def create_moe(
 
     moe_cls = get_moe_cls(model_config, override_quant_config)
 
-    enable_configurable_moe = os.environ.get("ENABLE_CONFIGURABLE_MOE", "0") == "1"
+    enable_configurable_moe = os.environ.get("ENABLE_CONFIGURABLE_MOE",
+                                             "1") == "1"
     if enable_configurable_moe or moe_cls == CuteDslFusedMoE:
         if moe_cls in (DeepGemmFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE,
                        CutlassFusedMoE):
@@ -374,11 +376,11 @@ def create_moe(
                     f"ENABLE_CONFIGURABLE_MOE is set but TRTLLM backend fallback to {moe_cls.__name__} due to quant_config. "
                     f"ConfigurableMoE only supports TRTLLMGenFusedMoE and CuteDslFusedMoE backends. "
                     f"Continuing with legacy MoE backend {moe_cls.__name__}.")
-            else:
-                # For other incompatible backends, raise error
-                raise ValueError(
-                    f"ENABLE_CONFIGURABLE_MOE is set but backend {moe_cls.__name__} is not supported. "
-                    f"ConfigurableMoE only supports TRTLLMGenFusedMoE backend.")
+            # else:
+            #     # For other incompatible backends, raise error
+            #     raise ValueError(
+            #         f"ENABLE_CONFIGURABLE_MOE is set but backend {moe_cls.__name__} is not supported. "
+            #         f"ConfigurableMoE only supports TRTLLMGenFusedMoE backend.")
 
     # Use legacy create_moe_backend for other backends or when ConfigurableMoE is disabled
     return create_moe_backend(

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -20,9 +20,6 @@ from .interface import MoE, MoEWeightLoadingMode
 from .moe_load_balancer import get_moe_load_balancer
 from .routing import BaseMoeRoutingMethod
 
-ENABLE_CONFIGURABLE_MOE = os.environ.get("ENABLE_CONFIGURABLE_MOE", "0") == "1"
-
-
 def get_moe_cls(
         model_config: ModelConfig,
         override_quant_config: Optional[QuantConfig] = None) -> Type[MoE]:
@@ -344,7 +341,8 @@ def create_moe(
 
     moe_cls = get_moe_cls(model_config, override_quant_config)
 
-    if ENABLE_CONFIGURABLE_MOE or moe_cls == CuteDslFusedMoE:
+    enable_configurable_moe = os.environ.get("ENABLE_CONFIGURABLE_MOE", "0") == "1"
+    if enable_configurable_moe or moe_cls == CuteDslFusedMoE:
         if moe_cls in (DeepGemmFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE,
                        CutlassFusedMoE):
             return ConfigurableMoE(
@@ -359,6 +357,7 @@ def create_moe(
                 weight_loading_mode=weight_loading_mode,
                 apply_router_weight_on_input=apply_router_weight_on_input,
                 layer_idx=layer_idx,
+                override_quant_config=override_quant_config,
                 bias=bias,
                 swiglu_alpha=swiglu_alpha,
                 swiglu_beta=swiglu_beta,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -217,7 +217,8 @@ class TRTLLMGenFusedMoE(MoE):
             assert self.has_w4a16_mxfp4 or self.has_w4a8_mxfp4_fp8 or self.has_w4a8_mxfp4_mxfp8, "TRTLLMGenFusedMoE only supports mxfp4 quantization with bias, swiglu_alpha, swiglu_beta and swiglu_limit."
 
     def _get_quant_method(self):
-        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(exclude_kv_cache=True):
+        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
+                exclude_kv_cache=True):
             if self.quant_config.layer_quant_mode.has_fp8_block_scales():
                 return DeepSeekFP8BlockScalesFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_nvfp4():

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -217,7 +217,7 @@ class TRTLLMGenFusedMoE(MoE):
             assert self.has_w4a16_mxfp4 or self.has_w4a8_mxfp4_fp8 or self.has_w4a8_mxfp4_mxfp8, "TRTLLMGenFusedMoE only supports mxfp4 quantization with bias, swiglu_alpha, swiglu_beta and swiglu_limit."
 
     def _get_quant_method(self):
-        if self.quant_config is not None:
+        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(exclude_kv_cache=True):
             if self.quant_config.layer_quant_mode.has_fp8_block_scales():
                 return DeepSeekFP8BlockScalesFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_nvfp4():

--- a/tests/unittest/_torch/modules/test_awq_quantization.py
+++ b/tests/unittest/_torch/modules/test_awq_quantization.py
@@ -108,21 +108,21 @@ def test_fused_moe_trtllm_gen_input_scaling(has_scale):
     intermediate_size = 256
     top_k = 2
     seq_len = 4
-    
+
     # Create pretrained_config with necessary parameters (following test_fused_moe.py pattern)
     pretrained_config = PretrainedConfig()
     pretrained_config.num_experts = num_experts
     pretrained_config.hidden_size = hidden_size
     pretrained_config.intermediate_size = intermediate_size
     pretrained_config.torch_dtype = torch.bfloat16
-    
+
     mapping = Mapping(world_size=1, rank=0, tp_size=1)
     quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
     model_config = ModelConfig(
         pretrained_config=pretrained_config,
         mapping=mapping,
         quant_config=quant_config,
-        moe_backend="TRTLLM"
+        moe_backend="TRTLLM",
     )
 
     routing_method = DefaultMoeRoutingMethod(top_k=top_k)
@@ -140,7 +140,7 @@ def test_fused_moe_trtllm_gen_input_scaling(has_scale):
     # Set fc31_act_scale directly (simulating AWQ pre_quant_scale)
     if has_scale:
         scale = torch.full((hidden_size,), 0.5, dtype=torch.bfloat16, device="cuda")
-        
+
         # For ConfigurableMoE, set fc31_act_scale on backend instead of the wrapper
         if isinstance(moe, ConfigurableMoE):
             moe.backend.fc31_act_scale = torch.nn.Parameter(scale, requires_grad=False)

--- a/tests/unittest/_torch/modules/test_awq_quantization.py
+++ b/tests/unittest/_torch/modules/test_awq_quantization.py
@@ -2,10 +2,12 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from transformers.configuration_utils import PretrainedConfig
 from utils.util import skip_pre_blackwell
 
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules.fused_moe import DefaultMoeRoutingMethod, create_moe
+from tensorrt_llm._torch.modules.fused_moe.configurable_moe import ConfigurableMoE
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -101,28 +103,36 @@ def test_fused_moe_trtllm_gen_input_scaling(has_scale):
         pytest.skip("CUDA not available")
 
     # Setup
-    mapping = Mapping(world_size=1, rank=0, tp_size=1)
-    quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
-    model_config = ModelConfig(mapping=mapping, quant_config=quant_config, moe_backend="TRTLLM")
-
     num_experts = 8
     hidden_size = 128
     intermediate_size = 256
     top_k = 2
     seq_len = 4
+    
+    # Create pretrained_config with necessary parameters (following test_fused_moe.py pattern)
+    pretrained_config = PretrainedConfig()
+    pretrained_config.num_experts = num_experts
+    pretrained_config.hidden_size = hidden_size
+    pretrained_config.intermediate_size = intermediate_size
+    pretrained_config.torch_dtype = torch.bfloat16
+    
+    mapping = Mapping(world_size=1, rank=0, tp_size=1)
+    quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    model_config = ModelConfig(
+        pretrained_config=pretrained_config,
+        mapping=mapping,
+        quant_config=quant_config,
+        moe_backend="TRTLLM"
+    )
 
     routing_method = DefaultMoeRoutingMethod(top_k=top_k)
 
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
 
-    # Create actual MoE module
+    # Create actual MoE module (parameters inferred from model_config.pretrained_config)
     moe = create_moe(
-        num_experts=num_experts,
         routing_method=routing_method,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        dtype=torch.bfloat16,
         reduce_results=False,
         model_config=model_config,
     ).cuda()
@@ -130,7 +140,13 @@ def test_fused_moe_trtllm_gen_input_scaling(has_scale):
     # Set fc31_act_scale directly (simulating AWQ pre_quant_scale)
     if has_scale:
         scale = torch.full((hidden_size,), 0.5, dtype=torch.bfloat16, device="cuda")
-        moe.fc31_act_scale = torch.nn.Parameter(scale, requires_grad=False)
+        
+        # For ConfigurableMoE, set fc31_act_scale on backend instead of the wrapper
+        if isinstance(moe, ConfigurableMoE):
+            moe.backend.fc31_act_scale = torch.nn.Parameter(scale, requires_grad=False)
+        else:
+            # For direct TRTLLMGenFusedMoE, set on moe itself
+            moe.fc31_act_scale = torch.nn.Parameter(scale, requires_grad=False)
 
     # Prepare input
     x = torch.ones(seq_len, hidden_size, dtype=torch.bfloat16, device="cuda")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for quantization configuration overrides influencing MOE backend selection.
  * Enhanced workspace memory management for distributed MOE training with communication strategies.

* **Bug Fixes**
  * Strengthened quantization method selection with stricter validation requirements.

* **Tests**
  * Updated quantization unit tests with improved compatibility handling for MOE implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
