### PR TITLE
[None][perf] Add more optimization options for MOE CuteDSL finalized kernel

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -1151,6 +1151,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     f"{self.__class__.kernel_class.__name__} supports SM 100 (B200) and SM 103 (B300) only, but got SM {sm_version}"
                 )
 
+            if self.tile_size not in [128, 256]:
+                raise ValueError(
+                    f"{self.__class__.kernel_class.__name__} supports tile size (mma tile M dimension) 128 and 256 only, but got {self.tile_size}"
+                )
+
         def unique_id(self):
             return (
                 self.num_experts,
@@ -1173,9 +1178,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l, n = b.size(0), b.size(1)
 
             # TODO: Add full shmoo
-            mma_tiler_mn_candidates = [(128, 128), (128, 256), (256, 128),
-                                       (256, 256)]
-            cluster_shape_mn_candidates = [(1, 1), (1, 2), (2, 1), (2, 2)]
+            mma_tiler_mn_candidates = [(self.tile_size, 128),
+                                       (self.tile_size, 256)]
+            cluster_shape_mn_candidates = [(self.tile_size // 128, 1),
+                                           (self.tile_size // 128, 2)]
             raster_along_m_candidates = [True, False]
 
             valid_tactics = []

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -1314,12 +1314,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if isinstance(tactic, tuple):
                 mma_tiler_mn, cluster_shape_mn, raster_along_m = tactic
             else:
-                if self.tile_size == 256:
-                    mma_tiler_mn, cluster_shape_mn, raster_along_m = (
-                        256, 128), (2, 1), False
-                else:
-                    mma_tiler_mn, cluster_shape_mn, raster_along_m = (
-                        128, 128), (1, 1), False
+                mma_tiler_mn, cluster_shape_mn, raster_along_m = (
+                    self.tile_size, 128), (self.tile_size // 128, 1), False
 
             cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
                          cluster_shape_mn)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -37,7 +37,7 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass.cutlass_dsl import Int32, T, dsl_user_op
 
 from .utils import is_power_of_2
 
@@ -101,21 +101,21 @@ The accumulator in TMEM must then be loaded to registers before writing back to 
 
 .. code-block:: bash
 
-    python examples/blackwell/contiguous_blockscaled_grouped_gemm.py         \
-      --ab_dtype Float4E2M1FN --out_dtype BFloat16 --acc_dtype Float32            \
+    python blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py         \
+      --ab_dtype Float4E2M1FN --out_dtype BFloat16         \
       --sf_dtype Float8E4M3FN --sf_vec_size 16                                   \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
-      --mnkl 256,4096,7168,1 --use_2cta_instrs --m_aligned 256
+      --benchmark 1024x7168x2048x64
 
 To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/contiguous_blockscaled_grouped_gemm.py     \
-      --ab_dtype Float4E2M1FN --out_dtype BFloat16 --acc_dtype Float32            \
+    ncu python blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py        \\     \
+      --ab_dtype Float4E2M1FN --out_dtype BFloat16           \
       --sf_dtype Float8E4M3FN --sf_vec_size 16                                   \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
-      --mnkl 256,4096,7168,1 --use_2cta_instrs --m_aligned 256
+      --benchmark [80,120,160]x7168x2048x64
 
 Constraints:
 * Supported input data types: mxf8, mxf4, nvf4
@@ -147,6 +147,144 @@ CUDA Graph Support:
 * Only rows within (aligned_groupm[0]+aligned_groupm[1]+...) contain valid data
 * Padding rows in C matrix will not be written by the kernel
 """
+
+
+# TODO(zhichenj): Remove this hook helper function after nvidia-cutlass-dsl 4.4 is released.
+def hooked_PersistentTileSchedulerParams_init(
+    self,
+    problem_shape_ntile_mnl: cute.Shape,
+    cluster_shape_mnk: cute.Shape,
+    swizzle_size: int = 1,
+    raster_along_m: bool = True,
+    *,
+    loc=None,
+    ip=None,
+):
+    if cluster_shape_mnk[2] != 1:
+        raise ValueError(f"unsupported cluster_shape_k {cluster_shape_mnk[2]}")
+    if swizzle_size < 1:
+        raise ValueError(f"expect swizzle_size >= 1, but get {swizzle_size}")
+
+    self.problem_shape_ntile_mnl = problem_shape_ntile_mnl
+    # cluster_shape_mnk is kept for reconstruction
+    self._cluster_shape_mnk = cluster_shape_mnk
+    self.cluster_shape_mn = cluster_shape_mnk[:2]
+    self.swizzle_size = swizzle_size
+    self._raster_along_m = raster_along_m
+    self._loc = loc
+
+    # Apply swizzle if swizzle_size > 1
+    if swizzle_size > 1:
+        problem_shape_ncluster_mnl = cute.round_up(
+            self.problem_layout_ncluster_mnl.shape,
+            (1, swizzle_size, 1) if raster_along_m else (swizzle_size, 1, 1),
+        )
+
+        if raster_along_m:
+            self.problem_layout_ncluster_mnl = cute.make_layout(
+                (
+                    problem_shape_ncluster_mnl[0],
+                    (swizzle_size, problem_shape_ncluster_mnl[1] // swizzle_size),
+                    problem_shape_ncluster_mnl[2],
+                ),
+                stride=(
+                    swizzle_size,
+                    (1, swizzle_size * problem_shape_ncluster_mnl[0]),
+                    problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],
+                ),
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            self.problem_layout_ncluster_mnl = cute.make_layout(
+                (
+                    (swizzle_size, problem_shape_ncluster_mnl[0] // swizzle_size),
+                    problem_shape_ncluster_mnl[1],
+                    problem_shape_ncluster_mnl[2],
+                ),
+                stride=(
+                    (1, swizzle_size * problem_shape_ncluster_mnl[1]),
+                    swizzle_size,
+                    problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],
+                ),
+                loc=loc,
+                ip=ip,
+            )
+
+    # Create FastDivmod divisors (only when swizzle_size == 1 for correctness)
+    # FastDivmod assumes simple col-major/row-major layout, incompatible with swizzled layouts
+    if swizzle_size == 1:
+        problem_shape_ncluster_mnl = cute.ceil_div(
+            self.problem_shape_ntile_mnl, cluster_shape_mnk[:2], loc=loc, ip=ip
+        )
+        if raster_along_m:
+            self.problem_layout_ncluster_mnl = cute.make_layout(
+                problem_shape_ncluster_mnl,
+                stride=(
+                    1,
+                    problem_shape_ncluster_mnl[0],
+                    problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],
+                ),
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            self.problem_layout_ncluster_mnl = cute.make_layout(
+                problem_shape_ncluster_mnl,
+                stride=(
+                    problem_shape_ncluster_mnl[1],
+                    1,
+                    problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],
+                ),
+                loc=loc,
+                ip=ip,
+            )
+        problem_layout_size = cute.size(self.problem_layout_ncluster_mnl, loc=loc, ip=ip)
+        cluster_count_m = self.problem_layout_ncluster_mnl.shape[0]
+        cluster_count_n = self.problem_layout_ncluster_mnl.shape[1]
+
+        # batch_fdd: Used to map linear_idx to work_unit_id (handles persistent scheduling)
+        self.batch_fdd = cute.fast_divmod_create_divisor(problem_layout_size, loc=loc, ip=ip)
+
+        # cluster_shape_m_fdd: Used to decode work_unit_id to cluster coordinates
+        self.cluster_shape_m_fdd = cute.fast_divmod_create_divisor(cluster_count_m, loc=loc, ip=ip)
+
+        # cluster_shape_n_fdd: Used for the second level decomposition
+        self.cluster_shape_n_fdd = cute.fast_divmod_create_divisor(cluster_count_n, loc=loc, ip=ip)
+    else:
+        # FastDivmod not applicable with swizzling, set to None
+        self.batch_fdd = None
+        self.cluster_shape_m_fdd = None
+        self.cluster_shape_n_fdd = None
+
+
+def hooked_get_cluster_work_idx_with_fastdivmod(
+    self, current_work_linear_idx: Int32, *, loc=None, ip=None
+) -> Tuple[Int32, Int32, Int32]:
+    work_iteration, work_unit_id = divmod(current_work_linear_idx, self.params.batch_fdd)
+
+    if self.params._raster_along_m:
+        # raster_along_m=True means column major (m is fastest)
+        # First, get cluster_m using cluster_shape_m_fdd
+        cluster_n_batch, cluster_m = divmod(work_unit_id, self.params.cluster_shape_m_fdd)
+
+        # Then decode cluster_n_batch to get cluster_n and batch_l using FastDivmod
+        batch_l, cluster_n = divmod(cluster_n_batch, self.params.cluster_shape_n_fdd)
+    else:
+        # raster_along_m=False means row major (n is fastest)
+        # First, get cluster_n using cluster_shape_n_fdd
+        cluster_m_batch, cluster_n = divmod(work_unit_id, self.params.cluster_shape_n_fdd)
+
+        # Then decode cluster_m_batch to get cluster_m and batch_l using FastDivmod
+        batch_l, cluster_m = divmod(cluster_m_batch, self.params.cluster_shape_m_fdd)
+
+    return (cluster_m, cluster_n, batch_l)
+
+
+cutlass.utils.PersistentTileSchedulerParams.__init__ = hooked_PersistentTileSchedulerParams_init
+cutlass.utils.StaticPersistentTileScheduler._get_cluster_work_idx_with_fastdivmod = (
+    hooked_get_cluster_work_idx_with_fastdivmod
+)
 
 
 # TODO(zhichenj): try to move these to NVVM wrapper or helper functions
@@ -258,42 +396,37 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
     def __init__(
         self,
         sf_vec_size: int,
-        acc_dtype: Type[cutlass.Numeric],
-        use_2cta_instrs: bool,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
+        raster_along_m: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
 
         This configuration includes several key aspects:
 
         1.  MMA Instruction Settings (tcgen05):
-            - acc_dtype: Data types for MMA accumulator.
             - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
-            - use_2cta_instrs: Boolean indicating if the tcgen05 MMA variant
-              with cta_group=2 should be used.
 
         2.  Cluster Shape:
             - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
 
-        :param acc_dtype: Data type of the accumulator.
-        :type acc_dtype: type[cutlass.Numeric]
         :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
         :type mma_tiler_mn: Tuple[int, int]
-        :param use_2cta_instrs: Boolean, True to use cta_group=2 MMA variant.
-        :type use_2cta_instrs: bool
         :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
         :type cluster_shape_mn: Tuple[int, int]
+        :param raster_along_m: Boolean, True to use raster along M.
+        :type raster_along_m: bool
         """
 
         self.sf_vec_size = sf_vec_size
-        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
-        self.use_2cta_instrs = use_2cta_instrs
+        self.acc_dtype: Type[cutlass.Numeric] = cutlass.Float32
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256 and cluster_shape_mn[0] % 2 == 0
         self.cluster_shape_mn = cluster_shape_mn
+        self.raster_along_m = raster_along_m
         # K dimension is deferred in _setup_attributes
         self.mma_tiler = (*mma_tiler_mn, 1)
 
-        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
         self.occupancy = 1
         self.epilog_warp_id = (0, 1, 2, 3)
@@ -355,7 +488,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         - Computing A/B/C shared memory layout
         - Computing tensor memory allocation columns
         """
-
         self.mma_inst_shape_mn = (
             self.mma_tiler[0],
             self.mma_tiler[1],
@@ -408,6 +540,12 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.mma_tiler[2],
         )
 
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
         # Compute cluster layout
         self.cluster_layout_vmnk = cute.tiled_divide(
             cute.make_layout((*self.cluster_shape_mn, 1)),
@@ -433,6 +571,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.out_dtype,
         )
 
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+
         # Setup A/B/C/Scale stage count in shared memory and ACC stage count in tensor memory
         (
             self.num_acc_stage,
@@ -444,9 +584,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.mma_tiler,
             self.a_dtype,
             self.b_dtype,
-            self.epi_tile,
             self.out_dtype,
             self.gemm_output_layout,
+            self.epi_tile,
             self.sf_dtype,
             self.sf_vec_size,
             self.num_smem_capacity,
@@ -485,6 +625,21 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.epi_tile,
             self.num_c_stage,
         )
+        # Overlap and double buffer accumulator when num_acc_stage == 1 for cta_tile_n = 256 case
+        self.overlapping_accum = self.num_acc_stage == 1
+
+        sf_atom_mn = 32
+
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = (
+            self.cta_tile_shape_mnk[1] * self.num_acc_stage
+            if not self.overlapping_accum
+            else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        )
+
+        self.iter_acc_early_release_in_epilogue = self.num_sf_tmem_cols // self.epi_tile_n
 
         # Compute the number of tensor memory allocation columns
         self.num_tmem_alloc_cols = 512
@@ -497,7 +652,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         out: cute.Tensor,
         sfa: cute.Tensor,
         sfb: cute.Tensor,
-        gemm_output_major: cutlass.Constexpr,
         tile_idx_to_expert_idx: cute.Tensor,
         num_non_exiting_tiles: cute.Tensor,
         tile_idx_to_mn_limit: cute.Tensor,
@@ -525,8 +679,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type sfa: cute.Tensor
         :param sfb: Scale factor tensor B
         :type sfb: cute.Tensor
-        :param gemm_output_major: Major dimension of GEMM output ("n" for N-major/row-major, "m" for M-major/col-major)
-        :type gemm_output_major: cutlass.Constexpr
         :param tile_idx_to_expert_idx: Mapping from tile index to expert ID, shape (permuted_m/cta_tile_m,) where
         cta_tile_m is the CTA tile M size
         :type tile_idx_to_expert_idx: cute.Tensor
@@ -554,13 +706,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.final_scale_dtype: Type[cutlass.Numeric] = token_final_scales.element_type
         self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
         self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.gemm_output_layout = None
-        if cutlass.const_expr(gemm_output_major == "n"):
-            self.gemm_output_layout = utils.LayoutEnum.ROW_MAJOR
-        elif cutlass.const_expr(gemm_output_major == "m"):
-            self.gemm_output_layout = utils.LayoutEnum.COL_MAJOR
-        else:
-            raise ValueError(f"Invalid gemm_output_major: {gemm_output_major}, must be 'n' or 'm'")
+        self.gemm_output_layout = utils.LayoutEnum.ROW_MAJOR
 
         self.topK = token_final_scales.shape[1]
         # Check if input data types are compatible with MMA instruction
@@ -676,19 +822,41 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
         ) * atom_thr_size
 
-        # Compute grid size based on GEMM workspace (permuted space), not final output C
-        # GEMM operates on [permuted_m, n, 1] and then scatters to C [seq_len, n, 1]
-        gemm_m = a.shape[0]  # This is permuted_m (or valid_m if no padding)
-        gemm_n = b.shape[0]  # N dimension
-        gemm_output_shape = (gemm_m, gemm_n, a.shape[2])
         self.tile_sched_params, grid = self._compute_grid(
-            gemm_output_shape,
+            (a.shape[0], b.shape[0], a.shape[2]),
             self.cta_tile_shape_mnk,
             self.cluster_shape_mn,
             max_active_clusters,
+            self.raster_along_m,
         )
 
         self.buffer_align_bytes = 1024
+
+        #### finalized epi layout ####
+        epi_tile_m = cute.size(self.epi_tile[0])
+        epi_tile_n = cute.size(self.epi_tile[1])
+        epi_tile_size = epi_tile_m * epi_tile_n
+        num_epilogue_threads = 32 * len(self.epilog_warp_id)
+        self.ttr_racc_size = epi_tile_size // num_epilogue_threads
+
+        if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
+            # 8-element vectorization for BF16
+            self.epi_layout = cute.make_layout(
+                shape=(self.ttr_racc_size // 8, 4, 2), stride=(8, 2, 1)
+            )
+            self.epi_loop_size = self.ttr_racc_size // 8
+            self.element_offset = 8
+
+        elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
+            # 2-element vectorization for FP32
+            self.epi_layout = cute.make_layout(shape=(self.ttr_racc_size // 2, 2), stride=(2, 1))
+            self.epi_loop_size = self.ttr_racc_size // 2
+            self.element_offset = 2
+        else:
+            # Scalar fallback
+            self.epi_layout = cute.make_layout(shape=(self.ttr_racc_size,), stride=(1,))
+            self.epi_loop_size = self.ttr_racc_size
+            self.element_offset = 1
 
         # Define shared storage for kernel
         @cute.struct
@@ -752,8 +920,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.b_smem_layout_staged,
             self.sfa_smem_layout_staged,
             self.sfb_smem_layout_staged,
-            self.c_smem_layout_staged,
             self.epi_tile,
+            self.epi_layout,
             self.tile_sched_params,
             epilogue_op,
         ).launch(
@@ -808,7 +976,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
 
-    # GPU device kernel
     @cute.kernel
     def kernel(
         self,
@@ -835,8 +1002,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         b_smem_layout_staged: cute.ComposedLayout,
         sfa_smem_layout_staged: cute.Layout,
         sfb_smem_layout_staged: cute.Layout,
-        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
         epi_tile: cute.Tile,
+        epi_layout: cute.Layout,
         tile_sched_params: utils.PersistentTileSchedulerParams,
         epilogue_op: cutlass.Constexpr,
     ):
@@ -1081,8 +1248,29 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         tCrB = tiled_mma.make_fragment_B(sB)
         # (MMA, MMA_M, MMA_N)
         acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
-        # (MMA, MMA_M, MMA_N, STAGE)
-        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, num_acc_stage_overlapped)
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
         gC_mnl = cute.local_tile(
             out, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
         )
@@ -1116,32 +1304,68 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 pipeline.PipelineUserType.Producer, self.num_tile_stage
             )
 
-            while work_tile.is_valid_tile:
-                cur_tile_coord = work_tile.tile_idx
-                mma_tile_coord_m = cur_tile_coord[0] // self.cluster_shape_mn[0]
-                if mma_tile_coord_m < num_non_exiting_tiles[0]:
-                    tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            num_valid_tiles = num_non_exiting_tiles[0]
+
+            if cutlass.const_expr(self.raster_along_m):
+                while work_tile.is_valid_tile:
                     cur_tile_coord = work_tile.tile_idx
+                    mma_tile_coord_m = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
                     expert_idx = tile_idx_to_expert_idx[mma_tile_coord_m]
-                    with cute.arch.elect_one():
-                        sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
-                        sInfo[(1, tile_info_producer_state.index)] = cur_tile_coord[1]
-                        sInfo[(2, tile_info_producer_state.index)] = expert_idx
-                        sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(
-                            work_tile.is_valid_tile
+                    tile_idx = mma_tile_coord_m
+
+                    if tile_idx < num_valid_tiles:
+                        tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                        with cute.arch.elect_one():
+                            sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
+                            sInfo[(1, tile_info_producer_state.index)] = cur_tile_coord[1]
+                            sInfo[(2, tile_info_producer_state.index)] = expert_idx
+                            sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(
+                                work_tile.is_valid_tile
+                            )
+                            # fence view async shared
+                        cute.arch.fence_proxy(
+                            cute.arch.ProxyKind.async_shared,
+                            space=cute.arch.SharedSpace.shared_cta,
                         )
-                        # fence view async shared
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
 
-                    self.sched_sync_barrier.arrive_and_wait()
-                    tile_info_pipeline.producer_commit(tile_info_producer_state)
-                    tile_info_producer_state.advance()
+                        self.sched_sync_barrier.arrive_and_wait()
+                        tile_info_pipeline.producer_commit(tile_info_producer_state)
+                        tile_info_producer_state.advance()
 
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+            else:
+                is_continue = cutlass.Boolean(1)
+                while work_tile.is_valid_tile and is_continue:
+                    cur_tile_coord = work_tile.tile_idx
+                    mma_tile_coord_m = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
+                    expert_idx = tile_idx_to_expert_idx[mma_tile_coord_m]
+                    tile_idx = mma_tile_coord_m
+
+                    if tile_idx < num_valid_tiles:
+                        tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                        with cute.arch.elect_one():
+                            sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
+                            sInfo[(1, tile_info_producer_state.index)] = cur_tile_coord[1]
+                            sInfo[(2, tile_info_producer_state.index)] = expert_idx
+                            sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(
+                                work_tile.is_valid_tile
+                            )
+                            # fence view async shared
+                        cute.arch.fence_proxy(
+                            cute.arch.ProxyKind.async_shared,
+                            space=cute.arch.SharedSpace.shared_cta,
+                        )
+
+                        self.sched_sync_barrier.arrive_and_wait()
+                        tile_info_pipeline.producer_commit(tile_info_producer_state)
+                        tile_info_producer_state.advance()
+
+                    else:
+                        is_continue = cutlass.Boolean(0)
+
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
 
             tile_info_pipeline.producer_acquire(tile_info_producer_state)
             with cute.arch.elect_one():
@@ -1305,7 +1529,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
             # Make SFA tmem tensor
             sfa_tmem_ptr = cute.recast_ptr(
-                acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base),
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
                 dtype=self.sf_dtype,
             )
             # (MMA, MMA_M, MMA_K)
@@ -1318,10 +1542,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
 
             # Make SFB tmem tensor
+            # Make SFB tmem tensor
             sfb_tmem_ptr = cute.recast_ptr(
-                acc_tmem_ptr
-                + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
-                + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
                 dtype=self.sf_dtype,
             )
             # (MMA, MMA_N, MMA_K)
@@ -1383,7 +1606,13 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     tile_info[2],
                 )
 
-                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
 
                 tCtSFB_mma = tCtSFB
                 if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
@@ -1394,8 +1623,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     )
                     shifted_ptr = cute.recast_ptr(
                         acc_tmem_ptr
-                        + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
-                        + tcgen05.find_tmem_tensor_col_offset(tCtSFA)
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
                         + offset,
                         dtype=self.sf_dtype,
                     )
@@ -1405,13 +1634,13 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
                     shifted_ptr = cute.recast_ptr(
                         acc_tmem_ptr
-                        + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
-                        + tcgen05.find_tmem_tensor_col_offset(tCtSFA)
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
                         + offset,
                         dtype=self.sf_dtype,
                     )
                     tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
-                    #
+                #
                 # Wait for accumulator buffer empty
                 #
                 if is_leader_cta:
@@ -1554,11 +1783,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
             tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.out_dtype)
 
-            copy_atom_r2s = sm100_utils.get_smem_store_op(
-                self.gemm_output_layout, self.out_dtype, self.acc_dtype, tiled_copy_t2r
-            )
-            tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
-
             acc_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
             )
@@ -1594,9 +1818,18 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 expert_idx = mma_tile_coord_mnl[2]
                 alpha_val = alpha[expert_idx]
 
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = (
+                        cutlass.Boolean(True) if acc_stage_index == 0 else cutlass.Boolean(False)
+                    )
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
                 # Set tensor memory buffer for current tile
                 # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
-                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_stage_index)]
 
                 #
                 # Wait for accumulator buffer full
@@ -1617,75 +1850,77 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
                 token_idx = cutlass.Int32(0)
                 token_scale = self.final_scale_dtype(0.0)
-                topK = token_final_scales.shape[1]
-
                 tile_mn_limit = tile_idx_to_mn_limit[mma_tile_coord_mnl[0]]
+                is_valid_row = permuted_row < tile_mn_limit
 
-                if permuted_row < tile_mn_limit:
+                if is_valid_row:
+                    topK = token_final_scales.shape[1]
                     token_idx = expanded_idx // topK
                     topk_idx = expanded_idx % topK
                     token_scale = token_final_scales[(token_idx, topk_idx)]
+                    alpha_val = alpha_val * token_scale
 
                 scatter_out = cute.domain_offset(
                     (token_idx, 0, 0),
                     out,  # Use original tensor to get real pointer
                 )
 
-                if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
-                    layout = cute.make_layout(
-                        shape=(cute.size(tTR_rAcc) // 8, 4, 2), stride=(8, 2, 1)
-                    )
-                    loop_size = cute.size(tTR_rAcc) // 8
-                elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
-                    layout = cute.make_layout(shape=(cute.size(tTR_rAcc) // 2, 2), stride=(2, 1))
-                    loop_size = cute.size(tTR_rAcc) // 2
-                else:
-                    layout = cute.make_layout(shape=(cute.size(tTR_rAcc),), stride=(1,))
-                    loop_size = cute.size(tTR_rAcc)
-
                 for subtile_idx in cutlass.range(subtile_cnt):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = subtile_cnt - 1 - subtile_idx
                     #
                     # Load accumulator from tensor memory buffer to register
                     #
-                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
 
                     cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                    #
+                    # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
+                    #
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            # Fence for TMEM load
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+
                     # Get vectorized accumulator and apply alpha scaling
-                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
-                    acc_vec_scaled = alpha_val * acc_vec
+                    acc_vec = tTR_rAcc.load()
+                    acc_vec_final = alpha_val * acc_vec
 
-                    # Apply router scale to the entire row (broadcast scalar to vector)
-                    acc_vec_finalized = token_scale * acc_vec_scaled
+                    tTR_rC.store(acc_vec_final.to(self.out_dtype))
 
-                    tTR_rC.store(acc_vec_finalized.to(self.out_dtype))
-                    rOut_epi = cute.make_tensor(tTR_rC.iterator, layout)
+                    if is_valid_row:
+                        rOut_epi = cute.make_tensor(tTR_rC.iterator, epi_layout)
 
-                    if permuted_row < tile_mn_limit:
-                        coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[
+                        base_coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[
                             1
-                        ] + subtile_idx * cute.size(tTR_rAcc)
+                        ] + real_subtile_idx * cute.size(tTR_rC)
 
-                        for index in cutlass.range(loop_size):
+                        for index in cutlass.range(self.epi_loop_size, unroll_full=True):
+                            coord_n = base_coord_n + index * self.element_offset
                             scatter_out_offset = cute.domain_offset((0, coord_n, 0), scatter_out)
                             if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
                                 rOut_epi_packed = rOut_epi[index, None, None]
                                 vectorized_atomic_add_bf16x8(rOut_epi_packed, scatter_out_offset)
-                                coord_n += cute.size(rOut_epi_packed)
                             elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
                                 rOut_epi_packed = rOut_epi[index, None]
                                 vectorized_atomic_add_fp32x2(rOut_epi_packed, scatter_out_offset)
-                                coord_n += cute.size(rOut_epi_packed)
                             else:
                                 rOut_epi_packed = rOut_epi[index]
                                 atomic_add_func(rOut_epi_packed, scatter_out_offset)
-                                coord_n += 1
-                    self.epilog_sync_barrier.arrive_and_wait()
                 #
                 # Async arrive accumulator buffer empty
                 #
-                with cute.arch.elect_one():
-                    acc_pipeline.consumer_release(acc_consumer_state)
-                acc_consumer_state.advance()
+                if cutlass.const_expr(not self.overlapping_accum):
+                    cute.arch.fence_view_async_tmem_load()
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
 
                 #
                 # Advance to next tile
@@ -1776,9 +2011,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         mma_tiler_mnk: Tuple[int, int, int],
         a_dtype: Type[cutlass.Numeric],
         b_dtype: Type[cutlass.Numeric],
-        epi_tile: cute.Tile,
         out_dtype: Type[cutlass.Numeric],
         gemm_output_layout: utils.LayoutEnum,
+        epi_tile: cute.Tile,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         num_smem_capacity: int,
@@ -1856,14 +2091,14 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
             + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
         )
-        # 1024B alignment
+        # 1024B alignment for mbar
         mbar_helpers_bytes = 1024
 
         # Calculate A/B stages:
         # Start with total smem per CTA (capacity / occupancy)
         # Subtract reserved bytes and initial C stages bytes
         # Divide remaining by bytes needed per A/B stage
-        num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes)) // ab_bytes_per_stage
+        num_ab_stage = (num_smem_capacity // occupancy - mbar_helpers_bytes) // ab_bytes_per_stage
 
         # Refine epilogue stages:
         # Calculate remaining smem after allocating for A/B stages and reserved bytes
@@ -1877,6 +2112,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         cta_tile_shape_mnk: Tuple[int, int, int],
         cluster_shape_mn: Tuple[int, int],
         max_active_clusters: cutlass.Constexpr,
+        raster_along_m: bool,
     ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
         """Use persistent tile scheduler to compute the grid size based on GEMM shape.
 
@@ -1888,6 +2124,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type cluster_shape_mn: tuple[int, int]
         :param max_active_clusters: Maximum number of active clusters.
         :type max_active_clusters: cutlass.Constexpr
+        :param raster_along_m: Boolean, True to use raster along M.
+        :type raster_along_m: bool
 
         :return: A tuple containing:
             - tile_sched_params: Parameters for the persistent tile scheduler.
@@ -1903,7 +2141,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         num_ctas_mnl = (num_ctas_m, num_ctas_n, num_ctas_l)
         cluster_shape_mnl = (*cluster_shape_mn, 1)
 
-        tile_sched_params = utils.PersistentTileSchedulerParams(num_ctas_mnl, cluster_shape_mnl)
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl, raster_along_m=raster_along_m
+        )
         grid = utils.StaticPersistentTileScheduler.get_grid_shape(
             tile_sched_params, max_active_clusters
         )
@@ -1943,7 +2183,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         ab_dtype: Type[cutlass.Numeric],
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
-        acc_dtype: Type[cutlass.Numeric],
         out_dtype: Type[cutlass.Numeric],
     ) -> bool:
         """
@@ -1955,8 +2194,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type sf_dtype: Type[cutlass.Numeric]
         :param sf_vec_size: The vector size of the scale factor
         :type sf_vec_size: int
-        :param acc_dtype: The data type of the accumulator
-        :type acc_dtype: Type[cutlass.Numeric]
         :param out_dtype: The data type of the output tensor
         :type out_dtype: Type[cutlass.Numeric]
 
@@ -1985,8 +2222,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
             is_valid = False
 
-        if acc_dtype not in {cutlass.Float32}:
-            is_valid = False
         if out_dtype not in {cutlass.Float32, cutlass.Float16, cutlass.BFloat16}:
             is_valid = False
 
@@ -1998,7 +2233,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         out_dtype: Type[cutlass.Numeric],
         a_major: str,
         b_major: str,
-        c_major: str,
+        out_major: str,
     ) -> bool:
         """
         Check if layouts and dtypes are valid combinations
@@ -2011,8 +2246,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type a_major: str
         :param b_major: The major dimension of the B tensor
         :type b_major: str
-        :param c_major: The major dimension of the C tensor
-        :type c_major: str
+        :param out_major: The major dimension of the C tensor
+        :type out_major: str
 
         :return: True if the layouts are valid, False otherwise
         :rtype: bool
@@ -2021,16 +2256,14 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
             is_valid = False
-        if out_dtype is cutlass.Float4E2M1FN and c_major == "m":
+        if out_dtype is cutlass.Float4E2M1FN and out_major == "m":
             is_valid = False
         return is_valid
 
     @staticmethod
     def is_valid_mma_tiler_and_cluster_shape(
-        use_2cta_instrs: bool,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
-        m_aligned: cutlass.Int64,
     ) -> bool:
         """
         Check if the mma tiler and cluster shape are valid
@@ -2041,8 +2274,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type mma_tiler_mn: Tuple[int, int]
         :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
         :type cluster_shape_mn: Tuple[int, int]
-        :param m_aligned: The alignment requirement for group M dimension (default: 128)
-        :type m_aligned: cutlass.Int64
 
         :return: True if the mma tiler and cluster shape are valid, False otherwise
         :rtype: bool
@@ -2050,18 +2281,15 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         is_valid = True
 
         # Skip invalid mma tile shape
-        if not (
-            (not use_2cta_instrs and mma_tiler_mn[0] in [64, 128])
-            or (use_2cta_instrs and mma_tiler_mn[0] in [128, 256])
-        ):
+        if mma_tiler_mn[0] not in (128, 256):
             is_valid = False
         # Skip invalid mma tile n
         if mma_tiler_mn[1] not in (64, 128, 192, 256):
             is_valid = False
-        # Skip illegal cluster shape
-        if cluster_shape_mn[0] % (2 if use_2cta_instrs else 1) != 0:
-            is_valid = False
 
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
         # Skip invalid cluster shape
         if (
             cluster_shape_mn[0] * cluster_shape_mn[1] > 16
@@ -2074,21 +2302,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             or not is_power_of_2(cluster_shape_mn[0])
             or not is_power_of_2(cluster_shape_mn[1])
         ):
-            is_valid = False
-        cluster_tiler_m = (cluster_shape_mn[0] // (2 if use_2cta_instrs else 1)) * mma_tiler_mn[0]
-
-        # Skip invalid cluster tiler shape since contiguous layout can't handle oob access
-        # The contiguous layout means the aligned data is stored in a contiguous manner.
-        # It can't handle runtime oob when alignment is not align with the tile_M,
-        # since the problem shape of TMA store can't be changed at runtime.
-        if cluster_tiler_m not in [64, 128, 256]:
-            is_valid = False
-
-        # Check if m_aligned is a multiple of cluster_tiler_m
-        # This ensures that each group's M dimension (which is a multiple of m_aligned)
-        # won't be split across tiles, preventing a single tile from loading data
-        # from multiple groups (which would access wrong B matrix data)
-        if m_aligned % mma_tiler_mn[0] != 0:
             is_valid = False
 
         return is_valid
@@ -2103,7 +2316,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         out_dtype: Type[cutlass.Numeric],
         a_major: str,
         b_major: str,
-        c_major: str,
+        out_major: str,
     ) -> bool:
         """
         Check if the tensor alignment is valid
@@ -2124,8 +2337,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type a_major: str
         :param b_major: The major axis of the B tensor
         :type b_major: str
-        :param c_major: The major axis of the C tensor
-        :type c_major: str
+        :param out_major: The major axis of the C tensor
+        :type out_major: str
 
         :return: True if the problem shape is valid, False otherwise
         :rtype: bool
@@ -2141,20 +2354,17 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         if (
             not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
             or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
-            or not check_contigous_16B_alignment(out_dtype, c_major == "m", (m, n, l))
+            or not check_contigous_16B_alignment(out_dtype, out_major == "m", (m, n, l))
         ):
             is_valid = False
         return is_valid
 
-    @classmethod
+    @staticmethod
     def can_implement(
-        cls,
         ab_dtype: Type[cutlass.Numeric],
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
-        acc_dtype: Type[cutlass.Numeric],
         out_dtype: Type[cutlass.Numeric],
-        use_2cta_instrs: bool,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
         m: cutlass.Int64,
@@ -2163,8 +2373,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         l: cutlass.Int64,  # noqa: E741
         a_major: str,
         b_major: str,
-        c_major: str,
-        m_aligned: cutlass.Int64,
+        out_major: str,
     ) -> bool:
         """
         Check if the gemm can be implemented
@@ -2175,12 +2384,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type sf_dtype: Type[cutlass.Numeric]
         :param sf_vec_size: The vector size of the scale factor
         :type sf_vec_size: int
-        :param acc_dtype: The data type of the accumulator
-        :type acc_dtype: Type[cutlass.Numeric]
         :param out_dtype: The data type of the output tensor
         :type out_dtype: Type[cutlass.Numeric]
-        :param use_2cta_instrs: Whether to use 2 CTA groups
-        :type use_2cta_instrs: bool
         :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
         :type mma_tiler_mn: Tuple[int, int]
         :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
@@ -2197,33 +2402,33 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type a_major: str
         :param b_major: The major axis of the B tensor
         :type b_major: str
-        :param c_major: The major axis of the C tensor
-        :type c_major: str
-        :param m_aligned: The alignment requirement for group M dimension (default: 128)
-        :type m_aligned: cutlass.Int64
+        :param out_major: The major axis of the C tensor
+        :type out_major: str
 
         :return: True if the gemm can be implemented, False otherwise
         :rtype: bool
         """
         can_implement = True
         # Skip unsupported types
-        if not cls.is_valid_dtypes_and_scale_factor_vec_size(
-            ab_dtype, sf_dtype, sf_vec_size, acc_dtype, out_dtype
+        if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, out_dtype
         ):
             can_implement = False
 
         # Skip unsupported layouts
-        if not cls.is_valid_layouts(ab_dtype, out_dtype, a_major, b_major, c_major):
+        if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.is_valid_layouts(
+            ab_dtype, out_dtype, a_major, b_major, out_major
+        ):
             can_implement = False
 
         # Skip invalid mma tile shape and cluster shape
-        if not cls.is_valid_mma_tiler_and_cluster_shape(
-            use_2cta_instrs, mma_tiler_mn, cluster_shape_mn, m_aligned
+        if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mn, cluster_shape_mn
         ):
             can_implement = False
         # Skip illegal problem shape for load/store alignment
-        if not cls.is_valid_tensor_alignment(
-            m, n, k, l, ab_dtype, out_dtype, a_major, b_major, c_major
+        if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, out_dtype, a_major, b_major, out_major
         ):
             can_implement = False
         # Skip unsupported A/B layout
@@ -2301,7 +2506,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             c,
             a_sf,
             b_sf,
-            "n",
             tile_idx_to_group_idx,
             num_non_exiting_tiles,
             tile_idx_to_mn_limit,
@@ -2312,3 +2516,18 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             token_final_scales=token_final_scales,
             epilogue_op=epilogue_op,
         )
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1,0 +1,1087 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# TODO(zhichenj): This file is copied and modified from cutlass example
+
+"""Example usage of the kernel.
+
+python cutlass_ir/compiler/python/examples/blackwell/contiguous_blockscaled_grouped_gemm_finalize_fusion.py \
+        --ab_dtype Float4E2M1FN --out_dtype Float32 \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 256,256 --cluster_shape_mn 1,1 --seq_len 4096 \
+        --benchmark 128x7168x2048x8 --iterations 1
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+try:
+    from tensorrt_llm._torch.cute_dsl_kernels.blackwell import (
+        blockscaled_contiguous_grouped_gemm_finalize_fusion as kernel_module,
+    )
+except (ModuleNotFoundError, ImportError):
+    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    from blackwell import blockscaled_contiguous_grouped_gemm_finalize_fusion as kernel_module
+
+Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel = (
+    kernel_module.Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel
+)
+cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
+
+try:
+    from .testing import benchmark
+except ImportError:
+    from testing import benchmark
+
+
+def create_mask(group_m_list, cta_tile_mn, permuted_m=None):
+    """Create mask and group mapping for contiguous grouped GEMM.
+
+    :param group_m_list: List of M values for each group (will be aligned to cta_tile_mn[0])
+    :param cta_tile_m: CTA tile size in M dimension (from mma_tiler_mn[0])
+    :param permuted_m: Optional padded M dimension for cuda_graph support. If provided,
+                     tile_idx_to_expert_idx will be padded to this size.
+                     When tile_idx >= num_non_exiting_tiles, the kernel exits.
+
+    Note: For cuda_graph support, set permuted_m to the pre-calculated padded size:
+          permuted_m = m * topK + num_local_experts * (256 - 1)
+          Example: 4096*8 + (256/32)*255 = 34808
+          Only the actual valid rows (aligned_groupm[0]+aligned_groupm[1]+...) contain
+          valid data. The kernel will exit when tile_idx >= num_non_exiting_tiles.
+
+    :return: Tuple of (valid_m, aligned_group_m_list, tile_idx_to_expert_idx, num_non_exiting_tiles)
+             - tile_idx_to_expert_idx: shape (permuted_m/cta_tile_m,) if permuted_m provided, else (valid_m/cta_tile_m,)
+             - num_non_exiting_tiles: scalar value = valid_m/cta_tile_m
+    """
+    m_aligned = cta_tile_mn[0]
+    valid_m = 0
+    aligned_group_m_list = []
+    tile_idx_to_expert_idx = []
+    tile_idx_to_mn_limit = []
+
+    for i, group_m in enumerate(group_m_list):
+        aligned_group_m = ((group_m + m_aligned - 1) // m_aligned) * m_aligned
+        aligned_group_m_list.append(aligned_group_m)
+
+        # Calculate number of tiles for this group based on CTA tile M size
+        # Each tile covers cta_tile_m rows in M dimension
+        num_tiles_in_group = aligned_group_m // cta_tile_mn[0]
+        # Add expert_idx for each tile in this group
+        tile_idx_to_expert_idx.extend([i] * num_tiles_in_group)
+
+        tile_idx_to_mn_limit.extend([group_m + valid_m] * num_tiles_in_group)
+        valid_m += aligned_group_m
+
+    # Compute num_non_exiting_tiles (number of valid tiles in M dimension)
+    num_non_exiting_tiles = len(tile_idx_to_expert_idx)
+
+    # Apply padding if requested (for cuda_graph support)
+    if permuted_m is not None:
+        if permuted_m < valid_m:
+            raise ValueError(
+                f"permuted_m ({permuted_m}) must be >= valid_m ({valid_m}). "
+                f"Cannot pad to a smaller size."
+            )
+        if permuted_m > valid_m:
+            # Calculate how many padding tiles are needed based on CTA tile M size
+            num_padding_tiles = (permuted_m - valid_m) // cta_tile_mn[0]
+            # Pad with 0 (these tiles won't be accessed due to num_non_exiting_tiles check)
+            tile_idx_to_expert_idx.extend([0] * num_padding_tiles)
+
+    # Final shape of tile_idx_to_expert_idx: (permuted_m/cta_tile_m,) if permuted_m provided, else (valid_m/cta_tile_m,)
+    tile_idx_to_expert_idx = torch.tensor(tile_idx_to_expert_idx, device="cuda", dtype=torch.int32)
+    num_non_exiting_tiles_tensor = torch.tensor(
+        [num_non_exiting_tiles], device="cuda", dtype=torch.int32
+    )
+
+    tile_idx_to_mn_limit_tensor = torch.tensor(
+        tile_idx_to_mn_limit, device="cuda", dtype=torch.int32
+    )
+
+    return (
+        valid_m,
+        aligned_group_m_list,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles_tensor,
+        tile_idx_to_mn_limit_tensor,
+    )
+
+
+def create_fused_finalize_tensors(
+    seq_len, topK, permuted_m, group_m_list, mma_tiler_mn, final_scale_dtype
+):
+    m_aligned = mma_tiler_mn[0]
+    permuted_idx_to_expanded_idx_tensor = torch.empty(
+        (permuted_m,), dtype=torch.int32, device="cuda"
+    ).fill_(-1)
+    # # normalized token final scales
+    token_final_scales = (
+        torch.rand(seq_len, topK).to(dtype=cutlass_torch.dtype(final_scale_dtype)).cuda()
+    )
+    token_final_scales = token_final_scales / token_final_scales.sum(dim=1, keepdim=True)
+
+    start_idx = 0
+    for group_idx in range(len(group_m_list)):
+        m_per_group = group_m_list[group_idx]
+
+        if m_per_group > 0:
+            # Sequential/Blocked assignment for better atomic add memory access (Friendly Layout)
+            # Experts are grouped into sets of size topK.
+            # Expert Set S (experts S*topK ... S*topK+topK-1) serves a contiguous block of tokens.
+            # This ensures that within an expert, we process tokens T, T+1, T+2... sequentially.
+
+            expert_set_idx = group_idx // topK
+            k_in_set = group_idx % topK
+
+            # Start token index for this expert set
+            start_token = expert_set_idx * m_per_group
+
+            # Generate sequential token indices for this expert
+            token_indices = torch.arange(
+                start_token, start_token + m_per_group, dtype=torch.int32, device="cuda"
+            )
+            token_indices = token_indices % seq_len
+
+            # expanded_idx = token_idx * topK + k
+            expanded_idx = token_indices * topK + k_in_set
+
+            permuted_idx_to_expanded_idx_tensor[start_idx : (start_idx + m_per_group)] = (
+                expanded_idx
+            )
+        # Move to next aligned group
+        m_aligned_per_group = ((m_per_group + m_aligned - 1) // m_aligned) * m_aligned
+        start_idx += m_aligned_per_group
+
+    return (
+        permuted_idx_to_expanded_idx_tensor,
+        token_final_scales,
+        from_dlpack(permuted_idx_to_expanded_idx_tensor).mark_layout_dynamic(),
+        from_dlpack(token_final_scales).mark_layout_dynamic(),
+    )
+
+
+def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
+    def ceil_div(a, b):
+        return (a + b - 1) // b
+
+    sf_k = ceil_div(k, sf_vec_size)
+    ref_shape = (l, mn, sf_k)
+
+    atom_m = (32, 4)
+    atom_k = 4
+    mma_shape = (
+        l,
+        ceil_div(mn, atom_m[0] * atom_m[1]),
+        ceil_div(sf_k, atom_k),
+        atom_m[0],
+        atom_m[1],
+        atom_k,
+    )
+
+    ref_permute_order = (1, 2, 0)
+    mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+    # Create f32 ref torch tensor (cpu)
+    ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        ref_shape,
+        torch.float32,
+        permute_order=ref_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=1,
+            max_val=3,
+        ),
+    )
+
+    # Create f32 cute torch tensor (cpu)
+    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape,
+        torch.float32,
+        permute_order=mma_permute_order,
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(
+            min_val=0,
+            max_val=1,
+        ),
+    )
+
+    # convert ref f32 tensor to cute f32 tensor
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+        from_dlpack(ref_f32_torch_tensor_cpu),
+        from_dlpack(cute_f32_torch_tensor_cpu),
+    )
+
+    cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+    # reshape makes memory contiguous
+    ref_f32_torch_tensor_cpu = (
+        ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+        .unsqueeze(-1)
+        .expand(l, mn, sf_k, sf_vec_size)
+        .reshape(l, mn, sf_k * sf_vec_size)
+        .permute(*ref_permute_order)
+    )
+    # prune to mkl for reference check.
+    ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+    # Create dtype cute torch tensor (cpu)
+    cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+        cute_f32_torch_tensor_cpu,
+        dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    # Convert f32 cute tensor to dtype cute tensor
+    cute_tensor = cutlass_torch.convert_cute_tensor(
+        cute_f32_torch_tensor,
+        cute_tensor,
+        dtype,
+        is_dynamic_layout=True,
+    )
+
+    return ref_f32_torch_tensor_cpu, cute_tensor, cute_torch_tensor
+
+
+def create_tensors(
+    l,  # noqa: E741
+    group_m_list,
+    n,
+    k,
+    a_major,
+    b_major,
+    cd_major,
+    ab_dtype,
+    out_dtype,
+    sf_dtype,
+    sf_vec_size,
+    mma_tiler_mn,
+    permuted_m=None,
+    seq_len=None,
+):
+    """Create tensors for contiguous grouped GEMM.
+
+    :param permuted_m: Optional padded M dimension for cuda_graph support. If provided,
+                     A matrix, C matrix, and scale factor A will be padded to this size.
+                     The kernel exits when tile_idx >= num_non_exiting_tiles.
+    :param topK: Number of experts per token (for MoE with fused finalize)
+    :return: Tuple of (a_tensor, b_tensor, out_tensor, sfa_tensor, sfb_tensor,
+                      tile_idx_to_expert_idx, num_non_exiting_tiles, alpha,
+                      a_torch_cpu, b_torch_cpu, out_torch_cpu, sfa_torch_cpu, sfb_torch_cpu,
+                      alpha_torch_cpu, a_torch_gpu, b_torch_gpu, sfa_torch_gpu, sfb_torch_gpu,
+                      out_torch_gpu, aligned_group_m_list, valid_m
+
+    Example with CUDA graph padding:
+        # For MoE: m=4096, topK=8, num_local_experts=256, experts_per_rank=8
+        permuted_m = 4096 * 8 + 8 * 255  # = 34808
+        tensors = create_tensors(
+            l=8,  # num_local_experts
+            group_m_list=[512, 1024, ...],  # actual group sizes
+            n=4096, k=7168,
+            a_major="k", b_major="k", cd_major="n",
+            ab_dtype=cutlass.Float4E2M1FN,
+            out_dtype=cutlass.BFloat16,
+            sf_dtype=cutlass.Float8E4M3FN,
+            sf_vec_size=16,
+            cta_tile_m=128,  # CTA tile size in M dimension
+            permuted_m=34808,  # Enable padding for cuda_graph
+        )
+        # Returns tensors with A, C, and SFA padded to permuted_m rows,
+        # kernel exits early when tile_idx >= num_non_exiting_tiles
+        # Also returns permuted_idx_to_expanded_idx and token_final_scales for fusion
+    """
+    torch.manual_seed(1111)
+
+    alpha_torch_cpu = torch.ones((l,), dtype=torch.float32) * 0.1
+
+    (
+        valid_m,
+        aligned_group_m_list,
+        _tile_idx_to_expert_idx,
+        _num_non_exiting_tiles,
+        _tile_idx_to_mn_limit,
+    ) = create_mask(group_m_list, mma_tiler_mn, permuted_m)
+
+    # Use permuted_m for A/C tensors if provided (for cuda_graph support)
+    tensor_m = permuted_m if permuted_m is not None else valid_m
+
+    a_torch_cpu = cutlass_torch.matrix(1, tensor_m, k, a_major == "m", cutlass.Float32)
+    b_torch_cpu = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    out_torch_cpu = cutlass_torch.matrix(1, seq_len, n, cd_major == "m", cutlass.Float32)
+
+    out_torch_cpu.fill_(0)
+
+    a_tensor, a_torch_gpu = cutlass_torch.cute_tensor_like(
+        a_torch_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch_gpu = cutlass_torch.cute_tensor_like(
+        b_torch_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    out_tensor, out_torch_gpu = cutlass_torch.cute_tensor_like(
+        out_torch_cpu, out_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor with element divisibility for 16B alignment
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    out_tensor.mark_compact_shape_dynamic(
+        mode=1 if cd_major == "n" else 0,
+        stride_order=(2, 0, 1) if cd_major == "n" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    # Use tensor_m (permuted_m if provided) for scale factor A
+    sfa_torch_cpu, sfa_tensor, sfa_torch_gpu = create_scale_factor_tensor(
+        1, tensor_m, k, sf_vec_size, sf_dtype
+    )
+    sfb_torch_cpu, sfb_tensor, sfb_torch_gpu = create_scale_factor_tensor(
+        l, n, k, sf_vec_size, sf_dtype
+    )
+
+    tile_idx_to_expert_idx = from_dlpack(_tile_idx_to_expert_idx).mark_layout_dynamic()
+    num_non_exiting_tiles = from_dlpack(_num_non_exiting_tiles).mark_layout_dynamic()
+    tile_idx_to_mn_limit = from_dlpack(_tile_idx_to_mn_limit).mark_layout_dynamic()
+
+    alpha = from_dlpack(alpha_torch_cpu.cuda()).mark_layout_dynamic()
+
+    out_torch_gpu.fill_(0)
+
+    return (
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        a_torch_cpu,
+        b_torch_cpu,
+        out_torch_cpu,
+        sfa_torch_cpu,
+        sfb_torch_cpu,
+        alpha_torch_cpu,
+        a_torch_gpu,
+        b_torch_gpu,
+        sfa_torch_gpu,
+        sfb_torch_gpu,
+        out_torch_gpu,
+        aligned_group_m_list,
+        valid_m,
+    )
+
+
+def verify_reference_result(
+    a_torch_cpu: torch.Tensor,
+    b_torch_cpu: torch.Tensor,
+    sfa_torch_cpu: torch.Tensor,
+    sfb_torch_cpu: torch.Tensor,
+    alpha_torch_cpu: torch.Tensor,
+    permuted_idx_to_expanded_idx_torch: torch.Tensor,
+    token_final_scales_torch: torch.Tensor,
+    group_m_list: List[int],
+    aligned_group_m_list: List[int],
+    out_dtype: torch.dtype,
+    valid_m: int,
+    n: int,
+    topK: int,
+    seq_len: int,
+) -> torch.Tensor:
+    gemm_output = torch.empty((1, valid_m, n), dtype=torch.float32)
+    valid_mask = torch.zeros((valid_m,), dtype=torch.bool, device="cuda")
+    #########  gemm caculcation #########
+    start = 0
+    for i, group_m in enumerate(aligned_group_m_list):
+        end = start + group_m
+        res_a = torch.einsum(
+            "mk,mk->mk",
+            a_torch_cpu[start:end, :, 0],
+            sfa_torch_cpu[start:end, :, 0],
+        )
+        res_b = torch.einsum("nk,nk->nk", b_torch_cpu[:, :, i], sfb_torch_cpu[:, :, i])
+        gemm_output[0, start:end, :] = torch.einsum("mk,nk->mn", res_a, res_b) * alpha_torch_cpu[i]
+        valid_mask[start : start + group_m_list[i]] = 1
+        start = end
+
+    #########  finalize caculcation#########
+    # Considering BF16 accumulator gpu accuracy error, we used gpu to verify the result
+    gemm_output = gemm_output.permute((1, 2, 0)).cuda()
+
+    final_output = torch.zeros((seq_len, n), dtype=out_dtype).cuda()
+
+    gemm_output = gemm_output[:valid_m, :, 0].clone()  # (valid_m, n)
+    expanded_idx_all = permuted_idx_to_expanded_idx_torch[:valid_m]  # (valid_m,
+
+    # Step 3: Filter valid rows (expanded_idx >= 0)
+    expanded_idx_valid = expanded_idx_all[valid_mask]  # (num_valid,)
+    gemm_output_valid = gemm_output[valid_mask]  # (num_valid, n)
+
+    token_idx = expanded_idx_valid // topK  # (num_valid,)
+    topk_idx = expanded_idx_valid % topK  # (num_valid,)
+
+    scales = token_final_scales_torch[token_idx, topk_idx]  # (num_valid,)
+    scaled_output = gemm_output_valid * scales.unsqueeze(1)  # (num_valid, n)
+    scaled_output = scaled_output.to(out_dtype)
+
+    for i in range(len(token_idx)):
+        final_output[token_idx[i]] += scaled_output[i]
+
+    return final_output
+
+
+def run(
+    nkl: Tuple[int, int, int],
+    group_m_list: Tuple[int, ...],
+    ab_dtype: Type[cutlass.Numeric],
+    out_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    final_scale_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    out_major: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    tolerance: float,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    permuted_m: int = None,
+    topK: int = 8,
+    seq_len: int = 4096,
+    raster_along_m: bool = False,
+    use_cupti: bool = False,
+    **kwargs,
+):
+    """Prepare A/B/C tensors, launch GPU kernel, and reference checking.
+
+    :param nkl: Tuple of (N, K, L) dimensions of the GEMM problem.
+    :param group_m_list: List of M values for each group.
+    :param ab_dtype: Data type for input tensors A and B.
+    :param out_dtype: Data type for the output tensor C.
+    :param sf_dtype: Data type for the scale factor tensors.
+    :param sf_vec_size: Vector size for the scale factor tensors.
+    :param final_scale_dtype: Data type for the final scale factor tensors.
+    :param a_major: The major axis of the A tensor.
+    :param b_major: The major axis of the B tensor.
+    :param out_major: The major axis of the C tensor.
+    :param mma_tiler_mn: The shape of the MMA tile.
+    :param cluster_shape_mn: The shape of the CTA cluster.
+    :param tolerance: Tolerance for result validation.
+    :param warmup_iterations: Number of warmup runs.
+    :param iterations: Number of benchmark iterations.
+    :param skip_ref_check: If True, skips reference checking.
+    :param use_cold_l2: If True, uses a circular buffer to ensure a cold L2 cache.
+    :param permuted_m: Optional padded M dimension for CUDA graph support. If provided,
+                    A/C matrices and scale factor A will be padded to this size.
+    :param topK: Number of experts per token (for MoE with fused finalize)
+    :param seq_len: Sequence length for MoE, used by fused finalize,
+            need to know the sequence length to do finalize correctly.
+    :param raster_along_m: If True, raster along M dimensionfor tile scheduler.
+    :param use_cupti (bool, optional): If True, uses CUPTI to measure execution time.
+            Defaults to False.
+    """
+    m_aligned = mma_tiler_mn[0]
+    use_2cta_instrs = mma_tiler_mn[0] == 256 and cluster_shape_mn[0] % 2 == 0
+
+    print("Running Blackwell Persistent Dense Contiguous Grouped GEMM test with:")
+    print(f"nkl: {nkl}")
+    print(f"group_m_list: {group_m_list}")
+    print(
+        f"AB dtype: {ab_dtype}, C dtype: {out_dtype}, Scale factor dtype: {sf_dtype}, SF Vec size: {sf_vec_size}"
+    )
+    print(f"Group M alignment: {m_aligned}")
+    if permuted_m is not None:
+        print(f"Padded M (CUDA graph support): {permuted_m}")
+    print(f"Fused finalize enabled with topK={topK}")
+    print(f"Sequence length: {seq_len}")
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, Out: {out_major}")
+    print(f"Mma Tiler (M, N): {mma_tiler_mn}, Cluster Shape (M, N): {cluster_shape_mn}")
+    print(f"2CTA MMA instructions: {'True' if use_2cta_instrs else 'False'}")
+    print(f"Use TMA Store: {'True'}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use TMA prefetch: {'True'}")
+    print(f"Raster along M: {raster_along_m}")
+    print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+
+    # Unpack parameters
+    n, k, l = nkl  # noqa: E741
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    # Skip unsupported testcase
+    if not Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel.can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        out_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        m_aligned,
+        n,
+        k,
+        l,
+        a_major,
+        b_major,
+        out_major,
+    ):
+        raise TypeError(
+            f"Unsupported testcase {ab_dtype}, {sf_dtype}, {sf_vec_size}, {out_dtype}, "
+            f"{use_2cta_instrs}, {mma_tiler_mn}, {cluster_shape_mn}, {n}, {k}, {l}, "
+            f"{a_major}, {b_major}, {out_major}, {m_aligned}"
+        )
+
+    (
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        a_torch_cpu,
+        b_torch_cpu,
+        out_torch_cpu,
+        sfa_torch_cpu,
+        sfb_torch_cpu,
+        alpha_torch_cpu,
+        a_torch_gpu,
+        b_torch_gpu,
+        sfa_torch_gpu,
+        sfb_torch_gpu,
+        out_torch_gpu,
+        aligned_group_m_list,
+        valid_m,
+    ) = create_tensors(
+        l,
+        group_m_list,
+        n,
+        k,
+        a_major,
+        b_major,
+        out_major,
+        ab_dtype,
+        out_dtype,
+        sf_dtype,
+        sf_vec_size,
+        mma_tiler_mn,  # cta_tile_m
+        permuted_m,
+        seq_len,  # Pass seq_len as num_tokens for C tensor shape
+    )
+
+    # Calculate actual tensor_m used (with padding if permuted_m provided)
+    tensor_m = permuted_m if permuted_m is not None else valid_m
+
+    (
+        permuted_idx_to_expanded_idx_torch,
+        token_final_scales_torch,
+        permuted_idx_to_expanded_idx,
+        token_final_scales,
+    ) = create_fused_finalize_tensors(
+        seq_len,
+        topK,
+        tensor_m,
+        group_m_list,
+        mma_tiler_mn,
+        final_scale_dtype,
+    )
+
+    # Configure gemm kernel
+    gemm = Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel(
+        sf_vec_size,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        raster_along_m,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+
+    # Initialize Stream
+    current_stream = cutlass_torch.default_stream()
+
+    # Compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        out_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        tile_idx_to_expert_idx,
+        num_non_exiting_tiles,
+        tile_idx_to_mn_limit,
+        alpha,
+        max_active_clusters,
+        current_stream,
+        permuted_idx_to_expanded_idx,
+        token_final_scales,
+        options="--opt-level 2",
+    )
+
+    # Compute reference result
+    if not skip_ref_check:
+        print("Verifying results...")
+        # Execution
+        compiled_gemm(
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            current_stream,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        )
+
+        torch.cuda.synchronize()
+        ref_result = verify_reference_result(
+            a_torch_cpu,
+            b_torch_cpu,
+            sfa_torch_cpu,
+            sfb_torch_cpu,
+            alpha_torch_cpu,
+            permuted_idx_to_expanded_idx_torch,
+            token_final_scales_torch,
+            group_m_list,
+            aligned_group_m_list,
+            out_torch_gpu.dtype,
+            valid_m,
+            n,
+            topK,
+            seq_len,
+        )
+
+        # Convert c back to f32 for comparison.
+        actual_result = out_torch_gpu[:, :, 0]
+        if out_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(actual_result, ref_result, atol=tolerance, rtol=1e-02)
+        elif out_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(1, valid_m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f8.element_type = out_dtype
+            ref_device = ref_result.cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            torch.testing.assert_close(
+                actual_result.cpu(), ref_device.cpu(), atol=tolerance, rtol=1e-02
+            )
+        # {$nv-internal-release begin}
+        elif out_dtype is cutlass.Float4E2M1FN:
+            # Convert ref : f32 -> f4 -> f32
+            ref_f4_ = torch.empty(*(1, valid_m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f4 = from_dlpack(ref_f4_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f4.element_type = out_dtype
+            ref_device = ref_result.cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f4)
+            cute.testing.convert(ref_f4, ref_tensor)
+            torch.testing.assert_close(
+                actual_result.cpu(), ref_device.cpu(), atol=tolerance, rtol=1e-02
+            )
+        # {$nv-internal-release end}
+
+    def generate_tensors():
+        (
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            a_torch_cpu,
+            b_torch_cpu,
+            out_torch_cpu,
+            sfa_torch_cpu,
+            sfb_torch_cpu,
+            alpha_torch_cpu,
+            a_torch_gpu,
+            b_torch_gpu,
+            sfa_torch_gpu,
+            sfb_torch_gpu,
+            out_torch_gpu,
+            aligned_group_m_list,
+            valid_m,
+        ) = create_tensors(
+            l,
+            group_m_list,
+            n,
+            k,
+            a_major,
+            b_major,
+            out_major,
+            ab_dtype,
+            out_dtype,
+            sf_dtype,
+            sf_vec_size,
+            mma_tiler_mn,  # cta_tile_m
+            permuted_m,
+            seq_len,  # Pass seq_len as num_tokens for C tensor shape
+        )
+
+        (
+            permuted_idx_to_expanded_idx_torch,
+            token_final_scales_torch,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        ) = create_fused_finalize_tensors(
+            seq_len,
+            topK,
+            tensor_m,
+            group_m_list,
+            mma_tiler_mn,
+            final_scale_dtype,
+        )
+
+        return cute.testing.JitArguments(
+            a_tensor,
+            b_tensor,
+            out_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            tile_idx_to_expert_idx,
+            num_non_exiting_tiles,
+            tile_idx_to_mn_limit,
+            alpha,
+            current_stream,
+            permuted_idx_to_expanded_idx,
+            token_final_scales,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_torch_gpu.numel() * a_torch_gpu.element_size()
+            + b_torch_gpu.numel() * b_torch_gpu.element_size()
+            + out_torch_gpu.numel() * out_torch_gpu.element_size()
+            + sfa_torch_gpu.numel() * sfa_torch_gpu.element_size()
+            + sfb_torch_gpu.numel() * sfb_torch_gpu.element_size()
+            + (tensor_m // mma_tiler_mn[0])
+            * 4  # tile_idx_to_expert_idx length (tiles) * sizeof(int32)
+            + 1 * 4  # num_non_exiting_tiles (1 element) * sizeof(int32)
+            + alpha_torch_cpu.numel() * alpha_torch_cpu.element_size()
+        )
+        workspace_count = cute.testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        use_cupti=use_cupti,
+    )
+
+    return exec_time  # Return execution time in microseconds
+
+
+if __name__ == "__main__":
+
+    def parse_comma_separated_ints(s: str) -> Tuple[int, ...]:
+        try:
+            return tuple(int(x.strip()) for x in s.split(","))
+        except ValueError:
+            raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.")
+
+    def read_benchmark_file(
+        filepath: str,
+    ) -> Tuple[Tuple[int, int, int], Tuple[int, ...]]:
+        """Read benchmark file and return nkl and group_m_list.
+
+        File format:
+            0 256x512x128
+            1 512x512x512
+            2 1024x256x128
+            ...
+
+        Returns:
+            Tuple of ((n, k, l), (m0, m1, m2, ...)) where:
+            - n, k are from the first problem
+            - l is the total number of problems (groups)
+            - (m0, m1, m2, ...) are the M values for each group
+        """
+        problems = []
+        try:
+            with open(filepath, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+
+                    parts = line.split()
+                    if len(parts) < 2:
+                        continue
+
+                    # Parse index and dimensions (e.g., "256x512x128")
+                    dims = parts[1].split("x")
+                    if len(dims) == 3:
+                        m, n, k = int(dims[0]), int(dims[1]), int(dims[2])
+                        problems.append((m, n, k))
+
+            if not problems:
+                raise ValueError(f"No valid problems found in benchmark file: {filepath}")
+
+            # Use first problem's N, K dimensions
+            m_first, n, k = problems[0]
+            l = len(problems)  # noqa: E741
+
+            # Extract M values for each group
+            m_values = tuple(m for m, _, _ in problems)
+
+            print(f"Loaded {l} problems from benchmark file")
+            print(f"Using N={n}, K={k}, L={l}")
+            print(f"M values per group: {m_values}")
+
+            return ((n, k, l), m_values)
+
+        except FileNotFoundError:
+            raise argparse.ArgumentTypeError(f"Benchmark file not found: {filepath}")
+        except Exception as e:
+            raise argparse.ArgumentTypeError(f"Error reading benchmark file: {e}")
+
+    def parse_benchmark_arg(
+        arg: str,
+    ) -> Tuple[Tuple[int, int, int], Tuple[int, ...]]:
+        """Parse benchmark argument string.
+
+        Supported formats:
+        1. 'MxNxKxL': 128x512x1024x4 -> n=512, k=1024, l=4, m_values=(128, 128, 128, 128)
+        2. '[m0,m1,...]xNxK': [128,256]x512x1024 -> n=512, k=1024, l=2, m_values=(128, 256)
+        """
+        # Try matching [m0, m1, ...]xNxK format
+        match_list = re.match(r"\[([\d,\s]+)\]\s*x\s*(\d+)\s*x\s*(\d+)", arg)
+        if match_list:
+            m_str = match_list.group(1)
+            n = int(match_list.group(2))
+            k = int(match_list.group(3))
+            try:
+                m_values = tuple(int(x.strip()) for x in m_str.split(","))
+                l = len(m_values)  # noqa: E741
+                print(f"Parsed benchmark arg: N={n}, K={k}, L={l}")
+                print(f"M values per group: {m_values}")
+                return ((n, k, l), m_values)
+            except ValueError:
+                raise argparse.ArgumentTypeError(
+                    f"Invalid integer list in benchmark argument: {arg}"
+                )
+
+        # Try matching MxNxKxL format
+        parts = arg.split("x")
+        if len(parts) == 4:
+            try:
+                m, n, k, l = [int(x.strip()) for x in parts]  # noqa: E741
+                m_values = tuple([m] * l)
+                print(f"Parsed benchmark arg: M={m}, N={n}, K={k}, L={l}")
+                return ((n, k, l), m_values)
+            except ValueError:
+                pass
+
+        raise argparse.ArgumentTypeError(
+            f"Invalid benchmark argument format. Expected file path, 'MxNxKxL', or '[m0,m1,...]xNxK'. Got: {arg}"
+        )
+
+    parser = argparse.ArgumentParser(description="Example of Dense Persistent GEMM on Blackwell.")
+
+    parser.add_argument(
+        "--nkl",
+        type=parse_comma_separated_ints,
+        default=(256, 512, 1),
+        help="nkl dimensions: N, K, L (number of groups) (comma-separated)",
+    )
+
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        default=None,
+        help="Path to benchmark file with problem sizes (format: 'index MxNxK' per line),"
+        "or 'MxNxKxL' format or '[m0,m1,...]xNxK' format",
+    )
+
+    parser.add_argument(
+        "--permuted_m",
+        type=int,
+        default=None,
+        help="Optional padded M dimension for CUDA graph support. If specified,"
+        "A/C matrices and scale factor A will be padded to this size."
+        "Example: For MoE with m=4096, topK=8, experts_per_rank=8: permuted_m = 4096*8 + 8*255 = 34808",
+    )
+
+    parser.add_argument(
+        "--seq_len",
+        type=int,
+        default=4096,
+        help="Sequence length for MoE, used by fused finalize, need to know"
+        "the sequence length to do finalize correctly",
+    )
+
+    parser.add_argument(
+        "--topk",
+        type=int,
+        default=8,
+        help="Top-K experts per token (used for fused finalize)",
+    )
+
+    parser.add_argument(
+        "--mma_tiler_mn",
+        type=parse_comma_separated_ints,
+        default=(128, 128),
+        help="Mma tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=parse_comma_separated_ints,
+        default=(1, 1),
+        help="Cluster shape (comma-separated)",
+    )
+    parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float8E4M3FN)
+    parser.add_argument("--out_dtype", type=cutlass.dtype, default=cutlass.BFloat16)
+    parser.add_argument("--final_scale_dtype", type=cutlass.dtype, default=cutlass.Float32)
+    parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float32)
+    parser.add_argument("--sf_vec_size", type=int, default=16)
+    parser.add_argument("--a_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--out_major", choices=["n", "m"], type=str, default="n")
+    parser.add_argument("--tolerance", type=float, default=1e-01, help="Tolerance for validation")
+    parser.add_argument("--warmup_iterations", type=int, default=0, help="Warmup iterations")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
+    parser.add_argument("--use_cold_l2", action="store_true", default=False, help="Use cold L2")
+
+    parser.add_argument(
+        "--raster_along_m",
+        action="store_true",
+        dest="raster_along_m",
+        default=False,
+        help="Enable raster along M (default: True)",
+    )
+
+    parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=False,
+        help="Use CUPTI to measure execution time",
+    )
+
+    args = parser.parse_args()
+
+    # Process arguments to generate nkl and group_m_list
+    if args.benchmark:
+        # Read from benchmark file or parse string
+        if os.path.isfile(args.benchmark):
+            nkl, group_m_list = read_benchmark_file(args.benchmark)
+        else:
+            nkl, group_m_list = parse_benchmark_arg(args.benchmark)
+    else:
+        parser.error("No benchmark file or benchmark argument provided")
+    if len(args.mma_tiler_mn) != 2:
+        parser.error("--mma_tiler_mn must contain exactly 2 values")
+
+    if len(args.cluster_shape_mn) != 2:
+        parser.error("--cluster_shape_mn must contain exactly 2 values")
+
+    exec_time = run(
+        nkl,
+        group_m_list,
+        args.ab_dtype,
+        args.out_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.final_scale_dtype,
+        args.a_major,
+        args.b_major,
+        args.out_major,
+        args.mma_tiler_mn,
+        args.cluster_shape_mn,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+        args.permuted_m,
+        args.topk,
+        args.seq_len,
+        args.raster_along_m,
+        args.use_cupti,
+    )
+    print("exec_time: ", exec_time)
+    print("PASS")

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -493,7 +493,7 @@ def test_nvfp4_grouped_gemm_blackwell(num_tokens: int, top_k: int, ep_size: int,
     get_sm_version() not in (100, 103),
     reason="This test is only supported on SM 100 and SM 103 GPUs",
 )
-@pytest.mark.parametrize("tile_size", [128])
+@pytest.mark.parametrize("tile_size", [128, 256])
 @pytest.mark.parametrize("ep_size", [1, 8, 32])
 @pytest.mark.parametrize("top_k", [1, 2, 8])
 @pytest.mark.parametrize("num_tokens", [128, 515, 1024, 8192])


### PR DESCRIPTION
## Description

Enabled more optimization features for contiguous groupedgemm: 2CTA, tmem overlapping and tma prefetch:

- 2CTA is suitable for larger tokens. 

- TMEM overlap helps alleviate TMA load pressure and thus improves MATH SOL. 

- Rasterizing the tile scheduler from the M dimension to the N dimension provides improvements for small EPs.

Added `mma_tiler_mn` , `cluster_shape_mn`  and  `raster_along_m`candidates to help get best tactic for different problem sizes.

For example: 1024x7168x2048x8 (MxNxKxL) 's best tactic is `mma_tiler_mn: (256,256)` and `cluster_shape_mn: (2,2)` 

In addition, some redundant parameters in the previous code have been cleaned up. The M dimension is aligned according to `tile M`; when `tile M ` is 256 and `cluster_m` is divisible by 2, 2CTA is enabled by default. 

## Test Coverage
`tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py` added 2CTA test.
`tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py` added finalized kernel's example test.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added raster_along_m parameter to control kernel rasterization behavior.
  * Introduced new scale factor layout conversion functionality.
  * Expanded kernel tactic search space for improved optimization opportunities.

* **Tests**
  * Extended test coverage with additional tile size parametrization (256).
  * Added comprehensive test harness for kernel validation and benchmarking.

* **Chores**
  * Updated public API signatures: renamed c_major to out_major; removed deprecated parameters.
  * Refactored kernel configuration validation functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->