### PR TITLE
Spilt memory management part from KVCacheBlock

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
+++ b/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
@@ -26,6 +26,8 @@ using namespace tensorrt_llm::batch_manager::kv_cache_manager;
 namespace tensorrt_llm::batch_manager::eviction_policy
 {
 
+using MemoryBlockPtr = std::shared_ptr<MemoryBlock>;
+
 class BaseEvictionPolicy
 {
 public:
@@ -33,21 +35,21 @@ public:
 
     // TODO(TRTLLM-1564): Don't use a separate `initialize` function. Ensure eviction policies can't be in-between a
     // state of construction and initialization.
-    virtual void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> sizes,
+    virtual void initialize(std::vector<MemoryBlockPtr>& mAllMemoryBlocksById, std::vector<SizeType32> sizes,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority)
         = 0;
 
     /// @brief Get a free block from the specified cache level
     /// @returns The pointer to the free block, along with whether it can be offloaded
-    virtual std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) = 0;
+    virtual std::tuple<MemoryBlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) = 0;
     /// @brief Release a block. Prioritize the block for eviction if toFront=true
-    virtual void releaseBlock(BlockPtr block) = 0;
-    virtual void releaseBlock(BlockPtr block, bool toFront) = 0;
+    virtual void releaseBlock(MemoryBlockPtr block) = 0;
+    virtual void releaseBlock(MemoryBlockPtr block, bool toFront) = 0;
     /// @brief Get the amount of free blocks in the primary memory pool
     virtual SizeType32 getNumFreeBlocks(SizeType32 cacheLevel) = 0;
     /// @brief Claim a free block. Called when the cache manager allocates or reuses a new block
-    virtual void claimBlock(BlockPtr block) = 0;
-    virtual void claimBlock(BlockPtr block, std::optional<executor::RetentionPriority> priority,
+    virtual void claimBlock(MemoryBlockPtr block) = 0;
+    virtual void claimBlock(MemoryBlockPtr block, std::optional<executor::RetentionPriority> priority,
         std::optional<std::chrono::milliseconds> durationMs)
         = 0;
     /// @brief Perform any per-iteration bookkeeping
@@ -58,7 +60,7 @@ public:
 
 struct ExpiringBlockComparator
 {
-    bool operator()(BlockPtr const& a, BlockPtr const& b) const
+    bool operator()(MemoryBlockPtr const& a, MemoryBlockPtr const& b) const
     {
         // If two blocks expire in the same millisecond, their expiration times will be equal. As a fallback, check the
         // raw pointer values.
@@ -70,17 +72,17 @@ struct ExpiringBlockComparator
 class LRUEvictionPolicy : public BaseEvictionPolicy
 {
 public:
-    void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> sizes,
+    void initialize(std::vector<MemoryBlockPtr>& mAllMemoryBlocksById, std::vector<SizeType32> sizes,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority) override;
-    std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) override;
+    std::tuple<MemoryBlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) override;
 
-    void releaseBlock(BlockPtr block) override;
-    void releaseBlock(BlockPtr block, bool toFront) override;
+    void releaseBlock(MemoryBlockPtr block) override;
+    void releaseBlock(MemoryBlockPtr block, bool toFront) override;
 
     SizeType32 getNumFreeBlocks(SizeType32 cacheLevel) override;
 
-    void claimBlock(BlockPtr block) override;
-    void claimBlock(BlockPtr block, std::optional<executor::RetentionPriority> priority,
+    void claimBlock(MemoryBlockPtr block) override;
+    void claimBlock(MemoryBlockPtr block, std::optional<executor::RetentionPriority> priority,
         std::optional<std::chrono::milliseconds> durationMs) override;
 
     // Check the expiring blocks heap, and move expired blocks back to the default queue.
@@ -93,15 +95,15 @@ public:
 
 private:
     // Queues of available leaf blocks, split by cache level and priority level
-    std::vector<std::vector<FreeBlocksQueue>> mFreeQueues;
+    std::vector<std::vector<FreeMemoryQueue>> mFreeQueues;
     // Iterators to block entries in mFreeQueues
-    std::vector<std::optional<FreeBlocksQueue::iterator>> mFreeBlockIterators;
+    std::vector<std::optional<FreeMemoryQueue::iterator>> mFreeBlockIterators;
     // Amount of free blocks at each cache level
     std::vector<SizeType32> mNumFreeBlocksPerLevel;
     // Secondary offload threshold. Blocks below this priority won't be evicted.
     executor::RetentionPriority mSecondaryOffloadMinPriority;
     // Heap of block times
-    std::set<BlockPtr, ExpiringBlockComparator> mExpiringBlockHeap;
+    std::set<MemoryBlockPtr, ExpiringBlockComparator> mExpiringBlockHeap;
 };
 
 } // namespace tensorrt_llm::batch_manager::eviction_policy

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheTransferManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheTransferManager.h
@@ -37,14 +37,14 @@ public:
         tr::BufferManager const& bufferManager, std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr);
 
     //! \brief Onboard a block to gpu memory.
-    void onboard(BlockPtr const& offloadBlock, BlockPtr const& block, std::vector<KVCacheBlockPool> const& pools,
-        int numTokensToCopy = 0, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
-        std::string const& directory = "");
+    void onboard(MemoryBlockPtr const& offloadBlock, MemoryBlockPtr const& block,
+        std::vector<KVCacheBlockPool> const& pools, int numTokensToCopy = 0,
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
 
     //! \brief Offload a block to cpu memory.
-    void offload(BlockPtr const& block, BlockPtr const& offloadBlock, std::vector<KVCacheBlockPool> const& pools,
-        int numTokensToCopy = 0, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
-        std::string const& directory = "");
+    void offload(MemoryBlockPtr const& block, MemoryBlockPtr const& offloadBlock,
+        std::vector<KVCacheBlockPool> const& pools, int numTokensToCopy = 0,
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
 
     //! \brief Synchronize internal streams with bufferManager stream.
     //! \details The buffer manager uses the same stream as the prefill and decode kernels. This method ensures that the
@@ -60,7 +60,7 @@ public:
 private:
     //! \brief Get pointer to pool specified by cache block.
     static tr::ITensor::SharedPtr computeBlockPointer(
-        BlockPtr const& block, std::vector<KVCacheBlockPool> const& pools, size_t poolIdx);
+        MemoryBlockPtr const& block, std::vector<KVCacheBlockPool> const& pools, size_t poolIdx);
 
     /*!
      * \brief The key method that copies the src block to the dst block.
@@ -75,9 +75,9 @@ private:
      *
      * The default param is set to executor::KvCacheTransferMode::DRAM.
      */
-    void copyBlock(BlockPtr const& src, BlockPtr const& dst, std::vector<KVCacheBlockPool> const& pools, bool isOffload,
-        int numTokensToCopy = 0, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
-        std::string const& directory = "");
+    void copyBlock(MemoryBlockPtr const& src, MemoryBlockPtr const& dst, std::vector<KVCacheBlockPool> const& pools,
+        bool isOffload, int numTokensToCopy = 0,
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
 
     runtime::BufferManager mBufferManager;
     runtime::BufferManager mOnboardManager;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -291,7 +291,8 @@ private:
             {
                 BlockPtr const& block = mRange->mCacheManager->getBlockManager().getBlockById(
                     mRange->mBlockIds.at(mIdx), mRange->mWindowSize);
-                TLLM_CHECK_WITH_INFO(block->isPrimary(), "cache transceiver only supports primary blocks");
+                TLLM_CHECK_WITH_INFO(
+                    block->getMemoryBlock()->isPrimary(), "cache transceiver only supports primary blocks");
                 auto const blockOffset = block->getMemoryPoolBlockIndex();
                 mCurrent = runtime::ITensor::slice(mRange->mPool, blockOffset, 1);
             }

--- a/cpp/tensorrt_llm/batch_manager/kvCacheEventManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheEventManager.cpp
@@ -102,7 +102,8 @@ void KVCacheEventManager::enqueueStoredEvent(std::vector<BlockPtr> const& blocks
     for (auto const& block : blocks)
     {
         data.blocks.emplace_back(block->getHash(), block->getUniqueTokens(), block->getBlockKey().loraTaskId,
-            block->isPrimary() ? kPrimaryLevel : kSecondaryLevel, block->getPriority());
+            block->getMemoryBlock()->isPrimary() ? kPrimaryLevel : kSecondaryLevel,
+            block->getMemoryBlock()->getPriority());
     }
 
     enqueueEvent({mEventId++, data, windowSize, mAttentionDpRank});

--- a/cpp/tests/unit_tests/batch_manager/evictionPolicyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/evictionPolicyTest.cpp
@@ -47,17 +47,17 @@ public:
     void SetUp() override
     {
         policy = std::make_shared<MockLRUPolicy>();
-        std::vector<BlockPtr> allBlocksById;
+        std::vector<MemoryBlockPtr> allBlocksById;
 
         for (KVCacheBlock::IdType blockId = 0; blockId < NUM_PRIMARY_BLOCKS; ++blockId)
         {
-            allBlocksById.push_back(std::make_shared<KVCacheBlock>(blockId, tk::KVCacheIndex{blockId, false}));
+            allBlocksById.push_back(std::make_shared<MemoryBlock>(blockId, tk::KVCacheIndex{blockId, false}));
         }
 
         for (KVCacheBlock::IdType blockId = 0; blockId < NUM_SECONDARY_BLOCKS; ++blockId)
         {
-            allBlocksById.push_back(
-                std::make_shared<KVCacheBlock>(NUM_PRIMARY_BLOCKS + blockId, tk::KVCacheIndex{blockId, true}));
+            allBlocksById.push_back(std::make_shared<MemoryBlock>(
+                NUM_PRIMARY_BLOCKS + blockId, tk::KVCacheIndex{NUM_PRIMARY_BLOCKS + blockId, true}));
         }
         policy->initialize(allBlocksById, {NUM_PRIMARY_BLOCKS, NUM_SECONDARY_BLOCKS}, std::nullopt);
     }
@@ -107,15 +107,15 @@ TEST_F(LRUPolicyTest, ReleaseBlockTest)
     auto origPrimaryBlock = std::get<0>(policy->getFreeBlock(0));
     policy->claimBlock(origPrimaryBlock);
 
-    EXPECT_NE(origPrimaryBlock->getBlockId(), std::get<0>(policy->getFreeBlock(0))->getBlockId());
+    EXPECT_NE(origPrimaryBlock->getUniqueId(), std::get<0>(policy->getFreeBlock(0))->getUniqueId());
 
     policy->releaseBlock(origPrimaryBlock, true);
-    EXPECT_EQ(origPrimaryBlock->getBlockId(), std::get<0>(policy->getFreeBlock(0))->getBlockId());
+    EXPECT_EQ(origPrimaryBlock->getUniqueId(), std::get<0>(policy->getFreeBlock(0))->getUniqueId());
 
     policy->claimBlock(origPrimaryBlock);
     policy->releaseBlock(origPrimaryBlock);
 
-    EXPECT_NE(origPrimaryBlock->getBlockId(), std::get<0>(policy->getFreeBlock(0))->getBlockId());
+    EXPECT_NE(origPrimaryBlock->getUniqueId(), std::get<0>(policy->getFreeBlock(0))->getUniqueId());
 }
 
 TEST_F(LRUPolicyTest, LRUTest)
@@ -134,11 +134,11 @@ TEST_F(LRUPolicyTest, LRUTest)
         auto block = std::get<0>(policy->getFreeBlock(0));
         policy->claimBlock(block);
     }
-    ASSERT_EQ(std::get<0>(policy->getFreeBlock(0))->getBlockId(), block2->getBlockId());
+    ASSERT_EQ(std::get<0>(policy->getFreeBlock(0))->getUniqueId(), block2->getUniqueId());
 
     policy->claimBlock(std::get<0>(policy->getFreeBlock(0)));
 
-    ASSERT_EQ(std::get<0>(policy->getFreeBlock(0))->getBlockId(), block1->getBlockId());
+    ASSERT_EQ(std::get<0>(policy->getFreeBlock(0))->getUniqueId(), block1->getUniqueId());
 }
 
 TEST_F(LRUPolicyTest, PriorityTest)
@@ -168,7 +168,7 @@ TEST_F(LRUPolicyTest, PriorityTest)
     policy->releaseBlock(block1);
     policy->releaseBlock(block2);
 
-    EXPECT_EQ(std::get<0>(policy->getFreeBlock(0))->getBlockId(), block2->getBlockId());
+    EXPECT_EQ(std::get<0>(policy->getFreeBlock(0))->getUniqueId(), block2->getUniqueId());
 }
 
 TEST_F(LRUPolicyTest, TimedBlockTest)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
