### PR TITLE
[#10137][feat] AutoDeploy FP8 MoE refactor

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -221,11 +221,11 @@ def trtllm_quant_fp8_moe_fused_fake(
     fc1_expert_weights: torch.Tensor,
     fc2_expert_weights: torch.Tensor,
     fc1_act_scale: torch.Tensor,
-    gemm1_dequant: torch.Tensor,
-    gemm2_act_quant: torch.Tensor,
-    gemm2_dequant: torch.Tensor,
-    is_gated_mlp: bool,
-    act_fn: int,
+    fc1_dequant_scale: torch.Tensor,
+    fc2_act_scale_reciprocal: torch.Tensor,
+    fc2_dequant_scale: torch.Tensor,
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -107,47 +107,42 @@ def trtllm_quant_fp8_moe_fused(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
-    w1_weight: torch.Tensor,  # [E, I, H] stacked FP8 weights
-    w2_weight: torch.Tensor,  # [E, H, I] stacked FP8 weights
-    w3_weight: torch.Tensor,  # [E, I, H] for gated_mlp, unused for mlp
-    w1_input_scale: torch.Tensor,  # [E] stacked input scales
-    w2_input_scale: torch.Tensor,  # [E] stacked input scales
-    w3_input_scale: torch.Tensor,  # [E] or unused
-    w1_weight_scale: torch.Tensor,  # [E] stacked weight scales
-    w2_weight_scale: torch.Tensor,  # [E] stacked weight scales
-    w3_weight_scale: torch.Tensor,  # [E] or unused
-    gemm1_dequant: torch.Tensor,  # [E]
-    gemm2_act_quant: torch.Tensor,  # [E]
-    gemm2_dequant: torch.Tensor,  # [E]
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_act_scale: torch.Tensor,
+    fc1_dequant_scale: torch.Tensor,
+    fc2_act_scale_reciprocal: torch.Tensor,
+    fc2_dequant_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:
-    """
-    TensorRT-LLM Cutlass FP8 W8A8 MoE for gated and non-gated MLP.
+    """TensorRT-LLM Cutlass FP8 (W8A8) MoE for gated and non-gated MLP.
+
+    Computes (per expert):
+        For gated_mlp:
+            y = (act(x @ w1.T) * (x @ w3.T)) @ w2.T  # act := SiLU
+        For mlp:
+            y = act(x @ w1.T) @ w2.T                 # act := ReLU^2
+    Notes:
+        - FC1 implements: fc1_output = (act(x @ w1.T) * (x @ w3.T)) or fc1_output = act(x @ w1.T)
+        - FC2 implements: fc2_output = fc1_output @ w2.T
+        - FC1 weights are concatenated w3 and w1 if gated_mlp, otherwise w1
+
     Parameters:
         x: BF16/FP16 input tensor of shape (B, H) or (B, S, H)
         selected_experts: Expert indices (B*S, TOP_K)
         routing_weights: Routing weights (B*S, TOP_K)
-        w1_weight: FP8 w1 weights [E, I, H]
-        w2_weight: FP8 w2 weights [E, H, I]
-        w3_weight: FP8 w3 weights [E, I, H] (for gated_mlp)
-        w1_input_scale: Input scales for w1 [E]
-        w2_input_scale: Input scales for w2 [E]
-        w3_input_scale: Input scales for w3 [E]
-        w1_weight_scale: Weight scales for w1 [E]
-        w2_weight_scale: Weight scales for w2 [E]
-        w3_weight_scale: Weight scales for w3 [E]
-        gemm1_dequant: Precomputed gemm1 dequant scale [E]
-        gemm2_act_quant: Precomputed gemm2 act quant scale [1]
-        gemm2_dequant: Precomputed gemm2 dequant scale [E]
+        fc1_expert_weights: FC1 weights [E, 2*I, H] for gated_mlp, [E, I, H] for mlp
+        fc2_expert_weights: FC2 weights [E, H, I]
+        fc1_act_scale: FC1 activation scale [E]
+        fc1_dequant_scale: FC1 dequant scale [E]
+        fc2_act_scale_reciprocal: FC2 activation scale reciprocal [E]
+        fc2_dequant_scale: FC2 dequant scale [E]
         is_gated_mlp: True for gated_mlp, False for mlp
         act_fn: ActivationType.Silu for gated_mlp, ActivationType.Relu2 for mlp
 
-    Non-Gated MLP:
-        activation_fn(expert_inputs @ w1_expert.t())@ w2_expert.t()
-
-    Gated MLP:
-        activation_fn(expert_inputs @ w1_expert.t()) * (expert_inputs @ w3_expert.t()) @ w2_expert.t()
+    Returns:
+        Output tensor of shape (B, H) or (B, S, H)
     """
 
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
@@ -155,24 +150,24 @@ def trtllm_quant_fp8_moe_fused(
     # Store original shape and flatten to 2D
     x_shape = x.shape
     x2d = x.view(-1, x_shape[-1])
-    # Quantize input
-    x_q_fp8 = _quantize_fp8(x2d, w1_input_scale[0])
+    # Quantize the input
+    x_q_fp8 = _quantize_fp8(x2d, fc1_act_scale[0])
 
     # Scales are stored in float32
-    w1_input_scale = w1_input_scale[0]
+    w1_input_scale = fc1_act_scale[0]
 
-    # Prepare quant_scales for TensorRT-LLM FP8 format:
-    # [gemm1_dequant_scale, gemm2_act_quant_scale, gemm2_dequant_scale, gemm1_input_dequant_scale]
+    # Prepare quant_scales for TensorRT-LLM (Cutlass) FP8 format:
+    # [fc1_dequant_scale, fc2_act_scale_reciprocal, fc2_dequant_scale, gemm1_input_dequant_scale]
     # For gated MLP:
     # These are precomputed in `fused_moe` transform
-    # - gemm1_dequant_scale: w1_weight_scale * w1_input_scale (combined for w1 and w3)
-    # - gemm2_act_quant_scale: 1 / w2_input_scale
-    # - gemm2_dequant_scale: w2_weight_scale * w2_input_scale
-    # - gemm1_input_dequant_scale: w1_input_scale
+    # - fc1_dequant_scale: w1_weight_scale * w1_input_scale (combined for w1 and w3)
+    # - fc2_act_scale_reciprocal: 1 / w2_input_scale
+    # - fc1_dequant_scale: w2_weight_scale * w2_input_scale
+    # - fc1_act_scale: w1_input_scale
 
-    assert gemm1_dequant.ndim == 1, "gemm1_dequant must be 1D"
-    assert gemm2_dequant.ndim == 1, "gemm2_dequant must be 1D"
-    quant_scales = [gemm1_dequant, gemm2_act_quant, gemm2_dequant, w1_input_scale]
+    assert fc1_dequant_scale.ndim == 1, "fc1_dequant_scale must be 1D"
+    assert fc2_dequant_scale.ndim == 1, "fc2_dequant_scale must be 1D"
+    quant_scales = [fc1_dequant_scale, fc2_act_scale_reciprocal, fc2_dequant_scale, w1_input_scale]
 
     # Ensure contiguous tensors
     selected_experts = selected_experts.int().contiguous()
@@ -182,11 +177,9 @@ def trtllm_quant_fp8_moe_fused(
 
     # Determine activation type
     activation_type = ActivationType.Swiglu
+
     if is_gated_mlp:
         # Gated MLP uses Silu: silu(x @ w1.T) * (x @ w3.T)
-        # For gated MLP, concatenate w1 and w3 as [w3, w1]
-        w3_w1_stacked = torch.cat([w3_weight, w1_weight], dim=1).contiguous()  # [E, 2*I, H]
-        fc1_expert_weights = w3_w1_stacked
         if act_fn in [ActivationType.Silu, ActivationType.Swiglu]:
             activation_type = ActivationType.Swiglu
         else:
@@ -195,7 +188,6 @@ def trtllm_quant_fp8_moe_fused(
             )
     else:
         # For non-gated MLP with ReLU^2
-        fc1_expert_weights = w1_weight.contiguous()
         if act_fn == ActivationType.Relu2:
             activation_type = ActivationType.Relu2
         else:
@@ -210,7 +202,7 @@ def trtllm_quant_fp8_moe_fused(
         routing_weights,
         fc1_expert_weights=fc1_expert_weights,
         fc1_expert_biases=None,
-        fc2_expert_weights=w2_weight.contiguous(),
+        fc2_expert_weights=fc2_expert_weights.contiguous(),
         fc2_expert_biases=None,
         output_dtype=x.dtype,
         quant_scales=quant_scales,
@@ -226,15 +218,9 @@ def trtllm_quant_fp8_moe_fused_fake(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
-    w1_weight: torch.Tensor,
-    w2_weight: torch.Tensor,
-    w3_weight: torch.Tensor,
-    w1_input_scale: torch.Tensor,
-    w2_input_scale: torch.Tensor,
-    w3_input_scale: torch.Tensor,
-    w1_weight_scale: torch.Tensor,
-    w2_weight_scale: torch.Tensor,
-    w3_weight_scale: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_act_scale: torch.Tensor,
     gemm1_dequant: torch.Tensor,
     gemm2_act_quant: torch.Tensor,
     gemm2_dequant: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -1272,118 +1272,99 @@ def _stack_fp8_moe_weights(gm: GraphModule, backend: Literal["auto", "trtllm", "
     This is fast because we directly stack the tensor values (not graph nodes).
     Similar to _insert_fused_moe_ops but for quantized MoE.
     """
-    fused_key_counter = 0
-    graph = gm.graph
 
-    backend = backend.lower()
-    replacement_op = {
-        "auto": torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
-        "trtllm": torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
-        "triton": torch.ops.auto_deploy.triton_quant_fp8_moe,
-    }[backend]
+    def _register_parameter(gm: GraphModule, target, value):
+        gm.register_parameter(target, torch.nn.Parameter(value, requires_grad=False))
 
-    for node in graph.nodes:
-        if not is_op(node, torch.ops.auto_deploy.torch_quant_fp8_moe):
-            continue
-
-        # Extract weight and scale lists from args
+    # Helper to get parameter or buffer
+    def get_param_or_buffer(target):
+        """Get parameter or buffer by target name."""
         try:
-            (
+            return gm.get_parameter(target)
+        except AttributeError:
+            # It's a buffer, not a parameter
+            parts = target.rsplit(".", 1)
+            if len(parts) == 2:
+                mod = gm.get_submodule(parts[0])
+                return getattr(mod, parts[1])
+            else:
+                return getattr(gm, target)
+
+    def _extract_op_args(node):
+        return extract_op_args(
+            node,
+            "x",
+            "selected_experts",
+            "routing_weights",
+            "w1_weight",
+            "w2_weight",
+            "w3_weight",
+            "w1_input_scale",
+            "w2_input_scale",
+            "w3_input_scale",
+            "w1_weight_scale",
+            "w2_weight_scale",
+            "w3_weight_scale",
+            "mlp_style",
+        )
+
+    def _stack(param_list, dim=0):
+        return torch.stack(
+            [get_param_or_buffer(element.target) for element in param_list], dim=dim
+        ).contiguous()
+
+    def _prepare_args_cutlass_format():
+        if mlp_style == "gated_mlp":
+            # For gated MLP, concatenate w1 and w3 as [w3, w1]
+            fc1_expert_weights = torch.cat(
+                [w3_stacked, w1_stacked], dim=1
+            ).contiguous()  # [E, 2*I, H]
+            fc1_act_scale = torch.cat(
+                [w3_input_scale_stacked, w1_input_scale_stacked], dim=1
+            ).contiguous()
+        elif mlp_style == "mlp":
+            fc1_expert_weights = w1_stacked
+            fc1_act_scale = w1_input_scale_stacked
+        else:
+            raise ValueError(f"Unknown mlp_style '{mlp_style}'. Use 'gated_mlp' or 'mlp'.")
+
+        fc2_expert_weights = w2_stacked
+
+        # For optimization reasons, we precompute a few additional arguments to the trtllm_quant_fp8_moe_fused op
+        # to avoid computing them at runtime.
+        fc1_dequant = (w1_weight_scale_stacked * w1_input_scale_stacked[0]).squeeze()
+        fc2_act_scale_recip = (1.0 / w2_input_scale_stacked[0]).to(torch.float32)
+        fc2_dequant = (w2_weight_scale_stacked * w2_input_scale_stacked[0]).squeeze()
+
+        new_key_fc1_dequant = f"quant_moe_fc1_dequant_stacked_{fused_key_counter}"
+        new_key_fc2_act_scale_recip = f"quant_moe_fc2_act_scale_recip_stacked_{fused_key_counter}"
+        new_key_fc2_dequant = f"quant_moe_fc2_dequant_stacked_{fused_key_counter}"
+        new_key_fc1_expert_weights = f"quant_moe_w3_w1_stacked_{fused_key_counter}"
+        new_key_fc2_expert_weights = f"quant_moe_w2_stacked_{fused_key_counter}"
+        new_key_fc1_act_scale = f"quant_moe_w3_w1_input_scale_stacked_{fused_key_counter}"
+
+        _register_parameter(gm, new_key_fc1_dequant, fc1_dequant)
+        _register_parameter(gm, new_key_fc2_act_scale_recip, fc2_act_scale_recip)
+        _register_parameter(gm, new_key_fc2_dequant, fc2_dequant)
+        _register_parameter(gm, new_key_fc1_expert_weights, fc1_expert_weights)
+        _register_parameter(gm, new_key_fc2_expert_weights, fc2_expert_weights)
+        _register_parameter(gm, new_key_fc1_act_scale, fc1_act_scale)
+
+        with graph.inserting_before(node):
+            args = (
                 hidden_states,
                 selected_experts,
                 routing_weights,
-                w1_list,
-                w2_list,
-                w3_list,
-                w1_input_scale,
-                w2_input_scale,
-                w3_input_scale,
-                w1_weight_scale,
-                w2_weight_scale,
-                w3_weight_scale,
-            ) = extract_op_args(
-                node,
-                "x",
-                "selected_experts",
-                "routing_weights",
-                "w1_weight",
-                "w2_weight",
-                "w3_weight",
-                "w1_input_scale",
-                "w2_input_scale",
-                "w3_input_scale",
-                "w1_weight_scale",
-                "w2_weight_scale",
-                "w3_weight_scale",
+                graph.get_attr(new_key_fc1_expert_weights),
+                graph.get_attr(new_key_fc2_expert_weights),
+                graph.get_attr(new_key_fc1_act_scale),
+                graph.get_attr(new_key_fc1_dequant),
+                graph.get_attr(new_key_fc2_act_scale_recip),
+                graph.get_attr(new_key_fc2_dequant),
             )
-        except Exception:
-            continue
+        return args
 
-        # Helper to get parameter or buffer
-        def get_param_or_buffer(target):
-            """Get parameter or buffer by target name."""
-            try:
-                return gm.get_parameter(target)
-            except AttributeError:
-                # It's a buffer, not a parameter
-                parts = target.rsplit(".", 1)
-                if len(parts) == 2:
-                    mod = gm.get_submodule(parts[0])
-                    return getattr(mod, parts[1])
-                else:
-                    return getattr(gm, target)
-
-        # Stack the actual tensor values (fast, like in quantize_moe.py)
-        w1_stacked = torch.stack([gm.get_parameter(n.target) for n in w1_list], dim=0)
-        w2_stacked = torch.stack([gm.get_parameter(n.target) for n in w2_list], dim=0)
-        w3_stacked = (
-            torch.stack([gm.get_parameter(n.target) for n in w3_list], dim=0)
-            if w3_list
-            else torch.empty(0, device=w1_stacked.device, dtype=w1_stacked.dtype)
-        )
-
-        # Scales are buffers, not parameters
-        w1_input_scale_stacked = torch.stack(
-            [get_param_or_buffer(n.target) for n in w1_input_scale], dim=0
-        )
-        w2_input_scale_stacked = torch.stack(
-            [get_param_or_buffer(n.target) for n in w2_input_scale], dim=0
-        )
-        w3_input_scale_stacked = (
-            torch.stack([get_param_or_buffer(n.target) for n in w3_input_scale], dim=0)
-            if w3_input_scale
-            else torch.empty(
-                0, device=w1_input_scale_stacked.device, dtype=w1_input_scale_stacked.dtype
-            )
-        )
-
-        w1_weight_scale_stacked = (
-            torch.stack([get_param_or_buffer(n.target) for n in w1_weight_scale], dim=0)
-            .to(torch.float32)
-            .contiguous()
-        )
-        w2_weight_scale_stacked = (
-            torch.stack([get_param_or_buffer(n.target) for n in w2_weight_scale], dim=0)
-            .to(torch.float32)
-            .contiguous()
-        )
-        w3_weight_scale_stacked = (
-            (
-                torch.stack([get_param_or_buffer(n.target) for n in w3_weight_scale], dim=0)
-                if w3_weight_scale
-                else torch.empty(
-                    0, device=w1_weight_scale_stacked.device, dtype=w1_weight_scale_stacked.dtype
-                )
-            )
-            .to(torch.float32)
-            .contiguous()
-        )
-        assert torch.all(w1_input_scale_stacked[0] == w1_input_scale_stacked), (
-            "All w1 scales should have the same value."
-        )
-        assert torch.all(w2_input_scale_stacked[0] == w2_input_scale_stacked), (
-            "All w2 scales should have the same value."
-        )
+    def _prepare_args_triton_format():
         # Register stacked tensors as new parameters
         new_key_w1 = f"quant_moe_w1_stacked_{fused_key_counter}"
         new_key_w2 = f"quant_moe_w2_stacked_{fused_key_counter}"
@@ -1395,64 +1376,16 @@ def _stack_fp8_moe_weights(gm: GraphModule, backend: Literal["auto", "trtllm", "
         new_key_w2_weight_scale = f"quant_moe_w2_weight_scale_stacked_{fused_key_counter}"
         new_key_w3_weight_scale = f"quant_moe_w3_weight_scale_stacked_{fused_key_counter}"
 
-        fused_key_counter += 1
+        _register_parameter(gm, new_key_w1, w1_stacked)
+        _register_parameter(gm, new_key_w2, w2_stacked)
+        _register_parameter(gm, new_key_w3, w3_stacked)
+        _register_parameter(gm, new_key_w1_input_scale, w1_input_scale_stacked)
+        _register_parameter(gm, new_key_w2_input_scale, w2_input_scale_stacked)
+        _register_parameter(gm, new_key_w3_input_scale, w3_input_scale_stacked)
+        _register_parameter(gm, new_key_w1_weight_scale, w1_weight_scale_stacked)
+        _register_parameter(gm, new_key_w2_weight_scale, w2_weight_scale_stacked)
+        _register_parameter(gm, new_key_w3_weight_scale, w3_weight_scale_stacked)
 
-        # Register as parameters (not buffers, to match the original per-expert params)
-        gm.register_parameter(new_key_w1, torch.nn.Parameter(w1_stacked, requires_grad=False))
-        gm.register_parameter(new_key_w2, torch.nn.Parameter(w2_stacked, requires_grad=False))
-        gm.register_parameter(new_key_w3, torch.nn.Parameter(w3_stacked, requires_grad=False))
-        gm.register_parameter(
-            new_key_w1_input_scale, torch.nn.Parameter(w1_input_scale_stacked, requires_grad=False)
-        )
-        gm.register_parameter(
-            new_key_w2_input_scale, torch.nn.Parameter(w2_input_scale_stacked, requires_grad=False)
-        )
-        gm.register_parameter(
-            new_key_w3_input_scale, torch.nn.Parameter(w3_input_scale_stacked, requires_grad=False)
-        )
-        gm.register_parameter(
-            new_key_w1_weight_scale,
-            torch.nn.Parameter(w1_weight_scale_stacked, requires_grad=False),
-        )
-        gm.register_parameter(
-            new_key_w2_weight_scale,
-            torch.nn.Parameter(w2_weight_scale_stacked, requires_grad=False),
-        )
-        gm.register_parameter(
-            new_key_w3_weight_scale,
-            torch.nn.Parameter(w3_weight_scale_stacked, requires_grad=False),
-        )
-
-        additional_nodes = []
-        if backend == "trtllm":
-            # For optimization reasons, we precompute a few additional arguments to the trtllm_quant_fp8_moe_fused op
-            # to avoid computing them at runtime.
-            gemm1_dequant = (w1_weight_scale_stacked * w1_input_scale_stacked[0]).squeeze()
-            gemm2_act_quant = (1.0 / w2_input_scale_stacked[0]).to(torch.float32)
-            gemm2_dequant = (w2_weight_scale_stacked * w2_input_scale_stacked[0]).squeeze()
-
-            new_key_gemm1_dequant = f"quant_moe_gemm1_dequant_stacked_{fused_key_counter}"
-            new_key_gemm2_act_quant = f"quant_moe_gemm2_act_quant_stacked_{fused_key_counter}"
-            new_key_gemm2_dequant = f"quant_moe_gemm2_dequant_stacked_{fused_key_counter}"
-            gm.register_parameter(
-                new_key_gemm1_dequant,
-                torch.nn.Parameter(gemm1_dequant, requires_grad=False),
-            )
-            gm.register_parameter(
-                new_key_gemm2_act_quant,
-                torch.nn.Parameter(gemm2_act_quant, requires_grad=False),
-            )
-            gm.register_parameter(
-                new_key_gemm2_dequant,
-                torch.nn.Parameter(gemm2_dequant, requires_grad=False),
-            )
-            additional_nodes = [
-                new_key_gemm1_dequant,
-                new_key_gemm2_act_quant,
-                new_key_gemm2_dequant,
-            ]
-
-        # Create new node with get_attr for stacked parameters
         with graph.inserting_before(node):
             args = (
                 hidden_states,
@@ -1468,10 +1401,92 @@ def _stack_fp8_moe_weights(gm: GraphModule, backend: Literal["auto", "trtllm", "
                 graph.get_attr(new_key_w2_weight_scale),
                 graph.get_attr(new_key_w3_weight_scale),
             )
-            additional_args = (graph.get_attr(node) for node in additional_nodes)
+
+        return args
+
+    fused_key_counter = 0
+    graph = gm.graph
+
+    backend = backend.lower()
+    replacement_op = {
+        "auto": torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
+        "trtllm": torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused,
+        "triton": torch.ops.auto_deploy.triton_quant_fp8_moe,
+    }[backend]
+
+    matched_nodes = [
+        node for node in graph.nodes if is_op(node, torch.ops.auto_deploy.torch_quant_fp8_moe)
+    ]
+    for node in matched_nodes:
+        # Extract weight and scale lists from args
+        (
+            hidden_states,
+            selected_experts,
+            routing_weights,
+            w1_list,
+            w2_list,
+            w3_list,
+            w1_input_scale,
+            w2_input_scale,
+            w3_input_scale,
+            w1_weight_scale,
+            w2_weight_scale,
+            w3_weight_scale,
+            mlp_style,
+        ) = _extract_op_args(node)
+
+        # Stack the actual tensor values (fast, like in quantize_moe.py)
+        w1_stacked = _stack(w1_list, dim=0)
+        w2_stacked = _stack(w2_list, dim=0)
+        w3_stacked = (
+            _stack(w3_list, dim=0)
+            if w3_list
+            else torch.empty(0, device=w1_stacked.device, dtype=w1_stacked.dtype)
+        )
+
+        # Scales are buffers, not parameters
+        w1_input_scale_stacked = _stack(w1_input_scale, dim=0)
+        w2_input_scale_stacked = _stack(w2_input_scale, dim=0)
+        w3_input_scale_stacked = (
+            _stack(w3_input_scale, dim=0)
+            if w3_input_scale
+            else torch.empty(
+                0, device=w1_input_scale_stacked.device, dtype=w1_input_scale_stacked.dtype
+            )
+        )
+        assert torch.all(w1_input_scale_stacked[0] == w1_input_scale_stacked), (
+            "All w1 scales should have the same value."
+        )
+        assert torch.all(w2_input_scale_stacked[0] == w2_input_scale_stacked), (
+            "All w2 scales should have the same value."
+        )
+
+        w1_weight_scale_stacked = _stack(w1_weight_scale, dim=0).to(torch.float32)
+        w2_weight_scale_stacked = _stack(w2_weight_scale, dim=0).to(torch.float32)
+        w3_weight_scale_stacked = (
+            (
+                _stack(w3_weight_scale, dim=0)
+                if w3_weight_scale
+                else torch.empty(
+                    0, device=w1_weight_scale_stacked.device, dtype=w1_weight_scale_stacked.dtype
+                )
+            )
+            .to(torch.float32)
+            .contiguous()
+        )
+
+        if backend == "trtllm":
+            args = _prepare_args_cutlass_format()
+        else:
+            args = _prepare_args_triton_format()
+
+        fused_key_counter += 1
+
+        # Create new node with get_attr for stacked parameters
+        with graph.inserting_before(node):
             new_node = graph.call_function(
                 replacement_op,
-                args=(*args, *additional_args),
+                args,
                 kwargs=node.kwargs,
             )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
@@ -197,7 +197,6 @@ def triton_moe_fused_aux_fake(
     return torch.empty_like(x)
 
 
-# trtllm fp8
 @torch.library.custom_op("auto_deploy::trtllm_quant_fp8_moe_fused_aux", mutates_args=())
 def trtllm_quant_fp8_moe_fused_aux(
     x: torch.Tensor,
@@ -240,18 +239,12 @@ def trtllm_quant_fp8_moe_fused_aux_fake(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
-    w1_weight: torch.Tensor,
-    w2_weight: torch.Tensor,
-    w3_weight: torch.Tensor,
-    w1_input_scale: torch.Tensor,
-    w2_input_scale: torch.Tensor,
-    w3_input_scale: torch.Tensor,
-    w1_weight_scale: torch.Tensor,
-    w2_weight_scale: torch.Tensor,
-    w3_weight_scale: torch.Tensor,
-    gemm1_dequant: torch.Tensor,
-    gemm2_act_quant: torch.Tensor,
-    gemm2_dequant: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_act_scale: torch.Tensor,
+    fc1_dequant_scale: torch.Tensor,
+    fc2_act_scale_reciprocal: torch.Tensor,
+    fc2_dequant_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
@@ -203,18 +203,12 @@ def trtllm_quant_fp8_moe_fused_aux(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
-    w1_weight: torch.Tensor,  # [E, I, H] stacked FP8 weights
-    w2_weight: torch.Tensor,  # [E, H, I] stacked FP8 weights
-    w3_weight: torch.Tensor,  # [E, I, H] for gated_mlp, unused for mlp
-    w1_input_scale: torch.Tensor,  # [E] stacked input scales
-    w2_input_scale: torch.Tensor,  # [E] stacked input scales
-    w3_input_scale: torch.Tensor,  # [E] or unused
-    w1_weight_scale: torch.Tensor,  # [E] stacked weight scales
-    w2_weight_scale: torch.Tensor,  # [E] stacked weight scales
-    w3_weight_scale: torch.Tensor,  # [E] or unused
-    gemm1_dequant: torch.Tensor,  # [E]
-    gemm2_act_quant: torch.Tensor,  # [E]
-    gemm2_dequant: torch.Tensor,  # [E]
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_act_scale: torch.Tensor,
+    fc1_dequant_scale: torch.Tensor,
+    fc2_act_scale_reciprocal: torch.Tensor,
+    fc2_dequant_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:
@@ -227,18 +221,12 @@ def trtllm_quant_fp8_moe_fused_aux(
             x,
             selected_experts,
             routing_weights,
-            w1_weight,
-            w2_weight,
-            w3_weight,
-            w1_input_scale,
-            w2_input_scale,
-            w3_input_scale,
-            w1_weight_scale,
-            w2_weight_scale,
-            w3_weight_scale,
-            gemm1_dequant,
-            gemm2_act_quant,
-            gemm2_dequant,
+            fc1_expert_weights,
+            fc2_expert_weights,
+            fc1_act_scale,
+            fc1_dequant_scale,
+            fc2_act_scale_reciprocal,
+            fc2_dequant_scale,
             is_gated_mlp,
             act_fn,
         )

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -155,16 +155,6 @@ def worker_main(
 
     mpi_comm().barrier()
 
-    if mpi_rank() == 0 and "VSCODE_DEBUGPY_ADAPTER_ENDPOINTS" in os.environ:
-        # cf. https://github.com/microsoft/vscode-python-debugger/blob/f64b217c4d2445f7f55255b102de1d94c19cf450/bundled/scripts/noConfigScripts/debugpy#L4
-        os.environ["DEBUGPY_ADAPTER_ENDPOINTS"] = os.environ[
-            "VSCODE_DEBUGPY_ADAPTER_ENDPOINTS"]
-        # TODO: is listen() needed?
-        # TODO: Could use 'env' in MpiPoolExecutor instead (and if-env-contains-vscode...)
-        import debugpy
-        debugpy.listen(0)
-        debugpy.wait_for_client()
-
     if llm_args is not None and llm_args.env_overrides:
         # this is needed because MPI_Init seems to cache the env at import time.
         # The cached env snapshot is used to spawn workers.

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -155,6 +155,16 @@ def worker_main(
 
     mpi_comm().barrier()
 
+    if mpi_rank() == 0 and "VSCODE_DEBUGPY_ADAPTER_ENDPOINTS" in os.environ:
+        # cf. https://github.com/microsoft/vscode-python-debugger/blob/f64b217c4d2445f7f55255b102de1d94c19cf450/bundled/scripts/noConfigScripts/debugpy#L4
+        os.environ["DEBUGPY_ADAPTER_ENDPOINTS"] = os.environ[
+            "VSCODE_DEBUGPY_ADAPTER_ENDPOINTS"]
+        # TODO: is listen() needed?
+        # TODO: Could use 'env' in MpiPoolExecutor instead (and if-env-contains-vscode...)
+        import debugpy
+        debugpy.listen(0)
+        debugpy.wait_for_client()
+
     if llm_args is not None and llm_args.env_overrides:
         # this is needed because MPI_Init seems to cache the env at import time.
         # The cached env snapshot is used to spawn workers.

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
@@ -411,9 +411,7 @@ def test_trtllm_fused_moe_fp8(
         x,  # Note! unquantized input is expected
         selected_experts.to(torch.int),
         routing_weights,
-        fc1_expert_weights=w31_weight.contiguous()
-        if is_gated_mlp
-        else w1_weight.contiguous(),
+        fc1_expert_weights=w31_weight.contiguous() if is_gated_mlp else w1_weight.contiguous(),
         fc2_expert_weights=w2_weight.contiguous(),
         fc1_act_scale=hidden_states_scale.unsqueeze(0),
         fc1_dequant_scale=gemm1_dequant,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_trtllm_moe.py
@@ -411,18 +411,14 @@ def test_trtllm_fused_moe_fp8(
         x,  # Note! unquantized input is expected
         selected_experts.to(torch.int),
         routing_weights,
-        w1_weight=w1_weight.contiguous(),
-        w2_weight=w2_weight.contiguous(),
-        w3_weight=w3_weight.contiguous(),
-        w1_input_scale=hidden_states_scale.unsqueeze(0),
-        w2_input_scale=w2_input_scale,
-        w3_input_scale=w3_input_scale,
-        w1_weight_scale=w1_scales,
-        w2_weight_scale=w2_scales,
-        w3_weight_scale=w3_scales,
-        gemm1_dequant=gemm1_dequant,
-        gemm2_act_quant=gemm2_act_quant,
-        gemm2_dequant=gemm2_dequant,
+        fc1_expert_weights=w31_weight.contiguous()
+        if is_gated_mlp
+        else w1_weight.contiguous(),
+        fc2_expert_weights=w2_weight.contiguous(),
+        fc1_act_scale=hidden_states_scale.unsqueeze(0),
+        fc1_dequant_scale=gemm1_dequant,
+        fc2_act_scale_reciprocal=gemm2_act_quant,
+        fc2_dequant_scale=gemm2_dequant,
         is_gated_mlp=is_gated_mlp,
         act_fn=activation_func,
     )


### PR DESCRIPTION
The trtllm (cutlass) fp8 moe operator performs W3+W1 fusion (concat) during inference and we want to move this fusion to the model optimization time.

The Cutlass MoE kernel is provided thru a trtllm torch operator.
Its implementation uses two FC operations (fc1 and fc2) while the MoE APi defines three FC operations and their associated weights (W1, W2, W3) so when we switch from the torch.moe op to the trtllm.moe op we also change terminology from w1,w2,w3 to fc1, fc2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Updated MoE fusion function signatures: consolidated weight parameters into `fc1_expert_weights` and `fc2_expert_weights` with new quantization scale arguments for improved consistency and flexibility.

* **Chores**
  * Added VSCode Python debugger support for development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
