### PR TITLE
[None][fix] Mistral large 3 VLM updates + SLMs

### DIFF
--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -272,9 +272,10 @@ def main():
         args.prompt = example_medias_and_prompts[args.modality]["prompt"]
     if args.media is None:
         args.media = example_medias_and_prompts[args.modality]["media"]
-    
+
     #FIXME WAR for mistral-common processors
-    keep_source_media=(args.model_type=="mistral3" and args.checkpoint_format == "mistral_large_3")
+    keep_source_media = (args.model_type == "mistral3"
+                         and args.checkpoint_format == "mistral_large_3")
     inputs = default_multimodal_input_loader(
         tokenizer=llm.tokenizer,
         model_dir=str(llm._hf_model_dir),

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -272,6 +272,9 @@ def main():
         args.prompt = example_medias_and_prompts[args.modality]["prompt"]
     if args.media is None:
         args.media = example_medias_and_prompts[args.modality]["media"]
+    
+    #FIXME WAR for mistral-common processors
+    keep_source_media=(args.model_type=="mistral3" and args.checkpoint_format == "mistral_large_3")
     inputs = default_multimodal_input_loader(
         tokenizer=llm.tokenizer,
         model_dir=str(llm._hf_model_dir),
@@ -279,7 +282,7 @@ def main():
         modality=args.modality,
         prompts=args.prompt,
         media=args.media,
-        keep_source_media=(args.checkpoint_format == "mistral_large_3"),
+        keep_source_media=keep_source_media,
         processor=getattr(llm, "input_processor", None),
         image_data_format=image_format,
         num_frames=args.num_frames,

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -272,15 +272,18 @@ def main():
         args.prompt = example_medias_and_prompts[args.modality]["prompt"]
     if args.media is None:
         args.media = example_medias_and_prompts[args.modality]["media"]
-    inputs = default_multimodal_input_loader(tokenizer=llm.tokenizer,
-                                             model_dir=str(llm._hf_model_dir),
-                                             model_type=model_type,
-                                             modality=args.modality,
-                                             prompts=args.prompt,
-                                             media=args.media,
-                                             image_data_format=image_format,
-                                             num_frames=args.num_frames,
-                                             device=args.device)
+    inputs = default_multimodal_input_loader(
+        tokenizer=llm.tokenizer,
+        model_dir=str(llm._hf_model_dir),
+        model_type=model_type,
+        modality=args.modality,
+        prompts=args.prompt,
+        media=args.media,
+        keep_source_media=(args.checkpoint_format == "mistral_large_3"),
+        processor=getattr(llm, "input_processor", None),
+        image_data_format=image_format,
+        num_frames=args.num_frames,
+        device=args.device)
 
     lora_request = None
     if args.load_lora:

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -272,21 +272,15 @@ def main():
         args.prompt = example_medias_and_prompts[args.modality]["prompt"]
     if args.media is None:
         args.media = example_medias_and_prompts[args.modality]["media"]
-    
-    #FIXME WAR for mistral-common processors
-    keep_source_media=(args.model_type=="mistral3" and args.checkpoint_format == "mistral_large_3")
-    inputs = default_multimodal_input_loader(
-        tokenizer=llm.tokenizer,
-        model_dir=str(llm._hf_model_dir),
-        model_type=model_type,
-        modality=args.modality,
-        prompts=args.prompt,
-        media=args.media,
-        keep_source_media=keep_source_media,
-        processor=getattr(llm, "input_processor", None),
-        image_data_format=image_format,
-        num_frames=args.num_frames,
-        device=args.device)
+    inputs = default_multimodal_input_loader(tokenizer=llm.tokenizer,
+                                             model_dir=str(llm._hf_model_dir),
+                                             model_type=model_type,
+                                             modality=args.modality,
+                                             prompts=args.prompt,
+                                             media=args.media,
+                                             image_data_format=image_format,
+                                             num_frames=args.num_frames,
+                                             device=args.device)
 
     lora_request = None
     if args.load_lora:

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -273,21 +273,17 @@ def main():
     if args.media is None:
         args.media = example_medias_and_prompts[args.modality]["media"]
 
-    #FIXME WAR for mistral-common processors
-    keep_source_media = (args.model_type == "mistral3"
-                         and args.checkpoint_format == "mistral_large_3")
-    inputs = default_multimodal_input_loader(
-        tokenizer=llm.tokenizer,
-        model_dir=str(llm._hf_model_dir),
-        model_type=model_type,
-        modality=args.modality,
-        prompts=args.prompt,
-        media=args.media,
-        keep_source_media=keep_source_media,
-        processor=getattr(llm, "input_processor", None),
-        image_data_format=image_format,
-        num_frames=args.num_frames,
-        device=args.device)
+    inputs = default_multimodal_input_loader(tokenizer=llm.tokenizer,
+                                             model_dir=str(llm._hf_model_dir),
+                                             model_type=model_type,
+                                             modality=args.modality,
+                                             prompts=args.prompt,
+                                             media=args.media,
+                                             processor=getattr(
+                                                 llm, "input_processor", None),
+                                             image_data_format=image_format,
+                                             num_frames=args.num_frames,
+                                             device=args.device)
 
     lora_request = None
     if args.load_lora:

--- a/examples/models/core/mistral_large_3/README.md
+++ b/examples/models/core/mistral_large_3/README.md
@@ -19,7 +19,7 @@ mpirun -n 1 --allow-run-as-root --oversubscribe python3 examples/llm-api/quickst
     --checkpoint_format mistral_large_3 \
     --model_type mistral3 \ 
     --kv_cache_fraction 0.25 \
-    --moe_backend TRTLLM # optional
+    --image_format pil
 ```
 
 ## LLM-only run

--- a/examples/models/core/mistral_large_3/README.md
+++ b/examples/models/core/mistral_large_3/README.md
@@ -14,8 +14,7 @@ export mistral_large_3_eagle_model_path=<mistral_large_3_eagle_model_path>
 ```bash
 mpirun -n 1 --allow-run-as-root --oversubscribe python3 examples/llm-api/quickstart_multimodal.py \
     --model_dir ${mistral_large_3_model_path} \
-    --tp_size 4 \
-    --moe_ep_size 4 \
+    --tp_size 8 \
     --max_tokens 100 \
     --checkpoint_format mistral_large_3 \
     --model_type mistral3 \ 

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -329,10 +329,8 @@ class ModelConfig(Generic[TConfig]):
                     128), "FP8_BLOCK_SCALES only supports block_size=(128,128)"
                 quant_config.group_size = block_size[0]
 
-            # DeepSeek V3 FP8 per tensor hack
             elif hf_quant_config.get("activation_scheme", None) == "static":
-                logger.debug(f"Expanding weight scale to mimic DS FP8 recipe")
-                quant_config.quant_algo = QuantAlgo.FP8_BLOCK_SCALES
+                quant_config.quant_algo = QuantAlgo.FP8
                 if moe_backend == 'TRTLLM':
                     # TODO: This is a hack. Remove after fp8 bmm is integrated.
                     quant_config.exclude_modules = [
@@ -340,9 +338,6 @@ class ModelConfig(Generic[TConfig]):
                     ]
                 else:
                     quant_config.exclude_modules = ["*eh_proj"]
-
-                block_size = (128, 128)
-                quant_config.group_size = block_size[0]
 
         # MXFP4 checkpoints.
         elif hf_quant_config.get("quant_method") == "mxfp4":

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -26,13 +26,16 @@ class HfWeightLoader(BaseWeightLoader):
     Loads weights from SafeTensors/bin/pth files.
     """
 
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self,
+                     checkpoint_dir: str,
+                     use_consolidated: bool = False) -> dict[str, Any]:
         weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
         # Some model checkpoint directories contain not only the sharded safetensors, but one
-        # consolidated tensor. In the presence of both, we favor the former, as there really is no need
-        # to prefetch the (usually) ridiculously large consolidated tensor into memory in such a case.
+        # consolidated tensor. In the presence of both, unless specified explicitly, we favor the former,
+        # as there really is no need to prefetch the (usually) ridiculously large consolidated tensor into memory in such a case.
         filtered_weight_files = [
-            x for x in weight_files if "consolidated" not in os.path.split(x)[1]
+            x for x in weight_files
+            if ("consolidated" in os.path.split(x)[1] == use_consolidated)
         ]
         if len(filtered_weight_files) > 0:
             weight_files = filtered_weight_files

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
@@ -38,12 +38,12 @@ class MistralCheckpointLoader(HfCheckpointLoader):
             modules = key.split(".")
 
             if modules[0] not in self.mm_module_mapping.keys():
-                    hf_weights["language_model." + key] = value
+                hf_weights["language_model." + key] = value
 
             else:
                 modules[0] = self.mm_module_mapping[modules[0]]
                 hf_weights[".".join(modules)] = value
-                    
+
         return hf_weights
 
     def broadcast_per_tensor_scales(self, weights):

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
@@ -65,10 +65,10 @@ class MistralCheckpointLoader(HfCheckpointLoader):
                 weights[key] = 1.0 / weights[key]
 
     def load_weights(self, checkpoint_dir: str, **kwargs):
-        weights = super().weight_loader.load_weights(checkpoint_dir, **kwargs)
+        weights = super().weight_loader.load_weights(
+            checkpoint_dir, use_consolidated=True, **kwargs
+        )
         weights = self.preprocess_weights(weights)
-        # FIXME mimic DS fp8 till per tensor supported
-        self.broadcast_per_tensor_scales(weights)
         self.reverse_nvfp4_global_scales(weights)
         return weights
 

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
@@ -68,7 +68,9 @@ class MistralCheckpointLoader(HfCheckpointLoader):
         weights = super().weight_loader.load_weights(
             checkpoint_dir, use_consolidated=True, **kwargs
         )
-        weights = self.preprocess_weights(weights)
+        mm_key = next((x for x in weights.keys() if x.startswith("vision_encoder")), None)
+        if mm_key is not None:
+            weights = self.preprocess_weights(weights)
         self.reverse_nvfp4_global_scales(weights)
         return weights
 

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/checkpoint_loader.py
@@ -38,12 +38,12 @@ class MistralCheckpointLoader(HfCheckpointLoader):
             modules = key.split(".")
 
             if modules[0] not in self.mm_module_mapping.keys():
-                hf_weights["language_model." + key] = value
+                    hf_weights["language_model." + key] = value
 
             else:
                 modules[0] = self.mm_module_mapping[modules[0]]
                 hf_weights[".".join(modules)] = value
-
+                    
         return hf_weights
 
     def broadcast_per_tensor_scales(self, weights):

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
@@ -24,7 +24,9 @@ def adapt_config_dict(
         config_dict = _remap_mistral_quantization_args(config_dict)
 
     is_moe = bool(config_dict.get("moe"))
-    is_mistral_large_3 = is_moe and (config_dict["moe"].get("num_shared_experts") or 0) > 0
+    is_mistral_large_3 = (
+        is_moe and (config_dict["moe"].get("num_shared_experts") or 0) > 0
+    )
     if config_dict.get("model_type") == "mamba":
         config_dict["architectures"] = ["Mamba2ForCausalLM"]
     elif is_moe and is_mistral_large_3:
@@ -32,11 +34,19 @@ def adapt_config_dict(
         config_dict["model_type"] = "deepseek_v3"
         config_dict["architectures"] = ["MistralLarge3ForCausalLM"]
 
-        assert "llama_4_scaling" in config_dict, "MistralLarge3 expect llama4 scaling config."
+        assert "llama_4_scaling" in config_dict, (
+            "MistralLarge3 expect llama4 scaling config."
+        )
         llama_4_scaling_config_keys = ["original_max_position_embeddings", "beta"]
         assert all(
-            [key in config_dict["llama_4_scaling"] for key in llama_4_scaling_config_keys]
-        ), f"llama_4_scaling config should define the keys: {','.join(llama_4_scaling_config_keys)}"
+            [
+                key in config_dict["llama_4_scaling"]
+                for key in llama_4_scaling_config_keys
+            ]
+        ), (
+            "llama_4_scaling config should define the keys: "
+            f"{','.join(llama_4_scaling_config_keys)}"
+        )
     elif is_moe:
         config_dict["architectures"] = ["MixtralForCausalLM"]
     else:
@@ -48,14 +58,22 @@ def adapt_config_dict(
     if bool(config_dict.get("llama_4_scaling")):
         llama_4_scaling_config_keys = ["original_max_position_embeddings", "beta"]
         assert all(
-            [key in config_dict["llama_4_scaling"] for key in llama_4_scaling_config_keys]
-        ), f"llama_4_scaling config should define the keys: {','.join(llama_4_scaling_config_keys)}"
+            [
+                key in config_dict["llama_4_scaling"]
+                for key in llama_4_scaling_config_keys
+            ]
+        ), (
+            "llama_4_scaling config should define the keys: "
+            f"{','.join(llama_4_scaling_config_keys)}"
+        )
 
-    is_vision = (config_dict.get("multimodal") or {}).get("vision_encoder_args") or config_dict.get(
-        "vision_encoder"
-    )
+    is_vision = (config_dict.get("multimodal") or {}).get(
+        "vision_encoder_args"
+    ) or config_dict.get("vision_encoder")
     is_audio = bool(
-        ((config_dict.get("multimodal") or {}).get("whisper_model_args") or {}).get("encoder_args")
+        ((config_dict.get("multimodal") or {}).get("whisper_model_args") or {}).get(
+            "encoder_args"
+        )
     )
 
     assert not (is_vision and is_audio), "Vision and audio are mutually exclusive"

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
@@ -100,17 +100,14 @@ def _remap_mistral_yarn_args(config: dict) -> dict:
         "apply_scale": "apply_yarn_scaling",
     }
     yarn_config = config.get("yarn") or {}
-    config["rope_parameters"] = {
+    config["rope_scaling"] = {
         "rope_type": "yarn",
         "mscale_all_dim": 1,
     }
 
-    if rope_theta := config.pop("rope_theta", None):
-        config["rope_parameters"]["rope_theta"] = rope_theta
-
     for old_name, new_name in yarn_config_map.items():
         if old_name in yarn_config:
-            config["rope_parameters"][new_name] = yarn_config.pop(old_name)
+            config["rope_scaling"][new_name] = yarn_config.pop(old_name)
 
     assert len(yarn_config) == 0, f"Unparsed yarn config: {yarn_config}"
 

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/config_loader.py
@@ -24,9 +24,7 @@ def adapt_config_dict(
         config_dict = _remap_mistral_quantization_args(config_dict)
 
     is_moe = bool(config_dict.get("moe"))
-    is_mistral_large_3 = (
-        is_moe and (config_dict["moe"].get("num_shared_experts") or 0) > 0
-    )
+    is_mistral_large_3 = is_moe and (config_dict["moe"].get("num_shared_experts") or 0) > 0
     if config_dict.get("model_type") == "mamba":
         config_dict["architectures"] = ["Mamba2ForCausalLM"]
     elif is_moe and is_mistral_large_3:
@@ -34,19 +32,11 @@ def adapt_config_dict(
         config_dict["model_type"] = "deepseek_v3"
         config_dict["architectures"] = ["MistralLarge3ForCausalLM"]
 
-        assert "llama_4_scaling" in config_dict, (
-            "MistralLarge3 expect llama4 scaling config."
-        )
+        assert "llama_4_scaling" in config_dict, "MistralLarge3 expect llama4 scaling config."
         llama_4_scaling_config_keys = ["original_max_position_embeddings", "beta"]
         assert all(
-            [
-                key in config_dict["llama_4_scaling"]
-                for key in llama_4_scaling_config_keys
-            ]
-        ), (
-            "llama_4_scaling config should define the keys: "
-            f"{','.join(llama_4_scaling_config_keys)}"
-        )
+            [key in config_dict["llama_4_scaling"] for key in llama_4_scaling_config_keys]
+        ), f"llama_4_scaling config should define the keys: {','.join(llama_4_scaling_config_keys)}"
     elif is_moe:
         config_dict["architectures"] = ["MixtralForCausalLM"]
     else:
@@ -58,22 +48,14 @@ def adapt_config_dict(
     if bool(config_dict.get("llama_4_scaling")):
         llama_4_scaling_config_keys = ["original_max_position_embeddings", "beta"]
         assert all(
-            [
-                key in config_dict["llama_4_scaling"]
-                for key in llama_4_scaling_config_keys
-            ]
-        ), (
-            "llama_4_scaling config should define the keys: "
-            f"{','.join(llama_4_scaling_config_keys)}"
-        )
+            [key in config_dict["llama_4_scaling"] for key in llama_4_scaling_config_keys]
+        ), f"llama_4_scaling config should define the keys: {','.join(llama_4_scaling_config_keys)}"
 
-    is_vision = (config_dict.get("multimodal") or {}).get(
-        "vision_encoder_args"
-    ) or config_dict.get("vision_encoder")
+    is_vision = (config_dict.get("multimodal") or {}).get("vision_encoder_args") or config_dict.get(
+        "vision_encoder"
+    )
     is_audio = bool(
-        ((config_dict.get("multimodal") or {}).get("whisper_model_args") or {}).get(
-            "encoder_args"
-        )
+        ((config_dict.get("multimodal") or {}).get("whisper_model_args") or {}).get("encoder_args")
     )
 
     assert not (is_vision and is_audio), "Vision and audio are mutually exclusive"

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
@@ -78,7 +78,7 @@ class MistralWeightMapper(HfWeightMapper):
         processed_weights = {}
         config = self.config.pretrained_config
 
-        def permute(w: torch.Tensor, n_heads: int, attn_out: int):
+        def permute(w, n_heads: int, attn_out: int):
             attn_in = config.head_dim * n_heads
 
             return (
@@ -86,7 +86,6 @@ class MistralWeightMapper(HfWeightMapper):
                 .transpose(1, 2)
                 .reshape(attn_in, attn_out)
             )
-
 
         # rotary embeds should be sliced
         # If using quantized model in mistral format,
@@ -97,14 +96,10 @@ class MistralWeightMapper(HfWeightMapper):
                 config.num_key_value_heads if new_name == "k_proj" else config.num_attention_heads
             )
 
-            processed_weights["weight"] = permute(
-                weights["weight"], n_heads, config.hidden_size
-            )
+            processed_weights["weight"] = permute(weights["weight"], n_heads, config.hidden_size)
 
             if "qscale_weight" in weights and weights["qscale_weight"].numel() > 1:
-                processed_weights["qscale_weight"] = permute(
-                    weights["qscale_weight"], n_heads, 1
-                )
+                processed_weights["qscale_weight"] = permute(weights["qscale_weight"], n_heads, 1)
 
             return processed_weights
 

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
@@ -78,7 +78,7 @@ class MistralWeightMapper(HfWeightMapper):
         processed_weights = {}
         config = self.config.pretrained_config
 
-        def permute(w, n_heads: int, attn_out: int):
+        def permute(w: torch.Tensor, n_heads: int, attn_out: int):
             attn_in = config.head_dim * n_heads
 
             return (
@@ -86,6 +86,7 @@ class MistralWeightMapper(HfWeightMapper):
                 .transpose(1, 2)
                 .reshape(attn_in, attn_out)
             )
+
 
         # rotary embeds should be sliced
         # If using quantized model in mistral format,
@@ -96,10 +97,14 @@ class MistralWeightMapper(HfWeightMapper):
                 config.num_key_value_heads if new_name == "k_proj" else config.num_attention_heads
             )
 
-            processed_weights["weight"] = permute(weights["weight"], n_heads, config.hidden_size)
+            processed_weights["weight"] = permute(
+                weights["weight"], n_heads, config.hidden_size
+            )
 
             if "qscale_weight" in weights and weights["qscale_weight"].numel() > 1:
-                processed_weights["qscale_weight"] = permute(weights["qscale_weight"], n_heads, 1)
+                processed_weights["qscale_weight"] = permute(
+                    weights["qscale_weight"], n_heads, 1
+                )
 
             return processed_weights
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1739,7 +1739,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                return_context_logits=return_context_logits,
                                **kwargs)
 
-    def load_weights(self, weights: Dict, weight_mapper=None):
+    def load_weights(self, weights: Dict, weight_mapper=None, params_map=None):
         weight_loader = DeepseekV3WeightLoader(self)
         # TODO: remove when DeepSeek is integrated with _load_weights_impl_v2
         if weight_mapper is not None:

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -49,6 +49,7 @@ from tensorrt_llm.logger import logger
 
 from ..modules.fused_moe import RenormalizeNaiveMoeRoutingMethod
 
+from mistral_common.tokens.tokenizers.multimodal import ImageEncoder
 from PIL import Image
 
 _MULTIMODAL_ENV_NAME = "TLLM_MULTIMODAL_DISAGGREGATED"
@@ -522,6 +523,15 @@ class Mistral3Gate(nn.Module):
         #      src/mistral_common/tokens/tokenizers/base.py#L326
         # However, accuracy tests show that the model generates higher quality output when the image
         # precedes the text (the relative difference can be as much as ~30% for both vLLM and TRT-LLM).
+        placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+    ))
+@register_input_processor(
+    Mistral3InputProcessor, 
+    model_type="mistral3",
+    placeholder_metadata=MultimodalPlaceholderMetadata(
+        placeholder_map={
+            "image": "[IMG]",
+        },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
     ))
 class Mistral3VLM(PreTrainedModel):

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -533,15 +533,6 @@ class Mistral3Gate(nn.Module):
         # precedes the text (the relative difference can be as much as ~30% for both vLLM and TRT-LLM).
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
     ))
-@register_input_processor(
-    Mistral3InputProcessor,
-    model_type="mistral3",
-    placeholder_metadata=MultimodalPlaceholderMetadata(
-        placeholder_map={
-            "image": "[IMG]",
-        },
-        placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
-    ))
 class Mistral3VLM(PreTrainedModel):
     """Mistral3VLM implementation for TRTLLM.
 

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -229,11 +229,12 @@ class MistralForCausalLM(DecoderModelForCausalLM[MistralModel, MistralConfig]):
 
 
 class MistralCommonImageProcessor:
+
     def __init__(self, tokenizer: MistralTokenizer, dtype) -> None:
         super().__init__()
         self.tokenizer = tokenizer
         self.dtype = dtype
-    
+
     @property
     def image_processor(self) -> ImageEncoder:
         image_encoder = self.tokenizer.instruct.mm_encoder
@@ -243,7 +244,7 @@ class MistralCommonImageProcessor:
     @property
     def image_break_id(self) -> int:
         return self.image_processor.special_ids.img_break
-    
+
     @property
     def image_break_token_id(self) -> int:
         return self.image_break_id
@@ -269,16 +270,18 @@ class MistralCommonImageProcessor:
         return self.image_processor.mm_config.image_patch_size
 
     def _get_num_multimodal_tokens(self, image_sizes):
-        return {"num_image_tokens": [self.get_num_tokens_per_image(size) for size in image_sizes]}
-    
+        return {
+            "num_image_tokens":
+            [self.get_num_tokens_per_image(size) for size in image_sizes]
+        }
+
     def get_num_tokens_per_image(self, image_sizes):
         # FIXME avoid double loading with custom loader
         h, w = image_sizes
         ncols, nrows = self.image_processor._image_to_num_tokens(
-            Image.new("RGB", (w, h))
-        )
+            Image.new("RGB", (w, h)))
         return ncols * nrows + nrows
-    
+
     def __call__(self, text, images, media, **kwargs):
         assert media is not None
         if isinstance(media, str):
@@ -288,16 +291,24 @@ class MistralCommonImageProcessor:
 
         print(f"text: {text}")
 
-        conversation = [
-            {"role":"user", 
-             "content":[{"type": "text", "text": text}, 
-                        *mm_items]}]
-        
-        encoded = self.tokenizer.transformers_tokenizer.apply_chat_template(conversation, tokenize=True, return_dict=True, return_tensors='pt')
+        conversation = [{
+            "role": "user",
+            "content": [{
+                "type": "text",
+                "text": text
+            }, *mm_items]
+        }]
 
-        print(f"encoded.pixel_values.shape: {encoded.pixel_values.shape}, encoded.input_ids: {encoded.input_ids[0][-20:]}")
-        print(f"encoded.input_ids list: {self.tokenizer.transformers_tokenizer.apply_chat_template(conversation)}")
-        
+        encoded = self.tokenizer.transformers_tokenizer.apply_chat_template(
+            conversation, tokenize=True, return_dict=True, return_tensors='pt')
+
+        print(
+            f"encoded.pixel_values.shape: {encoded.pixel_values.shape}, encoded.input_ids: {encoded.input_ids[0][-20:]}"
+        )
+        print(
+            f"encoded.input_ids list: {self.tokenizer.transformers_tokenizer.apply_chat_template(conversation)}"
+        )
+
         processed = {
             "input_ids": encoded.input_ids,
             "pixel_values": encoded.pixel_values.to(self.dtype),
@@ -336,7 +347,8 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
 
         self._model_path = model_path
         if isinstance(self._tokenizer, MistralTokenizer):
-            self._processor = MistralCommonImageProcessor(tokenizer=self._tokenizer, dtype=self.dtype)
+            self._processor = MistralCommonImageProcessor(
+                tokenizer=self._tokenizer, dtype=self.dtype)
         else:
             self._processor = AutoProcessor.from_pretrained(
                 model_path,
@@ -379,11 +391,10 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
             # format is "pt" (pytorch tensors), but not for "pil" (PIL images).
             do_rescale = False
 
-        processed = self.processor(
-            text=inputs["prompt"],
-            images=images,
-            do_rescale=do_rescale,
-        )
+        processed = self.processor(text=inputs["prompt"],
+                                   images=images,
+                                   do_rescale=do_rescale,
+                                   **mm_processor_kwargs)
         input_ids = processed.pop("input_ids").tolist()[0]
         # Remaining in `processed`:
         # * "attention_mask": [B, num_input_tokens]
@@ -526,7 +537,7 @@ class Mistral3Gate(nn.Module):
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
     ))
 @register_input_processor(
-    Mistral3InputProcessor, 
+    Mistral3InputProcessor,
     model_type="mistral3",
     placeholder_metadata=MultimodalPlaceholderMetadata(
         placeholder_map={
@@ -589,6 +600,7 @@ class Mistral3VLM(PreTrainedModel):
                                                          "vision_config",
                                                          attn_backend="VANILLA",
                                                          quant_config=None)
+
         self._vision_tower = modeling_pixtral.PixtralVisionModel(
             vision_model_config)
 
@@ -951,4 +963,3 @@ class Mistral3MultiModalProjector(torch.nn.Module):
 
     def load_weights(self, weights, *args, **kwargs):
         _load_weights_impl(self, weights, *args, **kwargs)
-

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -67,9 +67,9 @@ class MistralAttention(Attention):
     ):
         config = model_config.pretrained_config
         rope_params = RopeParams.from_config(config)
-        rope_params_section = getattr(config, "rope_scaling") or getattr(
-            config, "rope_parameters")
-        rope_type = rope_params_section.get("rope_type")
+        rope_params_section = getattr(config, "rope_scaling", None) or getattr(
+            config, "rope_parameters", None)
+        rope_type = getattr(rope_params_section, "rope_type", None)
         if rope_type == "yarn":
             pos_embd_params = PositionalEmbeddingParams(
                 type=PositionEmbeddingType.yarn,

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -286,8 +286,6 @@ class MistralCommonImageProcessor:
 
         mm_items = [{"type": "image_url", "image_url": url} for url in media]
 
-        print(f"text: {text}")
-
         conversation = [{
             "role": "user",
             "content": [{
@@ -298,13 +296,6 @@ class MistralCommonImageProcessor:
 
         encoded = self.tokenizer.transformers_tokenizer.apply_chat_template(
             conversation, tokenize=True, return_dict=True, return_tensors='pt')
-
-        print(
-            f"encoded.pixel_values.shape: {encoded.pixel_values.shape}, encoded.input_ids: {encoded.input_ids[0][-20:]}"
-        )
-        print(
-            f"encoded.input_ids list: {self.tokenizer.transformers_tokenizer.apply_chat_template(conversation)}"
-        )
 
         processed = {
             "input_ids": encoded.input_ids,
@@ -351,9 +342,12 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
                 model_path,
                 use_fast=self.use_fast,
                 trust_remote_code=trust_remote_code)
-        
-        logger.debug(f"Mistral3InputProcessor: using {type(self._processor)} preprocessor")
-        logger.debug(f"Mistral3InputProcessor: using {type(self._tokenizer)} tokenizer")
+
+        logger.debug(
+            f"Mistral3InputProcessor: using {type(self._processor)} preprocessor"
+        )
+        logger.debug(
+            f"Mistral3InputProcessor: using {type(self._tokenizer)} tokenizer")
 
     @property
     def config(self) -> PretrainedConfig:
@@ -444,7 +438,9 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
             self.processor.image_end_token_id,
         ])
 
+
 class MistralCommonInputProcessor(Mistral3InputProcessor):
+
     def __init__(
         self,
         model_path: str,
@@ -460,19 +456,22 @@ class MistralCommonInputProcessor(Mistral3InputProcessor):
                          **kwargs)
 
     @staticmethod
-    def load_tokenizer(model_path: str, config: PretrainedConfig, checkpoint_format: Optional[str] = "mistral_large_3"):
+    def load_tokenizer(model_path: str,
+                       config: PretrainedConfig,
+                       checkpoint_format: Optional[str] = "mistral_large_3"):
         if checkpoint_format == "mistral_large_3":
             try:
                 return MistralTokenizer.from_pretrained(model_path)
-            
-            except ValueError:
-                logger.info(f"Could not load mistral-common tokenizer from {model_path}, falling back to HuggingFace")
 
-        tokenizer = AutoTokenizer.from_pretrained(
-                    model_path,
-                    config=config,
-                    use_fast=True,
-                    trust_remote_code=True)
+            except ValueError:
+                logger.info(
+                    f"Could not load mistral-common tokenizer from {model_path}, falling back to HuggingFace"
+                )
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path,
+                                                  config=config,
+                                                  use_fast=True,
+                                                  trust_remote_code=True)
         return tokenizer
 
 

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -482,7 +482,7 @@ class MistralCommonInputProcessor(Mistral3InputProcessor):
                 return MistralTokenizer.from_pretrained(model_path)
 
             except ValueError:
-                logger.info(
+                logger.warning(
                     f"Could not load mistral-common tokenizer from {model_path}, falling back to HuggingFace"
                 )
 
@@ -597,7 +597,7 @@ class Mistral3VLM(PreTrainedModel):
 
         llm_model_config.pretrained_config.gate_cls = "Mistral3Gate"
 
-        logger.info(f"Loaded llm model config: {llm_model_config}")
+        logger.debug(f"Loaded llm model config: {llm_model_config}")
 
         self.llm = llm_class(llm_model_config)
         self.model_config.extra_attrs.update(llm_model_config.extra_attrs)
@@ -609,7 +609,7 @@ class Mistral3VLM(PreTrainedModel):
                                                          attn_backend="VANILLA",
                                                          quant_config=None)
 
-        logger.info(f"Loaded vision model config: {vision_model_config}")
+        logger.debug(f"Loaded vision model config: {vision_model_config}")
 
         self._vision_tower = modeling_pixtral.PixtralVisionModel(
             vision_model_config)

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -49,9 +49,6 @@ from tensorrt_llm.logger import logger
 
 from ..modules.fused_moe import RenormalizeNaiveMoeRoutingMethod
 
-from mistral_common.tokens.tokenizers.multimodal import ImageEncoder
-from PIL import Image
-
 _MULTIMODAL_ENV_NAME = "TLLM_MULTIMODAL_DISAGGREGATED"
 
 

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -839,7 +839,6 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
         raise ValueError("model must have a config attribute")
 
     if params_map is not None:
-        print(f"Params map is not None")
         weights = rename_weights_with_regex(params_map, weights)
         logger.info(f"Renamed weights with params_map: {params_map}")
 

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -559,8 +559,8 @@ class DecoderModelForCausalLM(nn.Module,
     def load_weights(self,
                      weights: Dict,
                      weight_mapper: Optional["BaseWeightMapper"] = None,
-                     params_map: Optional[Dict] = None,
                      skip_modules: List[str] = [],
+                     params_map: Optional[Dict] = None,
                      allow_partial_loading: bool = False):
         # TODO smor- this solution is a temporary solution to load weights while we are still using
         # the old checkpoint format loading process. Once checkpoint format is unified

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -559,8 +559,8 @@ class DecoderModelForCausalLM(nn.Module,
     def load_weights(self,
                      weights: Dict,
                      weight_mapper: Optional["BaseWeightMapper"] = None,
-                     skip_modules: List[str] = [],
                      params_map: Optional[Dict] = None,
+                     skip_modules: List[str] = [],
                      allow_partial_loading: bool = False):
         # TODO smor- this solution is a temporary solution to load weights while we are still using
         # the old checkpoint format loading process. Once checkpoint format is unified

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -518,13 +518,21 @@ class FP8QDQLinearMethod(LinearMethodBase):
                 v_scale.append(w["v_scale"][...].reshape([]))
         return k_scale, v_scale
 
+    def _get_scale_name(self, weights: List[Dict]):
+        # `weight_scale_inv` for Mistral HF models
+        scale_name = "weight_scale"
+        if scale_name not in weights[0]:
+            scale_name = "weight_scale_inv"
+        return scale_name
+
     def load_weight_scales(self, weights: List[Dict]):
         input_scale, weight_scale = [], []
+        scale_name = self._get_scale_name(weights)
         for w in weights:
             if "input_scale" in w:
                 input_scale.append(w["input_scale"][...].reshape([]))
-            if "weight_scale" in w:
-                weight_scale.append(w["weight_scale"][...].reshape([]))
+            if scale_name in w:
+                weight_scale.append(w[scale_name][...].reshape([]))
         return input_scale, weight_scale
 
     def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -732,7 +732,5 @@ def create_py_executor(
     if mapping.rank == 0:
         logger.info(f"LLM Args:\n{llm_args}")
 
-    logger.info(f"{llm_args}")
-
     py_executor.start_worker()
     return py_executor

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -697,7 +697,8 @@ class KVCacheManager(BaseResourceManager):
                 num_key_value_heads)
 
         # get head dim
-        mla = hasattr(config, "kv_lora_rank")
+        mla = hasattr(config,
+                      "kv_lora_rank") and config.kv_lora_rank is not None
         if mla:
             head_dim = config.kv_lora_rank + config.qk_rope_head_dim
             kv_factor = 1

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -9,7 +9,8 @@ from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Type,
 import torch
 from PIL import Image
 from torch import Tensor, nn
-from transformers import (AutoProcessor, PretrainedConfig, PreTrainedTokenizerBase)
+from transformers import (AutoProcessor, PretrainedConfig,
+                          PreTrainedTokenizerBase, AutoTokenizer)
 
 import tensorrt_llm
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -9,8 +9,7 @@ from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Type,
 import torch
 from PIL import Image
 from torch import Tensor, nn
-from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
-                          PreTrainedTokenizerBase)
+from transformers import (AutoProcessor, PretrainedConfig, PreTrainedTokenizerBase)
 
 import tensorrt_llm
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -9,8 +9,8 @@ from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Type,
 import torch
 from PIL import Image
 from torch import Tensor, nn
-from transformers import (AutoProcessor, PretrainedConfig,
-                          PreTrainedTokenizerBase, AutoTokenizer)
+from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
+                          PreTrainedTokenizerBase)
 
 import tensorrt_llm
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -9,7 +9,8 @@ from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Type,
 import torch
 from PIL import Image
 from torch import Tensor, nn
-from transformers import (AutoProcessor, PretrainedConfig, PreTrainedTokenizerBase)
+from transformers import (AutoProcessor, PretrainedConfig,
+                          PreTrainedTokenizerBase)
 
 import tensorrt_llm
 
@@ -598,8 +599,6 @@ def create_input_processor(
                 MistralCommonInputProcessor
             tokenizer = MistralCommonInputProcessor.load_tokenizer(
                 model_path_or_dir, config=None)
-
-        print(f"loaded tokenizer: {type(tokenizer)}")
 
     else:
         logger.debug(

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -598,7 +598,9 @@ def create_input_processor(
             from tensorrt_llm._torch.models.modeling_mistral import \
                 MistralCommonInputProcessor
             tokenizer = MistralCommonInputProcessor.load_tokenizer(
-                model_path_or_dir, config=None)
+                model_path_or_dir,
+                config=None,
+                checkpoint_format=checkpoint_format)
 
     else:
         logger.debug(

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -767,10 +767,6 @@ def default_multimodal_input_loader(
             add_generation_prompt=True,
             mm_placeholder_counts=[mm_placeholder_counts])
         input = {"prompt": prompt}
-
-        if keep_source_media:  # WAR for mistral-common processors
-            input["mm_processor_kwargs"] = {"media": media}
-
         if mm_placeholder_counts:
             if mm_embeddings is not None:
                 input[

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -621,7 +621,6 @@ def default_multimodal_input_loader(
         prompts: List[str],
         processor: Optional[BaseMultimodalInputProcessor] = None,
         media: Optional[Union[List[str], List[List[str]]]] = None,
-        keep_source_media: bool = False,
         image_data_format: str = "pt",
         num_frames: int = 8,
         mm_embeddings: Optional[Union[List[torch.Tensor],

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -411,10 +411,11 @@ class ModelLoader:
                     f"Found quantization_config field in {hf_config_path}, pre-quantized checkpoint is used."
                 )
                 # DeepSeek V3 FP8 ckpt
-                if hf_quant_config.get(
-                        "quant_method") == "fp8" and hf_quant_config.get(
-                            "weight_block_size"):
-                    quant_config.quant_algo = QuantAlgo.FP8_BLOCK_SCALES
+                if hf_quant_config.get("quant_method") == "fp8":
+                    if hf_quant_config.get("weight_block_size"):
+                        quant_config.quant_algo = QuantAlgo.FP8_BLOCK_SCALES
+                    elif hf_quant_config.get("activation_scheme") == "static":
+                        quant_config.quant_algo = QuantAlgo.FP8
                     quant_config.exclude_modules = ["*eh_proj"]
                 elif hf_quant_config.get("quant_method") == "mxfp4":
                     from .._torch.model_config import ModelConfig


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[None][fix] Mistral large 3 VLM updates**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR improves Mistral format usage and enables Mistral 3 SLMs

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
