### PR TITLE
[None][fix] NVFP4 linear method's weight and weight_scale padding

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1144,24 +1144,30 @@ class NVFP4LinearMethod(LinearMethodBase):
             assert (
                 weight_col_size * 2
             ) % module.scaling_vector_size == 0, f"weight column size after padding {weight_col_size} must be divisible by scaling_vector_size {module.scaling_vector_size}"
-            # Pad weight_scale to match padded weight dimensions
-            # Padding should be performed on unswizzled weight_scale tensor
             scale_rows = fp4_utils.pad_up(module.out_features, 128)
             scale_cols = fp4_utils.pad_up(
                 module.in_features // module.scaling_vector_size, 4)
-            weight_scale_unswizzle = unswizzle_sf(module.weight_scale.data,
-                                                  scale_rows, scale_cols,
-                                                  module.scaling_vector_size)
-            weight_scale_unswizzle_pad = F.pad(
-                weight_scale_unswizzle,
-                (0, (col_pad_size * 2) // module.scaling_vector_size, 0,
-                 row_pad_size),
-                mode='constant',
-                value=0)
-            module.weight_scale = Parameter(
-                torch.ops.trtllm.block_scale_interleave(
-                    weight_scale_unswizzle_pad),
-                requires_grad=False)
+            scale_pad_row = fp4_utils.pad_up(module.out_features + row_pad_size,
+                                             128) - scale_rows
+            scale_pad_col = fp4_utils.pad_up(
+                (module.in_features + (col_pad_size * 2)) //
+                module.scaling_vector_size, 4) - scale_rows
+            # Pad weight_scale to match padded weight dimensions
+            # Padding should be performed on unswizzled weight_scale tensor
+            if scale_pad_row != 0 or scale_pad_col != 0:
+                weight_scale_unswizzle = unswizzle_sf(
+                    module.weight_scale.data, scale_rows,
+                    scale_cols * module.scaling_vector_size,
+                    module.scaling_vector_size)
+                weight_scale_unswizzle_pad = F.pad(
+                    weight_scale_unswizzle,
+                    (0, scale_pad_col, 0, scale_pad_row),
+                    mode='constant',
+                    value=0)
+                module.weight_scale = Parameter(
+                    torch.ops.trtllm.block_scale_interleave(
+                        weight_scale_unswizzle_pad),
+                    requires_grad=False)
 
 
 class W4A8NVFP4FP8LinearMethod(LinearMethodBase):

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1149,9 +1149,10 @@ class NVFP4LinearMethod(LinearMethodBase):
                 module.in_features // module.scaling_vector_size, 4)
             scale_pad_row = fp4_utils.pad_up(module.out_features + row_pad_size,
                                              128) - scale_rows
+            # here one col_size of weight equals two linear in_features
             scale_pad_col = fp4_utils.pad_up(
                 (module.in_features + (col_pad_size * 2)) //
-                module.scaling_vector_size, 4) - scale_rows
+                module.scaling_vector_size, 4) - scale_cols
             # Pad weight_scale to match padded weight dimensions
             # Padding should be performed on unswizzled weight_scale tensor
             if scale_pad_row != 0 or scale_pad_col != 0:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of weight scale padding operations by making them conditional, reducing unnecessary computation when padding adjustments are not required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


-->

## Description

<!--
Previous weight and weight scale padding in NVFP4LinearMethod have errors. Now fix it.
-->

## Test Coverage


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
