### PR TITLE
[#8460][feat] Revive and simplify Model Explorer visualization integration

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -149,7 +149,7 @@ transforms:
   ############################################################################################
   visualize_namespace:
     stage: visualize
-    enabled: false # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/8460
+    enabled: false
   ############################################################################################
   # SWITCH TO CACHED+FLATTENED ATTENTION + INITIALIZE CACHES
   ############################################################################################

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/visualization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/visualization.py
@@ -1,92 +1,30 @@
 """Transformation to the graph to render nicely in model_explorer."""
 
-import json
 from typing import Tuple
 
-import torch
 import torch.export as te
 from torch.fx import GraphModule
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+from ...utils.logger import ad_logger
 from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
 
 try:
     import model_explorer
-    from model_explorer.graph_builder import GraphNode, KeyValue, MetadataItem
-    from model_explorer.pytorch_exported_program_adater_impl import (
-        PytorchExportedProgramAdapterImpl,
-    )
 except ImportError:
     model_explorer = None
-    GraphNode = KeyValue = MetadataItem = PytorchExportedProgramAdapterImpl = None
-    # Optionally, you can log a warning or handle this gracefully elsewhere
-
-
-def print_tensor(self, tensor: torch.Tensor, size_limit: int = 16):
-    shape = tensor.shape
-    total_size = 1
-    for dim in shape:
-        total_size *= dim
-
-    if size_limit < 0 or size_limit >= total_size:
-        return json.dumps(tensor.cpu().detach().to(torch.float32).numpy().tolist())
-
-    return json.dumps(
-        (tensor.cpu().detach().to(torch.float32).numpy().flatten())[:size_limit].tolist()
-    )
-
-
-def _get_shape(val):
-    return json.dumps(
-        list(
-            map(
-                lambda x: int(x) if str(x).isdigit() else str(x),
-                val.shape,
-            )
-        )
-    )
-
-
-def add_outputs_metadata(self, fx_node: torch.fx.node.Node, node: GraphNode):
-    out_vals = fx_node.meta.get("val")
-    if out_vals is None:
-        return
-
-    if isinstance(out_vals, (tuple, list)):
-        for idx, val in enumerate(out_vals):
-            metadata = MetadataItem(id=str(idx), attrs=[])
-            if val is None:
-                continue
-            dtype = str(val.dtype)
-            shape = _get_shape(val)
-            metadata.attrs.append(KeyValue(key="tensor_shape", value=dtype + shape))
-            node.outputsMetadata.append(metadata)
-    elif isinstance(out_vals, torch.Tensor):
-        dtype = str(out_vals.dtype)
-        shape = _get_shape(out_vals)
-        metadata = MetadataItem(id="0", attrs=[KeyValue(key="tensor_shape", value=dtype + shape)])
-        node.outputsMetadata.append(metadata)
-    elif isinstance(out_vals, bool):
-        metadata = MetadataItem(id="0", attrs=[KeyValue(key="tensor_shape", value="bool[1]")])
-        node.outputsMetadata.append(metadata)
-    else:
-        raise ValueError(f"Unsupported output type: {type(out_vals)}")
-
-
-# TODO(yudong): make custom_ops configurable
-CUSTOM_OPS = (
-    torch.ops.auto_deploy.torch_dist_all_reduce.default,
-    torch.ops.auto_deploy.trtllm_dist_all_reduce.default,
-    torch.ops.aten.slice.Tensor,
-    torch.ops.auto_deploy.triton_attention_fused_mha_with_cache.default,
-    torch.ops.auto_deploy.torch_linear_simple.default,
-    torch.ops.aten.split_with_sizes.default,
-)
 
 
 @TransformRegistry.register("visualize_namespace")
 class VisualizeNamespace(BaseTransform):
+    """Transform to visualize the graph using Model Explorer.
+
+    This transform exports the graph module to an ExportedProgram and launches
+    Model Explorer for interactive visualization. The visualization helps debug
+    and understand the graph structure after AutoDeploy transformations.
+    """
+
     def _apply(
         self,
         gm: GraphModule,
@@ -94,17 +32,37 @@ class VisualizeNamespace(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        PytorchExportedProgramAdapterImpl.print_tensor = print_tensor
-        PytorchExportedProgramAdapterImpl.add_outputs_metadata = add_outputs_metadata
+        """Export the graph and launch Model Explorer for visualization.
 
-        # TODO(yudong): make viz as non-block call.
-        ep = te.export(gm, args=cm.args, dynamic_shapes=cm.dynamic_shapes)
-        graph = ep.graph
-        # Ensure the ops land up in the right module for better viz
-        for n in graph.nodes:
-            if n.target in CUSTOM_OPS:
-                n.meta["nn_module_stack"] = n.args[0].meta["nn_module_stack"]
+        Args:
+            gm: The graph module to visualize.
+            cm: The cached sequence interface with input arguments.
+            factory: The model factory (unused).
+            shared_config: Shared configuration across transforms (unused).
 
-        model_explorer.visualize_pytorch("model-viz", ep)
+        Returns:
+            A tuple of the unchanged graph module and transform info indicating
+            whether visualization was successful or skipped.
+        """
+        if model_explorer is None:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
 
-        return gm, TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
+        try:
+            # Export graph module to ExportedProgram for visualization
+            exported_program = te.export(gm, args=(), kwargs=cm.named_args, dynamic_shapes=None)
+
+            ad_logger.info("Launching Model Explorer visualization...")
+            model_explorer.visualize_pytorch("model-viz", exported_program)
+
+            return gm, TransformInfo(
+                skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True
+            )
+
+        except Exception as e:
+            ad_logger.error(f"Failed to visualize graph with Model Explorer: {e}")
+            # Don't fail the pipeline if visualization fails
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )


### PR DESCRIPTION

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
This PR revives the Model Explorer graph visualization integration that was broken/outdated (fixes #8460).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Ran the AutoDeploy example with visualization enabled:
```
python examples/auto_deploy/build_and_run_ad.py \
  --model "TinyLlama/TinyLlama-1.1B-Chat-v1.0" \
  --args.transforms.visualize-namespace.enabled=true
```

Verified the transform gracefully skips when model_explorer is not installed:
- Returns` TransformInfo(skipped=True, ...)` without raising exceptions
- Pipeline continues without interruption


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced visualization pipeline resilience—visualization now gracefully handles missing dependencies without interrupting the deployment process.
  * Improved error handling and logging for visualization operations to provide better diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->