### PR TITLE
[https://nvbugs/5753250][fix] Fix undefined local variable in responses utils

### DIFF
--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -974,6 +974,7 @@ def _create_output_content(
     available_tools = _get_chat_completion_function_tools(tools)
 
     for output in final_res.outputs:
+        calls = []
         text, reasoning_text = _apply_reasoning_parser(reasoning_parser,
                                                        output.index,
                                                        output.text, False)

--- a/tests/unittest/llmapi/apps/_test_openai_responses.py
+++ b/tests/unittest/llmapi/apps/_test_openai_responses.py
@@ -140,7 +140,12 @@ async def test_chat(client: openai.AsyncOpenAI, model: str):
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_multi_turn_chat(client: openai.AsyncOpenAI, model: str):
+async def test_multi_turn_chat(client: openai.AsyncOpenAI, model: str,
+                               num_postprocess_workers: int):
+    if num_postprocess_workers > 0:
+        pytest.skip(
+            "Response store is disabled when num_postprocess_workers > 0")
+
     response = await client.responses.create(
         model=model,
         input=_get_qwen3_nothink_input(model, "What is the answer of 1+1?"),

--- a/tests/unittest/llmapi/apps/_test_openai_responses.py
+++ b/tests/unittest/llmapi/apps/_test_openai_responses.py
@@ -51,6 +51,7 @@ def client(server: RemoteOpenAIServer):
 
 
 def check_reponse(response, prefix=""):
+    print(f"response: {response}")
     reasoning_exist, message_exist = False, False
     for output in response.output:
         if output.type == "reasoning":
@@ -63,6 +64,7 @@ def check_reponse(response, prefix=""):
 
 
 def check_tool_calling(response, first_resp=True, prefix=""):
+    print(f"response: {response}")
     reasoning_exist, tool_call_exist, message_exist = False, False, False
     reasoning_content, message_content = "", ""
     function_call = None
@@ -90,18 +92,20 @@ def check_tool_calling(response, first_resp=True, prefix=""):
         assert not tool_call_exist, f"{err_msg} tool call content should not exist! ({function_call})"
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
+def _get_qwen3_nothink_input(model: str, input: str):
+    return f"{input} /no_think" if model.startswith("Qwen3") else input
+
+
 @pytest.mark.asyncio(loop_scope="module")
 async def test_reasoning(client: openai.AsyncOpenAI, model: str):
     response = await client.responses.create(
         model=model,
         input="Which one is larger as numeric, 9.9 or 9.11?",
-        max_output_tokens=1024)
+    )
 
     check_reponse(response, "test_reasoning: ")
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_reasoning_effort(client: openai.AsyncOpenAI, model: str):
     for effort in ["low", "medium", "high"]:
@@ -110,48 +114,45 @@ async def test_reasoning_effort(client: openai.AsyncOpenAI, model: str):
             instructions="Use less than 1024 tokens for the whole response",
             input="Which one is larger as numeric, 9.9 or 9.11?",
             reasoning={"effort": effort},
-            max_output_tokens=1024)
+        )
         check_reponse(response, f"test_reasoning_effort_{effort}: ")
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_chat(client: openai.AsyncOpenAI, model: str):
-    response = await client.responses.create(model=model,
-                                             input=[{
-                                                 "role":
-                                                 "developer",
-                                                 "content":
-                                                 "Respond in Chinese."
-                                             }, {
-                                                 "role": "user",
-                                                 "content": "Hello!"
-                                             }, {
-                                                 "role":
-                                                 "assistant",
-                                                 "content":
-                                                 "Hello! How can I help you?"
-                                             }, {
-                                                 "role": "user",
-                                                 "content": "Tell me a joke."
-                                             }],
-                                             max_output_tokens=1024)
+    response = await client.responses.create(
+        model=model,
+        input=[{
+            "role": "developer",
+            "content": "Respond in Chinese."
+        }, {
+            "role": "user",
+            "content": "Hello!"
+        }, {
+            "role": "assistant",
+            "content": "Hello! How can I help you?"
+        }, {
+            "role": "user",
+            "content": "Tell me a joke."
+        }],
+    )
     check_reponse(response, "test_chat: ")
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_multi_turn_chat(client: openai.AsyncOpenAI, model: str):
-    response = await client.responses.create(model=model,
-                                             input="What is the answer of 1+1?",
-                                             max_output_tokens=1024)
+    response = await client.responses.create(
+        model=model,
+        input=_get_qwen3_nothink_input(model, "What is the answer of 1+1?"),
+    )
     check_reponse(response, "test_multi_turn_chat_1: ")
 
     response_2 = await client.responses.create(
         model=model,
-        input="What is the answer of previous question?",
+        input=_get_qwen3_nothink_input(
+            model, "What is the answer of previous question?"),
         previous_response_id=response.id,
-        max_output_tokens=1024)
+    )
     check_reponse(response_2, "test_multi_turn_chat_2: ")
 
 
@@ -159,7 +160,6 @@ def get_current_weather(location: str, format: str = "celsius") -> dict:
     return {"sunny": True, "temperature": 20 if format == "celsius" else 68}
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_tool_calls(client: openai.AsyncOpenAI, model: str):
     if model.startswith("DeepSeek-R1"):
@@ -186,10 +186,11 @@ async def test_tool_calls(client: openai.AsyncOpenAI, model: str):
         }
     }
     messages = [{"role": "user", "content": "What is the weather like in SF?"}]
-    response = await client.responses.create(model=model,
-                                             input=messages,
-                                             tools=[tool_get_current_weather],
-                                             max_output_tokens=1024)
+    response = await client.responses.create(
+        model=model,
+        input=messages,
+        tools=[tool_get_current_weather],
+    )
     messages.extend(response.output)
     function_call = check_tool_calling(response, True, "test_tool_calls: ")
 
@@ -203,22 +204,22 @@ async def test_tool_calls(client: openai.AsyncOpenAI, model: str):
         "output": json.dumps(answer),
     })
 
-    response = await client.responses.create(model=model,
-                                             input=messages,
-                                             tools=[tool_get_current_weather],
-                                             max_output_tokens=1024)
+    response = await client.responses.create(
+        model=model,
+        input=messages,
+        tools=[tool_get_current_weather],
+    )
 
     check_tool_calling(response, False, "test_tool_calls: ")
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_streaming(client: openai.AsyncOpenAI, model: str):
     stream = await client.responses.create(
         model=model,
         input="Explain the theory of relativity in brief.",
         stream=True,
-        max_output_tokens=1024)
+    )
 
     reasoning_deltas, message_deltas = list(), list()
     async for event in stream:
@@ -233,7 +234,6 @@ async def test_streaming(client: openai.AsyncOpenAI, model: str):
     assert full_reasoning_response
 
 
-@pytest.mark.skip(reason="https://nvbugs/5753250")
 @pytest.mark.asyncio(loop_scope="module")
 async def test_streaming_tool_call(client: openai.AsyncOpenAI, model: str):
     if model.startswith("DeepSeek-R1"):
@@ -260,11 +260,12 @@ async def test_streaming_tool_call(client: openai.AsyncOpenAI, model: str):
         }
     }
     messages = [{"role": "user", "content": "What is the weather like in SF?"}]
-    stream = await client.responses.create(model=model,
-                                           input=messages,
-                                           tools=[tool_get_current_weather],
-                                           stream=True,
-                                           max_output_tokens=1024)
+    stream = await client.responses.create(
+        model=model,
+        input=messages,
+        tools=[tool_get_current_weather],
+        stream=True,
+    )
 
     function_call = None
     reasoning_deltas = list()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable initialization in response handling to ensure stable operation across different output scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
