### PR TITLE
[None][fix] Optimize flashinfer sampling via filter_apply_order=joint

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
@@ -491,7 +491,7 @@ class _StrategyImpls:
                 #     compute unnecessarily softmax also for situations allowing
                 #     flashinfer.sampling...._sampling_from_logits.
                 # indices=group_logit_indices,
-                filter_apply_order="top_k_first",
+                filter_apply_order="joint",
                 deterministic=True,
                 check_nan=self._flashinfer_check_nans(logits),
                 generator=generator,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sampling behavior by adjusting how top-k and top-p filtering are applied during token generation, potentially enhancing sampling quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

When min_tokens is set in Sampling Params, using FlashInfer's top_k_top_p_sampling_from_logits kernel causes a significant increase in TPOT and TTFT. This is because the default filter_apply_order="top_k_first" is sensitive to -inf logit values, causing severe performance degradation when they are present. Switching the order to "joint" fixes this regression and additionally improves performance in general scenarios where min_tokens is not set.

For some torch profiler traces and Accuracy test of what this looks like, see an identical bug in vLLM: https://github.com/vllm-project/vllm/pull/29979

this PR. With min_tokens (introduces -inf):
```
# server 
trtllm-serve serve /workspace/models/Qwen3-32B/
# client
aiperf profile --model /workspace/models/Qwen3-32B/ --endpoint-type chat --url localhost:8000 --streaming --concurrency 1 --request-count 256 --warmup-request-count 0 --isl 50 --osl 200  --extra-inputs min_tokens:200  --extra-inputs top_k:20 --extra-inputs top_p:0.8   --artifact-dir /tmp --profile-export-file qwen3-32b

                                           NVIDIA AIPerf | LLM Metrics                                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃                               Metric ┃      avg ┃      min ┃      max ┃      p99 ┃      p90 ┃      p50 ┃  std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
│             Time to First Token (ms) │    40.10 │    38.35 │    44.13 │    43.82 │    41.05 │    39.84 │ 1.50 │
│            Time to Second Token (ms) │    24.36 │    23.97 │    24.61 │    24.60 │    24.49 │    24.37 │ 0.16 │
│                 Request Latency (ms) │ 4,943.07 │ 4,941.66 │ 4,946.19 │ 4,946.00 │ 4,944.31 │ 4,942.87 │ 1.26 │
│             Inter Token Latency (ms) │    24.64 │    24.63 │    24.64 │    24.64 │    24.64 │    24.64 │ 0.00 │
│     Output Token Throughput Per User │    40.59 │    40.58 │    40.60 │    40.59 │    40.59 │    40.59 │ 0.00 │
│                    (tokens/sec/user) │          │          │          │          │          │          │      │
│      Output Sequence Length (tokens) │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │ 0.00 │
│       Input Sequence Length (tokens) │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │ 0.00 │
│ Output Token Throughput (tokens/sec) │    40.43 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│    Request Throughput (requests/sec) │     0.20 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│             Request Count (requests) │    10.00 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
└──────────────────────────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
```
main. With min_tokens (introduces -inf):
```
                                           NVIDIA AIPerf | LLM Metrics                                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃                               Metric ┃      avg ┃      min ┃      max ┃      p99 ┃      p90 ┃      p50 ┃  std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
│             Time to First Token (ms) │    81.87 │    77.23 │    95.02 │    93.93 │    84.04 │    80.53 │ 4.69 │
│            Time to Second Token (ms) │    39.57 │    39.18 │    40.34 │    40.32 │    40.16 │    39.34 │ 0.41 │
│                 Request Latency (ms) │ 7,125.91 │ 7,119.39 │ 7,143.17 │ 7,142.23 │ 7,133.76 │ 7,123.78 │ 7.17 │
│             Inter Token Latency (ms) │    35.40 │    35.37 │    35.43 │    35.43 │    35.42 │    35.39 │ 0.02 │
│     Output Token Throughput Per User │    28.25 │    28.22 │    28.27 │    28.27 │    28.27 │    28.25 │ 0.02 │
│                    (tokens/sec/user) │          │          │          │          │          │          │      │
│      Output Sequence Length (tokens) │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │ 0.00 │
│       Input Sequence Length (tokens) │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │ 0.00 │
│ Output Token Throughput (tokens/sec) │    28.05 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│    Request Throughput (requests/sec) │     0.14 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│             Request Count (requests) │    10.00 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
└──────────────────────────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
```
main. Without min_tokens (no -inf):
```
aiperf profile --model /workspace/models/Qwen3-32B/ --endpoint-type chat --url localhost:8000 --streaming --concurrency 1 --request-count 256 --warmup-request-count 0 --isl 50 --osl 200   --extra-inputs top_k:20 --extra-inputs top_p:0.8   --artifact-dir /tmp --profile-export-file qwen3-32b

                                           NVIDIA AIPerf | LLM Metrics                                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃                               Metric ┃      avg ┃      min ┃      max ┃      p99 ┃      p90 ┃      p50 ┃  std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
│             Time to First Token (ms) │    40.84 │    38.58 │    47.18 │    46.69 │    42.24 │    40.35 │ 2.33 │
│            Time to Second Token (ms) │    25.62 │    25.16 │    25.87 │    25.87 │    25.83 │    25.67 │ 0.21 │
│                 Request Latency (ms) │ 5,177.12 │ 5,171.70 │ 5,185.02 │ 5,184.60 │ 5,180.82 │ 5,176.47 │ 3.91 │
│             Inter Token Latency (ms) │    25.81 │    25.79 │    25.83 │    25.83 │    25.83 │    25.81 │ 0.01 │
│     Output Token Throughput Per User │    38.74 │    38.72 │    38.77 │    38.77 │    38.77 │    38.74 │ 0.02 │
│                    (tokens/sec/user) │          │          │          │          │          │          │      │
│      Output Sequence Length (tokens) │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │   200.00 │ 0.00 │
│       Input Sequence Length (tokens) │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │    50.00 │ 0.00 │
│ Output Token Throughput (tokens/sec) │    38.60 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│    Request Throughput (requests/sec) │     0.19 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│             Request Count (requests) │    10.00 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
└──────────────────────────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
```


<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
