### PR TITLE
[#10170][fix] Add export patch for GraniteMoe MoE models to enable torch.export compatibility

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/patches/granitemoe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/granitemoe.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A patch for GraniteMoe to make it compatible with torch.export.
+
+The main issue is that GraniteMoeTopKGating calls `.tolist()` on a tensor which is:
+1. Incompatible with meta tensors (no data to access)
+2. Incompatible with torch.compile/export (data-dependent operation)
+
+This patch rewrites the MoE forward to use the torch_moe custom op instead.
+"""
+
+import torch
+import torch.nn.functional as F
+from transformers.models.granitemoe import modeling_granitemoe
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+def _forward_moe(self, layer_input: torch.Tensor):
+    """GraniteMoe forward rewritten for torch.export compatibility.
+
+    This replaces the original forward which uses data-dependent operations
+    like `.tolist()` that are incompatible with torch.export and meta tensors.
+
+    Uses the torch_moe custom op for export compatibility.
+    """
+    bsz, length, emb_size = layer_input.size()
+    layer_input_flat = layer_input.reshape(-1, emb_size)
+
+    # Compute router logits directly - avoid the problematic router.forward() which calls .tolist()
+    router_logits = self.router.layer(layer_input_flat).float()
+
+    # Get top-k routing (matches original router: topk first, then softmax on top-k only)
+    top_k_logits, selected_experts = torch.topk(router_logits, self.router.top_k, dim=-1)
+    routing_weights = F.softmax(top_k_logits, dim=1, dtype=torch.float)
+    routing_weights = routing_weights.to(layer_input_flat.dtype)
+
+    input_weight = self.input_linear.weight  # [E, 2*I, H]
+    intermediate_size = input_weight.shape[1] // 2  # I = intermediate_size
+
+    # GraniteMoe stores weights as [gate, up] = [w1, w3]
+    # torch_moe expects [w3, w1] order for stacked format
+    gate_proj = input_weight[:, :intermediate_size, :]  # [E, I, H] - this is w1 (gate)
+    up_proj = input_weight[:, intermediate_size:, :]  # [E, I, H] - this is w3 (up)
+    w3_w1_stacked = torch.cat([up_proj, gate_proj], dim=1)  # [E, 2*I, H] - [w3, w1] order
+
+    w2_stacked = self.output_linear.weight  # [E, H, I]
+
+    # Use torch_moe with stacked tensor format (single-element list)
+    layer_output = torch.ops.auto_deploy.torch_moe(
+        layer_input_flat,
+        selected_experts,
+        routing_weights,
+        w1_weight=[w3_w1_stacked],  # Stacked format: single tensor [E, 2*I, H]
+        w2_weight=[w2_stacked],  # Stacked format: single tensor [E, H, I]
+        w3_weight=[],  # Empty for stacked format
+        mlp_style="gated_mlp",
+        act_fn="silu",
+    )
+
+    layer_output = layer_output.view(bsz, length, self.input_size)
+    return layer_output, router_logits
+
+
+@ExportPatchRegistry.register("hf_granitemoe_moe")
+class GraniteMoePatch(BaseExportPatch):
+    """Patch for GraniteMoe to make it compatible with torch.export.
+
+    GraniteMoe has a critical issue: GraniteMoeTopKGating calls `.tolist()` on a tensor,
+    which is:
+    1. Incompatible with meta tensors (no data to access - causes "Cannot copy out of meta tensor")
+    2. Incompatible with torch.compile/export (data-dependent operation)
+
+    This patch rewrites the MoE forward to use the torch_moe custom op instead,
+    which handles routing in an export-compatible way.
+    """
+
+    def _apply_patch(self):
+        """Apply the GraniteMoe patch."""
+        # Store original forward method
+        self.original_values["GraniteMoeMoE.forward"] = modeling_granitemoe.GraniteMoeMoE.forward
+
+        # Apply patch by replacing the forward method
+        modeling_granitemoe.GraniteMoeMoE.forward = _forward_moe
+
+    def _revert_patch(self):
+        """Revert the GraniteMoe patch."""
+        # Restore original forward method
+        modeling_granitemoe.GraniteMoeMoE.forward = self.original_values["GraniteMoeMoE.forward"]


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Fixes #10170 AutoDeploy compilation failures for IBM Granite MoE models (e.g., `ibm-granite/granite-3.1-3b-a800m-instruct`) with the error:
> "Cannot copy out of meta tensor; no data!"

**Root Cause:** `GraniteMoeTopKGating` calls `.tolist()` on a tensor, which is:
1. Incompatible with meta tensors (no data to access)
2. Incompatible with torch.compile/export 

**Solution**: Adds a new export patch (`hf_granitemoe_moe`) that rewrites the MoE forward pass.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

1) Ran both original and patched forward with real tensors on CPU — compared for numerical accuracy. 
2) Tested that the patch enables successful `torch.export` of the full model, which was previously failing with the "Cannot copy out of meta tensor" error.
3) Verified the patch correctly applies and reverts, restoring the original method after use.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced torch.export compatibility for Granite MoE models, enabling optimized model export and improved deployment capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->