### PR TITLE
[#10143][fix] Enable reasoning_parser in LLM API

### DIFF
--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -30,6 +30,8 @@ class PostprocArgs:
     first_iteration: bool = True
     num_prompt_tokens: Optional[int] = None
     tokenizer: Optional[TransformersTokenizer] = None
+    reasoning_parser: Optional[
+        str] = None  # For LLM API reasoning parser support
 
 
 @dataclass(kw_only=True)

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -1,8 +1,184 @@
 import pytest
 
+from tensorrt_llm.executor.postproc_worker import PostprocArgs, PostprocParams
+from tensorrt_llm.executor.result import CompletionOutput
 from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 
 R1_START, R1_END = "<think>", "</think>"
+
+# ============================================================================
+# Tests for PostprocArgs reasoning_parser field
+# ============================================================================
+
+
+def test_postproc_args_has_reasoning_parser_field():
+    """Test that PostprocArgs has the reasoning_parser field."""
+    args = PostprocArgs()
+    assert hasattr(args, 'reasoning_parser')
+    assert args.reasoning_parser is None
+
+
+def test_postproc_args_with_reasoning_parser():
+    """Test PostprocArgs can be created with reasoning_parser."""
+    args = PostprocArgs(reasoning_parser="qwen3")
+    assert args.reasoning_parser == "qwen3"
+
+
+def test_postproc_params_with_reasoning_parser():
+    """Test PostprocParams can carry reasoning_parser via PostprocArgs."""
+    args = PostprocArgs(reasoning_parser="deepseek-r1")
+    params = PostprocParams(postproc_args=args)
+    assert params.postproc_args.reasoning_parser == "deepseek-r1"
+
+
+# ============================================================================
+# Tests for CompletionOutput reasoning_content field
+# ============================================================================
+
+
+def test_completion_output_has_reasoning_content_field():
+    """Test that CompletionOutput has the reasoning_content field."""
+    output = CompletionOutput(index=0)
+    assert hasattr(output, 'reasoning_content')
+    assert output.reasoning_content is None
+
+
+def test_completion_output_with_reasoning_content():
+    """Test CompletionOutput can store reasoning_content."""
+    output = CompletionOutput(index=0)
+    output.text = "The answer is 42."
+    output.reasoning_content = "Let me think step by step..."
+    assert output.text == "The answer is 42."
+    assert output.reasoning_content == "Let me think step by step..."
+
+
+# ============================================================================
+# Tests for reasoning parser integration with result layer
+# ============================================================================
+
+
+class MockGenerationResultBase:
+    """Mock class to test _apply_reasoning_parser_if_needed logic."""
+
+    def __init__(self, postproc_params=None):
+        self.postproc_params = postproc_params
+        self._outputs = [CompletionOutput(index=0)]
+
+    def _apply_reasoning_parser_if_needed(self) -> None:
+        """Apply reasoning parser to completed outputs (non-streaming, no postproc workers)."""
+        if self.postproc_params is None:
+            return
+        postproc_args = self.postproc_params.postproc_args
+        if postproc_args is None:
+            return
+        reasoning_parser_name = getattr(postproc_args, 'reasoning_parser', None)
+        if not reasoning_parser_name:
+            return
+        # Avoid re-parsing if already done by postproc workers
+        if self.postproc_params.post_processor is not None:
+            return
+        parser = ReasoningParserFactory.create_reasoning_parser(
+            reasoning_parser_name)
+        for output in self._outputs:
+            parsed = parser.parse(output.text)
+            output.text = parsed.content
+            output.reasoning_content = parsed.reasoning_content
+
+
+def test_apply_reasoning_parser_no_postproc_params():
+    """Test that no parsing happens when postproc_params is None."""
+    result = MockGenerationResultBase(postproc_params=None)
+    result._outputs[0].text = "<think>reasoning</think>answer"
+    result._apply_reasoning_parser_if_needed()
+    # Should remain unchanged
+    assert result._outputs[0].text == "<think>reasoning</think>answer"
+    assert result._outputs[0].reasoning_content is None
+
+
+def test_apply_reasoning_parser_no_postproc_args():
+    """Test that no parsing happens when postproc_args is None."""
+    params = PostprocParams(postproc_args=None)
+    result = MockGenerationResultBase(postproc_params=params)
+    result._outputs[0].text = "<think>reasoning</think>answer"
+    result._apply_reasoning_parser_if_needed()
+    # Should remain unchanged
+    assert result._outputs[0].text == "<think>reasoning</think>answer"
+    assert result._outputs[0].reasoning_content is None
+
+
+def test_apply_reasoning_parser_no_parser_name():
+    """Test that no parsing happens when reasoning_parser is None."""
+    args = PostprocArgs(reasoning_parser=None)
+    params = PostprocParams(postproc_args=args)
+    result = MockGenerationResultBase(postproc_params=params)
+    result._outputs[0].text = "<think>reasoning</think>answer"
+    result._apply_reasoning_parser_if_needed()
+    # Should remain unchanged
+    assert result._outputs[0].text == "<think>reasoning</think>answer"
+    assert result._outputs[0].reasoning_content is None
+
+
+def test_apply_reasoning_parser_skips_when_post_processor_set():
+    """Test that no parsing happens when post_processor is already set (postproc workers)."""
+    args = PostprocArgs(reasoning_parser="qwen3")
+    params = PostprocParams(postproc_args=args,
+                            post_processor=lambda x, y: x)  # Dummy processor
+    result = MockGenerationResultBase(postproc_params=params)
+    result._outputs[0].text = "<think>reasoning</think>answer"
+    result._apply_reasoning_parser_if_needed()
+    # Should remain unchanged because post_processor is set
+    assert result._outputs[0].text == "<think>reasoning</think>answer"
+    assert result._outputs[0].reasoning_content is None
+
+
+@pytest.mark.parametrize(
+    ("parser_name", "text", "expected_content", "expected_reasoning"), [
+        ("qwen3", "<think>step by step</think>42", "42", "step by step"),
+        ("qwen3", "<think>let me think</think>The answer is 60",
+         "The answer is 60", "let me think"),
+        ("qwen3", "no thinking tags here", "no thinking tags here", ""),
+        ("deepseek-r1", "thinking process</think>final answer", "final answer",
+         "thinking process"),
+        ("deepseek-r1", "all reasoning no end tag", "",
+         "all reasoning no end tag"),
+    ])
+def test_apply_reasoning_parser_parses_correctly(parser_name, text,
+                                                 expected_content,
+                                                 expected_reasoning):
+    """Test that reasoning parser correctly parses text with various patterns."""
+    args = PostprocArgs(reasoning_parser=parser_name)
+    params = PostprocParams(postproc_args=args)
+    result = MockGenerationResultBase(postproc_params=params)
+    result._outputs[0].text = text
+    result._apply_reasoning_parser_if_needed()
+    assert result._outputs[0].text == expected_content
+    assert result._outputs[0].reasoning_content == expected_reasoning
+
+
+def test_apply_reasoning_parser_multiple_outputs():
+    """Test that reasoning parser is applied to all outputs."""
+    args = PostprocArgs(reasoning_parser="qwen3")
+    params = PostprocParams(postproc_args=args)
+    result = MockGenerationResultBase(postproc_params=params)
+    # Add multiple outputs
+    result._outputs = [
+        CompletionOutput(index=0),
+        CompletionOutput(index=1),
+    ]
+    result._outputs[0].text = "<think>reason1</think>answer1"
+    result._outputs[1].text = "<think>reason2</think>answer2"
+
+    result._apply_reasoning_parser_if_needed()
+
+    assert result._outputs[0].text == "answer1"
+    assert result._outputs[0].reasoning_content == "reason1"
+    assert result._outputs[1].text == "answer2"
+    assert result._outputs[1].reasoning_content == "reason2"
+
+
+# ============================================================================
+# Original reasoning parser unit tests
+# ============================================================================
 
 
 @pytest.mark.parametrize(("text", "content", "reasoning_context"), [


### PR DESCRIPTION
Add support for reasoning_parser in the direct LLM API (generate/generate_async). Previously, reasoning_parser was only functional in trtllm-serve.

Changes:
- Add reasoning_parser field to PostprocArgs
- Add reasoning_content field to CompletionOutput
- Apply reasoning parser in result() and aresult() methods
- Pass PostprocParams through generate() to generate_async()

Fixes: #10143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reasoning parser support to the LLM API, enabling extraction of reasoning content from model outputs.
  * Reasoning content is now available in completion outputs for compatible parser configurations (Qwen3, DeepSeek-R1).

* **Tests**
  * Added comprehensive unit tests validating reasoning parser integration and output handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [V] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
