### PR TITLE
[https://nvbugs/5633700][fix] Cache tiktoken vocab for gpt-oss

### DIFF
--- a/tensorrt_llm/serve/harmony_adapter.py
+++ b/tensorrt_llm/serve/harmony_adapter.py
@@ -217,8 +217,9 @@ class HarmonyStreamState:
 
                 # Check if tool is allowed
                 if self.should_filter_tools and func_name not in self.available_tools:
-                    logger.debug("Request %s: tool %s not in available tools",
-                                 self.request_id, func_name)
+                    logger.debug(
+                        f"Request {self.request_id}: tool {func_name} not in available tools"
+                    )
                     return None
 
                 # Get or create tool call
@@ -273,8 +274,9 @@ class HarmonyStreamState:
             else:
                 return {"content": self.parser.last_content_delta}
         else:
-            logger.debug("Request %s: no delta generated for channel=%s",
-                         self.request_id, self.parser.current_channel)
+            logger.debug(
+                f"Request {self.request_id}: no delta generated for channel={self.parser.current_channel}"
+            )
             return None
 
     def _get_or_create_tool_call(self, func_name: str) -> str:
@@ -295,8 +297,9 @@ class HarmonyStreamState:
             "active": True
         }
         self.tool_call_index += 1
-        logger.debug("Request %s: created new tool call %s for function %s",
-                     self.request_id, tool_id, func_name)
+        logger.debug(
+            f"Request {self.request_id}: created new tool call {tool_id} for function {func_name}"
+        )
         return tool_id
 
     def get_debug_info(self) -> dict[str, Any]:
@@ -896,8 +899,8 @@ class HarmonyAdapter:
                 }
             except json.JSONDecodeError:
                 logger.warning(
-                    "Failed to parse tool call arguments as JSON: %s",
-                    function_call_args)
+                    f"Failed to parse tool call arguments as JSON: {function_call_args}"
+                )
                 return None
         elif msg_content_type and "code" in msg_content_type:
             function_name = str(msg_recipient)
@@ -1023,10 +1026,11 @@ class HarmonyAdapter:
             except (HarmonyError, UnicodeDecodeError,
                     ValueError) as parse_error:
                 logger.warning(
-                    "Failed to parse harmony messages from tokens: %s",
-                    parse_error)
-                logger.debug("Problematic clean tokens (%d): %s",
-                             len(clean_tokens), clean_tokens)
+                    f"Failed to parse harmony messages from tokens: {parse_error}"
+                )
+                logger.debug(
+                    f"Problematic clean tokens ({len(clean_tokens)}): {clean_tokens}"
+                )
                 # Fallback to raw text parsing
                 raise RuntimeError(f"Harmony parsing failed: {parse_error}"
                                    )  # This will be caught by outer try-catch
@@ -1103,9 +1107,9 @@ class HarmonyAdapter:
         except Exception as e:
             raw_text = self._safe_decode_utf8(harmony_output_tokens,
                                               "HARMONY _OUTPUT: ")
-            logger.warning("Failed to parse harmony output: %s. Raw output: %s",
-                           e, raw_text)
-            logger.debug("Detailed error: %s", traceback.format_exc())
+            logger.warning(
+                f"Failed to parse harmony output: {e}. Raw output: {raw_text}")
+            logger.debug(f"Detailed error: {traceback.format_exc()}")
 
             # Check if raw_text contains a decode error (fallback content)
             if "HARMONY_OUTPUT:" in raw_text:
@@ -1276,9 +1280,9 @@ class HarmonyAdapter:
             return deltas
         except (HarmonyError, UnicodeDecodeError, ValueError):
             logger.error(
-                f"Streaming: Failed to process token batch of {len(tokens)} tokens for request {request_id}",
+                f"Streaming: Failed to process token batch of {len(tokens)} tokens for request {request_id}"
             )
-            logger.debug("Problematic streaming tokens: %s", tokens)
+            logger.debug(f"Problematic streaming tokens: {tokens}")
 
             # Return empty deltas to continue processing
             return []
@@ -1457,8 +1461,8 @@ class HarmonyAdapter:
         """
         if request_id in self._stream_states:
             logger.warning(
-                "Stream state already exists for request %s, replacing",
-                request_id)
+                f"Stream state already exists for request {request_id}, replacing"
+            )
 
         stream_state = HarmonyStreamState(
             request_id=request_id,
@@ -1494,7 +1498,7 @@ class HarmonyAdapter:
 
             # Filter unavailable external tools
             if should_filter_external_tools and func_name not in external_tools:
-                logger.debug("Filtered unavailable tool call: %s", func_name)
+                logger.debug(f"Filtered unavailable tool call: {func_name}")
                 continue
 
             filtered.append(tool_call)
@@ -1644,7 +1648,7 @@ def handle_non_streaming_response(tools: List[ChatCompletionToolsParam],
         output.token_ids, tools_for_parser, tool_choice)
 
     # CONVERTED OUTPUT (after harmony to openai conversion)
-    logger.debug("✅ CONVERTED OUTPUT: %s", json.dumps(parsed_output, indent=2))
+    logger.debug(f"✅ CONVERTED OUTPUT: {json.dumps(parsed_output, indent=2)}")
 
     # Create response message
     response_message = _create_response_message(parsed_output)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -369,7 +369,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_nvfp4[tp4ep4-cutla
 accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_nvfp4[tp4ep4-trtllm] SKIP (https://nvbugs/5702795)
 test_e2e.py::test_ptp_quickstart_multimodal[mistral-small-3.1-24b-instruct-Mistral-Small-3.1-24B-Instruct-2503-mixture_text_image-True] SKIP (https://nvbugs/5648560)
 test_e2e.py::test_ptp_quickstart_multimodal_2gpu[mistral-small-3.1-24b-instruct-Mistral-Small-3.1-24B-Instruct-2503] SKIP (https://nvbugs/5648560)
-test_e2e.py::test_openai_chat_harmony SKIP (https://nvbugs/5633700)
 accuracy/test_cli_flow.py::TestGpt2::test_weight_only[int4] SKIP (https://nvbugs/5705193)
 accuracy/test_cli_flow.py::TestGpt2::test_int8_kv_cache SKIP (https://nvbugs/5705193)
 accuracy/test_cli_flow.py::TestLlama2_7B::test_fp8_2gpus[cp2] SKIP (https://nvbugs/5705194)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated logging message formatting to use modern f-string syntax.

* **Tests**
  * Enabled previously skipped test for enhanced coverage.
  * Extended test cases with additional validation parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
