### PR TITLE
[#10244][feat] AutoDeploy: separate prefill/decode in flashinfer

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -508,6 +508,9 @@ class SequenceInfo:
         # Create the InputBuffer that manages contiguous host and device memory
         # Starts on default device; use to() to move to target device
         self._input_buffer = InputBuffer(tensor_specs)
+        self._available_args = set(self._input_buffer.tensor_names) | {
+            f"{name}_host" for name in self._input_buffer.tensor_names
+        }
 
         # Initialize args_list from tensor specs
         self._args_list: Dict[str, List[int]] = {
@@ -515,9 +518,7 @@ class SequenceInfo:
         }
 
         self._active_args = ("input_ids", "position_ids")
-        self._shapeable_args = ("input_ids", "position_ids")
-        # Args that should be returned from host (pinned memory) instead of device in _named_args
-        self._host_return_args = ("batch_info", "logits_gather_info")
+        self._shapeable_args = ("input_ids", "position_ids", "input_ids_host", "position_ids_host")
         ############################################################################################
 
         # EXTRA TENSOR FIELDS ######################################################################
@@ -558,14 +559,13 @@ class SequenceInfo:
 
     def _get_arg(self, name: str) -> torch.Tensor:
         """Get the argument from the input buffer either on device or host."""
-        if name in self._host_return_args:
-            arg = self._input_buffer.get_host_view(name)
+        if name.endswith("_host"):
+            arg = self._input_buffer.get_host_view(name.replace("_host", ""))
         else:
             arg = self._input_buffer.get_view(name)
         return self._shape_for_forward(arg) if name in self._shapeable_args else arg
 
     def _named_args(self, include_extra_args: bool = True) -> Dict[str, torch.Tensor]:
-        # Build args dict, using host views for _host_return_args, device views otherwise
         args = {k: self._get_arg(k) for k in self._active_args}
 
         # check other args to include
@@ -577,7 +577,7 @@ class SequenceInfo:
     @property
     def available_args(self) -> Set[str]:
         """Return a list of available arguments."""
-        return set(self._input_buffer.tensor_names)
+        return self._available_args
 
     @property
     def named_args(self) -> Dict[str, torch.Tensor]:
@@ -697,68 +697,6 @@ class SequenceInfo:
         pages_per_seq = [len(p) for p in page_assignments]
         return cache_loc_flat, pages_per_seq
 
-    # TODO: remove after updating all cached backends
-    @classmethod
-    def _get_sanitized_seq_len(
-        cls, input_or_position_ids: torch.Tensor, seq_len: torch.Tensor
-    ) -> torch.Tensor:
-        """Sanitize sequence lengths.
-
-        We want to cover the following scenarios with this function:
-
-        1. Pre-fill:
-            input_ids: [1, s_total, ...]
-            seq_len: [s_0, s_1, ..., s_{b-1}, 0, 0, ..., 0]
-            ---> returns [s_0, s_1, ..., s_{b-1}]
-        2. Decode:
-            input_ids: [b, 1, ...]
-            seq_len: [1, 1, ..., 1, 0, 0, ..., ..., ..., ..., 0]
-                     |---- b ----|--- (max_batch_size - b) ---|
-            --> returns [1,] * b
-        3. Decode in Cudagraph:
-            input_ids: [b_cudagraph, 1, ...]
-            seq_len: [1, 1, ..., 1, 0, 0, ..., ..., ..., ..., 0]
-                     |---- b ----|--- (max_batch_size - b) ---|
-
-            --> returns [1,] * b_cudagraph
-            Here b <= b_cudagraph. We want to make sure that the seq_len is one-padded to
-            b_cudagraph.
-
-            # TODO: I could see one possible issue with this approach in the future.
-            # If we have b < b_cudagraph we now one-pad. However, we don't pad the cache location
-            # information. What could happen is that the for the padded sequences the cache location
-            # tensors point to allocated pages. This could lead to a situation where we write into
-            # allocated cache pages polluting the cache of other sequences. Now this is not an issue
-            # if we write the dummy sequences into unallocated cache pages... One fix could be to
-            # pad not only the seq len but also pad the cache locations by just repeating the last
-            # valid cache location in the batch. This would ensure that the dummy sequences just
-            # repeats valid computation...
-        """
-        _, s = input_or_position_ids.shape[:2]
-        num_seq = cls._get_sanitized_num_sequences(input_or_position_ids, seq_len)
-        if s > 1:
-            return seq_len[:num_seq].clone()
-        else:
-            return torch.ones(num_seq, dtype=seq_len.dtype, device=seq_len.device)
-
-    @staticmethod
-    def _get_sanitized_num_sequences(
-        input_or_position_ids: torch.Tensor, seq_len: torch.Tensor
-    ) -> int:
-        """Get number of sequences.
-
-        We makes sure that this function is compatible with both torch graph capture and cudagraph.
-        Both can be a bit temparamental when trying to extract the number of sequences from a tensor
-        with max_batch_size or max_batch_size*max_seq_len.
-        """
-        b, s = input_or_position_ids.shape[:2]
-        if s > 1:
-            num_seq = torch.sum(seq_len > 0)
-            assert seq_len[num_seq:].sum() == 0, "seq_len should be zero-padded"
-        else:
-            num_seq = b
-        return num_seq
-
     def activate_arg(self, arg_name: str) -> bool:
         """Activate a desired argument.
 
@@ -869,7 +807,7 @@ class SequenceInfo:
             self._args_list[name] = tnsr_like.copy()
 
             # Only store to buffer when the argument is active or force_copy is True
-            if not (name in self._active_args or force_copy):
+            if not (name in self._active_args or f"{name}_host" in self._active_args or force_copy):
                 return
 
             # Store to the InputBuffer's pinned host memory
@@ -1090,12 +1028,12 @@ class SequenceInfo:
     def maybe_gather_and_squeeze_logits(self, logits: torch.Tensor) -> torch.Tensor:
         """Maybe gather the logits if logits have not been gathered yet."""
         num_tokens = logits.shape[0] * logits.shape[1]
-        num_tokens_to_gather, gather_required = self._get_arg("logits_gather_info").tolist()
+        num_tokens_to_gather, gather_required = self._get_arg("logits_gather_info_host").tolist()
         if gather_required and num_tokens_to_gather < num_tokens:
             logits = torch.ops.auto_deploy.gather_logits_before_lm_head(
                 logits,
                 self._get_arg("logits_gather_indices"),
-                self._get_arg("logits_gather_info"),
+                self._get_arg("logits_gather_info_host"),
             )
         return logits.squeeze(int(self.is_generate))
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_delta.py
@@ -35,7 +35,7 @@ def fla_cached_delta_rule(
     v: torch.Tensor,
     beta: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
     use_initial_states: torch.Tensor,
@@ -58,7 +58,7 @@ def fla_cached_delta_rule(
     y = torch.empty_like(v, memory_format=torch.contiguous_format)
     y_flat = y.view(b * s, num_heads, -1)
 
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
 
     # clean up metadata
@@ -120,7 +120,7 @@ def fla_cached_delta_rule_fake(
     v: torch.Tensor,
     beta: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
     use_initial_states: torch.Tensor,
@@ -160,7 +160,7 @@ class FlaDeltaBackend(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "cu_seqlen", "slot_idx", "use_initial_states"]
+        return ["batch_info_host", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
@@ -53,7 +53,7 @@ def _cuda_cached_causal_conv1d(
     weight: torch.Tensor,  # [c_out, c_in/groups, k] but we expect depthwise use: [c_in, k]
     bias: Optional[torch.Tensor],
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
     use_initial_states: torch.Tensor,
@@ -80,7 +80,7 @@ def _cuda_cached_causal_conv1d(
     """
     b, s = input.shape[:2]
 
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
     num_total_tokens = num_prefill_tokens + num_decode
 
@@ -138,7 +138,7 @@ def _cuda_cached_causal_conv1d_fake(
     weight: torch.Tensor,  # [c_out, c_in/groups, k] but we expect depthwise use: [c_in, k]
     bias: Optional[torch.Tensor],
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
     use_initial_states: torch.Tensor,
@@ -189,7 +189,7 @@ class CudaBackendCausalConv(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "cu_seqlen", "slot_idx", "use_initial_states"]
+        return ["batch_info_host", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_causal_conv.py
@@ -147,7 +147,7 @@ def _torch_cached_causal_conv1d(
     weight: torch.Tensor,  # [c_out, c_in/groups, k]
     bias: Optional[torch.Tensor],
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
@@ -174,7 +174,7 @@ def _torch_cached_causal_conv1d(
     num_seq = seq_len.shape[0]
 
     # get cleaned up metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
     seq_len = seq_len[:num_seq]
     seq_start = cu_seqlen[:num_seq]
@@ -247,7 +247,7 @@ def _torch_cached_causal_conv1d_fake(
     weight: torch.Tensor,  # [c_out, c_in/groups, k]
     bias: Optional[torch.Tensor],
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
@@ -296,7 +296,7 @@ class TorchBackendCausalConv(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "seq_len", "cu_seqlen", "slot_idx", "use_initial_states"]
+        return ["batch_info_host", "seq_len", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -121,7 +121,7 @@ def _torch_cached_ssm(
     dt: torch.Tensor,  # [b, s, num_heads]
     dt_bias: torch.Tensor,  # [num_heads]
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
@@ -145,7 +145,7 @@ def _torch_cached_ssm(
     num_seq = seq_len.shape[0]
 
     # get cleaned up metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
     seq_len = seq_len[:num_seq]
     seq_start = cu_seqlen[:num_seq]
@@ -246,7 +246,7 @@ def _torch_cached_ssm_fake(
     dt: torch.Tensor,  # [b, s, num_heads]
     dt_bias: torch.Tensor,  # [num_heads]
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     cu_seqlen: torch.Tensor,
     slot_idx: torch.Tensor,
@@ -293,7 +293,7 @@ class TorchBackendSSM(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "seq_len", "cu_seqlen", "slot_idx", "use_initial_states"]
+        return ["batch_info_host", "seq_len", "cu_seqlen", "slot_idx", "use_initial_states"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -31,7 +31,7 @@ def fused_flattened_mla_with_cache(
     kv: torch.Tensor,
     k_pe: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -55,7 +55,7 @@ def fused_flattened_mla_with_cache(
     #    and number of tokens per sequence are encoded in seq_len and seq_start.
 
     # check for sequence info and truncate metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
 
     seq_len = seq_len[:num_seq]
@@ -166,7 +166,7 @@ def fused_flattened_mla_with_cache_fake(
     kv: torch.Tensor,
     k_pe: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -212,7 +212,7 @@ class MultiHeadLatentAttention(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
+        return ["batch_info_host", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
@@ -253,7 +253,7 @@ def torch_backend_mha_with_cache(
     k: torch.Tensor,
     v: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -278,7 +278,7 @@ def torch_backend_mha_with_cache(
     b, s = q.shape[:2]
 
     # get cleaned up metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
     seq_len = seq_len[:num_seq]
     input_pos = input_pos[:num_seq]
@@ -352,7 +352,7 @@ def torch_backend_mha_with_cache_fake(
     k: torch.Tensor,
     v: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -400,7 +400,7 @@ class TorchBackendAttention(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
+        return ["batch_info_host", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_gather_logits.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_gather_logits.py
@@ -5,14 +5,14 @@ import torch
 def gather_logits_before_lm_head(
     hidden_states: torch.Tensor,
     logits_gather_indices: torch.Tensor,  # long tensor
-    logits_gather_info: torch.Tensor,  # int tensor
+    logits_gather_info_host: torch.Tensor,  # int tensor
 ) -> torch.Tensor:
     """Gather hidden states using logits_gather_indices before LM head.
 
     Args:
         hidden_states: Hidden states tensor [b, 1, hidden] or [1, s_total, hidden]
         logits_gather_indices: indices for gathering logits.
-        logits_gather_info: info for gathering logits.
+        logits_gather_info_host: info for gathering logits.
     Returns:
         Gathered and flattened hidden states [num_gathered_tokens, hidden]
     """
@@ -21,7 +21,7 @@ def gather_logits_before_lm_head(
     hidden_states = hidden_states.squeeze(int(is_decode_only))
 
     # info object
-    num_tokens_to_gather, gather_required = logits_gather_info.tolist()
+    num_tokens_to_gather, gather_required = logits_gather_info_host.tolist()
 
     if gather_required:
         out = hidden_states.index_select(0, logits_gather_indices[:num_tokens_to_gather])
@@ -34,7 +34,7 @@ def gather_logits_before_lm_head(
 def gather_logits_before_lm_head_fake(
     hidden_states: torch.Tensor,
     logits_gather_indices: torch.Tensor,
-    logits_gather_info: torch.Tensor,
+    logits_gather_info_host: torch.Tensor,
 ) -> torch.Tensor:
     # NOTE: shape is not correct in fake mode
     # see https://github.com/NVIDIA/TensorRT-LLM/issues/9878

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -188,7 +188,7 @@ def flattened_mha_with_cache(
     k: torch.Tensor,
     v: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -210,7 +210,7 @@ def flattened_mha_with_cache(
     NOTE: this op can also handle seq_len==0, which might be useful for CUDAGRAPH.
     """
     # check for sequence info and truncate metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info.tolist()
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
 
     seq_len = seq_len[:num_seq]
@@ -290,7 +290,7 @@ def flattened_mha_fake(
     k: torch.Tensor,
     v: torch.Tensor,
     # STANDARD METADATA
-    batch_info: torch.Tensor,
+    batch_info_host: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
@@ -337,7 +337,7 @@ class TritonAttention(AttentionDescriptor):
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
-        return ["batch_info", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
+        return ["batch_info_host", "seq_len", "input_pos", "cache_loc", "cu_seqlen"]
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
@@ -49,15 +49,15 @@ def _bamba_mixer_torch_forward(
         )
         slot_idx_t = torch.arange(batch_size, device=input_states.device, dtype=torch.long)
         use_initial_states_t = torch.zeros(batch_size, device=input_states.device, dtype=torch.bool)
-        # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+        # batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
         # For context phase (seq_len > 1): [batch_size, batch_size * seq_len, 0]
         # For generate phase (seq_len == 1): [0, 0, batch_size]
         if seq_len == 1:
-            batch_info_t = torch.tensor(
+            batch_info_host_t = torch.tensor(
                 [0, 0, batch_size], device=input_states.device, dtype=torch.int32
             )
         else:
-            batch_info_t = torch.tensor(
+            batch_info_host_t = torch.tensor(
                 [batch_size, batch_size * seq_len, 0], device=input_states.device, dtype=torch.int32
             )
     if use_caching:
@@ -68,7 +68,7 @@ def _bamba_mixer_torch_forward(
                 self.conv1d.weight,
                 self.conv1d.bias,
                 # STANDARD METADATA
-                batch_info_t,
+                batch_info_host_t,
                 seq_len_t,
                 cu_seqlen_t,
                 slot_idx_t,
@@ -123,7 +123,7 @@ def _bamba_mixer_torch_forward(
             dt=dt,
             dt_bias=self.dt_bias,
             # STANDARD METADATA
-            batch_info=batch_info_t,
+            batch_info_host=batch_info_host_t,
             seq_len=seq_len_t,
             cu_seqlen=cu_seqlen_t,
             slot_idx=slot_idx_t,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -379,7 +379,7 @@ def maybe_pad_for_cuda_graph(func):
 
         # check if we have a dummy request to use
         if self.padding_dummy_request is None:
-            ad_logger.error("No CUDA graph padding possible due to missing dummy request.")
+            ad_logger.info("No CUDA graph padding possible due to missing dummy request.")
             return _call_func()
 
         # pad the scheduled requests with the dummy request

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/gather_logits_before_lm_head.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/gather_logits_before_lm_head.py
@@ -67,12 +67,14 @@ class GatherLogitsBeforeLmHeadTransform(BaseTransform):
 
         # Add logits_gather_mask as input in the graph and the sequence info interface
         logits_gather_indices_node = self._add_or_retrieve_input(gm, cm, "logits_gather_indices")
-        logits_gather_info_node = self._add_or_retrieve_input(gm, cm, "logits_gather_info")
+        logits_gather_info_host_node = self._add_or_retrieve_input(
+            gm, cm, "logits_gather_info_host"
+        )
 
         with gm.graph.inserting_after(node_to_gather):
             gathered_node = gm.graph.call_function(
                 torch.ops.auto_deploy.gather_logits_before_lm_head.default,
-                args=(node_to_gather, logits_gather_indices_node, logits_gather_info_node),
+                args=(node_to_gather, logits_gather_indices_node, logits_gather_info_host_node),
             )
         node_to_gather.replace_all_uses_with(gathered_node)
         gathered_node.replace_input_with(gathered_node, node_to_gather)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -1,5 +1,6 @@
 """Graph transformation to automatically add kv cache into fused MHA op."""
 
+import inspect
 import operator
 from typing import Dict, List, Optional, Tuple, Type
 
@@ -106,6 +107,23 @@ class InsertCachedAttention(BaseTransform):
             gm, prep_meta_op, inputs_for_prep_meta, const_args, num_meta_out
         )
 
+    def _process_metadata_host(self, cm: CachedSequenceInterface):
+        """Process the host-side prepare metadata function."""
+        prep_meta_host_op = self.attn_descriptor.get_host_prepare_metadata_function()
+        if prep_meta_host_op is None:
+            return
+
+        # analyze the args of the host-side prepare metadata function using inspect
+        sig = inspect.signature(prep_meta_host_op)
+        args = sig.parameters.keys()
+
+        # check if all args are available in the cached sequence interface
+        unavailable_args = args - cm.info.available_args
+        assert not unavailable_args, f"Missing args in SequenceInfo: {unavailable_args=}"
+
+        # add the host-side prepare metadata function to the graph
+        cm.info.register_host_prepare_for_attention_forward(prep_meta_host_op, list(args))
+
     def _process_cache_node(self, gm: GraphModule, cache_name: str) -> Node:
         """Process the cache nodes by inserting a cached attention replacement op."""
         return add_graph_input(gm, cache_name)
@@ -173,6 +191,9 @@ class InsertCachedAttention(BaseTransform):
         # insert metadata computation and extract each argument as a node
         meta_nodes_extra = self._process_metadata_extra(gm, cm, source_attn_nodes[0])
 
+        # Register host-side prepare_metadata function for attention descriptor.
+        self._process_metadata_host(cm)
+
         buffer_in_lookup: Dict[str, Node] = {}
 
         # replace fused attention node with attention node that has kv cache
@@ -213,11 +234,7 @@ class InsertCachedAttention(BaseTransform):
                 buffer_in_nodes,
                 constants,
             )
-            # Attention descriptor should register its host function with SequenceInfo.
-            # This function will be called before graph invocation.
-            cm.info.register_host_prepare_for_attention_forward(
-                attn_descriptor.host_prepare_for_forward
-            )
+
             num_cached_attn_replacements += 1
 
         info = TransformInfo(

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -220,7 +220,6 @@ class TestNemotronMOE(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device_memory(32000)
     def test_fp8(self):
         kwargs = self.get_default_kwargs()
-        sampling_params = self.get_default_sampling_params()
         with AutoDeployLLM(model=self.MODEL_PATH_FP8,
                            tokenizer=self.MODEL_PATH_FP8,
                            **kwargs) as llm:
@@ -228,8 +227,8 @@ class TestNemotronMOE(LlmapiAccuracyTestHarness):
             llm.args.quant_config.quant_algo = QuantAlgo.FP8
             llm.args.quant_config.kv_cache_quant_algo = QuantAlgo.FP8
 
-            task = MMLU(self.MODEL_NAME)
-            task.evaluate(llm, sampling_params=sampling_params)
+            # task = MMLU(self.MODEL_NAME)
+            # task.evaluate(llm, sampling_params=sampling_params)
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
 

--- a/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/torch_attention_reference.py
@@ -40,13 +40,13 @@ class TorchAttentionReference:
             0, batch_size * seq_len, seq_len, device=q.device, dtype=torch.int32
         )
 
-        # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+        # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
         # For context phase (seq_len > 1): [batch_size, batch_size * seq_len, 0]
         # For generate phase (seq_len == 1): [0, 0, batch_size]
         if seq_len == 1:
-            batch_info = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
+            batch_info_host = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
         else:
-            batch_info = torch.tensor(
+            batch_info_host = torch.tensor(
                 [batch_size, batch_size * seq_len, 0], device=q.device, dtype=torch.int32
             )
 
@@ -60,7 +60,7 @@ class TorchAttentionReference:
             q_flat,
             k_flat,
             v_flat,
-            batch_info,
+            batch_info_host,
             seq_len_tensor,
             input_positions,
             cache_loc,
@@ -84,7 +84,7 @@ class TorchAttentionReference:
         q,
         k,
         v,
-        batch_info,
+        batch_info_host,
         seq_len,
         input_positions,
         cache_loc,
@@ -101,7 +101,7 @@ class TorchAttentionReference:
             q,
             k,
             v,
-            batch_info,
+            batch_info_host,
             seq_len,
             input_positions,
             cache_loc,
@@ -144,15 +144,15 @@ class TorchAttentionReference:
         k_flat = k_new.view(1, batch_size, -1)
         v_flat = v_new.view(1, batch_size, -1)
 
-        # Create batch_info for decode phase: [num_prefill, num_prefill_tokens, num_decode]
-        batch_info = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
+        # Create batch_info_host for decode phase: [num_prefill, num_prefill_tokens, num_decode]
+        batch_info_host = torch.tensor([0, 0, batch_size], device=q.device, dtype=torch.int32)
 
         # Call torch backend via custom op registry
         output_flat = torch.ops.auto_deploy.torch_cached_attention_with_cache(
             q_flat,
             k_flat,
             v_flat,
-            batch_info,
+            batch_info_host,
             seq_len,
             input_positions,
             cache_loc,
@@ -170,7 +170,7 @@ class TorchAttentionReference:
         q,
         k,
         v,
-        batch_info,
+        batch_info_host,
         seq_len,
         input_positions,
         cache_loc,
@@ -189,7 +189,7 @@ class TorchAttentionReference:
             q,
             k,
             v,
-            batch_info,
+            batch_info_host,
             seq_len,
             input_positions,
             cache_loc,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
@@ -59,9 +59,9 @@ def test_generate_only_with_slot_mapping_cuda(conv_env):
     # Metadata (not used in generate-only op entry, but required by the interface)
     cu_seqlen = torch.zeros(batch, device=device, dtype=torch.int32)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
-    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
     # For generate-only: num_decode = batch, num_prefill = 0
-    batch_info = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
+    batch_info_host = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
     # Snapshot caches for reference before running op (op mutates caches)
     gathered_before = conv_state_cache.clone().index_select(0, slot_idx)
     x_ref = x.clone()
@@ -72,7 +72,7 @@ def test_generate_only_with_slot_mapping_cuda(conv_env):
         w,
         b,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         cu_seqlen,
         slot_idx,
         use_initial_states,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -69,7 +69,6 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -113,7 +112,6 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -184,7 +182,6 @@ def test_flashinfer_attention_op_decode(
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -259,7 +256,6 @@ def test_flashinfer_attention_op_decode(
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -350,7 +346,6 @@ def test_flashinfer_attention_context_and_generate(
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V for prefill phase
     q_1 = torch.randn(BATCH_SIZE, PREFILL_SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -394,7 +389,6 @@ def test_flashinfer_attention_context_and_generate(
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -453,7 +447,6 @@ def test_flashinfer_attention_context_and_generate(
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM.
     q_3 = torch.randn(BATCH_SIZE, 1, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -486,7 +479,6 @@ def test_flashinfer_attention_context_and_generate(
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -568,7 +560,6 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -612,7 +603,6 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -702,7 +692,6 @@ def test_flashinfer_attention_with_fp8_cache(
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM, in fp16
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -776,7 +765,6 @@ def test_flashinfer_attention_with_fp8_cache(
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -858,7 +846,6 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
     paged_kv_indptr_host = paged_kv_indptr.cpu()
     paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
     seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
-    seq_len_host = seq_len_tensor.cpu()
 
     # make sure planner is initialized
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
@@ -887,7 +874,6 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         paged_kv_last_page_len,
         paged_kv_last_page_len_host,
         seq_len_with_cache_host,
-        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -957,7 +943,6 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
     paged_kv_indptr2_host = paged_kv_indptr2.cpu()
     paged_kv_last_page_len2_host = paged_kv_last_page_len2.cpu()
     seq_len_with_cache2_host = (offsets2 + seq_len_tensor2).cpu()
-    seq_len2_host = seq_len_tensor2.cpu()
 
     # Create FlashInferAttention class before calling the custom op
     _GlobalFlashInferPlanner.reset()
@@ -985,7 +970,6 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         paged_kv_last_page_len2,
         paged_kv_last_page_len2_host,
         seq_len_with_cache2_host,
-        seq_len2_host,
         # EXTRA METADATA
         batch_indices,
         positions,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -64,6 +64,13 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
     k = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -99,10 +106,14 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         v,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -167,6 +178,13 @@ def test_flashinfer_attention_op_decode(
     paged_kv_indptr = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device)
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
+
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
 
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -234,10 +252,14 @@ def test_flashinfer_attention_op_decode(
         v,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -323,6 +345,13 @@ def test_flashinfer_attention_context_and_generate(
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # Q,K,V for prefill phase
     q_1 = torch.randn(BATCH_SIZE, PREFILL_SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
     k_1 = torch.randn(BATCH_SIZE, PREFILL_SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -358,10 +387,14 @@ def test_flashinfer_attention_context_and_generate(
         v_1,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -415,6 +448,13 @@ def test_flashinfer_attention_context_and_generate(
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # Q,K,V are computed using GEMM.
     q_3 = torch.randn(BATCH_SIZE, 1, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
     k_3 = torch.randn(BATCH_SIZE, 1, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -439,10 +479,14 @@ def test_flashinfer_attention_context_and_generate(
         v_3,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -519,6 +563,13 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # Q,K,V are computed using GEMM.
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
     k = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -554,10 +605,14 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         v,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -642,6 +697,13 @@ def test_flashinfer_attention_with_fp8_cache(
     paged_kv_indices = torch.arange(BATCH_SIZE).int().to(device)
     paged_kv_last_page_len = offsets + seq_len_tensor
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # Q,K,V are computed using GEMM, in fp16
     q = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
     k = torch.randn(BATCH_SIZE, SEQ_LEN, N_HEADS * D_HEAD, dtype=DTYPE).to(device)
@@ -707,10 +769,14 @@ def test_flashinfer_attention_with_fp8_cache(
         v,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -787,6 +853,13 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
     )
     paged_kv_last_page_len = ((offsets + seq_len_tensor - 1) % PAGE_SIZE) + 1
 
+    # Host copies of metadata
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    paged_kv_last_page_len_host = paged_kv_last_page_len.cpu()
+    seq_len_with_cache_host = (offsets + seq_len_tensor).cpu()
+    seq_len_host = seq_len_tensor.cpu()
+
     # make sure planner is initialized
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
     _GlobalFlashInferPlanner.init_workspace(workspace)
@@ -807,10 +880,14 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         v,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr,
+        qo_indptr_host,
         paged_kv_indptr,
+        paged_kv_indptr_host,
         paged_kv_indices,
         paged_kv_last_page_len,
+        paged_kv_last_page_len_host,
+        seq_len_with_cache_host,
+        seq_len_host,
         # EXTRA METADATA
         batch_indices,
         positions,
@@ -875,6 +952,13 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
     )
     paged_kv_last_page_len2 = ((offsets2 + seq_len_tensor2 - 1) % PAGE_SIZE) + 1
 
+    # Host copies of metadata
+    qo_indptr2_host = qo_indptr2.cpu()
+    paged_kv_indptr2_host = paged_kv_indptr2.cpu()
+    paged_kv_last_page_len2_host = paged_kv_last_page_len2.cpu()
+    seq_len_with_cache2_host = (offsets2 + seq_len_tensor2).cpu()
+    seq_len2_host = seq_len_tensor2.cpu()
+
     # Create FlashInferAttention class before calling the custom op
     _GlobalFlashInferPlanner.reset()
 
@@ -894,10 +978,14 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         v_gen,
         # STANDARD METADATA
         batch_info_host,
-        qo_indptr2,
+        qo_indptr2_host,
         paged_kv_indptr2,
+        paged_kv_indptr2_host,
         paged_kv_indices2,
         paged_kv_last_page_len2,
+        paged_kv_last_page_len2_host,
+        seq_len_with_cache2_host,
+        seq_len2_host,
         # EXTRA METADATA
         batch_indices,
         positions,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -88,8 +88,8 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor(
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor(
         [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
     )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
@@ -98,7 +98,7 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         k,
         v,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -224,16 +224,16 @@ def test_flashinfer_attention_op_decode(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
     # For decode phase: num_decode = BATCH_SIZE, num_prefill = 0
-    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
+    batch_info_host = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -347,8 +347,8 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * PREFILL_SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor(
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor(
         [BATCH_SIZE, BATCH_SIZE * PREFILL_SEQ_LEN, 0], dtype=torch.int32, device=device
     )
     flashinfer_output_1 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
@@ -357,7 +357,7 @@ def test_flashinfer_attention_context_and_generate(
         k_1,
         v_1,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -430,15 +430,15 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * 1,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output_3 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_3,
         k_3,
         v_3,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -543,8 +543,8 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor(
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor(
         [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
     )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
@@ -553,7 +553,7 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         k,
         v,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -696,8 +696,8 @@ def test_flashinfer_attention_with_fp8_cache(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor(
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor(
         [BATCH_SIZE, BATCH_SIZE * SEQ_LEN, 0], dtype=torch.int32, device=device
     )
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
@@ -706,7 +706,7 @@ def test_flashinfer_attention_with_fp8_cache(
         k,
         v,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -798,15 +798,15 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         SEQ_LEN,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor([BATCH_SIZE, SEQ_LEN, 0], dtype=torch.int32, device=device)
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor([BATCH_SIZE, SEQ_LEN, 0], dtype=torch.int32, device=device)
     flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
         v,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr,
         paged_kv_indptr,
         paged_kv_indices,
@@ -885,15 +885,15 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         BATCH_SIZE * 1,
     )
-    # Create batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
+    # Create batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor([0, 0, BATCH_SIZE], dtype=torch.int32, device=device)
     flashinfer_output_gen = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_gen,
         k_gen,
         v_gen,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         qo_indptr2,
         paged_kv_indptr2,
         paged_kv_indices2,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
@@ -246,14 +246,16 @@ class TestTorchBackendAttention:
 
         if seq_len == 1:
             # Generate phase: [num_prefill, num_prefill_tokens, num_decode]
-            batch_info = torch.tensor([0, 0, batch_size], device=self.device, dtype=torch.int32)
+            batch_info_host = torch.tensor(
+                [0, 0, batch_size], device=self.device, dtype=torch.int32
+            )
             seq_start = torch.arange(batch_size, device=self.device, dtype=torch.int32)
             q_flat = q.view(batch_size, seq_len, -1)
             k_flat = k.view(batch_size, seq_len, -1)
             v_flat = v.view(batch_size, seq_len, -1)
         else:
             # Context phase: [num_prefill, num_prefill_tokens, num_decode]
-            batch_info = torch.tensor(
+            batch_info_host = torch.tensor(
                 [batch_size, batch_size * seq_len, 0], device=self.device, dtype=torch.int32
             )
             seq_start = torch.arange(
@@ -267,7 +269,7 @@ class TestTorchBackendAttention:
             "q": q_flat,
             "k": k_flat,
             "v": v_flat,
-            "batch_info": batch_info,
+            "batch_info_host": batch_info_host,
             "seq_len": seq_len_tensor,
             "input_pos": input_positions,
             "cache_loc": cache_loc,
@@ -286,7 +288,7 @@ class TestTorchBackendAttention:
             data["k"],
             data["v"],
             # STANDARD METADATA
-            data["batch_info"],
+            data["batch_info_host"],
             data["seq_len"],
             data["input_pos"],
             data["cache_loc"],

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
@@ -66,9 +66,9 @@ def test_generate_only_with_slot_mapping(mamba_env):
     seq_len = torch.ones(batch, device=device, dtype=torch.int32)
     cu_seqlen = torch.zeros(batch, device=device, dtype=torch.int32)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
-    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
     # For generate-only: num_decode = batch, num_prefill = 0
-    batch_info = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
+    batch_info_host = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
     # Snapshot caches for reference before running op (op mutates caches)
     gathered_before = ssm_state_cache.clone().index_select(0, slot_idx)
 
@@ -83,7 +83,7 @@ def test_generate_only_with_slot_mapping(mamba_env):
         dt,
         dt_bias,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         seq_len,
         cu_seqlen,
         slot_idx,
@@ -141,11 +141,13 @@ def test_context_flattened_and_state_writeback(mamba_env):
     seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
     cu_seqlen = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
     use_initial_states = torch.zeros(batch, device=device, dtype=torch.bool)
-    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
+    # batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
     # For context/prefill phase: num_prefill = len(lens), num_decode = 0
     num_seqs = len(lens)
     num_prefill_tokens = sum(lens)
-    batch_info = torch.tensor([num_seqs, num_prefill_tokens, 0], device=device, dtype=torch.int32)
+    batch_info_host = torch.tensor(
+        [num_seqs, num_prefill_tokens, 0], device=device, dtype=torch.int32
+    )
     y = torch.ops.auto_deploy.torch_cached_ssm(
         # INPUTS
         hidden_states,
@@ -156,7 +158,7 @@ def test_context_flattened_and_state_writeback(mamba_env):
         dt,
         dt_bias,
         # STANDARD METADATA
-        batch_info,
+        batch_info_host,
         seq_len,
         cu_seqlen,
         slot_idx,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
@@ -134,8 +134,8 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         torch.arange(len(lens), device=device, dtype=torch.int32),
         seq_len,
     ).view(1, -1)
-    # batch_info: [num_prefill, num_prefill_tokens, num_decode]
-    batch_info_tensor = torch.tensor([len(lens), sum(lens), 0], dtype=torch.int32, device=device)
+    # batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+    batch_info_host = torch.tensor([len(lens), sum(lens), 0], dtype=torch.int32, device=device)
     # Torch reference
     y_torch = torch.ops.auto_deploy.torch_cached_ssm(
         hidden_states,
@@ -146,7 +146,7 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         dt,
         dt_bias,
         # STANDARD METADATA
-        batch_info_tensor,
+        batch_info_host,
         seq_len,
         cu_seqlen,
         slot_idx,
@@ -168,7 +168,7 @@ def test_triton_context_flattened_and_state_writeback(mamba_env):
         dt,
         dt_bias,
         # STANDARD METADATA
-        batch_info_tensor,
+        batch_info_host,
         cu_seqlens,
         slot_idx,
         use_initial_states,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
@@ -56,10 +56,10 @@ class TestGatherLogitsBeforeLmHeadOp:
 
         # Create gather info: num_tokens_to_gather=batch_size, gather_required=0 (False)
         logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info = torch.tensor([batch_size, 0], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
 
         output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-            hidden_states, logits_gather_indices, logits_gather_info
+            hidden_states, logits_gather_indices, logits_gather_info_host
         )
 
         # Should return [batch, 1, hidden] for generate format (3D shape preserved)
@@ -82,10 +82,10 @@ class TestGatherLogitsBeforeLmHeadOp:
         gather_indices = torch.arange(0, num_gather, dtype=torch.long, device="cuda")
 
         # Create gather info: num_tokens_to_gather=num_gather, gather_required=1 (True)
-        logits_gather_info = torch.tensor([num_gather, 1], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
 
         output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-            hidden_states, gather_indices, logits_gather_info
+            hidden_states, gather_indices, logits_gather_info_host
         )
 
         # Should return [1, num_gather, hidden] for packed format (3D shape preserved)
@@ -105,15 +105,15 @@ class TestGatherLogitsBeforeLmHeadOp:
 
         # Create gather info
         logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info = torch.tensor([batch_size, 0], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
 
         # Use fake implementation directly
         with FakeTensorMode() as mode:
             hidden_states_fake = mode.from_tensor(hidden_states)
             logits_gather_indices_fake = mode.from_tensor(logits_gather_indices)
-            logits_gather_info_fake = mode.from_tensor(logits_gather_info)
+            logits_gather_info_host_fake = mode.from_tensor(logits_gather_info_host)
             output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_fake
+                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_host_fake
             )
 
         # Should return [batch, 1, hidden_size] (fake returns empty_like which preserves 3D shape)
@@ -132,15 +132,15 @@ class TestGatherLogitsBeforeLmHeadOp:
 
         # Create gather info
         logits_gather_indices = torch.arange(num_gather, dtype=torch.long, device="cuda")
-        logits_gather_info = torch.tensor([num_gather, 1], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
 
         # Use fake implementation directly
         with FakeTensorMode() as mode:
             hidden_states_fake = mode.from_tensor(hidden_states)
             logits_gather_indices_fake = mode.from_tensor(logits_gather_indices)
-            logits_gather_info_fake = mode.from_tensor(logits_gather_info)
+            logits_gather_info_host_fake = mode.from_tensor(logits_gather_info_host)
             output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_fake
+                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_host_fake
             )
 
         # The fake implementation returns empty_like which preserves input shape [1, total_tokens, hidden]
@@ -217,13 +217,13 @@ class TestGatherLogitsBeforeLmHeadTransform:
         # Test forward pass
         # We must pass the new graph inputs manually since we are running the graph directly
         logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info = torch.tensor([batch_size, 0], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
         output = gm_transformed(
             hidden_states,
             logit_gather_ids,
             seq_len,
             logits_gather_indices=logits_gather_indices,
-            logits_gather_info=logits_gather_info,
+            logits_gather_info_host=logits_gather_info_host,
         )
         # Output should be [batch_size, 1, vocab_size] since gather now returns 3D
         assert output.shape == (batch_size, 1, vocab_size)
@@ -278,13 +278,13 @@ class TestGatherLogitsBeforeLmHeadTransform:
         # We must pass the new graph inputs manually since we are running the graph directly
         num_gather = len(logit_gather_ids)
         logits_gather_indices = logit_gather_ids
-        logits_gather_info = torch.tensor([num_gather, 1], dtype=torch.int32, device="cuda")
+        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
         output = gm_transformed(
             hidden_states,
             logit_gather_ids_padded,
             seq_len,
             logits_gather_indices=logits_gather_indices,
-            logits_gather_info=logits_gather_info,
+            logits_gather_info_host=logits_gather_info_host,
         )
         # Output should be [1, num_gather, vocab_size] since gather now returns 3D
         assert output.shape == (1, num_gather, vocab_size)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced host-aware metadata handling for attention and custom operations, enabling improved tensor processing on host and device sides.
  * Implemented split prefill and decode planning for FlashInfer attention, optimizing performance for different inference phases.

* **Refactor**
  * Standardized metadata tensor naming convention with host-side suffix for consistency across attention and custom operation backends.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

fixes #10244

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
