### PR TITLE
[TRTLLM-10147][perf] Balanced random MoE workload generator for CuteDSL kernel UT, autotuner and layerwise benchmark

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -882,6 +882,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                           5, 0,
                                           helper.infer_shape_max_num_tiles)),
                     inputs_pre_hook=helper.inputs_pre_hook,
+                    use_cold_l2_cache=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
@@ -1180,6 +1181,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                             8, 0, helper.infer_shape_max_num_permuted_tokens),
                         ConstraintSpec(10, 0, helper.infer_shape_num_tokens)),
                     inputs_pre_hook=helper.inputs_pre_hook_finalize_fusion,
+                    use_cold_l2_cache=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
@@ -1560,6 +1562,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                           5, 0,
                                           helper.infer_shape_max_num_tiles)),
                     inputs_pre_hook=helper.inputs_pre_hook,
+                    use_cold_l2_cache=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
@@ -1889,6 +1892,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                           6, 0,
                                           helper.infer_shape_max_num_tiles)),
                     inputs_pre_hook=helper.inputs_pre_hook,
+                    use_cold_l2_cache=True,
                 )
             return self.__class__.tuning_config_cache[key]
 

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -121,8 +121,7 @@ class GroupedGemmInputsHelper:
         for j, num_tokens_j in enumerate(num_tokens_per_expert):
             selection_order_j = selection_orders[j].tolist()
             prioritized = torch.nonzero(num_selected_experts <= (
-                self.top_k -
-                (self.num_local_experts - j))).squeeze(-1).tolist()
+                self.top_k - (self.num_experts - j))).squeeze(-1).tolist()
             if len(prioritized) > 0:
                 selection_order_j = prioritized + [
                     i for i in selection_order_j if i not in prioritized

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -258,6 +258,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                                   ConstraintSpec(
                                       4, 0, helper.infer_shape_num_tokens)),
                 inputs_pre_hook=helper.inputs_pre_hook,
+                use_cold_l2_cache=True,
             )
         return self.__class__.tuning_config_cache[key]
 

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -175,7 +175,8 @@ class CuteDslFusedMoENvfp4InputsHelper(GroupedGemmInputsHelper):
     def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
         x, token_selected_experts, *others = inputs
         num_tokens = token_selected_experts.size(0)
-        num_tokens_per_expert = self.generate_num_tokens_per_expert(num_tokens)
+        num_tokens_per_expert = self.generate_num_tokens_per_expert(
+            num_tokens, approx_max_load=True)
 
         new_token_selected_experts = []
         for i, curr_num_tokens in enumerate(num_tokens_per_expert,

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -88,7 +88,7 @@ def get_balanced_selection_impl_random(
     ep_size: int,
 ):
     helper = GroupedGemmInputsHelper(num_experts, top_k, num_experts, 0, 128)
-    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_tokens)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_tokens, approx_max_load=False)
     assert sum(num_tokens_per_expert) == num_tokens * top_k
     token_selected_experts = helper.generate_token_selected_experts(
         num_tokens, num_tokens_per_expert

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -11,6 +11,7 @@ import torch
 import tensorrt_llm._torch.model_config
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_utils import PostInitCaller, skip_forward
@@ -54,8 +55,15 @@ def round_up(a, b):
     return ceil_div(a, b) * b
 
 
-def get_balanced_selection_no_cache(
-    num_tokens, top_k, num_experts, dtype, device, dp_size, dp_rank, ep_size
+def get_balanced_selection_impl_default(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    dp_size: int,
+    dp_rank: int,
+    ep_size: int,
 ):
     token_id = torch.arange(dp_rank * num_tokens * top_k, (dp_rank + 1) * num_tokens * top_k).view(
         num_tokens, top_k
@@ -66,6 +74,32 @@ def get_balanced_selection_no_cache(
     ) % experts_per_rank
     token_selected_experts = token_selected_experts.sort(dim=-1).values
     return token_selected_experts.contiguous().to(dtype=dtype, device=device)
+
+
+def get_balanced_selection_impl_random(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    dp_size: int,
+    dp_rank: int,
+    ep_size: int,
+):
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_experts, 0, 128)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_tokens)
+    assert sum(num_tokens_per_expert) == num_tokens * top_k
+    token_selected_experts = helper.generate_token_selected_experts(
+        num_tokens, num_tokens_per_expert
+    )
+    return token_selected_experts.contiguous().to(dtype=dtype, device=device)
+
+
+def get_balanced_selection_no_cache(*args, **kwargs):
+    if os.environ.get("TRTLLM_LAYERWISE_BENCHMARK_BALANCED_IMPL", "DEFAULT") == "RANDOM":
+        return get_balanced_selection_impl_random(*args, **kwargs)
+    else:
+        return get_balanced_selection_impl_default(*args, **kwargs)
 
 
 get_balanced_selection = functools.cache(get_balanced_selection_no_cache)

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import itertools
+import os
 import unittest.mock
 import weakref
 from enum import IntEnum

--- a/tests/scripts/cute_dsl_kernels/README.md
+++ b/tests/scripts/cute_dsl_kernels/README.md
@@ -5,13 +5,13 @@
 ```bash
 # Generate workload using a balanced random method
 # Per-rank token number 128, EP size 32 (a typical workload for large EP gen phase)
-python moe_workload_generator.py --num_tokens 128 --ep_size 32
+python moe_workload_generator.py --num_tokens 128 --ep_size 32 --tile_size 128
 # Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
-python moe_workload_generator.py --num_tokens 8192 --ep_size 4
+python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --tile_size 256
 
 # Generate workload using the balanced method from layer-wise benchmarking
 # Per-rank token number 128, EP size 32 (a typical workload for large EP gen phase)
-python moe_workload_generator.py --num_tokens 128 --ep_size 32 --method balanced_layer_wise_benchmark
+python moe_workload_generator.py --num_tokens 128 --ep_size 32 --tile_size 128 --method balanced_layer_wise_benchmark
 # Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
-python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --method balanced_layer_wise_benchmark
+python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --tile_size 256 --method balanced_layer_wise_benchmark
 ```

--- a/tests/scripts/cute_dsl_kernels/README.md
+++ b/tests/scripts/cute_dsl_kernels/README.md
@@ -8,10 +8,4 @@
 python moe_workload_generator.py --num_tokens 128 --ep_size 32 --tile_size 128
 # Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
 python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --tile_size 256
-
-# Generate workload using the balanced method from layer-wise benchmarking
-# Per-rank token number 128, EP size 32 (a typical workload for large EP gen phase)
-python moe_workload_generator.py --num_tokens 128 --ep_size 32 --tile_size 128 --method balanced_layer_wise_benchmark
-# Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
-python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --tile_size 256 --method balanced_layer_wise_benchmark
 ```

--- a/tests/scripts/cute_dsl_kernels/README.md
+++ b/tests/scripts/cute_dsl_kernels/README.md
@@ -1,0 +1,17 @@
+# Launch Scripts for CuTe DSL Kernels
+
+## MoE Workload Generator
+
+```bash
+# Generate workload using a balanced random method
+# Per-rank token number 128, EP size 32 (a typical workload for large EP gen phase)
+python moe_workload_generator.py --num_tokens 128 --ep_size 32
+# Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
+python moe_workload_generator.py --num_tokens 8192 --ep_size 4
+
+# Generate workload using the balanced method from layer-wise benchmarking
+# Per-rank token number 128, EP size 32 (a typical workload for large EP gen phase)
+python moe_workload_generator.py --num_tokens 128 --ep_size 32 --method balanced_layer_wise_benchmark
+# Per-rank token number 8192, EP size 4 (a typical workload for ctx phase)
+python moe_workload_generator.py --num_tokens 8192 --ep_size 4 --method balanced_layer_wise_benchmark
+```

--- a/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
+++ b/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import os
 
@@ -6,12 +5,21 @@ import click
 import safetensors.torch
 import torch
 
-from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
-from tensorrt_llm.tools.layer_wise_benchmarks.runner_utils import get_balanced_selection_no_cache
+from tensorrt_llm.tools.layer_wise_benchmarks.runner_utils import (
+    get_balanced_selection_impl_default,
+    get_balanced_selection_impl_random,
+)
 
 
-def get_balanced_selection_no_cache_legacy(
-    num_tokens, top_k, num_experts, dtype, device, dp_size, dp_rank, ep_size
+def get_balanced_selection_impl_default_legacy(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    dp_size: int,
+    dp_rank: int,
+    ep_size: int,
 ):
     world_size = ep_size
     rank = dp_rank
@@ -34,17 +42,23 @@ def get_balanced_selection_no_cache_legacy(
     return token_selected_experts.contiguous().to(dtype=dtype, device=device)
 
 
-def gen_moe_workload_layer_wise_benchmark(
+def gen_moe_workload(
     num_tokens: int,
     top_k: int,
     num_experts: int,
     ep_size: int,
     tile_size: int,
-    legacy: bool = False,
+    method: str = "balanced_random",
 ):
-    get_balanced_selection_impl = (
-        get_balanced_selection_no_cache_legacy if legacy else get_balanced_selection_no_cache
-    )
+    if method == "balanced_random":
+        get_balanced_selection_impl = get_balanced_selection_impl_random
+    elif method == "balanced_default":
+        get_balanced_selection_impl = get_balanced_selection_impl_default
+    elif method == "balanced_default_legacy":
+        get_balanced_selection_impl = get_balanced_selection_impl_default_legacy
+    else:
+        raise ValueError(f"Invalid method: {method}.")
+
     token_selected_experts = [
         get_balanced_selection_impl(
             num_tokens=num_tokens,
@@ -59,6 +73,7 @@ def gen_moe_workload_layer_wise_benchmark(
         for i in range(ep_size)
     ]
     token_selected_experts = torch.cat(token_selected_experts, dim=0)
+    assert token_selected_experts.size() == (num_tokens * ep_size, top_k)
     token_final_scales = torch.ones_like(token_selected_experts, dtype=torch.float32)
     return torch.ops.trtllm.moe_sort(
         token_selected_experts=token_selected_experts,
@@ -71,31 +86,6 @@ def gen_moe_workload_layer_wise_benchmark(
     )
 
 
-def gen_moe_workload_balanced_random(
-    num_tokens: int, top_k: int, num_experts: int, ep_size: int, tile_size: int
-):
-    num_local_experts = num_experts // ep_size
-    num_total_tokens = num_tokens * ep_size
-    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
-    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_total_tokens)
-    assert sum(num_tokens_per_expert) == num_total_tokens * top_k // ep_size
-    token_selected_experts = helper.generate_token_selected_experts(
-        num_total_tokens, num_tokens_per_expert
-    )
-
-    token_selected_experts = token_selected_experts.cuda()
-    token_final_scales = torch.ones_like(token_selected_experts, dtype=torch.float32)
-    return torch.ops.trtllm.moe_sort(
-        token_selected_experts=token_selected_experts,
-        token_final_scales=token_final_scales,
-        num_experts=num_experts,
-        top_k=top_k,
-        local_expert_offset=0,
-        local_num_experts=num_local_experts,
-        tile_tokens_dim=tile_size,
-    )
-
-
 @click.command("moe_workload_generator")
 @click.option("--num_tokens", type=int, default=128)
 @click.option("--top_k", type=int, default=8)
@@ -104,9 +94,7 @@ def gen_moe_workload_balanced_random(
 @click.option("--tile_size", type=click.Choice([128, 256]), default=128)
 @click.option(
     "--method",
-    type=click.Choice(
-        ["balanced_random", "balanced_layer_wise_benchmark", "balanced_layer_wise_benchmark_legacy"]
-    ),
+    type=click.Choice(["balanced_random", "balanced_default", "balanced_default_legacy"]),
     default="balanced_random",
 )
 @click.option("--seed", type=int, default=515)
@@ -123,15 +111,6 @@ def main(
 ):
     torch.manual_seed(seed)
 
-    if method == "balanced_random":
-        generator = gen_moe_workload_balanced_random
-    elif method == "balanced_layer_wise_benchmark":
-        generator = gen_moe_workload_layer_wise_benchmark
-    elif method == "balanced_layer_wise_benchmark_legacy":
-        generator = functools.partial(gen_moe_workload_layer_wise_benchmark, legacy=True)
-    else:
-        raise ValueError(f"Invalid method: {method}.")
-
     (
         tile_idx_to_group_idx,
         tile_idx_to_mn_limit,
@@ -139,12 +118,13 @@ def main(
         permuted_idx_to_expanded_idx,
         total_num_padded_tokens,
         num_non_exiting_tiles,
-    ) = generator(
+    ) = gen_moe_workload(
         num_tokens=num_tokens,
         top_k=top_k,
         num_experts=num_experts,
         ep_size=ep_size,
         tile_size=tile_size,
+        method=method,
     )
 
     if not os.path.isdir(output_path):

--- a/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
+++ b/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
@@ -7,7 +7,7 @@ import safetensors.torch
 import torch
 
 from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
-from tensorrt_llm.tools.layer_wise_benchmarks.runner_utils import (
+from tensorrt_llm.tools.layer_wise_benchmarks.runner import (
     get_balanced_selection_impl_default,
     get_balanced_selection_impl_random,
 )

--- a/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
+++ b/tests/scripts/cute_dsl_kernels/moe_workload_generator.py
@@ -1,0 +1,131 @@
+import click
+import safetensors.torch
+import torch
+
+from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
+from tensorrt_llm.tools.layer_wise_benchmarks.runner_utils import get_balanced_selection_no_cache
+
+
+def gen_moe_workload_layer_wise_benchmark(
+    num_tokens: int, top_k: int, num_experts: int, ep_size: int, tile_size: int
+):
+    token_selected_experts = [
+        get_balanced_selection_no_cache(
+            num_tokens, top_k, num_experts, torch.int32, "cuda", ep_size, i
+        )
+        for i in range(ep_size)
+    ]
+    token_selected_experts = torch.cat(token_selected_experts, dim=0)
+    token_final_scales = torch.ones_like(token_selected_experts, dtype=torch.float32)
+    return torch.ops.trtllm.moe_sort(
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        num_experts=num_experts,
+        top_k=top_k,
+        local_expert_offset=0,
+        local_num_experts=num_experts // ep_size,
+        tile_tokens_dim=tile_size,
+    )
+
+
+def gen_moe_workload_balanced_random(
+    num_tokens: int, top_k: int, num_experts: int, ep_size: int, tile_size: int
+):
+    num_local_experts = num_experts // ep_size
+    num_total_tokens = num_tokens * ep_size
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_total_tokens)
+    if sum(num_tokens_per_expert) != num_total_tokens * top_k:
+        num_tokens_per_expert[0] -= 1
+    assert sum(num_tokens_per_expert) == num_total_tokens * top_k // ep_size
+
+    token_expert_selection = torch.zeros(num_total_tokens, num_local_experts, dtype=torch.int32)
+    token_selected_experts = -torch.ones(num_total_tokens, top_k, dtype=torch.int32)
+    for j, curr_num_tokens in enumerate(num_tokens_per_expert):
+        curr_num_selected_tokens = 0
+        for i in torch.randperm(num_total_tokens).tolist():
+            if (curr_num_selected_experts := token_expert_selection[i].sum()) < top_k:
+                token_selected_experts[i, curr_num_selected_experts] = j
+                token_expert_selection[i, j] = 1
+                curr_num_selected_tokens += 1
+                if curr_num_selected_tokens >= curr_num_tokens:
+                    break
+    assert (
+        ((token_selected_experts >= 0).sum(dim=-1) == token_expert_selection.sum(dim=-1))
+        .all()
+        .item()
+    )
+
+    token_selected_experts = token_selected_experts.cuda()
+    token_final_scales = torch.ones_like(token_selected_experts, dtype=torch.float32)
+    return torch.ops.trtllm.moe_sort(
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        num_experts=num_experts,
+        top_k=top_k,
+        local_expert_offset=0,
+        local_num_experts=num_local_experts,
+        tile_tokens_dim=tile_size,
+    )
+
+
+@click.command("moe_workload_generator")
+@click.option("--num_tokens", type=int, default=128)
+@click.option("--top_k", type=int, default=8)
+@click.option("--num_experts", type=int, default=256)
+@click.option("--ep_size", type=int, default=32)
+@click.option("--tile_size", type=click.Choice([128, 256]), default=128)
+@click.option(
+    "--method",
+    type=click.Choice(["balanced_random", "balanced_layer_wise_benchmark"]),
+    default="balanced_random",
+)
+@click.option("--seed", type=int, default=515)
+@click.option("--output_file", type=str, default="./moe_workload.safetensors")
+def main(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    ep_size: int,
+    tile_size: int,
+    method: str,
+    seed: int,
+    output_file: str,
+):
+    torch.manual_seed(seed)
+
+    if method == "balanced_random":
+        generator = gen_moe_workload_balanced_random
+    elif method == "balanced_layer_wise_benchmark":
+        generator = gen_moe_workload_layer_wise_benchmark
+    else:
+        raise ValueError(f"Invalid method: {method}.")
+
+    (
+        tile_idx_to_group_idx,
+        tile_idx_to_mn_limit,
+        expanded_idx_to_permuted_idx,
+        permuted_idx_to_expanded_idx,
+        total_num_padded_tokens,
+        num_non_exiting_tiles,
+    ) = generator(
+        num_tokens=num_tokens,
+        top_k=top_k,
+        num_experts=num_experts,
+        ep_size=ep_size,
+        tile_size=tile_size,
+    )
+
+    workload = {
+        "tile_idx_to_group_idx": tile_idx_to_group_idx,
+        "tile_idx_to_mn_limit": tile_idx_to_mn_limit,
+        "expanded_idx_to_permuted_idx": expanded_idx_to_permuted_idx,
+        "permuted_idx_to_expanded_idx": permuted_idx_to_expanded_idx,
+        "total_num_padded_tokens": total_num_padded_tokens,
+        "num_non_exiting_tiles": num_non_exiting_tiles,
+    }
+    safetensors.torch.save_file(workload, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -2,10 +2,7 @@ import pytest
 import torch
 from utils.util import check_accuracy
 
-from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import (
-    GatherGroupedGemmInputsHelper,
-    GroupedGemmInputsHelper,
-)
+from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import GroupedGemmInputsHelper
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import cute_dsl_nvfp4_grouped_gemm_ref
 from tensorrt_llm._torch.modules.fused_moe.quantization import interleave_linear_and_gate
 from tensorrt_llm._torch.utils import swizzle_sf, unswizzle_sf
@@ -740,55 +737,29 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
 
     # Generate routing information
     routing_logits = torch.randn(num_tokens, num_experts, device="cuda")
-    _, token_selected_experts = routing_logits.topk(top_k, dim=-1)
+    token_final_scales, token_selected_experts = routing_logits.topk(top_k, dim=-1)
     token_selected_experts = token_selected_experts.to(torch.int32)
-    num_tokens_per_expert = torch.bincount(token_selected_experts.flatten(), minlength=num_experts)
-    num_tokens_per_expert = num_tokens_per_expert[:num_local_experts]
-    # Ensure at least one valid token
-    if num_tokens_per_expert.sum().item() == 0:
-        num_tokens_per_expert[0] = 1
-    num_tiles_per_expert = (num_tokens_per_expert + tile_size - 1) // tile_size
-    num_tokens_per_expert = num_tokens_per_expert.cpu()
-    num_tiles_per_expert = num_tiles_per_expert.cpu()
-    num_valid_tiles = num_tiles_per_expert.sum().item()
-    num_valid_permuted_tokens = num_valid_tiles * tile_size
+    token_final_scales = token_final_scales.softmax(dim=-1).to(torch.float32)
 
-    # Create helper
-    helper = GatherGroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, tile_size)
-    max_num_tiles = helper.get_max_num_tiles(num_tokens)
-    max_num_permuted_tokens = helper.get_max_num_permuted_tokens(num_tokens)
-    assert 0 <= num_valid_tiles <= max_num_tiles
-    assert 0 <= num_valid_permuted_tokens <= max_num_permuted_tokens
-
-    # Generate tile metadata
-    num_non_exiting_tiles = torch.tensor([num_valid_tiles], dtype=torch.int32, device="cuda")
-    tile_idx_to_group_idx = torch.empty(max_num_tiles, dtype=torch.int32)
-    tile_idx_to_mn_limit = torch.empty(max_num_tiles, dtype=torch.int32)
-    tile_idx_to_group_idx.fill_(int(-2e9))
-    tile_idx_to_mn_limit.fill_(int(-2e9))
-
-    tile_idx_to_group_idx_list = helper.generate_tile_idx_to_group_idx(
-        num_tokens_per_expert.tolist()
+    (
+        tile_idx_to_group_idx,
+        tile_idx_to_mn_limit,
+        expanded_idx_to_permuted_idx,
+        permuted_idx_to_expanded_idx,
+        total_num_padded_tokens,
+        num_non_exiting_tiles,
+    ) = torch.ops.trtllm.moe_sort(
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        num_experts=num_experts,
+        top_k=top_k,
+        local_expert_offset=0,
+        local_num_experts=num_local_experts,
+        tile_tokens_dim=tile_size,
     )
-    tile_idx_to_mn_limit_list = helper.generate_tile_idx_to_mn_limit(num_tokens_per_expert.tolist())
 
-    for idx, (group_idx, mn_limit) in enumerate(
-        zip(tile_idx_to_group_idx_list, tile_idx_to_mn_limit_list)
-    ):
-        tile_idx_to_group_idx[idx] = group_idx
-        tile_idx_to_mn_limit[idx] = mn_limit
-
-    tile_idx_to_group_idx = tile_idx_to_group_idx.cuda()
-    tile_idx_to_mn_limit = tile_idx_to_mn_limit.cuda()
-
-    # Generate permuted_idx_to_expanded_idx for gather operation
-    permuted_idx_to_expanded_idx_list = helper.generate_permuted_idx_to_expanded_idx(
-        num_tokens, num_tokens_per_expert.tolist(), max_num_permuted_tokens
-    )
-    permuted_idx_to_expanded_idx = torch.tensor(
-        permuted_idx_to_expanded_idx_list, dtype=torch.int32, device="cuda"
-    )
-    assert permuted_idx_to_expanded_idx.size(0) == max_num_permuted_tokens
+    max_num_permuted_tokens = permuted_idx_to_expanded_idx.size(0)
+    num_valid_permuted_tokens = total_num_padded_tokens.item()
 
     # Create input tensors (original size, not permuted)
     a = torch.randint(-5, 5, (num_tokens, hidden_size), dtype=torch.int32, device="cuda").to(
@@ -826,18 +797,22 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
     )
 
     # Compute reference: manually gather, compute GEMM, apply SwiGLU, then quantize
-    a_gathered = torch.empty(
-        max_num_permuted_tokens, hidden_size // 2, dtype=a.dtype, device=a.device
-    )
+    permuted_idx_to_expanded_idx_list = permuted_idx_to_expanded_idx.cpu().tolist()
+    tile_idx_to_mn_limit_list = tile_idx_to_mn_limit.cpu().tolist()
+
+    a_gathered = torch.empty(max_num_permuted_tokens, hidden_size // 2, dtype=a.dtype)
     a_sf_gathered = torch.empty(
-        max_num_permuted_tokens, hidden_size // sf_vec_size, dtype=a_sf.dtype, device=a_sf.device
+        max_num_permuted_tokens, hidden_size // sf_vec_size, dtype=a_sf.dtype
     )
     for i in range(num_valid_permuted_tokens):
-        expanded_idx = permuted_idx_to_expanded_idx[i].item()
-        if expanded_idx != helper.pad_val:
-            token_id = expanded_idx // top_k
-            a_gathered[i] = a[token_id]
-            a_sf_gathered[i] = a_sf_unswizzled[token_id]
+        if i >= tile_idx_to_mn_limit_list[i // tile_size]:
+            continue
+        expanded_idx = permuted_idx_to_expanded_idx_list[i]
+        token_id = expanded_idx // top_k
+        a_gathered[i] = a[token_id]
+        a_sf_gathered[i] = a_sf_unswizzled[token_id]
+    a_gathered = a_gathered.to(a.device)
+    a_sf_gathered = a_sf_gathered.to(a.device)
 
     # Swizzle a_sf_gathered for reference GEMM
     a_sf_gathered_swizzled = swizzle_sf(
@@ -886,8 +861,9 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
     # Create mask for valid tokens
     valid_token_mask = torch.zeros(num_valid_permuted_tokens, dtype=torch.bool, device="cuda")
     for i in range(num_valid_permuted_tokens):
-        if permuted_idx_to_expanded_idx[i].item() != helper.pad_val:
-            valid_token_mask[i] = True
+        if i >= tile_idx_to_mn_limit_list[i // tile_size]:
+            continue
+        valid_token_mask[i] = True
 
     num_valid_tokens = valid_token_mask.sum().item()
     if num_valid_tokens > 0:
@@ -905,9 +881,10 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
         c_sf_valid = []
         c_sf_ref_valid = []
         for i in range(num_valid_permuted_tokens):
-            if permuted_idx_to_expanded_idx[i].item() != helper.pad_val:
-                c_sf_valid.append(c_sf_unswizzled[i])
-                c_sf_ref_valid.append(c_sf_ref_unswizzled[i])
+            if i >= tile_idx_to_mn_limit_list[i // tile_size]:
+                continue
+            c_sf_valid.append(c_sf_unswizzled[i])
+            c_sf_ref_valid.append(c_sf_ref_unswizzled[i])
 
         c_sf_valid = torch.cat(c_sf_valid)
         c_sf_ref_valid = torch.cat(c_sf_ref_valid)


### PR DESCRIPTION
## Description

This PR introduces a more unbiased strategy for MoE workload generation.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MoE Workload Generator tool supporting multiple token balancing strategies (random, default, legacy).
  * Introduced seed-based deterministic randomness for token-expert selection.

* **Improvements**
  * Enhanced token-expert distribution with balanced random approach.
  * Added L2 cache optimization to performance tuning configurations.

* **Documentation**
  * New usage guide for MoE Workload Generator.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->