### PR TITLE
[TRTLLM-9707][infra] Support abort stage also upload results.xml to artifactory to support reuse test

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -198,7 +198,11 @@ def runIsolatedTests(preprocessedLists, testCmdLine, llmSrc, stageName) {
                 ${isolateTestCmdLine.join(" ")}
             """
         } catch (InterruptedException e) {
-            throw e
+            echo "Isolated test ${i} (${isolateTestName}) was interrupted. Stopping further isolated tests to allow result upload."
+            // Mark as failed and break instead of throwing immediately
+            // This allows cacheErrorAndUploadResult to collect partial results
+            rerunFailed = true
+            break
         } catch (Exception e) {
             def isRerunFailed = rerunFailedTests(stageName, llmSrc, isolateTestCmdLine, "results_isolated_${i}.xml", "isolated_${i}")
             if (isRerunFailed) {
@@ -1497,34 +1501,47 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
     checkStageName([stageName])
     def Boolean stageIsInterrupted = false
     def Boolean stageIsFailed = true
+    def Exception interruptedException = null
     try {
         taskRunner()
         stageIsFailed = false
     } catch (InterruptedException e) {
         stageIsInterrupted = true
-        throw e
+        interruptedException = e
+        // Don't throw immediately - upload results first
     } finally {
         ensureStageResultNotUploaded(stageName + postTag)
-        if (stageIsInterrupted) {
-            echo "Stage is interrupted, skip to upload test result."
-        } else {
-            // Temporarily disable to reduce the log size
-            // sh 'if [ "$(id -u)" -eq 0 ]; then dmesg || true; fi'
-            if (noResultIfSuccess && !stageIsFailed) {
-                // Clean up the workspace
-                sh """
-                    env | sort
-                    pwd && ls -alh
-                    rm -rf ./*
-                """
 
-                echo "Finished test stage execution."
-                return
-            }
-            echo "noResultIfSuccess: ${noResultIfSuccess}, stageIsFailed: ${stageIsFailed}"
+        // Temporarily disable to reduce the log size
+        // sh 'if [ "$(id -u)" -eq 0 ]; then dmesg || true; fi'
+
+        if (noResultIfSuccess && !stageIsFailed && !stageIsInterrupted) {
+            // Only skip result upload if succeeded and noResultIfSuccess is true (not interrupted)
+            sh """
+                env | sort
+                pwd && ls -alh
+                rm -rf ./*
+            """
+            echo "Finished test stage execution."
+            return
+        }
+
+        echo "noResultIfSuccess: ${noResultIfSuccess}, stageIsFailed: ${stageIsFailed}, stageIsInterrupted: ${stageIsInterrupted}"
+
+        try {
             sh "mkdir -p ${stageName}"
-            finallyRunner()
-            if (stageIsFailed) {
+
+            // Execute finallyRunner, but don't let it block result upload if it fails
+            try {
+                finallyRunner()
+            } catch (InterruptedException e) {
+                echo "WARNING: finallyRunner was interrupted, but continuing with result upload to preserve partial test results"
+                // Don't re-throw - continue with upload
+            } catch (Exception finallyException) {
+                echo "WARNING: finallyRunner encountered an error, but continuing with result upload: ${finallyException.message}"
+                // Continue with XML generation and upload even if finallyRunner fails
+            }
+            if (stageIsFailed || stageIsInterrupted) {
                 def timeoutTestXml = generateTimeoutTestResultXml(stageName, "unfinished_test.txt")
                 if (timeoutTestXml != null) {
                     sh """
@@ -1533,9 +1550,11 @@ ${timeoutTestXml}
 EOF_TIMEOUT_XML
                     """
                 }
-                def stageXml = generateStageFailTestResultXml(stageName, "Stage Failed", "Stage run failed without result", "results*.xml")
-                if (stageXml != null) {
-                    sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
+                if (stageIsFailed && !stageIsInterrupted) {
+                    def stageXml = generateStageFailTestResultXml(stageName, "Stage Failed", "Stage run failed without result", "results*.xml")
+                    if (stageXml != null) {
+                        sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
+                    }
                 }
             }
             sh "STAGE_NAME=${stageName}"
@@ -1546,17 +1565,29 @@ EOF_TIMEOUT_XML
                 "results-${stageName}${postTag}.tar.gz",
                 "${UPLOAD_PATH}/test-results/"
             )
-            junit(testResults: "${stageName}/results*.xml")
+            junit(testResults: "${stageName}/results*.xml", allowEmptyResults: true)
+        } catch (Exception uploadException) {
+            echo "WARNING: Failed to upload test results after ${stageIsInterrupted ? 'interruption' : 'failure'}: ${uploadException.message}"
+            // Continue to cleanup and re-throw the original exception if needed
         }
 
         // Clean up the workspace
-        sh """
-            env | sort
-            pwd && ls -alh
-            rm -rf ./*
-        """
+        try {
+            sh """
+                env | sort
+                pwd && ls -alh
+                rm -rf ./*
+            """
+        } catch (Exception cleanupException) {
+            echo "WARNING: Failed to clean up workspace: ${cleanupException.message}"
+        }
 
         echo "Finished test stage execution."
+
+        // Re-throw the interruption exception after uploading results
+        if (interruptedException != null) {
+            throw interruptedException
+        }
     }
 }
 
@@ -2711,6 +2742,9 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                         """
                     }
                 } catch (InterruptedException e) {
+                    echo "Regular pytest was interrupted. Partial results may be available via --periodic-junit-xmlpath"
+                    // Re-throw to let cacheErrorAndUploadResult handle it
+                    // Pytest should have saved partial results via --periodic-save-unfinished-test
                     throw e
                 } catch (Exception e) {
                     def isRerunFailed = rerunFailedTests(stageName, llmSrc, pytestCommand, "results.xml", "regular")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Test results now upload even when pipeline execution is interrupted, preventing data loss during unexpected stops.

* **Bug Fixes**
  * Improved error handling for interruptions and timeouts to maintain pipeline stability.
  * Enhanced logging for interrupted test runs to provide better execution visibility.

* **Chores**
  * Added robustness improvements for result handling and cleanup operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
