### PR TITLE
[TRTLLM-10185][feat] AutoTuner Cache: Support cache file lock and merge all ranks into one

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -2,6 +2,7 @@ import ast
 import contextlib
 import copy
 import enum
+import fcntl
 import inspect
 import itertools
 import json
@@ -266,15 +267,11 @@ def autotune(tune_mode: bool = True, cache_path: str = None):
     tune_required = tune_mode
     if cache_path is not None:
         # check if the rank-specific file exists
-        cache_path_no_ext = os.path.splitext(cache_path)[0]
-        cache_path_no_ext_rank = cache_path_no_ext + f".rank{rank}.json"
         # if the rank-specific file exists, load it
-        file_exists = os.path.exists(cache_path_no_ext_rank)
-        # if the rank-specific file exists, do not enable tuning mode
+        file_exists = os.path.exists(cache_path)
         if file_exists:
-            logger.info(
-                f"[Autotuner] Loading cache from {cache_path_no_ext_rank}")
-            autotuner.profiling_cache.load_cache(cache_path_no_ext_rank)
+            logger.info(f"[Autotuner] Loading cache from {cache_path}")
+            autotuner.profiling_cache.load_cache(cache_path, rank)
 
     # record the old tuning mode
     old_mode = autotuner.is_tuning_mode
@@ -293,8 +290,8 @@ def autotune(tune_mode: bool = True, cache_path: str = None):
 
         # save cache
         if cache_path is not None:
-            logger.info(f"[Autotuner] Saving cache to {cache_path_no_ext_rank}")
-            autotuner.profiling_cache.save_cache(cache_path_no_ext_rank)
+            logger.info(f"[Autotuner] Saving cache to {cache_path}")
+            autotuner.profiling_cache.save_cache(cache_path, rank)
 
 
 @dataclass
@@ -439,7 +436,7 @@ class AutoTunerProfilingCache:
     def get_specific_custom_op(self, custom_op: str) -> Dict[Tuple, Tuple]:
         return {k: v for k, v in self.cache.items() if k[0] == custom_op}
 
-    def save_cache(self, file_path: Union[str, Path]) -> None:
+    def save_cache(self, file_path: Union[str, Path], rank: int) -> None:
         """Save the profiling cache to disk in JSON format.
 
         Args:
@@ -456,9 +453,21 @@ class AutoTunerProfilingCache:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            serializable_cache = self._serialize_cache_to_json()
-            with open(file_path, 'w') as f:
-                json.dump(serializable_cache, f, indent=2, default=str)
+            serialized_rank_cache_data = self._serialize_cache_data()
+            with open(file_path, 'a+') as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                f.seek(0)
+                content = f.read()
+                if content.strip():
+                    current_cache = json.loads(content)
+                else:
+                    current_cache = {
+                        "metadata": self._serialize_metadata(),
+                    }
+                f.seek(0)
+                f.truncate()
+                current_cache[f"rank_{rank}"] = serialized_rank_cache_data
+                json.dump(current_cache, f, indent=2, default=str)
             logger.info(
                 f"[AutoTuner] Successfully saved cache to {file_path} using JSON format"
             )
@@ -466,7 +475,7 @@ class AutoTunerProfilingCache:
             logger.error(f"[AutoTuner] Failed to save cache with JSON: {e}")
             raise
 
-    def load_cache(self, file_path: Union[str, Path]) -> None:
+    def load_cache(self, file_path: Union[str, Path], rank: int) -> None:
         """Load the profiling cache from disk in JSON format.
 
         Args:
@@ -486,8 +495,12 @@ class AutoTunerProfilingCache:
 
         try:
             with open(file_path, 'r') as f:
-                serializable_cache = json.load(f)
-            self.cache = self._deserialize_cache_from_json(serializable_cache)
+                fcntl.flock(f, fcntl.LOCK_SH)
+                current_cache_contents = json.load(f)
+                self._deserialize_metadata(current_cache_contents["metadata"])
+                assert f"rank_{rank}" in current_cache_contents, f"Rank {rank} cache not found in {file_path}"
+            self.cache = self._deserialize_cache_data(
+                current_cache_contents[f'rank_{rank}'])
             logger.info(
                 f"[AutoTuner] Successfully loaded cache from {file_path} using JSON format"
             )
@@ -495,7 +508,21 @@ class AutoTunerProfilingCache:
             logger.error(f"[AutoTuner] Failed to load cache with JSON: {e}")
             raise
 
-    def _serialize_cache_to_json(self) -> Dict[str, Any]:
+    def _serialize_metadata(self) -> Dict[str, Any]:
+        return {
+            "lib_version": self.lib_version,
+            "creation_timestamp": self.creation_timestamp,
+            "device_name": self.device_name,
+            "device_capability": self.device_capability,
+        }
+
+    def _deserialize_metadata(self, metadata: Dict[str, Any]) -> None:
+        self.lib_version = metadata["lib_version"]
+        self.creation_timestamp = metadata["creation_timestamp"]
+        self.device_name = metadata["device_name"]
+        self.device_capability = metadata["device_capability"]
+
+    def _serialize_cache_data(self) -> Dict[str, Any]:
         """Convert the profiling cache to a JSON-serializable format.
 
         Returns:
@@ -505,15 +532,7 @@ class AutoTunerProfilingCache:
             This method handles the conversion of complex objects to JSON-compatible
             representations. Some type information may be lost in the conversion.
         """
-        serializable_cache = {
-            "metadata": {
-                "lib_version": self.lib_version,
-                "creation_timestamp": self.creation_timestamp,
-                "device_name": self.device_name,
-                "device_capability": self.device_capability,
-            },
-            "cache_data": {},
-        }
+        serializable_cache = {}
 
         for key, value in self.cache.items():
             # Convert any simple object to string for JSON compatibility
@@ -529,7 +548,7 @@ class AutoTunerProfilingCache:
                     f"[AutoTuner] Could not serialize tactic: {tactic_str} for cache key {key_str} due to {e}. Deserialization may fail.",
                     key=tactic_str)
 
-            serializable_cache["cache_data"][key_str] = {
+            serializable_cache[key_str] = {
                 "runner_id": runner_id,
                 "tactic": tactic_str,
                 "min_time": min_time,
@@ -537,8 +556,8 @@ class AutoTunerProfilingCache:
 
         return serializable_cache
 
-    def _deserialize_cache_from_json(
-            self, serializable_cache: Dict[str, Any]) -> Dict[Tuple, Tuple]:
+    def _deserialize_cache_data(
+            self, cache_data: Dict[str, Any]) -> Dict[Tuple, Tuple]:
         """Convert JSON-serialized cache back to the original format.
 
         Args:
@@ -551,14 +570,7 @@ class AutoTunerProfilingCache:
             This attempts to reconstruct the original data structures but may not
             perfectly preserve all type information, especially for complex tactic objects.
         """
-        metadata = serializable_cache["metadata"]
-        self.lib_version = metadata["lib_version"]
-        self.creation_timestamp = metadata["creation_timestamp"]
-        self.device_name = metadata["device_name"]
-        self.device_capability = metadata["device_capability"]
-
         cache = {}
-        cache_data = serializable_cache["cache_data"]
 
         for key_str, value in cache_data.items():
             # Reconstruct the tuple key safely

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -15,6 +15,7 @@ l0_dgx_b200:
       backend: pytorch
       orchestrator: mpi
   tests:
+  - unittest/_torch/misc/test_autotuner.py::test_autotuner_distributed_strategy
   - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_alltoall_fp4[DeepEPLowLatency]
   - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_alltoall_fp4[MNNVL]
   - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_nvfp4[enable_configurable_moe-disable_finalize_fusion-TRTLLM-dtype1]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced autotuner profiling cache with rank-aware operations for improved distributed computing support.
  * Introduced file-locking mechanism to safely handle concurrent cache access across multiple ranks.
  * Cache metadata persistence to preserve environment information alongside tuning data.

* **API Changes**
  * Updated `save_cache()` and `load_cache()` methods to require a rank parameter for proper cache isolation.

* **Tests**
  * Added distributed autotuner functionality tests with multi-rank scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
