### PR TITLE
[#10374][fix] fixed race condition in AutoDeploy's mp tests port acquisition

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -85,9 +85,21 @@ def get_rank_world_size() -> Tuple[int, int]:
     return get_rank(), get_world_size()
 
 
-def initialize_or_skip(*args, **kwargs) -> Tuple[int, int]:
+def initialize_or_skip(
+    rank: int = 0,
+    world_size: int = 1,
+    port: Optional[int] = None,
+    shared_port: Optional["mp.Value"] = None,
+    port_ready_barrier: Optional["mp.Barrier"] = None,
+) -> Tuple[int, int]:
     if not dist.is_initialized():
-        return initialize(*args, **kwargs)
+        return initialize(
+            rank=rank,
+            world_size=world_size,
+            port=port,
+            shared_port=shared_port,
+            port_ready_barrier=port_ready_barrier,
+        )
     return get_rank(), get_world_size()
 
 
@@ -112,7 +124,48 @@ def cleanup():
         dist.destroy_process_group()
 
 
-def initialize(rank: int = 0, world_size: int = 1, port: Optional[int] = None) -> Tuple[int, int]:
+def _try_init_process_group(local_rank: int, world_size: int, port: int) -> bool:
+    """Attempt to initialize process group. Returns True on success, False on EADDRINUSE."""
+    os.environ["RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+
+    try:
+        dist.init_process_group(
+            "nccl",
+            world_size=world_size,
+            rank=local_rank,
+            device_id=torch.device(local_rank),
+        )
+        return True
+    except Exception as e:
+        # Check if this is a port-in-use error (only rank 0 binds, so only rank 0 can get this)
+        if "EADDRINUSE" in str(e) or "address already in use" in str(e).lower():
+            ad_logger.warning(f"Port {port} already in use, will retry with new port")
+            return False
+        raise
+
+
+def initialize(
+    rank: int = 0,
+    world_size: int = 1,
+    port: Optional[int] = None,
+    shared_port: Optional["mp.Value"] = None,
+    port_ready_barrier: Optional["mp.Barrier"] = None,
+    max_retries: int = 5,
+) -> Tuple[int, int]:
+    """Initialize distributed process group.
+
+    Args:
+        rank: Process rank (ignored for OMPI/torchelastic).
+        world_size: Total number of processes (ignored for OMPI/torchelastic).
+        port: Initial port to try. If None, a free port will be selected.
+        shared_port: Optional mp.Value for rank 0 to share the final port with other ranks.
+        port_ready_barrier: Optional mp.Barrier to synchronize port selection.
+        max_retries: Maximum number of port retry attempts for rank 0.
+    """
     if is_ompi():
         lib = "OMPI"
         local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
@@ -131,25 +184,53 @@ def initialize(rank: int = 0, world_size: int = 1, port: Optional[int] = None) -
         port = get_free_port()
 
     ad_logger.set_rank(local_rank)
-    ad_logger.info(f"Initializing for: {lib=}, {local_rank=}, {world_size=}, {port=}")
-
-    # Set up environment variable to run with mpirun
-    os.environ["RANK"] = str(local_rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
-    os.environ["MASTER_ADDR"] = "127.0.0.1"
-    os.environ["MASTER_PORT"] = str(port)
-    os.environ["LOCAL_RANK"] = str(local_rank)
 
     # Necessary to assign a device to each rank.
     torch.cuda.set_device(local_rank)
 
-    # We use nccl backend
-    dist.init_process_group(
-        "nccl",
-        world_size=world_size,
-        rank=local_rank,
-        device_id=torch.device(local_rank),
-    )
+    # If we have shared port synchronization (multiprocess spawn mode)
+    if shared_port is not None and port_ready_barrier is not None:
+        if local_rank == 0:
+            # Rank 0: try ports until one works, then share with other ranks
+            for attempt in range(max_retries):
+                ad_logger.info(
+                    f"Initializing for: {lib=}, {local_rank=}, {world_size=}, {port=} (attempt {attempt + 1})"
+                )
+                if _try_init_process_group(local_rank, world_size, port):
+                    # Success! Share the working port with other ranks
+                    shared_port.value = port
+                    port_ready_barrier.wait()  # Signal other ranks
+                    break
+                else:
+                    # Port was taken, try a new one
+                    port = get_free_port()
+            else:
+                # All retries exhausted
+                shared_port.value = -1  # Signal failure
+                port_ready_barrier.wait()
+                raise RuntimeError(f"Failed to find available port after {max_retries} attempts")
+        else:
+            # Other ranks: wait for rank 0 to find a working port
+            port_ready_barrier.wait()
+            port = shared_port.value
+            if port == -1:
+                raise RuntimeError("Rank 0 failed to initialize, cannot proceed")
+            ad_logger.info(f"Initializing for: {lib=}, {local_rank=}, {world_size=}, {port=}")
+            dist.init_process_group(
+                "nccl",
+                world_size=world_size,
+                rank=local_rank,
+                device_id=torch.device(local_rank),
+            )
+    else:
+        # Original path: no retry mechanism (OMPI, torchelastic, or single process)
+        ad_logger.info(f"Initializing for: {lib=}, {local_rank=}, {world_size=}, {port=}")
+        dist.init_process_group(
+            "nccl",
+            world_size=world_size,
+            rank=local_rank,
+            device_id=torch.device(local_rank),
+        )
 
     # Register cleanup function to be called at exit
     atexit.register(cleanup)
@@ -160,9 +241,13 @@ def initialize(rank: int = 0, world_size: int = 1, port: Optional[int] = None) -
     return local_rank, world_size
 
 
-def init_and_run_process(job, rank, size, port, **kwargs):
+def init_and_run_process(
+    job, rank, size, port, shared_port=None, port_ready_barrier=None, **kwargs
+):
     try:
-        initialize_or_skip(rank, size, port)
+        initialize_or_skip(
+            rank, size, port, shared_port=shared_port, port_ready_barrier=port_ready_barrier
+        )
         job(rank, size, **kwargs)
     except Exception as e:
         # Close the input and output queues to parent process can exit.
@@ -212,8 +297,15 @@ def _start_multiprocess_job(
         init_and_run_process(job, 0, 1, port, **kwargs)
         return None
 
-    mp.set_start_method("spawn", force=True)
+    # Use explicit spawn context to ensure synchronization primitives work correctly
+    ctx = mp.get_context("spawn")
     processes: List[mp.Process] = []
+
+    # Create shared state for port synchronization with retry mechanism:
+    # - shared_port: rank 0 writes the final working port here
+    # - port_ready_barrier: all ranks wait here until rank 0 has bound successfully
+    shared_port = ctx.Value("i", port)  # 'i' = signed int
+    port_ready_barrier = ctx.Barrier(size)
 
     for rank in range(size):
         if input_queues:
@@ -221,10 +313,11 @@ def _start_multiprocess_job(
         if output_queue:
             kwargs["output_queue"] = output_queue if rank == 0 else None
 
-        # Use thread for the single worker case.
-        launch_method = mp.Process
-        p = launch_method(
-            target=init_and_run_process, args=(job, rank, size, port), kwargs=kwargs, daemon=True
+        p = ctx.Process(
+            target=init_and_run_process,
+            args=(job, rank, size, port),
+            kwargs={**kwargs, "shared_port": shared_port, "port_ready_barrier": port_ready_barrier},
+            daemon=True,
         )
         p.start()
         processes.append(p)

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -752,27 +752,27 @@ def _register_fake():
             for i in range(0, len(input_list), num_ranks)
         ]
 
-    @torch.library.register_fake("trtllm::alltoall_helix_native")
-    def _(partial_o, softmax_stats, workspace, cp_rank, cp_size):
-        # Returns outputs with same shapes as inputs
-        return partial_o.new_empty(partial_o.shape), softmax_stats.new_empty(
-            softmax_stats.shape)
+    # @torch.library.register_fake("trtllm::alltoall_helix_native")
+    # def _(partial_o, softmax_stats, workspace, cp_rank, cp_size):
+    #     # Returns outputs with same shapes as inputs
+    #     return partial_o.new_empty(partial_o.shape), softmax_stats.new_empty(
+    #         softmax_stats.shape)
 
-    @torch.library.register_fake("trtllm::initialize_helix_workspace")
-    def _(workspace, cp_rank, cp_size):
-        # This op initializes workspace in-place and returns nothing
-        return None
+    # @torch.library.register_fake("trtllm::initialize_helix_workspace")
+    # def _(workspace, cp_rank, cp_size):
+    #     # This op initializes workspace in-place and returns nothing
+    #     return None
 
-    @torch.library.register_fake("trtllm::helix_post_process")
-    def _(gathered_o, gathered_stats, scale):
-        return gathered_o.new_empty(*gathered_o.shape[1:])
+    # @torch.library.register_fake("trtllm::helix_post_process")
+    # def _(gathered_o, gathered_stats, scale):
+    #     return gathered_o.new_empty(*gathered_o.shape[1:])
 
-    @torch.library.register_fake("trtllm::helix_post_process_native")
-    def _(gathered_o, gathered_stats, scale, cp_dim):
-        # Remove the dimension at cp_dim (context parallelism dimension)
-        out_shape = list(gathered_o.shape)
-        del out_shape[cp_dim]
-        return gathered_o.new_empty(*out_shape)
+    # @torch.library.register_fake("trtllm::helix_post_process_native")
+    # def _(gathered_o, gathered_stats, scale, cp_dim):
+    #     # Remove the dimension at cp_dim (context parallelism dimension)
+    #     out_shape = list(gathered_o.shape)
+    #     del out_shape[cp_dim]
+    #     return gathered_o.new_empty(*out_shape)
 
     @torch.library.register_fake("trtllm::tinygemm2")
     def _(input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -752,27 +752,27 @@ def _register_fake():
             for i in range(0, len(input_list), num_ranks)
         ]
 
-    # @torch.library.register_fake("trtllm::alltoall_helix_native")
-    # def _(partial_o, softmax_stats, workspace, cp_rank, cp_size):
-    #     # Returns outputs with same shapes as inputs
-    #     return partial_o.new_empty(partial_o.shape), softmax_stats.new_empty(
-    #         softmax_stats.shape)
+    @torch.library.register_fake("trtllm::alltoall_helix_native")
+    def _(partial_o, softmax_stats, workspace, cp_rank, cp_size):
+        # Returns outputs with same shapes as inputs
+        return partial_o.new_empty(partial_o.shape), softmax_stats.new_empty(
+            softmax_stats.shape)
 
-    # @torch.library.register_fake("trtllm::initialize_helix_workspace")
-    # def _(workspace, cp_rank, cp_size):
-    #     # This op initializes workspace in-place and returns nothing
-    #     return None
+    @torch.library.register_fake("trtllm::initialize_helix_workspace")
+    def _(workspace, cp_rank, cp_size):
+        # This op initializes workspace in-place and returns nothing
+        return None
 
-    # @torch.library.register_fake("trtllm::helix_post_process")
-    # def _(gathered_o, gathered_stats, scale):
-    #     return gathered_o.new_empty(*gathered_o.shape[1:])
+    @torch.library.register_fake("trtllm::helix_post_process")
+    def _(gathered_o, gathered_stats, scale):
+        return gathered_o.new_empty(*gathered_o.shape[1:])
 
-    # @torch.library.register_fake("trtllm::helix_post_process_native")
-    # def _(gathered_o, gathered_stats, scale, cp_dim):
-    #     # Remove the dimension at cp_dim (context parallelism dimension)
-    #     out_shape = list(gathered_o.shape)
-    #     del out_shape[cp_dim]
-    #     return gathered_o.new_empty(*out_shape)
+    @torch.library.register_fake("trtllm::helix_post_process_native")
+    def _(gathered_o, gathered_stats, scale, cp_dim):
+        # Remove the dimension at cp_dim (context parallelism dimension)
+        out_shape = list(gathered_o.shape)
+        del out_shape[cp_dim]
+        return gathered_o.new_empty(*out_shape)
 
     @torch.library.register_fake("trtllm::tinygemm2")
     def _(input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):


### PR DESCRIPTION
**Problem**
Failure seen in CI: 
```

[2025-12-29T21:42:44.381Z] [W1229 12:47:08.489869130 TCPStore.cpp:340] [c10d] TCP client failed to connect/validate to host 127.0.0.1:30325 - retrying (try=0, timeout=600000ms, delay=385ms): Ping failed, invalid value returned from server. Expected: 297731, Got: 68681728

[2025-12-29T21:42:44.381Z] Exception raised from ping at /opt/pytorch/pytorch/torch/csrc/distributed/c10d/TCPStore.cpp:427 (most recent call first):
```
https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fmain%2FL0_Test-x86_64-Multi-GPU/detail/L0_Test-x86_64-Multi-GPU/3663/pipeline/3347

The spawn_multiprocess_job function had a TOCTOU (Time-Of-Check-To-Time-Of-Use) race condition when selecting ports for distributed process group initialization. The original flow was:
1. Call get_free_port() which binds to port 0, gets an available port, and closes the socket
2. Spawn child processes with that port number
3. Child processes try to bind to the port via dist.init_process_group()
Between steps 1 and 3, another process could claim the port, causing EADDRINUSE errors and test failures in CI.

**Solution**
Implemented a retry mechanism with shared state synchronization:
Rank 0 retries: If init_process_group fails with EADDRINUSE, rank 0 picks a new port and retries (up to 5 attempts)
Shared port communication: Use multiprocessing.Value to share the working port with other ranks
Barrier synchronization: Use multiprocessing.Barrier so other ranks wait until rank 0 successfully binds
Explicit spawn context: Use mp.get_context("spawn") to create synchronization primitives, ensuring they work correctly with spawned processes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced distributed training initialization with automatic port binding and retry capability for improved synchronization across multiple ranks.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
