### PR TITLE
[https://nvbugs/5649010][fix] use 0 port as arbitrary port when disagg service discovery is enabled

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -18,7 +18,7 @@ from torch.cuda import device_count
 from tensorrt_llm import LLM as PyTorchLLM
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._tensorrt_engine import LLM
-from tensorrt_llm._utils import mpi_rank
+from tensorrt_llm._utils import get_free_port, mpi_rank
 from tensorrt_llm.executor.utils import LlmLauncherEnvs
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
@@ -180,10 +180,27 @@ def launch_server(
     backend = llm_args["backend"]
     model = llm_args["model"]
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.bind((host, port))
-        except OSError as e:
-            raise RuntimeError(f"Failed to bind socket to {host}:{port}: {e}")
+        # If disagg cluster config is provided and port is not specified, try to find a free port, otherwise try to bind to the specified port
+        assert port > 0 or disagg_cluster_config is not None, "Port must be specified if disagg cluster config is not provided"
+        if port > 0:
+            port_retries = 1
+        else:
+            port_retries = 100
+            port = get_free_port()
+        while port_retries > 0:
+            try:
+                s.bind((host, port))
+                break
+            except OSError as e:
+                port_retries -= 1
+                if port_retries == 0:
+                    raise RuntimeError(
+                        f"Failed to bind socket to {host}:{port}: {e}")
+                else:
+                    logger.warning(
+                        f"Failed to bind socket to {host}:{port}: {e}, retrying {port_retries}..."
+                    )
+                port = get_free_port()
 
         if backend == 'pytorch':
             llm_args.pop("build_config", None)

--- a/tests/integration/defs/disaggregated/test_auto_scaling.py
+++ b/tests/integration/defs/disaggregated/test_auto_scaling.py
@@ -23,24 +23,6 @@ INACTIVE_TIMEOUT = 2
 CHECK_STATUS_INTERVAL = 3
 
 ROUTER_TYPES = ["round_robin", "load_balancing", "kv_cache_aware"]
-USED_PORTS = set()
-
-
-# get_free_port doesn't guarantee that consecutive calls will return different ports
-# if no server is bound to the port immediately after the call
-def get_free_unused_port():
-    global USED_PORTS
-    max_attempts = 100
-    for _ in range(max_attempts):
-        port = get_free_port()
-        assert port > 0, f"get_free_port returned {port}"
-        if port not in USED_PORTS:
-            USED_PORTS.add(port)
-            return port
-        else:
-            logger.info(f"Port {port} is already used, trying another one")
-    raise Exception(
-        f"Failed to find a free unused port after {max_attempts} attempts")
 
 
 @pytest.fixture
@@ -53,7 +35,7 @@ def model_name():
 
 @pytest.fixture
 def disagg_port():
-    return get_free_unused_port()
+    return get_free_port()
 
 
 @pytest.fixture
@@ -145,8 +127,6 @@ def _run_worker(model_name,
                 work_dir,
                 device=-1,
                 save_log=False):
-    if port == 0:
-        port = get_free_unused_port()
     worker_config_path = os.path.join(work_dir, f"{role}_{port}_config.yaml")
     with open(worker_config_path, "w+") as f:
         yaml.dump(worker_config, f)
@@ -187,6 +167,7 @@ def _run_worker(model_name,
                               port=port)
 
 
+# Use 0 as the port and provide disagg_cluster_config to let the worker choose a free port
 def run_ctx_worker(model_name, ctx_worker_config, work_dir, port=0, device=0):
     return _run_worker(model_name, ctx_worker_config, "ctx", port, work_dir,
                        device)
@@ -246,17 +227,36 @@ def periodic_check(timeout=300, interval=3):
     return decorator
 
 
-@periodic_check(timeout=300, interval=3)
-async def wait_for_disagg_server_ready(port):
+async def _wait_for_disagg_server_status(port,
+                                         ready=True,
+                                         min_ctx_workers=-1,
+                                         min_gen_workers=-1):
     info_resp = requests.get(f"http://localhost:{port}/cluster_info")
     logger.info(
         f"Waiting for disagg server {port} to be ready: {info_resp.json()}")
     if info_resp.status_code == 200:
         info = info_resp.json()
-        return info["is_ready"]
-    else:
-        logger.info(f"Failed to get cluster info: {info_resp.status_code}")
+        if ready:
+            return info["is_ready"]
+        else:
+            return len(info["current_workers"]
+                       ["context_servers"]) >= min_ctx_workers and len(
+                           info["current_workers"]
+                           ["generation_servers"]) >= min_gen_workers
     return False
+
+
+@periodic_check(timeout=300, interval=3)
+async def wait_for_disagg_server_ready(port):
+    return await _wait_for_disagg_server_status(port, True)
+
+
+@periodic_check(timeout=300, interval=3)
+async def wait_for_disagg_server_status(port,
+                                        min_ctx_workers=-1,
+                                        min_gen_workers=-1):
+    return await _wait_for_disagg_server_status(port, False, min_ctx_workers,
+                                                min_gen_workers)
 
 
 @periodic_check(timeout=300, interval=3)
@@ -314,9 +314,6 @@ def terminate(*args, show_log_lines=30, release_port=True):
                     if arg.log_file:
                         arg.log_file.close()
                         arg.log_file = None
-                    if release_port:
-                        global USED_PORTS
-                        USED_PORTS.discard(arg.port)
                 except Exception:
                     print(f"Failed to terminate process {arg.process.pid}")
             else:
@@ -399,8 +396,7 @@ async def test_minimal_instances(model_name, disagg_server_config,
         gen_worker1 = run_gen_worker(model_name, worker_config, work_dir)
         disagg_server = run_disagg_server(disagg_server_config, work_dir,
                                           disagg_port)
-        await wait_for_worker_ready(ctx_worker1.port)
-        await wait_for_worker_ready(gen_worker1.port)
+        await wait_for_disagg_server_status(disagg_port, 1, 1)
         verify_cluster_info(False, 1, 1, port=disagg_port)
         # with only 1 ctx and 1 gen worker, the request should fail
         with pytest.raises(Exception):
@@ -470,7 +466,7 @@ async def test_worker_restart(model_name, disagg_server_config, worker_config,
                                      work_dir,
                                      port=0,
                                      device=2)
-        await wait_for_worker_ready(gen_worker2.port)
+        await wait_for_disagg_server_status(disagg_port, 1, 1)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
         verify_cluster_info(True, 1, 1, port=disagg_port)
 
@@ -492,7 +488,8 @@ async def test_worker_restart(model_name, disagg_server_config, worker_config,
                                      work_dir,
                                      port=0,
                                      device=3)
-        await wait_for_worker_ready(ctx_worker2.port)
+        await wait_for_disagg_server_status(disagg_port, 1, 1)
+        await asyncio.sleep(CHECK_STATUS_INTERVAL)
         verify_cluster_info(True, 1, 1, port=disagg_port)
 
         response = request_completion(model_name, test_prompt, port=disagg_port)
@@ -510,8 +507,7 @@ async def test_worker_restart(model_name, disagg_server_config, worker_config,
                                      work_dir,
                                      port=0,
                                      device=1)
-        await wait_for_worker_ready(ctx_worker1.port)
-        await wait_for_worker_ready(gen_worker1.port)
+        await wait_for_disagg_server_status(disagg_port, 2, 2)
         await asyncio.sleep(CHECK_STATUS_INTERVAL)
         verify_cluster_info(True, 2, 2, port=disagg_port)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Disaggregated clusters now support automatic port allocation with retry logic
  * Added cluster status checks to verify worker configuration readiness before deployment

* **Bug Fixes**
  * Enhanced server port binding robustness with configurable retry mechanism for failed bindings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
