### PR TITLE
[None] [feat] Add densegemm backend for MoE

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import math
 from typing import List, Optional, Tuple
@@ -319,6 +322,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Sm100BlockwiseGemmKernel
     from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
         Sm100BlockScaledPersistentDenseGemmKernel
+    from ..cute_dsl_kernels.blackwell.moe_as_dense_gemm.fc1 import \
+        Sm100BlockScaledPersistentDenseGemmKernel as DenseGemmSwigluKernel
     from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
         FilteredTopKKernelVarlenDecode
     from ..cute_dsl_kernels.blackwell.top_k.single_pass_multi_cta_radix_topk import \
@@ -2818,6 +2823,726 @@ if IS_CUTLASS_DSL_AVAILABLE:
         assert output.dtype == torch.bfloat16, "CuTe DSL fp8 bmm output dtype must be bf16"
         assert output.shape == (batch_size, m,
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
+
+    # =============================================================================
+    # Dense GEMM with SwiGLU Fusion (FC1 Kernel for MoE as Dense GEMM)
+    # =============================================================================
+
+    class CuteDSLNVFP4DenseGemmSwigluRunner(TunableRunner):
+        """Runner for Dense GEMM with SwiGLU fusion (MoE FC1 layer as dense GEMM).
+
+        This kernel performs: C = SwiGLU(alpha * (SFA * A) @ (SFB * B))
+        where SwiGLU(x) = up * silu(gate), with up/gate extracted from interleaved output.
+
+        Input shapes:
+        - A: (M, K) - activation tensor
+        - B: (N, K, L) - weight tensor (L is typically 1 for dense)
+        - alpha: (expert_count,) - per-expert scaling, indexed by weight_per_expert
+
+        Output shape:
+        - C: (M, N//2) - N//2 due to SwiGLU fusion
+        """
+
+        kernel_class = DenseGemmSwigluKernel
+        kernel_cache = dict()
+        tuning_config_cache = dict()
+
+        def __init__(
+            self,
+            expert_count: int,
+            weight_per_expert: int,
+            output_dtype: torch.dtype,
+            scaling_vector_size: int = 16,
+        ):
+            super().__init__()
+            self.expert_count = expert_count
+            self.weight_per_expert = weight_per_expert
+            self.output_dtype = output_dtype
+            self.scaling_vector_size = scaling_vector_size
+
+        def unique_id(self):
+            return (
+                self.expert_count,
+                self.weight_per_expert,
+                self.output_dtype,
+                self.scaling_vector_size,
+            )
+
+        def __hash__(self):
+            return hash(self.unique_id())
+
+        def __eq__(self, other):
+            if not isinstance(other, CuteDSLNVFP4DenseGemmSwigluRunner):
+                return False
+            return self.unique_id() == other.unique_id()
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+            **kwargs,
+        ) -> List[Tuple[Tuple[int, int], Tuple[int, int]]]:
+            """Return valid (mma_tiler_mn, cluster_shape_mn) combinations."""
+            # Check SM version - only supports SM 100 and SM 103
+            major, minor = torch.cuda.get_device_capability()
+            if not (major == 10 and minor in [0, 3]):
+                return []
+
+            a = inputs[0]
+            b = inputs[1]
+            # a: [m, k//2] (fp4 packed), b: [num_expert, weight_per_expert, k//2]
+            m = a.shape[0]
+            k = a.shape[1] * 2  # fp4 packed in k dimension
+            n = b.shape[0] * b.shape[1]  # num_expert * weight_per_expert
+            l = 1  # dense GEMM
+
+            # Define candidates together
+            mma_tiler_mn_candidates = [(128, 128), (128, 256)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
+
+            # Map torch dtype to cutlass dtype
+            c_cutlass_dtype = {
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float16: cutlass.Float16,
+                torch.float32: cutlass.Float32,
+                torch.float4_e2m1fn_x2: cutlass.Float4E2M1FN,
+            }.get(self.output_dtype, cutlass.BFloat16)
+
+            tactics = []
+            for mma_tiler_mn, cluster_shape_mn in itertools.product(
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                if self.kernel_class.can_implement(
+                        cutlass.Float4E2M1FN,  # ab_dtype
+                        cutlass.Float8E4M3FN,  # sf_dtype
+                        self.scaling_vector_size,
+                        c_cutlass_dtype,  # c_dtype
+                        mma_tiler_mn,
+                        cluster_shape_mn,
+                        m,
+                        n,
+                        k,
+                        l,
+                        "k",  # a_major
+                        "k",  # b_major
+                        "n",  # c_major
+                        self.expert_count,
+                        self.weight_per_expert,
+                ):
+                    tactics.append((mma_tiler_mn, cluster_shape_mn))
+
+            return tactics
+
+        def get_tuning_config(self) -> TuningConfig:
+            key = self.unique_id()
+            if key not in self.tuning_config_cache:
+                self.tuning_config_cache[key] = TuningConfig(
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, get_last_power_of_2_num_tokens_buckets,
+                        last_positive_power_of_2), ),
+                    constraint_specs=(ConstraintSpec(2, 0,
+                                                     fp4_scale_infer_shape), ),
+                    use_cold_l2_cache=True,
+                    tune_max_num_tokens=256,
+                    distributed_tuning_strategy=DistributedTuningStrategy.
+                    PARALLEL,
+                )
+            return self.tuning_config_cache[key]
+
+        def forward(
+            self,
+            inputs: List[Optional[torch.Tensor]],
+            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
+            """Execute the dense GEMM with SwiGLU fusion.
+
+            Args:
+                inputs: [a, b, a_sf, b_sf, alpha, alpha_post, norm_const]
+                    - alpha_post can be None to skip post-SwiGLU scaling
+                tactic: ((mma_m, mma_n), (cluster_m, cluster_n))
+
+            Returns:
+                Tuple of (output, output_scale_factor)
+            """
+            a, b, a_sf, b_sf, alpha, alpha_post, norm_const = inputs[:7]
+
+            # Get dimensions
+            # a: [m, k//2] (fp4 packed), b: [num_expert, weight_per_expert, k//2]
+            m = a.shape[0]
+            k = a.shape[1] * 2  # fp4 packed in k dimension
+            n = b.shape[0] * b.shape[1]  # num_expert * weight_per_expert
+            l = 1  # dense GEMM
+            n_out = n // 2  # SwiGLU output
+
+            # Default tactic if not provided
+            if isinstance(tactic, tuple):
+                mma_tiler_mn, cluster_shape_mn = tactic
+            else:
+                mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+
+            # Allocate output tensor
+            c_dtype = self.output_dtype
+            if c_dtype == torch.float4_e2m1fn_x2:
+                # FP4 packed: 2 elements per byte, so shape is (m, n_out // 2)
+                c = torch.empty((m, n_out // 2), dtype=c_dtype, device=a.device)
+            else:
+                c = torch.empty((m, n_out), dtype=c_dtype, device=a.device)
+
+            # Allocate output scale factor (for FP4 output quantization)
+            # Shape: (32, 4, pad_up(m, 128) // 128, 4, scale_n_out // 4, l)
+            scale_n_out = n_out // self.scaling_vector_size
+            c_sf_shape = (32, 4, pad_up(m, 128) // 128, 4, scale_n_out // 4, l)
+            c_sf = torch.empty(c_sf_shape, dtype=torch.uint8, device=a.device)
+
+            # Get CUDA stream
+            torch_stream = torch.cuda.current_stream()
+            stream = cuda.CUstream(torch_stream.cuda_stream)
+
+            # Map torch dtype to cutlass dtype
+            c_cutlass_dtype = {
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float16: cutlass.Float16,
+                torch.float32: cutlass.Float32,
+                torch.float4_e2m1fn_x2: cutlass.Float4E2M1FN,
+            }.get(c_dtype, cutlass.BFloat16)
+
+            # Create pointers for kernel
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            c_ptr = make_ptr(c_cutlass_dtype,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=16)
+            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                c_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
+                                 cute.AddressSpace.gmem)
+            alpha_post_ptr = None
+            if alpha_post is not None:
+                alpha_post_ptr = make_ptr(cutlass.Float32,
+                                          alpha_post.data_ptr(),
+                                          cute.AddressSpace.gmem)
+            norm_const_ptr = make_ptr(cutlass.Float32, norm_const.data_ptr(),
+                                      cute.AddressSpace.gmem)
+
+            # Cache key for compiled kernel
+            cache_key = (
+                self.weight_per_expert,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                self.scaling_vector_size,
+                self.expert_count,
+                alpha_post is not None,  # Whether alpha_post is enabled
+            )
+
+            if cache_key not in self.__class__.kernel_cache:
+                # Get max active clusters only when compiling kernel
+                hardware_info = cutlass.utils.HardwareInfo()
+                max_active_clusters = hardware_info.get_max_active_clusters(
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
+
+                kernel = self.kernel_class(
+                    sf_vec_size=self.scaling_vector_size,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    weight_per_expert=self.weight_per_expert,
+                )
+
+                # Compile the kernel and cache it
+                compiled_gemm = cute.compile(
+                    kernel.wrapper,
+                    a_ptr,
+                    b_ptr,
+                    a_sf_ptr,
+                    b_sf_ptr,
+                    c_ptr,
+                    c_sf_ptr,
+                    alpha_ptr,
+                    alpha_post_ptr,
+                    norm_const_ptr,
+                    m,
+                    n,
+                    k,
+                    l,
+                    expert_count=self.expert_count,
+                    scaling_vector_size=self.scaling_vector_size,
+                    max_active_clusters=max_active_clusters,
+                    stream=stream,
+                )
+                self.__class__.kernel_cache[cache_key] = compiled_gemm
+            else:
+                compiled_gemm = self.__class__.kernel_cache[cache_key]
+
+            # Call the compiled kernel
+            compiled_gemm(
+                a_ptr,
+                b_ptr,
+                a_sf_ptr,
+                b_sf_ptr,
+                c_ptr,
+                c_sf_ptr,
+                alpha_ptr,
+                alpha_post_ptr,
+                norm_const_ptr,
+                m,
+                n,
+                k,
+                l,
+                stream=stream,
+            )
+
+            return c, c_sf
+
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_swiglu_blackwell",
+        mutates_args=(),
+        device_types="cuda",
+    )
+    def cute_dsl_nvfp4_dense_gemm_swiglu_blackwell(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        alpha_post: Optional[torch.Tensor],
+        norm_const: torch.Tensor,
+        expert_count: int,
+        weight_per_expert: int,
+        output_dtype: torch.dtype,
+        scaling_vector_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Dense GEMM with SwiGLU fusion for MoE FC1 layer.
+
+        Computes: C = alpha_post * SwiGLU(alpha * (input @ weight.T))
+        When alpha_post is None: C = SwiGLU(alpha * (input @ weight.T))
+
+        Args:
+            input: Input activation tensor (M, K//2) in fp4 packed format
+            weight: Weight tensor [num_expert, weight_per_expert, k//2] in fp4 packed format
+            input_scale: Scale factor for input
+            weight_scale: Scale factor for weight
+            alpha: Per-expert alpha scale (expert_count,)
+            alpha_post: Per-token per-expert alpha scale (M, expert_count) applied after SwiGLU,
+                or None to skip post-SwiGLU scaling
+            norm_const: Normalization constant for SFC generation
+            expert_count: Number of experts
+            weight_per_expert: Number of weight columns per expert
+            output_dtype: Output data type (bfloat16 or float16)
+            scaling_vector_size: Block scaling vector size (default: 16)
+
+        Returns:
+            Tuple of (output, output_scale_factor)
+        """
+        runner = CuteDSLNVFP4DenseGemmSwigluRunner(
+            expert_count=expert_count,
+            weight_per_expert=weight_per_expert,
+            output_dtype=output_dtype,
+            scaling_vector_size=scaling_vector_size,
+        )
+
+        inputs = [
+            input, weight, input_scale, weight_scale, alpha, alpha_post,
+            norm_const
+        ]
+
+        tuner = AutoTuner.get()
+        _, best_tactic = tuner.choose_one(
+            "trtllm::cute_dsl_nvfp4_dense_gemm_swiglu_blackwell",
+            [runner],
+            runner.get_tuning_config(),
+            inputs,
+        )
+
+        output, output_sf = runner(inputs, tactic=best_tactic)
+        return output, output_sf
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_swiglu_blackwell")
+    def _(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        alpha_post: Optional[torch.Tensor],
+        norm_const: torch.Tensor,
+        expert_count: int,
+        weight_per_expert: int,
+        output_dtype: torch.dtype,
+        scaling_vector_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # weight: [num_expert, weight_per_expert, k//2] (fp4 packed)
+        m = input.shape[0]
+        n = weight.shape[0] * weight.shape[1]  # num_expert * weight_per_expert
+        n_out = n // 2  # SwiGLU output
+        l = 1  # dense GEMM
+
+        if output_dtype == torch.float4_e2m1fn_x2:
+            # FP4 packed: 2 elements per byte
+            output = input.new_empty((m, n_out // 2), dtype=output_dtype)
+        else:
+            output = input.new_empty((m, n_out), dtype=output_dtype)
+
+        # Output scale factor shape
+        scale_n_out = n_out // scaling_vector_size
+        c_sf_shape = (32, 4, pad_up(m, 128) // 128, 4, scale_n_out // 4, l)
+        output_sf = input.new_empty(c_sf_shape, dtype=torch.uint8)
+
+        return output, output_sf
+
+    # Import FC2 kernel
+    from ..cute_dsl_kernels.blackwell.moe_as_dense_gemm.fc2 import \
+        Sm100BlockScaledPersistentDenseGemmKernel as DenseGemmFC2Kernel
+
+    class CuteDSLNVFP4DenseGemmFC2Runner(TunableRunner):
+        """Runner for Dense GEMM FC2 layer (MoE second projection).
+
+        This kernel performs: C = (A * SFA) @ (B * SFB) * alpha_scale
+        where alpha_scale has shape (m, expert_count) for per-token-per-expert scaling.
+
+        Input shapes:
+        - A: (M, K) - activation tensor, K = weight_per_expert * expert_count
+        - B: (N, K) - weight tensor
+        - alpha_scale: (M, expert_count) - per-token-per-expert scaling
+
+        Output shape:
+        - C: (M, N)
+        """
+
+        kernel_class = DenseGemmFC2Kernel
+        kernel_cache = dict()
+        tuning_config_cache = dict()
+
+        def __init__(
+            self,
+            expert_count: int,
+            weight_per_expert: int,
+            output_dtype: torch.dtype,
+            scaling_vector_size: int = 16,
+        ):
+            super().__init__()
+            self.expert_count = expert_count
+            self.weight_per_expert = weight_per_expert
+            self.output_dtype = output_dtype
+            self.scaling_vector_size = scaling_vector_size
+
+        def unique_id(self):
+            return (
+                self.expert_count,
+                self.weight_per_expert,
+                self.output_dtype,
+                self.scaling_vector_size,
+            )
+
+        def __hash__(self):
+            return hash(self.unique_id())
+
+        def __eq__(self, other):
+            if not isinstance(other, CuteDSLNVFP4DenseGemmFC2Runner):
+                return False
+            return self.unique_id() == other.unique_id()
+
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+            **kwargs,
+        ) -> List[Tuple[Tuple[int, int], Tuple[int, int]]]:
+            """Return valid (mma_tiler_mn, cluster_shape_mn) combinations."""
+            # Check SM version - only supports SM 100 and SM 103
+            major, minor = torch.cuda.get_device_capability()
+            if not (major == 10 and minor in [0, 3]):
+                return []
+
+            a = inputs[0]
+            b = inputs[1]
+            # a: [m, k//2] (fp4 packed), b: [n, k//2]
+            m = a.shape[0]
+            k = a.shape[1] * 2  # fp4 packed in k dimension
+            n = b.shape[0]
+            l = 1  # dense GEMM
+
+            # Define candidates together
+            mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
+
+            # Map torch dtype to cutlass dtype
+            c_cutlass_dtype = {
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float16: cutlass.Float16,
+                torch.float32: cutlass.Float32,
+            }.get(self.output_dtype, cutlass.BFloat16)
+
+            tactics = []
+            for mma_tiler_mn, cluster_shape_mn in itertools.product(
+                    mma_tiler_mn_candidates, cluster_shape_mn_candidates):
+                if self.kernel_class.can_implement(
+                        cutlass.Float4E2M1FN,  # ab_dtype
+                        cutlass.Float8E4M3FN,  # sf_dtype
+                        self.scaling_vector_size,
+                        c_cutlass_dtype,  # c_dtype
+                        mma_tiler_mn,
+                        cluster_shape_mn,
+                        m,
+                        n,
+                        k,
+                        l,
+                        "k",  # a_major
+                        "k",  # b_major
+                        "n",  # c_major
+                        self.expert_count,
+                        self.weight_per_expert,
+                ):
+                    tactics.append((mma_tiler_mn, cluster_shape_mn))
+
+            return tactics
+
+        def get_tuning_config(self) -> TuningConfig:
+            key = self.unique_id()
+            if key not in self.tuning_config_cache:
+                self.tuning_config_cache[key] = TuningConfig(
+                    dynamic_tensor_specs=(DynamicTensorSpec(
+                        0, 0, get_last_power_of_2_num_tokens_buckets,
+                        last_positive_power_of_2), ),
+                    constraint_specs=(
+                        ConstraintSpec(2, 0, fp4_scale_infer_shape),
+                        ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),
+                    ),
+                    use_cold_l2_cache=True,
+                    tune_max_num_tokens=256,
+                    distributed_tuning_strategy=DistributedTuningStrategy.
+                    PARALLEL,
+                )
+            return self.tuning_config_cache[key]
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+        ) -> torch.Tensor:
+            """Execute the dense GEMM FC2.
+
+            Args:
+                inputs: [a, b, a_sf, b_sf, alpha_scale]
+                tactic: ((mma_m, mma_n), (cluster_m, cluster_n))
+
+            Returns:
+                Output tensor
+            """
+            a, b, a_sf, b_sf, alpha_scale = inputs[:5]
+
+            # Get dimensions
+            # a: [m, k//2] (fp4 packed), b: [n, k//2]
+            m = a.shape[0]
+            k = a.shape[1] * 2  # fp4 packed in k dimension
+            n = b.shape[0]
+            l = 1  # dense GEMM
+
+            # Default tactic if not provided
+            if isinstance(tactic, tuple):
+                mma_tiler_mn, cluster_shape_mn = tactic
+            else:
+                mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+
+            # Allocate output tensor
+            c_dtype = self.output_dtype
+            c = torch.empty((m, n), dtype=c_dtype, device=a.device)
+
+            # Get CUDA stream
+            torch_stream = torch.cuda.current_stream()
+            stream = cuda.CUstream(torch_stream.cuda_stream)
+
+            # Map torch dtype to cutlass dtype
+            c_cutlass_dtype = {
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float16: cutlass.Float16,
+                torch.float32: cutlass.Float32,
+            }.get(c_dtype, cutlass.BFloat16)
+
+            # Create pointers for kernel
+            a_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             a.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            b_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             b.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                a_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                b_sf.data_ptr(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16)
+            alpha_scale_ptr = make_ptr(cutlass.Float32,
+                                       alpha_scale.data_ptr(),
+                                       cute.AddressSpace.gmem,
+                                       assumed_align=4)
+            c_ptr = make_ptr(c_cutlass_dtype,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=16)
+
+            # Cache key for compiled kernel
+            cache_key = (
+                self.expert_count,
+                self.weight_per_expert,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                self.scaling_vector_size,
+            )
+
+            if cache_key not in self.__class__.kernel_cache:
+                # Get max active clusters only when compiling kernel
+                hardware_info = cutlass.utils.HardwareInfo()
+                max_active_clusters = hardware_info.get_max_active_clusters(
+                    cluster_shape_mn[0] * cluster_shape_mn[1])
+
+                kernel = self.kernel_class(
+                    sf_vec_size=self.scaling_vector_size,
+                    mma_tiler_mn=mma_tiler_mn,
+                    cluster_shape_mn=cluster_shape_mn,
+                    expert_count=self.expert_count,
+                    weight_per_expert=self.weight_per_expert,
+                )
+
+                # Compile the kernel and cache it
+                compiled_gemm = cute.compile(
+                    kernel.wrapper,
+                    a_ptr,
+                    b_ptr,
+                    a_sf_ptr,
+                    b_sf_ptr,
+                    alpha_scale_ptr,
+                    c_ptr,
+                    m,
+                    n,
+                    k,
+                    l,
+                    expert_count=self.expert_count,
+                    scaling_vector_size=self.scaling_vector_size,
+                    max_active_clusters=max_active_clusters,
+                    stream=stream,
+                )
+                self.__class__.kernel_cache[cache_key] = compiled_gemm
+            else:
+                compiled_gemm = self.__class__.kernel_cache[cache_key]
+
+            # Call the compiled kernel
+            compiled_gemm(
+                a_ptr,
+                b_ptr,
+                a_sf_ptr,
+                b_sf_ptr,
+                alpha_scale_ptr,
+                c_ptr,
+                m,
+                n,
+                k,
+                l,
+                stream=stream,
+            )
+
+            return c
+
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_fc2_blackwell",
+        mutates_args=(),
+        device_types="cuda",
+    )
+    def cute_dsl_nvfp4_dense_gemm_fc2_blackwell(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha_scale: torch.Tensor,
+        expert_count: int,
+        weight_per_expert: int,
+        output_dtype: torch.dtype,
+        scaling_vector_size: int = 16,
+    ) -> torch.Tensor:
+        """Dense GEMM FC2 for MoE second projection.
+
+        Performs: C = (A * SFA) @ (B * SFB) * alpha_scale
+
+        Args:
+            input: Input activation (M, K//2) in fp4 packed format
+            weight: Weight tensor (N, K//2) in fp4 packed format
+            input_scale: Scale factor for input (swizzled)
+            weight_scale: Scale factor for weight (swizzled)
+            alpha_scale: Per-token-per-expert scale (M, expert_count)
+            expert_count: Number of experts
+            weight_per_expert: Number of weights per expert
+            output_dtype: Output data type (bfloat16 or float16)
+            scaling_vector_size: Block scaling vector size (default: 16)
+
+        Returns:
+            Output tensor (M, N)
+        """
+        # FC2 DenseGEMM kernel tiles K with MMA tile size 256.
+        # weight_per_expert must be 256-aligned so expert boundaries
+        # align with MMA tile boundaries for correct alpha_scale splitting.
+        _MMA_TILE_K = 256
+        assert weight_per_expert % _MMA_TILE_K == 0, (
+            f"cute_dsl_nvfp4_dense_gemm_fc2_blackwell requires weight_per_expert "
+            f"to be a multiple of {_MMA_TILE_K} (got {weight_per_expert})")
+
+        runner = CuteDSLNVFP4DenseGemmFC2Runner(
+            expert_count=expert_count,
+            weight_per_expert=weight_per_expert,
+            output_dtype=output_dtype,
+            scaling_vector_size=scaling_vector_size,
+        )
+
+        inputs = [input, weight, input_scale, weight_scale, alpha_scale]
+
+        tuner = AutoTuner.get()
+        _, best_tactic = tuner.choose_one(
+            "trtllm::cute_dsl_nvfp4_dense_gemm_fc2_blackwell",
+            [runner],
+            runner.get_tuning_config(),
+            inputs,
+        )
+
+        output = runner(inputs, tactic=best_tactic)
+        return output
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_fc2_blackwell")
+    def _(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha_scale: torch.Tensor,
+        expert_count: int,
+        weight_per_expert: int,
+        output_dtype: torch.dtype,
+        scaling_vector_size: int = 16,
+    ) -> torch.Tensor:
+        # input: [m, k//2] (fp4 packed), weight: [n, k//2]
+        m = input.shape[0]
+        n = weight.shape[0]
+
+        output = input.new_empty((m, n), dtype=output_dtype)
+        return output
 
     def _get_num_sms() -> int:
         """Return the number of SMs on the current device (cached)."""

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3048,6 +3048,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.scaling_vector_size,
                 self.expert_count,
                 alpha_post is not None,  # Whether alpha_post is enabled
+                self.
+                output_dtype,  # Include output dtype to avoid cache collision
             )
 
             if cache_key not in self.__class__.kernel_cache:
@@ -3407,6 +3409,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 mma_tiler_mn,
                 cluster_shape_mn,
                 self.scaling_vector_size,
+                self.
+                output_dtype,  # Include output dtype to avoid cache collision
             )
 
             if cache_key not in self.__class__.kernel_cache:

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2846,6 +2846,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_class = DenseGemmSwigluKernel
         kernel_cache = dict()
         tuning_config_cache = dict()
+        _CUTLASS_DTYPE_MAP = {
+            torch.bfloat16: cutlass.BFloat16,
+            torch.float16: cutlass.Float16,
+            torch.float32: cutlass.Float32,
+            torch.float4_e2m1fn_x2: cutlass.Float4E2M1FN,
+        }
 
         def __init__(
             self,
@@ -2901,12 +2907,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
 
             # Map torch dtype to cutlass dtype
-            c_cutlass_dtype = {
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float16: cutlass.Float16,
-                torch.float32: cutlass.Float32,
-                torch.float4_e2m1fn_x2: cutlass.Float4E2M1FN,
-            }.get(self.output_dtype, cutlass.BFloat16)
+            if self.output_dtype not in self._CUTLASS_DTYPE_MAP:
+                raise ValueError(
+                    f"Unsupported output_dtype {self.output_dtype} for FC1 DenseGEMM runner"
+                )
+            c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[self.output_dtype]
 
             tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
@@ -2998,12 +3003,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             stream = cuda.CUstream(torch_stream.cuda_stream)
 
             # Map torch dtype to cutlass dtype
-            c_cutlass_dtype = {
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float16: cutlass.Float16,
-                torch.float32: cutlass.Float32,
-                torch.float4_e2m1fn_x2: cutlass.Float4E2M1FN,
-            }.get(c_dtype, cutlass.BFloat16)
+            if c_dtype not in self._CUTLASS_DTYPE_MAP:
+                raise ValueError(
+                    f"Unsupported output_dtype {c_dtype} for FC1 DenseGEMM runner"
+                )
+            c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[c_dtype]
 
             # Create pointers for kernel
             a_ptr = make_ptr(cutlass.Float4E2M1FN,
@@ -3229,6 +3233,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_class = DenseGemmFC2Kernel
         kernel_cache = dict()
         tuning_config_cache = dict()
+        _CUTLASS_DTYPE_MAP = {
+            torch.bfloat16: cutlass.BFloat16,
+            torch.float16: cutlass.Float16,
+            torch.float32: cutlass.Float32,
+        }
 
         def __init__(
             self,
@@ -3284,11 +3293,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
 
             # Map torch dtype to cutlass dtype
-            c_cutlass_dtype = {
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float16: cutlass.Float16,
-                torch.float32: cutlass.Float32,
-            }.get(self.output_dtype, cutlass.BFloat16)
+            if self.output_dtype not in self._CUTLASS_DTYPE_MAP:
+                raise ValueError(
+                    f"Unsupported output_dtype {self.output_dtype} for FC2 DenseGEMM runner"
+                )
+            c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[self.output_dtype]
 
             tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
@@ -3370,11 +3379,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             stream = cuda.CUstream(torch_stream.cuda_stream)
 
             # Map torch dtype to cutlass dtype
-            c_cutlass_dtype = {
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float16: cutlass.Float16,
-                torch.float32: cutlass.Float32,
-            }.get(c_dtype, cutlass.BFloat16)
+            if c_dtype not in self._CUTLASS_DTYPE_MAP:
+                raise ValueError(
+                    f"Unsupported output_dtype {c_dtype} for FC2 DenseGEMM runner"
+                )
+            c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[c_dtype]
 
             # Create pointers for kernel
             a_ptr = make_ptr(cutlass.Float4E2M1FN,

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -16,7 +16,8 @@ from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
                          DynamicTensorSpec, OptimizationProfile, TunableRunner,
                          TuningConfig)
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
-from ..utils import (fp4_scale_infer_shape, fp8_scale_infer_shape,
+from ..utils import (deep_gemm_gen_tuning_buckets, fp4_scale_infer_shape,
+                     fp8_scale_infer_shape,
                      get_last_power_of_2_num_tokens_buckets,
                      last_positive_power_of_2, next_positive_power_of_2)
 
@@ -2942,12 +2943,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if key not in self.tuning_config_cache:
                 self.tuning_config_cache[key] = TuningConfig(
                     dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, get_last_power_of_2_num_tokens_buckets,
-                        last_positive_power_of_2), ),
+                        0, 0, deep_gemm_gen_tuning_buckets), ),
                     constraint_specs=(ConstraintSpec(2, 0,
                                                      fp4_scale_infer_shape), ),
                     use_cold_l2_cache=True,
-                    tune_max_num_tokens=256,
+                    tune_max_num_tokens=512,
                     distributed_tuning_strategy=DistributedTuningStrategy.
                     PARALLEL,
                 )

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2897,8 +2897,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l = 1  # dense GEMM
 
             # Define candidates together
-            mma_tiler_mn_candidates = [(128, 128), (128, 256)]
-            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
+            mma_tiler_mn_candidates = [(128, 128), (128, 256), (256, 256)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
 
             # Map torch dtype to cutlass dtype
             c_cutlass_dtype = {

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -20,7 +20,8 @@ from ..cublaslt_utils import IS_CUBLASLT_AVAILABLE
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..modules.multi_stream_utils import do_multi_stream
 from ..modules.swiglu import silu_and_mul_kernel
-from ..utils import (ActivationType, fp4_scale_infer_shape,
+from ..utils import (ActivationType, deep_gemm_gen_tuning_buckets,
+                     fp4_scale_infer_shape,
                      get_last_power_of_2_num_tokens_buckets,
                      last_positive_power_of_2)
 
@@ -1449,14 +1450,7 @@ def _(
     return input.new_empty((M, N), dtype=output_dtype)
 
 
-def deep_gemm_gen_tuning_buckets(x: int):
-    buckets = tuple(range(8, 128, 8))
-    # Clamp x to be between 4096 and 8192.
-    if x >= 128:
-        x = min(x, 8192)
-        x = max(x, 4096)
-        buckets += tuple(range(128, x, 128))
-    return buckets
+# deep_gemm_gen_tuning_buckets is imported from ..utils
 
 
 def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
@@ -1,0 +1,2652 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from typing import Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass._mlir.dialects import math
+from cutlass.cute.nvgpu import cpasync, tcgen05
+
+from tensorrt_llm._torch.cute_dsl_kernels.blackwell.utils import fmin, silu_f32
+
+"""
+This example provides an experimental implementation of the SM100 batched dense blockscaled
+GEMM kernel, please note that the APIs and implementation details related to this kernel
+may change in future releases.
+
+A high-performance persistent batched dense blockscaled GEMM example for the NVIDIA Blackwell
+SM100 architecture using CUTE DSL.
+- Matrix A is MxKxL, L is batch dimension, A can be row-major("K") or column-major("M")
+  for MXF8 input type and can only be row-major("K") for MXF4/NVF4 input type
+- Matrix B is NxKxL, L is batch dimension, B can be row-major("N") or column-major("K")
+  for MXF8 input type and can only be row-major("K") for MXF4/NVF4 input type
+- Matrix C is MxNxL, L is batch dimension, C can be row-major("N") or column-major("M")
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk,
+  which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk,
+  which has N×ceil_div(K, sf_vec_size)×L elements respectively
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes Blackwell's tcgen05.mma for matrix multiply-accumulate (MMA) operations (including 2cta mma instructions)
+    - Implements TMA multicast with cluster to reduce L2 memory traffic
+    - Support persistent tile scheduling to better overlap memory load/store with mma between tiles
+    - Support warp specialization to avoid explicit pipelining between mainloop load and mma
+
+This GEMM works as follows:
+1. DMA warp: Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. MMA warp:
+    - Load scale factor A/B from shared memory (SMEM) to tensor memory (TMEM) using tcgen05.cp instruction.
+    - Perform matrix multiply-accumulate (MMA) operations using tcgen05.mma instruction.
+3. EPILOGUE warp:
+    - Load completed accumulator from tensor memory (TMEM) to registers (RMEM) using tcgen05.ld.
+    - Type convert C matrix to output type.
+    - Optionally store C matrix from registers (RMEM) to shared memory (SMEM) to global
+      memory (GMEM) with TMA operations, or directly store C matrix from registers (RMEM)
+      to global memory (GMEM) without TMA operations.
+    - Optionally accept an elementwise lambda function epilogue_op to apply to the output tensor:
+      e.g., relu can set epilogue_op = lambda x: cute.where(x > 0, x, cute.full_like(x, 0))
+
+SM100 tcgen05.mma.kind.block_scale instructions operate as follows:
+- Read matrix A from SMEM
+- Read matrix B from SMEM
+- Read scalefactor A from TMEM
+- Read scalefactor B from TMEM
+- Write accumulator to TMEM
+The accumulator in TMEM must then be loaded to registers before writing back to GMEM.
+
+Input arguments to this example is shown below:
+
+.. code-block:: bash
+
+    python examples/blackwell/dense_blockscaled_gemm_persistent.py            \
+      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
+      --c_dtype Float16                                                        \
+      --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
+      --mnkl 8192,8192,1024,1
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python examples/blackwell/dense_blockscaled_gemm_persistent.py        \
+      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
+      --c_dtype Float16                                                        \
+      --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
+      --mnkl 8192,8192,1024,1                                                  \
+      --warmup_iterations 1 --iterations 10 --skip_ref_check
+
+
+Constraints:
+* Supported input data types: mxf8, mxf4, nvf4
+  see detailed valid dtype combinations in below Sm100BlockScaledPersistentDenseGemmKernel class documentation
+* A/B tensor must have the same data type, mixed data type is not supported (e.g., mxf8 x mxf4)
+* Mma tiler M must be 128 or 256(use_2cta_instrs)
+* Mma tiler N must be 128 or 256
+* Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+* Cluster shape M must be multiple of 2 if Mma tiler M is 256(use_2cta_instrs)
+* The contiguous dimension of A/B/C tensors must be at least 16 bytes aligned,
+  i.e, number of elements is a multiple of 16 and 32 for Float8 and Float4, respectively.
+"""
+
+
+class Sm100BlockScaledPersistentDenseGemmKernel:
+    """This class implements batched matrix multiplication (C = A x SFA x B x SFB) with support for various data types
+    and architectural features specific to Blackwell GPUs with persistent tile scheduling and warp specialization.
+
+    :param sf_vec_size: Scalefactor vector size.
+    :type sf_vec_size: int
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float8E4M3FN for A and Float8E5M2 for B is not supported
+
+    :note: Supported combinations of A/B data types, SF data typs and SF vector size:
+        - MXF8: A/B: Float8E5M2/Float8E4M3FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - MXF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - NVF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU/Float8E4M3FN + sf_vec_size: 16
+
+    :note: Supported accumulator data types:
+        - Float32
+
+    :note: Supported C data types:
+        - Float32
+        - Float16/BFloat16
+        - Float8E4M3FN/Float8E5M2
+        # {$nv-internal-release begin}
+        # Note: We don't have SFD generation support in this example for now,
+        # so Float4E2M1FN output is only for internal testing and will not be released.
+        - Float4E2M1FN
+        # {$nv-internal-release end}
+
+    :note: Constraints:
+        - MMA tiler M must be 128 or 256 (use_2cta_instrs)
+        # TODO: Add 64 and 192 support # {$nv-internal-release}
+        - MMA tiler N must be 128/256
+        - Cluster shape M must be multiple of 2 if Mma tiler M is 256
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+        - Also, Cluster shape M/N must be <= 4 for scale factor multicasts due to limited size of scale factors
+
+    Example:
+        >>> gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        ...     sf_vec_size=16, mma_tiler_mn=(256, 128), cluster_shape_mn=(2, 1)
+        ... )
+        >>> gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        weight_per_expert: int,
+        use_prefetch: bool = False,
+        prefetch_dist: int = 3,
+        vectorized_f32: bool = True,
+    ):
+        """Initializes the configuration for a Blackwell dense GEMM kernel with SwiGLU fusion.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator, always set to Float32
+            - sf_vec_size: Scalefactor A/B vector size.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        3.  SwiGLU Fusion:
+            - The kernel computes C = up * silu(gate) where up and gate come from
+              interleaved weight matrix B (granularity=64)
+            - Output N dimension is N/2 due to SwiGLU fusion
+
+        :param sf_vec_size: Scalefactor vector size.
+        :type sf_vec_size: int
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param weight_per_expert: Number of weights per expert (computed as N // num_experts).
+        :type weight_per_expert: int
+        :param use_prefetch: Enable prefetch operations (default: False).
+        :type use_prefetch: bool
+        :param prefetch_dist: Prefetch distance for TMA operations (default: 3).
+        :type prefetch_dist: int
+        :param vectorized_f32: Enable vectorized f32x2 operations for better performance (default: True).
+        :type vectorized_f32: bool
+        """
+
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+
+        self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilog_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_cta = 32 * len((self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id))
+        # Set barrier id for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.epilog_warp_id)),
+        )
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        self.weight_per_expert = weight_per_expert
+
+        self.use_prefetch = use_prefetch
+        self.prefetch_dist = prefetch_dist
+        self.vectorized_f32 = vectorized_f32
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        """
+        # Compute mma instruction shapes
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        # TODO: round up to 128, it is prepared for supporting N=64 or 192. # {$nv-internal-release}
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+
+        # Output tile shape for C (N dimension is halved due to SwiGLU fusion)
+        self.mma_tiler_c = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1] // 2,
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk_c = (
+            self.mma_tiler_c[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_c[1],
+            self.mma_tiler_c[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Compute epilogue subtile
+        # self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+        #     self.cta_tile_shape_mnk,
+        #     self.use_2cta_instrs,
+        #     self.c_layout,
+        #     self.c_dtype,
+        # )
+        self.epi_tile = (128, 64)
+        # Compute epilogue tile count for SFC quantization (use output tile shape)
+        self.epi_tile_cnt = (
+            self.cta_tile_shape_mnk_c[0] // self.epi_tile[0],
+            self.cta_tile_shape_mnk_c[1] // self.epi_tile[1],
+        )
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        # Overlap and double buffer accumulator when num_acc_stage == 1 for cta_tile_n = 256 case
+        self.overlapping_accum = self.num_acc_stage == 1
+
+        # Compute number of TMEM columns for SFA/SFB/Accumulator
+        sf_atom_mn = 32
+        mma_inst_tile_k = 4
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk[1] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = (
+            self.cta_tile_shape_mnk[1] * self.num_acc_stage
+            if not self.overlapping_accum
+            else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        )
+
+        self.epi_tile_n_required = 2 * cute.size(self.epi_tile[1])
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = self.num_sf_tmem_cols // self.epi_tile_n_required
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        alpha_scale: cute.Tensor,
+        alpha_scale_post: Optional[cute.Tensor],
+        c_tensor: cute.Tensor,
+        sfc_tensor: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM operation with SwiGLU fusion and optional quantization.
+
+        This method performs FC1 layer computation:
+        1. GEMM: acc = alpha * (SFA * A) * (SFB * B)
+        2. SwiGLU: out = up * silu(gate), where up/gate are extracted from interleaved acc (granularity=64)
+        3. Post-SwiGLU scaling (optional): C = out * alpha_post (per-token per-expert)
+        4. Optional Quant: When sfc_tensor is provided, generates SFC and quantizes output
+
+        Steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a_tensor: Input tensor A
+        :type a_tensor: cute.Tensor
+        :param b_tensor: Input tensor B (weights are interleaved: [up_0:64, gate_64:128, ...])
+        :type b_tensor: cute.Tensor
+        :param sfa_tensor: Scale factor tensor A
+        :type sfa_tensor: cute.Tensor
+        :param sfb_tensor: Scale factor tensor B
+        :type sfb_tensor: cute.Tensor
+        :param alpha_scale: Pre-SwiGLU alpha scaling tensor for each expert (expert_count, l)
+        :type alpha_scale: cute.Tensor
+        :param alpha_scale_post: Post-SwiGLU alpha scaling tensor per-token per-expert (m, expert_count, l),
+            or None to skip post-SwiGLU scaling
+        :type alpha_scale_post: Optional[cute.Tensor]
+        :param c_tensor: Output tensor C (N dimension is N/2 due to SwiGLU)
+        :type c_tensor: cute.Tensor
+        :param sfc_tensor: Scale factor tensor C for quantized output (None if not quantizing)
+        :type sfc_tensor: Optional[cute.Tensor]
+        :param norm_const_tensor: Normalization constant for scale factor generation (None if not quantizing)
+        :type norm_const_tensor: Optional[cute.Tensor]
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
+        :type epilogue_op: cutlass.Constexpr
+        :raises TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a_tensor.shape, self.sf_vec_size)
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b_tensor.shape, self.sf_vec_size)
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        # Determine if we need to apply post-SwiGLU alpha scaling
+        self.apply_alpha_post = alpha_scale_post is not None
+
+        # Determine if we need to generate scale factor C for quantization
+        self.generate_sfc = sfc_tensor is not None and norm_const_tensor is not None
+        if cutlass.const_expr(self.generate_sfc):
+            sfc_layout = blockscaled_utils.tile_atom_to_shape_SF(c_tensor.shape, self.sf_vec_size)
+            sfc_tensor = cute.make_tensor(sfc_tensor.iterator, sfc_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs. # {$nv-internal-release}
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_tensor,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_tensor,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+        # Setup TMA store for C
+        epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            c_tensor,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # Compute grid size (use output tile shape for C due to SwiGLU fusion)
+        self.tile_sched_params, grid = self._compute_grid(
+            c_tensor,
+            self.cta_tile_shape_mnk_c,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.c_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Extract M dimension for epilogue boundary check (prevents OOB access
+        # on alpha_scale_post when M < epi_tile_m)
+        m_total = cute.size(a_tensor.shape, mode=[0])
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            sfc_tensor,
+            norm_const_tensor,
+            alpha_scale,
+            alpha_scale_post,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+            m_total,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        mSFC_mnl: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        alpha_scale: cute.Tensor,
+        alpha_scale_post: Optional[cute.Tensor],
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        m_total: cutlass.Int32,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilog_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bK, RestM, RestK, RestL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, RestM, RestN, RestL) - use mma_tiler_c for output due to SwiGLU fusion
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler_c, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+
+        # Alpha scale post-SwiGLU global tensor tiling (optional)
+        # alpha_scale_post shape: (M, expert_count, L)
+        # (bM, RestM, expert_count, RestL)
+        galpha_scale_post_mel = None
+        if cutlass.const_expr(self.apply_alpha_post):
+            galpha_scale_post_mel = cute.local_tile(
+                alpha_scale_post,
+                cute.slice_(self.cta_tile_shape_mnk, (None, 0, 0)),
+                (None, None, None),
+            )
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgSFA = thr_mma.partition_A(gSFA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        # TMA load SFA partition_S/D
+        sfa_cta_layout = a_cta_layout
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA load SFB partition_S/D
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, num_acc_stage_overlapped)
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+
+                # ((atom_v, rest_v), RestK)
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+                slice_n = mma_tile_coord_mnl[1]
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_mnl[1] // 2
+                # ((atom_v, rest_v), RestK)
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, mma_tile_coord_mnl[2])]
+
+                prefetch_dist = self.prefetch_dist
+                # Sending a batch of inflight Prefetches before starting TMALDG loop
+                # Prefetch logic: use_prefetch for both A&B, or explicit A-only/B-only
+                if self.use_prefetch:
+                    # Prefetch both A and B (default behavior)
+                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt), unroll=1):
+                        # Prefetch both A and B (default behavior)
+                        cute.prefetch(
+                            tma_atom_a,
+                            tAgA_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_b,
+                            tBgB_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfa,
+                            tAgSFA_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfb,
+                            tBgSFB_slice[(None, k_tile)],
+                        )
+
+                # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+
+                    # TMA load A/B/SFA/SFB
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAsSFA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBsSFB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                    # Prefetch logic in the loop: use_prefetch for both A&B, or explicit A-only/B-only
+                    if k_tile < k_tile_cnt - prefetch_dist:
+                        if self.use_prefetch:
+                            # Prefetch both A and B (default behavior)
+                            cute.prefetch(
+                                tma_atom_a,
+                                tAgA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_b,
+                                tBgB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfa,
+                                tAgSFA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfb,
+                                tBgSFB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+
+                    # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # Make accumulator tmem tensor
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base),
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr
+                + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                #
+                # Wait for accumulator buffer empty
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                        + tcgen05.find_tmem_tensor_col_offset(tCtSFA)
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                #
+                # Mma mainloop
+                #
+                for k_tile in range(k_tile_cnt):
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (
+                                None,
+                                None,
+                                kblock_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kblock_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kblock_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblock_coord],
+                                tCrB[kblock_coord],
+                                tCtAcc,
+                            )
+
+                            # Enable accumulate on tCtAcc after first kblock
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_tile_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                #
+                # Async arrive accumulator buffer full
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc_up,
+                tTR_rAcc_gate,
+                tTR_gAlphaPost,
+                tTR_gC,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx, tCtAcc_base, tCgC, galpha_scale_post_mel, epi_tile, use_2cta_instrs
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc_up.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r, tTR_rC, epi_tidx, sC
+            )
+            (
+                tma_atom_c,
+                bSG_sC,
+                bSG_gC_partitioned,
+            ) = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_c, tCgC, epi_tile, sC)
+
+            # Setup SFC tensor partition for quantization (if needed)
+            if cutlass.const_expr(self.generate_sfc):
+                norm_const = norm_const_tensor[0]
+                # (EPI_TILE_M, EPI_TILE_N, RestM, RestN, RestL)
+                gSFC_mnl = cute.local_tile(mSFC_mnl, epi_tile, (None, None, None))
+                thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+                # (T2R, T2R_M, T2R_N, RestM, RestN, RestL)
+                tCgSFC_mnl = thr_copy_t2r.partition_D(gSFC_mnl)
+                tCgSFC_mnl = cute.filter_zeros(tCgSFC_mnl)
+                # (T2R, T2R_M, T2R_N)
+                tCrSFC = cute.make_rmem_tensor(
+                    tCgSFC_mnl[(None, None, None, 0, 0, 0)].layout, self.sf_dtype
+                )
+                tCrSFC_pvscale = cute.make_rmem_tensor_like(tCrSFC, cutlass.Float32)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            # Threads/warps participating in tma store pipeline
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage,
+                producer_group=c_producer_group,
+            )
+
+            ### core code to get alpha_scale (pre-SwiGLU)
+            unroll_scale_idx = work_tile.tile_idx[1] // (
+                self.weight_per_expert // self.cta_tile_shape_mnk[1]
+            )
+            current_alpha_scale = alpha_scale[unroll_scale_idx, work_tile.tile_idx[2]]
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                bSG_gC = bSG_gC_partitioned[
+                    (
+                        None,
+                        None,
+                        None,
+                        *mma_tile_coord_mnl,
+                    )
+                ]
+
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = (
+                        cutlass.Boolean(True) if acc_stage_index == 0 else cutlass.Boolean(False)
+                    )
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_stage_index)]
+
+                if cutlass.const_expr(self.generate_sfc):
+                    # (T2R, T2R_M, T2R_N, RestM, RestN)
+                    tCgSFC_mn = tCgSFC_mnl[
+                        (
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            0,
+                        )
+                    ]
+
+                #
+                # Wait for accumulator buffer full
+                #
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                # Calculate expert index and batch index for alpha scaling
+                # tiles_per_expert: number of MMA tiles (in pre-SwiGLU N dimension) per expert
+                # weight_per_expert is in pre-SwiGLU space, cta_tile_shape_mnk[1] is MMA tile N
+                tiles_per_expert = self.weight_per_expert // self.cta_tile_shape_mnk[1]
+                expert_idx = cur_tile_coord[1] // tiles_per_expert
+                batch_idx = cur_tile_coord[2]
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                #
+                # Process accumulator subtiles with SwiGLU fusion and store to global memory
+                # Each iteration processes a pair of subtiles (up, gate) and computes
+                # up * silu(gate)
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 2):
+                    real_subtile_idx = subtile_idx // 2
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = (
+                                self.cta_tile_shape_mnk[1] // self.epi_tile_n_required
+                                - 1
+                                - subtile_idx // 2
+                            )
+                    #
+                    # Load accumulator from tensor memory buffer to register
+                    # Load both up and gate subtiles
+                    #
+                    tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, real_subtile_idx * 2)]
+                    tTR_tAcc_mn_gate = tTR_tAcc[(None, None, None, real_subtile_idx * 2 + 1)]
+
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+
+                    #
+                    # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
+                    #
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx // 2 == self.iter_acc_early_release_in_epilogue:
+                            # Fence for TMEM load
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+
+                    acc_vec_up = tTR_rAcc_up.load()
+                    acc_vec_gate = tTR_rAcc_gate.load()
+
+                    #
+                    # SwiGLU activation: output = up * silu(gate)
+                    # where silu(x) = x * sigmoid(x)
+                    # up and gate are extracted from interleaved accumulator subtiles
+                    #
+                    tCompute = cute.make_rmem_tensor(acc_vec_gate.shape, self.acc_dtype)
+                    if cutlass.const_expr(self.vectorized_f32):
+                        # SwiGLU Packed Version: uses f32x2 packed operations for better performance
+                        # Computes: output = (alpha * up) * silu(alpha * gate)
+                        # where silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+                        LOG2_E = cutlass.Float32(1.4426950408889634)
+                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
+                            acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                                (acc_vec_up[i], acc_vec_up[i + 1]),
+                                (
+                                    cutlass.Float32(current_alpha_scale),
+                                    cutlass.Float32(current_alpha_scale),
+                                ),
+                            )
+                            acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                                (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                (
+                                    cutlass.Float32(current_alpha_scale),
+                                    cutlass.Float32(current_alpha_scale),
+                                ),
+                            )
+                            tCompute_log2e = cute.arch.mul_packed_f32x2(
+                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]), (-LOG2_E, -LOG2_E)
+                            )
+                            (
+                                tCompute[i],
+                                tCompute[i + 1],
+                            ) = cute.arch.add_packed_f32x2(
+                                (
+                                    cute.math.exp2(tCompute_log2e[0], fastmath=True),
+                                    cute.math.exp2(tCompute_log2e[1], fastmath=True),
+                                ),
+                                (1.0, 1.0),
+                            )
+                            tCompute[i] = cute.arch.rcp_approx(tCompute[i])
+                            tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
+                            (
+                                tCompute[i],
+                                tCompute[i + 1],
+                            ) = cute.arch.mul_packed_f32x2(
+                                (tCompute[i], tCompute[i + 1]),
+                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                            )
+                            (
+                                tCompute[i],
+                                tCompute[i + 1],
+                            ) = cute.arch.mul_packed_f32x2(
+                                (tCompute[i], tCompute[i + 1]),
+                                (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
+                            )
+                    else:
+                        # SwiGLU Unpacked Version: scalar operations
+                        # Computes: output = (alpha * up) * silu(alpha * gate)
+                        for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
+                            acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(current_alpha_scale)
+                            acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(
+                                current_alpha_scale
+                            )
+                            tCompute[i] = acc_vec_up_alpha * silu_f32(
+                                acc_vec_gate_alpha, fastmath=True
+                            )
+
+                    # Apply post-SwiGLU alpha scaling - per-token version (optional)
+                    if cutlass.const_expr(self.apply_alpha_post):
+                        # galpha_scale_post_mel has shape: (bM, RestM, expert_count, RestL)
+                        # - bM: within-tile M coordinate (0 to cta_tile_shape_mnk[0]-1)
+                        # - RestM: tile index in M dimension (cur_tile_coord[0])
+                        # Each epilogue thread (epi_tidx) handles exactly ONE M coordinate
+                        # Thread layout: 128 threads map to 128 M coordinates in the epilogue tile
+                        # Guard with M boundary check to prevent OOB global memory access
+                        # when M < epi_tile_m (e.g., M=64 with epi_tile_m=128).
+                        m_start = mma_tile_coord_mnl[0] * self.epi_tile[0]
+                        if epi_tidx < (m_total - m_start):
+                            current_alpha_scale_post = tTR_gAlphaPost[
+                                epi_tidx, cur_tile_coord[0], expert_idx, batch_idx
+                            ]
+                            for i in cutlass.range_constexpr(cute.size(tCompute)):
+                                tCompute[i] = tCompute[i] * cutlass.Float32(
+                                    current_alpha_scale_post
+                                )
+
+                    if cutlass.const_expr(self.generate_sfc):
+                        #
+                        # Quantization path for Float4E2M1FN output:
+                        # 1. Compute per-vector absolute max from SwiGLU result
+                        # 2. Generate scale factor C (SFC) based on max values
+                        # 3. Store SFC to global memory
+                        # 4. Quantize output by scaling with reciprocal of SFC
+                        #
+                        # Assume subtile partitioned always happens on n dimension
+                        sfc_subtile_idx_mn = (
+                            cur_tile_coord[0] * self.epi_tile_cnt[0],
+                            cur_tile_coord[1] * self.epi_tile_cnt[1] + real_subtile_idx,
+                        )
+                        tCgSFC = tCgSFC_mn[
+                            (
+                                None,
+                                None,
+                                None,
+                                *sfc_subtile_idx_mn,
+                            )
+                        ]
+
+                        #
+                        # Get absolute max across a vector and Compute SFC
+                        #
+                        tTR_rAcc_frg = cute.logical_divide(
+                            tCompute, cute.make_layout(self.sf_vec_size)
+                        )
+                        acc_frg = tTR_rAcc_frg.load()
+                        acc_frg = epilogue_op(acc_frg)
+
+                        # Apply element-wise absolute value using math.absf (supports vectors)
+                        abs_acc_frg_ir = math.absf(acc_frg.ir_value())
+                        abs_acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
+
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+                                tCrSFC_pvscale[vi] = abs_acc_frg[None, vi].reduce(
+                                    cute.ReductionOp.MAX,
+                                    cutlass.Float32(0.0),
+                                    0,  # Use 0.0 as init for abs values
+                                )
+                            for vi in cutlass.range_constexpr(0, abs_acc_frg.shape[1], 2):
+                                tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1] = (
+                                    cute.arch.mul_packed_f32x2(
+                                        (tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1]),
+                                        (
+                                            self.get_dtype_rcp_limits(self.c_dtype),
+                                            self.get_dtype_rcp_limits(self.c_dtype),
+                                        ),
+                                    )
+                                )
+                                tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1] = (
+                                    cute.arch.mul_packed_f32x2(
+                                        (tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1]),
+                                        (norm_const, norm_const),
+                                    )
+                                )
+                        else:
+                            for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+                                tCrSFC_pvscale[vi] = (
+                                    abs_acc_frg[None, vi].reduce(
+                                        cute.ReductionOp.MAX,
+                                        cutlass.Float32(0.0),
+                                        0,  # Use 0.0 as init for abs values
+                                    )
+                                    * self.get_dtype_rcp_limits(self.c_dtype)
+                                    * norm_const
+                                )
+
+                        # Store SFC to register
+                        tCrSFC.store(tCrSFC_pvscale.load().to(self.sf_dtype))
+
+                        #
+                        # Store SFC to global memory
+                        #
+                        cute.autovec_copy(tCrSFC, tCgSFC)
+
+                        #
+                        # Compute quantized output values and convert to C type
+                        #
+                        tCrSFC_qpvscale_up = tCrSFC.load().to(cutlass.Float32)
+                        fp32_max = cutlass.Float32(3.40282346638528859812e38)
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for vi in cutlass.range_constexpr(0, cute.size(tCrSFC), 2):
+                                acc_scale = cute.arch.mul_packed_f32x2(
+                                    (
+                                        cute.arch.rcp_approx(tCrSFC_qpvscale_up[vi]),
+                                        cute.arch.rcp_approx(tCrSFC_qpvscale_up[vi + 1]),
+                                    ),
+                                    (norm_const, norm_const),
+                                )
+                                acc_scale_min0 = fmin(acc_scale[0], fp32_max, nan=True)
+                                acc_scale_min1 = fmin(acc_scale[1], fp32_max, nan=True)
+
+                                vec0 = tTR_rAcc_frg[None, vi]
+                                vec1 = tTR_rAcc_frg[None, vi + 1]
+                                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                                    vec0[ei], vec1[ei] = cute.arch.mul_packed_f32x2(
+                                        (vec0[ei], vec1[ei]),
+                                        (acc_scale_min0, acc_scale_min1),
+                                    )
+                        else:
+                            for vi in cutlass.range_constexpr(cute.size(tCrSFC)):
+                                acc_scale = norm_const * cute.arch.rcp_approx(
+                                    tCrSFC_qpvscale_up[vi]
+                                )
+                                acc_scale = fmin(acc_scale, fp32_max, nan=True)
+
+                                vec = tTR_rAcc_frg[None, vi]
+                                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                                    vec[ei] = vec[ei] * acc_scale
+
+                        acc_vec = tiled_copy_r2s.retile(tCompute).load()
+                        tRS_rC.store(acc_vec.to(self.c_dtype))
+                    else:
+                        #
+                        # Convert to C type (non-quantization path)
+                        #
+                        acc_vec = tiled_copy_r2s.retile(tCompute).load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                    #
+                    # Store C to shared memory
+                    #
+                    num_prev_subtiles = num_prev_subtiles + 1
+                    c_buffer = num_prev_subtiles % self.num_c_stage
+
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rC,
+                        tRS_sC[(None, None, None, c_buffer)],
+                    )
+                    # Fence and barrier to make sure shared memory store is visible to TMA store
+                    cute.arch.fence_proxy(
+                        cute.arch.ProxyKind.async_shared,
+                        space=cute.arch.SharedSpace.shared_cta,
+                    )
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    #
+                    # TMA store C to global memory
+                    #
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, real_subtile_idx)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                if cutlass.const_expr(not self.overlapping_accum):
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+
+                prev_work_tile_tile_idx_n = work_tile.tile_idx[1]
+                work_tile = tile_sched.get_current_work()
+
+                # if previous tile and current tile has same tile_idx_n,
+                # then we don't need to update alpha_scale,
+                # otherwise we need to update alpha_scale with ldg
+                if work_tile.is_valid_tile and prev_work_tile_tile_idx_n != work_tile.tile_idx[1]:
+                    unroll_scale_idx = work_tile.tile_idx[1] // (
+                        self.weight_per_expert // self.cta_tile_shape_mnk[1]
+                    )
+                    current_alpha_scale = alpha_scale[unroll_scale_idx, work_tile.tile_idx[2]]
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(acc_tmem_ptr)
+            #
+            # Wait for C store complete
+            #
+            c_pipeline.producer_tail()
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it
+        to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        galpha_scale_post_mel: Optional[cute.Tensor],
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[
+        cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor, Optional[cute.Tensor], cute.Tensor
+    ]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory
+        (source) and register array (destination). Returns separate accumulator tensors
+        for up and gate values used in SwiGLU fusion, plus alpha_scale_post and tTR_gC.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param galpha_scale_post_mel: The global alpha_scale_post tensor (bM, RestM, expert_count, RestL),
+            or None if post-SwiGLU scaling is disabled
+        :type galpha_scale_post_mel: Optional[cute.Tensor]
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate, gAlphaPost, tTR_gC) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor
+            - tTR_rAcc_up: The accumulated tensor in register for up values
+            - tTR_rAcc_gate: The accumulated tensor in register for gate values
+            - gAlphaPost: The alpha_scale_post tensor for per-token access (None if disabled)
+            - tTR_gC: The partitioned output tensor for coordinate mapping
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor, Optional[cute.Tensor], cute.Tensor]
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N) - for up values
+        tTR_rAcc_up = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+        # (T2R, T2R_M, T2R_N) - for gate values
+        tTR_rAcc_gate = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+
+        # Pass through the tiled alpha_scale_post tensor and tTR_gC for direct access in epilogue
+        # galpha_scale_post_mel: (bM, RestM, expert_count, RestL)
+        # tTR_gC: (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        # We'll compute per-token indices in the epilogue based on tTR_gC coordinates
+
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate, galpha_scale_post_mel, tTR_gC
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition
+        register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+        :type sepi: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rC: The partitioned tensor C (register source)
+            - tRS_sC: The partitioned tensor C (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing (tma_atom_c, bSG_sC, bSG_gC) where:
+            - tma_atom_c: The TMA copy atom
+            - bSG_sC: The partitioned shared memory tensor C
+            - bSG_gC: The partitioned global tensor C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+
+        tma_atom_c = atom
+        sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+        gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            tma_atom_c,
+            0,
+            cute.make_layout(1),
+            sC_for_tma_partition,
+            gC_for_tma_partition,
+        )
+        return tma_atom_c, bSG_sC, bSG_gC
+
+    @staticmethod
+    def get_dtype_rcp_limits(dtype: Type[cutlass.Numeric]) -> float:
+        """
+        Get the reciprocal of the maximum representable value for quantization.
+
+        This is used to compute the scale factor for block-scaled quantization.
+        The scale factor is computed as: sf = max_abs_value * rcp_limit * norm_const
+
+        :param dtype: The target data type for quantization
+        :type dtype: Type[cutlass.Numeric]
+        :return: The reciprocal of the maximum representable value
+        :rtype: float
+        """
+        if dtype == cutlass.Float4E2M1FN:
+            return 1.0 / 6.0  # 6.0 is max value for FP4 E2M1
+        elif dtype == cutlass.Float8E4M3FN:
+            return 1.0 / 448.0  # Max value for FP8 E4M3
+        elif dtype == cutlass.Float8E5M2:
+            return 1.0 / 57344.0  # Max value for FP8 E5M2
+        else:
+            return 1.0
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: Layout enum of operand C.
+        :type c_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of Scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Scale factor vector size.
+        :type sf_vec_size: int
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, C stages)
+        :rtype: tuple[int, int, int]
+        """
+        # ACC stages
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 2
+
+        # Default C stages
+        num_c_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Calculate A/B/SFA/SFB stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B/SFA/SFB stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B/SFA/SFB stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Use persistent tile scheduler to compute the grid size for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param cta_tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type cta_tile_shape_mnk: tuple[int, int, int]
+        :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
+        :type cluster_shape_mn: tuple[int, int]
+        :param max_active_clusters: Maximum number of active clusters.
+        :type max_active_clusters: cutlass.Constexpr
+
+        :return: A tuple containing:
+            - tile_sched_params: Parameters for the persistent tile scheduler.
+            - grid: Grid shape for kernel launch.
+        :rtype: Tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(num_ctas_mnl, cluster_shape_mnl)
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the dtypes and sf_vec_size are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size of the scale factor
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+
+        :return: True if the dtypes and sf_vec_size are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        # Check valid ab_dtype
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        # Check valid sf_vec_size
+        if sf_vec_size not in {16, 32}:
+            is_valid = False
+
+        # Check valid sf_dtype
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        # Check valid sf_dtype and sf_vec_size combinations
+        if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+            cutlass.Float4E2M1FN,  # {$nv-internal-release}
+        }:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_layouts(
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if layouts and dtypes are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major dimension of the A tensor
+        :type a_major: str
+        :param b_major: The major dimension of the B tensor
+        :type b_major: str
+        :param c_major: The major dimension of the C tensor
+        :type c_major: str
+
+        :return: True if the layouts are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+            is_valid = False
+        # {$nv-internal-release begin}
+        # TODO: Currently we don't support m major output for Float4E2M1FN
+        if c_dtype is cutlass.Float4E2M1FN and c_major == "m":
+            is_valid = False
+        # {$nv-internal-release end}
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the mma tiler and cluster shape are valid
+
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+
+        :return: True if the mma tiler and cluster shape are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        # TODO: Add tile_n=64 and tile_n=192 support  # {$nv-internal-release}
+        if mma_tiler_mn[1] not in [64, 128, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+
+        # Skip invalid cluster shape
+        def is_power_of_2(x):
+            return x > 0 and (x & (x - 1)) == 0
+
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not is_power_of_2(cluster_shape_mn[0])
+            or not is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,  # noqa: E741
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,  # noqa: E741
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        expert_count: int,
+        weight_per_expert: int,
+    ) -> bool:
+        """
+        Check if the gemm can be implemented
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor tensor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+        :param expert_count: The number of experts
+        :type expert_count: int
+        :param weight_per_expert: The number of weights per expert
+        :type weight_per_expert: int
+
+        :return: True if the gemm can be implemented, False otherwise
+        :rtype: bool
+        """
+        can_implement = True
+        # Skip unsupported types
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_layouts(
+            ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mn, cluster_shape_mn
+        ):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+
+        # n must equal expert_count * weight_per_expert
+        if n != expert_count * weight_per_expert:
+            can_implement = False
+
+        # weight_per_expert should divide cta_tile_shape_n
+        cta_tile_shape_n = 128
+        if weight_per_expert % cta_tile_shape_n != 0:
+            can_implement = False
+
+        return can_implement
+
+    @cute.jit
+    def wrapper(
+        self,
+        a_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        c_sf_ptr: Optional[cute.Pointer],
+        alpha_ptr: cute.Pointer,
+        alpha_post_ptr: Optional[cute.Pointer],
+        norm_const_ptr: Optional[cute.Pointer],
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,  # noqa: E741
+        expert_count: cutlass.Constexpr,
+        scaling_vector_size: cutlass.Constexpr,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        """Wrapper function to create cute tensors from raw pointers and call the kernel.
+
+        This wrapper is designed for integration with TensorRT-LLM custom ops.
+        It creates the appropriate cute tensor layouts from raw pointers and dimensions.
+
+        :param a_ptr: Pointer to input activation tensor A (M, K, L)
+        :type a_ptr: cute.Pointer
+        :param b_ptr: Pointer to weight tensor B (N, K, L)
+        :type b_ptr: cute.Pointer
+        :param a_sf_ptr: Pointer to scale factor tensor for A
+        :type a_sf_ptr: cute.Pointer
+        :param b_sf_ptr: Pointer to scale factor tensor for B
+        :type b_sf_ptr: cute.Pointer
+        :param c_ptr: Pointer to output tensor C (M, N//2, L) - N//2 due to SwiGLU
+        :type c_ptr: cute.Pointer
+        :param c_sf_ptr: Pointer to scale factor tensor for C (can be null)
+        :type c_sf_ptr: Optional[cute.Pointer]
+        :param alpha_ptr: Pointer to per-expert alpha scale tensor (expert_count, L)
+        :type alpha_ptr: cute.Pointer
+        :param alpha_post_ptr: Pointer to post-SwiGLU alpha scale tensor (M, expert_count, L),
+            or None to skip post-SwiGLU scaling
+        :type alpha_post_ptr: Optional[cute.Pointer]
+        :param norm_const_ptr: Pointer to normalization constant for SFC generation (can be null)
+        :type norm_const_ptr: Optional[cute.Pointer]
+        :param m: M dimension (number of tokens/rows)
+        :type m: cutlass.Int64
+        :param n: N dimension (full weight width, before SwiGLU)
+        :type n: cutlass.Int64
+        :param k: K dimension (hidden size)
+        :type k: cutlass.Int64
+        :param l: L dimension (batch/expert dimension, typically 1 for dense)
+        :type l: cutlass.Int64
+        :param expert_count: Number of experts
+        :type expert_count: cutlass.Constexpr
+        :param scaling_vector_size: Vector size for block scaling (typically 16)
+        :type scaling_vector_size: cutlass.Constexpr
+        :param max_active_clusters: Maximum number of active clusters for persistent scheduling
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for kernel execution
+        :type stream: cuda.CUstream
+        """
+        # Compute derived dimensions
+        scale_k = k // scaling_vector_size
+        n_out = n // 2  # Output N dimension after SwiGLU fusion
+        scale_n_out = n_out // scaling_vector_size
+
+        # Create A tensor: (M, K, L) row-major K
+        a = cute.make_tensor(a_ptr, layout=cute.make_ordered_layout((m, k, l), order=(1, 0, 2)))
+
+        # Create B tensor: (N, K, L) row-major K
+        b = cute.make_tensor(b_ptr, layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)))
+
+        # Create C tensor: (M, N//2, L) row-major N
+        c = cute.make_tensor(c_ptr, layout=cute.make_ordered_layout((m, n_out, l), order=(1, 0, 2)))
+
+        # Create scale factor tensors with blockscaled MMA layout
+        # Layout: (32, 4, ceil_div(dim, 128), 4, scale_k // 4, L) with order (2, 1, 4, 0, 3, 5)
+        # Use ceil_div for M dimension to avoid zero-volume tensors when M < 128
+        m_blocks = (m + 127) // 128
+        a_sf = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, m_blocks, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+
+        b_sf = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, n // 128, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+
+        # Create C scale factor tensor (optional, for FP4 output quantization)
+        # Use m_blocks (ceil_div) to avoid zero-volume tensors when M < 128
+        c_sf = None
+        if cutlass.const_expr(c_sf_ptr is not None):
+            c_sf = cute.make_tensor(
+                c_sf_ptr,
+                layout=cute.make_ordered_layout(
+                    (32, 4, m_blocks, 4, scale_n_out // 4, l), order=(2, 1, 4, 0, 3, 5)
+                ),
+            )
+
+        # Create alpha scale tensor: (expert_count, L)
+        # Indexed by N dimension using weight_per_expert
+        alpha = cute.make_tensor(
+            alpha_ptr,
+            layout=cute.make_ordered_layout((expert_count, l), order=(1, 0)),
+        )
+
+        # Create alpha_scale_post tensor: (M, expert_count, L) (optional)
+        # Per-token per-expert scaling applied after SwiGLU
+        alpha_post = None
+        if cutlass.const_expr(alpha_post_ptr is not None):
+            alpha_post = cute.make_tensor(
+                alpha_post_ptr,
+                layout=cute.make_ordered_layout((m, expert_count, l), order=(1, 0, 2)),
+            )
+
+        # Create norm_const tensor (optional, for FP4 output quantization)
+        norm_const = None
+        if cutlass.const_expr(norm_const_ptr is not None):
+            norm_const = cute.make_tensor(norm_const_ptr, layout=cute.make_layout((1,)))
+
+        return self(
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha,
+            alpha_post,
+            c,
+            c_sf,
+            norm_const,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+        )
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]
+
+
+@cute.jit
+def cvt_sf_M32x4xrm_K4xrk_L_to_MKL(
+    sf_mma_tensor: cute.Tensor,
+    sf_ref_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from mma specification M(32x4xrest_m)xK(4xrest_k)xL layout to MKL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_ref_tensor[mkl_coord] = sf_mma_tensor[mkl_coord]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
@@ -1623,17 +1623,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         # - RestM: tile index in M dimension (cur_tile_coord[0])
                         # Each epilogue thread (epi_tidx) handles exactly ONE M coordinate
                         # Thread layout: 128 threads map to 128 M coordinates in the epilogue tile
-                        # Guard with M boundary check to prevent OOB global memory access
-                        # when M < epi_tile_m (e.g., M=64 with epi_tile_m=128).
-                        m_start = mma_tile_coord_mnl[0] * self.epi_tile[0]
-                        if epi_tidx < (m_total - m_start):
-                            current_alpha_scale_post = tTR_gAlphaPost[
-                                epi_tidx, cur_tile_coord[0], expert_idx, batch_idx
-                            ]
-                            for i in cutlass.range_constexpr(cute.size(tCompute)):
-                                tCompute[i] = tCompute[i] * cutlass.Float32(
-                                    current_alpha_scale_post
-                                )
+                        # Guard with M boundary check to prevent OOB global memory access.
+                        # Use cur_tile_coord[0] (not mma_tile_coord_mnl[0]) so that in 2CTA
+                        # mode each CTA correctly computes its own M offset within the cluster.
+                        # Nest the checks to avoid unsigned subtraction underflow.
+                        m_start = cur_tile_coord[0] * self.epi_tile[0]
+                        if m_start < m_total:
+                            if epi_tidx < (m_total - m_start):
+                                current_alpha_scale_post = tTR_gAlphaPost[
+                                    epi_tidx, cur_tile_coord[0], expert_idx, batch_idx
+                                ]
+                                for i in cutlass.range_constexpr(cute.size(tCompute)):
+                                    tCompute[i] = tCompute[i] * cutlass.Float32(
+                                        current_alpha_scale_post
+                                    )
 
                     if cutlass.const_expr(self.generate_sfc):
                         #
@@ -1643,6 +1646,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         # 3. Store SFC to global memory
                         # 4. Quantize output by scaling with reciprocal of SFC
                         #
+                        # Guard: skip SFC store for CTA tiles beyond the M boundary.
+                        # In 2CTA mode, CTA 1 may have cur_tile_coord[0] beyond
+                        # the actual M tile count; direct memory SFC store would
+                        # write OOB and corrupt adjacent GPU memory.
+                        m_tile_in_bounds = cur_tile_coord[0] * self.epi_tile[0] < m_total
                         # Assume subtile partitioned always happens on n dimension
                         sfc_subtile_idx_mn = (
                             cur_tile_coord[0] * self.epi_tile_cnt[0],
@@ -1709,9 +1717,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         tCrSFC.store(tCrSFC_pvscale.load().to(self.sf_dtype))
 
                         #
-                        # Store SFC to global memory
+                        # Store SFC to global memory (guarded for M boundary)
                         #
-                        cute.autovec_copy(tCrSFC, tCgSFC)
+                        if m_tile_in_bounds:
+                            cute.autovec_copy(tCrSFC, tCgSFC)
 
                         #
                         # Compute quantized output values and convert to C type
@@ -2474,9 +2483,14 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         if n != expert_count * weight_per_expert:
             can_implement = False
 
-        # weight_per_expert should divide cta_tile_shape_n
-        cta_tile_shape_n = 128
+        # weight_per_expert must be divisible by the CTA N tile size.
+        # CTA N tile = mma_tiler_mn[1] (e.g. 128 for (128,128), 256 for (256,256))
+        cta_tile_shape_n = mma_tiler_mn[1]
         if weight_per_expert % cta_tile_shape_n != 0:
+            can_implement = False
+
+        # cluster_m > 1 requires 2CTA mode (mma_m=256)
+        if cluster_shape_mn[0] > 1 and mma_tiler_mn[0] != 256:
             can_implement = False
 
         return can_implement

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
@@ -146,15 +146,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         - Float32
         - Float16/BFloat16
         - Float8E4M3FN/Float8E5M2
-        # {$nv-internal-release begin}
         # Note: We don't have SFD generation support in this example for now,
         # so Float4E2M1FN output is only for internal testing and will not be released.
         - Float4E2M1FN
-        # {$nv-internal-release end}
 
     :note: Constraints:
         - MMA tiler M must be 128 or 256 (use_2cta_instrs)
-        # TODO: Add 64 and 192 support # {$nv-internal-release}
+        # TODO: Add 64 and 192 support
         - MMA tiler N must be 128/256
         - Cluster shape M must be multiple of 2 if Mma tiler M is 256
         - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
@@ -273,7 +271,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.mma_tiler[1],
         )
         # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
-        # TODO: round up to 128, it is prepared for supporting N=64 or 192. # {$nv-internal-release}
+        # TODO: round up to 128, it is prepared for supporting N=64 or 192.
         self.mma_inst_shape_mn_sfb = (
             self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
             cute.round_up(self.mma_inst_shape_mn[1], 128),
@@ -530,7 +528,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.mma_inst_shape_mn,
         )
 
-        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs. # {$nv-internal-release}
+        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs.
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
             self.a_major_mode,
@@ -2261,7 +2259,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             cutlass.BFloat16,
             cutlass.Float8E5M2,
             cutlass.Float8E4M3FN,
-            cutlass.Float4E2M1FN,  # {$nv-internal-release}
+            cutlass.Float4E2M1FN,
         }:
             is_valid = False
 
@@ -2296,11 +2294,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
             is_valid = False
-        # {$nv-internal-release begin}
         # TODO: Currently we don't support m major output for Float4E2M1FN
         if c_dtype is cutlass.Float4E2M1FN and c_major == "m":
             is_valid = False
-        # {$nv-internal-release end}
 
         return is_valid
 
@@ -2324,7 +2320,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # Skip invalid mma tile shape
         if mma_tiler_mn[0] not in [128, 256]:
             is_valid = False
-        # TODO: Add tile_n=64 and tile_n=192 support  # {$nv-internal-release}
+        # TODO: Add tile_n=64 and tile_n=192 support
         if mma_tiler_mn[1] not in [64, 128, 256]:
             is_valid = False
         # Skip illegal cluster shape

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py
@@ -1,30 +1,17 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-
-# 1. Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
-
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-
-# 3. Neither the name of the copyright holder nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import Optional, Tuple, Type, Union
 
 import cuda.bindings.driver as cuda

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -1,0 +1,2424 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+
+"""
+This example provides an experimental implementation of the SM100 batched dense blockscaled
+GEMM kernel, please note that the APIs and implementation details related to this kernel
+may change in future releases.
+
+A high-performance persistent batched dense blockscaled GEMM example for the NVIDIA Blackwell
+SM100 architecture using CUTE DSL.
+- Matrix A is MxKxL, L is batch dimension, A can be row-major("K") or column-major("M")
+  for MXF8 input type and can only be row-major("K") for MXF4/NVF4 input type
+- Matrix B is NxKxL, L is batch dimension, B can be row-major("N") or column-major("K")
+  for MXF8 input type and can only be row-major("K") for MXF4/NVF4 input type
+- Matrix C is MxNxL, L is batch dimension, C can be row-major("N") or column-major("M")
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk,
+  which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk,
+  which has N×ceil_div(K, sf_vec_size)×L elements respectively
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes Blackwell's tcgen05.mma for matrix multiply-accumulate (MMA) operations (including 2cta mma instructions)
+    - Implements TMA multicast with cluster to reduce L2 memory traffic
+    - Support persistent tile scheduling to better overlap memory load/store with mma between tiles
+    - Support warp specialization to avoid explicit pipelining between mainloop load and mma
+
+This GEMM works as follows:
+1. DMA warp: Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. MMA warp:
+    - Load scale factor A/B from shared memory (SMEM) to tensor memory (TMEM) using tcgen05.cp instruction.
+    - Perform matrix multiply-accumulate (MMA) operations using tcgen05.mma instruction.
+3. EPILOGUE warp:
+    - Load completed accumulator from tensor memory (TMEM) to registers (RMEM) using tcgen05.ld.
+    - Type convert C matrix to output type.
+    - Optionally store C matrix from registers (RMEM) to shared memory (SMEM) to global
+      memory (GMEM) with TMA operations, or directly store C matrix from registers (RMEM)
+      to global memory (GMEM) without TMA operations.
+    - Optionally accept an elementwise lambda function epilogue_op to apply to the output tensor:
+      e.g., relu can set epilogue_op = lambda x: cute.where(x > 0, x, cute.full_like(x, 0))
+
+SM100 tcgen05.mma.kind.block_scale instructions operate as follows:
+- Read matrix A from SMEM
+- Read matrix B from SMEM
+- Read scalefactor A from TMEM
+- Read scalefactor B from TMEM
+- Write accumulator to TMEM
+The accumulator in TMEM must then be loaded to registers before writing back to GMEM.
+
+Input arguments to this example is shown below:
+
+.. code-block:: bash
+
+    python examples/blackwell/dense_blockscaled_gemm_persistent.py            \
+      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
+      --c_dtype Float16                                                        \
+      --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
+      --mnkl 8192,8192,1024,1
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python examples/blackwell/dense_blockscaled_gemm_persistent.py        \
+      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
+      --c_dtype Float16                                                        \
+      --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
+      --mnkl 8192,8192,1024,1                                                  \
+      --warmup_iterations 1 --iterations 10 --skip_ref_check
+
+
+Constraints:
+* Supported input data types: mxf8, mxf4, nvf4
+  see detailed valid dtype combinations in below Sm100BlockScaledPersistentDenseGemmKernel class documentation
+* A/B tensor must have the same data type, mixed data type is not supported (e.g., mxf8 x mxf4)
+* Mma tiler M must be 128 or 256(use_2cta_instrs)
+* Mma tiler N must be 128 or 256
+* Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+* Cluster shape M must be multiple of 2 if Mma tiler M is 256(use_2cta_instrs)
+* The contiguous dimension of A/B/C tensors must be at least 16 bytes aligned,
+  i.e, number of elements is a multiple of 16 and 32 for Float8 and Float4, respectively.
+"""
+
+
+class Sm100BlockScaledPersistentDenseGemmKernel:
+    """This class implements batched matrix multiplication (C = A x SFA x B x SFB) with support for various data types
+    and architectural features specific to Blackwell GPUs with persistent tile scheduling and warp specialization.
+
+    :param sf_vec_size: Scalefactor vector size.
+    :type sf_vec_size: int
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float8E4M3FN for A and Float8E5M2 for B is not supported
+
+    :note: Supported combinations of A/B data types, SF data typs and SF vector size:
+        - MXF8: A/B: Float8E5M2/Float8E4M3FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - MXF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - NVF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU/Float8E4M3FN + sf_vec_size: 16
+
+    :note: Supported accumulator data types:
+        - Float32
+
+    :note: Supported C data types:
+        - Float32
+        - Float16/BFloat16
+        - Float8E4M3FN/Float8E5M2
+        # {$nv-internal-release begin}
+        # Note: We don't have SFD generation support in this example for now,
+        # so Float4E2M1FN output is only for internal testing and will not be released.
+        - Float4E2M1FN
+        # {$nv-internal-release end}
+
+    :note: Constraints:
+        - MMA tiler M must be 128 or 256 (use_2cta_instrs)
+        # TODO: Add 64 and 192 support # {$nv-internal-release}
+        - MMA tiler N must be 128/256
+        - Cluster shape M must be multiple of 2 if Mma tiler M is 256
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+        - Also, Cluster shape M/N must be <= 4 for scale factor multicasts due to limited size of scale factors
+
+    Example:
+        >>> gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        ...     sf_vec_size=16, mma_tiler_mn=(256, 128), cluster_shape_mn=(2, 1)
+        ... )
+        >>> gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        expert_count: int,
+        weight_per_expert: int,
+        use_prefetch: bool = False,
+        prefetch_dist: int = 3,
+    ):
+        """Initializes the configuration for a Blackwell dense GEMM kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator, always set to Float32
+            - sf_vec_size: Scalefactor A/B vector size.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        :param sf_vec_size: Scalefactor vector size.
+        :type sf_vec_size: int
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param expert_count: The number of experts
+        :type expert_count: int
+        :param weight_per_expert: The number of weights per expert
+        :type weight_per_expert: int
+        :param use_prefetch: Enable prefetch operations (default: False).
+        :type use_prefetch: bool
+        :param prefetch_dist: Prefetch distance for TMA operations (default: 3).
+        :type prefetch_dist: int
+        """
+
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+
+        self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilog_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.alpha_scale_load_warp_id = 6
+        self.dummy_warp_id = 7
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_warp_id,
+                *self.epilog_warp_id,
+                self.alpha_scale_load_warp_id,
+                self.dummy_warp_id,
+            )
+        )
+        # Set barrier id for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.epilog_warp_id)),
+        )
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        self.expert_count = expert_count
+        self.weight_per_expert = weight_per_expert
+
+        self.use_prefetch = use_prefetch
+        self.prefetch_dist = prefetch_dist
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        """
+        # Compute mma instruction shapes
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        # TODO: round up to 128, it is prepared for supporting N=64 or 192. # {$nv-internal-release}
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Compute epilogue subtile
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage, self.num_alpha_scale_stage = (
+            self._compute_stages(
+                tiled_mma,
+                self.mma_tiler,
+                self.a_dtype,
+                self.b_dtype,
+                self.epi_tile,
+                self.c_dtype,
+                self.c_layout,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.smem_capacity,
+                self.occupancy,
+            )
+        )
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        self.alpha_scale_smem_layout_staged = cute.make_layout(
+            (
+                self.cta_tile_shape_mnk[0],
+                self.num_alpha_scale_stage,
+            ),
+            stride=(
+                self.num_alpha_scale_stage,
+                1,
+            ),
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        alpha_scale_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a_tensor: Input tensor A
+        :type a_tensor: cute.Tensor
+        :param b_tensor: Input tensor B
+        :type b_tensor: cute.Tensor
+        :param sfa_tensor: Scale factor tensor A
+        :type sfa_tensor: cute.Tensor
+        :param sfb_tensor: Scale factor tensor B
+        :type sfb_tensor: cute.Tensor
+        :param alpha_scale_tensor: Alpha scale tensor
+        :type alpha_scale_tensor: cute.Tensor
+        :param c_tensor: Output tensor C
+        :type c_tensor: cute.Tensor
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
+        :type epilogue_op: cutlass.Constexpr
+        :raises TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a_tensor.shape, self.sf_vec_size)
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b_tensor.shape, self.sf_vec_size)
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs. # {$nv-internal-release}
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_tensor,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_tensor,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+        # Setup TMA store for C
+        epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            c_tensor,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # Compute grid size
+        self.tile_sched_params, grid = self._compute_grid(
+            c_tensor,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            alpha_scale_load_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_alpha_scale_stage * 2
+            ]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.c_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # Alpha scale shared memory
+            sAlphaScale: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32, cute.cosize(self.alpha_scale_smem_layout_staged)
+                ],
+                16,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            alpha_scale_tensor,
+            tma_atom_c,
+            tma_tensor_c,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.alpha_scale_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        malpha_scale_mnl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        alpha_scale_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilog_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize alpha_scale_pipeline (barrier) and states
+        alpha_scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            32 * 1,  # alpha_scale_load_warp_id threads
+            32 * 1,
+        )
+        alpha_scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            32 * len(self.epilog_warp_id),  # epilogue warps
+            32 * len(self.epilog_warp_id),
+        )
+        alpha_scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.alpha_scale_load_mbar_ptr.data_ptr(),
+            num_stages=self.num_alpha_scale_stage,
+            producer_group=alpha_scale_pipeline_producer_group,
+            consumer_group=alpha_scale_pipeline_consumer_group,
+        )
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        # Alpha scale shared memory tensor
+        sAlphaScale = storage.sAlphaScale.get_tensor(alpha_scale_smem_layout_staged)
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bK, RestM, RestK, RestL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+            (None, None, None),
+        )
+
+        # (bM, bN, loopM, loopN, loopL)
+        galpha_scale_mnl = cute.local_tile(
+            malpha_scale_mnl,
+            cute.slice_(self.cta_tile_shape_mnk, (None, 0, 0)),
+            (None, None, None),
+        )
+
+        # (bM, bN, RestM, RestN, RestL)
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgSFA = thr_mma.partition_A(gSFA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        # TMA load SFA partition_S/D
+        sfa_cta_layout = a_cta_layout
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA load SFB partition_S/D
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+
+                # ((atom_v, rest_v), RestK)
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+                slice_n = mma_tile_coord_mnl[1]
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_mnl[1] // 2
+                # ((atom_v, rest_v), RestK)
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, mma_tile_coord_mnl[2])]
+
+                prefetch_dist = self.prefetch_dist
+                # Sending a batch of inflight Prefetches before starting TMALDG loop
+                # Prefetch logic: use_prefetch for both A&B, or explicit A-only/B-only
+                if self.use_prefetch:
+                    # Prefetch both A and B (default behavior)
+                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt), unroll=1):
+                        # Prefetch both A and B (default behavior)
+                        cute.prefetch(
+                            tma_atom_a,
+                            tAgA_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_b,
+                            tBgB_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfa,
+                            tAgSFA_slice[(None, k_tile)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfb,
+                            tBgSFB_slice[(None, k_tile)],
+                        )
+
+                # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+
+                    # TMA load A/B/SFA/SFB
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAsSFA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBsSFB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                    # Prefetch logic in the loop: use_prefetch for both A&B, or explicit A-only/B-only
+                    if k_tile < k_tile_cnt - prefetch_dist:
+                        if self.use_prefetch:
+                            # Prefetch both A and B (default behavior)
+                            cute.prefetch(
+                                tma_atom_a,
+                                tAgA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_b,
+                                tBgB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfa,
+                                tAgSFA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfb,
+                                tBgSFB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                            )
+
+                    # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized Alpha Scale Load warp
+        #
+        if warp_idx == self.alpha_scale_load_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            alpha_scale_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_alpha_scale_stage
+            )
+
+            # Setup copy atom for alpha scale loading
+            atom_copy = cute.make_copy_atom(
+                cute.nvgpu.cpasync.CopyG2SOp(),
+                malpha_scale_mnl.element_type,
+                num_bits_per_copy=malpha_scale_mnl.element_type.width,
+            )
+            tiled_copy_alpha_scale = cute.make_tiled_copy_tv(
+                atom_copy, cute.make_layout((32,)), cute.make_layout((1,))
+            )
+            thr_copy_alpha_scale = tiled_copy_alpha_scale.get_slice(cute.arch.lane_idx())
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+
+                # Reset producer state for this tile
+                alpha_scale_producer_state.reset_count()
+                peek_alpha_scale_empty_status = cutlass.Boolean(1)
+                if alpha_scale_producer_state.count < k_tile_cnt:
+                    peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
+                        alpha_scale_producer_state
+                    )
+
+                galpha_scale_mnl_current_tile = galpha_scale_mnl[
+                    None, cur_tile_coord[0], None, cur_tile_coord[2]
+                ]
+
+                tAgAlphaScale = thr_copy_alpha_scale.partition_S(galpha_scale_mnl_current_tile)
+                tAsAlphaScale = thr_copy_alpha_scale.partition_D(sAlphaScale)
+
+                # Load alpha scale for each k tile
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Calculate expert index for this k_tile
+                    expert_idx = k_tile // (self.weight_per_expert // self.mma_tiler[2])
+
+                    # Slice alpha scale for current tile and expert
+                    tAgAlphaScale_slice = tAgAlphaScale[(None, None, expert_idx)]
+                    tAsAlphaScale_slice = tAsAlphaScale[
+                        (None, None, alpha_scale_producer_state.index)
+                    ]
+
+                    # Wait for alpha scale buffer empty
+                    alpha_scale_pipeline.producer_acquire(
+                        alpha_scale_producer_state, peek_alpha_scale_empty_status
+                    )
+
+                    num_iters = cute.size(tAgAlphaScale_slice, mode=[1])
+
+                    # Load alpha scale from global to shared memory
+                    for iter_idx in cutlass.range(num_iters, unroll_full=True):
+                        iter_coord = (None, iter_idx)
+                        pred = cutlass.Boolean(
+                            32 * iter_idx + cute.arch.lane_idx() < malpha_scale_mnl.shape[0]
+                        )
+                        if pred:
+                            cute.copy(
+                                tiled_copy_alpha_scale,
+                                tAgAlphaScale_slice[iter_coord],
+                                tAsAlphaScale_slice[iter_coord],
+                            )
+
+                    # Commit and advance
+                    alpha_scale_pipeline.producer_commit(alpha_scale_producer_state)
+                    alpha_scale_producer_state.advance()
+
+                    # Peek next
+                    peek_alpha_scale_empty_status = cutlass.Boolean(1)
+                    if alpha_scale_producer_state.count < k_tile_cnt:
+                        peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
+                            alpha_scale_producer_state
+                        )
+
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            # Wait for alpha scale buffer empty
+            alpha_scale_pipeline.producer_tail(alpha_scale_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # Make accumulator tmem tensor
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base),
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr
+                + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                        + tcgen05.find_tmem_tensor_col_offset(tCtSFA)
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                #
+                # Mma mainloop
+                #
+                for k_tile in range(k_tile_cnt):
+                    # Set tensor memory buffer for current tile
+                    # (MMA, MMA_M, MMA_N)
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                    if is_leader_cta:
+                        # Wait for accumulator buffer empty(each kblock)
+                        acc_pipeline.producer_acquire(acc_producer_state)
+
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        #
+                        # Reset the ACCUMULATE field for each tile
+                        #
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (
+                                None,
+                                None,
+                                kblock_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kblock_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kblock_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblock_coord],
+                                tCrB[kblock_coord],
+                                tCtAcc,
+                            )
+
+                            # Enable accumulate on tCtAcc after first kblock
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_tile_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                    #
+                    # Async arrive accumulator buffer full
+                    #
+                    if is_leader_cta:
+                        acc_pipeline.producer_commit(acc_producer_state)
+                    acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r, tTR_rC, epi_tidx, sC
+            )
+            (
+                tma_atom_c,
+                bSG_sC,
+                bSG_gC_partitioned,
+            ) = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_c, tCgC, epi_tile, sC)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            # Alpha scale consumer state
+            alpha_scale_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_alpha_scale_stage
+            )
+
+            # Threads/warps participating in tma store pipeline
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage,
+                producer_group=c_producer_group,
+            )
+
+            # Create copy atom for loading alpha scale from smem
+            alpha_scale_copy_atom_s2r = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=32,
+            )
+            tiled_copy_alpha_scale_s2r = cute.make_tiled_copy_tv(
+                alpha_scale_copy_atom_s2r,
+                cute.make_layout((32 * len(self.epilog_warp_id),)),
+                cute.make_layout((1,)),
+            )
+            thr_copy_alpha_scale_s2r = tiled_copy_alpha_scale_s2r.get_slice(tidx)
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                bSG_gC = bSG_gC_partitioned[
+                    (
+                        None,
+                        None,
+                        None,
+                        *mma_tile_coord_mnl,
+                    )
+                ]
+
+                # initialize the final accumulator
+                tTR_rAcc_final.fill(0.0)
+
+                # Initialize alpha_scale consumer state for this tile
+                alpha_scale_consumer_state.reset_count()
+                peek_alpha_scale_full_status = cutlass.Boolean(1)
+                if alpha_scale_consumer_state.count < k_tile_cnt:
+                    peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                        alpha_scale_consumer_state
+                    )
+
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                for k_tile in cutlass.range(k_tile_cnt):
+                    # Set tensor memory buffer for current tile
+                    # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                    tTR_tAcc = tTR_tAcc_base[
+                        (None, None, None, None, None, acc_consumer_state.index)
+                    ]
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                    #
+                    # Update accumulator by scale factor in subtiles
+                    #
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                    # for subtile_idx in cutlass.range_dynamic(subtile_cnt):
+
+                    #
+                    # Wait for alpha scale buffer full
+                    #
+                    alpha_scale_pipeline.consumer_wait(
+                        alpha_scale_consumer_state, peek_alpha_scale_full_status
+                    )
+
+                    # Load alpha scale from shared memory for current expert
+                    alpha_scale_smem_slice = sAlphaScale[(None, alpha_scale_consumer_state.index)]
+
+                    tAsAlphaScale_slice = thr_copy_alpha_scale_s2r.partition_S(
+                        alpha_scale_smem_slice
+                    )
+                    current_alpha_scale_reg = cute.make_rmem_tensor(
+                        tAsAlphaScale_slice.shape, cutlass.Float32
+                    )
+
+                    cute.copy(
+                        alpha_scale_copy_atom_s2r, tAsAlphaScale_slice, current_alpha_scale_reg
+                    )
+                    current_alpha_scale = current_alpha_scale_reg[0]
+
+                    #
+                    # Wait for accumulator buffer full
+                    #
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        #
+                        # Load accumulator from tensor memory buffer to register
+                        #
+                        # (T2R, T2R_M, T2R_N)
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        #
+                        # Update accumulator by scale factor
+                        #
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+
+                        acc_vec = tTR_rAcc.load()
+                        final_vec = tTR_rAcc_subtile.load()
+
+                        final_vec = acc_vec * current_alpha_scale + final_vec
+                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                    # Release alpha scale buffer
+                    alpha_scale_pipeline.consumer_release(alpha_scale_consumer_state)
+                    alpha_scale_consumer_state.advance()
+
+                    # Peek next alpha scale
+                    peek_alpha_scale_full_status = cutlass.Boolean(1)
+                    if alpha_scale_consumer_state.count < k_tile_cnt:
+                        peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                            alpha_scale_consumer_state
+                        )
+                    #
+                    # Async arrive accumulator buffer empty
+                    #
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                #
+                # Store accumulator to global memory in subtiles
+                #
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    #
+                    # Store accumulator to shared memory or global memory
+                    #
+                    tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+
+                    #
+                    # Convert to C type
+                    #
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc_subtile).load()
+                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                    tRS_rC.store(acc_vec)
+
+                    #
+                    # Store C to shared memory
+                    #
+                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rC,
+                        tRS_sC[(None, None, None, c_buffer)],
+                    )
+                    # Fence and barrier to make sure shared memory store is visible to TMA store
+                    cute.arch.fence_proxy(
+                        cute.arch.ProxyKind.async_shared,
+                        space=cute.arch.SharedSpace.shared_cta,
+                    )
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    #
+                    # TMA store C to global memory
+                    #
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, subtile_idx)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(acc_tmem_ptr)
+            #
+            # Wait for C store complete
+            #
+            c_pipeline.producer_tail()
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it
+        to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory
+        (source) and register array (destination).
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor
+            - tTR_rAcc: The accumulated tensor in register used to hold t2r results
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N)
+        tTR_rAcc_final_ = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype
+        )
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tTR_tAcc,
+            tTR_rAcc,
+            tTR_rAcc_final,
+        )
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition
+        register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+        :type sepi: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rC: The partitioned tensor C (register source)
+            - tRS_sC: The partitioned tensor C (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing (tma_atom_c, bSG_sC, bSG_gC) where:
+            - tma_atom_c: The TMA copy atom
+            - bSG_sC: The partitioned shared memory tensor C
+            - bSG_gC: The partitioned global tensor C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+
+        tma_atom_c = atom
+        sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+        gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            tma_atom_c,
+            0,
+            cute.make_layout(1),
+            sC_for_tma_partition,
+            gC_for_tma_partition,
+        )
+        return tma_atom_c, bSG_sC, bSG_gC
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> Tuple[int, int, int, int]:
+        """Computes the number of stages for A/B/C/Alpha_Scale operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: Layout enum of operand C.
+        :type c_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of Scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Scale factor vector size.
+        :type sf_vec_size: int
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, C stages, Alpha_Scale stages)
+        :rtype: tuple[int, int, int, int]
+        """
+        # ACC stages
+        num_acc_stage = 2
+        if mma_tiler_mnk[1] == 256:
+            num_acc_stage = 1
+        # else if mma_tiler_mnk[1] == 64:
+        #     num_acc_stage = 6
+
+        # Default C stages
+        num_c_stage = 2
+
+        # Default Alpha scale stages
+        num_alpha_scale_stage = 10
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Alpha scale shared memory
+        # hardcode cta tile shape
+        alpha_bytes = cute.size_in_bytes(
+            cutlass.Float32,
+            cute.make_layout(
+                (mma_tiler_mnk[0] // tiled_mma.thr_id.shape, num_alpha_scale_stage),
+                stride=(num_alpha_scale_stage, 1),
+            ),
+        )
+        # Calculate A/B/SFA/SFB stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B/SFA/SFB stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + alpha_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B/SFA/SFB stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes + alpha_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_c_stage, num_alpha_scale_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Use persistent tile scheduler to compute the grid size for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param cta_tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type cta_tile_shape_mnk: tuple[int, int, int]
+        :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
+        :type cluster_shape_mn: tuple[int, int]
+        :param max_active_clusters: Maximum number of active clusters.
+        :type max_active_clusters: cutlass.Constexpr
+
+        :return: A tuple containing:
+            - tile_sched_params: Parameters for the persistent tile scheduler.
+            - grid: Grid shape for kernel launch.
+        :rtype: Tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(num_ctas_mnl, cluster_shape_mnl)
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the dtypes and sf_vec_size are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size of the scale factor
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+
+        :return: True if the dtypes and sf_vec_size are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        # Check valid ab_dtype
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        # Check valid sf_vec_size
+        if sf_vec_size not in {16, 32}:
+            is_valid = False
+
+        # Check valid sf_dtype
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        # Check valid sf_dtype and sf_vec_size combinations
+        if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+            cutlass.Float4E2M1FN,  # {$nv-internal-release}
+        }:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_layouts(
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if layouts and dtypes are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major dimension of the A tensor
+        :type a_major: str
+        :param b_major: The major dimension of the B tensor
+        :type b_major: str
+        :param c_major: The major dimension of the C tensor
+        :type c_major: str
+
+        :return: True if the layouts are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+            is_valid = False
+        # {$nv-internal-release begin}
+        # TODO: Currently we don't support m major output for Float4E2M1FN
+        if c_dtype is cutlass.Float4E2M1FN and c_major == "m":
+            is_valid = False
+        # {$nv-internal-release end}
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the mma tiler and cluster shape are valid
+
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+
+        :return: True if the mma tiler and cluster shape are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        # TODO: Add tile_n=64 and tile_n=192 support  # {$nv-internal-release}
+        if mma_tiler_mn[1] not in [64, 128, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+
+        # Skip invalid cluster shape
+        def is_power_of_2(x):
+            return x > 0 and (x & (x - 1)) == 0
+
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not is_power_of_2(cluster_shape_mn[0])
+            or not is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,  # noqa: E741
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+    @cute.jit
+    def wrapper(
+        self,
+        a_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_scale_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,  # noqa: E741
+        expert_count: cutlass.Constexpr,
+        scaling_vector_size: cutlass.Constexpr,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        """Wrapper function to create cute.Tensor objects from raw pointers and call the kernel.
+
+        :param a_ptr: Pointer to input tensor A (M, K, L) - K-major
+        :type a_ptr: cute.Pointer
+        :param b_ptr: Pointer to weight tensor B (N, K, L) - K-major
+        :type b_ptr: cute.Pointer
+        :param a_sf_ptr: Pointer to scale factor tensor for A
+        :type a_sf_ptr: cute.Pointer
+        :param b_sf_ptr: Pointer to scale factor tensor for B
+        :type b_sf_ptr: cute.Pointer
+        :param alpha_scale_ptr: Pointer to alpha scale tensor (M, expert_count, L)
+        :type alpha_scale_ptr: cute.Pointer
+        :param c_ptr: Pointer to output tensor C (M, N, L) - N-major
+        :type c_ptr: cute.Pointer
+        :param m: M dimension (number of tokens)
+        :type m: cutlass.Int64
+        :param n: N dimension (output hidden size)
+        :type n: cutlass.Int64
+        :param k: K dimension (weight_per_expert * expert_count)
+        :type k: cutlass.Int64
+        :param l: L dimension (batch, typically 1)
+        :type l: cutlass.Int64
+        :param expert_count: Number of experts
+        :type expert_count: cutlass.Constexpr
+        :param scaling_vector_size: Scale factor vector size
+        :type scaling_vector_size: cutlass.Constexpr
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream
+        :type stream: cuda.CUstream
+        """
+        scale_k = k // scaling_vector_size
+
+        # Create A tensor (M, K, L) - K-major
+        a = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout((m, k, l), order=(1, 0, 2)),
+        )
+
+        # Create B tensor (N, K, L) - K-major
+        b = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
+        )
+
+        # Create C tensor (M, N, L) - N-major
+        c = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+        )
+
+        # Create A scale factor tensor (swizzled layout)
+        # Shape: (32, 4, m // 128, 4, scale_k // 4, l)
+        a_sf = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, m // 128, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+
+        # Create B scale factor tensor (swizzled layout)
+        # Shape: (32, 4, n // 128, 4, scale_k // 4, l)
+        b_sf = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, n // 128, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+
+        # Create alpha scale tensor (M, expert_count, L) - expert_count-major
+        alpha_scale = cute.make_tensor(
+            alpha_scale_ptr,
+            layout=cute.make_ordered_layout((m, expert_count, l), order=(1, 0, 2)),
+        )
+
+        # Call the kernel
+        self.__call__(
+            a,
+            b,
+            a_sf,
+            b_sf,
+            alpha_scale,
+            c,
+            max_active_clusters,
+            stream,
+        )
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,  # noqa: E741
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        expert_count: int,
+        weight_per_expert: int,
+    ) -> bool:
+        """
+        Check if the gemm can be implemented
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor tensor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+        :param expert_count: The number of experts
+        :type expert_count: int
+        :param weight_per_expert: The number of weights per expert
+        :type weight_per_expert: int
+
+        :return: True if the gemm can be implemented, False otherwise
+        :rtype: bool
+        """
+        can_implement = True
+        # Skip unsupported types
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_layouts(
+            ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mn, cluster_shape_mn
+        ):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+
+        # Add specific check for weight_per_expert, expert_count and k size.
+        # skip unsupported weight_per_expert
+        mma_tile_shape_k = 256
+        if weight_per_expert % mma_tile_shape_k != 0:
+            can_implement = False
+
+        # mma_tile_shape_k = 256
+        if not (k % expert_count == 0 and k // expert_count == weight_per_expert):
+            can_implement = False
+
+        return can_implement
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -144,15 +144,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         - Float32
         - Float16/BFloat16
         - Float8E4M3FN/Float8E5M2
-        # {$nv-internal-release begin}
         # Note: We don't have SFD generation support in this example for now,
         # so Float4E2M1FN output is only for internal testing and will not be released.
         - Float4E2M1FN
-        # {$nv-internal-release end}
 
     :note: Constraints:
         - MMA tiler M must be 128 or 256 (use_2cta_instrs)
-        # TODO: Add 64 and 192 support # {$nv-internal-release}
+        # TODO: Add 64 and 192 support
         - MMA tiler N must be 128/256
         - Cluster shape M must be multiple of 2 if Mma tiler M is 256
         - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
@@ -276,7 +274,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.mma_tiler[1],
         )
         # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
-        # TODO: round up to 128, it is prepared for supporting N=64 or 192. # {$nv-internal-release}
+        # TODO: round up to 128, it is prepared for supporting N=64 or 192.
         self.mma_inst_shape_mn_sfb = (
             self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
             cute.round_up(self.mma_inst_shape_mn[1], 128),
@@ -482,7 +480,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.mma_inst_shape_mn,
         )
 
-        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs. # {$nv-internal-release}
+        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs.
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
             self.a_major_mode,
@@ -2073,7 +2071,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             cutlass.BFloat16,
             cutlass.Float8E5M2,
             cutlass.Float8E4M3FN,
-            cutlass.Float4E2M1FN,  # {$nv-internal-release}
+            cutlass.Float4E2M1FN,
         }:
             is_valid = False
 
@@ -2108,11 +2106,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
             is_valid = False
-        # {$nv-internal-release begin}
         # TODO: Currently we don't support m major output for Float4E2M1FN
         if c_dtype is cutlass.Float4E2M1FN and c_major == "m":
             is_valid = False
-        # {$nv-internal-release end}
 
         return is_valid
 
@@ -2136,7 +2132,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # Skip invalid mma tile shape
         if mma_tiler_mn[0] not in [128, 256]:
             is_valid = False
-        # TODO: Add tile_n=64 and tile_n=192 support  # {$nv-internal-release}
+        # TODO: Add tile_n=64 and tile_n=192 support
         if mma_tiler_mn[1] not in [64, 128, 256]:
             is_valid = False
         # Skip illegal cluster shape

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -1,30 +1,17 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-
-# 1. Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
-
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-
-# 3. Neither the name of the copyright holder nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Tuple, Type, Union
 

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -53,6 +53,7 @@ from .communication import (
 from .fused_moe_cute_dsl import CuteDslFusedMoE
 from .fused_moe_cutlass import CutlassFusedMoE
 from .fused_moe_deepgemm import DeepGemmFusedMoE
+from .fused_moe_densegemm import DenseGEMMFusedMoE
 from .fused_moe_trtllm_gen import TRTLLMGenFusedMoE
 
 
@@ -1117,7 +1118,12 @@ class ConfigurableMoE(MoE):
         kwargs = {}
 
         # Common parameters for Cutlass and DeepGemm
-        if self.backend.__class__ in (CutlassFusedMoE, DeepGemmFusedMoE, CuteDslFusedMoE):
+        if self.backend.__class__ in (
+            CutlassFusedMoE,
+            DeepGemmFusedMoE,
+            CuteDslFusedMoE,
+            DenseGEMMFusedMoE,
+        ):
             pass
 
         # Cutlass-specific parameters

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -606,8 +606,8 @@ class ConfigurableMoE(MoE):
 
             assert token_selected_experts.shape[1] == self.routing_method.experts_per_token
             assert token_selected_experts.shape == token_final_scales.shape
-            # CutlassFusedMoE expects float32, while TRTLLMGenFusedMoE uses bfloat16
-            if isinstance(self.backend, CutlassFusedMoE):
+            # CutlassFusedMoE and DenseGEMMFusedMoE expect float32, while TRTLLMGenFusedMoE uses bfloat16
+            if isinstance(self.backend, (CutlassFusedMoE, DenseGEMMFusedMoE)):
                 assert token_final_scales.dtype == torch.float32
             assert token_selected_experts.dtype == torch.int32
 

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -47,14 +47,21 @@ def get_moe_cls(
     elif moe_backend.upper() == "DEEPGEMM":
         return DeepGemmFusedMoE
     elif moe_backend.upper() == "DENSEGEMM":
-        if quant_config is not None and quant_config.quant_mode.has_nvfp4():
-            return DenseGEMMFusedMoE
-        else:
+        if quant_config is None or not quant_config.quant_mode.has_nvfp4():
             logger.warning(
                 "DenseGEMMFusedMoE only supports nvfp4. "
                 f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
             )
             return CutlassFusedMoE
+        # DenseGEMM CuTe DSL kernels only support SM100/SM103.
+        from tensorrt_llm._utils import get_sm_version
+        sm_version = get_sm_version()
+        if sm_version not in DenseGEMMFusedMoE._SUPPORTED_SM_VERSIONS:
+            logger.warning(
+                f"DenseGEMMFusedMoE only supports SM {DenseGEMMFusedMoE._SUPPORTED_SM_VERSIONS} "
+                f"(got SM {sm_version}). Using CutlassFusedMoE instead.")
+            return CutlassFusedMoE
+        return DenseGEMMFusedMoE
     elif moe_backend.upper() == "TRTLLM":
         if quant_config is not None and (
                 quant_config.quant_mode.has_fp8_block_scales()
@@ -302,6 +309,7 @@ def create_moe_backend(
             layer_idx=layer_idx,
             init_load_balancer=init_load_balancer,
             without_comm=without_comm,
+            activation_type=activation_type,
         )
     else:
         raise ValueError(f"Unsupported moe backend: {moe_cls}")

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -149,8 +149,8 @@ def create_moe_backend(
     if moe_load_balancer is not None:
         assert moe_cls in [
             WideEPMoE, CutlassFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE,
-            DeepGemmFusedMoE
-        ], "MoE Load Balance is only supported in WideEPMoE, CutlassFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE, and DeepGemmFusedMoE."
+            DeepGemmFusedMoE, DenseGEMMFusedMoE
+        ], "MoE Load Balance is only supported in WideEPMoE, CutlassFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE, DeepGemmFusedMoE, and DenseGEMMFusedMoE."
 
     if bias:
         assert moe_cls in [CutlassFusedMoE, TritonFusedMoE, TRTLLMGenFusedMoE

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -12,6 +12,7 @@ from .configurable_moe import ConfigurableMoE
 from .fused_moe_cute_dsl import CuteDslFusedMoE
 from .fused_moe_cutlass import CutlassFusedMoE
 from .fused_moe_deepgemm import DeepGemmFusedMoE
+from .fused_moe_densegemm import DenseGEMMFusedMoE
 from .fused_moe_triton import TritonFusedMoE
 from .fused_moe_trtllm_gen import TRTLLMGenFusedMoE
 from .fused_moe_vanilla import VanillaMoE
@@ -45,6 +46,15 @@ def get_moe_cls(
             return CutlassFusedMoE
     elif moe_backend.upper() == "DEEPGEMM":
         return DeepGemmFusedMoE
+    elif moe_backend.upper() == "DENSEGEMM":
+        if quant_config is not None and quant_config.quant_mode.has_nvfp4():
+            return DenseGEMMFusedMoE
+        else:
+            logger.warning(
+                "DenseGEMMFusedMoE only supports nvfp4. "
+                f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
+            )
+            return CutlassFusedMoE
     elif moe_backend.upper() == "TRTLLM":
         if quant_config is not None and (
                 quant_config.quant_mode.has_fp8_block_scales()
@@ -277,6 +287,22 @@ def create_moe_backend(
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
         )
+    elif moe_cls == DenseGEMMFusedMoE:
+        return moe_cls(
+            routing_method=routing_method,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            dtype=dtype,
+            reduce_results=reduce_results,
+            model_config=model_config,
+            aux_stream_dict=aux_stream_dict,
+            weight_loading_mode=weight_loading_mode,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            layer_idx=layer_idx,
+            init_load_balancer=init_load_balancer,
+            without_comm=without_comm,
+        )
     else:
         raise ValueError(f"Unsupported moe backend: {moe_cls}")
 
@@ -350,7 +376,7 @@ def create_moe(
                                              "1") == "1"
     if enable_configurable_moe or moe_cls == CuteDslFusedMoE:
         if moe_cls in (DeepGemmFusedMoE, TRTLLMGenFusedMoE, CuteDslFusedMoE,
-                       CutlassFusedMoE):
+                       CutlassFusedMoE, DenseGEMMFusedMoE):
             return ConfigurableMoE(
                 routing_method=routing_method,
                 num_experts=num_experts,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import os
 from typing import Dict, List, Optional, Union
 
@@ -13,9 +14,8 @@ from ...distributed import allgather
 from ...memory_buffer_utils import get_memory_buffers
 from ...model_config import ModelConfig
 from ...utils import AuxStreamType, EventType, Fp4QuantizedTensor, swizzle_sf, unswizzle_sf
-from .fused_moe_cutlass import CutlassFusedMoE
-from .interface import AlltoallMethodType
-from .quantization import MoEWeightLoadingMode, NVFP4CuteDslFusedMoEMethod
+from .interface import MoE, MoEWeightLoadingMode
+from .quantization import NVFP4CuteDslFusedMoEMethod
 from .routing import BaseMoeRoutingMethod
 
 
@@ -80,8 +80,16 @@ def gen_fc2_alpha_fused(
     return fc2_alpha.scatter_(1, token_selected_experts.long(), scaled_values)
 
 
-class DenseGEMMFusedMoE(CutlassFusedMoE):
-    """CuteDSL flow of fused mixture of experts (MoE) Layer.
+class DenseGEMMFusedMoE(MoE):
+    """CuteDSL DenseGEMM flow of fused mixture of experts (MoE) Layer.
+
+    This backend uses CuTe DSL dense GEMM kernels with fused SwiGLU for MoE
+    computation. It supports NVFP4 quantization only and is restricted to
+    SM100/SM103 (Blackwell) architectures.
+
+    Unlike CutlassFusedMoE which uses per-expert scattered GEMM, DenseGEMM
+    packs all experts into a single dense matrix and uses standard GEMM operations,
+    which can be more efficient for small token counts (min-latency scenarios).
 
     Args:
         num_experts (int): Number of experts in the MoE layer.
@@ -155,6 +163,8 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
         # DenseGEMM CuTe DSL kernels only support SM100 and SM103.
         from tensorrt_llm._utils import get_sm_version
 
+        from ...utils import ActivationType
+
         sm_version = get_sm_version()
         assert sm_version in self._SUPPORTED_SM_VERSIONS, (
             f"DenseGEMMFusedMoE only supports SM {self._SUPPORTED_SM_VERSIONS} "
@@ -163,8 +173,6 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
 
         # DenseGEMM kernel hardcodes SwiGLU fusion — reject other activation types
         # before calling super().__init__() to fail fast with a clear message.
-        from ...utils import ActivationType
-
         if activation_type is None:
             activation_type = ActivationType.Swiglu
         assert activation_type == ActivationType.Swiglu, (
@@ -184,6 +192,10 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             f"when weight_per_expert is not MMA tile-K aligned."
         )
 
+        # Call MoE base class directly (not CutlassFusedMoE).
+        # Note: `without_comm` and `apply_router_weight_on_input` are accepted
+        # for API compatibility with create_moe_backend() but are not passed to
+        # MoE.__init__() since DenseGEMM does not use alltoall communication.
         super().__init__(
             routing_method=routing_method,
             num_experts=num_experts,
@@ -194,10 +206,8 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             model_config=model_config,
             aux_stream_dict=aux_stream_dict,
             weight_loading_mode=weight_loading_mode,
-            apply_router_weight_on_input=apply_router_weight_on_input,
             layer_idx=layer_idx,
             init_load_balancer=init_load_balancer,
-            without_comm=without_comm,
             activation_type=activation_type,
         )
 
@@ -214,14 +224,53 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             self.aux_stream_dict = aux_stream_dict if aux_stream_dict is not None else {}
         if AuxStreamType.MoeFc2Alpha not in self.aux_stream_dict:
             self.aux_stream_dict[AuxStreamType.MoeFc2Alpha] = torch.cuda.Stream()
-        if self.event_dict is None:
-            self.event_dict = {}
+        self.event_dict = {}
         for key in [EventType.Main, EventType.MoeFc2Alpha]:
-            if key not in self.event_dict:
-                self.event_dict[key] = torch.cuda.Event()
+            self.event_dict[key] = torch.cuda.Event()
 
-    def load_weights(self, weights: List[Dict]):
-        super().load_weights(weights)
+        # Weight creation
+        self._weights_created = False
+        if not model_config.skip_create_weights_in_init:
+            self.create_weights()
+
+    def _supports_load_balancer(self) -> bool:
+        """DenseGEMMFusedMoE supports load balancer."""
+        return True
+
+    def _get_quant_method(self):
+        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
+            exclude_kv_cache=True
+        ):
+            if self.quant_config.layer_quant_mode.has_nvfp4():
+                return NVFP4CuteDslFusedMoEMethod()
+            raise ValueError(
+                f"{self.__class__.__name__} only supports NVFP4 quantization, "
+                f"got {self.quant_config.quant_mode}."
+            )
+        raise ValueError(
+            f"{self.__class__.__name__} requires quantization (NVFP4), "
+            f"but no quantization config was provided."
+        )
+
+    def create_weights(self):
+        if self._weights_created:
+            return
+
+        self.quant_method = self._get_quant_method()
+        self.quant_method.create_weights(self)
+
+        self._weights_created = True
+
+    def load_weights(self, weights: List[Dict], allow_partial_loading: bool = False):
+        assert self._weights_created
+        assert len(weights) == 1
+        weights = weights[0]
+
+        kargs = {}
+        if "allow_partial_loading" in inspect.getfullargspec(self.quant_method.load_weights).args:
+            kargs["allow_partial_loading"] = allow_partial_loading
+        self.quant_method.load_weights(self, weights, self.weight_loading_mode, **kargs)
+
         # Transpose w2_weight layout: (E, H, ...) -> (H, E, ...) for dense GEMM.
         # NOTE: .contiguous() on the transposed view allocates a full-size temporary,
         # temporarily doubling peak memory.  An in-place multi-dim transpose is not
@@ -240,6 +289,9 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
                     f"{self.__class__.__name__} only supports nvfp4 quantization, "
                     f"got {self.quant_config.quant_mode}."
                 )
+
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)
 
     def _transform_w2_weight_scale_for_min_latency(self):
         """Transform w2_weight_scale for minimum latency path optimization."""
@@ -277,17 +329,6 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             w2_weight_scale.view(self.w2_weight_scale.dtype).view(self.w2_weight_scale.shape),
             non_blocking=True,
         )
-
-    def select_alltoall_method_type(self) -> AlltoallMethodType:
-        return AlltoallMethodType.NotEnabled
-
-    def _get_quant_method(self):
-        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
-            exclude_kv_cache=True
-        ):
-            if self.quant_config.layer_quant_mode.has_nvfp4():
-                return NVFP4CuteDslFusedMoEMethod()
-        return super()._get_quant_method()
 
     def quantize_input(
         self, x: Union[torch.Tensor, Fp4QuantizedTensor], post_quant_comm: bool = True
@@ -524,3 +565,39 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             enable_alltoall=False,
         )
         return x
+
+    def forward_impl(
+        self,
+        x: Union[torch.Tensor, Fp4QuantizedTensor],
+        router_logits: torch.Tensor,
+        *,
+        do_finalize: bool = True,
+        output_dtype: Optional[torch.dtype] = None,
+        all_rank_num_tokens: Optional[List[int]] = None,
+        use_dp_padding: Optional[bool] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        assert do_finalize, "DenseGEMMFusedMoE does not support do_finalize=False"
+
+        is_first_call = self.repeat_idx == 0
+        is_last_call = self.repeat_idx == self.repeat_count - 1
+
+        outputs = self.forward_chunk(
+            x,
+            router_logits,
+            output_dtype,
+            all_rank_num_tokens=all_rank_num_tokens,
+            use_dp_padding=use_dp_padding,
+            repeating_info=(is_first_call, is_last_call),
+        )
+        outputs = self.reducescatter_or_allreduce(
+            outputs,
+            all_rank_num_tokens=all_rank_num_tokens,
+            use_dp_padding=use_dp_padding,
+        )
+
+        if self.use_dp and self.parallel_size > 1:
+            rank = self.parallel_rank
+            outputs = outputs[: all_rank_num_tokens[rank]]
+        self.repeat_idx = 0 if self.repeat_idx == self.repeat_count - 1 else self.repeat_idx + 1
+        return outputs

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Union
 
 import torch
 
+from tensorrt_llm.models.modeling_utils import QuantAlgo
 from tensorrt_llm.quantization.utils import fp4_utils
 
 from ...distributed import allgather
@@ -98,6 +99,40 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
 
     # DenseGEMM only supports SM100 and SM103 (Blackwell CuTe DSL kernels).
     _SUPPORTED_SM_VERSIONS = (100, 103)
+
+    @classmethod
+    def can_implement(
+        cls,
+        quant_algo: Optional[QuantAlgo],
+        dtype_activation: torch.dtype = torch.bfloat16,
+        swiglu_gptoss_style: bool = False,
+    ) -> tuple:
+        """Check if DenseGEMMFusedMoE can implement the given configuration.
+
+        DenseGEMMFusedMoE supports:
+        - NVFP4 quantization only
+        - SM100/SM103 (Blackwell) only
+        - SwiGLU activation only (swiglu_gptoss_style not supported)
+        """
+        from tensorrt_llm._utils import get_sm_version
+
+        from .interface import _warn_and_return
+
+        sm_version = get_sm_version()
+        if sm_version not in cls._SUPPORTED_SM_VERSIONS:
+            return _warn_and_return(
+                f"DenseGEMMFusedMoE requires SM {cls._SUPPORTED_SM_VERSIONS}, got SM{sm_version}"
+            )
+
+        if quant_algo != QuantAlgo.NVFP4:
+            return _warn_and_return(
+                f"DenseGEMMFusedMoE only supports NVFP4 quantization (got quant_algo={quant_algo})"
+            )
+
+        if swiglu_gptoss_style:
+            return _warn_and_return("DenseGEMMFusedMoE does not support swiglu_gptoss_style")
+
+        return (True, None)
 
     def __init__(
         self,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -201,9 +201,9 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             activation_type=activation_type,
         )
 
-        # Environment variable to control fc2_alpha fusion into FC1's alpha_post
-        # Default: enabled (1). Set to "0" to use the original per-token per-expert fc2_alpha in FC2.
-        self.use_fused_fc2_alpha = os.environ.get("TRTLLM_MOE_FUSED_FC2_ALPHA", "1") == "1"
+        # Environment variable to control fc2_alpha fusion into FC1's alpha_post.
+        # Default: disabled (0). Set to "1" to enable fusion (known accuracy issue under TP).
+        self.use_fused_fc2_alpha = os.environ.get("TRTLLM_MOE_FUSED_FC2_ALPHA", "0") == "1"
 
         # Pre-register fc2_alpha_max buffer for fused fc2_alpha optimization.
         # Populated in load_weights() with max(fc2_alpha).

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -96,6 +96,9 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
     # Memory buffer pool for CUDA graph compatibility
     buffers = get_memory_buffers()
 
+    # DenseGEMM only supports SM100 and SM103 (Blackwell CuTe DSL kernels).
+    _SUPPORTED_SM_VERSIONS = (100, 103)
+
     def __init__(
         self,
         *,
@@ -112,7 +115,29 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
         layer_idx: Optional[int] = None,
         init_load_balancer: bool = True,
         without_comm: bool = False,
+        activation_type=None,
     ):
+        # DenseGEMM CuTe DSL kernels only support SM100 and SM103.
+        from tensorrt_llm._utils import get_sm_version
+
+        sm_version = get_sm_version()
+        assert sm_version in self._SUPPORTED_SM_VERSIONS, (
+            f"DenseGEMMFusedMoE only supports SM {self._SUPPORTED_SM_VERSIONS} "
+            f"(got SM {sm_version}). The CuTe DSL kernels require Blackwell architecture."
+        )
+
+        # DenseGEMM kernel hardcodes SwiGLU fusion — reject other activation types
+        # before calling super().__init__() to fail fast with a clear message.
+        from ...utils import ActivationType
+
+        if activation_type is None:
+            activation_type = ActivationType.Swiglu
+        assert activation_type == ActivationType.Swiglu, (
+            f"DenseGEMMFusedMoE only supports SwiGLU activation "
+            f"(got activation_type={activation_type}). "
+            f"The FC1 kernel fuses SwiGLU into the GEMM epilogue."
+        )
+
         # FC2 DenseGEMM kernel tiles K dimension with MMA tile size 256.
         # weight_per_expert (= intermediate_size) must be 256-aligned so that
         # expert boundaries align with MMA tile boundaries.
@@ -138,7 +163,9 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
             layer_idx=layer_idx,
             init_load_balancer=init_load_balancer,
             without_comm=without_comm,
+            activation_type=activation_type,
         )
+
         # Environment variable to control fc2_alpha fusion into FC1's alpha_post
         # Default: enabled (1). Set to "0" to use the original per-token per-expert fc2_alpha in FC2.
         self.use_fused_fc2_alpha = os.environ.get("TRTLLM_MOE_FUSED_FC2_ALPHA", "1") == "1"
@@ -161,9 +188,10 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
     def load_weights(self, weights: List[Dict]):
         super().load_weights(weights)
         # Transpose w2_weight layout: (E, H, ...) -> (H, E, ...) for dense GEMM.
-        # Use contiguous() to materialize the transposed layout, then copy back
-        # into self.w2_weight in-place. This avoids clone() which would double
-        # peak memory for large expert counts.
+        # NOTE: .contiguous() on the transposed view allocates a full-size temporary,
+        # temporarily doubling peak memory.  An in-place multi-dim transpose is not
+        # feasible without complex cycle-following, and this runs only once during
+        # weight loading, so the trade-off is acceptable.
         w2_transposed = self.w2_weight.transpose(0, 1).contiguous()
         self.w2_weight.reshape([-1]).copy_(w2_transposed.reshape([-1]), non_blocking=True)
         del w2_transposed

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -64,8 +64,12 @@ def gen_fc2_alpha_fused(
         output.zero_()
         fc2_alpha = output
     else:
+        assert alpha is not None, (
+            "alpha must be provided when output buffer is not pre-allocated, "
+            "since expert_size cannot be inferred from token_final_scales alone"
+        )
         num_tokens = token_selected_experts.shape[0]
-        expert_size = alpha.shape[0] if alpha is not None else token_final_scales.shape[1]
+        expert_size = alpha.shape[0]
         fc2_alpha = torch.zeros(
             [num_tokens, expert_size],
             dtype=torch.float32,
@@ -156,10 +160,13 @@ class DenseGEMMFusedMoE(CutlassFusedMoE):
 
     def load_weights(self, weights: List[Dict]):
         super().load_weights(weights)
-        w2_weight = self.w2_weight.clone()
-        self.w2_weight.reshape([-1]).copy_(
-            w2_weight.transpose(0, 1).reshape([-1]), non_blocking=True
-        )
+        # Transpose w2_weight layout: (E, H, ...) -> (H, E, ...) for dense GEMM.
+        # Use contiguous() to materialize the transposed layout, then copy back
+        # into self.w2_weight in-place. This avoids clone() which would double
+        # peak memory for large expert counts.
+        w2_transposed = self.w2_weight.transpose(0, 1).contiguous()
+        self.w2_weight.reshape([-1]).copy_(w2_transposed.reshape([-1]), non_blocking=True)
+        del w2_transposed
         if self.has_any_quant:
             if self.has_nvfp4:
                 self._transform_w2_weight_scale_for_min_latency()

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Dict, List, Optional, Union
+
+import torch
+
+from tensorrt_llm.quantization.utils import fp4_utils
+
+from ...distributed import allgather
+from ...memory_buffer_utils import get_memory_buffers
+from ...model_config import ModelConfig
+from ...utils import AuxStreamType, EventType, Fp4QuantizedTensor, swizzle_sf, unswizzle_sf
+from .fused_moe_cutlass import CutlassFusedMoE
+from .interface import AlltoallMethodType
+from .quantization import MoEWeightLoadingMode, NVFP4CuteDslFusedMoEMethod
+from .routing import BaseMoeRoutingMethod
+
+
+@torch.compile(options={"max-autotune": True})
+def gen_fc2_alpha_fused(
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    alpha: Optional[torch.Tensor],
+    alpha_max: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Generate fc2 alpha values, optionally normalized for FC1 alpha_post fusion.
+
+    Instead of:
+        1. zeros() -> scatter_() -> multiply with alpha (operates on large [N, E] tensor)
+
+    We do:
+        1. Gather alpha values for selected experts (small [N, top_k] tensor)
+        2. Multiply scales with gathered alpha (small tensor operation)
+        3. Optionally normalize by alpha_max for FC1 alpha_post fusion
+        4. Scatter to output (single write to large tensor)
+
+    This reduces memory bandwidth by avoiding read-modify-write on the large tensor.
+
+    Args:
+        token_selected_experts: Expert indices for each token [num_tokens, top_k]
+        token_final_scales: Final scaling factors [num_tokens, top_k]
+        alpha: Per-expert alpha values [expert_size]
+        alpha_max: Max alpha value for normalization (optional)
+        output: Pre-allocated output buffer [num_tokens, expert_size] (optional).
+                If None, a new tensor will be allocated (not compatible with CUDA graph).
+    """
+    # Pre-compute scaled values on small tensor [num_tokens, top_k]
+    if alpha is not None:
+        # Gather alpha for selected experts: alpha[expert_idx] for each selection
+        gathered_alpha = alpha[token_selected_experts.long()]  # [num_tokens, top_k]
+        scaled_values = token_final_scales * gathered_alpha
+    else:
+        scaled_values = token_final_scales
+
+    # Normalize by alpha_max for FC1 alpha_post fusion
+    if alpha_max is not None:
+        scaled_values = scaled_values / alpha_max
+
+    # Use pre-allocated output or create new tensor
+    if output is not None:
+        output.zero_()
+        fc2_alpha = output
+    else:
+        num_tokens = token_selected_experts.shape[0]
+        expert_size = alpha.shape[0] if alpha is not None else token_final_scales.shape[1]
+        fc2_alpha = torch.zeros(
+            [num_tokens, expert_size],
+            dtype=torch.float32,
+            device=token_selected_experts.device,
+        )
+
+    return fc2_alpha.scatter_(1, token_selected_experts.long(), scaled_values)
+
+
+class DenseGEMMFusedMoE(CutlassFusedMoE):
+    """CuteDSL flow of fused mixture of experts (MoE) Layer.
+
+    Args:
+        num_experts (int): Number of experts in the MoE layer.
+        top_k (int): Number of top experts to select for each input token.
+        hidden_size (int): Size of the hidden state.
+        intermediate_size (int): Size of the intermediate state.
+        aux_stream_dict (Optional[Dict[AuxStreamType, torch.cuda.Stream]]): Auxiliary CUDA streams for overlapping.
+        dtype (Optional[torch.dtype]): Data type for the weights.
+        reduce_results (bool): Whether to reduce the results across devices.
+        model_config (ModelConfig): Configuration object for the model.
+    """
+
+    # Memory buffer pool for CUDA graph compatibility
+    buffers = get_memory_buffers()
+
+    def __init__(
+        self,
+        *,
+        routing_method: BaseMoeRoutingMethod,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        dtype: Optional[torch.dtype] = None,
+        reduce_results: bool = False,
+        model_config: ModelConfig = ModelConfig(),
+        aux_stream_dict: Optional[Dict[AuxStreamType, torch.cuda.Stream]] = None,
+        weight_loading_mode: MoEWeightLoadingMode = MoEWeightLoadingMode.VANILLA,
+        apply_router_weight_on_input: bool = False,
+        layer_idx: Optional[int] = None,
+        init_load_balancer: bool = True,
+        without_comm: bool = False,
+    ):
+        # FC2 DenseGEMM kernel tiles K dimension with MMA tile size 256.
+        # weight_per_expert (= intermediate_size) must be 256-aligned so that
+        # expert boundaries align with MMA tile boundaries.
+        _MMA_TILE_K = 256
+        assert intermediate_size % _MMA_TILE_K == 0, (
+            f"DenseGEMMFusedMoE requires intermediate_size to be a multiple of "
+            f"{_MMA_TILE_K} (got intermediate_size={intermediate_size}). "
+            f"FC2 kernel cannot correctly split alpha_scale at expert boundaries "
+            f"when weight_per_expert is not MMA tile-K aligned."
+        )
+
+        super().__init__(
+            routing_method=routing_method,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            dtype=dtype,
+            reduce_results=reduce_results,
+            model_config=model_config,
+            aux_stream_dict=aux_stream_dict,
+            weight_loading_mode=weight_loading_mode,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            layer_idx=layer_idx,
+            init_load_balancer=init_load_balancer,
+            without_comm=without_comm,
+        )
+        # Environment variable to control fc2_alpha fusion into FC1's alpha_post
+        # Default: enabled (1). Set to "0" to use the original per-token per-expert fc2_alpha in FC2.
+        self.use_fused_fc2_alpha = os.environ.get("TRTLLM_MOE_FUSED_FC2_ALPHA", "1") == "1"
+
+        # Pre-register fc2_alpha_max buffer for fused fc2_alpha optimization.
+        # Populated in load_weights() with max(fc2_alpha).
+        self.register_buffer("fc2_alpha_max", torch.zeros(1, dtype=torch.float32))
+
+        # Initialize auxiliary stream and events for gen_fc2_alpha_fused overlap with fc1
+        if self.aux_stream_dict is None:
+            self.aux_stream_dict = aux_stream_dict if aux_stream_dict is not None else {}
+        if AuxStreamType.MoeFc2Alpha not in self.aux_stream_dict:
+            self.aux_stream_dict[AuxStreamType.MoeFc2Alpha] = torch.cuda.Stream()
+        if self.event_dict is None:
+            self.event_dict = {}
+        for key in [EventType.Main, EventType.MoeFc2Alpha]:
+            if key not in self.event_dict:
+                self.event_dict[key] = torch.cuda.Event()
+
+    def load_weights(self, weights: List[Dict]):
+        super().load_weights(weights)
+        w2_weight = self.w2_weight.clone()
+        self.w2_weight.reshape([-1]).copy_(
+            w2_weight.transpose(0, 1).reshape([-1]), non_blocking=True
+        )
+        if self.has_any_quant:
+            if self.has_nvfp4:
+                self._transform_w2_weight_scale_for_min_latency()
+                # Compute fc2_alpha_max for fused fc2_alpha optimization
+                self.fc2_alpha_max.copy_(torch.max(self.fc2_alpha).reshape(1), non_blocking=True)
+            else:
+                raise ValueError(
+                    f"{self.__class__.__name__} only supports nvfp4 quantization, "
+                    f"got {self.quant_config.quant_mode}."
+                )
+
+    def _transform_w2_weight_scale_for_min_latency(self):
+        """Transform w2_weight_scale for minimum latency path optimization."""
+        # Calculate padded dimensions
+        nrows = fp4_utils.pad_up(self.hidden_size, 128)
+        ncols = fp4_utils.pad_up(
+            self.intermediate_size_per_partition // self.scaling_vector_size, 4
+        )
+
+        # Clone and convert weight scale to uint8
+        w2_weight_scale = self.w2_weight_scale.clone().view(torch.uint8)
+
+        # Unswizzle the scale factor
+        w2_weight_scale = unswizzle_sf(
+            w2_weight_scale,
+            self.hidden_size * self.expert_size_per_partition,
+            self.intermediate_size_per_partition,
+        )
+
+        # Reshape and transpose for min latency layout
+        w2_weight_scale = w2_weight_scale.reshape([self.expert_size_per_partition, nrows, ncols])
+        w2_weight_scale = w2_weight_scale.transpose(0, 1).reshape(
+            nrows, self.expert_size_per_partition * ncols
+        )
+
+        # Swizzle back with new layout
+        w2_weight_scale = swizzle_sf(
+            w2_weight_scale,
+            self.hidden_size,
+            self.expert_size_per_partition * self.intermediate_size_per_partition,
+        )
+
+        # Copy back to original tensor
+        self.w2_weight_scale.copy_(
+            w2_weight_scale.view(self.w2_weight_scale.dtype).view(self.w2_weight_scale.shape),
+            non_blocking=True,
+        )
+
+    def select_alltoall_method_type(self) -> AlltoallMethodType:
+        return AlltoallMethodType.NotEnabled
+
+    def _get_quant_method(self):
+        if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
+            exclude_kv_cache=True
+        ):
+            if self.quant_config.layer_quant_mode.has_nvfp4():
+                return NVFP4CuteDslFusedMoEMethod()
+        return super()._get_quant_method()
+
+    def quantize_input(
+        self, x: Union[torch.Tensor, Fp4QuantizedTensor], post_quant_comm: bool = True
+    ):
+        """Quantize inputs prior to post-communication (alltoall/allgather) or before MoE computation.
+
+        Args:
+            x: Input tensor to quantize
+            post_quant_comm:
+                If True, quantize for post-quant communication path.
+                If False, quantize for non-communication path
+
+        Returns: (x, x_sf) where x_sf is already reshaped to 2D if needed
+
+        For quantization methods that produce scaling factors:
+        - x_sf is reshaped from 1D to 2D: [num_elements] -> [batch_size, ceil_div(hidden_size, scaling_vector_size)]
+        - The 2D shape is required for proper handling in alltoall/allgather operations
+        - scaling_vector_size is typically the group size for block-wise quantization
+        """
+        x_sf = None
+        if self.has_nvfp4:
+            if isinstance(x, Fp4QuantizedTensor):
+                assert not x.is_sf_swizzled, (
+                    "Fp4QuantizedTensor should not be swizzled before communication"
+                )
+                x_row = x.shape[0]
+                x, x_sf = x.fp4_tensor, x.scaling_factor
+            else:
+                x_row = x.shape[0]
+                x, x_sf = torch.ops.trtllm.fp4_quantize(
+                    x, self.fc31_input_scale, self.scaling_vector_size, False, False
+                )
+        else:
+            raise ValueError(
+                f"{self.__class__.__name__} only supports nvfp4 quantization, "
+                f"got {self.quant_config.quant_mode}."
+            )
+
+        if x_sf is not None:
+            x_sf = x_sf.view(x_row, -1)
+
+        return x, x_sf
+
+    def run_moe_nvfp4(
+        self,
+        x: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: Optional[torch.Tensor],
+        x_sf: Optional[torch.Tensor] = None,
+        enable_alltoall: bool = False,
+    ) -> torch.Tensor:
+        """Run MoE computation with NVFP4 quantization.
+
+        Args:
+            x: Input tensor
+            token_selected_experts: Expert indices for each token
+            token_final_scales: Final scaling factors for each token
+            x_sf: Input scale factors
+            enable_alltoall: Whether alltoall communication is enabled
+
+        Note:
+            The implementation is controlled by TRTLLM_MOE_FUSED_FC2_ALPHA env var (default: enabled).
+            When enabled, fc2_alpha is fused into FC1's alpha_post with scalar fc2_alpha_max in FC2.
+            When disabled, uses the original per-token per-expert fc2_alpha in FC2.
+        """
+        assert self.has_nvfp4
+        num_tokens = x.shape[0]
+
+        # Get pre-allocated buffer for fc2_alpha (CUDA graph compatible)
+        capture_graph = torch.cuda.is_current_stream_capturing()
+        fc2_alpha_buffer = DenseGEMMFusedMoE.buffers.get_buffer(
+            (num_tokens, self.expert_size_per_partition),
+            dtype=torch.float32,
+            buffer_name="fc2_alpha",
+            reserve_buffer=capture_graph,
+        )
+
+        if self.use_fused_fc2_alpha:
+            # New implementation: fuse fc2_alpha into FC1's alpha_post
+            x_sf = swizzle_sf(x_sf, num_tokens, self.hidden_size)
+
+            # Generate normalized fc2_alpha for FC1 alpha_post fusion
+            fc2_alpha_normalized = gen_fc2_alpha_fused(
+                token_selected_experts,
+                token_final_scales,
+                self.fc2_alpha,
+                self.fc2_alpha_max,  # Normalize by max for FC1 alpha_post
+                fc2_alpha_buffer,  # Pre-allocated buffer
+            )
+
+            # FC1: GEMM + SwiGLU with post-SwiGLU alpha scaling (fused fc2_alpha)
+            fc1_output, fc1_output_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_swiglu_blackwell(
+                x,
+                self.w3_w1_weight.view(torch.uint8),
+                x_sf,
+                self.w3_w1_weight_scale,
+                self.fc31_alpha,
+                fc2_alpha_normalized,  # Pass normalized fc2_alpha as alpha_post
+                self.fc2_input_scale,
+                expert_count=self.expert_size_per_partition,
+                weight_per_expert=2 * self.intermediate_size_per_partition,
+                output_dtype=torch.float4_e2m1fn_x2,
+                scaling_vector_size=self.scaling_vector_size,
+            )
+
+            # FC2: Standard nvfp4_gemm with scalar alpha = fc2_alpha_max
+            final_hidden_states = torch.ops.trtllm.nvfp4_gemm(
+                fc1_output.view(torch.uint8),
+                self.w2_weight.view(torch.uint8).reshape(self.hidden_size, -1),
+                fc1_output_sf.view(torch.uint8).reshape(-1),
+                self.w2_weight_scale.view(torch.uint8),
+                self.fc2_alpha_max,
+                torch.bfloat16,
+                to_userbuffers=False,
+                allowed_backends="cutlass,cublaslt,cutedsl,cuda_core",
+            )
+        else:
+            # Original implementation: per-token per-expert fc2_alpha in FC2
+            self.event_dict[EventType.Main].record()
+            x_sf = swizzle_sf(x_sf, num_tokens, self.hidden_size)
+
+            # FC1: GEMM + SwiGLU, output is fp4 quantized
+            fc1_output, fc1_output_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_swiglu_blackwell(
+                x,
+                self.w3_w1_weight.view(torch.uint8),
+                x_sf,
+                self.w3_w1_weight_scale,
+                self.fc31_alpha,
+                None,  # alpha_post: no post-SwiGLU scaling
+                self.fc2_input_scale,
+                expert_count=self.expert_size_per_partition,
+                weight_per_expert=2 * self.intermediate_size_per_partition,
+                output_dtype=torch.float4_e2m1fn_x2,
+                scaling_vector_size=self.scaling_vector_size,
+            )
+
+            with torch.cuda.stream(self.aux_stream_dict[AuxStreamType.MoeFc2Alpha]):
+                self.event_dict[EventType.Main].wait()
+                fc2_alpha = gen_fc2_alpha_fused(
+                    token_selected_experts,
+                    token_final_scales,
+                    self.fc2_alpha,
+                    output=fc2_alpha_buffer,  # Use pre-allocated buffer
+                )
+                self.event_dict[EventType.MoeFc2Alpha].record()
+
+            self.event_dict[EventType.MoeFc2Alpha].wait()
+
+            # FC2: input k = expert_count * intermediate_size (after SwiGLU)
+            final_hidden_states = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_fc2_blackwell(
+                fc1_output,
+                self.w2_weight.view(torch.uint8).reshape(self.hidden_size, -1),
+                fc1_output_sf.reshape(-1),
+                self.w2_weight_scale,
+                fc2_alpha,
+                expert_count=self.expert_size_per_partition,
+                weight_per_expert=self.intermediate_size_per_partition,
+                output_dtype=torch.bfloat16,
+                scaling_vector_size=self.scaling_vector_size,
+            )
+
+        return final_hidden_states
+
+    def run_moe(
+        self,
+        x: torch.Tensor,
+        token_selected_experts: torch.Tensor,
+        token_final_scales: Optional[torch.Tensor],
+        x_sf: Optional[torch.Tensor] = None,
+        enable_alltoall: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Run MoE computation with DenseGEMM backend (NVFP4 only).
+
+        Args:
+            x: Input hidden states (pre-quantized to NVFP4)
+            token_selected_experts: Expert IDs [num_tokens, top_k]. If EPLB is enabled,
+                                    this represents expert slots [num_tokens, top_k] instead.
+            token_final_scales: Final scaling factors for each token
+            x_sf: Input scale factors for NVFP4
+            enable_alltoall: Whether alltoall communication is enabled.
+            **kwargs: Additional arguments for forward compatibility.
+
+        Returns:
+            final_hidden_states tensor.
+        """
+        assert self.has_nvfp4, (
+            f"{self.__class__.__name__} only supports nvfp4 quantization, "
+            f"got {self.quant_config.quant_mode}."
+        )
+        return self.run_moe_nvfp4(
+            x=x,
+            token_selected_experts=token_selected_experts,
+            token_final_scales=token_final_scales,
+            x_sf=x_sf,
+            enable_alltoall=enable_alltoall,
+        )
+
+    def forward_chunk(
+        self,
+        x: Union[torch.Tensor, Fp4QuantizedTensor],
+        router_logits: torch.Tensor,
+        output_dtype: Optional[torch.dtype] = None,
+        all_rank_num_tokens: Optional[List[int]] = None,
+        use_dp_padding: Optional[bool] = None,
+        repeating_info: tuple = (True, True),
+    ) -> torch.Tensor:
+        # Currently, the default path is that ConfigurableMoE calls DenseGEMMFusedMoE.run_moe.
+        # This forward_chunk method is a reference implementation of the legacy path.
+        # Apply routing
+        token_selected_experts, token_final_scales = self.routing_method.apply(router_logits)
+        assert token_selected_experts.shape[1] == self.routing_method.experts_per_token
+        assert token_selected_experts.shape == token_final_scales.shape
+        assert token_selected_experts.shape[0] == router_logits.shape[0]
+        assert token_final_scales.dtype == torch.float32
+        assert token_selected_experts.dtype == torch.int32
+
+        x, x_sf = self.quantize_input(x)
+
+        if self.use_dp and self.parallel_size > 1:
+            x, x_sf, token_selected_experts, token_final_scales = allgather(
+                [x, x_sf, token_selected_experts, token_final_scales],
+                self.mapping,
+                dim=0,
+                sizes=None if use_dp_padding else all_rank_num_tokens,
+            )
+
+        x = self.run_moe(
+            x=x,
+            token_selected_experts=token_selected_experts,
+            token_final_scales=token_final_scales,
+            x_sf=x_sf,
+            enable_alltoall=False,
+        )
+        return x

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -23,6 +23,7 @@ aux_stream_name_list = [
     'MoeChunkingOverlap',
     'MoeBalancer',
     'MoeOutputMemset',
+    'MoeFc2Alpha',
 ]
 AuxStreamType = Enum(
     'AuxStreamType',

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -297,6 +297,16 @@ def get_last_power_of_2_num_tokens_buckets(max_num_tokens) -> List[int]:
     return tuple(num_token_buckets[::-1])
 
 
+def deep_gemm_gen_tuning_buckets(x: int):
+    buckets = tuple(range(8, 128, 8))
+    # Clamp x to be between 4096 and 8192.
+    if x >= 128:
+        x = min(x, 8192)
+        x = max(x, 4096)
+        buckets += tuple(range(128, x, 128))
+    return buckets
+
+
 def fp4_scale_infer_shape(input_shapes: List[List[int]]):
     """Calculate the dimensions of the fp4 scale tensor.
     """

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -482,8 +482,8 @@ class MoeConfig(StrictBaseModel):
     Configuration for MoE.
     """
     backend: Literal[
-        "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM", "VANILLA",
-        "TRITON"] = Field(
+        "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM",
+        "DENSEGEMM", "VANILLA", "TRITON"] = Field(
             default='AUTO',
             description="MoE backend to use. "
             "AUTO selects default backend based on model. It currently doesn\'t always give the best choice for all scenarios. The capabilities of auto selection will be improved in future releases."

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -111,11 +111,13 @@ l0_b200:
   - unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend -k "TRTLLM"
   - unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend -k "CUTEDSL"
   - unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend -k "DEEPGEMM"
+  - unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend -k "DENSEGEMM"
   # ------------- MoE: test_single_gpu (by backend) ---------------
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "CUTLASS"
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "TRTLLM"
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "CUTEDSL"
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "DEEPGEMM"
+  - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "DENSEGEMM"
   # ------------- MoE: FlashInfer & TRTLLM symbol collision tests ---------------
   - unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
   # --- MoE end

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
@@ -1,0 +1,1035 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Example usage of the MoE as Dense GEMM FC1 kernel.
+
+Functional testing:
+python run_moe_as_dense_gemm_fc1.py \
+        --ab_dtype Float4E2M1FN --c_dtype Float16 \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1 \
+        --mnkl 128,65536,256,1 --expert_count 256
+
+Perf testing:
+python run_moe_as_dense_gemm_fc1.py \
+        --ab_dtype Float4E2M1FN --c_dtype Float16 \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1 \
+        --mnkl 128,65536,256,1 --expert_count 256 \
+        --skip_ref_check --use_cold_l2 --warmup_iterations 10 --iterations 50
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+# Import kernel module
+try:
+    from tensorrt_llm._torch.cute_dsl_kernels.blackwell.moe_as_dense_gemm import (
+        fc1 as kernel_module,
+    )
+except (ModuleNotFoundError, ImportError):
+    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    from blackwell.moe_as_dense_gemm import fc1 as kernel_module
+
+Sm100BlockScaledPersistentDenseGemmKernel = kernel_module.Sm100BlockScaledPersistentDenseGemmKernel
+cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
+cvt_sf_M32x4xrm_K4xrk_L_to_MKL = kernel_module.cvt_sf_M32x4xrm_K4xrk_L_to_MKL
+
+# Add parent directory to path to import testing module
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from testing import benchmark  # noqa: E402
+
+
+def create_sf_layout_tensor(l, mn, k, sf_vec_size):  # noqa: E741
+    """Create scale factor tensor in MMA layout for SFC verification.
+
+    :param l: Batch dimension (L)
+    :param mn: M or N dimension
+    :param k: K dimension (for SFC, this is n_out // sf_vec_size)
+    :param sf_vec_size: Vector size for scale factor
+    :return: Tuple of (swizzled_tensor_cpu, ref_shape)
+    """
+
+    def ceil_div(a, b):
+        return (a + b - 1) // b
+
+    sf_k = ceil_div(k, sf_vec_size)
+    ref_shape = (l, mn, sf_k)
+
+    atom_m = (32, 4)
+    atom_k = 4
+    mma_shape = (
+        l,
+        ceil_div(mn, atom_m[0] * atom_m[1]),
+        ceil_div(sf_k, atom_k),
+        atom_m[0],
+        atom_m[1],
+        atom_k,
+    )
+
+    mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+    # Create f32 cute torch tensor (cpu) with MMA layout
+    cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape,
+        torch.float32,
+        permute_order=mma_permute_order,
+        init_type=cutlass_torch.TensorInitType.SCALAR,
+        init_config=cutlass_torch.ScalarInitConfig(value=0.0),
+    )
+
+    return cute_f32_torch_tensor_cpu, ref_shape
+
+
+def run(
+    mnkl: Tuple[int, int, int, int],
+    expert_count: int,
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    use_prefetch: bool = False,
+    prefetch_dist: int = 3,
+    vectorized_f32: bool = True,
+    tolerance: float = 1e-01,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    use_cupti: bool = True,
+    no_alpha_post: bool = False,
+    **kwargs,
+):
+    """Execute a persistent batched dense blockscaled GEMM operation on Blackwell architecture.
+
+    This function prepares input tensors, configures and launches the persistent GEMM kernel,
+    optionally performs reference validation, and benchmarks the execution performance.
+
+    :param mnkl: Problem size (M, N, K, L)
+    :type mnkl: Tuple[int, int, int, int]
+    :param ab_dtype: Data type for input tensors A and B
+    :type ab_dtype: Type[cutlass.Numeric]
+    :param sf_dtype: Data type for scale factor tensor
+    :type sf_dtype: Type[cutlass.Numeric]
+    :param sf_vec_size: Vector size for scale factor tensor
+    :type sf_vec_size: int
+    :param c_dtype: Data type for output tensor C
+    :type c_dtype: Type[cutlass.Numeric]
+    :param a_major/b_major/c_major: Memory layout of tensor A/B/C
+    :type a_major/b_major/c_major: str
+    :param mma_tiler_mn: MMA tiling size.
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster shape.
+    :type cluster_shape_mn: Tuple[int, int]
+    :param tolerance: Tolerance value for reference validation comparison, defaults to 1e-01
+    :type tolerance: float, optional
+    :param warmup_iterations: Number of warmup iterations before benchmarking, defaults to 0
+    :type warmup_iterations: int, optional
+    :param iterations: Number of benchmark iterations to run, defaults to 1
+    :type iterations: int, optional
+    :param skip_ref_check: Whether to skip reference result validation, defaults to False
+    :type skip_ref_check: bool, optional
+    :param use_cold_l2: Whether to use circular buffer strategy to ensure cold L2 cache, defaults to False
+    :type use_cold_l2: bool, optional
+    :raises RuntimeError: If CUDA GPU is not available
+    :raises ValueError: If the configuration is invalid or unsupported by the kernel
+    :return: Execution time of the GEMM kernel
+    :rtype: float
+    """
+    # Unpack parameters
+    m, n, k, l = mnkl  # noqa: E741
+
+    # Compute weight_per_expert from n and expert_count
+    weight_per_expert = n // expert_count
+
+    print("Running Sm100 Persistent Dense BlockScaled GEMM with SwiGLU fusion test with:")
+    print(f"mnkl: {mnkl}")
+    print(f"AB dtype: {ab_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}")
+    print(f"C dtype: {c_dtype}")
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, C: {c_major}")
+    print(f"Mma Tiler (M, N): {mma_tiler_mn}, Cluster Shape (M, N): {cluster_shape_mn}")
+    print(f"Expert count: {expert_count}")
+    print(f"Weight per expert (n // expert_count): {weight_per_expert}")
+    print(f"Use prefetch: {'True' if use_prefetch else 'False'}")
+    print(f"Prefetch dist: {prefetch_dist}")
+    print(f"Vectorized f32: {'True' if vectorized_f32 else 'False'}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
+    print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+    print(f"No alpha post: {'True' if no_alpha_post else 'False'}")
+
+    # Skip unsupported testcase
+    if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        m,
+        n,
+        k,
+        l,
+        a_major,
+        b_major,
+        c_major,
+        expert_count,
+        weight_per_expert,
+    ):
+        raise TypeError(
+            f"Unsupported testcase {ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
+            f"{mma_tiler_mn}, {cluster_shape_mn}, {m}, {n}, {k}, {l}, "
+            f"{a_major}, {b_major}, {c_major}, {expert_count}, {weight_per_expert}"
+        )
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    torch.manual_seed(1111)
+
+    # Create tensor A/B/C
+    # Note: C has n//2 columns due to SwiGLU fusion (pairs of up/gate columns are combined)
+    a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
+    b_ref = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    c_ref = cutlass_torch.matrix(l, m, n // 2, c_major == "m", cutlass.Float32)
+
+    a_tensor, a_torch = cutlass_torch.cute_tensor_like(
+        a_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch = cutlass_torch.cute_tensor_like(
+        b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(
+        c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor with element divisibility for 16B alignment
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    c_tensor.mark_compact_shape_dynamic(
+        mode=1 if c_major == "n" else 0,
+        stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    # Create scale factor tensor SFA/SFB
+    def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
+        def ceil_div(a, b):
+            return (a + b - 1) // b
+
+        sf_k = ceil_div(k, sf_vec_size)
+        ref_shape = (l, mn, sf_k)
+
+        atom_m = (32, 4)
+        atom_k = 4
+        mma_shape = (
+            l,
+            ceil_div(mn, atom_m[0] * atom_m[1]),
+            ceil_div(sf_k, atom_k),
+            atom_m[0],
+            atom_m[1],
+            atom_k,
+        )
+
+        ref_permute_order = (1, 2, 0)
+        mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+        # Create f32 ref torch tensor (cpu)
+        ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            ref_shape,
+            torch.float32,
+            permute_order=ref_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=1,
+                max_val=2,  # Reduced from 3 to 2 to reduce overflow risk
+            ),
+        )
+
+        # Create f32 cute torch tensor (cpu)
+        cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            mma_shape,
+            torch.float32,
+            permute_order=mma_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=0,
+                max_val=1,
+            ),
+        )
+
+        # convert ref f32 tensor to cute f32 tensor
+        cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+            from_dlpack(ref_f32_torch_tensor_cpu),
+            from_dlpack(cute_f32_torch_tensor_cpu),
+        )
+        cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+        # reshape makes memory contiguous
+        ref_f32_torch_tensor_cpu = (
+            ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+            .unsqueeze(-1)
+            .expand(l, mn, sf_k, sf_vec_size)
+            .reshape(l, mn, sf_k * sf_vec_size)
+            .permute(*ref_permute_order)
+        )
+        # prune to mkl for reference check.
+        ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+        # Create dtype cute torch tensor (cpu)
+        cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+            cute_f32_torch_tensor_cpu,
+            dtype,
+            is_dynamic_layout=True,
+            assumed_align=16,
+        )
+
+        # Convert f32 cute tensor to dtype cute tensor
+        cute_tensor = cutlass_torch.convert_cute_tensor(
+            cute_f32_torch_tensor,
+            cute_tensor,
+            dtype,
+            is_dynamic_layout=True,
+        )
+        return ref_f32_torch_tensor_cpu, cute_tensor, cute_torch_tensor
+
+    sfa_ref, sfa_tensor, sfa_torch = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+    sfb_ref, sfb_tensor, sfb_torch = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+
+    # Create scale factor tensor alpha_scale_tensor
+    # Alpha scale is indexed by N dimension (not M) since we don't swap A/B
+    def create_alpha_scale_tensor(l, expert_count, weight_per_expert):  # noqa: E741
+        ref_shape = (l, expert_count)
+        ref_permute_order = (1, 0)
+
+        # Create f32 ref torch tensor (cpu)
+        ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            ref_shape,
+            torch.float32,
+            permute_order=ref_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=-2,
+                max_val=2,
+            ),
+            # init_type=cutlass_torch.TensorInitType.SCALAR,
+            # init_config=cutlass_torch.ScalarInitConfig(
+            #     value=1.0,
+            # ),
+        )
+
+        # Create cute alpha_scale_tensor
+        cute_alpha_scale_tensor, cute_alpha_scale_torch_tensor = cutlass_torch.cute_tensor_like(
+            ref_f32_torch_tensor_cpu,
+            cutlass.Float32,
+            is_dynamic_layout=True,
+            assumed_align=4,
+        )
+
+        # Expand to (n, l) for einsum "mnl,nl->mnl" (alpha indexed by N dimension)
+        # n = expert_count * weight_per_expert
+        ref_f32_torch_tensor_cpu = (
+            ref_f32_torch_tensor_cpu.permute(1, 0)
+            .unsqueeze(-1)
+            .expand(l, expert_count, weight_per_expert)
+            .reshape(l, expert_count * weight_per_expert)
+            .permute(*ref_permute_order)
+        )
+
+        return (
+            ref_f32_torch_tensor_cpu,
+            cute_alpha_scale_tensor,
+            cute_alpha_scale_torch_tensor,
+        )
+
+    alpha_scale_ref, alpha_scale_tensor, alpha_scale_torch = create_alpha_scale_tensor(
+        l, expert_count, weight_per_expert
+    )
+
+    # Create post-SwiGLU alpha scale tensor
+    # Shape: (m, expert_count, l) for per-token per-expert scaling
+    def create_alpha_scale_post_swiglu_tensor(l, m, expert_count, weight_per_expert):  # noqa: E741
+        """Create alpha scale tensor to apply after SwiGLU.
+
+        Post-SwiGLU alpha has shape (m, expert_count, l) for per-token per-expert scaling.
+        This provides fine-grained control over each token's contribution to each expert.
+
+        Args:
+            l: batch size
+            m: sequence length (number of tokens)
+            expert_count: number of experts
+            weight_per_expert: weights per expert in input (before SwiGLU)
+
+        Returns:
+            tuple: (ref_tensor_expanded, cute_tensor, torch_tensor)
+                - ref_tensor_expanded: (m, n_out, l) for reference check
+                - cute_tensor: (m, expert_count, l) for kernel input
+                - torch_tensor: backing torch tensor
+        """
+        weight_per_expert_out = weight_per_expert // 2
+        n_out = expert_count * weight_per_expert_out
+
+        # Create tensor with shape (m, expert_count, l) in contiguous memory order
+        # This matches the convention of other tensors (L as last dimension)
+        ref_shape = (m, expert_count, l)
+
+        # Create f32 tensor directly without permutation
+        # Use positive range [0.8, 1.2] to minimize numerical variation while still testing functionality
+        ref_f32_torch_tensor_cpu = torch.rand(ref_shape, dtype=torch.float32) * 0.4 + 0.8
+
+        # Create cute alpha_scale_tensor with shape (m, expert_count, l)
+        cute_alpha_scale_tensor, cute_alpha_scale_torch_tensor = cutlass_torch.cute_tensor_like(
+            ref_f32_torch_tensor_cpu,
+            cutlass.Float32,
+            is_dynamic_layout=True,
+            assumed_align=4,
+        )
+
+        # Expand to (m, n_out, l) for reference computation
+        # Each expert's alpha (per token) is repeated for weight_per_expert_out elements
+        # Input: (m, expert_count, l)
+        # Need to expand to (m, n_out, l) where n_out = expert_count * weight_per_expert_out
+        ref_expanded = (
+            ref_f32_torch_tensor_cpu.unsqueeze(2)  # (m, expert_count, 1, l)
+            .expand(m, expert_count, weight_per_expert_out, l)  # (m, expert_count, wpe_out, l)
+            .reshape(m, n_out, l)  # (m, n_out, l)
+        )
+
+        return (
+            ref_expanded,
+            cute_alpha_scale_tensor,
+            cute_alpha_scale_torch_tensor,
+        )
+
+    # Create alpha_scale_post tensor (optional, disabled when no_alpha_post=True)
+    alpha_scale_post_ref = None
+    alpha_scale_post_tensor = None
+    alpha_scale_post_torch = None
+    if not no_alpha_post:
+        alpha_scale_post_ref, alpha_scale_post_tensor, alpha_scale_post_torch = (
+            create_alpha_scale_post_swiglu_tensor(l, m, expert_count, weight_per_expert)
+        )
+
+        # Debug: print alpha statistics
+        print(f"Alpha post shape: {alpha_scale_post_torch.shape}")
+        print(
+            f"Alpha post min: {alpha_scale_post_torch.min().item():.4f}, max: {alpha_scale_post_torch.max().item():.4f}"
+        )
+        print(f"Alpha post mean: {alpha_scale_post_torch.mean().item():.4f}")
+        print(f"Alpha post with abs < 0.1: {(alpha_scale_post_torch.abs() < 0.1).sum().item()}")
+    else:
+        print("Alpha post: disabled (no_alpha_post=True)")
+
+    # Create SFC tensor and norm_const tensor for FP4 quantized output
+    # SFC (Scale Factor C) is used to store per-block scale factors for FP4 quantization
+    generate_sfc = c_dtype is cutlass.Float4E2M1FN
+    sfc_tensor = None
+    sfc_torch = None
+    norm_const_tensor = None
+    norm_const = 1.0
+
+    print(f"FP4 quantization with SFC: {'True' if generate_sfc else 'False'}")
+
+    if generate_sfc:
+        # SFC shape: (m, n_out // sf_vec_size, l) where n_out = n // 2 due to SwiGLU
+        # SFC tensor needs to be created with swizzled MMA layout (same as SFA/SFB)
+        n_out = n // 2
+
+        # Create SFC tensor with swizzled MMA layout using create_sf_layout_tensor
+        # This creates tensor with ref_shape (l, m, sfc_n) in MMA swizzled layout
+        sfc_swizzled_cpu, _ = create_sf_layout_tensor(l, m, n_out, sf_vec_size)
+        sfc_tensor, sfc_torch = cutlass_torch.cute_tensor_like(
+            sfc_swizzled_cpu, sf_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+
+        # Create norm_const tensor (scalar tensor containing normalization constant)
+        norm_const_ref = torch.tensor([norm_const], dtype=torch.float32)
+        norm_const_tensor, _ = cutlass_torch.cute_tensor_like(
+            norm_const_ref, cutlass.Float32, is_dynamic_layout=True, assumed_align=4
+        )
+
+    # Configure gemm kernel with SwiGLU fusion
+    gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        sf_vec_size,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        weight_per_expert,
+        use_prefetch,
+        prefetch_dist,
+        vectorized_f32,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+
+    # Initialize Stream
+    current_stream = cutlass_torch.default_stream()
+
+    # Compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        alpha_scale_tensor,
+        alpha_scale_post_tensor,  # Post-SwiGLU alpha: (l, m, expert_count)
+        c_tensor,
+        sfc_tensor,  # SFC tensor for FP4 quantized output (None if not quantizing)
+        norm_const_tensor,  # Normalization constant tensor (None if not quantizing)
+        max_active_clusters,
+        current_stream,
+    )
+
+    # Compute reference result
+    if not skip_ref_check:
+        # Execute kernel once for reference checking
+        compiled_gemm(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            alpha_scale_tensor,
+            alpha_scale_post_tensor,  # Post-SwiGLU alpha: (l, m, expert_count)
+            c_tensor,
+            sfc_tensor,  # SFC tensor for FP4 quantized output
+            norm_const_tensor,  # Normalization constant tensor
+            current_stream,
+        )
+        print("Verifying results...")
+        res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
+        res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
+        ref = torch.einsum("mkl,nkl->mnl", res_a, res_b)
+        # Alpha scale indexed by N dimension (not M) since we don't swap A/B
+        ref = torch.einsum("mnl,nl->mnl", ref, alpha_scale_ref)
+
+        # Apply SwiGLU fusion: output = up * silu(gate)
+        # up and gate are interleaved in the N dimension (granularity=64)
+        # Extract up (even subtiles) and gate (odd subtiles)
+        # ref shape is (m, n, l), we need to reshape to extract up and gate
+        # Assuming interleaving at granularity 64
+        granularity = 64
+        ref_reshaped = ref.view(m, n // granularity, granularity, l)
+        ref_up = ref_reshaped[:, 0::2, :, :].contiguous().view(m, n // 2, l)
+        ref_gate = ref_reshaped[:, 1::2, :, :].contiguous().view(m, n // 2, l)
+
+        # silu(x) = x * sigmoid(x)
+        ref = ref_up * (ref_gate * torch.sigmoid(ref_gate))
+        # Now ref shape: (m, n_out, l) where n_out = n // 2
+
+        # Apply post-SwiGLU alpha scale (optional)
+        # Alpha is per-token per-expert: (m, n_out, l) * (m, n_out, l)
+        if alpha_scale_post_ref is not None:
+            ref = ref * alpha_scale_post_ref
+
+        # Convert c back to f32 for comparison.
+        c_ref_device = c_ref.cuda()
+        cute.testing.convert(
+            c_tensor,
+            from_dlpack(c_ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=(1 if c_major == "n" else 0)
+            ),
+        )
+        c_ref = c_ref_device.cpu()
+
+        # Note: n_out = n // 2 due to SwiGLU fusion
+        n_out = n // 2
+        if c_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(l, m, n_out), dtype=torch.uint8, device="cuda").permute(1, 2, 0)
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f8.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        # {$nv-internal-release begin}
+        elif c_dtype is cutlass.Float4E2M1FN:
+            # FP4 quantization with SFC (Scale Factor C) verification
+            # Reference: run_blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
+
+            def ceil_div(a, b):
+                return (a + b - 1) // b
+
+            def simulate_f8_quantization(tensor_f32: torch.Tensor, f8_dtype) -> torch.Tensor:
+                """Simulate f8 quantization: fp32 -> f8 -> fp32.
+
+                This models the precision loss when storing scale factors in f8 format.
+
+                :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, num_groups)
+                :param f8_dtype: Target f8 dtype (e.g., cutlass.Float8E4M3FN)
+                :return: Tensor after f32 -> f8 -> f32 round-trip (on CPU)
+                """
+                shape = tensor_f32.shape
+                # Create f8 tensor on GPU
+                f8_torch = torch.empty(*shape, dtype=torch.uint8, device="cuda")
+                f8_tensor = from_dlpack(f8_torch, assumed_align=16).mark_layout_dynamic(
+                    leading_dim=1
+                )
+                f8_tensor.element_type = f8_dtype
+                # Create f32 tensor on GPU
+                f32_device = tensor_f32.cuda()
+                f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(
+                    leading_dim=1
+                )
+                # f32 -> f8 -> f32
+                cute.testing.convert(f32_tensor, f8_tensor)
+                cute.testing.convert(f8_tensor, f32_tensor)
+                return f32_device.cpu()
+
+            def simulate_nvfp4_quantization(tensor_f32: torch.Tensor) -> torch.Tensor:
+                """Simulate nvfp4 quantization: fp32 -> nvfp4 -> fp32.
+
+                This models the precision loss when storing output in nvfp4 format.
+
+                :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, ng)
+                :return: Tensor after f32 -> nvfp4 -> f32 round-trip (on CPU)
+                """
+                m_dim, n_dim, ng = tensor_f32.shape
+                # Create properly packed nvfp4 tensor using cutlass_torch utilities
+                ref_f32_torch = cutlass_torch.matrix(ng, m_dim, n_dim, False, cutlass.Float32)
+                f4_tensor, _ = cutlass_torch.cute_tensor_like(
+                    ref_f32_torch, cutlass.Float4E2M1FN, is_dynamic_layout=True, assumed_align=16
+                )
+                # Create f32 tensor on GPU
+                f32_device = tensor_f32.cuda()
+                f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(
+                    leading_dim=1
+                )
+                # f32 -> f4 -> f32
+                cute.testing.convert(f32_tensor, f4_tensor)
+                cute.testing.convert(f4_tensor, f32_tensor)
+                return f32_device.cpu()
+
+            def compute_scale_factor(
+                tensor_f32: torch.Tensor,
+                sf_vec_size_local: int,
+                norm_const_local: float,
+                rcp_limits: float,
+            ) -> torch.Tensor:
+                """Compute scale factor for nvfp4 quantization.
+
+                Scale factor = abs_max_per_vector * norm_const * rcp_limits
+
+                :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
+                :param sf_vec_size_local: Vector size for scale factor (e.g., 16)
+                :param norm_const_local: Normalization constant
+                :param rcp_limits: Reciprocal of dtype max value (e.g., 1/6.0 for nvfp4)
+                :return: Scale factor tensor, shape (m, sfn, ng) where sfn = ceil(n / sf_vec_size)
+                """
+                m_dim, n_dim, ng = tensor_f32.shape
+                sfn = ceil_div(n_dim, sf_vec_size_local)
+                # Reshape to (m, sfn, sf_vec_size, ng) for abs max computation
+                # Pad n dimension if needed
+                padded_n = sfn * sf_vec_size_local
+                if padded_n > n_dim:
+                    tensor_padded = torch.zeros(m_dim, padded_n, ng, dtype=tensor_f32.dtype)
+                    tensor_padded[:, :n_dim, :] = tensor_f32
+                else:
+                    tensor_padded = tensor_f32
+                tensor_reshaped = tensor_padded.view(m_dim, sfn, sf_vec_size_local, ng)
+                # Compute abs max over sf_vec_size dimension
+                abs_max, _ = torch.abs(tensor_reshaped).max(dim=2)  # (m, sfn, ng)
+                # Compute scale factor
+                scale_factor = abs_max * norm_const_local * rcp_limits
+                return scale_factor
+
+            def apply_quantization_scale(
+                tensor_f32: torch.Tensor,
+                scale_factor: torch.Tensor,
+                sf_vec_size_local: int,
+                norm_const_local: float,
+            ) -> torch.Tensor:
+                """Apply quantization scale to tensor.
+
+                Output = tensor * (norm_const / scale_factor).
+                This simulates the kernel's quantization scaling.
+
+                :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
+                :param scale_factor: Scale factor tensor, shape (m, sfn, ng)
+                :param sf_vec_size_local: Vector size for scale factor
+                :param norm_const_local: Normalization constant
+                :return: Scaled tensor, shape (m, n, ng)
+                """
+                m_dim, n_dim, ng = tensor_f32.shape
+                sfn = scale_factor.shape[1]
+                # Compute reciprocal scale, clamping inf to fp32_max (matching kernel fmin behavior)
+                fp32_max = torch.tensor(3.40282346638528859812e38, dtype=torch.float32)
+                scale_rcp = norm_const_local * scale_factor.reciprocal()
+                scale_rcp = torch.where(torch.isinf(scale_rcp), fp32_max, scale_rcp)
+                # Expand scale factor to match tensor dimensions
+                # (m, sfn, ng) -> (m, sfn, sf_vec_size, ng) -> (m, sfn * sf_vec_size, ng)
+                scale_rcp_expanded = scale_rcp.unsqueeze(2).expand(
+                    m_dim, sfn, sf_vec_size_local, ng
+                )
+                scale_rcp_expanded = scale_rcp_expanded.reshape(m_dim, sfn * sf_vec_size_local, ng)
+                # Trim to exact n dimension
+                scale_rcp_expanded = scale_rcp_expanded[:, :n_dim, :]
+                # Apply scale
+                return tensor_f32 * scale_rcp_expanded
+
+            def unswizzle_kernel_sfc(
+                sfc_cute_tensor,
+                m_dim: int,
+                n_dim: int,
+                sf_vec_size_local: int,
+                l_dim: int,
+            ) -> torch.Tensor:
+                """Unswizzle kernel's scale factor tensor from MMA layout to MKL layout.
+
+                :param sfc_cute_tensor: Kernel's scale factor cute tensor (swizzled MMA layout)
+                :param m_dim: M dimension
+                :param n_dim: Output N dimension (n_out)
+                :param sf_vec_size_local: Vector size for scale factor
+                :param l_dim: L dimension (batch)
+                :return: Unswizzled scale factor tensor, shape (m, sfn, l)
+                """
+                sfn = ceil_div(n_dim, sf_vec_size_local)
+
+                # Create swizzled layout tensor matching kernel's SFC layout
+                swizzled_sfc_cpu, _ = create_sf_layout_tensor(
+                    l_dim, m_dim, n_dim, sf_vec_size_local
+                )
+                swizzled_sfc_tensor, swizzled_sfc_torch = cutlass_torch.cute_tensor_like(
+                    swizzled_sfc_cpu, cutlass.Float32, is_dynamic_layout=True, assumed_align=16
+                )
+
+                # Copy kernel SFC (sf_dtype) to swizzled layout tensor (Float32)
+                cute.testing.convert(sfc_cute_tensor, swizzled_sfc_tensor)
+                swizzled_sfc_cpu = swizzled_sfc_torch.cpu()
+
+                # Unswizzle: MMA layout -> MKL layout (m, sfn, l)
+                unswizzled_sfc = torch.empty(m_dim, sfn, l_dim, dtype=torch.float32)
+                cvt_sf_M32x4xrm_K4xrk_L_to_MKL(
+                    from_dlpack(swizzled_sfc_cpu),
+                    from_dlpack(unswizzled_sfc),
+                )
+
+                return unswizzled_sfc
+
+            # ============================================================
+            # Step 1: Compute reference scale factor (SFC) from SwiGLU output
+            # ============================================================
+            rcp_limits = gemm.get_dtype_rcp_limits(c_dtype)
+
+            # Compute reference SFC: abs_max * norm_const * rcp_limits
+            ref_sfc_before_f8 = compute_scale_factor(ref, sf_vec_size, norm_const, rcp_limits)
+            # Simulate f8 quantization for SFC (kernel stores SFC in sf_dtype format)
+            ref_sfc_f32 = simulate_f8_quantization(ref_sfc_before_f8, sf_dtype)
+
+            # ============================================================
+            # Step 2: Verify kernel SFC matches reference SFC (using pass rate)
+            # ============================================================
+            if sfc_tensor is not None:
+                kernel_sfc = unswizzle_kernel_sfc(sfc_tensor, m, n_out, sf_vec_size, l)
+
+                sfc_diff = torch.abs(ref_sfc_f32 - kernel_sfc)
+                sfc_within_tolerance = (sfc_diff <= tolerance) | (
+                    sfc_diff <= torch.abs(ref_sfc_f32) * 1e-02
+                )
+                sfc_pass_rate = sfc_within_tolerance.float().mean().item()
+                print(f"SFC Tensor pass rate: {sfc_pass_rate * 100:.2f}%")
+
+            # ============================================================
+            # Step 3: Apply quantization scale and simulate nvfp4 precision loss
+            # ============================================================
+            # Apply scale: ref_scaled = ref * (norm_const / sfc)
+            ref_scaled = apply_quantization_scale(ref, ref_sfc_f32, sf_vec_size, norm_const)
+            # Simulate nvfp4 quantization: f32 -> nvfp4 -> f32
+            ref_quantized = simulate_nvfp4_quantization(ref_scaled)
+
+            # ============================================================
+            # Step 4: Compare kernel output with reference (using pass rate)
+            # ============================================================
+            print("Verifying C Tensor...")
+            diff = torch.abs(c_ref - ref_quantized)
+            within_tolerance = (diff <= tolerance) | (diff <= torch.abs(ref_quantized) * 1e-02)
+            pass_rate = within_tolerance.float().mean().item()
+            print(f"C Tensor pass rate: {pass_rate * 100:.2f}% (threshold: 95%)")
+            assert pass_rate >= 0.95, (
+                f"Only {pass_rate * 100:.2f}% elements within tolerance, expected >= 95%"
+            )
+        # {$nv-internal-release end}
+
+    def generate_tensors():
+        a_tensor, _ = cutlass_torch.cute_tensor_like(
+            a_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        b_tensor, _ = cutlass_torch.cute_tensor_like(
+            b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        c_tensor, _ = cutlass_torch.cute_tensor_like(
+            c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+
+        # Mark tensor to be byte aligned
+        a_tensor.mark_compact_shape_dynamic(
+            mode=1 if a_major == "k" else 0,
+            stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+            divisibility=2 if ab_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        b_tensor.mark_compact_shape_dynamic(
+            mode=1 if b_major == "k" else 0,
+            stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+            divisibility=2 if ab_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        c_tensor.mark_compact_shape_dynamic(
+            mode=1 if c_major == "n" else 0,
+            stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+            divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+        )
+
+        _, sfa_tensor, _ = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+        _, sfb_tensor, _ = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+        _, alpha_scale_tensor, _ = create_alpha_scale_tensor(l, expert_count, weight_per_expert)
+        gen_alpha_scale_post_tensor = None
+        if not no_alpha_post:
+            _, gen_alpha_scale_post_tensor, _ = create_alpha_scale_post_swiglu_tensor(
+                l, m, expert_count, weight_per_expert
+            )
+
+        # Create SFC tensor and norm_const tensor for FP4 quantized output
+        gen_sfc_tensor = None
+        gen_norm_const_tensor = None
+        if generate_sfc:
+            n_out = n // 2
+            # Create SFC tensor with swizzled MMA layout
+            sfc_swizzled_cpu_gen, _ = create_sf_layout_tensor(l, m, n_out, sf_vec_size)
+            gen_sfc_tensor, _ = cutlass_torch.cute_tensor_like(
+                sfc_swizzled_cpu_gen, sf_dtype, is_dynamic_layout=True, assumed_align=16
+            )
+            norm_const_ref_gen = torch.tensor([norm_const], dtype=torch.float32)
+            gen_norm_const_tensor, _ = cutlass_torch.cute_tensor_like(
+                norm_const_ref_gen, cutlass.Float32, is_dynamic_layout=True, assumed_align=4
+            )
+
+        return cute.testing.JitArguments(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            alpha_scale_tensor,
+            gen_alpha_scale_post_tensor,  # Post-SwiGLU alpha: (l, m, expert_count) or None
+            c_tensor,
+            gen_sfc_tensor,  # SFC tensor for FP4 quantized output
+            gen_norm_const_tensor,  # Normalization constant tensor
+            current_stream,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_torch.numel() * a_torch.element_size()
+            + b_torch.numel() * b_torch.element_size()
+            + sfa_torch.numel() * sfa_torch.element_size()
+            + sfb_torch.numel() * sfb_torch.element_size()
+            + alpha_scale_torch.numel() * alpha_scale_torch.element_size()
+            + (
+                alpha_scale_post_torch.numel() * alpha_scale_post_torch.element_size()
+                if alpha_scale_post_torch is not None
+                else 0
+            )
+            + c_torch.numel() * c_torch.element_size()
+        )
+        if sfc_torch is not None:
+            one_workspace_bytes += sfc_torch.numel() * sfc_torch.element_size()
+        workspace_count = cute.testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        use_cupti=use_cupti,
+    )
+
+    return exec_time  # Return execution time in microseconds
+
+
+if __name__ == "__main__":
+
+    def parse_comma_separated_ints(s: str) -> Tuple[int, ...]:
+        try:
+            return tuple(int(x.strip()) for x in s.split(","))
+        except ValueError:
+            raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.")
+
+    parser = argparse.ArgumentParser(
+        description="Example of Sm100 Dense Persistent BlockScaled GEMM with SwiGLU fusion."
+    )
+
+    parser.add_argument(
+        "--mnkl",
+        type=parse_comma_separated_ints,
+        default=(512, 256, 256, 1),
+        help="mnkl dimensions (comma-separated)",
+    )
+    parser.add_argument(
+        "--expert_count",  # should be 256 or 257 normally
+        type=int,
+        default=257,
+        help="expert count",
+    )
+    parser.add_argument(
+        "--use_prefetch",
+        action="store_true",
+        default=False,
+        help="Enable prefetch operations (default: False)",
+    )
+    parser.add_argument(
+        "--prefetch_dist",
+        type=int,
+        default=7,
+        help="Prefetch distance for TMA operations (default: 3)",
+    )
+    parser.add_argument(
+        "--vectorized_f32",
+        action="store_true",
+        default=True,
+        help="Enable vectorized f32x2 operations for better performance (default: True)",
+    )
+    parser.add_argument(
+        "--mma_tiler_mn",
+        type=parse_comma_separated_ints,
+        default=(128, 128),
+        help="Mma tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=parse_comma_separated_ints,
+        default=(1, 1),
+        help="Cluster shape (comma-separated)",
+    )
+    parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
+    parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float8E4M3FN)
+    parser.add_argument("--sf_vec_size", type=int, default=16)
+    parser.add_argument("--c_dtype", type=cutlass.dtype, default=cutlass.Float16)
+    parser.add_argument("--a_major", choices=["k", "m"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k", "n"], type=str, default="k")
+    parser.add_argument("--c_major", choices=["n", "m"], type=str, default="n")
+    parser.add_argument("--tolerance", type=float, default=1e-01, help="Tolerance for validation")
+    parser.add_argument("--warmup_iterations", type=int, default=10, help="Warmup iterations")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=50,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
+    parser.add_argument(
+        "--use_cold_l2",
+        action="store_true",
+        default=False,
+        help="Use circular buffer tensor sets to ensure L2 cold cache",
+    )
+    parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=True,
+        help="Use CUPTI for profiling (default: True)",
+    )
+    parser.add_argument(
+        "--no_alpha_post",
+        action="store_true",
+        default=False,
+        help="Disable post-SwiGLU alpha scaling (alpha_post=None)",
+    )
+
+    args = parser.parse_args()
+
+    if len(args.mnkl) != 4:
+        parser.error("--mnkl must contain exactly 4 values")
+
+    if len(args.mma_tiler_mn) != 2:
+        parser.error("--mma_tiler_mn must contain exactly 2 values")
+
+    if len(args.cluster_shape_mn) != 2:
+        parser.error("--cluster_shape_mn must contain exactly 2 values")
+
+    exec_time = run(
+        args.mnkl,
+        args.expert_count,
+        args.ab_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.c_dtype,
+        args.a_major,
+        args.b_major,
+        args.c_major,
+        args.mma_tiler_mn,
+        args.cluster_shape_mn,
+        args.use_prefetch,
+        args.prefetch_dist,
+        args.vectorized_f32,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+        args.use_cupti,
+        args.no_alpha_post,
+    )
+    print(f"Execution time: {exec_time:.2f} us")
+    print("PASS")

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
@@ -61,7 +61,7 @@ try:
         fc1 as kernel_module,
     )
 except (ModuleNotFoundError, ImportError):
-    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    sys.path.insert(0, str(Path(__file__).parents[4] / "tensorrt_llm/_torch/cute_dsl_kernels"))
     from blackwell.moe_as_dense_gemm import fc1 as kernel_module
 
 Sm100BlockScaledPersistentDenseGemmKernel = kernel_module.Sm100BlockScaledPersistentDenseGemmKernel
@@ -71,6 +71,146 @@ cvt_sf_M32x4xrm_K4xrk_L_to_MKL = kernel_module.cvt_sf_M32x4xrm_K4xrk_L_to_MKL
 # Add parent directory to path to import testing module
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from testing import benchmark  # noqa: E402
+
+# Fixed random seed for reproducible tensor initialization.
+DEFAULT_RANDOM_SEED = 1111
+
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def simulate_f8_quantization(tensor_f32: torch.Tensor, f8_dtype) -> torch.Tensor:
+    """Simulate f8 quantization: fp32 -> f8 -> fp32.
+
+    This models the precision loss when storing scale factors in f8 format.
+
+    :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, num_groups)
+    :param f8_dtype: Target f8 dtype (e.g., cutlass.Float8E4M3FN)
+    :return: Tensor after f32 -> f8 -> f32 round-trip (on CPU)
+    """
+    shape = tensor_f32.shape
+    f8_torch = torch.empty(*shape, dtype=torch.uint8, device="cuda")
+    f8_tensor = from_dlpack(f8_torch, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+    f8_tensor.element_type = f8_dtype
+    f32_device = tensor_f32.cuda()
+    f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+    cute.testing.convert(f32_tensor, f8_tensor)
+    cute.testing.convert(f8_tensor, f32_tensor)
+    return f32_device.cpu()
+
+
+def simulate_nvfp4_quantization(tensor_f32: torch.Tensor) -> torch.Tensor:
+    """Simulate nvfp4 quantization: fp32 -> nvfp4 -> fp32.
+
+    This models the precision loss when storing output in nvfp4 format.
+
+    :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, ng)
+    :return: Tensor after f32 -> nvfp4 -> f32 round-trip (on CPU)
+    """
+    m_dim, n_dim, ng = tensor_f32.shape
+    ref_f32_torch = cutlass_torch.matrix(ng, m_dim, n_dim, False, cutlass.Float32)
+    f4_tensor, _ = cutlass_torch.cute_tensor_like(
+        ref_f32_torch, cutlass.Float4E2M1FN, is_dynamic_layout=True, assumed_align=16
+    )
+    f32_device = tensor_f32.cuda()
+    f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+    cute.testing.convert(f32_tensor, f4_tensor)
+    cute.testing.convert(f4_tensor, f32_tensor)
+    return f32_device.cpu()
+
+
+def compute_scale_factor(
+    tensor_f32: torch.Tensor,
+    sf_vec_size_local: int,
+    norm_const_local: float,
+    rcp_limits: float,
+) -> torch.Tensor:
+    """Compute scale factor for nvfp4 quantization.
+
+    Scale factor = abs_max_per_vector * norm_const * rcp_limits
+
+    :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
+    :param sf_vec_size_local: Vector size for scale factor (e.g., 16)
+    :param norm_const_local: Normalization constant
+    :param rcp_limits: Reciprocal of dtype max value (e.g., 1/6.0 for nvfp4)
+    :return: Scale factor tensor, shape (m, sfn, ng) where sfn = ceil(n / sf_vec_size)
+    """
+    m_dim, n_dim, ng = tensor_f32.shape
+    sfn = ceil_div(n_dim, sf_vec_size_local)
+    padded_n = sfn * sf_vec_size_local
+    if padded_n > n_dim:
+        tensor_padded = torch.zeros(m_dim, padded_n, ng, dtype=tensor_f32.dtype)
+        tensor_padded[:, :n_dim, :] = tensor_f32
+    else:
+        tensor_padded = tensor_f32
+    tensor_reshaped = tensor_padded.view(m_dim, sfn, sf_vec_size_local, ng)
+    abs_max, _ = torch.abs(tensor_reshaped).max(dim=2)
+    scale_factor = abs_max * norm_const_local * rcp_limits
+    return scale_factor
+
+
+def apply_quantization_scale(
+    tensor_f32: torch.Tensor,
+    scale_factor: torch.Tensor,
+    sf_vec_size_local: int,
+    norm_const_local: float,
+) -> torch.Tensor:
+    """Apply quantization scale to tensor.
+
+    Output = tensor * (norm_const / scale_factor).
+    This simulates the kernel's quantization scaling.
+
+    :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
+    :param scale_factor: Scale factor tensor, shape (m, sfn, ng)
+    :param sf_vec_size_local: Vector size for scale factor
+    :param norm_const_local: Normalization constant
+    :return: Scaled tensor, shape (m, n, ng)
+    """
+    m_dim, n_dim, ng = tensor_f32.shape
+    sfn = scale_factor.shape[1]
+    fp32_max = torch.tensor(3.40282346638528859812e38, dtype=torch.float32)
+    scale_rcp = norm_const_local * scale_factor.reciprocal()
+    scale_rcp = torch.where(torch.isinf(scale_rcp), fp32_max, scale_rcp)
+    scale_rcp_expanded = scale_rcp.unsqueeze(2).expand(m_dim, sfn, sf_vec_size_local, ng)
+    scale_rcp_expanded = scale_rcp_expanded.reshape(m_dim, sfn * sf_vec_size_local, ng)
+    scale_rcp_expanded = scale_rcp_expanded[:, :n_dim, :]
+    return tensor_f32 * scale_rcp_expanded
+
+
+def unswizzle_kernel_sfc(
+    sfc_cute_tensor,
+    m_dim: int,
+    n_dim: int,
+    sf_vec_size_local: int,
+    l_dim: int,
+) -> torch.Tensor:
+    """Unswizzle kernel's scale factor tensor from MMA layout to MKL layout.
+
+    :param sfc_cute_tensor: Kernel's scale factor cute tensor (swizzled MMA layout)
+    :param m_dim: M dimension
+    :param n_dim: Output N dimension (n_out)
+    :param sf_vec_size_local: Vector size for scale factor
+    :param l_dim: L dimension (batch)
+    :return: Unswizzled scale factor tensor, shape (m, sfn, l)
+    """
+    sfn = ceil_div(n_dim, sf_vec_size_local)
+
+    swizzled_sfc_cpu, _ = create_sf_layout_tensor(l_dim, m_dim, n_dim, sf_vec_size_local)
+    swizzled_sfc_tensor, swizzled_sfc_torch = cutlass_torch.cute_tensor_like(
+        swizzled_sfc_cpu, cutlass.Float32, is_dynamic_layout=True, assumed_align=16
+    )
+
+    cute.testing.convert(sfc_cute_tensor, swizzled_sfc_tensor)
+    swizzled_sfc_cpu = swizzled_sfc_torch.cpu()
+
+    unswizzled_sfc = torch.empty(m_dim, sfn, l_dim, dtype=torch.float32)
+    cvt_sf_M32x4xrm_K4xrk_L_to_MKL(
+        from_dlpack(swizzled_sfc_cpu),
+        from_dlpack(unswizzled_sfc),
+    )
+
+    return unswizzled_sfc
 
 
 def create_sf_layout_tensor(l, mn, k, sf_vec_size):  # noqa: E741
@@ -82,10 +222,6 @@ def create_sf_layout_tensor(l, mn, k, sf_vec_size):  # noqa: E741
     :param sf_vec_size: Vector size for scale factor
     :return: Tuple of (swizzled_tensor_cpu, ref_shape)
     """
-
-    def ceil_div(a, b):
-        return (a + b - 1) // b
-
     sf_k = ceil_div(k, sf_vec_size)
     ref_shape = (l, mn, sf_k)
 
@@ -226,7 +362,7 @@ def run(
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
-    torch.manual_seed(1111)
+    torch.manual_seed(DEFAULT_RANDOM_SEED)
 
     # Create tensor A/B/C
     # Note: C has n//2 columns due to SwiGLU fusion (pairs of up/gate columns are combined)
@@ -263,9 +399,6 @@ def run(
 
     # Create scale factor tensor SFA/SFB
     def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
-        def ceil_div(a, b):
-            return (a + b - 1) // b
-
         sf_k = ceil_div(k, sf_vec_size)
         ref_shape = (l, mn, sf_k)
 
@@ -604,165 +737,6 @@ def run(
         elif c_dtype is cutlass.Float4E2M1FN:
             # FP4 quantization with SFC (Scale Factor C) verification
             # Reference: run_blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
-
-            def ceil_div(a, b):
-                return (a + b - 1) // b
-
-            def simulate_f8_quantization(tensor_f32: torch.Tensor, f8_dtype) -> torch.Tensor:
-                """Simulate f8 quantization: fp32 -> f8 -> fp32.
-
-                This models the precision loss when storing scale factors in f8 format.
-
-                :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, num_groups)
-                :param f8_dtype: Target f8 dtype (e.g., cutlass.Float8E4M3FN)
-                :return: Tensor after f32 -> f8 -> f32 round-trip (on CPU)
-                """
-                shape = tensor_f32.shape
-                # Create f8 tensor on GPU
-                f8_torch = torch.empty(*shape, dtype=torch.uint8, device="cuda")
-                f8_tensor = from_dlpack(f8_torch, assumed_align=16).mark_layout_dynamic(
-                    leading_dim=1
-                )
-                f8_tensor.element_type = f8_dtype
-                # Create f32 tensor on GPU
-                f32_device = tensor_f32.cuda()
-                f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(
-                    leading_dim=1
-                )
-                # f32 -> f8 -> f32
-                cute.testing.convert(f32_tensor, f8_tensor)
-                cute.testing.convert(f8_tensor, f32_tensor)
-                return f32_device.cpu()
-
-            def simulate_nvfp4_quantization(tensor_f32: torch.Tensor) -> torch.Tensor:
-                """Simulate nvfp4 quantization: fp32 -> nvfp4 -> fp32.
-
-                This models the precision loss when storing output in nvfp4 format.
-
-                :param tensor_f32: Input fp32 tensor (on CPU), shape (m, n, ng)
-                :return: Tensor after f32 -> nvfp4 -> f32 round-trip (on CPU)
-                """
-                m_dim, n_dim, ng = tensor_f32.shape
-                # Create properly packed nvfp4 tensor using cutlass_torch utilities
-                ref_f32_torch = cutlass_torch.matrix(ng, m_dim, n_dim, False, cutlass.Float32)
-                f4_tensor, _ = cutlass_torch.cute_tensor_like(
-                    ref_f32_torch, cutlass.Float4E2M1FN, is_dynamic_layout=True, assumed_align=16
-                )
-                # Create f32 tensor on GPU
-                f32_device = tensor_f32.cuda()
-                f32_tensor = from_dlpack(f32_device, assumed_align=16).mark_layout_dynamic(
-                    leading_dim=1
-                )
-                # f32 -> f4 -> f32
-                cute.testing.convert(f32_tensor, f4_tensor)
-                cute.testing.convert(f4_tensor, f32_tensor)
-                return f32_device.cpu()
-
-            def compute_scale_factor(
-                tensor_f32: torch.Tensor,
-                sf_vec_size_local: int,
-                norm_const_local: float,
-                rcp_limits: float,
-            ) -> torch.Tensor:
-                """Compute scale factor for nvfp4 quantization.
-
-                Scale factor = abs_max_per_vector * norm_const * rcp_limits
-
-                :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
-                :param sf_vec_size_local: Vector size for scale factor (e.g., 16)
-                :param norm_const_local: Normalization constant
-                :param rcp_limits: Reciprocal of dtype max value (e.g., 1/6.0 for nvfp4)
-                :return: Scale factor tensor, shape (m, sfn, ng) where sfn = ceil(n / sf_vec_size)
-                """
-                m_dim, n_dim, ng = tensor_f32.shape
-                sfn = ceil_div(n_dim, sf_vec_size_local)
-                # Reshape to (m, sfn, sf_vec_size, ng) for abs max computation
-                # Pad n dimension if needed
-                padded_n = sfn * sf_vec_size_local
-                if padded_n > n_dim:
-                    tensor_padded = torch.zeros(m_dim, padded_n, ng, dtype=tensor_f32.dtype)
-                    tensor_padded[:, :n_dim, :] = tensor_f32
-                else:
-                    tensor_padded = tensor_f32
-                tensor_reshaped = tensor_padded.view(m_dim, sfn, sf_vec_size_local, ng)
-                # Compute abs max over sf_vec_size dimension
-                abs_max, _ = torch.abs(tensor_reshaped).max(dim=2)  # (m, sfn, ng)
-                # Compute scale factor
-                scale_factor = abs_max * norm_const_local * rcp_limits
-                return scale_factor
-
-            def apply_quantization_scale(
-                tensor_f32: torch.Tensor,
-                scale_factor: torch.Tensor,
-                sf_vec_size_local: int,
-                norm_const_local: float,
-            ) -> torch.Tensor:
-                """Apply quantization scale to tensor.
-
-                Output = tensor * (norm_const / scale_factor).
-                This simulates the kernel's quantization scaling.
-
-                :param tensor_f32: Input fp32 tensor, shape (m, n, ng)
-                :param scale_factor: Scale factor tensor, shape (m, sfn, ng)
-                :param sf_vec_size_local: Vector size for scale factor
-                :param norm_const_local: Normalization constant
-                :return: Scaled tensor, shape (m, n, ng)
-                """
-                m_dim, n_dim, ng = tensor_f32.shape
-                sfn = scale_factor.shape[1]
-                # Compute reciprocal scale, clamping inf to fp32_max (matching kernel fmin behavior)
-                fp32_max = torch.tensor(3.40282346638528859812e38, dtype=torch.float32)
-                scale_rcp = norm_const_local * scale_factor.reciprocal()
-                scale_rcp = torch.where(torch.isinf(scale_rcp), fp32_max, scale_rcp)
-                # Expand scale factor to match tensor dimensions
-                # (m, sfn, ng) -> (m, sfn, sf_vec_size, ng) -> (m, sfn * sf_vec_size, ng)
-                scale_rcp_expanded = scale_rcp.unsqueeze(2).expand(
-                    m_dim, sfn, sf_vec_size_local, ng
-                )
-                scale_rcp_expanded = scale_rcp_expanded.reshape(m_dim, sfn * sf_vec_size_local, ng)
-                # Trim to exact n dimension
-                scale_rcp_expanded = scale_rcp_expanded[:, :n_dim, :]
-                # Apply scale
-                return tensor_f32 * scale_rcp_expanded
-
-            def unswizzle_kernel_sfc(
-                sfc_cute_tensor,
-                m_dim: int,
-                n_dim: int,
-                sf_vec_size_local: int,
-                l_dim: int,
-            ) -> torch.Tensor:
-                """Unswizzle kernel's scale factor tensor from MMA layout to MKL layout.
-
-                :param sfc_cute_tensor: Kernel's scale factor cute tensor (swizzled MMA layout)
-                :param m_dim: M dimension
-                :param n_dim: Output N dimension (n_out)
-                :param sf_vec_size_local: Vector size for scale factor
-                :param l_dim: L dimension (batch)
-                :return: Unswizzled scale factor tensor, shape (m, sfn, l)
-                """
-                sfn = ceil_div(n_dim, sf_vec_size_local)
-
-                # Create swizzled layout tensor matching kernel's SFC layout
-                swizzled_sfc_cpu, _ = create_sf_layout_tensor(
-                    l_dim, m_dim, n_dim, sf_vec_size_local
-                )
-                swizzled_sfc_tensor, swizzled_sfc_torch = cutlass_torch.cute_tensor_like(
-                    swizzled_sfc_cpu, cutlass.Float32, is_dynamic_layout=True, assumed_align=16
-                )
-
-                # Copy kernel SFC (sf_dtype) to swizzled layout tensor (Float32)
-                cute.testing.convert(sfc_cute_tensor, swizzled_sfc_tensor)
-                swizzled_sfc_cpu = swizzled_sfc_torch.cpu()
-
-                # Unswizzle: MMA layout -> MKL layout (m, sfn, l)
-                unswizzled_sfc = torch.empty(m_dim, sfn, l_dim, dtype=torch.float32)
-                cvt_sf_M32x4xrm_K4xrk_L_to_MKL(
-                    from_dlpack(swizzled_sfc_cpu),
-                    from_dlpack(unswizzled_sfc),
-                )
-
-                return unswizzled_sfc
 
             # ============================================================
             # Step 1: Compute reference scale factor (SFC) from SwiGLU output

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc1.py
@@ -601,7 +601,6 @@ def run(
             cute.testing.convert(ref_f8, ref_tensor)
             ref = ref_device.cpu()
             torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
-        # {$nv-internal-release begin}
         elif c_dtype is cutlass.Float4E2M1FN:
             # FP4 quantization with SFC (Scale Factor C) verification
             # Reference: run_blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
@@ -807,7 +806,6 @@ def run(
             assert pass_rate >= 0.95, (
                 f"Only {pass_rate * 100:.2f}% elements within tolerance, expected >= 95%"
             )
-        # {$nv-internal-release end}
 
     def generate_tensors():
         a_tensor, _ = cutlass_torch.cute_tensor_like(

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -1,0 +1,609 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Example usage of the MoE as Dense GEMM FC2 kernel.
+
+Functional testing:
+python run_moe_as_dense_gemm_fc2.py \
+        --ab_dtype Float4E2M1FN --c_dtype Float16 \
+        --sf_dtype Float8E8M0FNU --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1 \
+        --mnkl 512,256,256,1 --expert_count 256
+
+Perf testing:
+python run_moe_as_dense_gemm_fc2.py \
+        --ab_dtype Float4E2M1FN --c_dtype Float16 \
+        --sf_dtype Float8E8M0FNU --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1 \
+        --mnkl 512,256,256,1 --expert_count 256 \
+        --skip_ref_check --use_cold_l2 --warmup_iterations 10 --iterations 50
+
+Note: weight_per_expert is automatically computed as k // expert_count.
+      Ensure k is divisible by expert_count.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+# Import kernel module
+try:
+    from tensorrt_llm._torch.cute_dsl_kernels.blackwell.moe_as_dense_gemm import (
+        fc2 as kernel_module,
+    )
+except (ModuleNotFoundError, ImportError):
+    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    from blackwell.moe_as_dense_gemm import fc2 as kernel_module
+
+Sm100BlockScaledPersistentDenseGemmKernel = kernel_module.Sm100BlockScaledPersistentDenseGemmKernel
+cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
+
+# Add parent directory to path to import testing module
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from testing import benchmark  # noqa: E402
+
+
+def run(
+    mnkl: Tuple[int, int, int, int],
+    expert_count: int,
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    use_prefetch: bool = False,
+    prefetch_dist: int = 3,
+    tolerance: float = 1e-01,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    use_cupti: bool = True,
+    **kwargs,
+):
+    """Execute a persistent batched dense blockscaled GEMM operation on Blackwell architecture.
+
+    This function prepares input tensors, configures and launches the persistent GEMM kernel,
+    optionally performs reference validation, and benchmarks the execution performance.
+
+    :param mnkl: Problem size (M, N, K, L)
+    :type mnkl: Tuple[int, int, int, int]
+    :param ab_dtype: Data type for input tensors A and B
+    :type ab_dtype: Type[cutlass.Numeric]
+    :param sf_dtype: Data type for scale factor tensor
+    :type sf_dtype: Type[cutlass.Numeric]
+    :param sf_vec_size: Vector size for scale factor tensor
+    :type sf_vec_size: int
+    :param c_dtype: Data type for output tensor C
+    :type c_dtype: Type[cutlass.Numeric]
+    :param a_major/b_major/c_major: Memory layout of tensor A/B/C
+    :type a_major/b_major/c_major: str
+    :param mma_tiler_mn: MMA tiling size.
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster shape.
+    :type cluster_shape_mn: Tuple[int, int]
+    :param tolerance: Tolerance value for reference validation comparison, defaults to 1e-01
+    :type tolerance: float, optional
+    :param warmup_iterations: Number of warmup iterations before benchmarking, defaults to 0
+    :type warmup_iterations: int, optional
+    :param iterations: Number of benchmark iterations to run, defaults to 1
+    :type iterations: int, optional
+    :param skip_ref_check: Whether to skip reference result validation, defaults to False
+    :type skip_ref_check: bool, optional
+    :param use_cold_l2: Whether to use circular buffer strategy to ensure cold L2 cache, defaults to False
+    :type use_cold_l2: bool, optional
+    :raises RuntimeError: If CUDA GPU is not available
+    :raises ValueError: If the configuration is invalid or unsupported by the kernel
+    :return: Execution time of the GEMM kernel
+    :rtype: float
+    """
+    # Unpack parameters
+    m, n, k, l = mnkl  # noqa: E741
+
+    # Compute weight_per_expert from k and expert_count
+    if k % expert_count != 0:
+        raise ValueError(f"k ({k}) must be divisible by expert_count ({expert_count})")
+    weight_per_expert = k // expert_count
+
+    print("Running Sm100 Persistent Dense BlockScaled GEMM test with:")
+    print(f"mnkl: {mnkl}")
+    print(f"AB dtype: {ab_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}")
+    print(f"C dtype: {c_dtype}")
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, C: {c_major}")
+    print(f"Mma Tiler (M, N): {mma_tiler_mn}, Cluster Shape (M, N): {cluster_shape_mn}")
+    print(f"Expert count: {expert_count}")
+    print(f"Weight per expert (k // expert_count): {weight_per_expert}")
+    print(f"Use prefetch: {'True' if use_prefetch else 'False'}")
+    print(f"Prefetch dist: {prefetch_dist}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
+    print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+
+    # Skip unsupported testcase
+    if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        m,
+        n,
+        k,
+        l,
+        a_major,
+        b_major,
+        c_major,
+        expert_count,
+        weight_per_expert,
+    ):
+        raise TypeError(
+            f"Unsupported testcase {ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
+            f"{mma_tiler_mn}, {cluster_shape_mn}, {m}, {n}, {k}, {l}, "
+            f"{a_major}, {b_major}, {c_major}, {expert_count}, {weight_per_expert}"
+        )
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    torch.manual_seed(1111)
+
+    # Create tensor A/B/C
+    a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
+    b_ref = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    c_ref = cutlass_torch.matrix(l, m, n, c_major == "m", cutlass.Float32)
+
+    a_tensor, a_torch = cutlass_torch.cute_tensor_like(
+        a_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch = cutlass_torch.cute_tensor_like(
+        b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(
+        c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor with element divisibility for 16B alignment
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+    c_tensor.mark_compact_shape_dynamic(
+        mode=1 if c_major == "n" else 0,
+        stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+    )
+
+    # Create scale factor tensor SFA/SFB
+    def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
+        def ceil_div(a, b):
+            return (a + b - 1) // b
+
+        sf_k = ceil_div(k, sf_vec_size)
+        ref_shape = (l, mn, sf_k)
+
+        atom_m = (32, 4)
+        atom_k = 4
+        mma_shape = (
+            l,
+            ceil_div(mn, atom_m[0] * atom_m[1]),
+            ceil_div(sf_k, atom_k),
+            atom_m[0],
+            atom_m[1],
+            atom_k,
+        )
+
+        ref_permute_order = (1, 2, 0)
+        mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+        # Create f32 ref torch tensor (cpu)
+        ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            ref_shape,
+            torch.float32,
+            permute_order=ref_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=1,
+                max_val=3,
+            ),
+        )
+
+        # Create f32 cute torch tensor (cpu)
+        cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            mma_shape,
+            torch.float32,
+            permute_order=mma_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=0,
+                max_val=1,
+            ),
+        )
+
+        # convert ref f32 tensor to cute f32 tensor
+        cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+            from_dlpack(ref_f32_torch_tensor_cpu),
+            from_dlpack(cute_f32_torch_tensor_cpu),
+        )
+        cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+        # reshape makes memory contiguous
+        ref_f32_torch_tensor_cpu = (
+            ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+            .unsqueeze(-1)
+            .expand(l, mn, sf_k, sf_vec_size)
+            .reshape(l, mn, sf_k * sf_vec_size)
+            .permute(*ref_permute_order)
+        )
+        # prune to mkl for reference check.
+        ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+        # Create dtype cute torch tensor (cpu)
+        cute_tensor, cute_torch_tensor = cutlass_torch.cute_tensor_like(
+            cute_f32_torch_tensor_cpu,
+            dtype,
+            is_dynamic_layout=True,
+            assumed_align=16,
+        )
+
+        # Convert f32 cute tensor to dtype cute tensor
+        cute_tensor = cutlass_torch.convert_cute_tensor(
+            cute_f32_torch_tensor,
+            cute_tensor,
+            dtype,
+            is_dynamic_layout=True,
+        )
+        return ref_f32_torch_tensor_cpu, cute_tensor, cute_torch_tensor
+
+    sfa_ref, sfa_tensor, sfa_torch = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+    sfb_ref, sfb_tensor, sfb_torch = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+
+    # Additional Alpha scale tensor
+    def create_alpha_scale_tensor(l, m, n, expert_count, dtype):  # noqa: E741
+        ### if not swapAB
+        # True means alpha_scale is expert_count major.
+        alpha_scale_ref = cutlass_torch.matrix(
+            l,
+            m,
+            expert_count,
+            False,  # expert_count is major
+            cutlass.Float32,
+            # Debug alpha scale data
+            # init_type=cutlass_torch.TensorInitType.SCALAR,
+            # init_config=cutlass_torch.ScalarInitConfig(value=1),
+        )
+        # currently we assume alpha_scale is n major, which means token major and 4B aligned, should be 4B aligned.
+        alpha_scale_tensor, alpha_scale_torch = cutlass_torch.cute_tensor_like(
+            alpha_scale_ref, cutlass.Float32, is_dynamic_layout=True, assumed_align=4
+        )
+        # print(f"alpha_scale_ref: {alpha_scale_ref.shape}")
+        # reshape makes memory contiguous for reference check.
+        alpha_scale_ref = (
+            alpha_scale_ref.permute(2, 0, 1)
+            .unsqueeze(-1)
+            .expand(l, m, expert_count, weight_per_expert)
+            .reshape(l, m, expert_count * weight_per_expert)
+            .permute((1, 2, 0))
+        )
+
+        return alpha_scale_ref, alpha_scale_tensor, alpha_scale_torch
+
+    alpha_scale_ref, alpha_scale_tensor, alpha_scale_torch = create_alpha_scale_tensor(
+        l, m, n, expert_count, cutlass.Float32
+    )
+
+    # Configure gemm kernel
+    gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        sf_vec_size,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        expert_count,
+        weight_per_expert,
+        use_prefetch,
+        prefetch_dist,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+
+    # Initialize Stream
+    current_stream = cutlass_torch.default_stream()
+
+    # Compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        alpha_scale_tensor,
+        c_tensor,
+        max_active_clusters,
+        current_stream,
+    )
+
+    # Compute reference result
+    if not skip_ref_check:
+        # Execute kernel once for reference checking
+        compiled_gemm(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            alpha_scale_tensor,
+            c_tensor,
+            current_stream,
+        )
+        print("Verifying results...")
+        res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
+        res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
+        # Final reference result is the product of res_a, res_b and alpha_scale_ref.
+        ref = torch.einsum("mkl,nkl,mkl->mnl", res_a, res_b, alpha_scale_ref)
+
+        # Convert c back to f32 for comparison.
+        c_ref_device = c_ref.cuda()
+        cute.testing.convert(
+            c_tensor,
+            from_dlpack(c_ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=(1 if c_major == "n" else 0)
+            ),
+        )
+        c_ref = c_ref_device.cpu()
+
+        if c_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(1, 2, 0)
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f8.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        # {$nv-internal-release begin}
+        elif c_dtype is cutlass.Float4E2M1FN:
+            # Convert ref : f32 -> f4 -> f32
+            ref_f4_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(1, 2, 0)
+            ref_f4 = from_dlpack(ref_f4_, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+            ref_f4.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f4)
+            cute.testing.convert(ref_f4, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        # {$nv-internal-release end}
+
+    def generate_tensors():
+        a_tensor, _ = cutlass_torch.cute_tensor_like(
+            a_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        b_tensor, _ = cutlass_torch.cute_tensor_like(
+            b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        c_tensor, _ = cutlass_torch.cute_tensor_like(
+            c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+
+        # Mark tensor to be byte aligned
+        a_tensor.mark_compact_shape_dynamic(
+            mode=1 if a_major == "k" else 0,
+            stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+            divisibility=2 if ab_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        b_tensor.mark_compact_shape_dynamic(
+            mode=1 if b_major == "k" else 0,
+            stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+            divisibility=2 if ab_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        c_tensor.mark_compact_shape_dynamic(
+            mode=1 if c_major == "n" else 0,
+            stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+            divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+        )
+
+        _, sfa_tensor, _ = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+        _, sfb_tensor, _ = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+        _, alpha_scale_tensor, _ = create_alpha_scale_tensor(l, m, n, expert_count, cutlass.Float32)
+        return cute.testing.JitArguments(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            alpha_scale_tensor,
+            c_tensor,
+            current_stream,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_torch.numel() * a_torch.element_size()
+            + b_torch.numel() * b_torch.element_size()
+            + sfa_torch.numel() * sfa_torch.element_size()
+            + sfb_torch.numel() * sfb_torch.element_size()
+            + alpha_scale_torch.numel() * alpha_scale_torch.element_size()
+            + c_torch.numel() * c_torch.element_size()
+        )
+        workspace_count = cute.testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        use_cupti=use_cupti,
+    )
+
+    return exec_time  # Return execution time in microseconds
+
+
+if __name__ == "__main__":
+
+    def parse_comma_separated_ints(s: str) -> Tuple[int, ...]:
+        try:
+            return tuple(int(x.strip()) for x in s.split(","))
+        except ValueError:
+            raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.")
+
+    parser = argparse.ArgumentParser(
+        description="Example of Sm100 Dense Persistent BlockScaled GEMM."
+    )
+
+    parser.add_argument(
+        "--mnkl",
+        type=parse_comma_separated_ints,
+        default=(512, 256, 256, 1),
+        help="mnkl dimensions (comma-separated)",
+    )
+    parser.add_argument(
+        "--expert_count",
+        type=int,
+        default=256,
+        help="Expert count (k must be divisible by expert_count)",
+    )
+    parser.add_argument(
+        "--use_prefetch",
+        action="store_true",
+        default=False,
+        help="Enable prefetch operations (default: False)",
+    )
+    parser.add_argument(
+        "--prefetch_dist",
+        type=int,
+        default=7,
+        help="Prefetch distance for TMA operations (default: 3)",
+    )
+    parser.add_argument(
+        "--mma_tiler_mn",
+        type=parse_comma_separated_ints,
+        default=(128, 128),
+        help="Mma tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=parse_comma_separated_ints,
+        default=(1, 1),
+        help="Cluster shape (comma-separated)",
+    )
+    parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
+    parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float8E8M0FNU)
+    parser.add_argument("--sf_vec_size", type=int, default=16)
+    parser.add_argument("--c_dtype", type=cutlass.dtype, default=cutlass.Float16)
+    parser.add_argument("--a_major", choices=["k", "m"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k", "n"], type=str, default="k")
+    parser.add_argument("--c_major", choices=["n", "m"], type=str, default="n")
+    parser.add_argument("--tolerance", type=float, default=1e-01, help="Tolerance for validation")
+    parser.add_argument("--warmup_iterations", type=int, default=10, help="Warmup iterations")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=50,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
+    parser.add_argument(
+        "--use_cold_l2",
+        action="store_true",
+        default=False,
+        help="Use circular buffer tensor sets to ensure L2 cold cache",
+    )
+    parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=True,
+        help="Use CUPTI for profiling (default: True)",
+    )
+    args = parser.parse_args()
+
+    if len(args.mnkl) != 4:
+        parser.error("--mnkl must contain exactly 4 values")
+
+    if len(args.mma_tiler_mn) != 2:
+        parser.error("--mma_tiler_mn must contain exactly 2 values")
+
+    if len(args.cluster_shape_mn) != 2:
+        parser.error("--cluster_shape_mn must contain exactly 2 values")
+
+    exec_time = run(
+        args.mnkl,
+        args.expert_count,
+        args.ab_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.c_dtype,
+        args.a_major,
+        args.b_major,
+        args.c_major,
+        args.mma_tiler_mn,
+        args.cluster_shape_mn,
+        args.use_prefetch,
+        args.prefetch_dist,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+        args.use_cupti,
+    )
+    print(f"Execution time: {exec_time:.2f} us")
+    print("PASS")

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -413,7 +413,6 @@ def run(
             cute.testing.convert(ref_f8, ref_tensor)
             ref = ref_device.cpu()
             torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
-        # {$nv-internal-release begin}
         elif c_dtype is cutlass.Float4E2M1FN:
             # Convert ref : f32 -> f4 -> f32
             ref_f4_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(1, 2, 0)
@@ -427,7 +426,6 @@ def run(
             cute.testing.convert(ref_f4, ref_tensor)
             ref = ref_device.cpu()
             torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
-        # {$nv-internal-release end}
 
     def generate_tensors():
         a_tensor, _ = cutlass_torch.cute_tensor_like(

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -64,7 +64,7 @@ try:
         fc2 as kernel_module,
     )
 except (ModuleNotFoundError, ImportError):
-    sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
+    sys.path.insert(0, str(Path(__file__).parents[4] / "tensorrt_llm/_torch/cute_dsl_kernels"))
     from blackwell.moe_as_dense_gemm import fc2 as kernel_module
 
 Sm100BlockScaledPersistentDenseGemmKernel = kernel_module.Sm100BlockScaledPersistentDenseGemmKernel
@@ -73,6 +73,13 @@ cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
 # Add parent directory to path to import testing module
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from testing import benchmark  # noqa: E402
+
+# Fixed random seed for reproducible tensor initialization.
+DEFAULT_RANDOM_SEED = 1111
+
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
 
 
 def run(
@@ -185,7 +192,7 @@ def run(
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
-    torch.manual_seed(1111)
+    torch.manual_seed(DEFAULT_RANDOM_SEED)
 
     # Create tensor A/B/C
     a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
@@ -221,9 +228,6 @@ def run(
 
     # Create scale factor tensor SFA/SFB
     def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):  # noqa: E741
-        def ceil_div(a, b):
-            return (a + b - 1) // b
-
         sf_k = ceil_div(k, sf_vec_size)
         ref_shape = (l, mn, sf_k)
 

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -540,6 +540,9 @@ def should_skip_densegemm(
     backend_type: MoeBackendType,
     quant_algo: Optional[QuantAlgo] = None,
     model_config: "MoeModelConfig" = None,
+    comm_method: Optional[str] = None,
+    moe_tp_size: int = 1,
+    parallel_mode: Optional[str] = None,
 ) -> Optional[str]:
     """
     Check DenseGEMM backend specific constraints.
@@ -550,8 +553,9 @@ def should_skip_densegemm(
     Constraints:
     - Only NVFP4 quantization
     - hidden_size and intermediate_size must be 128-aligned (NVFP4 requirement)
-    - top_k must be >= 2 (fc2_alpha scatter requires multiple expert selections)
-    - num_experts must be > top_k
+    - intermediate_size must be 256-aligned (MMA tile K boundary)
+    - DenseGEMM supports TP (DTP/TTP) but not EP (DEP/TEP) since all experts
+      must reside on a single GPU for the dense matrix formulation.
 
     Returns:
         Skip reason string if test should be skipped, None otherwise
@@ -563,25 +567,45 @@ def should_skip_densegemm(
     if quant_algo != QuantAlgo.NVFP4:
         return f"DenseGEMMFusedMoE only supports NVFP4 quantization (got quant_algo={quant_algo})"
 
+    # DenseGEMM does not support EP modes (DEP/TEP). All experts must reside
+    # on the same GPU for the dense matrix formulation. TP modes (DTP/TTP) are
+    # supported since they shard intermediate_size, not experts.
+    if parallel_mode in ("DEP", "TEP"):
+        return (
+            f"DenseGEMMFusedMoE does not support expert parallelism "
+            f"(got parallel_mode={parallel_mode}). All experts must reside on a single GPU."
+        )
+
+    # DenseGEMM does not support DeepEP communication.
+    if comm_method in ("DEEPEP", "DEEPEPLOWLATENCY"):
+        return (
+            f"DenseGEMMFusedMoE does not support EP communication (got comm_method={comm_method})."
+        )
+
     if model_config is not None:
         hidden_size = model_config.hidden_size
         intermediate_size = model_config.intermediate_size
 
+        # In TP mode, intermediate_size is sharded across moe_tp_size GPUs
+        sharded_intermediate = intermediate_size // moe_tp_size
+
         # 128-alignment required for NVFP4 dense GEMM kernels
-        if hidden_size % 128 != 0 or intermediate_size % 128 != 0:
+        if hidden_size % 128 != 0 or sharded_intermediate % 128 != 0:
             return (
                 f"DenseGEMMFusedMoE NVFP4 requires 128-aligned sizes "
-                f"(got h={hidden_size}, i={intermediate_size})"
+                f"(got h={hidden_size}, i={sharded_intermediate} "
+                f"[{intermediate_size}/tp{moe_tp_size}])"
             )
 
         # FC2 DenseGEMM kernel tiles K with MMA tile size 256.
         # intermediate_size (= weight_per_expert for FC2) must be 256-aligned
         # so expert boundaries align with MMA tile boundaries.
         _MMA_TILE_K = 256
-        if intermediate_size % _MMA_TILE_K != 0:
+        if sharded_intermediate % _MMA_TILE_K != 0:
             return (
                 f"DenseGEMMFusedMoE requires intermediate_size to be a multiple "
-                f"of {_MMA_TILE_K} (got intermediate_size={intermediate_size}). "
+                f"of {_MMA_TILE_K} (got {sharded_intermediate} "
+                f"[{intermediate_size}/tp{moe_tp_size}]). "
                 f"FC2 kernel cannot split alpha_scale at non-aligned expert boundaries."
             )
 

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -585,16 +585,6 @@ def should_skip_densegemm(
                 f"FC2 kernel cannot split alpha_scale at non-aligned expert boundaries."
             )
 
-        # DenseGEMM with very large intermediate_size has accuracy issues vs
-        # per-expert reference due to FP4 error accumulation in the large
-        # FC2 reduction dimension (expert_count * intermediate_size).
-        if intermediate_size >= 14336:
-            return (
-                f"[Design Limitation] DenseGEMMFusedMoE NVFP4 with large "
-                f"intermediate_size={intermediate_size} has accuracy issues "
-                f"vs per-expert reference due to FP4 error accumulation."
-            )
-
     return None
 
 

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -45,6 +45,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
     TRTLLMGenFusedMoE,
 )
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_densegemm import DenseGEMMFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE
 from tensorrt_llm._torch.utils import ActivationType, is_gated_activation
 from tensorrt_llm.models.modeling_utils import QuantAlgo
@@ -62,6 +63,7 @@ class MoeBackendType(str, Enum):
     TRTLLM = "TRTLLM"
     CUTEDSL = "CUTEDSL"
     DEEPGEMM = "DEEPGEMM"
+    DENSEGEMM = "DENSEGEMM"
 
 
 def get_backend_class(backend_type: MoeBackendType) -> Type[MoE]:
@@ -71,6 +73,7 @@ def get_backend_class(backend_type: MoeBackendType) -> Type[MoE]:
         MoeBackendType.TRTLLM: TRTLLMGenFusedMoE,
         MoeBackendType.CUTEDSL: CuteDslFusedMoE,
         MoeBackendType.DEEPGEMM: DeepGemmFusedMoE,
+        MoeBackendType.DENSEGEMM: DenseGEMMFusedMoE,
     }
     return backend_class_map[backend_type]
 
@@ -533,6 +536,68 @@ def should_skip_deepgemm(
     return None
 
 
+def should_skip_densegemm(
+    backend_type: MoeBackendType,
+    quant_algo: Optional[QuantAlgo] = None,
+    model_config: "MoeModelConfig" = None,
+) -> Optional[str]:
+    """
+    Check DenseGEMM backend specific constraints.
+
+    DenseGEMM reshapes all expert weights into a single dense matrix and performs
+    a single large GEMM. It only supports NVFP4 quantization on Blackwell (SM 100/103).
+
+    Constraints:
+    - Only NVFP4 quantization
+    - hidden_size and intermediate_size must be 128-aligned (NVFP4 requirement)
+    - top_k must be >= 2 (fc2_alpha scatter requires multiple expert selections)
+    - num_experts must be > top_k
+
+    Returns:
+        Skip reason string if test should be skipped, None otherwise
+    """
+    if backend_type != MoeBackendType.DENSEGEMM:
+        return None
+
+    # DenseGEMM only supports NVFP4
+    if quant_algo != QuantAlgo.NVFP4:
+        return f"DenseGEMMFusedMoE only supports NVFP4 quantization (got quant_algo={quant_algo})"
+
+    if model_config is not None:
+        hidden_size = model_config.hidden_size
+        intermediate_size = model_config.intermediate_size
+
+        # 128-alignment required for NVFP4 dense GEMM kernels
+        if hidden_size % 128 != 0 or intermediate_size % 128 != 0:
+            return (
+                f"DenseGEMMFusedMoE NVFP4 requires 128-aligned sizes "
+                f"(got h={hidden_size}, i={intermediate_size})"
+            )
+
+        # FC2 DenseGEMM kernel tiles K with MMA tile size 256.
+        # intermediate_size (= weight_per_expert for FC2) must be 256-aligned
+        # so expert boundaries align with MMA tile boundaries.
+        _MMA_TILE_K = 256
+        if intermediate_size % _MMA_TILE_K != 0:
+            return (
+                f"DenseGEMMFusedMoE requires intermediate_size to be a multiple "
+                f"of {_MMA_TILE_K} (got intermediate_size={intermediate_size}). "
+                f"FC2 kernel cannot split alpha_scale at non-aligned expert boundaries."
+            )
+
+        # DenseGEMM with very large intermediate_size has accuracy issues vs
+        # per-expert reference due to FP4 error accumulation in the large
+        # FC2 reduction dimension (expert_count * intermediate_size).
+        if intermediate_size >= 14336:
+            return (
+                f"[Design Limitation] DenseGEMMFusedMoE NVFP4 with large "
+                f"intermediate_size={intermediate_size} has accuracy issues "
+                f"vs per-expert reference due to FP4 error accumulation."
+            )
+
+    return None
+
+
 def should_skip_multi_gpu(
     parallel_mode: str,
     model_config: "MoeModelConfig",
@@ -703,15 +768,21 @@ def get_quick_skip_reason(
             lambda: should_skip_deepgemm(
                 backend_type, quant_algo=quant_algo, model_config=model_config
             ),
+            lambda: should_skip_densegemm(
+                backend_type, quant_algo=quant_algo, model_config=model_config
+            ),
         ]
         for check in skip_checks:
             skip_reason = check()
             if skip_reason:
                 return skip_reason
 
-        # DEEPGEMM: float16 reference module constraint
-        if backend_type == MoeBackendType.DEEPGEMM and dtype == torch.float16:
-            return "DeepGemmFusedMoE reference module requires bfloat16 input"
+        # DEEPGEMM/DENSEGEMM: float16 reference module constraint
+        if (
+            backend_type in (MoeBackendType.DEEPGEMM, MoeBackendType.DENSEGEMM)
+            and dtype == torch.float16
+        ):
+            return f"{backend_type.value} reference module requires bfloat16 input"
 
         # 128-alignment requirement for quantization
         if quant_algo is not None:

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -28,6 +28,7 @@ Design Goals:
 
 import itertools
 import logging
+import os
 from typing import List, Optional
 
 import pytest
@@ -220,6 +221,7 @@ BACKEND_TYPES_TO_TEST = [
     MoeBackendType.TRTLLM,
     MoeBackendType.CUTEDSL,
     MoeBackendType.DEEPGEMM,
+    MoeBackendType.DENSEGEMM,
 ]
 
 # Data types to test
@@ -466,6 +468,10 @@ def test_moe_backend(
     3. Different sequence lengths use appropriate tactics
     4. swiglu_gptoss_style (SwiGlu with custom parameters) works correctly
     """
+    # DENSEGEMM: disable fused fc2_alpha path for backend-level testing.
+    if backend_type == MoeBackendType.DENSEGEMM:
+        os.environ["TRTLLM_MOE_FUSED_FC2_ALPHA"] = "0"
+
     is_gated = is_gated_activation(activation_type)
     swiglu_gptoss_style = False
     if is_gated:

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -28,7 +28,6 @@ Design Goals:
 
 import itertools
 import logging
-import os
 from typing import List, Optional
 
 import pytest
@@ -458,6 +457,7 @@ def test_moe_backend(
     swiglu_alpha: Optional[float],
     swiglu_beta: Optional[float],
     swiglu_limit: Optional[float],
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Test MoE backend with autotune to capture all tactics.
@@ -470,7 +470,7 @@ def test_moe_backend(
     """
     # DENSEGEMM: disable fused fc2_alpha path for backend-level testing.
     if backend_type == MoeBackendType.DENSEGEMM:
-        os.environ["TRTLLM_MOE_FUSED_FC2_ALPHA"] = "0"
+        monkeypatch.setenv("TRTLLM_MOE_FUSED_FC2_ALPHA", "0")
 
     is_gated = is_gated_activation(activation_type)
     swiglu_gptoss_style = False

--- a/tests/unittest/_torch/modules/moe/test_moe_module.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_module.py
@@ -51,6 +51,7 @@ from _torch.modules.moe.moe_test_utils import (
     should_skip_cutedsl,
     should_skip_cutlass,
     should_skip_deepgemm,
+    should_skip_densegemm,
     should_skip_multi_gpu,
     should_skip_to_accelerate_ci,
     should_skip_trtllm,
@@ -977,6 +978,14 @@ def generate_multi_gpu_test_params(
                         model_config=model_config,
                         moe_tp_size=moe_tp_size,
                     ),
+                    should_skip_densegemm(
+                        backend_type,
+                        quant_algo=quant_algo,
+                        model_config=model_config,
+                        comm_method=comm_method,
+                        moe_tp_size=moe_tp_size,
+                        parallel_mode=parallel_mode,
+                    ),
                     should_skip_multi_gpu(
                         parallel_mode, model_config, world_size=4, comm_method=comm_method
                     ),
@@ -1099,10 +1108,6 @@ def test_configurable_moe_single_gpu(
     3. Autotune captures and replays all tactics properly
     4. swiglu_gptoss_style (SwiGLU with custom parameters) works correctly
     """
-    # DENSEGEMM: disable fused fc2_alpha path for testing against per-expert reference.
-    if moe_backend == MoeBackendType.DENSEGEMM.value:
-        os.environ["TRTLLM_MOE_FUSED_FC2_ALPHA"] = "0"
-
     swiglu_gptoss_style = swiglu_alpha != 1 or swiglu_beta != 0 or swiglu_limit != float("inf")
     ci_skip = should_skip_to_accelerate_ci(
         backend_type=MoeBackendType(moe_backend),

--- a/tests/unittest/_torch/modules/moe/test_moe_module.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_module.py
@@ -740,6 +740,7 @@ BACKEND_TYPES = [
     MoeBackendType.TRTLLM,
     MoeBackendType.CUTEDSL,
     MoeBackendType.DEEPGEMM,
+    MoeBackendType.DENSEGEMM,
 ]
 
 # Data types to test
@@ -1098,6 +1099,10 @@ def test_configurable_moe_single_gpu(
     3. Autotune captures and replays all tactics properly
     4. swiglu_gptoss_style (SwiGLU with custom parameters) works correctly
     """
+    # DENSEGEMM: disable fused fc2_alpha path for testing against per-expert reference.
+    if moe_backend == MoeBackendType.DENSEGEMM.value:
+        os.environ["TRTLLM_MOE_FUSED_FC2_ALPHA"] = "0"
+
     swiglu_gptoss_style = swiglu_alpha != 1 or swiglu_beta != 0 or swiglu_limit != float("inf")
     ci_skip = should_skip_to_accelerate_ci(
         backend_type=MoeBackendType(moe_backend),

--- a/tests/unittest/_torch/thop/parallel/test_moe_densegemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_moe_densegemm.py
@@ -398,5 +398,4 @@ def test_nvfp4_dense_gemm_fc2_blackwell(
     is_close = torch.isclose(c.float(), c_ref.float(), rtol=rtol, atol=atol)
     match_ratio = is_close.sum().item() / c.numel()
 
-    print(f"FC2 Output match ratio: {match_ratio * 100:.2f}%")
     assert match_ratio > 0.90, f"Only {match_ratio * 100:.2f}% elements match, expected >= 90%"

--- a/tests/unittest/_torch/thop/parallel/test_moe_densegemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_moe_densegemm.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Dense GEMM with SwiGLU fusion (FC1 kernel).
+
+This module tests the NVFP4 dense GEMM with SwiGLU fusion kernel used in MoE FC1 layers.
+The kernel performs: C = alpha_post * SwiGLU(alpha * (A @ B.T))
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.fused_moe.quantization import interleave_linear_and_gate
+from tensorrt_llm._torch.utils import swizzle_sf, unswizzle_sf
+from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.math_utils import pad_up
+
+
+def swiglu_ref(x: torch.Tensor) -> torch.Tensor:
+    """Reference SwiGLU implementation: x * silu(gate) where [x, gate] = chunk(input, 2)."""
+    x, gate = x.chunk(2, dim=-1)
+    return x * torch.nn.functional.silu(gate)
+
+
+def nvfp4_dense_gemm_ref(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_sf: torch.Tensor,
+    b_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    scaling_vector_size: int = 16,
+) -> torch.Tensor:
+    """Reference implementation for dense GEMM using nvfp4_gemm op.
+
+    Args:
+        a: Input activation (M, K//2) in fp4 packed format
+        b: Weight tensor (num_expert, weight_per_expert, K//2) in fp4 packed format
+        a_sf: Scale factor for a (swizzled)
+        b_sf: Scale factor for b (num_expert, weight_per_expert, scale_k)
+        alpha: Per-expert alpha scale (num_expert,)
+        output_dtype: Output data type
+        scaling_vector_size: Vector size for block scaling
+
+    Returns:
+        Output tensor (M, num_expert * weight_per_expert) in output_dtype
+    """
+    assert a.dtype == torch.float4_e2m1fn_x2
+    assert b.dtype == torch.float4_e2m1fn_x2
+
+    m = a.size(0)
+    num_expert = b.size(0)
+    weight_per_expert = b.size(1)
+    n = num_expert * weight_per_expert
+
+    # Compute reference output by calling nvfp4_gemm for each expert
+    ref = torch.empty(m, n, dtype=output_dtype, device="cuda")
+
+    for expert_idx in range(num_expert):
+        start_col = expert_idx * weight_per_expert
+        end_col = (expert_idx + 1) * weight_per_expert
+
+        # Get expert's weight and scale factor
+        b_expert = b[expert_idx]  # (weight_per_expert, k//2)
+        b_sf_expert = b_sf[expert_idx]  # (weight_per_expert, scale_k)
+
+        # Call nvfp4_gemm for this expert
+        ref[:, start_col:end_col] = torch.ops.trtllm.nvfp4_gemm(
+            a.view(torch.uint8),
+            b_expert.view(torch.uint8),
+            a_sf,
+            b_sf_expert,
+            alpha[expert_idx],
+            output_dtype,
+        )
+
+    return ref
+
+
+@pytest.mark.skipif(
+    get_sm_version() not in (100, 103),
+    reason="This test is only supported on SM 100 and SM 103 GPUs",
+)
+@pytest.mark.parametrize("num_expert", [1, 4, 8, 32])
+@pytest.mark.parametrize("weight_per_expert", [256, 512, 1024, 2816])
+@pytest.mark.parametrize("num_tokens", [1, 8, 127, 256])
+@pytest.mark.parametrize("hidden_size", [256, 512, 2048])
+@pytest.mark.parametrize("enable_alpha_post", [True, False])
+def test_nvfp4_dense_gemm_swiglu_blackwell(
+    num_tokens: int,
+    hidden_size: int,
+    num_expert: int,
+    weight_per_expert: int,
+    enable_alpha_post: bool,
+):
+    """Test Dense GEMM with SwiGLU fusion for FC1 layer.
+
+    This test validates the dense GEMM kernel which:
+    1. Performs GEMM: C = A @ B.T with per-expert alpha scaling
+    2. Applies SwiGLU fusion: output = up * silu(gate) where [up, gate] = chunk(C, 2)
+    3. Optionally applies post-SwiGLU alpha scaling (when enable_alpha_post=True)
+    4. Quantizes output to NVFP4 format with scale factor generation
+    """
+    sf_vec_size = 16
+    m = num_tokens
+    k = hidden_size
+    n = num_expert * weight_per_expert  # Full N before SwiGLU
+
+    # Create input tensors in bfloat16, then quantize to fp4
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    b_bf16 = torch.randint(
+        -5, 5, (num_expert, weight_per_expert, k), dtype=torch.int32, device="cuda"
+    ).to(torch.bfloat16)
+
+    # Compute global scale factors
+    a_global_sf = a_bf16.abs().max().float() / (448 * 6)
+    b_global_sf = b_bf16.abs().amax(dim=(1, 2)).float() / (448 * 6)
+
+    # Quantize to fp4
+    a, a_sf = torch.ops.trtllm.fp4_quantize(a_bf16, 1 / a_global_sf, sf_vec_size, False)
+    a = a.view(torch.float4_e2m1fn_x2)
+
+    b, b_sf = torch.ops.trtllm.fp4_quantize(b_bf16, 1 / b_global_sf, sf_vec_size, False)
+    b = b.view(torch.float4_e2m1fn_x2)
+    b_sf = b_sf.view(num_expert, weight_per_expert, k // sf_vec_size)
+
+    # Per-expert alpha = a_global_sf * b_global_sf
+    alpha = a_global_sf * b_global_sf
+
+    # Interleave weights for SwiGLU (linear and gate interleaved at group_size=64)
+    b_interleaved = interleave_linear_and_gate(b.view(torch.uint8), group_size=64, dim=1).view(
+        torch.float4_e2m1fn_x2
+    )
+
+    # Interleave scale factors
+    b_sf_unswizzled = unswizzle_sf(b_sf, weight_per_expert, k).view(
+        num_expert, weight_per_expert, k // sf_vec_size
+    )
+    b_sf_unswizzled_interleaved = interleave_linear_and_gate(b_sf_unswizzled, group_size=64, dim=1)
+    b_sf_interleaved = swizzle_sf(b_sf_unswizzled_interleaved, weight_per_expert, k).view(
+        num_expert, weight_per_expert, k // sf_vec_size
+    )
+
+    # Compute reference using nvfp4_gemm (simulates fp4 precision)
+    c_ref = nvfp4_dense_gemm_ref(
+        a,
+        b,
+        a_sf,
+        b_sf,
+        alpha,
+        output_dtype=torch.bfloat16,
+        scaling_vector_size=sf_vec_size,
+    )
+
+    # Apply SwiGLU separately for each expert: reshape -> swiglu -> flatten
+    c_ref = swiglu_ref(c_ref.view(m, num_expert, weight_per_expert))  # (m, num_expert, wpe//2)
+
+    # Conditionally apply alpha_post scaling
+    alpha_post = None
+    if enable_alpha_post:
+        # Create per-token per-expert alpha_post scale (m, num_expert)
+        # Use values close to 1.0 to minimize numerical variation while testing functionality
+        alpha_post = torch.rand(m, num_expert, dtype=torch.float32, device="cuda") * 0.4 + 0.8
+        # Apply alpha_post: (m, num_expert, wpe//2) * (m, num_expert, 1) -> (m, num_expert, wpe//2)
+        c_ref = c_ref * alpha_post.unsqueeze(-1)
+
+    c_ref = c_ref.to(torch.bfloat16)
+    c_ref = c_ref.view(m, -1)  # Flatten to (m, n_out)
+
+    # Output N after SwiGLU
+    n_out = n // 2
+
+    # Create norm_const tensor for fp4 output quantization
+    global_sf = c_ref.abs().max().float() / (448 * 6)
+    norm_const = torch.tensor([1 / global_sf], dtype=torch.float32, device="cuda")
+
+    # Quantize reference output to fp4
+    c_ref_quantized, c_sf_ref = torch.ops.trtllm.fp4_quantize(
+        c_ref, 1 / global_sf, sf_vec_size, False
+    )
+
+    # Call the kernel with fp4 output
+    c, c_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_swiglu_blackwell(
+        a,
+        b_interleaved,
+        a_sf,
+        b_sf_interleaved,
+        alpha,
+        alpha_post,  # None when enable_alpha_post=False
+        norm_const,
+        expert_count=num_expert,
+        weight_per_expert=weight_per_expert,
+        output_dtype=torch.float4_e2m1fn_x2,
+        scaling_vector_size=sf_vec_size,
+    )
+
+    # Verify output shape (fp4 packed: n_out // 2 bytes)
+    assert c.shape == (m, n_out // 2), f"Expected shape {(m, n_out // 2)}, got {c.shape}"
+    assert c.dtype == torch.float4_e2m1fn_x2, f"Expected dtype float4_e2m1fn_x2, got {c.dtype}"
+
+    # Verify output values by comparing fp4 nibbles.
+    # The kernel and fp4_quantize reference may round differently, so allow ±1 per nibble.
+    # Each uint8 byte packs two fp4 values: high nibble [7:4] and low nibble [3:0].
+    c_u8 = c.view(torch.uint8).flatten().int()
+    ref_u8 = c_ref_quantized.view(torch.uint8).flatten().int()
+    lo_diff = ((c_u8 & 0xF) - (ref_u8 & 0xF)).abs()
+    hi_diff = ((c_u8 >> 4) - (ref_u8 >> 4)).abs()
+    num_fp4_elements = c_u8.numel() * 2
+    close_count = (lo_diff <= 1).sum().item() + (hi_diff <= 1).sum().item()
+    nibble_close_ratio = close_count / num_fp4_elements
+    assert nibble_close_ratio > 0.95, (
+        f"Only {nibble_close_ratio * 100:.2f}% fp4 elements within ±1, expected >= 95%"
+    )
+
+    # Verify scale factor shape
+    scale_n_out = n_out // sf_vec_size
+    expected_c_sf_shape = (32, 4, pad_up(m, 128) // 128, 4, scale_n_out // 4, 1)
+    assert c_sf.shape == expected_c_sf_shape, (
+        f"Expected c_sf shape {expected_c_sf_shape}, got {c_sf.shape}"
+    )
+    assert c_sf.dtype == torch.uint8, f"Expected c_sf dtype uint8, got {c_sf.dtype}"
+
+    # Verify scale factor values
+    # Unswizzle both c_sf and c_sf_ref for comparison (both are padded to 128)
+    c_sf_unswizzled = unswizzle_sf(c_sf.view(-1), pad_up(m, 128), n_out)
+    c_sf_ref_unswizzled = unswizzle_sf(c_sf_ref.view(-1), pad_up(m, 128), n_out)
+
+    # Compare only the valid region (first m rows)
+    c_sf_valid = c_sf_unswizzled[:m, :].view(torch.uint8)
+    c_sf_ref_valid = c_sf_ref_unswizzled[:m, :].view(torch.uint8)
+
+    # Allow off-by-1 rounding differences between kernel and fp4_quantize reference.
+    # Both compute scale factors independently; ±1 in uint8 is expected FP rounding.
+    sf_diff = (c_sf_valid.int() - c_sf_ref_valid.int()).abs()
+    sf_close_ratio = (sf_diff <= 1).sum().item() / c_sf_valid.numel()
+    assert sf_close_ratio > 0.95, (
+        f"Scale factor: only {sf_close_ratio * 100:.2f}% within ±1, expected >= 95%"
+    )
+
+
+def nvfp4_dense_gemm_fc2_ref(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_sf: torch.Tensor,
+    b_sf: torch.Tensor,
+    alpha_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+    expert_count: int,
+    weight_per_expert: int,
+    scaling_vector_size: int = 16,
+) -> torch.Tensor:
+    """Reference implementation for FC2 dense GEMM.
+
+    For each expert, compute GEMM with corresponding A slice and B slice,
+    multiply by alpha_scale, then accumulate results.
+
+    C = sum_i(alpha_scale[:, i] * (A[:, i*wpe:(i+1)*wpe] @ B[:, i*wpe:(i+1)*wpe].T))
+
+    Args:
+        a: Input activation (M, K//2) in fp4 packed format, K = expert_count * weight_per_expert
+        b: Weight tensor (N, K//2) in fp4 packed format
+        a_sf: Scale factor for a (swizzled)
+        b_sf: Scale factor for b (swizzled)
+        alpha_scale: Per-token-per-expert scale (M, expert_count)
+        output_dtype: Output data type
+        expert_count: Number of experts
+        weight_per_expert: Number of weights per expert
+        scaling_vector_size: Vector size for block scaling
+
+    Returns:
+        Output tensor (M, N) in output_dtype
+    """
+    assert a.dtype == torch.float4_e2m1fn_x2
+    assert b.dtype == torch.float4_e2m1fn_x2
+
+    m = a.size(0)
+    k = a.size(1) * 2
+    n = b.size(0)
+
+    # Unswizzle scale factors for slicing
+    a_sf_unswizzled = unswizzle_sf(a_sf.view(-1), pad_up(m, 128), k)[:m, :]  # (m, scale_k)
+    b_sf_unswizzled = unswizzle_sf(b_sf.view(-1), n, k)  # (n, scale_k)
+
+    # Initialize output accumulator
+    c_ref = torch.zeros(m, n, dtype=output_dtype, device=a.device)
+
+    # For each expert, compute partial GEMM and accumulate
+    wpe = weight_per_expert
+    scale_wpe = wpe // scaling_vector_size
+    alpha_one = torch.tensor([1.0], dtype=torch.float32, device=a.device)
+
+    for expert_idx in range(expert_count):
+        # Slice A for this expert (in packed fp4 format, so divide by 2)
+        a_expert = a.view(torch.uint8)[
+            :, expert_idx * wpe // 2 : (expert_idx + 1) * wpe // 2
+        ].contiguous()
+        a_sf_expert = a_sf_unswizzled[:, expert_idx * scale_wpe : (expert_idx + 1) * scale_wpe]
+        a_sf_expert_swizzled = swizzle_sf(a_sf_expert.contiguous(), m, wpe)
+
+        # Slice B for this expert
+        b_expert = b.view(torch.uint8)[
+            :, expert_idx * wpe // 2 : (expert_idx + 1) * wpe // 2
+        ].contiguous()
+        b_sf_expert = b_sf_unswizzled[:, expert_idx * scale_wpe : (expert_idx + 1) * scale_wpe]
+        b_sf_expert_swizzled = swizzle_sf(b_sf_expert.contiguous(), n, wpe)
+
+        # Compute GEMM for this expert
+        c_expert = torch.ops.trtllm.nvfp4_gemm(
+            a_expert,
+            b_expert,
+            a_sf_expert_swizzled,
+            b_sf_expert_swizzled,
+            alpha_one,
+            output_dtype,
+        )
+
+        # Apply alpha_scale and accumulate
+        c_ref += c_expert * alpha_scale[:, expert_idx : expert_idx + 1]
+
+    return c_ref
+
+
+@pytest.mark.skipif(
+    get_sm_version() not in (100, 103),
+    reason="This test is only supported on SM 100 and SM 103 GPUs",
+)
+@pytest.mark.parametrize("num_expert", [1, 4, 8, 32, 256])
+@pytest.mark.parametrize("weight_per_expert", [256, 512, 1024])
+@pytest.mark.parametrize("num_tokens", [1, 8, 127, 256])
+@pytest.mark.parametrize("output_hidden_size", [256, 512, 2048])
+def test_nvfp4_dense_gemm_fc2_blackwell(
+    num_tokens: int, output_hidden_size: int, num_expert: int, weight_per_expert: int
+):
+    """Test Dense GEMM FC2 for MoE second projection.
+
+    This test validates the FC2 dense GEMM kernel which:
+    1. Performs GEMM: C = A @ B.T with per-token-per-expert alpha scaling
+    2. Each token has independent alpha values for each expert
+    """
+    sf_vec_size = 16
+    m = num_tokens
+    k = num_expert * weight_per_expert  # Input dimension from FC1 output
+    n = output_hidden_size  # Output hidden dimension
+
+    # Create input tensors in bfloat16, then quantize to fp4
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    b_bf16 = torch.randint(-5, 5, (n, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+
+    # Compute global scale factors
+    a_global_sf = a_bf16.abs().max().float() / (448 * 6)
+    b_global_sf = b_bf16.abs().max().float() / (448 * 6)
+
+    # Quantize to fp4
+    a, a_sf = torch.ops.trtllm.fp4_quantize(a_bf16, 1 / a_global_sf, sf_vec_size, False)
+    a = a.view(torch.float4_e2m1fn_x2)
+
+    b, b_sf = torch.ops.trtllm.fp4_quantize(b_bf16, 1 / b_global_sf, sf_vec_size, False)
+    b = b.view(torch.float4_e2m1fn_x2)
+
+    # Create per-token-per-expert alpha scale (m, expert_count)
+    # Each token has different alpha values for each expert
+    alpha_scale = torch.rand(m, num_expert, dtype=torch.float32, device="cuda") * 2.0
+
+    # Compute reference
+    c_ref = nvfp4_dense_gemm_fc2_ref(
+        a,
+        b,
+        a_sf,
+        b_sf,
+        alpha_scale,
+        output_dtype=torch.bfloat16,
+        expert_count=num_expert,
+        weight_per_expert=weight_per_expert,
+        scaling_vector_size=sf_vec_size,
+    )
+
+    # Call the kernel
+    c = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_fc2_blackwell(
+        a,
+        b,
+        a_sf,
+        b_sf,
+        alpha_scale,
+        expert_count=num_expert,
+        weight_per_expert=weight_per_expert,
+        output_dtype=torch.bfloat16,
+        scaling_vector_size=sf_vec_size,
+    )
+
+    # Verify output shape
+    assert c.shape == (m, n), f"Expected shape {(m, n)}, got {c.shape}"
+    assert c.dtype == torch.bfloat16, f"Expected dtype bfloat16, got {c.dtype}"
+
+    # Verify output values
+    # Use relative tolerance for floating point comparison
+    rtol = 0.1  # 10% relative tolerance
+    atol = 0.05  # Small absolute tolerance for values near zero
+
+    is_close = torch.isclose(c.float(), c_ref.float(), rtol=rtol, atol=atol)
+    match_ratio = is_close.sum().item() / c.numel()
+
+    print(f"FC2 Output match ratio: {match_ratio * 100:.2f}%")
+    assert match_ratio > 0.90, f"Only {match_ratio * 100:.2f}% elements match, expected >= 90%"


### PR DESCRIPTION
@coderabbitai summary

## Description

Add a new **DenseGEMM** backend for MoE that reshapes all expert weights into a single dense matrix and performs one large GEMM call per FC layer, targeting **minimum latency** on Blackwell (SM100/SM103) with NVFP4 quantization.

### Key design

Instead of the traditional per-expert grouped GEMM approach, DenseGEMM concatenates all expert weights along the N (FC1) or K (FC2) dimension and executes a single dense GEMM. This trades flexibility for maximum GPU utilization at small batch sizes where per-expert GEMMs underutilize SMs.

- **FC1 kernel**: Fuses GEMM + SwiGLU activation + FP4 output quantization (with SFC generation) into a single CuTe DSL kernel epilogue
- **FC2 kernel**: Fuses GEMM + per-token-per-expert alpha scaling into the epilogue, accumulating expert contributions in a single pass
- **fc2_alpha fusion optimization**: Normalizes fc2_alpha into FC1's alpha_post, reducing FC2 to a simple scalar-alpha `nvfp4_gemm` call (controlled by `TRTLLM_MOE_FUSED_FC2_ALPHA` env var, default: enabled)

### Files added/modified

| Category | Files | Description |
|----------|-------|-------------|
| CuTe DSL kernels | `cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc1.py`, `fc2.py` | Persistent tile-scheduled Blackwell GEMM kernels with SwiGLU fusion (FC1) and per-expert alpha scaling (FC2) |
| Custom ops | `custom_ops/cute_dsl_custom_ops.py` (+738 lines) | `TunableRunner` wrappers with autotuner integration for FC1/FC2 kernels |
| Backend module | `fused_moe/fused_moe_densegemm.py` (new) | `DenseGEMMFusedMoE` class: weight transpose, NVFP4 quantization, fc2_alpha fusion, CUDA stream overlap |
| Integration | `create_moe.py`, `configurable_moe.py`, `llm_args.py`, `utils.py` | Backend registration, `DENSEGEMM` option in `MoeConfig`, `MoeFc2Alpha` aux stream |
| Tests | `test_moe_densegemm.py` (564 cases), `test_moe_backend.py`, `test_moe_module.py` | FC1/FC2 kernel correctness tests + backend/module integration tests |
| Scripts | `run_moe_as_dense_gemm_fc1.py`, `run_moe_as_dense_gemm_fc2.py` | Standalone kernel runners for development and benchmarking |

### Constraints

- **SM100/SM103 only** — CuTe DSL kernels require Blackwell architecture. `get_moe_cls()` gracefully falls back to CutlassFusedMoE on other architectures.
- **NVFP4 only** — requires `quant_mode.has_nvfp4()`
- **SwiGLU only** — FC1 kernel hardcodes SwiGLU fusion. Non-SwiGLU `activation_type` is rejected at construction time.
- **`intermediate_size` must be 256-aligned** — FC2 kernel tiles K with MMA tile size 256; expert boundaries must align with tile boundaries.
- **AllToAll not supported** — DenseGEMM treats all experts as one matrix, incompatible with expert-parallel dispatch.

## Test Coverage

- FC1 kernel unit tests: 384 parametrized cases (num_expert × weight_per_expert × num_tokens × hidden_size × alpha_post) in `test_moe_densegemm.py`
- FC2 kernel unit tests: 180 parametrized cases (num_expert × weight_per_expert × num_tokens × output_hidden_size) in `test_moe_densegemm.py`
- Backend-level tests via `test_moe_backend.py` (DenseGEMM added to parametrized matrix with skip guards)
- Module-level tests via `test_moe_module.py` (ConfigurableMoE + DenseGEMM integration)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.