### PR TITLE
[https://nvbugs/5761665][fix] AutoDeploy: using Dim.DYNAMIC for robust dynamic shape

### DIFF
--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -278,8 +278,8 @@ class FakeFP8Linear(nn.Linear):
 def generate_dynamic_shapes(max_batch_size, max_seq_len):
     dynamic_shapes = (
         {
-            0: Dim("batch_size", max=max_batch_size),
-            1: Dim("seq_len", max=max_seq_len),
+            0: Dim.DYNAMIC,
+            1: Dim.DYNAMIC,
         },
     )
     return dynamic_shapes

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hybrid_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hybrid_patches.py
@@ -72,12 +72,11 @@ def test_bamba_patches(
     position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).repeat(
         input_ids.shape[0], 1
     )
+    batch_size_dynamic = Dim.DYNAMIC
+    seq_len_dynamic = Dim.DYNAMIC
     dynamic_shapes = (
-        {0: Dim("batch_size", min=0, max=8), 1: Dim("seq_len", min=0, max=512)},
-        {
-            0: Dim("batch_size", min=0, max=8),
-            1: Dim("seq_len", min=0, max=512),
-        },
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
     )
 
     def _run_torch_export_to_gm():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_modeling_nemotron_h.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_modeling_nemotron_h.py
@@ -184,12 +184,11 @@ def test_custom_model_implementation_can_be_exported(
     position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).repeat(
         input_ids.shape[0], 1
     )
+    batch_size_dynamic = Dim.DYNAMIC
+    seq_len_dynamic = Dim.DYNAMIC
     dynamic_shapes = (
-        {0: Dim("batch_size", min=0, max=8), 1: Dim("seq_len", min=0, max=512)},
-        {
-            0: Dim("batch_size", min=0, max=8),
-            1: Dim("seq_len", min=0, max=512),
-        },
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
     )
 
     def _run_torch_export_to_gm():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -84,7 +84,7 @@ class RepeatKVModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class RepeatKVModel2(RepeatKVModel):
@@ -185,7 +185,7 @@ class EagerAttentionModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class ComplexEagerAttentionModel(torch.nn.Module):
@@ -274,7 +274,7 @@ class ComplexEagerAttentionModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class CounterExampleModel(torch.nn.Module):
@@ -329,7 +329,7 @@ class CounterExampleModel(torch.nn.Module):
         return features_case1
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class GroupedAttentionModel(torch.nn.Module):
@@ -403,7 +403,7 @@ class GroupedAttentionModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 def _get_match_repeat_kv_optimizer() -> Callable:
@@ -907,7 +907,7 @@ class CausalAttentionModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class Llama3CausalAttentionModel(torch.nn.Module):
@@ -1013,7 +1013,7 @@ class Llama3CausalAttentionModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class AttentionLayoutModel(torch.nn.Module):
@@ -1102,7 +1102,7 @@ class AttentionLayoutModel(torch.nn.Module):
         return output
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 class BsndAttentionModel(AttentionLayoutModel):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -117,7 +117,7 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
         "attn_implementation": attn_implementation,
         **config,
     }
-    dynamic_shapes = {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=2, max=8)}
+    dynamic_shapes = {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
     # Build and export model on meta device
     with init_empty_weights():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fuse_rmsnorm.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fuse_rmsnorm.py
@@ -59,7 +59,7 @@ def _run_test(model, op, variant):
         return any(is_op(n, op) for n in gm.graph.nodes)
 
     x = torch.randn(2, 1024, device="cuda", dtype=torch.float16)
-    dynamic_shapes = {0: Dim("batch_size", max=8)}
+    dynamic_shapes = {0: Dim.DYNAMIC}
     gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
     gm_transformed = InferenceOptimizer(
         None,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fused_add_rms_norm.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fused_add_rms_norm.py
@@ -37,8 +37,9 @@ def _run_test(model):
     residual = torch.randn(bsz, seq_len, hidden, device="cuda", dtype=torch.bfloat16)
 
     # Dynamic shapes
-    ds_x = {0: Dim("batch_size", max=8)}
-    ds_res = {0: Dim("batch_size", max=8)}
+    dyn_batch_size = Dim.DYNAMIC
+    ds_x = {0: dyn_batch_size}
+    ds_res = {0: dyn_batch_size}
 
     gm = torch_export_to_gm(model, args=(x, residual), dynamic_shapes=(ds_x, ds_res), clone=True)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
@@ -189,7 +189,7 @@ class TestGatherLogitsBeforeLmHeadTransform:
         else:
             # dynamic_shapes should be a tuple matching the number of positional args
             dynamic_shapes = (
-                {0: Dim("batch_size", min=1, max=max_batch_size)},  # hidden_states
+                {0: Dim.DYNAMIC},  # hidden_states
                 None,  # logit_gather_ids (static)
                 None,  # seq_len (static)
             )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
@@ -135,7 +135,7 @@ class RoPEModel(torch.nn.Module):
         return out.to(torch.float16) if self.mode == "match" else out
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 @pytest.mark.parametrize(
@@ -387,7 +387,7 @@ class DSModel(torch.nn.Module):
         return torch.cat([q_out, k_out], dim=-1)
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", max=16)}
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/test_export.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/test_export.py
@@ -47,7 +47,7 @@ class MLPForExport(ModuleForExport):
         return torch.randn(2, 10)
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=100)}
+        return {0: Dim.DYNAMIC}
 
 
 class MLPDuplicate(ModuleForExport):
@@ -72,7 +72,7 @@ class MLPDuplicate(ModuleForExport):
         return {"fc3.weight"}
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=100)}
+        return {0: Dim.DYNAMIC}
 
 
 class ModuleWithWhere(ModuleForExport):
@@ -90,7 +90,7 @@ class ModuleWithWhere(ModuleForExport):
         return torch.randn(2, 10)
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=100)}
+        return {0: Dim.DYNAMIC}
 
     def check_xfail(self, f_export, use_dynamic_shape, device) -> bool:
         return (
@@ -129,7 +129,7 @@ class ModuleWithRouting(ModuleForExport):
         return torch.randn(self.seq_len, self.num_experts)
 
     def get_dynamic_shapes(self):
-        return {0: Dim("seq_len", max=100)}
+        return {0: Dim.DYNAMIC}
 
     def check_xfail(self, f_export, use_dynamic_shape, device) -> bool:
         return (
@@ -153,7 +153,7 @@ class ModuleWithModuleList(ModuleForExport):
         return torch.randn(2, 10, device=self.fcs[0].weight.device)
 
     def get_dynamic_shapes(self):
-        return {0: Dim("batch_size", max=100)}
+        return {0: Dim.DYNAMIC}
 
     def check_xfail(self, f_export, use_dynamic_shape, device) -> bool:
         # non-strict mode only works with our hack in torch_export_to_gm


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic shape handling during model export to prevent validation errors for reshape and view operations.

* **Tests**
  * Enhanced test coverage for export operations with dynamic shapes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
