### PR TITLE
[TRTLLM-10296][fix] Fix the potential misaligned access due to vectorized ld/st instructions in NVLinkOneSided A2A.

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -145,14 +145,9 @@ namespace kernels::moe_comm
 // Helper Functions for Expert-to-Rank Mapping
 // ============================================================================
 
-__device__ int compute_target_rank_id(int expert_id, int num_experts_per_rank, int ep_size)
+__device__ int compute_target_rank_id(int expert_id, int num_experts_per_rank)
 {
     // Compute which rank owns a given expert using contiguous partitioning
-    // Invalid routing result.
-    if (expert_id < 0 || expert_id >= num_experts_per_rank * ep_size)
-    {
-        return -1;
-    }
     // Experts are divided evenly across EP ranks:
     // - Rank 0 gets experts [0, num_experts_per_rank)
     // - Rank 1 gets experts [num_experts_per_rank, 2*num_experts_per_rank)
@@ -409,9 +404,9 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
         {
             int expert_id = token_selected_experts[local_token_idx * TOP_K + k];
             // Use contiguous partitioning to determine target rank
-            int target_rank = compute_target_rank_id(expert_id, num_experts_per_rank, ep_size);
+            int target_rank = compute_target_rank_id(expert_id, num_experts_per_rank);
 
-            if (target_rank == -1 || (already_copied & (1ULL << target_rank)))
+            if (already_copied & (1ULL << target_rank))
             {
                 if (thread_idx == 0)
                 {

--- a/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
@@ -423,7 +423,7 @@ torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumToke
         " for payload), but got ", sizePerRank);
 
     // Create output tensor (local on current rank), no need for initialization
-    // Typially, newly allocated torch tensors are at least 16-byte aligned.
+    // Typically, newly allocated GPU torch tensors are at least 16-byte aligned.
     torch::Tensor output = torch::empty({localNumTokens, elementsPerToken}, payload.options());
 
     // Setup combine parameters

--- a/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
@@ -33,6 +33,8 @@ namespace torch_ext
 namespace moe_comm
 {
 
+static constexpr size_t CACHELINE_ALIGNMENT = 128;
+
 // TODO: Is Alignment necessary?
 // Helper function to align offset to specified byte boundary
 inline size_t alignOffset(size_t offset, size_t alignment)
@@ -46,7 +48,6 @@ MoeA2ADataOffsets calculateOffsets(int epSize, int maxNumTokens)
     // TODO: Use lambdas to encapsulate offset and alignment for each entry, which is less error prone and easier to
     // read.
     constexpr size_t SIZEOF_INT32 = 4;
-    constexpr size_t CACHELINE_ALIGNMENT = 128;
 
     MoeA2ADataOffsets offsets;
     size_t offset = 0;
@@ -203,12 +204,18 @@ std::tuple<std::vector<torch::Tensor>, int64_t> moeA2ADispatchOp(torch::Tensor c
         TORCH_CHECK(payload.is_contiguous(), "All payloads must be contiguous");
     }
 
-    // Calculate buffer sizes for all payloads
-    // Each payload buffer needs space for data from ALL ranks: epSize * maxTokensPerRank * elementsPerToken
-    int64_t totalBytesNeeded = 0;
-    std::vector<int64_t> payloadByteSizes;
+    // Record the cacheline aligned start offset for each payload's recv buffer.
+    // 1. We assume the base workspace ptr of each rank is aligned (checked in this OP)
+    // 2. offsets[PAYLOAD_DATA_OFFSET_INDEX] is aligned (ensured in calculateOffsets)
+    // 3. We align the currentOffset during update.
+    // In this way, it is guaranteed that the recv buffer is (over-)aligned, sufficient for 128bit vectorized ld/st.
+
     std::vector<int> payloadElementSizes;
     std::vector<int> payloadElementsPerToken;
+    std::vector<size_t> payloadRecvBufferOffsets;
+
+    // Start offset for the first payload
+    size_t currentOffset = static_cast<size_t>(offsets[PAYLOAD_DATA_OFFSET_INDEX]);
     for (auto const& payload : inputPayloads)
     {
         CHECK_CONTIGUOUS(payload);
@@ -216,16 +223,24 @@ std::tuple<std::vector<torch::Tensor>, int64_t> moeA2ADispatchOp(torch::Tensor c
         TORCH_CHECK(payload.dim() == 2, "payload must be a 2D tensor");
         TORCH_CHECK(
             payload.size(0) == localNumTokens, "payload must have the same first dimension as tokenSelectedExperts");
+        // Unlike recv buffer for payloads, payload itself is not allocated by us and we cannot control its alignment.
+        // We only make sure the payload start offset is 16-byte aligned, while the actual vectorized ld/st width is
+        // dynamically determined based on bytes per token of this payload.
+        TORCH_CHECK(reinterpret_cast<uintptr_t>(payload.data_ptr()) % 16 == 0, "payload must be 16-byte aligned");
 
         int elementsPerToken = static_cast<int>(payload.size(1));
         int elementSize = static_cast<int>(payload.dtype().itemsize());
         // Each payload buffer stores data from ALL ranks
         int64_t bytesPerPayload = epSize * runtimeMaxTokensPerRank * elementsPerToken * elementSize;
 
-        payloadByteSizes.push_back(bytesPerPayload);
         payloadElementSizes.push_back(elementSize);
         payloadElementsPerToken.push_back(elementsPerToken);
-        totalBytesNeeded += bytesPerPayload;
+
+        payloadRecvBufferOffsets.push_back(currentOffset);
+
+        // Update offset and align to cacheline boundary for the next payload recv buffer.
+        currentOffset += bytesPerPayload;
+        currentOffset = alignOffset(currentOffset, CACHELINE_ALIGNMENT);
     }
 
     CHECK_TH_CUDA(workspace);
@@ -236,16 +251,18 @@ std::tuple<std::vector<torch::Tensor>, int64_t> moeA2ADispatchOp(torch::Tensor c
 
     // Validate workspace size - must include space for auxiliary data + payloads
     int64_t sizePerRank = workspace.size(1);
-    int64_t requiredSize = offsets[PAYLOAD_DATA_OFFSET_INDEX] + totalBytesNeeded;
+    int64_t requiredSize = static_cast<int64_t>(currentOffset);
     TORCH_CHECK(sizePerRank >= requiredSize,
         "Workspace size per rank insufficient for dispatch. "
         "Need at least ",
-        requiredSize, " bytes (", offsets[PAYLOAD_DATA_OFFSET_INDEX], " for auxiliary data + ", totalBytesNeeded,
-        " for payloads), but got ", sizePerRank);
+        requiredSize, " bytes (", offsets[PAYLOAD_DATA_OFFSET_INDEX], " for auxiliary data + payloads), but got ",
+        sizePerRank);
 
     // Get base workspace pointer
     uint8_t* workspacePtr = workspace.data_ptr<uint8_t>();
     uint8_t* rankWorkSpacePtr = workspacePtr + epRank * workspace.stride(0);
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(rankWorkSpacePtr) % CACHELINE_ALIGNMENT == 0,
+        "rankWorkSpacePtr must be %d-byte aligned", CACHELINE_ALIGNMENT);
 
     // Setup payload descriptors for source data
     int num_payloads = static_cast<int>(inputPayloads.size());
@@ -288,13 +305,10 @@ std::tuple<std::vector<torch::Tensor>, int64_t> moeA2ADispatchOp(torch::Tensor c
         params.completion_flags[target_rank]
             = reinterpret_cast<uint32_t*>(targetWorkSpacePtr + offsets[DISPATCH_COMPLETION_FLAGS_OFFSET_INDEX]);
 
-        size_t offset = static_cast<size_t>(offsets[PAYLOAD_DATA_OFFSET_INDEX]);
         for (int payload_idx = 0; payload_idx < num_payloads; payload_idx++)
         {
-            // Store pointer for current payload
-            params.recv_buffers[target_rank][payload_idx] = targetWorkSpacePtr + offset;
-            // Update offset for next payload
-            offset += payloadByteSizes[payload_idx];
+            // Store pointer for current payload using pre-calculated aligned offset
+            params.recv_buffers[target_rank][payload_idx] = targetWorkSpacePtr + payloadRecvBufferOffsets[payload_idx];
         }
     }
 
@@ -310,22 +324,17 @@ std::tuple<std::vector<torch::Tensor>, int64_t> moeA2ADispatchOp(torch::Tensor c
 
     // Create tensor views for the current rank's receive buffers only
     std::vector<torch::Tensor> recvTensors;
-    size_t offset = static_cast<size_t>(offsets[PAYLOAD_DATA_OFFSET_INDEX]);
     for (int payload_idx = 0; payload_idx < num_payloads; payload_idx++)
     {
         auto const& payload = inputPayloads[payload_idx];
-        // Create tensor view for this payload
-        auto recvTensor = torch::from_blob(rankWorkSpacePtr + offset,
+        // Create tensor view for this payload using pre-calculated aligned offset
+        auto recvTensor = torch::from_blob(rankWorkSpacePtr + payloadRecvBufferOffsets[payload_idx],
             {epSize, runtimeMaxTokensPerRank, payloadElementsPerToken[payload_idx]}, payload.options());
         recvTensors.push_back(recvTensor);
-
-        // Update offset for next payload
-        offset += payloadByteSizes[payload_idx];
     }
 
     // Compute aligned offset after dispatch payloads for combine payload region
-    constexpr size_t CACHELINE_ALIGNMENT = 128;
-    int64_t combinePayloadOffset = static_cast<int64_t>(alignOffset(static_cast<size_t>(offset), CACHELINE_ALIGNMENT));
+    int64_t combinePayloadOffset = static_cast<int64_t>(alignOffset(currentOffset, CACHELINE_ALIGNMENT));
 
     return std::make_tuple(std::move(recvTensors), combinePayloadOffset);
 }
@@ -356,6 +365,9 @@ torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumToke
     TORCH_CHECK(payload.size(0) == epSize, "payload first dimension must equal epSize");
     TORCH_CHECK(
         payload.size(1) == runtimeMaxTokensPerRank, "payload second dimension must equal runtimeMaxTokensPerRank");
+    // We only make sure the payload start offset is 16-byte aligned, while the actual vectorized ld/st width is
+    // dynamically determined based on bytes per token of this payload.
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(payload.data_ptr()) % 16 == 0, "payload must be 16-byte aligned");
     int64_t elementsPerToken = payload.size(2);
     TORCH_CHECK(elementsPerToken > 0, "elementsPerToken must be positive");
     TORCH_CHECK(epRank >= 0 && epRank < epSize, "epRank must be in the range [0, epSize)");
@@ -411,6 +423,7 @@ torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumToke
         " for payload), but got ", sizePerRank);
 
     // Create output tensor (local on current rank), no need for initialization
+    // Typially, newly allocated torch tensors are at least 16-byte aligned.
     torch::Tensor output = torch::empty({localNumTokens, elementsPerToken}, payload.options());
 
     // Setup combine parameters

--- a/tensorrt_llm/_torch/distributed/moe_alltoall.py
+++ b/tensorrt_llm/_torch/distributed/moe_alltoall.py
@@ -59,25 +59,24 @@ class MoeAlltoAll:
         workspace_size = MoeAlltoAll.get_aux_data_size(ep_size, max_num_tokens)
 
         # Dispatch needs workspace for [ep_size, max_tokens] tokens,
-        # but due to the variety of quantization recipes, we cannot know the exact size,i
-        # so we conservatively estimate assuming no quantization.
+        # but due to the variety of quantization recipes, we cannot know the exact size, so we conservatively estimate assuming no quantization.
         # Meanwhile, we consider the alignment requirement as in moeA2ADispatchOp and moeA2ACombineOp.
         # (Unquantized) token hidden states
         workspace_size += ep_size * max_num_tokens * hidden_size * element_size
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # token_selected_experts
         workspace_size += ep_size * max_num_tokens * top_k * 4
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # token_final_scales
         workspace_size += ep_size * max_num_tokens * top_k * 4
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # extra payload bytes per token
         workspace_size += ep_size * max_num_tokens * extra_payload_bytes_per_token
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
 
         # Required workspace for combine [ep_size, max_tokens] tokens
         workspace_size += ep_size * max_num_tokens * hidden_size * element_size
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
 
         return workspace_size
 

--- a/tensorrt_llm/_torch/distributed/moe_alltoall.py
+++ b/tensorrt_llm/_torch/distributed/moe_alltoall.py
@@ -54,25 +54,32 @@ class MoeAlltoAll:
             dtype: torch.dtype,
             extra_payload_bytes_per_token: int = 0) -> int:
         element_size = dtype.itemsize
+
         # Auxiliary data size
-        aux_size = MoeAlltoAll.get_aux_data_size(ep_size, max_num_tokens)
+        workspace_size = MoeAlltoAll.get_aux_data_size(ep_size, max_num_tokens)
 
         # Dispatch needs workspace for [ep_size, max_tokens] tokens,
-        # but due to the variety of quantization recipes, we cannot know the exact size,
+        # but due to the variety of quantization recipes, we cannot know the exact size,i
         # so we conservatively estimate assuming no quantization.
-        payload_size_dispatch = ep_size * max_num_tokens * (
-            hidden_size * element_size  # (Unquantized) token hidden states
-            + top_k * 4  # token_selected_experts
-            + top_k * 4  # token_final_scales
-            + extra_payload_bytes_per_token  # extra payload bytes per token
-        )
+        # Meanwhile, we consider the alignment requirement as in moeA2ADispatchOp and moeA2ACombineOp.
+        # (Unquantized) token hidden states
+        workspace_size += ep_size * max_num_tokens * hidden_size * element_size
+        pad_up(workspace_size, 128)
+        # token_selected_experts
+        workspace_size += ep_size * max_num_tokens * top_k * 4
+        pad_up(workspace_size, 128)
+        # token_final_scales
+        workspace_size += ep_size * max_num_tokens * top_k * 4
+        pad_up(workspace_size, 128)
+        # extra payload bytes per token
+        workspace_size += ep_size * max_num_tokens * extra_payload_bytes_per_token
+        pad_up(workspace_size, 128)
 
         # Required workspace for combine [ep_size, max_tokens] tokens
-        payload_size_combine = ep_size * max_num_tokens * hidden_size * element_size
+        workspace_size += ep_size * max_num_tokens * hidden_size * element_size
+        pad_up(workspace_size, 128)
 
-        # Pad to 128 bytes to ensure alignment. This matches the implementation of C++ torch OP code.
-        return pad_up(aux_size, 128) + pad_up(
-            payload_size_dispatch, 128) + pad_up(payload_size_combine, 128)
+        return workspace_size
 
     @classmethod
     def _init_constants(cls):

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -81,32 +81,32 @@ class NVLinkOneSided(Communication):
         extra_payload_bytes_per_token: int = 0,
     ) -> int:
         element_size = dtype.itemsize
+
         # Auxiliary data size
-        aux_size = NVLinkOneSided.get_aux_data_size(ep_size, max_num_tokens)
+        workspace_size = NVLinkOneSided.get_aux_data_size(ep_size, max_num_tokens)
 
         # Dispatch needs workspace for [ep_size, max_tokens] tokens,
         # but due to the variety of quantization recipes, we cannot know the exact size,
         # so we conservatively estimate assuming no quantization.
-        payload_size_dispatch = (
-            ep_size
-            * max_num_tokens
-            * (
-                hidden_size * element_size  # (Unquantized) token hidden states
-                + top_k * 4  # token_selected_experts
-                + top_k * 4  # token_final_scales
-                + extra_payload_bytes_per_token  # extra payload bytes per token
-            )
-        )
+        # Meanwhile, we consider the alignment requirement as in moeA2ADispatchOp and moeA2ACombineOp.
+        # (Unquantized) token hidden states
+        workspace_size += ep_size * max_num_tokens * hidden_size * element_size
+        pad_up(workspace_size, 128)
+        # token_selected_experts
+        workspace_size += ep_size * max_num_tokens * top_k * 4
+        pad_up(workspace_size, 128)
+        # token_final_scales
+        workspace_size += ep_size * max_num_tokens * top_k * 4
+        pad_up(workspace_size, 128)
+        # extra payload bytes per token
+        workspace_size += ep_size * max_num_tokens * extra_payload_bytes_per_token
+        pad_up(workspace_size, 128)
 
         # Required workspace for combine [ep_size, max_tokens] tokens
-        payload_size_combine = ep_size * max_num_tokens * hidden_size * element_size
+        workspace_size += ep_size * max_num_tokens * hidden_size * element_size
+        pad_up(workspace_size, 128)
 
-        # Pad to 128 bytes to ensure alignment. This matches the implementation of C++ torch OP code.
-        return (
-            pad_up(aux_size, 128)
-            + pad_up(payload_size_dispatch, 128)
-            + pad_up(payload_size_combine, 128)
-        )
+        return workspace_size
 
     @classmethod
     def _init_constants(cls):

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -86,25 +86,24 @@ class NVLinkOneSided(Communication):
         workspace_size = NVLinkOneSided.get_aux_data_size(ep_size, max_num_tokens)
 
         # Dispatch needs workspace for [ep_size, max_tokens] tokens,
-        # but due to the variety of quantization recipes, we cannot know the exact size,
-        # so we conservatively estimate assuming no quantization.
+        # but due to the variety of quantization recipes, we cannot know the exact size, so we conservatively estimate assuming no quantization.
         # Meanwhile, we consider the alignment requirement as in moeA2ADispatchOp and moeA2ACombineOp.
         # (Unquantized) token hidden states
         workspace_size += ep_size * max_num_tokens * hidden_size * element_size
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # token_selected_experts
         workspace_size += ep_size * max_num_tokens * top_k * 4
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # token_final_scales
         workspace_size += ep_size * max_num_tokens * top_k * 4
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
         # extra payload bytes per token
         workspace_size += ep_size * max_num_tokens * extra_payload_bytes_per_token
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
 
         # Required workspace for combine [ep_size, max_tokens] tokens
         workspace_size += ep_size * max_num_tokens * hidden_size * element_size
-        pad_up(workspace_size, 128)
+        workspace_size = pad_up(workspace_size, 128)
 
         return workspace_size
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added alignment validation for data pointers in mixture of experts distributed operations.

* **Refactor**
  * Improved workspace sizing and memory buffer alignment for mixture of experts all-to-all communication operations, introducing cacheline-aligned offsets to enhance performance and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
