### PR TITLE
[TRTLLM-10232][feat] Support LoRA adapter for nemotron-h models

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/loraModule.h
+++ b/cpp/include/tensorrt_llm/runtime/loraModule.h
@@ -50,6 +50,10 @@ public:
         kMOE_ROUTER = 16,
         kMLP_ROUTER = 17,
         kMLP_GATE_UP = 18,
+        kMAMBA_IN_PROJ = 19,
+        kMAMBA_OUT_PROJ = 20,
+        kMOE_LATENT_UP = 21,
+        kMOE_LATENT_DOWN = 22,
     };
 
     explicit constexpr LoraModule(ModuleType const& t, SizeType32 inDim, SizeType32 outDim, bool inDimFirst,
@@ -234,6 +238,14 @@ public:
             return ModuleType::kMLP_ROUTER;
         else if (name == "mlp_gate_up")
             return ModuleType::kMLP_GATE_UP;
+        else if (name == "mamba_in_proj")
+            return ModuleType::kMAMBA_IN_PROJ;
+        else if (name == "mamba_out_proj")
+            return ModuleType::kMAMBA_OUT_PROJ;
+        else if (name == "moe_latent_up")
+            return ModuleType::kMOE_LATENT_UP;
+        else if (name == "moe_latent_down")
+            return ModuleType::kMOE_LATENT_DOWN;
         else
             return ModuleType::kINVALID;
     }
@@ -261,6 +273,10 @@ public:
         case ModuleType::kMOE_ROUTER: return "moe_router";
         case ModuleType::kMLP_ROUTER: return "mlp_router";
         case ModuleType::kMLP_GATE_UP: return "mlp_gate_up";
+        case ModuleType::kMAMBA_IN_PROJ: return "mamba_in_proj";
+        case ModuleType::kMAMBA_OUT_PROJ: return "mamba_out_proj";
+        case ModuleType::kMOE_LATENT_UP: return "moe_latent_up";
+        case ModuleType::kMOE_LATENT_DOWN: return "moe_latent_down";
         case ModuleType::kINVALID: return "INVALID";
         }
         return "INVALID";

--- a/cpp/include/tensorrt_llm/runtime/modelConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/modelConfig.h
@@ -228,6 +228,26 @@ public:
         return countLocalLayers(LayerType::kRECURRENT, pipelineParallelism, pipelineParallelismRank);
     }
 
+    // Get number of layers that can have LoRA applied.
+    // For hybrid models (e.g., Nemotron-H with Mamba + Attention), this may differ from num_attention_layers
+    // because LoRA can be applied to non-attention layers (e.g., Mamba in_proj/out_proj).
+    [[nodiscard]] SizeType32 getNbLoraLayers(
+        SizeType32 pipelineParallelism = 1, SizeType32 pipelineParallelismRank = 0) const
+    {
+        TLLM_CHECK_WITH_INFO(pipelineParallelism > 0, "Invalid pipelineParallelism: %d", pipelineParallelism);
+        // If mNbLoraLayers is set (non-zero), use it; otherwise fall back to num_attention_layers
+        if (mNbLoraLayers > 0)
+        {
+            return mNbLoraLayers / pipelineParallelism;
+        }
+        return getNbAttentionLayers(pipelineParallelism, pipelineParallelismRank);
+    }
+
+    void setNbLoraLayers(SizeType32 nbLoraLayers)
+    {
+        mNbLoraLayers = nbLoraLayers;
+    }
+
     [[nodiscard]] SizeType32 constexpr getNbHeads() const noexcept
     {
         return mNbHeads;
@@ -922,6 +942,8 @@ private:
     std::vector<LoraModule> mLoraModules;
     SizeType32 mMlpHiddenSize;
     SizeType32 mMaxLoraRank;
+    // Number of layers that can have LoRA applied (for hybrid models this may be > num_attention_layers)
+    SizeType32 mNbLoraLayers{0};
 
     std::optional<RnnConfig> mRnnConfig;
 

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -217,7 +217,11 @@ NB_MODULE(TRTLLM_NB_MODULE, m)
         .value("MOE_GATE", tr::LoraModule::ModuleType::kMOE_GATE)
         .value("MOE_ROUTER", tr::LoraModule::ModuleType::kMOE_ROUTER)
         .value("MLP_ROUTER", tr::LoraModule::ModuleType::kMLP_ROUTER)
-        .value("MLP_GATE_UP", tr::LoraModule::ModuleType::kMLP_GATE_UP);
+        .value("MLP_GATE_UP", tr::LoraModule::ModuleType::kMLP_GATE_UP)
+        .value("MAMBA_IN_PROJ", tr::LoraModule::ModuleType::kMAMBA_IN_PROJ)
+        .value("MAMBA_OUT_PROJ", tr::LoraModule::ModuleType::kMAMBA_OUT_PROJ)
+        .value("MOE_LATENT_UP", tr::LoraModule::ModuleType::kMOE_LATENT_UP)
+        .value("MOE_LATENT_DOWN", tr::LoraModule::ModuleType::kMOE_LATENT_DOWN);
 
     nb::class_<tr::LoraModule>(m, "LoraModule")
         .def(nb::init<tr::LoraModule::ModuleType, SizeType32, SizeType32, bool, bool, SizeType32, SizeType32>(),
@@ -339,6 +343,9 @@ NB_MODULE(TRTLLM_NB_MODULE, m)
         .def_prop_rw("lora_modules", &tr::ModelConfig::getLoraModules, &tr::ModelConfig::setLoraModules)
         .def_prop_rw("max_lora_rank", &tr::ModelConfig::getMaxLoraRank, &tr::ModelConfig::setMaxLoraRank)
         .def_prop_rw("mlp_hidden_size", &tr::ModelConfig::getMlpHiddenSize, &tr::ModelConfig::setMlpHiddenSize)
+        .def("num_lora_layers", &tr::ModelConfig::getNbLoraLayers, nb::arg("pipeline_parallelism") = 1,
+            nb::arg("pipeline_parallelism_rank") = 0)
+        .def("set_num_lora_layers", &tr::ModelConfig::setNbLoraLayers, nb::arg("num_lora_layers"))
         .def_prop_rw("size_per_head", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead);
 
     nb::class_<tr::WorldConfig>(m, "WorldConfig")

--- a/cpp/tensorrt_llm/runtime/loraCache.cpp
+++ b/cpp/tensorrt_llm/runtime/loraCache.cpp
@@ -454,8 +454,8 @@ SizeType32 LoraCache::determineNumPages(TaskIdType taskId) const
 SizeType32 LoraCache::determineNumPages(TensorPtr loraConfig) const
 {
     TLLM_LOG_DEBUG("%s start", __PRETTY_FUNCTION__);
-    auto const localNumLayers = mModelConfig.getNbAttentionLayers(
-        mWorldConfig.getPipelineParallelism(), mWorldConfig.getPipelineParallelRank());
+    auto const localNumLayers
+        = mModelConfig.getNbLoraLayers(mWorldConfig.getPipelineParallelism(), mWorldConfig.getPipelineParallelRank());
     auto const firstLayerId = mWorldConfig.getPipelineParallelRank() * localNumLayers;
     auto const lastLayerId = firstLayerId + localNumLayers;
 
@@ -579,8 +579,7 @@ std::vector<LoraCache::TaskLayerModuleConfig> LoraCache::copyToPages(TensorPtr s
     auto const tpRank = worldConfig.getTensorParallelRank();
     auto const ppSize = worldConfig.getPipelineParallelism();
     auto const ppRank = worldConfig.getPipelineParallelRank();
-    // TODO(oargov): why *attention* layers?
-    auto const localNumLayers = modelConfig.getNbAttentionLayers(ppSize, ppRank);
+    auto const localNumLayers = modelConfig.getNbLoraLayers(ppSize, ppRank);
     auto const firstLayerId = ppRank * localNumLayers;
     auto const lastLayerId = firstLayerId + localNumLayers;
 

--- a/cpp/tensorrt_llm/runtime/loraManager.cpp
+++ b/cpp/tensorrt_llm/runtime/loraManager.cpp
@@ -72,7 +72,7 @@ void LoraManager::fillInputTensors(TensorPtr weightsPtrs, TensorPtr adapterSizes
 
     auto const ppSize = worldConfig.getPipelineParallelism();
     auto const ppRank = worldConfig.getPipelineParallelRank();
-    auto const localNumLayers = modelConfig.getNbAttentionLayers(ppSize, ppRank);
+    auto const localNumLayers = modelConfig.getNbLoraLayers(ppSize, ppRank);
     auto const firstLayerId = ppRank * localNumLayers;
 
     auto weightsPointersPtr = bufferCast<int64_t>(*weightsPtrs);
@@ -124,7 +124,7 @@ void LoraManager::insertInputTensors(TensorMap& inputTensors, TensorPtr weightsP
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto localNbLayers
-        = modelConfig.getNbAttentionLayers(worldConfig.getPipelineParallelism(), worldConfig.getPipelineParallelRank());
+        = modelConfig.getNbLoraLayers(worldConfig.getPipelineParallelism(), worldConfig.getPipelineParallelRank());
     auto firstLayerId = worldConfig.getPipelineParallelRank() * localNbLayers;
 
     for (auto const& [modId, mod] : mModuleIdToModule)

--- a/cpp/tensorrt_llm/runtime/loraModule.cpp
+++ b/cpp/tensorrt_llm/runtime/loraModule.cpp
@@ -65,6 +65,12 @@ std::vector<LoraModule> LoraModule::createLoraModules(std::vector<std::string> c
         case ModuleType::kMOE_ROUTER: modules.emplace_back(t, hidden, numExperts, false, true, -1, -1); break;
         case ModuleType::kMLP_ROUTER: modules.emplace_back(t, hidden, 1, false, true, -1, -1); break;
         case ModuleType::kMLP_GATE_UP: modules.emplace_back(t, hidden, 2 * mlpHidden, false, true, -1, 0); break;
+        // Mamba modules: in_proj expands, out_proj contracts (similar to MLP pattern)
+        case ModuleType::kMAMBA_IN_PROJ: modules.emplace_back(t, hidden, mlpHidden, false, true, -1, 0); break;
+        case ModuleType::kMAMBA_OUT_PROJ: modules.emplace_back(t, mlpHidden, hidden, false, true, 1, -1); break;
+        // MoE latent projections: up expands to moe_hidden, down contracts back
+        case ModuleType::kMOE_LATENT_UP: modules.emplace_back(t, hidden, mlpHidden, false, true, -1, 0); break;
+        case ModuleType::kMOE_LATENT_DOWN: modules.emplace_back(t, mlpHidden, hidden, false, true, 1, -1); break;
         case ModuleType::kINVALID: throw std::runtime_error("Invalid LoRA module " + moduleName);
         }
     }

--- a/cpp/tensorrt_llm/runtime/loraUtils.cpp
+++ b/cpp/tensorrt_llm/runtime/loraUtils.cpp
@@ -84,7 +84,7 @@ void loraValidateRequestTensors(std::optional<std::uint64_t> const& optTaskId,
             ? config
             : ITensor::view(config, ITensor::makeShape({config->getShape().d[1], config->getShape().d[2]}));
 
-        SizeType32 nbModelLayers = modelConfig.getNbAttentionLayers();
+        SizeType32 nbModelLayers = modelConfig.getNbLoraLayers();
         TLLM_CHECK_WITH_INFO(weights->getDataType() == modelConfig.getDataType(),
             "Expected lora weights to be the same data type as base model");
 

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -3,11 +3,13 @@ import json
 import time
 
 from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.llmapi import (AttentionDpConfig, AutoDecodingConfig,
                                  CudaGraphConfig, DraftTargetDecodingConfig,
                                  Eagle3DecodingConfig, KvCacheConfig, MoeConfig,
                                  MTPDecodingConfig, NGramDecodingConfig,
                                  TorchCompileConfig)
+from tensorrt_llm.lora_helper import LoraConfig
 
 example_prompts = [
     "Hello, my name is",
@@ -198,6 +200,12 @@ def add_llm_args(parser):
     parser.add_argument('--relaxed_topk', type=int, default=1)
     parser.add_argument('--relaxed_delta', type=float, default=0.)
 
+    # LoRA
+    parser.add_argument('--lora_dir',
+                        type=str,
+                        default=None,
+                        help='Path to LoRA adapter directory.')
+
     # HF
     parser.add_argument('--trust_remote_code',
                         default=False,
@@ -292,6 +300,18 @@ def setup_llm(args, **kwargs):
         batching_wait_iters=args.attention_dp_batching_wait_iters,
     )
 
+    lora_config = LoraConfig(
+        lora_dir=[args.lora_dir]) if args.lora_dir else None
+
+    # Create LoRARequest to use during generation
+    lora_request = None
+    if args.lora_dir:
+        lora_request = LoRARequest(
+            lora_name="lora_adapter",
+            lora_int_id=0,  # First adapter ID
+            lora_path=args.lora_dir,
+        )
+
     llm = LLM(
         model=args.model_dir,
         backend='pytorch',
@@ -327,6 +347,7 @@ def setup_llm(args, **kwargs):
         gather_generation_logits=args.return_generation_logits,
         max_beam_width=args.max_beam_width,
         orchestrator_type=args.orchestrator_type,
+        lora_config=lora_config,
         **kwargs)
 
     use_beam_search = args.max_beam_width > 1
@@ -352,14 +373,14 @@ def setup_llm(args, **kwargs):
         use_beam_search=use_beam_search,
         additional_model_outputs=args.additional_model_outputs,
     )
-    return llm, sampling_params
+    return llm, sampling_params, lora_request
 
 
 def main():
     args = parse_arguments()
     prompts = args.prompt if args.prompt else example_prompts
 
-    llm, sampling_params = setup_llm(args)
+    llm, sampling_params, lora_request = setup_llm(args)
     new_prompts = []
     if args.apply_chat_template:
         for prompt in prompts:
@@ -369,7 +390,7 @@ def main():
                                                   tokenize=False,
                                                   add_generation_prompt=True))
         prompts = new_prompts
-    outputs = llm.generate(prompts, sampling_params)
+    outputs = llm.generate(prompts, sampling_params, lora_request=lora_request)
 
     for i, output in enumerate(outputs):
         prompt = output.prompt

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -686,6 +686,12 @@ class ModelConfig(Generic[TConfig]):
             num_kv_heads = num_key_value_heads // (attn_tp_size * attn_cp_size)
             model_config_cpp.set_num_kv_heads(num_kv_heads)
 
+        # For hybrid models (e.g., Nemotron-H with Mamba + Attention), LoRA can be applied
+        # to non-attention layers (e.g., Mamba in_proj/out_proj). Set num_lora_layers to
+        # total layers so the C++ LoRA validation accepts all layer indices.
+        if is_nemotron_hybrid(self.pretrained_config):
+            model_config_cpp.set_num_lora_layers(num_layers)
+
         mlp_hidden_size = None
         if self.pretrained_config.intermediate_size is not None:
             mlp_hidden_size = self.pretrained_config.intermediate_size // self.mapping.tp_size

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -852,8 +852,11 @@ class DeepseekV3Gate(nn.Module):
         fuse_routing_kernel: bool = True,
         apply_routing: bool = False,
         moe_backend: str = 'CUTLASS',
+        lora_config: Optional["LoraConfig"] = None,
     ):
         super().__init__()
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
         self.weight = nn.Parameter(torch.empty((num_experts, hidden_size),
                                                dtype=dtype),
                                    requires_grad=False)
@@ -877,11 +880,27 @@ class DeepseekV3Gate(nn.Module):
             routed_scaling_factor=routed_scaling_factor,
             is_fused=fuse_routing_kernel)
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # LoRA for gate (router) - only create when LoRA is configured
+        from ..peft.lora.layer import LoraModuleType
+        self.gate_lora = (LoraLayer([LoraModuleType.MOE_ROUTER], [num_experts])
+                          if lora_config is not None else None)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        lora_params: Optional[dict] = None,
+        layer_idx: Optional[int] = None,
+    ) -> torch.Tensor:
         logits = torch.ops.trtllm.dsv3_router_gemm_op(hidden_states,
                                                       self.weight.t(),
                                                       bias=None,
                                                       out_dtype=torch.float32)
+        # Apply LoRA to gate (if LoRA is configured and weights are loaded)
+        if self.gate_lora is not None and bool(
+                lora_params) and layer_idx is not None:
+            lora_output = self.gate_lora(hidden_states, lora_params, layer_idx)
+            if lora_output is not None:
+                logits = logits + lora_output.to(logits.dtype)
         return logits
 
     def load_weights(self, weights: List[Dict]):

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -42,6 +42,7 @@ from ..modules.mamba.mamba2_mixer import Mamba2Mixer
 from ..modules.mlp import MLP
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
+from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..speculative import SpecMetadata
 from ..utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .modeling_deepseekv3 import DeepseekV3MTPHead
@@ -83,9 +84,10 @@ class MLPLayer(MLP):
         self,
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> torch.Tensor:
-        return super().forward(hidden_states)
+        return super().forward(hidden_states, lora_params=lora_params)
 
 
 class TransformerLayer(Attention):
@@ -115,11 +117,13 @@ class TransformerLayer(Attention):
         self,
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> torch.Tensor:
         return super().forward(position_ids=None,
                                hidden_states=hidden_states,
-                               attn_metadata=attn_metadata)
+                               attn_metadata=attn_metadata,
+                               lora_params=lora_params)
 
 
 # Ref code: https://huggingface.co/nvidia/Nemotron-Nano-3-30B-A3.5B-dev-1024/blob/main/modeling_nemotron_h.py#L818
@@ -182,6 +186,9 @@ class NemotronHMOE(nn.Module):
                 reduce_output=False,
                 overridden_tp_size=1
                 if model_config.mapping.enable_attention_dp else None,
+                # Use MoE LoRA types for shared experts
+                lora_up_module_type=LoraModuleType.MOE_H_TO_4H,
+                lora_down_module_type=LoraModuleType.MOE_4H_TO_H,
             )
         # Setup MoE gate.
         self.gate = DeepseekV3Gate(
@@ -195,6 +202,7 @@ class NemotronHMOE(nn.Module):
             fuse_routing_kernel=True,
             apply_routing=False,
             moe_backend=model_config.moe_backend,
+            lora_config=model_config.lora_config,
         )
 
         # For MIXED_PRECISION models, the global quant_config has quant_algo=MIXED_PRECISION
@@ -239,6 +247,10 @@ class NemotronHMOE(nn.Module):
         # These layers should NOT be TP-sharded to ensure MoE receives
         # full latent representation. They are replicated across all GPUs.
         if self.use_latent_moe:
+            # LoRA for fc1_latent_proj (only create when LoRA is configured)
+            self.fc1_latent_lora = (LoraLayer([LoraModuleType.MOE_LATENT_UP], [
+                self.moe_hidden_size
+            ]) if model_config.lora_config is not None else None)
             self.fc1_latent_proj = Linear(
                 in_features=self.hidden_size,
                 out_features=self.moe_hidden_size,
@@ -247,7 +259,12 @@ class NemotronHMOE(nn.Module):
                 quant_config=model_config.get_quant_config(),
                 skip_create_weights_in_init=model_config.
                 skip_create_weights_in_init,
+                lora=self.fc1_latent_lora,
             )
+            # LoRA for fc2_latent_proj (only create when LoRA is configured)
+            self.fc2_latent_lora = (
+                LoraLayer([LoraModuleType.MOE_LATENT_DOWN], [self.hidden_size])
+                if model_config.lora_config is not None else None)
             self.fc2_latent_proj = Linear(
                 in_features=self.moe_hidden_size,
                 out_features=self.hidden_size,
@@ -256,10 +273,13 @@ class NemotronHMOE(nn.Module):
                 quant_config=model_config.get_quant_config(),
                 skip_create_weights_in_init=model_config.
                 skip_create_weights_in_init,
+                lora=self.fc2_latent_lora,
             )
         else:
             self.fc1_latent_proj = None
             self.fc2_latent_proj = None
+            self.fc1_latent_lora = None
+            self.fc2_latent_lora = None
 
         self.aux_stream_shared = aux_stream_dict[AuxStreamType.MoeShared]
         self.event_dict = {
@@ -272,6 +292,7 @@ class NemotronHMOE(nn.Module):
         hidden_states: torch.Tensor
         | tuple[torch.Tensor | Fp4QuantizedTensor, torch.Tensor],
         attn_metadata: AttentionMetadata,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> torch.Tensor:
         if isinstance(hidden_states, tuple):
@@ -289,17 +310,25 @@ class NemotronHMOE(nn.Module):
 
         def _compute_shared_output():
             if self.shared_experts is not None:
-                shared_expert_output = self.shared_experts(hidden_states_hp)
+                shared_expert_output = self.shared_experts(
+                    hidden_states_hp, lora_params=lora_params)
             else:
                 shared_expert_output = 0
             return shared_expert_output
 
         def _compute_routed_output():
             # Gate uses high precision input for accurate routing decisions.
-            router_logits = self.gate(hidden_states_hp_2d)
+            router_logits = self.gate(hidden_states_hp_2d,
+                                      lora_params=lora_params,
+                                      layer_idx=self.layer_idx)
 
-            routed_hidden_states = self.fc1_latent_proj(
-                hidden_states_hp) if self.use_latent_moe else hidden_states
+            if self.use_latent_moe:
+                routed_hidden_states = self.fc1_latent_proj(
+                    hidden_states_hp,
+                    lora_params=lora_params,
+                    layer_idx=self.layer_idx)
+            else:
+                routed_hidden_states = hidden_states
 
             final_hidden_states = self.experts(
                 routed_hidden_states,
@@ -309,7 +338,10 @@ class NemotronHMOE(nn.Module):
             )
 
             if self.use_latent_moe:
-                final_hidden_states = self.fc2_latent_proj(final_hidden_states)
+                final_hidden_states = self.fc2_latent_proj(
+                    final_hidden_states,
+                    lora_params=lora_params,
+                    layer_idx=self.layer_idx)
 
             return final_hidden_states
 
@@ -458,6 +490,7 @@ class NemotronHLayer(DecoderLayer):
         attn_metadata: AttentionMetadata,
         residual: torch.Tensor | None = None,
         spec_metadata: SpecMetadata | None = None,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if residual is None:
@@ -472,6 +505,7 @@ class NemotronHLayer(DecoderLayer):
         hidden_states = self.mixer(hidden_states,
                                    attn_metadata,
                                    spec_metadata=spec_metadata,
+                                   lora_params=lora_params,
                                    **kwargs)
 
         if spec_metadata is not None and spec_metadata.is_layer_capture(
@@ -544,6 +578,7 @@ class NemotronHModel(DecoderModel):
         position_ids: torch.IntTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         spec_metadata: SpecMetadata | None = None,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -565,6 +600,7 @@ class NemotronHModel(DecoderModel):
                 residual=residual,
                 attn_metadata=attn_metadata,
                 spec_metadata=spec_metadata,
+                lora_params=lora_params,
                 mamba_metadata=mamba_metadata,
             )
         hidden_states, _ = self.norm_f(hidden_states, residual)
@@ -761,6 +797,7 @@ class NemotronHMTPDecoderLayer(NemotronHLayer):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self.has_start_projections:
@@ -790,6 +827,7 @@ class NemotronHMTPDecoderLayer(NemotronHLayer):
         hidden_states = self.mixer(
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
+            lora_params=lora_params,
             **kwargs,
         )
 
@@ -885,6 +923,7 @@ class NemotronHMTP(nn.Module):
         attn_metadata: AttentionMetadata,
         all_rank_num_tokens: list[int] | None = None,
         spec_metadata: SpecMetadata | None = None,
+        lora_params: dict | None = None,
         **kwargs,
     ) -> torch.Tensor:
         inputs_embeds = embed_tokens(input_ids)
@@ -898,6 +937,7 @@ class NemotronHMTP(nn.Module):
                 residual=residual,
                 attn_metadata=attn_metadata,
                 all_rank_num_tokens=all_rank_num_tokens,
+                lora_params=lora_params,
             )
         return hidden_states
 

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 from einops import rearrange, repeat
 from flashinfer.mamba import selective_state_update as selective_state_update_fi
@@ -26,6 +28,7 @@ from tensorrt_llm.mapping import Mapping
 
 from ...attention_backend import AttentionMetadata
 from ...model_config import ModelConfig
+from ...peft.lora.layer import LoraLayer, LoraModuleType
 from ...speculative import SpecMetadata
 from ..linear import Linear, TensorParallelMode
 from .causal_conv1d import causal_conv1d_fn, causal_conv1d_update
@@ -107,6 +110,10 @@ class Mamba2Mixer(nn.Module):
         self.slot_mapping = None
         self.is_paged_state = False
 
+        self.in_proj_lora = (LoraLayer([LoraModuleType.MAMBA_IN_PROJ],
+                                       [d_in_proj // tp_size])
+                             if config.lora_config is not None else None)
+
         # in_proj
         self.in_proj = Linear(
             d_model,
@@ -117,7 +124,8 @@ class Mamba2Mixer(nn.Module):
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             quant_config=config.get_quant_config(),
             skip_create_weights_in_init=config.skip_create_weights_in_init,
-            allreduce_strategy=config.allreduce_strategy)
+            allreduce_strategy=config.allreduce_strategy,
+            lora=self.in_proj_lora)
 
         # conv1d, reuse Linear to store weights since it has support for TP > 1 already
         self.conv1d = Linear(
@@ -193,6 +201,10 @@ class Mamba2Mixer(nn.Module):
             is_nvfp4=self.is_nvfp4,
         )
 
+        self.out_proj_lora = (LoraLayer([LoraModuleType.MAMBA_OUT_PROJ],
+                                        [d_model])
+                              if config.lora_config is not None else None)
+
         # out_proj
         self.out_proj = Linear(
             d_inner,
@@ -203,7 +215,8 @@ class Mamba2Mixer(nn.Module):
             tensor_parallel_mode=TensorParallelMode.ROW,
             quant_config=config.get_quant_config(),
             skip_create_weights_in_init=config.skip_create_weights_in_init,
-            allreduce_strategy=config.allreduce_strategy)
+            allreduce_strategy=config.allreduce_strategy,
+            lora=self.out_proj_lora)
 
     def post_load_weights(self):
         """Post-process after loading weights."""
@@ -215,6 +228,12 @@ class Mamba2Mixer(nn.Module):
 
         Called from post_load_weights (weights don't exist during __init__).
         """
+        # Don't use fused NVFP4 output if LoRA is enabled on out_proj.
+        # LoRA computation requires a regular tensor, not Fp4QuantizedTensor.
+        if getattr(self.out_proj, 'lora', None) is not None:
+            self.norm.is_nvfp4 = False
+            return
+
         if getattr(self.out_proj, 'input_scale', None) is not None:
             self.norm.nvfp4_scale = self.out_proj.input_scale
         else:
@@ -226,6 +245,7 @@ class Mamba2Mixer(nn.Module):
         attn_metadata: AttentionMetadata,
         mamba_metadata: Mamba2Metadata,
         spec_metadata: SpecMetadata | None = None,
+        lora_params: Optional[dict] = None,
         **kwargs,
     ) -> torch.Tensor:
 
@@ -257,8 +277,10 @@ class Mamba2Mixer(nn.Module):
         state_indices_p, state_indices_d = torch.split(state_indices,
                                                        batch_split_size)
 
-        # in_proj
-        zxbcdt = self.in_proj(hidden_states)
+        # in_proj (LoRA is applied internally by Linear layer)
+        zxbcdt = self.in_proj(hidden_states,
+                              lora_params=lora_params,
+                              layer_idx=self.layer_idx)
 
         # Split z and dt with views.
         z = zxbcdt[:, :self.tp_d_inner]
@@ -501,6 +523,8 @@ class Mamba2Mixer(nn.Module):
         hidden_states = self.norm(preallocated_ssm_out, z[:num_actual_tokens])
 
         # out_proj
-        out = self.out_proj(hidden_states)
+        out = self.out_proj(hidden_states,
+                            lora_params=lora_params,
+                            layer_idx=self.layer_idx)
 
         return out[:num_actual_tokens]

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -26,6 +26,8 @@ class MLP(nn.Module):
         layer_idx: Optional[int] = None,
         reduce_output: bool = True,
         overridden_tp_size: Optional[int] = None,
+        lora_up_module_type: LoraModuleType = LoraModuleType.MLP_H_TO_4H,
+        lora_down_module_type: LoraModuleType = LoraModuleType.MLP_4H_TO_H,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -51,7 +53,7 @@ class MLP(nn.Module):
             mapping = config.mapping
 
         self.up_lora = LoraLayer(
-            [LoraModuleType.MLP_H_TO_4H],
+            [lora_up_module_type],
             [self.intermediate_size // config.mapping.tp_size])
 
         self.up_proj = Linear(
@@ -69,8 +71,7 @@ class MLP(nn.Module):
             allreduce_strategy=config.allreduce_strategy,
             force_dynamic_quantization=config.force_dynamic_quantization)
 
-        self.down_lora = LoraLayer([LoraModuleType.MLP_4H_TO_H],
-                                   [self.hidden_size])
+        self.down_lora = LoraLayer([lora_down_module_type], [self.hidden_size])
         self.down_proj = Linear(
             self.intermediate_size,
             self.hidden_size,

--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -74,6 +74,12 @@ class LoraModuleType(IntEnum):
     MLP_ROUTER = 17  # MLP router
     MLP_GATE_UP = 18  # Combined gate and up projections
 
+    MAMBA_IN_PROJ = 19  # Mamba input projection
+    MAMBA_OUT_PROJ = 20  # Mamba output projection
+
+    MOE_LATENT_UP = 21  # MoE latent up projection (fc1_latent_proj)
+    MOE_LATENT_DOWN = 22  # MoE latent down projection (fc2_latent_proj)
+
     def __str__(self):
         """Return the name of the enum value."""
         return self.name
@@ -120,6 +126,11 @@ class LoraModuleType(IntEnum):
         return self in {
             self.MOE_H_TO_4H, self.MOE_4H_TO_H, self.MOE_GATE, self.MOE_ROUTER
         }
+
+    @property
+    def is_mamba(self) -> bool:
+        """Check if this is a Mamba module type."""
+        return self in {self.MAMBA_IN_PROJ, self.MAMBA_OUT_PROJ}
 
 
 class LoraLayer(torch.nn.Module):
@@ -475,14 +486,16 @@ class LoraLayer(torch.nn.Module):
         lora_weight_pointers = []
         active_lora_module_ids = []
 
+        # Check if this layer has any LoRA weights
+        layer_params = lora_params.get(layer_idx, {})
+
         for module_idx in self.lora_module_types:
             module_idx = int(module_idx)
-            if module_idx in lora_params[layer_idx]:
+            if module_idx in layer_params:
                 active_lora_module_ids.append(module_idx)
-                lora_ranks.append(
-                    lora_params[layer_idx][module_idx]['adapter_size'])
+                lora_ranks.append(layer_params[module_idx]['adapter_size'])
                 lora_weight_pointers.append(
-                    lora_params[layer_idx][module_idx]['weight_pointers'])
+                    layer_params[module_idx]['weight_pointers'])
 
         num_seqs = lora_params['num_seqs']
 

--- a/tensorrt_llm/lora_helper.py
+++ b/tensorrt_llm/lora_helper.py
@@ -53,10 +53,14 @@ def get_default_trtllm_modules_to_hf_modules():
         "mlp_4h_to_h": "down_proj",
         "mlp_gate": "up_proj",
         "mlp_gate_up": "gate_up_proj",
-        "moe_h_to_4h": "w1",
-        "moe_4h_to_h": "w2",
+        "moe_h_to_4h": ["w1", "shared_experts.up_proj"],
+        "moe_4h_to_h": ["w2", "shared_experts.down_proj"],
         "moe_gate": "w3",
         "moe_router": "gate",
+        "mamba_in_proj": "in_proj",
+        "mamba_out_proj": "out_proj",
+        "moe_latent_up": "fc1_latent_proj",
+        "moe_latent_down": "fc2_latent_proj",
     }
 
 

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -658,6 +658,10 @@ class LoraManager(object):
         "moe_router": 16,
         "mlp_router": 17,
         "mlp_gate_up": 18,
+        "mamba_in_proj": 19,
+        "mamba_out_proj": 20,
+        "moe_latent_up": 21,
+        "moe_latent_down": 22,
     }
 
     def __init__(

--- a/tests/unittest/_torch/modules/tests_lora_modules/test_nemotron_h_lora_sanity.py
+++ b/tests/unittest/_torch/modules/tests_lora_modules/test_nemotron_h_lora_sanity.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sanity tests for Nemotron-H LoRA support."""
+
+import json
+import os
+import tempfile
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from utils.llm_data import llm_models_root
+from utils.util import skip_gpu_memory_less_than_80gb, skip_pre_hopper
+
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.lora_helper import LoraConfig, get_default_trtllm_modules_to_hf_modules
+
+
+def _create_dummy_lora_adapter(output_dir: str, base_model_path: str, lora_rank: int = 8) -> str:
+    """Create a dummy LoRA adapter targeting attention layers."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    with open(os.path.join(base_model_path, "config.json")) as f:
+        cfg = json.load(f)
+
+    hidden = cfg["hidden_size"]
+    q_dim = cfg.get("num_attention_heads", 32) * cfg.get("head_dim", 128)
+    kv_dim = cfg.get("num_key_value_heads", 2) * cfg.get("head_dim", 128)
+    pattern = cfg.get("hybrid_override_pattern", "")
+    attn_layers = [i for i, c in enumerate(pattern) if c == "*"]
+
+    with open(os.path.join(output_dir, "adapter_config.json"), "w") as f:
+        json.dump(
+            {
+                "base_model_name_or_path": base_model_path,
+                "bias": "none",
+                "peft_type": "LORA",
+                "r": lora_rank,
+                "lora_alpha": 16,
+                "target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
+                "task_type": "CAUSAL_LM",
+            },
+            f,
+        )
+
+    # Projection dims: q(hidden->q_dim), k/v(hidden->kv_dim), o(q_dim->hidden)
+    proj_dims = {
+        "q_proj": (hidden, q_dim),
+        "k_proj": (hidden, kv_dim),
+        "v_proj": (hidden, kv_dim),
+        "o_proj": (q_dim, hidden),
+    }
+    weights = {}
+    for layer_idx in attn_layers:
+        for proj, (in_dim, out_dim) in proj_dims.items():
+            key = f"base_model.model.backbone.layers.{layer_idx}.mixer.{proj}"
+            weights[f"{key}.lora_A.weight"] = (
+                torch.randn(lora_rank, in_dim, dtype=torch.bfloat16) * 0.01
+            )
+            weights[f"{key}.lora_B.weight"] = torch.zeros(out_dim, lora_rank, dtype=torch.bfloat16)
+
+    save_file(weights, os.path.join(output_dir, "adapter_model.safetensors"))
+    return output_dir
+
+
+@skip_pre_hopper
+@skip_gpu_memory_less_than_80gb
+class TestNemotronHLoRASanity:
+    """Sanity test for Nemotron-H LoRA support."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+
+    def test_load_and_generate_with_lora(self):
+        """Test loading and running inference with a dummy LoRA adapter."""
+        if not os.path.exists(self.model_path):
+            pytest.skip(f"Model not found: {self.model_path}")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lora_dir = _create_dummy_lora_adapter(os.path.join(tmpdir, "lora"), self.model_path)
+
+            with LLM(
+                model=self.model_path,
+                lora_config=LoraConfig(lora_dir=[lora_dir], max_lora_rank=16, max_loras=2),
+                tensor_parallel_size=1,
+                max_batch_size=1,
+                max_num_tokens=128,
+            ) as llm:
+                outputs = llm.generate(
+                    ["Hello"],
+                    sampling_params=SamplingParams(max_tokens=5),
+                    lora_request=[LoRARequest("test-lora", 0, lora_dir)],
+                )
+                assert len(outputs) == 1
+                assert len(outputs[0].outputs[0].token_ids) > 0
+
+
+class TestNemotronHLoRAModuleMappings:
+    """Test LoRA module name mappings for Nemotron-H."""
+
+    def test_nemotron_h_modules_have_mappings(self):
+        """Verify Nemotron-H specific modules have correct HF mappings."""
+        mapping = get_default_trtllm_modules_to_hf_modules()
+        expected = {
+            "mamba_in_proj": "in_proj",
+            "mamba_out_proj": "out_proj",
+            "moe_latent_up": "fc1_latent_proj",
+            "moe_latent_down": "fc2_latent_proj",
+        }
+        for trtllm_name, hf_name in expected.items():
+            assert mapping.get(trtllm_name) == hf_name, f"{trtllm_name} should map to {hf_name}"


### PR DESCRIPTION
Support following moduel LoRAs:
* Attention Q/K/V/O proj
* MoE_shared_expert
* Mamba in/out proj

Not Supporte yet:
* MoE latent_proj
* MoE gate_proj
* MoE route_experts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LoRA support for Mamba in/out projection and MoE latent projection modules
  * Introduced Python API methods for configuring LoRA layer counts and handling pipeline parallelism
  * Extended model implementations (DeepSeek, Nemotron, Mamba) with integrated LoRA parameter support
  * Added quickstart example demonstrating LoRA integration with CLI support

* **Tests**
  * Added comprehensive test suite validating Nemotron-H LoRA functionality and module mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
