### PR TITLE
[TRTLLM-8425][doc] document Torch Sampler details

### DIFF
--- a/docs/source/features/sampling.md
+++ b/docs/source/features/sampling.md
@@ -25,6 +25,50 @@ llm.generate(["Hello, my name is",
 
 Note: The `enable_trtllm_sampler` option is not currently supported when using speculative decoders, such as MTP or Eagle-3, so there is a smaller subset of sampling options available.
 
+### LLM API sampling behavior when using Torch Sampler
+
+* The sampling is controlled via `SamplingParams`.
+
+* By default (`temperature = top_p = top_k = None`), greedy sampling is used.
+
+* If either `temperature = 0`, `top_p = 0`, and/or `top_k = 1`, is specified, sampling is greedy,
+  irrespective of the values of the remaining parameters.
+
+* Otherwise, sampling proceeds according to the specified sampling parameter values and any
+  unspecified parameters default to `top_k = 0`, `top_p = 1`, `temperature = 1.0`:
+
+  * The logits are scaled by `1/temperature` before applying softmax to compute probabilities.
+    Sampling is performed according to these probabilities.
+
+  * If `top_k = 0` (or `top_k = vocab_size`) and `top_p = 1`, the output tokens are sampled
+    from the entire vocabulary.
+
+  * If `1 < top_k < vocab_size` is specified, the sampling is restricted to
+    the `top_k` highest-probability tokens.
+
+  * If `0 < top_p < 1.0` is specified, the sampling is further restricted to a minimal subset
+    of highest-probability tokens with total probability greater than `top_p` ("nucleus sampling").
+    In particular, the probability of the lowest-probability token in the selected
+    subset is greater or equal than the probability of any not selected token.
+
+  * The implementation does not guarantee any particular treatment of tied probabilities.
+
+### Performance
+
+The Torch Sampler leverages the optimized sampling kernels provided by
+[FlashInfer](https://docs.flashinfer.ai/api/sampling.html). The sampler
+also uses the [sorting-free implementations](https://flashinfer.ai/2025/03/10/sampling.html)
+whenever possible. This optimization does not compute the complete set of token sampling probabilities
+(after top-k / top-p masking etc.), which typically can be omitted unless requested by the user or
+required for speculative decoding (rejection sampling).
+In case of unexpected problems, the use of FlashInfer in Torch Sampler can
+be disabled via the `disable_flashinfer_sampling` config option (note that this option is likely
+to be removed in a future TensorRT-LLM release).
+
+Moreover, Torch Sampler internally batches requests with compatible sampling parameters. This
+can greatly reduce the overall latency of the sampling step when request batches are comprised
+of requests with very heterogeneous sampling strategies (e.g. a mix of requests using greedy and top-p-after-top-k sampling).
+
 ## Beam search
 
 Beam search is a decoding strategy that maintains multiple candidate sequences (beams) during text generation, exploring different possible continuations to find higher quality outputs. Unlike greedy decoding or sampling, beam search considers multiple hypotheses simultaneously.

--- a/docs/source/features/sampling.md
+++ b/docs/source/features/sampling.md
@@ -65,7 +65,7 @@ whenever possible. This optimization does not compute the complete set of token 
 required for speculative decoding (rejection sampling).
 In case of unexpected problems, the use of FlashInfer in Torch Sampler can
 be disabled via the `disable_flashinfer_sampling` config option (note that this option is likely
-to be removed in a future TensorRT-LLM release).
+to be removed in a future TensorRT LLM release).
 
 Moreover, Torch Sampler internally batches requests with compatible sampling parameters. This
 can greatly reduce the overall latency of the sampling step when request batches are comprised

--- a/docs/source/features/sampling.md
+++ b/docs/source/features/sampling.md
@@ -50,6 +50,8 @@ Note: The `enable_trtllm_sampler` option is not currently supported when using s
     of highest-probability tokens with total probability greater than `top_p` ("nucleus sampling").
     In particular, the probability of the lowest-probability token in the selected
     subset is greater or equal than the probability of any not selected token.
+    When combined with `top_k`, the probabilities of the tokens selected by `top_k` are rescaled
+    such that they sum to one before `top_p` is applied.
 
   * The implementation does not guarantee any particular treatment of tied probabilities.
 


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/NVIDIA/TensorRT-LLM/pull/10083/changes#r2664940990, adding more details regarding Torch Sampler semantics and performance.

## Test Coverage

n/a

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on LLM API sampling behavior with Torch Sampler, covering sampling parameter controls, default values, greedy and nucleus sampling conditions, and performance optimization details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->