### PR TITLE
[https://nvbugs/5630196] [fix] Prevent flaky failures in C++ test_e2e.py by using local cached datasets for benchmarking

### DIFF
--- a/benchmarks/cpp/utils/prepare_real_data.py
+++ b/benchmarks/cpp/utils/prepare_real_data.py
@@ -251,41 +251,41 @@ def load_dataset_from_local(dataset_config: DatasetConfig):
 
 
 @click.command()
-@click.option("--dataset-name", type=str, help=f"Dataset name in HuggingFace.")
+@click.option("--dataset-name", type=str, help="Dataset name in HuggingFace.")
 @click.option("--dataset-config-name",
               type=str,
               default=None,
-              help=f"Dataset config name in HuggingFace (if exists).")
+              help="Dataset config name in HuggingFace (if exists).")
 @click.option("--dataset-split",
               type=str,
               required=True,
-              help=f"Split of the dataset to use.")
+              help="Split of the dataset to use.")
 @click.option("--dataset-input-key",
               type=str,
-              help=f"The dataset dictionary key for input.")
+              help="The dataset dictionary key for input.")
 @click.option("--dataset-image-key",
               type=str,
               default="image",
-              help=f"The dataset dictionary key for images.")
+              help="The dataset dictionary key for images.")
 @click.option("--dataset-prompt-key",
               type=str,
               default=None,
-              help=f"The dataset dictionary key for prompt (if exists).")
+              help="The dataset dictionary key for prompt (if exists).")
 @click.option(
     "--dataset-local-path",
     type=str,
     default=None,
     help=
-    f"The local path to the dataset to be loaded when using an offline cache.")
+    "The local path to the dataset to be loaded when using an offline cache.")
 @click.option(
     "--dataset-prompt",
     type=str,
     default=None,
-    help=f"The prompt string when there is no prompt key for the dataset.")
+    help="The prompt string when there is no prompt key for the dataset.")
 @click.option("--dataset-output-key",
               type=str,
               default=None,
-              help=f"The dataset dictionary key for output (if exists).")
+              help="The dataset dictionary key for output (if exists).")
 @click.option(
     "--num-requests",
     type=int,

--- a/benchmarks/cpp/utils/prepare_real_data.py
+++ b/benchmarks/cpp/utils/prepare_real_data.py
@@ -221,7 +221,8 @@ def load_dataset_from_local(dataset_config: DatasetConfig):
     if local_path.is_dir():
         try:
             dataset = datasets.load_dataset(*dataset_config.query,
-                                            split=dataset_config.split)
+                                            split=dataset_config.split,
+                                            trust_remote_code=True)
         except ValueError as e:
             raise _create_dataset_load_error(e)
     else:

--- a/benchmarks/cpp/utils/prepare_real_data.py
+++ b/benchmarks/cpp/utils/prepare_real_data.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import random
 import re
 import tempfile
@@ -122,10 +123,17 @@ def load_dataset_from_hf(dataset_config: DatasetConfig):
         ValueError: When dataset loading fails due to incorrect dataset config setting.
     """
     try:
+
+        # Use streaming mode if not local dataset
+        use_streaming_mode = not os.path.isdir(dataset_config.name)
+        logging.debug(
+            f"Loading dataset: query={dataset_config.query}, split={dataset_config.split}, streaming={use_streaming_mode}"
+        )
+
         dataset = iter(
             load_dataset(*dataset_config.query,
                          split=dataset_config.split,
-                         streaming=True,
+                         streaming=use_streaming_mode,
                          trust_remote_code=True))
     except ValueError as e:
         if "Config" in e:

--- a/tests/integration/defs/cpp/test_e2e.py
+++ b/tests/integration/defs/cpp/test_e2e.py
@@ -189,10 +189,11 @@ def run_benchmarks(
             prepare_dataset += [k, v]
 
         # Use environment variable to force HuggingFace to use offline cached dataset
+        offline_env = {**_os.environ, 'HF_DATASETS_OFFLINE': '1'}
         _cpp.run_command(prepare_dataset,
                          cwd=root_dir,
                          timeout=300,
-                         env={'HF_DATASETS_OFFLINE': '1'})
+                         env=offline_env)
 
         for batching_type in batching_types:
             for api_type in api_types:

--- a/tests/integration/defs/cpp/test_e2e.py
+++ b/tests/integration/defs/cpp/test_e2e.py
@@ -93,8 +93,9 @@ def run_benchmarks(
         )
         return NotImplementedError
 
+    dataset_names = ["ccdv/cnn_dailymail", "Open-Orca/1million-gpt-4"]
+
     prompt_datasets_args = [{
-        '--dataset-name': "ccdv/cnn_dailymail",
         '--dataset-local-path': f"{model_cache}/datasets/ccdv/cnn_dailymail",
         '--dataset-config-name': "3.0.0",
         '--dataset-split': "validation",
@@ -102,7 +103,6 @@ def run_benchmarks(
         '--dataset-prompt': "Summarize the following article:",
         '--dataset-output-key': "highlights"
     }, {
-        '--dataset-name': "Open-Orca/1million-gpt-4",
         '--dataset-local-path':
         "/datasets/1million-gpt-4/1M-GPT4-Augmented.parquet",
         '--dataset-split': "train",
@@ -112,9 +112,10 @@ def run_benchmarks(
     }]
 
     token_files = [
-        "prepared_" + s['--dataset-name'].replace('/', '_')
-        for s in prompt_datasets_args
+        "prepared_" + dataset_name.replace('/', '_')
+        for dataset_name in dataset_names
     ]
+
     max_input_lens = ["256", "20"]
     num_reqs = ["50", "10"]
     if model_name == "gpt":

--- a/tests/integration/defs/cpp/test_e2e.py
+++ b/tests/integration/defs/cpp/test_e2e.py
@@ -49,10 +49,12 @@ def get_benchmark_dataset_configs(model_cache: str) -> List[DatasetConfig]:
 
     To add a new dataset, add a new DatasetConfig entry to this list.
     """
+    datasets_dir = _pl.Path(model_cache) / "datasets"
+
     return [
         DatasetConfig(
             name="ccdv/cnn_dailymail",
-            local_path=f"{model_cache}/datasets/ccdv/cnn_dailymail",
+            local_path=str(datasets_dir / "ccdv" / "cnn_dailymail"),
             config_name="3.0.0",
             split="validation",
             input_key="article",
@@ -63,7 +65,8 @@ def get_benchmark_dataset_configs(model_cache: str) -> List[DatasetConfig]:
         ),
         DatasetConfig(
             name="Open-Orca/1million-gpt-4",
-            local_path="/datasets/1million-gpt-4/1M-GPT4-Augmented.parquet",
+            local_path=str(datasets_dir / "Open-Orca" / "1million-gpt-4" /
+                           "1M-GPT4-Augmented.parquet"),
             split="train",
             input_key="question",
             prompt_key="system_prompt",
@@ -217,7 +220,7 @@ def run_benchmarks(
                                  cwd=root_dir,
                                  timeout=600)
 
-        if "IFB" in batching_type and "executor" in api_types:
+        if "IFB" in batching_types and "executor" in api_types:
             # executor streaming test
             benchmark = [
                 str(benchmark_exe_dir / "gptManagerBenchmark"), "--engine_dir",
@@ -306,7 +309,6 @@ def test_model(build_google_tests, model, prepare_model, run_model_tests,
     run_model_tests(model, run_fp8)
 
 
-#@pytest.mark.skip(reason="https://nvbugs/5601670")
 @pytest.mark.parametrize("build_google_tests", ["80", "86", "89", "90"],
                          indirect=True)
 @pytest.mark.parametrize("model", ["bart", "gpt", "t5"])

--- a/tests/integration/defs/cpp/test_e2e.py
+++ b/tests/integration/defs/cpp/test_e2e.py
@@ -93,8 +93,13 @@ def run_benchmarks(
         )
         return NotImplementedError
 
+    # If local not found, fall back to HuggingFace
+    cnn_dailymail_dir = f"{model_cache}/datasets/ccdv/cnn_dailymail"
+    cnn_dailymail_dataset_name = cnn_dailymail_dir if _os.path.isdir(
+        cnn_dailymail_dir) else "ccdv/cnn_dailymail"
+
     prompt_datasets_args = [{
-        '--dataset-name': "cnn_dailymail",
+        '--dataset-name': cnn_dailymail_dataset_name,
         '--dataset-config-name': "3.0.0",
         '--dataset-split': "validation",
         '--dataset-input-key': "article",
@@ -147,7 +152,7 @@ def run_benchmarks(
         _cpp.run_command(prepare_dataset,
                          cwd=root_dir,
                          timeout=300,
-                         env={'HF_DATASETS_OFFLINE': '0'})
+                         env={'HF_DATASETS_OFFLINE': '1'})
 
         for batching_type in batching_types:
             for api_type in api_types:
@@ -263,7 +268,7 @@ def test_model(build_google_tests, model, prepare_model, run_model_tests,
     run_model_tests(model, run_fp8)
 
 
-@pytest.mark.skip(reason="https://nvbugs/5601670")
+#@pytest.mark.skip(reason="https://nvbugs/5601670")
 @pytest.mark.parametrize("build_google_tests", ["80", "86", "89", "90"],
                          indirect=True)
 @pytest.mark.parametrize("model", ["bart", "gpt", "t5"])

--- a/tests/integration/defs/cpp/test_e2e.py
+++ b/tests/integration/defs/cpp/test_e2e.py
@@ -2,10 +2,76 @@ import copy
 import logging as _logger
 import os as _os
 import pathlib as _pl
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 import defs.cpp.cpp_common as _cpp
 import pytest
+
+
+@dataclass(frozen=True)
+class DatasetConfig:
+    """Configuration for a benchmark dataset."""
+    name: str
+    local_path: str
+    split: str
+    input_key: str
+    output_key: str
+    max_input_len: str
+    num_requests: str
+    config_name: Optional[str] = None
+    prompt: Optional[str] = None
+    prompt_key: Optional[str] = None
+
+    @property
+    def token_file(self) -> str:
+        return "prepared_" + self.name.replace('/', '_')
+
+    def get_dataset_args(self) -> dict[str, str]:
+        """Build the dataset args dict for prepare_dataset.py."""
+        args = {
+            '--dataset-local-path': self.local_path,
+            '--dataset-split': self.split,
+            '--dataset-input-key': self.input_key,
+            '--dataset-output-key': self.output_key,
+        }
+        if self.config_name:
+            args['--dataset-config-name'] = self.config_name
+        if self.prompt:
+            args['--dataset-prompt'] = self.prompt
+        if self.prompt_key:
+            args['--dataset-prompt-key'] = self.prompt_key
+        return args
+
+
+def get_benchmark_dataset_configs(model_cache: str) -> List[DatasetConfig]:
+    """Define dataset configurations for benchmark tests.
+
+    To add a new dataset, add a new DatasetConfig entry to this list.
+    """
+    return [
+        DatasetConfig(
+            name="ccdv/cnn_dailymail",
+            local_path=f"{model_cache}/datasets/ccdv/cnn_dailymail",
+            config_name="3.0.0",
+            split="validation",
+            input_key="article",
+            prompt="Summarize the following article:",
+            output_key="highlights",
+            max_input_len="256",
+            num_requests="50",
+        ),
+        DatasetConfig(
+            name="Open-Orca/1million-gpt-4",
+            local_path="/datasets/1million-gpt-4/1M-GPT4-Augmented.parquet",
+            split="train",
+            input_key="question",
+            prompt_key="system_prompt",
+            output_key="response",
+            max_input_len="20",
+            num_requests="10",
+        ),
+    ]
 
 
 def run_single_gpu_tests(build_dir: _pl.Path,
@@ -93,31 +159,6 @@ def run_benchmarks(
         )
         return NotImplementedError
 
-    dataset_names = ["ccdv/cnn_dailymail", "Open-Orca/1million-gpt-4"]
-
-    prompt_datasets_args = [{
-        '--dataset-local-path': f"{model_cache}/datasets/ccdv/cnn_dailymail",
-        '--dataset-config-name': "3.0.0",
-        '--dataset-split': "validation",
-        '--dataset-input-key': "article",
-        '--dataset-prompt': "Summarize the following article:",
-        '--dataset-output-key': "highlights"
-    }, {
-        '--dataset-local-path':
-        "/datasets/1million-gpt-4/1M-GPT4-Augmented.parquet",
-        '--dataset-split': "train",
-        '--dataset-input-key': "question",
-        '--dataset-prompt-key': "system_prompt",
-        '--dataset-output-key': "response"
-    }]
-
-    token_files = [
-        "prepared_" + dataset_name.replace('/', '_')
-        for dataset_name in dataset_names
-    ]
-
-    max_input_lens = ["256", "20"]
-    num_reqs = ["50", "10"]
     if model_name == "gpt":
         model_engine_path = model_engine_dir / "fp16_plugin_packed_paged" / "tp1-pp1-cp1-gpu"
 
@@ -131,20 +172,17 @@ def run_benchmarks(
         # model_engine_path = model_engine_dir / model_spec_obj.get_model_path(
         # ) / "tp1-pp1-cp1-gpu"
 
-    for prompt_ds_args, tokens_f, len, num_req in zip(prompt_datasets_args,
-                                                      token_files,
-                                                      max_input_lens, num_reqs):
-
+    for config in get_benchmark_dataset_configs(model_cache):
         benchmark_src_dir = _pl.Path("benchmarks") / "cpp"
         data_dir = resources_dir / "data"
         prepare_dataset = [
             python_exe,
             str(benchmark_src_dir / "prepare_dataset.py"), "--tokenizer",
             str(tokenizer_dir), "--output",
-            str(data_dir / tokens_f), "dataset", "--max-input-len", len,
-            "--num-requests", num_req
+            str(data_dir / config.token_file), "dataset", "--max-input-len",
+            config.max_input_len, "--num-requests", config.num_requests
         ]
-        for k, v in prompt_ds_args.items():
+        for k, v in config.get_dataset_args().items():
             prepare_dataset += [k, v]
 
         # Use environment variable to force HuggingFace to use offline cached dataset
@@ -161,7 +199,7 @@ def run_benchmarks(
                     str(model_engine_path), "--type",
                     str(batching_type), "--api",
                     str(api_type), "--dataset",
-                    str(data_dir / tokens_f)
+                    str(data_dir / config.token_file)
                 ]
                 if model_name == "enc_dec":
                     benchmark += [
@@ -184,7 +222,8 @@ def run_benchmarks(
             benchmark = [
                 str(benchmark_exe_dir / "gptManagerBenchmark"), "--engine_dir",
                 str(model_engine_path), "--type", "IFB", "--dataset",
-                str(data_dir / tokens_f), "--api", "executor", "--streaming"
+                str(data_dir / config.token_file), "--api", "executor",
+                "--streaming"
             ]
             if model_name == "enc_dec":
                 benchmark += [


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local dataset loading from files (JSON, JSONL, CSV, Parquet formats)
  * New `--dataset-local-path` CLI option for offline and local data sources
  * `--dataset-name` is now optional when using local paths
  * Offline dataset access capability

* **Bug Fixes**
  * Improved error messages with clearer configuration guidance

* **Tests**
  * Re-enabled benchmark and model tests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Tests were failing due to refused connections from HuggingFace. This PR switches the relevant tests to use a locally cached dataset instead.

## Test Coverage

`tests/integration/defs/cpp/test_e2e.py::test_benchmarks[t5-90]`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
