### PR TITLE
[None][fix] Make Embedding respect allreduce_strategy

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_exaone4.py
+++ b/tensorrt_llm/_torch/models/modeling_exaone4.py
@@ -207,6 +207,7 @@ class Exaone4Model(DecoderModel):
             mapping=model_config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=model_config.allreduce_strategy,
         )
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_exaone_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_exaone_moe.py
@@ -463,6 +463,7 @@ class ExaoneMoeModel(DecoderModel):
             mapping=model_config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=model_config.allreduce_strategy,
         )
 
         aux_stream_list = [torch.cuda.Stream() for _ in range(3)]

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -536,6 +536,7 @@ class Transformer(DecoderModel):
                 enable_torch_compile_for_embedding=
                 enable_torch_compile_for_embedding,
                 use_custom_cublas_mm=self.use_custom_cublas_mm,
+                allreduce_strategy=config.allreduce_strategy,
             )
         # For modeling_speculative, different name expected
         self.embed_tokens = self.embedding

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
@@ -572,6 +572,7 @@ class HunYuanModel(DecoderModel):
             mapping=model_config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=model_config.allreduce_strategy,
         )
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
@@ -289,6 +289,7 @@ class HunYuanModel(DecoderModel):
             mapping=model_config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=model_config.allreduce_strategy,
         )
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -876,6 +876,7 @@ class Llama4Model(DecoderModel):
                 mapping=model_config.mapping,
                 tensor_parallel_mode=TensorParallelMode.COLUMN,
                 gather_output=True,
+                allreduce_strategy=model_config.allreduce_strategy,
             )
 
         # If enable_min_latency is True, we will use min-latency mode.
@@ -971,6 +972,7 @@ class LlamaModel(DecoderModel):
                 tensor_parallel_mode=TensorParallelMode.COLUMN,
                 gather_output=True,
                 use_custom_cublas_mm=self.use_custom_cublas_mm,
+                allreduce_strategy=model_config.allreduce_strategy,
             )
 
         if self.has_custom_embed_tokens:

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -169,6 +169,7 @@ class MistralModel(DecoderModel):
             mapping=model_config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=model_config.allreduce_strategy,
         )
         self.layers = nn.ModuleList([
             MistralDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -394,6 +394,7 @@ class NemotronHModel(DecoderModel):
                 mapping=model_config.mapping,
                 tensor_parallel_mode=TensorParallelMode.COLUMN,
                 gather_output=True,
+                allreduce_strategy=model_config.allreduce_strategy,
             )
 
         # create layers

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -192,6 +192,7 @@ class QwenModel(DecoderModel):
             mapping=config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=config.allreduce_strategy,
         )
         self.layers = nn.ModuleList([
             QwenDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -178,6 +178,7 @@ class Qwen3Model(DecoderModel):
             mapping=config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=config.allreduce_strategy,
         )
         self.layers = nn.ModuleList([
             Qwen3DecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -354,6 +354,7 @@ class Qwen3MoEModel(DecoderModel):
                 mapping=config.mapping,
                 tensor_parallel_mode=TensorParallelMode.COLUMN,
                 gather_output=True,
+                allreduce_strategy=config.allreduce_strategy,
             )
         self.layers = nn.ModuleList([
             Qwen3MoEDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1180,6 +1180,7 @@ class Qwen3NextModel(DecoderModel):
                 mapping=config.mapping,
                 tensor_parallel_mode=TensorParallelMode.COLUMN,
                 gather_output=True,
+                allreduce_strategy=config.allreduce_strategy,
             )
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_qwen_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen_moe.py
@@ -199,6 +199,7 @@ class QwenMoeModel(DecoderModel):
             mapping=config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=config.allreduce_strategy,
         )
         self.layers = nn.ModuleList([
             QwenMoeDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_seedoss.py
+++ b/tensorrt_llm/_torch/models/modeling_seedoss.py
@@ -132,6 +132,7 @@ class SeedOssModel(DecoderModel):
             mapping=config.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             gather_output=True,
+            allreduce_strategy=config.allreduce_strategy,
         )
         self.layers = nn.ModuleList([
             SeedOssDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -344,6 +344,7 @@ class Eagle3DraftModel(DecoderModel):
                     mapping=model_config.mapping,
                     tensor_parallel_mode=TensorParallelMode.COLUMN,
                     gather_output=True,
+                    allreduce_strategy=model_config.allreduce_strategy,
                 )
         else:
             # Shared with target model.

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
-from tensorrt_llm.functional import AllReduceParams
+from tensorrt_llm.functional import AllReduceParams, AllReduceStrategy
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.math_utils import ceil_div
 
@@ -22,6 +22,7 @@ class LMHead(Linear):
         dtype (Optional[torch.dtype]): type of the parameters.
         mapping (Optional[Mapping]): parallelism configuration.
             If not provided, the embedding is not parallelized.
+        allreduce_strategy (AllReduceStrategy): strategy for all-reduce operations.
     """
 
     def __init__(
@@ -34,6 +35,7 @@ class LMHead(Linear):
         gather_output: bool = False,
         reduce_output: bool = True,
         use_custom_cublas_mm: bool = False,
+        allreduce_strategy: AllReduceStrategy = AllReduceStrategy.AUTO,
     ):
         local_in_features = embedding_dim
         local_out_features = num_embeddings
@@ -66,6 +68,7 @@ class LMHead(Linear):
             gather_output=gather_output,
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
+            allreduce_strategy=allreduce_strategy,
         )
 
         if tensor_parallel_mode == TensorParallelMode.ROW:
@@ -211,6 +214,7 @@ class Embedding(LMHead):
         dtype (Optional[torch.dtype]): type of the parameters.
         mapping (Optional[Mapping]): parallelism configuration.
             If not provided, the embedding is not parallelized.
+        allreduce_strategy (AllReduceStrategy): strategy for all-reduce operations.
     """
 
     def __init__(
@@ -224,6 +228,7 @@ class Embedding(LMHead):
         reduce_output: bool = True,
         enable_torch_compile_for_embedding: Optional[bool] = False,
         use_custom_cublas_mm: bool = False,
+        allreduce_strategy: AllReduceStrategy = AllReduceStrategy.AUTO,
     ):
         super().__init__(
             embedding_dim=embedding_dim,
@@ -234,6 +239,7 @@ class Embedding(LMHead):
             gather_output=gather_output,
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
+            allreduce_strategy=allreduce_strategy,
         )
 
         self.enable_torch_compile_for_embedding = enable_torch_compile_for_embedding


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

We have an `allreduce_strategy` LLM API option that the `Embedding` module does not respect. I recently ran into an unrelated bug that was root caused to a bad AllReduce config. I messed around with `allreduce_strategy` early on but it did not help because `Embedding` was using `AllReduceStrategy.AUTO` and hitting the bad config every time. This change should help debugging in situations like this.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Existing tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable all-reduce strategy parameter to embedding layers across multiple model architectures, enabling flexible optimization of distributed tensor parallelism during embedding operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->