### PR TITLE
[https://nvbugs/5669671][fix] Support GuidedDecoder with sharded logits

### DIFF
--- a/cpp/tensorrt_llm/kernels/logitsBitmask.h
+++ b/cpp/tensorrt_llm/kernels/logitsBitmask.h
@@ -32,7 +32,7 @@ void invokeLogitsBitmask(
 
 template <typename T>
 void invokeContiguousLogitsBitmask(T* logits, uint32_t const* bitmask, int32_t const* tokenMask, int32_t const* d2t,
-    int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream);
+    int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskStride, cudaStream_t stream);
 
 } // namespace kernels
 

--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -145,11 +145,13 @@ class GuidedDecoder:
                  guided_decoding_config: GuidedDecodingConfig,
                  max_num_sequences: int,
                  vocab_size_padded: int,
-                 max_num_draft_tokens: int = 0):
+                 max_num_draft_tokens: int = 0,
+                 rank: int = 0):
         self.guided_decoding_backend = guided_decoding_config.backend
         self.max_num_sequences = max_num_sequences
         self.vocab_size_padded = vocab_size_padded
         self.max_num_draft_tokens = max_num_draft_tokens
+        self.rank = rank
 
         if self.guided_decoding_backend == GuidedDecodingConfig.GuidedDecodingBackend.XGRAMMAR:
             self.grammar_matcher_factory = XGrammarMatcherFactory(
@@ -305,9 +307,26 @@ class GuidedDecoder:
         """
         if num_bitmask_tokens is None:
             num_bitmask_tokens = requests.num_bitmask_tokens
+
+        # In general, the logits passed to GuidedDecoder are complete in the vocabulary dimension.
+        # In some special cases (e.g., MTP), the logits are sharded in the vocabulary dimension.
+        vocab_size_padded = self.vocab_size_padded if d2t is None else d2t.size(
+            0)
+        assert vocab_size_padded % logits.size(1) == 0
+        tp_size = vocab_size_padded // logits.size(1)
+        assert self.bitmask_size % tp_size == 0
+        tp_rank = self.rank % tp_size
+        bitmask_start = tp_rank * self.bitmask_size // tp_size
+        bitmask_end = bitmask_start + self.bitmask_size // tp_size
+
+        if d2t is not None:
+            d2t_start = tp_rank * vocab_size_padded // tp_size
+            d2t_end = d2t_start + vocab_size_padded // tp_size
+            d2t = d2t[d2t_start:d2t_end]
+
         torch.ops.trtllm.logits_bitmask(
             logits[:num_bitmask_tokens],
-            self.bitmask[:num_bitmask_tokens],
+            self.bitmask[:num_bitmask_tokens, bitmask_start:bitmask_end],
             token_mask=self.token_mask[:num_bitmask_tokens],
             d2t=d2t)
 
@@ -423,9 +442,13 @@ class CapturableGuidedDecoder(GuidedDecoder):
                  guided_decoding_config: GuidedDecodingConfig,
                  max_num_sequences: int,
                  vocab_size_padded: int,
-                 max_num_draft_tokens: int = 0):
-        super().__init__(guided_decoding_config, max_num_sequences,
-                         vocab_size_padded, max_num_draft_tokens)
+                 max_num_draft_tokens: int = 0,
+                 rank: int = 0):
+        super().__init__(guided_decoding_config=guided_decoding_config,
+                         max_num_sequences=max_num_sequences,
+                         vocab_size_padded=vocab_size_padded,
+                         max_num_draft_tokens=max_num_draft_tokens,
+                         rank=rank)
         # self.requests should be accessed by normal host code;
         # self.requests_hostfunc should be accessed by hostfunc (CUDA callback).
         self.requests_hostfunc: Optional[GuidedRequests] = None

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -505,7 +505,8 @@ def create_py_executor(
                 kwargs = {
                     "guided_decoding_config": guided_decoding_config,
                     "max_num_sequences": max_batch_size,
-                    "vocab_size_padded": model_engine.model.vocab_size_padded
+                    "vocab_size_padded": model_engine.model.vocab_size_padded,
+                    "rank": mapping.rank,
                 }
                 if spec_config is not None:
                     kwargs[


### PR DESCRIPTION
## Description

This PR supports GuidedDecoder with sharded logits, which resolves https://github.com/NVIDIA/TensorRT-LLM/issues/7878

------

When MTP is used with tensor parallelism:
* For the main model LM head, the logits are gathered immediately after the GEMM, so the logits passed to GuidedDecoder is complete.
* For the draft model LM head, the logits are NOT gathered, resulting in sharded logits passed to  GuidedDecoder.

This is the root cause of https://github.com/NVIDIA/TensorRT-LLM/issues/7878.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vocabulary sharding support for guided decoding across tensor parallelism partitions via a new `rank` parameter.

* **Bug Fixes**
  * Enhanced bitmask validation to correctly handle sharded vocabulary configurations.

* **Refactor**
  * Refactored bitmask handling to use stride-based calculations instead of size-based, improving compatibility with non-contiguous memory layouts and sharded vocabularies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->