### PR TITLE
[TRTLLM-6335][infra] Fix slurm stage (multi-node) failed will not generate a mock result.xml show Stage Failed

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -177,16 +177,20 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
             // Generate Stage Failed mock result if no results exist locally
             // This could mean either: 1) Slurm job failed to generate results, or 2) Results exist but download failed
             // generateStageFailTestResultXml will return null if any results*.xml already exists
-            def stageXml = generateStageFailTestResultXml(
-                stageName,
-                "Stage Failed or Results Download Failed",
-                "Slurm job may have failed, or results exist on ${nodeName} but could not be retrieved. Check Slurm job logs for details.",
-                "results*.xml"
-            )
-            if (stageXml != null) {
-                sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
-                hasMockResult = true
-                echo "WARNING: No result files were retrieved. This could indicate either a test failure or a download failure."
+            if (stageIsInterrupted) {
+                echo "Stage is interrupted, skip to generate Stage Failed mock test result."
+            } else {
+                def stageXml = generateStageFailTestResultXml(
+                    stageName,
+                    "Stage Failed or Results Download Failed",
+                    "Slurm job may have failed, or results exist on ${nodeName} but could not be retrieved. Check Slurm job logs for details.",
+                    "results*.xml"
+                )
+                if (stageXml != null) {
+                    sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
+                    hasMockResult = true
+                    echo "WARNING: No result files were retrieved. This could indicate either a test failure or a download failure."
+                }
             }
 
             // Upload results (at least one type of result should always exist)

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -118,6 +118,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
         def hasTimeoutTest = false
         def downloadResultSucceed = false
         def downloadPerfResultSucceed = false
+        def hasMockResult = false
 
         pipeline.stage('Submit Test Result') {
             sh "mkdir -p ${stageName}"
@@ -170,11 +171,37 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
             } else {
                 println("No results xml to submit")
             }
+
+            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}"
+
+            // Generate Stage Failed mock result if no results exist locally
+            // This could mean either: 1) Slurm job failed to generate results, or 2) Results exist but download failed
+            // generateStageFailTestResultXml will return null if any results*.xml already exists
+            def stageXml = generateStageFailTestResultXml(
+                stageName,
+                "Stage Failed or Results Download Failed",
+                "Slurm job may have failed, or results exist on ${nodeName} but could not be retrieved. Check Slurm job logs for details.",
+                "results*.xml"
+            )
+            if (stageXml != null) {
+                sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
+                hasMockResult = true
+                echo "WARNING: No result files were retrieved. This could indicate either a test failure or a download failure."
+            }
+
+            // Upload results (at least one type of result should always exist)
+            sh "ls ${stageName}"
+            echo "Upload test results."
+            sh "tar -czvf results-${stageName}.tar.gz ${stageName}/"
+            ensureStageResultNotUploaded(stageName)
+            trtllm_utils.uploadArtifacts(
+                "results-${stageName}.tar.gz",
+                "${UPLOAD_PATH}/test-results/"
+            )
         }
 
-        if (hasTimeoutTest || downloadResultSucceed) {
-            junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
-        }
+        // Always call junit since we guarantee at least one result exists
+        junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
     }
 }
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -325,6 +325,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
         def hasTimeoutTest = false
         def downloadResultSucceed = false
         def downloadPerfResultSucceed = false
+        def hasMockResult = false
 
         pipeline.stage('Submit Test Result') {
             sh "mkdir -p ${stageName}"
@@ -402,7 +403,41 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
             }
 
             echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}"
-            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed) {
+
+            // Generate Stage Failed mock result if no real results exist locally.
+            // This could mean either: 1) Slurm job failed to generate results, or
+            // 2) Results exist but download failed.
+            // generateStageFailTestResultXml returns null if any results*.xml already exists.
+            // Skip for interrupted stages and perf-only stages (no JUnit XML expected).
+            if (stageIsInterrupted) {
+                echo "Stage is interrupted, skip generating Stage Failed mock test result."
+            } else if (downloadPerfResultSucceed && !downloadResultSucceed && !hasTimeoutTest) {
+                echo "Performance results retrieved but no JUnit XML expected; skip generating Stage Failed mock test result."
+            } else {
+                def stageXml = generateStageFailTestResultXml(
+                    stageName,
+                    "Stage Failed or Results Download Failed",
+                    "Slurm job may have failed, or results exist on ${nodeName} but could not be retrieved. Check Slurm job logs for details.",
+                    "results*.xml"
+                )
+                if (stageXml != null) {
+                    sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
+                    hasMockResult = true
+                    echo "WARNING: No result files were retrieved. This could indicate either a test failure or a download failure."
+                }
+            }
+
+            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed || hasMockResult) {
+                // When reporting is suppressed (retryable failure with retry pending),
+                // rename result XMLs so the parent pipeline's junit() glob does not
+                // pick them up from the uploaded archive.
+                if (suppressTestReporting) {
+                    sh """
+                        cd ${stageName} && for f in results*.xml; do
+                            [ -e "\$f" ] && mv "\$f" "superseded-\$f"
+                        done || true
+                    """
+                }
                 // On retry attempts, rename freshly-downloaded result XMLs so that
                 // (a) the tar for this attempt is distinguishable from prior attempts
                 //     already uploaded to Artifactory, and
@@ -433,7 +468,8 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
             }
         }
 
-        if ((hasTimeoutTest || downloadResultSucceed) && !suppressTestReporting) {
+        // Report results via junit when we have any (real or mock) and reporting is not suppressed.
+        if ((hasTimeoutTest || downloadResultSucceed || hasMockResult) && !suppressTestReporting) {
             junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
         } else if (suppressTestReporting) {
             echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing junit() because a retry is still planned"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Adds fallback `result.xml` generation for non-interrupted Slurm stages without local JUnit XML.
- Skips mock-result generation for performance-only stages when performance results are available.
- Includes mock results in artifact upload and JUnit reporting.
- Preserves suppression and retry-renaming behavior.
- No test files, configuration files, or test-list files were changed.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
