### PR TITLE
[TRTLLM-10325][feat] Refactor speculative decoding workers

### DIFF
--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -377,15 +377,14 @@ class Eagle3OneModelWorker(SpecWorkerBase):
 
         raw_logits = logits
 
-        if self.guided_decoder is not None:
-            self.guided_decoder.execute(logits)
+        self._execute_guided_decoder_if_present(logits)
 
         # Sample and accept tokens
         accepted_tokens, num_accepted_tokens = self.sample_and_accept_draft_tokens(
             logits, attn_metadata, spec_metadata)
 
         # Save the old attn_metadata and spec_metadata
-        attn_metadata.prepare_for_spec_dec("_seq_lens", "_seq_lens_cuda")
+        self._prepare_attn_metadata_for_spec_dec(attn_metadata)
 
         # Prepare inputs for the 1st draft model forward
         position_ids = position_ids.squeeze(0)
@@ -479,8 +478,7 @@ class Eagle3OneModelWorker(SpecWorkerBase):
         next_draft_tokens = torch.stack(next_draft_tokens, dim=1)
 
         # restore attn_metadata to support cuda graph
-        attn_metadata.restore_from_spec_dec()
-        attn_metadata.on_update()
+        self._restore_attn_metadata_from_spec_dec(attn_metadata)
         # restore all_rank_num_tokens for attention DP
         if original_all_rank_num_tokens is not None:
             attn_metadata.all_rank_num_tokens = original_all_rank_num_tokens
@@ -512,39 +510,13 @@ class Eagle3OneModelWorker(SpecWorkerBase):
         num_contexts = attn_metadata.num_contexts
         num_gens = batch_size - num_contexts
 
-        if logits.dim() == 1:
-            logits = logits.unsqueeze(0)
-
-        # The return buffer
-        accepted_tokens = torch.empty((batch_size, (self.max_draft_len + 1)),
-                                      dtype=torch.int,
-                                      device=logits.device)
-        num_accepted_tokens = torch.ones(batch_size,
-                                         dtype=torch.int,
-                                         device=logits.device)
-
-        # Sample tokens using per-request sampling parameters
-        target_tokens = self._sample_tokens_for_batch(logits, spec_metadata,
-                                                      num_contexts, batch_size)
-        # context
-        accepted_tokens[:num_contexts, 0] = target_tokens[:num_contexts]
-
-        # generation
-        gen_target_tokens = target_tokens[num_contexts:].reshape(
-            num_gens, self.max_draft_len + 1)
-        accepted_tokens[num_contexts:, :] = gen_target_tokens
+        # Reshape draft tokens for base implementation
         draft_tokens = spec_metadata.draft_tokens.reshape(
             num_gens, self.max_draft_len)
-        num_accepted_tokens[num_contexts:] += torch.cumprod(
-            (draft_tokens == gen_target_tokens[:, :self.max_draft_len]).int(),
-            dim=-1).sum(1)
-        # Check for environment variable override
-        if self.force_num_accepted_tokens != 0:
-            # total tokens per iteration = accepted draft tokens + 1 target token
-            force_total_tokens = min(self.force_num_accepted_tokens + 1,
-                                     self.max_draft_len + 1)
-            num_accepted_tokens[num_contexts:] = force_total_tokens
-        return accepted_tokens, num_accepted_tokens
+
+        # Use base implementation for strict acceptance
+        return self._sample_and_accept_draft_tokens_base(
+            logits, draft_tokens, num_contexts, batch_size, spec_metadata)
 
     def draft_decoder(
         self,
@@ -570,15 +542,8 @@ class Eagle3OneModelWorker(SpecWorkerBase):
         # Note: using greedy for draft tokens is a bit easier to implement and
         # faster. It doesn't affect the final output and seems to have a negligible
         # impact on AR.
-        draft_tokens = torch.argmax(logits, dim=-1)
-
-        # Apply d2t (offsets between draft model dictionary and main model dictionary).
-        if (d2t := getattr(draft_model.model, "d2t", None)) is not None:
-            draft_tokens = d2t[draft_tokens] + draft_tokens
-
-        draft_tokens = draft_tokens.type(torch.int32)
-
-        return draft_tokens
+        d2t = getattr(draft_model.model, "d2t", None)
+        return self._draft_sampler_greedy(logits, d2t)
 
     def prepare_1st_drafter_inputs(
         self,

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -416,6 +416,130 @@ class SpecWorkerBase(nn.Module, ABC):
         self.guided_decoder = guided_decoder
         return True
 
+    def _prepare_attn_metadata_for_spec_dec(self, attn_metadata):
+        """
+        Prepare attention metadata before speculative decoding draft token generation.
+        Saves current state for later restoration.
+        """
+        attn_metadata.prepare_for_spec_dec("_seq_lens", "_seq_lens_cuda")
+
+    def _restore_attn_metadata_from_spec_dec(self, attn_metadata):
+        """
+        Restore attention metadata after speculative decoding draft token generation.
+        """
+        attn_metadata.restore_from_spec_dec()
+        attn_metadata.on_update()
+
+    def _apply_force_accepted_tokens(self, num_accepted_tokens, num_contexts):
+        """
+        Apply forced number of accepted tokens if environment variable is set.
+        This is used for testing and debugging.
+
+        Args:
+            num_accepted_tokens: Tensor of shape [batch_size] with current accepted counts
+            num_contexts: Number of context (prefill) requests
+
+        Returns:
+            Modified num_accepted_tokens tensor
+
+        Note:
+            For MTPWorker, self.max_draft_len equals num_nextn_predict_layers (mtp_num_modules).
+            For Eagle3OneModelWorker, self.max_draft_len equals spec_config.max_draft_len.
+        """
+        if self.force_num_accepted_tokens != 0:
+            # total tokens per iteration = accepted draft tokens + 1 target token
+            force_total_tokens = min(self.force_num_accepted_tokens + 1,
+                                     self.max_draft_len + 1)
+            num_accepted_tokens[num_contexts:] = force_total_tokens
+        return num_accepted_tokens
+
+    def _sample_and_accept_draft_tokens_base(
+        self,
+        logits: torch.Tensor,
+        draft_tokens: torch.Tensor,
+        num_contexts: int,
+        batch_size: int,
+        spec_metadata,
+    ):
+        """
+        Base implementation for sampling and accepting draft tokens.
+        Uses strict acceptance (token equality with cumulative product).
+
+        This is the common logic shared between Eagle3 and MTP (when relaxed
+        acceptance is disabled).
+
+        Args:
+            logits: [num_tokens, vocab_size] - Target model logits
+            draft_tokens: [num_gens, max_draft_len] - Previously predicted draft tokens
+            num_contexts: Number of context requests
+            batch_size: Total number of requests
+            spec_metadata: Speculative decoding metadata
+
+        Returns:
+            accepted_tokens: [batch_size, max_draft_len + 1] - Accepted tokens
+            num_accepted_tokens: [batch_size] - Number of accepted tokens per request
+        """
+        num_gens = batch_size - num_contexts
+
+        if logits.dim() == 1:
+            logits = logits.unsqueeze(0)
+
+        # Allocate return buffers
+        accepted_tokens = torch.empty((batch_size, self.max_draft_len + 1),
+                                      dtype=torch.int,
+                                      device=logits.device)
+        num_accepted_tokens = torch.ones(batch_size,
+                                         dtype=torch.int,
+                                         device=logits.device)
+
+        # Sample tokens using per-request sampling parameters
+        target_tokens = self._sample_tokens_for_batch(logits, spec_metadata,
+                                                      num_contexts, batch_size)
+
+        # Context requests: only accept the sampled token (no draft tokens yet)
+        accepted_tokens[:num_contexts, 0] = target_tokens[:num_contexts]
+
+        # Generation requests: verify draft tokens against target tokens
+        gen_target_tokens = target_tokens[num_contexts:].reshape(
+            num_gens, self.max_draft_len + 1)
+        accepted_tokens[num_contexts:, :] = gen_target_tokens
+
+        # Compare draft tokens with target tokens using cumulative product
+        # Counts consecutive matches from the start
+        num_accepted_tokens[num_contexts:] += torch.cumprod(
+            (draft_tokens == gen_target_tokens[:, :self.max_draft_len]).int(),
+            dim=-1).sum(1)
+
+        # Apply force override if set
+        num_accepted_tokens = self._apply_force_accepted_tokens(
+            num_accepted_tokens, num_contexts)
+
+        return accepted_tokens, num_accepted_tokens
+
+    def _draft_sampler_greedy(self, logits: torch.Tensor, d2t=None):
+        """
+        Simple greedy draft token sampling using argmax.
+
+        Args:
+            logits: [num_tokens, vocab_size] - Draft model logits
+            d2t: Optional dictionary offset tensor for vocab mapping
+
+        Returns:
+            draft_tokens: [num_tokens] - Sampled draft token ids (int32)
+        """
+        draft_tokens = torch.argmax(logits, dim=-1)
+
+        # Apply d2t (offsets between draft and target model dictionaries)
+        if d2t is not None:
+            draft_tokens = d2t[draft_tokens] + draft_tokens
+
+        return draft_tokens.type(torch.int32)
+
+    def _execute_guided_decoder_if_present(self, logits):
+        """Execute guided decoder on target model logits if available."""
+        if self.guided_decoder is not None:
+            self.guided_decoder.execute(logits)
+
     def _sample_tokens_for_batch(
         self,
         logits: torch.Tensor,


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Refactor `Eagle3OneModelWorker` and `MTPWorker` to move shared code into `SpecWorkerBase`. This will improve maintainability, reduce code duplication, and ensure critical correctness logic is centralized.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
