### PR TITLE
[None][chore] NVFP4 MoE - Move weights transformation to fusion phase…

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quant.py
@@ -14,6 +14,7 @@ TRTLLM_FP4_OP_AVAILABLE = True
 TRTLLM_NVFP4_SCALING_VECTOR_SIZE = 16
 TRTLLM_NVFP4_ROW_SIZE = 128
 TRTLLM_NVFP4_COLUMN_SIZE = 4
+TRTLLM_NVFP4_PACKING_FACTOR = 2
 
 
 @torch.library.custom_op("auto_deploy::torch_quant_fn", mutates_args=())

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -1627,14 +1627,13 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
             "w3_weight",
             "w1_input_scale",
             "w2_input_scale",
-            "w3_input_scale",
             "w1_weight_scale",
             "w2_weight_scale",
             "w3_weight_scale",
             "w1_alpha",
             "w2_alpha",
-            "w3_alpha",
             "is_gated_mlp",
+            "act_fn",
         )
 
     def _stack(param_list, dim=0, device=None, dtype=None):
@@ -1648,13 +1647,10 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
     def _prepare_args_cutlass_format_nvfp4():
         if is_gated_mlp:
             # For gated MLP, concatenate w1 and w3 as [w3, w1]
-            fc1_expert_weights = torch.cat(
-                [w3_stacked, w1_stacked], dim=1
-            ).contiguous()  # [E, 2*I, H]
-            fc1_act_scale = torch.cat(
-                [w3_input_scale_stacked, w1_input_scale_stacked], dim=1
-            ).contiguous()
-            fc1_alpha_stacked = torch.cat([w3_alpha_stacked, w1_alpha_stacked], dim=1).contiguous()
+            fc1_expert_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
+            # Expect w3 input scale and alpha to be the same as w1
+            fc1_act_scale = w1_input_scale_stacked
+            fc1_alpha_stacked = w1_alpha_stacked
             fc1_weight_blockscale_fp8_stacked = torch.cat(
                 [w3_weight_blockscale_fp8_stacked, w1_weight_blockscale_fp8_stacked], dim=1
             ).contiguous()
@@ -1666,6 +1662,7 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
 
         fc2_expert_weights = w2_stacked
         fc2_act_scale = w2_input_scale_stacked
+        fc2_weight_blockscale_fp8_stacked = w2_weight_blockscale_fp8_stacked
 
         new_key_fc1_expert_weights = f"nvfp4_moe_w3_w1_stacked_{fused_key_counter}"
         new_key_fc2_expert_weights = f"nvfp4_moe_w2_stacked_{fused_key_counter}"
@@ -1681,13 +1678,41 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
         new_key_fc1_alpha = f"nvfp4_moe_w1_alpha_stacked_{fused_key_counter}"
         new_key_fc2_alpha = f"nvfp4_moe_w2_alpha_stacked_{fused_key_counter}"
 
+        # Pad fc1_expert_weights to match the already padded scales
+        pad_size = fc1_weight_blockscale_fp8_stacked.shape[1] - fc1_expert_weights.shape[1]
+        if pad_size > 0:
+            fc1_expert_weights = torch.nn.functional.pad(
+                fc1_expert_weights, (0, 0, 0, pad_size), mode="constant", value=0
+            )
+            # need to update fc2 scales and weightes to match the padded size
+            # unswizzle fc2 scales
+            fc2_blockscale_shape = list(fc2_weight_blockscale_fp8_stacked.shape)
+            fc2_blockscale_shape[2] = fc2_blockscale_shape[2] + pad_size // 16
+            # fc2_blockscale_shape[2] = fc2_blockscale_shape[2] // 128 * 128
+            fc2_weight_blockscale_fp8_stacked = torch.ops.trtllm.block_scale_interleave_reverse(
+                fc2_weight_blockscale_fp8_stacked.view(torch.uint8)
+            )
+            fc2_weight_blockscale_fp8_stacked = torch.nn.functional.pad(
+                fc2_weight_blockscale_fp8_stacked, (0, pad_size // 16), mode="constant", value=0
+            )
+            fc2_weight_blockscale_fp8_stacked = (
+                torch.ops.trtllm.block_scale_interleave(fc2_weight_blockscale_fp8_stacked)
+                .view(torch.float8_e4m3fn)
+                .reshape(fc2_blockscale_shape)
+            )
+            fc2_expert_weights = torch.nn.functional.pad(
+                fc2_expert_weights, (0, pad_size // 2, 0, 0), mode="constant", value=0
+            ).view(torch.uint8)
+
         # FP4 weights are already packed as uint8, don't convert dtype
         _register_parameter(gm, new_key_fc1_expert_weights, fc1_expert_weights)
         _register_parameter(gm, new_key_fc2_expert_weights, fc2_expert_weights)
         _register_parameter(
             gm, new_key_fc1_weight_blockscale_fp8, fc1_weight_blockscale_fp8_stacked
         )
-        _register_parameter(gm, new_key_fc2_weight_blockscale_fp8, w2_weight_blockscale_fp8_stacked)
+        _register_parameter(
+            gm, new_key_fc2_weight_blockscale_fp8, fc2_weight_blockscale_fp8_stacked
+        )
         _register_parameter(gm, new_key_fc1_act_scale, fc1_act_scale)
         _register_parameter(gm, new_key_fc2_act_scale, fc2_act_scale)
         _register_parameter(gm, new_key_fc1_alpha, fc1_alpha_stacked)
@@ -1707,7 +1732,11 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
                 graph.get_attr(new_key_fc1_alpha),
                 graph.get_attr(new_key_fc2_alpha),
             )
-        return args
+        kwargs = {
+            "is_gated_mlp": is_gated_mlp,
+            "act_fn": act_fn,
+        }
+        return args, kwargs
 
     fused_key_counter = 0
     graph = gm.graph
@@ -1727,14 +1756,13 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
             w3_list,
             w1_input_scale,
             w2_input_scale,
-            w3_input_scale,
             w1_weight_scale,
             w2_weight_scale,
             w3_weight_scale,
             w1_alpha,
             w2_alpha,
-            w3_alpha,
             is_gated_mlp,
+            act_fn,
         ) = _extract_op_args(node)
 
         # Stack the actual tensor values (fast, like in quantize_moe.py)
@@ -1746,7 +1774,6 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
         # Scales are buffers, not parameters
         w1_input_scale_stacked = _stack(w1_input_scale, dim=0)
         w2_input_scale_stacked = _stack(w2_input_scale, dim=0)
-        w3_input_scale_stacked = _stack(w3_input_scale, dim=0, device=device, dtype=dtype)
 
         # Use .view() not .to() to reinterpret bytes as float8, not value conversion
         w1_weight_blockscale_fp8_stacked = _stack(w1_weight_scale, dim=0).view(torch.float8_e4m3fn)
@@ -1757,9 +1784,8 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
 
         w1_alpha_stacked = _stack(w1_alpha, dim=0)
         w2_alpha_stacked = _stack(w2_alpha, dim=0)
-        w3_alpha_stacked = _stack(w3_alpha, dim=0, device=device, dtype=dtype)
 
-        args = _prepare_args_cutlass_format_nvfp4()
+        args, kwargs = _prepare_args_cutlass_format_nvfp4()
 
         fused_key_counter += 1
 
@@ -1768,7 +1794,7 @@ def _stack_nvfp4_moe_weights(gm: GraphModule) -> int:
             new_node = graph.call_function(
                 replacement_op,
                 args,
-                kwargs=node.kwargs,
+                kwargs=kwargs,
             )
 
         node.replace_all_uses_with(new_node)

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -180,6 +180,9 @@ nvidia/Nemotron-MOE:
   - quant_algo: FP8
     kv_cache_quant_algo: FP8
     accuracy: 86.884
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    accuracy: 63.268
 nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 37.15
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -284,6 +284,9 @@ nvidia/Nemotron-MOE:
   - quant_algo: FP8
     kv_cache_quant_algo: FP8
     accuracy: 73.879
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    accuracy: 70.879
 microsoft/Phi-4-mini-instruct:
   - accuracy: 68.98
   - quant_algo: FP8

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -218,6 +218,6 @@ l0_dgx_b200:
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_bf16
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_fp8[4]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_fp8[8]
-  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[1]
-  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[2]
-  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[4]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_nvfp4[1]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_nvfp4[2]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_nvfp4[4]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -218,3 +218,6 @@ l0_dgx_b200:
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_bf16
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_fp8[4]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_fp8[8]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[1]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[2]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp4[4]


### PR DESCRIPTION
…. Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVIDIA Nemotron-3-Nano-30B model with NVFP4 quantization configuration.

* **Performance & Optimization**
  * Simplified padding logic in mixture-of-experts quantization processing.
  * Enhanced activation function handling for gated MLP quantization paths.

* **Tests**
  * Added comprehensive test coverage for quantized mixture-of-experts fusion scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
