### PR TITLE
[#10614][fix] gpt_oss first iteration streaming in trtllm-serve

### DIFF
--- a/tensorrt_llm/serve/harmony_adapter.py
+++ b/tensorrt_llm/serve/harmony_adapter.py
@@ -1535,8 +1535,8 @@ def get_harmony_adapter():
 def handle_streaming_response(tools: List[ChatCompletionToolsParam],
                               tool_choice: str, result: GenerationResult,
                               model: str, request_id: str, done: bool,
-                              num_prompt_tokens: int) -> List[str]:
-    first_iteration = True
+                              num_prompt_tokens: int,
+                              first_iteration: bool) -> List[str]:
     output = result.outputs[0]
 
     # Convert tools to dictionary format for harmony adapter (standard pattern)

--- a/tensorrt_llm/serve/harmony_adapter.py
+++ b/tensorrt_llm/serve/harmony_adapter.py
@@ -1521,10 +1521,10 @@ class HarmonyAdapter:
         return True
 
 
-_SERVE_HARMONY_ADAPTER: HarmonyAdapter = None
+_SERVE_HARMONY_ADAPTER: HarmonyAdapter | None = None
 
 
-def get_harmony_adapter():
+def get_harmony_adapter() -> HarmonyAdapter:
     global _SERVE_HARMONY_ADAPTER
     if _SERVE_HARMONY_ADAPTER is None:
         _SERVE_HARMONY_ADAPTER = HarmonyAdapter()

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -870,11 +870,12 @@ class OpenAIServer:
             return chat_response
 
         async def create_streaming_generator(promise: RequestOutput, postproc_params: PostprocParams):
-            if not self.postproc_worker_enabled:
-                post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
-
             async for res in promise:
-                pp_results = res.outputs[0]._postprocess_result if self.postproc_worker_enabled else post_processor(res, args)
+                if not self.postproc_worker_enabled:
+                    post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
+                    pp_results = post_processor(res, args)
+                else:
+                    pp_results = res.outputs[0]._postprocess_result
                 for pp_res in pp_results:
                     yield pp_res
 

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -547,7 +547,9 @@ def chat_harmony_streaming_post_processor(
         request_id=args.request_id,
         done=rsp._done,
         num_prompt_tokens=args.num_prompt_tokens,
+        first_iteration=args.first_iteration,
     )
+    args.first_iteration = False
     return response
 
 

--- a/tests/unittest/llmapi/apps/_test_openai_chat_harmony.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_harmony.py
@@ -161,15 +161,29 @@ async def test_streaming(client: openai.AsyncOpenAI, model: str):
         }],
         stream=True,
     )
-    collected_chunks = []
     collected_messages = []
+    first_iteration = True
     async for chunk in response:
-        # Last streaming response will only contains usage info
-        if len(chunk.choices) <= 0:
-            continue
-
-        collected_chunks.append(chunk)
-        collected_messages.append(chunk.choices[0].delta)
+        if chunk.choices:
+            delta = chunk.choices[0].delta
+            if first_iteration:
+                assert delta.role == "assistant", ValueError(
+                    "Expected role 'assistant' for first iteration")
+                collected_messages.append(delta)
+                first_iteration = False
+            else:
+                assert delta.role is None, ValueError(
+                    "Expected no role except for first iteration")
+                collected_messages.append(delta)
+        else:
+            assert hasattr(chunk, "usage"), ValueError(
+                "Expected usage info in last streaming response")
+            assert chunk.usage.prompt_tokens is not None
+            assert chunk.usage.completion_tokens is not None
+            assert chunk.usage.total_tokens is not None
+            assert chunk.usage.prompt_tokens > 0
+            assert chunk.usage.completion_tokens > 0
+            assert chunk.usage.total_tokens > 0
 
     full_response = "".join([
         m.content for m in collected_messages

--- a/tests/unittest/llmapi/apps/test_harmony_channel_validation.py
+++ b/tests/unittest/llmapi/apps/test_harmony_channel_validation.py
@@ -362,6 +362,7 @@ class TestHandleStreamingResponse:
                     request_id=request_id,
                     done=False,  # Not done yet, still streaming
                     num_prompt_tokens=10,
+                    first_iteration=True,
                 )
 
                 # CRITICAL ASSERTION: result.abort() should be called
@@ -424,6 +425,7 @@ class TestHandleStreamingResponse:
                     request_id=request_id,
                     done=False,
                     num_prompt_tokens=10,
+                    first_iteration=True,
                 )
 
                 # CRITICAL ASSERTION: result.abort() should NOT be called


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response post-processing to correctly handle all operational modes.
  
* **Refactor**
  * Enhanced type safety for streaming response handling by clarifying parameter requirements and initialization logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
