### PR TITLE
[#10245][feat] AutoDeploy: Support Finegrained FP8 quantization

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -72,9 +72,9 @@ transforms:
     stage: pattern_matcher
   quantize_nvfp4_linear_from_config:
     stage: pattern_matcher
-  quantize_hf_fp8_linear_from_config:
+  quantize_finegrained_fp8_linear_from_config:
     stage: pattern_matcher
-  quantize_hf_fp8_moe:
+  quantize_finegrained_fp8_moe:
     stage: pattern_matcher
   quantize_fp8_bmm_from_config:
     stage: pattern_matcher
@@ -151,7 +151,7 @@ transforms:
     backend: trtllm
   fuse_nvfp4_swiglu:
     stage: post_load_fusion
-  fuse_hf_fp8_linear:
+  fuse_finegrained_fp8_linear:
     stage: post_load_fusion
     backend: trtllm
   fuse_moe:
@@ -163,9 +163,10 @@ transforms:
     expect_mem_change: true
     backend: trtllm
     allow_different_input_scales: false
-  fuse_hf_fp8_moe:
+  fuse_finegrained_fp8_moe:
     stage: post_load_fusion
-    enabled: true
+    expect_mem_change: true
+    allow_different_input_scales: false
   fuse_nvfp4_moe:
     stage: post_load_fusion
     expect_mem_change: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -160,6 +160,9 @@ transforms:
     expect_mem_change: true
     backend: trtllm
     allow_different_input_scales: false
+  fuse_hf_fp8_moe:
+    stage: post_load_fusion
+    enabled: true
   fuse_nvfp4_moe:
     stage: post_load_fusion
     expect_mem_change: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -151,6 +151,9 @@ transforms:
     backend: trtllm
   fuse_nvfp4_swiglu:
     stage: post_load_fusion
+  fuse_hf_fp8_linear:
+    stage: post_load_fusion
+    backend: trtllm
   fuse_moe:
     stage: post_load_fusion
     expect_mem_change: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -72,6 +72,10 @@ transforms:
     stage: pattern_matcher
   quantize_nvfp4_linear_from_config:
     stage: pattern_matcher
+  quantize_hf_fp8_linear_from_config:
+    stage: pattern_matcher
+  quantize_hf_fp8_moe:
+    stage: pattern_matcher
   quantize_fp8_bmm_from_config:
     stage: pattern_matcher
   quantize_fp8_from_graph:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -788,6 +788,9 @@ def torch_quant_finegrained_fp8_moe(
     w3_weight_scale_inv: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
     """
     FineGrainedFP8 MoE op using block-wise FP8 quantized linear operations.
@@ -874,7 +877,15 @@ def torch_quant_finegrained_fp8_moe(
 
         mlps = [make_finegrained_fp8_mlp(i) for i in range(len(w1_weight))]
 
-    return _template_moe(x, selected_experts, routing_weights, mlps)
+    return _template_moe(
+        x,
+        selected_experts,
+        routing_weights,
+        mlps,
+        apply_routing_on_input,
+        mapping_config,
+        max_num_tokens,
+    )
 
 
 @torch_quant_finegrained_fp8_moe.register_fake
@@ -890,5 +901,8 @@ def torch_quant_finegrained_fp8_moe_fake(
     w3_weight_scale_inv: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -773,3 +773,122 @@ def _torch_moe_dense_mlp_fake(
     limit: float = 10.0,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
+
+
+@torch.library.custom_op("auto_deploy::torch_quant_hf_fp8_moe", mutates_args=())
+def torch_quant_hf_fp8_moe(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_weight_scale_inv: List[torch.Tensor],
+    w2_weight_scale_inv: List[torch.Tensor],
+    w3_weight_scale_inv: List[torch.Tensor],
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+) -> torch.Tensor:
+    """
+    HuggingFace FineGrainedFP8 MoE op using block-wise FP8 quantized linear operations.
+
+    This op uses the HF FineGrainedFP8 format with per-block weight scales and
+    dynamic input quantization.
+
+    Args:
+        x: Input tensor of shape (B, H) or (B, S, H).
+        selected_experts: Tensor (B, TOP_K) or (B*S, TOP_K) containing expert indices.
+        routing_weights: Tensor of normalized routing weights.
+        w1_weight: List of per-expert FP8 weight tensors for gate/up projection.
+        w2_weight: List of per-expert FP8 weight tensors for down projection.
+        w3_weight: List of per-expert FP8 weight tensors for up projection (gated MLP).
+        w1_weight_scale_inv: List of per-block weight scales for w1.
+        w2_weight_scale_inv: List of per-block weight scales for w2.
+        w3_weight_scale_inv: List of per-block weight scales for w3.
+        is_gated_mlp: If True, use gated MLP (y = W2(act(W1 x) * W3 x)).
+        act_fn: Activation function (default: SiLU).
+    """
+    torch_act_fn = _resolve_torch_fn(act_fn)
+
+    if is_gated_mlp:
+
+        def make_hf_fp8_mlp(i):
+            def mlp(inp):
+                gate_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                    inp,
+                    w1_weight[i],
+                    bias=None,
+                    input_scale=[],
+                    weight_scale=[w1_weight_scale_inv[i]],
+                    input_zp=[],
+                    weight_zp=[],
+                )
+                up_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                    inp,
+                    w3_weight[i],
+                    bias=None,
+                    input_scale=[],
+                    weight_scale=[w3_weight_scale_inv[i]],
+                    input_zp=[],
+                    weight_zp=[],
+                )
+                prod = torch_act_fn(gate_out) * up_out
+                return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                    prod,
+                    w2_weight[i],
+                    bias=None,
+                    input_scale=[],
+                    weight_scale=[w2_weight_scale_inv[i]],
+                    input_zp=[],
+                    weight_zp=[],
+                )
+
+            return mlp
+
+        mlps = [make_hf_fp8_mlp(i) for i in range(len(w1_weight))]
+
+    else:
+
+        def make_hf_fp8_mlp(i):
+            def mlp(inp):
+                up_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                    inp,
+                    w1_weight[i],
+                    bias=None,
+                    input_scale=[],
+                    weight_scale=[w1_weight_scale_inv[i]],
+                    input_zp=[],
+                    weight_zp=[],
+                )
+                return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                    torch_act_fn(up_out),
+                    w2_weight[i],
+                    bias=None,
+                    input_scale=[],
+                    weight_scale=[w2_weight_scale_inv[i]],
+                    input_zp=[],
+                    weight_zp=[],
+                )
+
+            return mlp
+
+        mlps = [make_hf_fp8_mlp(i) for i in range(len(w1_weight))]
+
+    return _template_moe(x, selected_experts, routing_weights, mlps)
+
+
+@torch_quant_hf_fp8_moe.register_fake
+def torch_quant_hf_fp8_moe_fake(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_weight_scale_inv: List[torch.Tensor],
+    w2_weight_scale_inv: List[torch.Tensor],
+    w3_weight_scale_inv: List[torch.Tensor],
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+) -> torch.Tensor:
+    return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -775,8 +775,8 @@ def _torch_moe_dense_mlp_fake(
     return torch.empty_like(hidden_states)
 
 
-@torch.library.custom_op("auto_deploy::torch_quant_hf_fp8_moe", mutates_args=())
-def torch_quant_hf_fp8_moe(
+@torch.library.custom_op("auto_deploy::torch_quant_finegrained_fp8_moe", mutates_args=())
+def torch_quant_finegrained_fp8_moe(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
@@ -790,7 +790,7 @@ def torch_quant_hf_fp8_moe(
     act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:
     """
-    HuggingFace FineGrainedFP8 MoE op using block-wise FP8 quantized linear operations.
+    FineGrainedFP8 MoE op using block-wise FP8 quantized linear operations.
 
     This op uses the HF FineGrainedFP8 format with per-block weight scales and
     dynamic input quantization.
@@ -812,9 +812,9 @@ def torch_quant_hf_fp8_moe(
 
     if is_gated_mlp:
 
-        def make_hf_fp8_mlp(i):
+        def make_finegrained_fp8_mlp(i):
             def mlp(inp):
-                gate_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                gate_out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     inp,
                     w1_weight[i],
                     bias=None,
@@ -823,7 +823,7 @@ def torch_quant_hf_fp8_moe(
                     input_zp=[],
                     weight_zp=[],
                 )
-                up_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                up_out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     inp,
                     w3_weight[i],
                     bias=None,
@@ -833,7 +833,7 @@ def torch_quant_hf_fp8_moe(
                     weight_zp=[],
                 )
                 prod = torch_act_fn(gate_out) * up_out
-                return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     prod,
                     w2_weight[i],
                     bias=None,
@@ -845,13 +845,13 @@ def torch_quant_hf_fp8_moe(
 
             return mlp
 
-        mlps = [make_hf_fp8_mlp(i) for i in range(len(w1_weight))]
+        mlps = [make_finegrained_fp8_mlp(i) for i in range(len(w1_weight))]
 
     else:
 
-        def make_hf_fp8_mlp(i):
+        def make_finegrained_fp8_mlp(i):
             def mlp(inp):
-                up_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                up_out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     inp,
                     w1_weight[i],
                     bias=None,
@@ -860,7 +860,7 @@ def torch_quant_hf_fp8_moe(
                     input_zp=[],
                     weight_zp=[],
                 )
-                return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+                return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     torch_act_fn(up_out),
                     w2_weight[i],
                     bias=None,
@@ -872,13 +872,13 @@ def torch_quant_hf_fp8_moe(
 
             return mlp
 
-        mlps = [make_hf_fp8_mlp(i) for i in range(len(w1_weight))]
+        mlps = [make_finegrained_fp8_mlp(i) for i in range(len(w1_weight))]
 
     return _template_moe(x, selected_experts, routing_weights, mlps)
 
 
-@torch_quant_hf_fp8_moe.register_fake
-def torch_quant_hf_fp8_moe_fake(
+@torch_quant_finegrained_fp8_moe.register_fake
+def torch_quant_finegrained_fp8_moe_fake(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -20,10 +20,15 @@ import torch
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import (
     TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
 )
+<<<<<<< HEAD
 from tensorrt_llm._torch.auto_deploy.utils.mapping_utils import deserialize_mapping
 from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
+=======
+from tensorrt_llm._torch.modules.fused_moe.routing import RoutingMethodType
+>>>>>>> d17461ce7 (added unit test)
 from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm._utils import is_sm_100f
 
 
 def _check_moe_alltoall(mapping_config: str, max_num_tokens: int) -> Tuple[Mapping | None, bool]:
@@ -569,4 +574,153 @@ def trtllm_quant_nvfp4_moe_fused_fake(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@torch.library.custom_op("auto_deploy::trtllm_quant_hf_fp8_block_scale_moe_fused", mutates_args=())
+def trtllm_quant_hf_fp8_block_scale_moe_fused(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_weight_scale: torch.Tensor,
+    fc2_weight_scale: torch.Tensor,
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+) -> torch.Tensor:
+    """TensorRT-LLM Cutlass FP8 Block Scale MoE for HuggingFace FineGrainedFP8 format.
+
+    This op uses the DeepSeek FP8 block scale format which is compatible with HF FP8.
+    Activations are quantized dynamically at runtime (no pre-computed activation scales).
+
+    Computes (per expert):
+        For gated_mlp:
+            y = (act(x @ w1.T) * (x @ w3.T)) @ w2.T  # act := SiLU
+        For mlp:
+            y = act(x @ w1.T) @ w2.T                 # act := ReLU^2
+
+    Notes:
+        - FC1 implements: fc1_output = (act(x @ w1.T) * (x @ w3.T)) or fc1_output = act(x @ w1.T)
+        - FC2 implements: fc2_output = fc1_output @ w2.T
+        - FC1 weights are concatenated w3 and w1 if gated_mlp, otherwise w1
+        - Uses per-block weight scales (128x128 blocks)
+        - On Hopper (SM90): Activation quantization happens dynamically inside the kernel
+        - On Blackwell (SM100+): Uses fp8_block_scale_moe_runner with external activation quantization
+
+    Parameters:
+        x: BF16/FP16 input tensor of shape (B, H) or (B, S, H)
+        selected_experts: Expert indices (B*S, TOP_K)
+        routing_weights: Routing weights (B*S, TOP_K)
+        fc1_expert_weights: FC1 FP8 weights [E, 2*I, H] for gated_mlp, [E, I, H] for mlp
+        fc2_expert_weights: FC2 FP8 weights [E, H, I]
+        fc1_weight_scale: FC1 block weight scales [E, 2*I/128, H/128] or [E, I/128, H/128]
+        fc2_weight_scale: FC2 block weight scales [E, H/128, I/128]
+        is_gated_mlp: True for gated_mlp, False for mlp
+        act_fn: ActivationType.Silu for gated_mlp, ActivationType.Relu2 for mlp
+
+    Returns:
+        Output tensor of shape (B, H) or (B, S, H)
+    """
+    _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
+    act_fn = ActivationType.Swiglu if act_fn == ActivationType.Silu else act_fn
+
+    # Store original shape and flatten to 2D
+    x_shape = x.shape
+    x2d = x.view(-1, x_shape[-1])
+
+    # Ensure contiguous tensors with correct dtypes
+    selected_experts = selected_experts.int().contiguous()
+
+    if is_sm_100f():
+        # --- Blackwell (SM100+) Path ---
+        # Uses fp8_block_scale_moe_runner with pre-computed routing (topk_weights/topk_ids)
+
+        # Quantize activations externally (Blackwell kernel expects FP8 input)
+        x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(x2d)
+
+        # Infer parameters from weight shapes
+        num_experts = fc1_expert_weights.shape[0]
+        top_k = selected_experts.shape[-1]
+        # For gated MLP, fc1 weights have shape [E, 2*I, H], so intermediate_size = shape[1] // 2
+        # For non-gated MLP, fc1 weights have shape [E, I, H], so intermediate_size = shape[1]
+        intermediate_size = (
+            fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
+        )
+
+        # Blackwell kernel expects bfloat16 for topk_weights
+        routing_weights_bf16 = routing_weights.to(torch.bfloat16).contiguous()
+
+        # Blackwell kernel expects float32 for weight scales
+        fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
+        fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+
+        # Call Blackwell fp8_block_scale_moe_runner with pre-computed routing
+        output = torch.ops.trtllm.fp8_block_scale_moe_runner(
+            None,  # routing_logits - not needed when topk_weights/topk_ids provided
+            None,  # routing_bias - not needed for pre-computed routing
+            x_fp8,
+            x_sf,
+            fc1_expert_weights.contiguous(),
+            fc1_weight_scale_f32,
+            fc2_expert_weights.contiguous(),
+            fc2_weight_scale_f32,
+            num_experts,
+            top_k,
+            None,  # n_group - default 0 (no grouped routing)
+            None,  # topk_group - default 0
+            intermediate_size,
+            0,  # local_expert_offset - default 0 (no EP sharding)
+            num_experts,  # local_num_experts - same as num_experts (no EP sharding)
+            None,  # routed_scaling_factor - default 1.0
+            RoutingMethodType.Renormalize,  # routing weights already pre-computed, type just needs a supported value
+            topk_weights=routing_weights_bf16,
+            topk_ids=selected_experts,
+        )
+
+        # Restore original shape
+        return output.view(x_shape)
+    else:
+        # --- Hopper (SM90) Path ---
+        # Uses fused_moe with DeepSeek FP8 block scale mode (activation quant inside kernel)
+
+        # TRTLLM kernel expects float32 for routing_weights
+        routing_weights = routing_weights.to(torch.float32).contiguous()
+
+        # For DeepSeek FP8 block scales, quant_scales is a tuple of (fc_weight_scales, proj_weight_scales)
+        # The kernel handles dynamic activation quantization internally
+        quant_scales = (fc1_weight_scale, fc2_weight_scale)
+
+        # Call fused_moe with DeepSeek FP8 block scale mode
+        output = torch.ops.trtllm.fused_moe(
+            x2d,
+            selected_experts,
+            routing_weights,
+            fc1_expert_weights=fc1_expert_weights.contiguous(),
+            fc1_expert_biases=None,
+            fc2_expert_weights=fc2_expert_weights.contiguous(),
+            fc2_expert_biases=None,
+            output_dtype=x.dtype,
+            quant_scales=quant_scales,
+            activation_type=act_fn,
+            use_deepseek_fp8_block_scale=True,
+        )
+
+        # Restore original shape
+        return output[0].view(x_shape)
+
+
+@trtllm_quant_hf_fp8_block_scale_moe_fused.register_fake
+def trtllm_quant_hf_fp8_block_scale_moe_fused_fake(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_weight_scale: torch.Tensor,
+    fc2_weight_scale: torch.Tensor,
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+) -> torch.Tensor:
+    _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -303,6 +303,13 @@ def _run_finegrained_moe_with_alltoall_blackwell(
 
     local_expert_offset = mapping.moe_ep_rank * local_num_experts
 
+    # TODO: pass act_type once FP8BlockScaleMoERunner C++ supports it.
+    # Currently defaults to SwiGlu; non-gated MLPs (Relu2) will be incorrect.
+    assert is_gated_mlp, (
+        "fp8_block_scale_moe_runner does not support act_type yet; "
+        "only gated MLP (SwiGlu) is supported on the Blackwell alltoall path"
+    )
+
     moe_out = torch.ops.trtllm.fp8_block_scale_moe_runner(
         None,  # routing_logits
         None,  # routing_bias
@@ -795,6 +802,13 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     # routing weights for remote experts are zeroed, all_reduce is added after this op
     if is_sm_100f():
         # --- Blackwell (SM100+) Path ---
+        # TODO: pass act_type once FP8BlockScaleMoERunner C++ supports it.
+        # Currently defaults to SwiGlu; non-gated MLPs (Relu2) will be incorrect.
+        assert is_gated_mlp, (
+            "fp8_block_scale_moe_runner does not support act_type yet; "
+            "only gated MLP (SwiGlu) is supported on the Blackwell EP all-reduce path"
+        )
+
         x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(x2d)
 
         num_experts = fc1_expert_weights.shape[0]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -60,22 +60,25 @@ def _run_moe_with_alltoall(
     fc2_expert_biases: torch.Tensor | None = None,
     nvfp4_act_global_scale: torch.Tensor | None = None,
     use_deepseek_fp8_block_scale: bool = False,
+    finegrained_fp8_block_scales: Tuple[torch.Tensor, torch.Tensor] | None = None,
+    is_gated_mlp: bool = True,
 ) -> torch.Tensor:
     """
     Execute MoE with all-to-all dispatch/combine pattern.
 
     Encapsulates the common all-to-all logic shared by the unquantized, FP8,
-    NVFP4, and FineGrained FP8 (Hopper) variants, calling
-    ``torch.ops.trtllm.fused_moe`` directly rather than going through a
-    caller-provided kernel closure.
+    NVFP4, and FineGrained FP8 variants, calling ``torch.ops.trtllm.fused_moe``
+    or ``fp8_block_scale_moe_runner`` (Blackwell) directly rather than going
+    through a caller-provided kernel closure.
 
     Args:
         x: 2-D input tensor ``(num_tokens, hidden_size)``.
             For unquantized / FP8: pass the (possibly quantized) flattened input.
             For NVFP4: pass the **bf16** flattened input (per-rank FP4 quantisation
             is performed after dispatch when *nvfp4_act_global_scale* is set).
-            For FineGrained FP8 (Hopper): pass the **bf16** flattened input
-            (dynamic activation quant happens inside the kernel).
+            For FineGrained FP8: pass the **bf16** flattened input
+            (dynamic activation quant happens inside the kernel on Hopper,
+            or externally via ``fp8_quantize_1x128`` on Blackwell).
         selected_experts: Expert indices in GLOBAL coordinates ``(num_tokens, top_k)``.
         routing_weights: Routing weights ``(num_tokens, top_k)``.
         fc1_expert_weights: FC1 weight tensor (shape[0] = local expert count).
@@ -95,6 +98,13 @@ def _run_moe_with_alltoall(
         use_deepseek_fp8_block_scale: When True, enables DeepSeek FP8 block scale
             mode in ``fused_moe``. Used by FineGrained FP8 on Hopper where
             activation quantization happens dynamically inside the kernel.
+        finegrained_fp8_block_scales: ``(fc1_weight_scale, fc2_weight_scale)`` tuple
+            for FineGrained FP8 MoE.  When set **and** on Blackwell (SM100+), the
+            function uses ``fp8_block_scale_moe_runner`` instead of ``fused_moe``.
+            When set on Hopper (SM90), it derives ``quant_scales`` and enables
+            ``use_deepseek_fp8_block_scale`` internally.
+        is_gated_mlp: Whether gated MLP is used. Needed by the Blackwell finegrained
+            FP8 path to compute ``intermediate_size``.
 
     Returns:
         2-D output tensor ``(num_tokens, hidden_size)`` — the caller reshapes to the
@@ -164,174 +174,100 @@ def _run_moe_with_alltoall(
     dispatched_selected = recv_results[1].reshape(-1, top_k)
     dispatched_weights = recv_results[2].reshape(-1, top_k)
 
-    # NVFP4: quantise the dispatched bf16 input to FP4 per-rank
-    input_sf_kwargs: dict = {}
-    if nvfp4_act_global_scale is not None:
-        dispatched_x, input_sf = torch.ops.trtllm.fp4_quantize(
-            dispatched_x, nvfp4_act_global_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE
-        )
-        dispatched_x = dispatched_x.view(torch.long)
-        input_sf_kwargs["input_sf"] = input_sf
+    # --- Kernel call ---
+    if finegrained_fp8_block_scales is not None and is_sm_100f():
+        # Blackwell finegrained FP8: external quant + fp8_block_scale_moe_runner
+        fc1_ws_f32 = finegrained_fp8_block_scales[0].to(torch.float32).contiguous()
+        fc2_ws_f32 = finegrained_fp8_block_scales[1].to(torch.float32).contiguous()
+        x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(dispatched_x)
 
-    # Call the fused MoE kernel with all-to-all parameters
-    moe_out = torch.ops.trtllm.fused_moe(
-        dispatched_x,
-        dispatched_selected,
-        dispatched_weights,
-        fc1_expert_weights=fc1_expert_weights,
-        fc1_expert_biases=fc1_expert_biases,
-        fc2_expert_weights=fc2_expert_weights,
-        fc2_expert_biases=fc2_expert_biases,
-        output_dtype=output_dtype,
-        quant_scales=quant_scales,
-        tp_size=mapping.moe_tp_size,
-        tp_rank=mapping.moe_tp_rank,
-        ep_size=mapping.moe_ep_size,
-        ep_rank=mapping.moe_ep_rank,
-        cluster_size=mapping.moe_cluster_size,
-        cluster_rank=mapping.moe_cluster_rank,
-        enable_alltoall=True,
-        tuner_num_tokens=dispatched_x.shape[0],
-        tuner_top_k=top_k,
-        activation_type=activation_type,
-        use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
-        use_w4_group_scaling=False,
-        use_int8_woq_per_channel=False,
-        use_mxfp8_act_scaling=False,
-        min_latency_mode=False,
-        use_fused_finalize=True,
-        **input_sf_kwargs,
-    )[0]
+        intermediate_size = (
+            fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
+        )
+        local_expert_offset = mapping.moe_ep_rank * local_num_experts
+        routing_weights_bf16 = dispatched_weights.to(torch.bfloat16).contiguous()
+
+        # TODO: pass act_type once FP8BlockScaleMoERunner C++ supports it.
+        # Currently defaults to SwiGlu; non-gated MLPs (Relu2) will be incorrect.
+        assert is_gated_mlp, (
+            "fp8_block_scale_moe_runner does not support act_type yet; "
+            "only gated MLP (SwiGlu) is supported on the Blackwell alltoall path"
+        )
+
+        moe_out = torch.ops.trtllm.fp8_block_scale_moe_runner(
+            None,  # routing_logits
+            None,  # routing_bias
+            x_fp8,
+            x_sf,
+            fc1_expert_weights.contiguous(),
+            fc1_ws_f32,
+            fc2_expert_weights.contiguous(),
+            fc2_ws_f32,
+            global_num_experts,
+            top_k,
+            None,  # n_group
+            None,  # topk_group
+            intermediate_size,
+            local_expert_offset,
+            local_num_experts,
+            None,  # routed_scaling_factor
+            RoutingMethodType.Renormalize,
+            topk_weights=routing_weights_bf16,
+            topk_ids=dispatched_selected,
+        )
+    else:
+        # All other paths: fused_moe (unquantized, FP8, NVFP4, finegrained Hopper)
+        if finegrained_fp8_block_scales is not None:
+            # Hopper finegrained: derive quant_scales from block scales
+            quant_scales = (
+                finegrained_fp8_block_scales[0].to(torch.float32).contiguous(),
+                finegrained_fp8_block_scales[1].to(torch.float32).contiguous(),
+            )
+            use_deepseek_fp8_block_scale = True
+
+        # NVFP4: quantise the dispatched bf16 input to FP4 per-rank
+        input_sf_kwargs: dict = {}
+        if nvfp4_act_global_scale is not None:
+            dispatched_x, input_sf = torch.ops.trtllm.fp4_quantize(
+                dispatched_x, nvfp4_act_global_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+            )
+            dispatched_x = dispatched_x.view(torch.long)
+            input_sf_kwargs["input_sf"] = input_sf
+
+        # Call the fused MoE kernel with all-to-all parameters
+        moe_out = torch.ops.trtllm.fused_moe(
+            dispatched_x,
+            dispatched_selected,
+            dispatched_weights,
+            fc1_expert_weights=fc1_expert_weights,
+            fc1_expert_biases=fc1_expert_biases,
+            fc2_expert_weights=fc2_expert_weights,
+            fc2_expert_biases=fc2_expert_biases,
+            output_dtype=output_dtype,
+            quant_scales=quant_scales,
+            tp_size=mapping.moe_tp_size,
+            tp_rank=mapping.moe_tp_rank,
+            ep_size=mapping.moe_ep_size,
+            ep_rank=mapping.moe_ep_rank,
+            cluster_size=mapping.moe_cluster_size,
+            cluster_rank=mapping.moe_cluster_rank,
+            enable_alltoall=True,
+            tuner_num_tokens=dispatched_x.shape[0],
+            tuner_top_k=top_k,
+            activation_type=activation_type,
+            use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
+            use_w4_group_scaling=False,
+            use_int8_woq_per_channel=False,
+            use_mxfp8_act_scaling=False,
+            min_latency_mode=False,
+            use_fused_finalize=True,
+            **input_sf_kwargs,
+        )[0]
 
     # COMBINE: Gather full results back to original GPUs.
     # runtime_max_tokens_per_rank is an over-approximation (max_num_tokens),
     # so the combined result has more rows than the original input.
     # Slice back to local_num_tokens (captured before padding) before returning.
-    moe_out = moe_out.view(mapping.moe_ep_size, runtime_max_tokens_per_rank, hidden_size)
-    combined = moe_a2a.combine(moe_out, runtime_max_tokens_per_rank)
-    return combined[:local_num_tokens]
-
-
-def _run_finegrained_moe_with_alltoall_blackwell(
-    x: torch.Tensor,
-    selected_experts: torch.Tensor,
-    routing_weights: torch.Tensor,
-    fc1_expert_weights: torch.Tensor,
-    fc2_expert_weights: torch.Tensor,
-    fc1_weight_scale: torch.Tensor,
-    fc2_weight_scale: torch.Tensor,
-    is_gated_mlp: bool,
-    mapping: Mapping,
-    max_num_tokens: int,
-) -> torch.Tensor:
-    """Execute FineGrained FP8 MoE with all-to-all on Blackwell (SM100+).
-
-    Wraps ``fp8_block_scale_moe_runner`` with alltoall dispatch/combine.
-    Activation quantization (bf16 -> FP8) is performed per-rank after dispatch.
-
-    Args:
-        x: 2-D bf16/fp16 input tensor ``(num_tokens, hidden_size)``.
-        selected_experts: Expert indices in GLOBAL coordinates ``(num_tokens, top_k)``.
-        routing_weights: Routing weights ``(num_tokens, top_k)``.
-        fc1_expert_weights: FC1 FP8 weights ``[local_E, 2*I, H]`` or ``[local_E, I, H]``.
-        fc2_expert_weights: FC2 FP8 weights ``[local_E, H, I]``.
-        fc1_weight_scale: FC1 block weight scales.
-        fc2_weight_scale: FC2 block weight scales.
-        is_gated_mlp: Whether gated MLP is used.
-        mapping: ``Mapping`` object with EP configuration.
-        max_num_tokens: Upper-bound token count per rank.
-
-    Returns:
-        2-D output tensor ``(num_tokens, hidden_size)``.
-    """
-    top_k = selected_experts.shape[1]
-    hidden_size = x.shape[-1]
-
-    local_num_experts = fc1_expert_weights.shape[0]
-    global_num_experts = local_num_experts * mapping.moe_ep_size
-    intermediate_size = (
-        fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
-    )
-
-    workspace_size = MoeAlltoAll.calculate_required_workspace_size(
-        mapping.moe_ep_size, top_k, max_num_tokens, hidden_size, x.dtype
-    )
-
-    runtime_max_tokens_per_rank = max_num_tokens
-
-    moe_a2a = MoeAlltoAll(
-        mapping=mapping,
-        max_num_tokens=max_num_tokens,
-        top_k=top_k,
-        num_slots=global_num_experts,
-        workspace_size_per_rank=workspace_size,
-        num_experts=None,
-    )
-
-    invalid_expert_id = global_num_experts
-
-    local_num_tokens = x.shape[0]
-    pad_expert_id = mapping.moe_ep_rank * local_num_experts
-    pad_size = runtime_max_tokens_per_rank - local_num_tokens
-    if pad_size > 0:
-        x = torch.nn.functional.pad(x, (0, 0, 0, pad_size))
-        selected_experts = torch.nn.functional.pad(
-            selected_experts, (0, 0, 0, pad_size), value=pad_expert_id
-        )
-        routing_weights = torch.nn.functional.pad(routing_weights, (0, 0, 0, pad_size))
-
-    payloads = [x.contiguous(), selected_experts.contiguous(), routing_weights.contiguous()]
-
-    recv_results = moe_a2a.dispatch(
-        selected_experts,
-        payloads,
-        runtime_max_tokens_per_rank,
-        invalid_token_expert_id=invalid_expert_id,
-        expert_id_payload_index=1,
-    )
-
-    dispatched_x = recv_results[0].reshape(-1, hidden_size)
-    dispatched_selected = recv_results[1].reshape(-1, top_k)
-    dispatched_weights = recv_results[2].reshape(-1, top_k)
-
-    # Quantize dispatched bf16 input to FP8 per-rank
-    x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(dispatched_x)
-
-    routing_weights_bf16 = dispatched_weights.to(torch.bfloat16).contiguous()
-    fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
-    fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
-
-    local_expert_offset = mapping.moe_ep_rank * local_num_experts
-
-    # TODO: pass act_type once FP8BlockScaleMoERunner C++ supports it.
-    # Currently defaults to SwiGlu; non-gated MLPs (Relu2) will be incorrect.
-    assert is_gated_mlp, (
-        "fp8_block_scale_moe_runner does not support act_type yet; "
-        "only gated MLP (SwiGlu) is supported on the Blackwell alltoall path"
-    )
-
-    moe_out = torch.ops.trtllm.fp8_block_scale_moe_runner(
-        None,  # routing_logits
-        None,  # routing_bias
-        x_fp8,
-        x_sf,
-        fc1_expert_weights.contiguous(),
-        fc1_weight_scale_f32,
-        fc2_expert_weights.contiguous(),
-        fc2_weight_scale_f32,
-        global_num_experts,
-        top_k,
-        None,  # n_group
-        None,  # topk_group
-        intermediate_size,
-        local_expert_offset,
-        local_num_experts,
-        None,  # routed_scaling_factor
-        RoutingMethodType.Renormalize,
-        topk_weights=routing_weights_bf16,
-        topk_ids=dispatched_selected,
-    )
-
     moe_out = moe_out.view(mapping.moe_ep_size, runtime_max_tokens_per_rank, hidden_size)
     combined = moe_a2a.combine(moe_out, runtime_max_tokens_per_rank)
     return combined[:local_num_tokens]
@@ -769,34 +705,20 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     mapping, enable_alltoall = _check_moe_alltoall(mapping_config, max_num_tokens)
 
     if enable_alltoall:
-        if is_sm_100f():
-            return _run_finegrained_moe_with_alltoall_blackwell(
-                x=x2d,
-                selected_experts=selected_experts,
-                routing_weights=routing_weights,
-                fc1_expert_weights=fc1_expert_weights,
-                fc2_expert_weights=fc2_expert_weights,
-                fc1_weight_scale=fc1_weight_scale,
-                fc2_weight_scale=fc2_weight_scale,
-                is_gated_mlp=is_gated_mlp,
-                mapping=mapping,
-                max_num_tokens=max_num_tokens,
-            ).view(x_shape)
-        else:
-            quant_scales = (fc1_weight_scale, fc2_weight_scale)
-            return _run_moe_with_alltoall(
-                x=x2d,
-                selected_experts=selected_experts,
-                routing_weights=routing_weights,
-                fc1_expert_weights=fc1_expert_weights.contiguous(),
-                fc2_expert_weights=fc2_expert_weights.contiguous(),
-                output_dtype=x.dtype,
-                quant_scales=quant_scales,
-                activation_type=act_fn,
-                mapping=mapping,
-                max_num_tokens=max_num_tokens,
-                use_deepseek_fp8_block_scale=True,
-            ).view(x_shape)
+        return _run_moe_with_alltoall(
+            x=x2d,
+            selected_experts=selected_experts,
+            routing_weights=routing_weights,
+            fc1_expert_weights=fc1_expert_weights,
+            fc2_expert_weights=fc2_expert_weights,
+            output_dtype=x.dtype,
+            quant_scales=[],
+            activation_type=act_fn,
+            mapping=mapping,
+            max_num_tokens=max_num_tokens,
+            finegrained_fp8_block_scales=(fc1_weight_scale, fc2_weight_scale),
+            is_gated_mlp=is_gated_mlp,
+        ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
     # routing weights for remote experts are zeroed, all_reduce is added after this op
@@ -846,7 +768,11 @@ def trtllm_quant_finegrained_fp8_moe_fused(
         return output.view(x_shape)
     else:
         # --- Hopper (SM90) Path ---
-        quant_scales = (fc1_weight_scale, fc2_weight_scale)
+        # TRT-LLM fused_moe kernel requires float32 scales; HF checkpoints may
+        # store them in bfloat16, so cast here (matching the Blackwell path).
+        fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
+        fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+        quant_scales = (fc1_weight_scale_f32, fc2_weight_scale_f32)
 
         output = torch.ops.trtllm.fused_moe(
             x2d,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -577,8 +577,8 @@ def trtllm_quant_nvfp4_moe_fused_fake(
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("auto_deploy::trtllm_quant_hf_fp8_block_scale_moe_fused", mutates_args=())
-def trtllm_quant_hf_fp8_block_scale_moe_fused(
+@torch.library.custom_op("auto_deploy::trtllm_quant_finegrained_fp8_moe_fused", mutates_args=())
+def trtllm_quant_finegrained_fp8_moe_fused(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
@@ -589,9 +589,9 @@ def trtllm_quant_hf_fp8_block_scale_moe_fused(
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
 ) -> torch.Tensor:
-    """TensorRT-LLM Cutlass FP8 Block Scale MoE for HuggingFace FineGrainedFP8 format.
+    """TensorRT-LLM Cutlass FP8 Block Scale MoE for FineGrainedFP8 format.
 
-    This op uses the DeepSeek FP8 block scale format which is compatible with HF FP8.
+    This op uses the DeepSeek FP8 block scale format which is compatible with FineGrained FP8.
     Activations are quantized dynamically at runtime (no pre-computed activation scales).
 
     Computes (per expert):
@@ -710,8 +710,8 @@ def trtllm_quant_hf_fp8_block_scale_moe_fused(
         return output[0].view(x_shape)
 
 
-@trtllm_quant_hf_fp8_block_scale_moe_fused.register_fake
-def trtllm_quant_hf_fp8_block_scale_moe_fused_fake(
+@trtllm_quant_finegrained_fp8_moe_fused.register_fake
+def trtllm_quant_finegrained_fp8_moe_fused_fake(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -20,15 +20,12 @@ import torch
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import (
     TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
 )
-<<<<<<< HEAD
 from tensorrt_llm._torch.auto_deploy.utils.mapping_utils import deserialize_mapping
 from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
-=======
 from tensorrt_llm._torch.modules.fused_moe.routing import RoutingMethodType
->>>>>>> d17461ce7 (added unit test)
 from tensorrt_llm._torch.utils import ActivationType
-from tensorrt_llm.mapping import Mapping
 from tensorrt_llm._utils import is_sm_100f
+from tensorrt_llm.mapping import Mapping
 
 
 def _check_moe_alltoall(mapping_config: str, max_num_tokens: int) -> Tuple[Mapping | None, bool]:
@@ -62,19 +59,23 @@ def _run_moe_with_alltoall(
     fc1_expert_biases: torch.Tensor | None = None,
     fc2_expert_biases: torch.Tensor | None = None,
     nvfp4_act_global_scale: torch.Tensor | None = None,
+    use_deepseek_fp8_block_scale: bool = False,
 ) -> torch.Tensor:
     """
     Execute MoE with all-to-all dispatch/combine pattern.
 
-    Encapsulates the common all-to-all logic shared by the unquantized, FP8 and
-    NVFP4 variants, calling ``torch.ops.trtllm.fused_moe`` directly rather than
-    going through a caller-provided kernel closure.
+    Encapsulates the common all-to-all logic shared by the unquantized, FP8,
+    NVFP4, and FineGrained FP8 (Hopper) variants, calling
+    ``torch.ops.trtllm.fused_moe`` directly rather than going through a
+    caller-provided kernel closure.
 
     Args:
         x: 2-D input tensor ``(num_tokens, hidden_size)``.
             For unquantized / FP8: pass the (possibly quantized) flattened input.
             For NVFP4: pass the **bf16** flattened input (per-rank FP4 quantisation
             is performed after dispatch when *nvfp4_act_global_scale* is set).
+            For FineGrained FP8 (Hopper): pass the **bf16** flattened input
+            (dynamic activation quant happens inside the kernel).
         selected_experts: Expert indices in GLOBAL coordinates ``(num_tokens, top_k)``.
         routing_weights: Routing weights ``(num_tokens, top_k)``.
         fc1_expert_weights: FC1 weight tensor (shape[0] = local expert count).
@@ -91,6 +92,9 @@ def _run_moe_with_alltoall(
         fc2_expert_biases: Optional FC2 biases (currently always ``None``).
         nvfp4_act_global_scale: When set, the dispatched bf16 input is quantised to
             NVFP4 per-rank before the kernel call (``torch.ops.trtllm.fp4_quantize``).
+        use_deepseek_fp8_block_scale: When True, enables DeepSeek FP8 block scale
+            mode in ``fused_moe``. Used by FineGrained FP8 on Hopper where
+            activation quantization happens dynamically inside the kernel.
 
     Returns:
         2-D output tensor ``(num_tokens, hidden_size)`` — the caller reshapes to the
@@ -190,7 +194,7 @@ def _run_moe_with_alltoall(
         tuner_num_tokens=dispatched_x.shape[0],
         tuner_top_k=top_k,
         activation_type=activation_type,
-        use_deepseek_fp8_block_scale=False,
+        use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
         use_w4_group_scaling=False,
         use_int8_woq_per_channel=False,
         use_mxfp8_act_scaling=False,
@@ -203,6 +207,124 @@ def _run_moe_with_alltoall(
     # runtime_max_tokens_per_rank is an over-approximation (max_num_tokens),
     # so the combined result has more rows than the original input.
     # Slice back to local_num_tokens (captured before padding) before returning.
+    moe_out = moe_out.view(mapping.moe_ep_size, runtime_max_tokens_per_rank, hidden_size)
+    combined = moe_a2a.combine(moe_out, runtime_max_tokens_per_rank)
+    return combined[:local_num_tokens]
+
+
+def _run_finegrained_moe_with_alltoall_blackwell(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_weight_scale: torch.Tensor,
+    fc2_weight_scale: torch.Tensor,
+    is_gated_mlp: bool,
+    mapping: Mapping,
+    max_num_tokens: int,
+) -> torch.Tensor:
+    """Execute FineGrained FP8 MoE with all-to-all on Blackwell (SM100+).
+
+    Wraps ``fp8_block_scale_moe_runner`` with alltoall dispatch/combine.
+    Activation quantization (bf16 -> FP8) is performed per-rank after dispatch.
+
+    Args:
+        x: 2-D bf16/fp16 input tensor ``(num_tokens, hidden_size)``.
+        selected_experts: Expert indices in GLOBAL coordinates ``(num_tokens, top_k)``.
+        routing_weights: Routing weights ``(num_tokens, top_k)``.
+        fc1_expert_weights: FC1 FP8 weights ``[local_E, 2*I, H]`` or ``[local_E, I, H]``.
+        fc2_expert_weights: FC2 FP8 weights ``[local_E, H, I]``.
+        fc1_weight_scale: FC1 block weight scales.
+        fc2_weight_scale: FC2 block weight scales.
+        is_gated_mlp: Whether gated MLP is used.
+        mapping: ``Mapping`` object with EP configuration.
+        max_num_tokens: Upper-bound token count per rank.
+
+    Returns:
+        2-D output tensor ``(num_tokens, hidden_size)``.
+    """
+    top_k = selected_experts.shape[1]
+    hidden_size = x.shape[-1]
+
+    local_num_experts = fc1_expert_weights.shape[0]
+    global_num_experts = local_num_experts * mapping.moe_ep_size
+    intermediate_size = (
+        fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
+    )
+
+    workspace_size = MoeAlltoAll.calculate_required_workspace_size(
+        mapping.moe_ep_size, top_k, max_num_tokens, hidden_size, x.dtype
+    )
+
+    runtime_max_tokens_per_rank = max_num_tokens
+
+    moe_a2a = MoeAlltoAll(
+        mapping=mapping,
+        max_num_tokens=max_num_tokens,
+        top_k=top_k,
+        num_slots=global_num_experts,
+        workspace_size_per_rank=workspace_size,
+        num_experts=None,
+    )
+
+    invalid_expert_id = global_num_experts
+
+    local_num_tokens = x.shape[0]
+    pad_expert_id = mapping.moe_ep_rank * local_num_experts
+    pad_size = runtime_max_tokens_per_rank - local_num_tokens
+    if pad_size > 0:
+        x = torch.nn.functional.pad(x, (0, 0, 0, pad_size))
+        selected_experts = torch.nn.functional.pad(
+            selected_experts, (0, 0, 0, pad_size), value=pad_expert_id
+        )
+        routing_weights = torch.nn.functional.pad(routing_weights, (0, 0, 0, pad_size))
+
+    payloads = [x.contiguous(), selected_experts.contiguous(), routing_weights.contiguous()]
+
+    recv_results = moe_a2a.dispatch(
+        selected_experts,
+        payloads,
+        runtime_max_tokens_per_rank,
+        invalid_token_expert_id=invalid_expert_id,
+        expert_id_payload_index=1,
+    )
+
+    dispatched_x = recv_results[0].reshape(-1, hidden_size)
+    dispatched_selected = recv_results[1].reshape(-1, top_k)
+    dispatched_weights = recv_results[2].reshape(-1, top_k)
+
+    # Quantize dispatched bf16 input to FP8 per-rank
+    x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(dispatched_x)
+
+    routing_weights_bf16 = dispatched_weights.to(torch.bfloat16).contiguous()
+    fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
+    fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+
+    local_expert_offset = mapping.moe_ep_rank * local_num_experts
+
+    moe_out = torch.ops.trtllm.fp8_block_scale_moe_runner(
+        None,  # routing_logits
+        None,  # routing_bias
+        x_fp8,
+        x_sf,
+        fc1_expert_weights.contiguous(),
+        fc1_weight_scale_f32,
+        fc2_expert_weights.contiguous(),
+        fc2_weight_scale_f32,
+        global_num_experts,
+        top_k,
+        None,  # n_group
+        None,  # topk_group
+        intermediate_size,
+        local_expert_offset,
+        local_num_experts,
+        None,  # routed_scaling_factor
+        RoutingMethodType.Renormalize,
+        topk_weights=routing_weights_bf16,
+        topk_ids=dispatched_selected,
+    )
+
     moe_out = moe_out.view(mapping.moe_ep_size, runtime_max_tokens_per_rank, hidden_size)
     combined = moe_a2a.combine(moe_out, runtime_max_tokens_per_rank)
     return combined[:local_num_tokens]
@@ -588,6 +710,9 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     fc2_weight_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
     """TensorRT-LLM Cutlass FP8 Block Scale MoE for FineGrainedFP8 format.
 
@@ -618,6 +743,9 @@ def trtllm_quant_finegrained_fp8_moe_fused(
         fc2_weight_scale: FC2 block weight scales [E, H/128, I/128]
         is_gated_mlp: True for gated_mlp, False for mlp
         act_fn: ActivationType.Silu for gated_mlp, ActivationType.Relu2 for mlp
+        mapping_config: Serialized Mapping config for distributed all-to-all
+        max_num_tokens: Maximum tokens for workspace allocation (all-to-all mode)
+        apply_routing_on_input: If True, apply routing weights to input before MLP
 
     Returns:
         Output tensor of shape (B, H) or (B, S, H)
@@ -625,40 +753,63 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     act_fn = ActivationType.Swiglu if act_fn == ActivationType.Silu else act_fn
 
-    # Store original shape and flatten to 2D
     x_shape = x.shape
     x2d = x.view(-1, x_shape[-1])
 
-    # Ensure contiguous tensors with correct dtypes
     selected_experts = selected_experts.int().contiguous()
+    routing_weights = routing_weights.to(torch.float32).contiguous()
 
+    mapping, enable_alltoall = _check_moe_alltoall(mapping_config, max_num_tokens)
+
+    if enable_alltoall:
+        if is_sm_100f():
+            return _run_finegrained_moe_with_alltoall_blackwell(
+                x=x2d,
+                selected_experts=selected_experts,
+                routing_weights=routing_weights,
+                fc1_expert_weights=fc1_expert_weights,
+                fc2_expert_weights=fc2_expert_weights,
+                fc1_weight_scale=fc1_weight_scale,
+                fc2_weight_scale=fc2_weight_scale,
+                is_gated_mlp=is_gated_mlp,
+                mapping=mapping,
+                max_num_tokens=max_num_tokens,
+            ).view(x_shape)
+        else:
+            quant_scales = (fc1_weight_scale, fc2_weight_scale)
+            return _run_moe_with_alltoall(
+                x=x2d,
+                selected_experts=selected_experts,
+                routing_weights=routing_weights,
+                fc1_expert_weights=fc1_expert_weights.contiguous(),
+                fc2_expert_weights=fc2_expert_weights.contiguous(),
+                output_dtype=x.dtype,
+                quant_scales=quant_scales,
+                activation_type=act_fn,
+                mapping=mapping,
+                max_num_tokens=max_num_tokens,
+                use_deepseek_fp8_block_scale=True,
+            ).view(x_shape)
+
+    # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
+    # routing weights for remote experts are zeroed, all_reduce is added after this op
     if is_sm_100f():
         # --- Blackwell (SM100+) Path ---
-        # Uses fp8_block_scale_moe_runner with pre-computed routing (topk_weights/topk_ids)
-
-        # Quantize activations externally (Blackwell kernel expects FP8 input)
         x_fp8, x_sf = torch.ops.trtllm.fp8_quantize_1x128(x2d)
 
-        # Infer parameters from weight shapes
         num_experts = fc1_expert_weights.shape[0]
         top_k = selected_experts.shape[-1]
-        # For gated MLP, fc1 weights have shape [E, 2*I, H], so intermediate_size = shape[1] // 2
-        # For non-gated MLP, fc1 weights have shape [E, I, H], so intermediate_size = shape[1]
         intermediate_size = (
             fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
         )
 
-        # Blackwell kernel expects bfloat16 for topk_weights
         routing_weights_bf16 = routing_weights.to(torch.bfloat16).contiguous()
-
-        # Blackwell kernel expects float32 for weight scales
         fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
         fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
 
-        # Call Blackwell fp8_block_scale_moe_runner with pre-computed routing
         output = torch.ops.trtllm.fp8_block_scale_moe_runner(
-            None,  # routing_logits - not needed when topk_weights/topk_ids provided
-            None,  # routing_bias - not needed for pre-computed routing
+            None,  # routing_logits
+            None,  # routing_bias
             x_fp8,
             x_sf,
             fc1_expert_weights.contiguous(),
@@ -667,31 +818,22 @@ def trtllm_quant_finegrained_fp8_moe_fused(
             fc2_weight_scale_f32,
             num_experts,
             top_k,
-            None,  # n_group - default 0 (no grouped routing)
-            None,  # topk_group - default 0
+            None,  # n_group
+            None,  # topk_group
             intermediate_size,
-            0,  # local_expert_offset - default 0 (no EP sharding)
-            num_experts,  # local_num_experts - same as num_experts (no EP sharding)
-            None,  # routed_scaling_factor - default 1.0
-            RoutingMethodType.Renormalize,  # routing weights already pre-computed, type just needs a supported value
+            0,  # local_expert_offset
+            num_experts,  # local_num_experts
+            None,  # routed_scaling_factor
+            RoutingMethodType.Renormalize,
             topk_weights=routing_weights_bf16,
             topk_ids=selected_experts,
         )
 
-        # Restore original shape
         return output.view(x_shape)
     else:
         # --- Hopper (SM90) Path ---
-        # Uses fused_moe with DeepSeek FP8 block scale mode (activation quant inside kernel)
-
-        # TRTLLM kernel expects float32 for routing_weights
-        routing_weights = routing_weights.to(torch.float32).contiguous()
-
-        # For DeepSeek FP8 block scales, quant_scales is a tuple of (fc_weight_scales, proj_weight_scales)
-        # The kernel handles dynamic activation quantization internally
         quant_scales = (fc1_weight_scale, fc2_weight_scale)
 
-        # Call fused_moe with DeepSeek FP8 block scale mode
         output = torch.ops.trtllm.fused_moe(
             x2d,
             selected_experts,
@@ -706,7 +848,6 @@ def trtllm_quant_finegrained_fp8_moe_fused(
             use_deepseek_fp8_block_scale=True,
         )
 
-        # Restore original shape
         return output[0].view(x_shape)
 
 
@@ -721,6 +862,9 @@ def trtllm_quant_finegrained_fp8_moe_fused_fake(
     fc2_weight_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -429,3 +429,61 @@ def torch_fake_quant_int4_gptq_linear_fake(
 ) -> torch.Tensor:
     N = weight_quantized.size(1)
     return torch.empty((*input.shape[:-1], N), dtype=input.dtype, device=input.device)
+
+
+@torch.library.custom_op("auto_deploy::torch_fake_quant_hf_fp8_linear", mutates_args=())
+def torch_fake_quant_hf_fp8_linear(
+    input: torch.Tensor,  # [..., K]
+    weight_quantized: torch.Tensor,  # [N, K] float8_e4m3fn
+    bias: Optional[torch.Tensor],  # [N] or None
+    input_scale: List[torch.Tensor],  # unused for HF FP8 (input quantized on the fly)
+    weight_scale: List[torch.Tensor],  # [weight_scale_inv]
+    input_zp: List[torch.Tensor],  # unused
+    weight_zp: List[torch.Tensor],  # unused
+) -> torch.Tensor:
+    """HuggingFace FineGrainedFP8 linear operation.
+    - weight_scale[0] = weight_scale_inv (per-block weight scale)
+    - input_scale, input_zp, weight_zp are unused
+    - block_size is inferred from weight and weight_scale_inv shapes
+    """
+    from transformers.integrations.finegrained_fp8 import act_quant, w8a8_block_fp8_matmul_triton
+
+    weight_scale_inv = weight_scale[0]
+
+    # Infer block_size from weight and weight_scale_inv shapes
+    # weight shape: [N, K], weight_scale_inv shape: [N/block_n, K/block_k]
+    N, K = weight_quantized.shape
+    scale_n, scale_k = weight_scale_inv.shape
+    block_n = N // scale_n
+    block_k = K // scale_k
+    block_size = [block_n, block_k]
+
+    qinput, scale = act_quant(input, block_size[1])
+    output = w8a8_block_fp8_matmul_triton(
+        qinput,
+        weight_quantized,
+        scale,
+        weight_scale_inv,
+        block_size,
+        output_dtype=input.dtype,
+    )
+
+    if bias is not None:
+        output = output + bias
+
+    return output.to(dtype=input.dtype)
+
+
+@torch_fake_quant_hf_fp8_linear.register_fake
+def _torch_fake_quant_hf_fp8_linear_fake(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    input_scale: List[torch.Tensor],
+    weight_scale: List[torch.Tensor],
+    input_zp: List[torch.Tensor],
+    weight_zp: List[torch.Tensor],
+) -> torch.Tensor:
+    """Fake implementation for torch.export tracing."""
+    out_features = weight_quantized.shape[0]
+    return torch.empty((*input.shape[:-1], out_features), dtype=input.dtype, device=input.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -487,3 +487,73 @@ def _torch_fake_quant_hf_fp8_linear_fake(
     """Fake implementation for torch.export tracing."""
     out_features = weight_quantized.shape[0]
     return torch.empty((*input.shape[:-1], out_features), dtype=input.dtype, device=input.device)
+
+
+@torch.library.custom_op("auto_deploy::trtllm_hf_fp8_linear", mutates_args=())
+def trtllm_hf_fp8_linear(
+    input: torch.Tensor,  # [..., K] bfloat16
+    weight: torch.Tensor,  # [N, K] float8_e4m3fn
+    bias: Optional[torch.Tensor],  # [N] or None
+    weight_scale: torch.Tensor,  # [N/128, K/128] per-block weight scale
+) -> torch.Tensor:
+    """TRT-LLM optimized HuggingFace FineGrainedFP8 linear operation.
+
+    Uses TRT-LLM's optimized fp8_block_scaling_gemm kernel instead of HF's triton kernel.
+    - weight_scale: per-block weight scale with shape [ceil(N/128), ceil(K/128)]
+    - Input is dynamically quantized using fp8_quantize_1x128
+    - Assumes 128x128 block size (standard for DeepSeek/MiniMax style FP8)
+    """
+    from tensorrt_llm._utils import get_sm_version, is_sm_100f
+
+    # Ensure input is bfloat16 for the optimized kernel
+    if input.dtype == torch.float8_e4m3fn:
+        raise ValueError("trtllm_hf_fp8_linear expects bfloat16 input, not FP8")
+
+    # Validate block size is 128 (required by TRT-LLM kernels)
+    N, K = weight.shape
+    scale_n, scale_k = weight_scale.shape
+    block_n = N // scale_n
+    block_k = K // scale_k
+    if block_n != 128 or block_k != 128:
+        raise ValueError(
+            f"trtllm_hf_fp8_linear requires 128x128 block size, but got {block_n}x{block_k}. "
+            f"Weight shape: {weight.shape}, scale shape: {weight_scale.shape}"
+        )
+
+    # Flatten input for GEMM: [..., K] -> [M, K]
+    input_shape = input.shape
+    input_2d = input.reshape(-1, input_shape[-1])
+
+    # SM version-specific paths (following linear.py pattern)
+    if is_sm_100f():
+        # Blackwell path: use fp8_quantize_1x128 + fp8_block_scaling_gemm
+        act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
+        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+    elif get_sm_version() == 120:
+        # SM120 path
+        from tensorrt_llm._torch.modules.linear import per_token_quant_and_transform
+
+        act_fp8, act_sf = per_token_quant_and_transform(input_2d)
+        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+    else:
+        # Hopper (SM90) path
+        act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
+        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+
+    if bias is not None:
+        output = output + bias
+
+    # Reshape back to original batch dimensions: [M, N] -> [..., N]
+    return output.reshape(*input_shape[:-1], weight.shape[0])
+
+
+@trtllm_hf_fp8_linear.register_fake
+def _trtllm_hf_fp8_linear_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Fake implementation for torch.export tracing."""
+    out_features = weight.shape[0]
+    return torch.empty((*input.shape[:-1], out_features), dtype=torch.bfloat16, device=input.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -16,6 +16,8 @@
 from typing import List, Optional
 
 import torch
+import triton
+import triton.language as tl
 
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
     cutlass_fp4_scale_to_modelopt_fp4_scale,
@@ -431,6 +433,54 @@ def torch_fake_quant_int4_gptq_linear_fake(
     return torch.empty((*input.shape[:-1], N), dtype=input.dtype, device=input.device)
 
 
+@triton.jit
+def _act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):
+    """Block-wise FP8 activation quantization, safe for all-zero blocks.
+
+    Identical to HuggingFace's act_quant_kernel except that the per-block scale
+    is clamped to a minimum of 1e-12 before dividing.  This avoids 0/0 = NaN
+    when every element in a block is zero.
+    """
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / 448.0
+    # Clamp scale so that all-zero blocks produce 0/eps = 0 instead of 0/0 = NaN.
+    s = tl.maximum(s, 1e-12)
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def _safe_act_quant(x: torch.Tensor, block_size: int = 128) -> tuple:
+    """Block-wise FP8 activation quantization (CUDA-graph safe).
+
+    Drop-in replacement for ``transformers.integrations.finegrained_fp8.act_quant``
+    that fixes the NaN-on-zero-block bug by clamping the per-block scale inside
+    the Triton kernel itself.  No post-hoc fixup tensors are created, so the
+    op is fully compatible with CUDA graphs.
+    """
+    assert x.is_contiguous()
+    assert x.shape[-1] % block_size == 0
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.shape[:-1], x.shape[-1] // block_size, dtype=torch.float32)
+
+    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)  # noqa: E731
+    _act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size)
+    return y, s
+
+
+def _dequant_block_fp8_weight(weight_fp8, weight_scale, block_n, block_k, dtype=torch.bfloat16):
+    """Dequantize block-scaled FP8 weight to BF16 for tiny projections."""
+    N, K = weight_fp8.shape
+    scale_expanded = weight_scale.repeat_interleave(block_n, dim=0).repeat_interleave(
+        block_k, dim=1
+    )
+    scale_expanded = scale_expanded[:N, :K]
+    return weight_fp8.to(dtype) * scale_expanded.to(dtype)
+
+
 @torch.library.custom_op("auto_deploy::torch_fake_quant_finegrained_fp8_linear", mutates_args=())
 def torch_fake_quant_finegrained_fp8_linear(
     input: torch.Tensor,  # [..., K]
@@ -446,7 +496,7 @@ def torch_fake_quant_finegrained_fp8_linear(
     - input_scale, input_zp, weight_zp are unused
     - block_size is inferred from weight and weight_scale_inv shapes
     """
-    from transformers.integrations.finegrained_fp8 import act_quant, w8a8_block_fp8_matmul_triton
+    from transformers.integrations.finegrained_fp8 import w8a8_block_fp8_matmul_triton
 
     weight_scale_inv = weight_scale[0]
 
@@ -458,7 +508,7 @@ def torch_fake_quant_finegrained_fp8_linear(
     block_k = K // scale_k
     block_size = [block_n, block_k]
 
-    qinput, scale = act_quant(input, block_size[1])
+    qinput, scale = _safe_act_quant(input, block_size[1])
     output = w8a8_block_fp8_matmul_triton(
         qinput,
         weight_quantized,
@@ -503,42 +553,52 @@ def trtllm_finegrained_fp8_linear(
     - Input is dynamically quantized using fp8_quantize_1x128
     - Assumes 128x128 block size (standard for DeepSeek/MiniMax style FP8)
     """
-    from tensorrt_llm._utils import get_sm_version, is_sm_100f
+    from tensorrt_llm._utils import get_sm_version
 
     # Ensure input is bfloat16 for the optimized kernel
     if input.dtype == torch.float8_e4m3fn:
         raise ValueError("trtllm_finegrained_fp8_linear expects bfloat16 input, not FP8")
 
-    # Validate block size is 128 (required by TRT-LLM kernels)
+    # TRT-LLM fp8_block_scaling_gemm requires float32 scales; HF checkpoints may
+    # store weight_scale_inv in bfloat16 to save space, so cast here.
+    if weight_scale.dtype != torch.float32:
+        weight_scale = weight_scale.float()
+
+    # Derive effective block size from weight and scale shapes.
+    input_shape = input.shape
     N, K = weight.shape
     scale_n, scale_k = weight_scale.shape
+    if scale_n == 0 or scale_k == 0:
+        raise ValueError(
+            f"trtllm_finegrained_fp8_linear: weight_scale has zero dimension "
+            f"(shape={weight_scale.shape}), weight shape={weight.shape}. "
+            f"This usually means scale tensor sharding produced an empty tensor."
+        )
     block_n = N // scale_n
     block_k = K // scale_k
+
+    # TRT-LLM fp8_block_scaling_gemm requires exact 128x128 blocks.
+    # For small layers where a dimension < 128 (e.g. N=64), the derived block
+    # size will be < 128.  Fall back to BF16 dequant + cuBLAS.
     if block_n != 128 or block_k != 128:
-        raise ValueError(
-            f"trtllm_finegrained_fp8_linear requires 128x128 block size, but got {block_n}x{block_k}. "
-            f"Weight shape: {weight.shape}, scale shape: {weight_scale.shape}"
+        weight_dequant = _dequant_block_fp8_weight(
+            weight, weight_scale, block_n, block_k, dtype=input.dtype
         )
+        output = torch.nn.functional.linear(input, weight_dequant, bias)
+        return output.reshape(*input_shape[:-1], N) if len(input_shape) > 2 else output
 
     # Flatten input for GEMM: [..., K] -> [M, K]
-    input_shape = input.shape
     input_2d = input.reshape(-1, input_shape[-1])
 
-    # SM version-specific paths (following linear.py pattern)
-    if is_sm_100f():
-        # Blackwell path: use fp8_quantize_1x128 + fp8_block_scaling_gemm
-        act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
-        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
-    elif get_sm_version() == 120:
-        # SM120 path
+    # SM version-specific activation quantization
+    if get_sm_version() == 120:
         from tensorrt_llm._torch.modules.linear import per_token_quant_and_transform
 
         act_fp8, act_sf = per_token_quant_and_transform(input_2d)
-        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
     else:
-        # Hopper (SM90) path
+        # Hopper (SM90) and Blackwell (SM100+) share the same path
         act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
-        output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+    output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
 
     if bias is not None:
         output = output + bias
@@ -556,4 +616,4 @@ def _trtllm_finegrained_fp8_linear_fake(
 ) -> torch.Tensor:
     """Fake implementation for torch.export tracing."""
     out_features = weight.shape[0]
-    return torch.empty((*input.shape[:-1], out_features), dtype=torch.bfloat16, device=input.device)
+    return torch.empty((*input.shape[:-1], out_features), dtype=input.dtype, device=input.device)

--- a/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
@@ -149,6 +149,7 @@ class HFQuantConfigReader(QuantConfigReader):
     """
 
     _ALWAYS_EXCLUDE = ("lm_head", "model.embed_tokens")
+    _SUPPORTED_QUANT_METHODS = ("mxfp4", "gptq", "fp8")
 
     def __init__(self):
         super().__init__()
@@ -188,7 +189,7 @@ class HFQuantConfigReader(QuantConfigReader):
         # TODO(Fridah-nv):this class is only verified with GPT-OSS MXFP4 and INT4-GPTQ, other hf quantizers
         # should have similar workflow and will be added to the pipeline
         quant_method = str(qconf.get("quant_method", "")).lower()
-        if quant_method not in ["mxfp4", "gptq"]:
+        if quant_method not in cls._SUPPORTED_QUANT_METHODS:
             return None
 
         # Validate GPTQ config: currently only INT4 with group_size=128 is supported

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -337,3 +337,164 @@ class FuseNVFP4Linear(BaseTransform):
             has_valid_shapes=(cnt == 0),
         )
         return gm, info
+
+
+# ============================================================================
+# HuggingFace FineGrained FP8 Linear Patterns (for MiniMax M2, DeepSeek, etc.)
+# ============================================================================
+
+
+# HF FP8: with bias=None
+def _hf_fp8_ref_pattern_1(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    weight_scale: torch.Tensor,
+):
+    return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        x,
+        w_fp8,
+        None,
+        input_scale=[],
+        weight_scale=[weight_scale],
+        input_zp=[],
+        weight_zp=[],
+    )
+
+
+def _hf_fp8_ref_repl_1(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    weight_scale: torch.Tensor,
+):
+    return torch.ops.auto_deploy.trtllm_hf_fp8_linear(
+        x,
+        w_fp8,
+        None,
+        weight_scale,
+    )
+
+
+# HF FP8: with bias!=None
+def _hf_fp8_ref_pattern_2(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    bias: torch.Tensor,
+    weight_scale: torch.Tensor,
+):
+    return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        x,
+        w_fp8,
+        bias,
+        input_scale=[],
+        weight_scale=[weight_scale],
+        input_zp=[],
+        weight_zp=[],
+    )
+
+
+def _hf_fp8_ref_repl_2(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    bias: torch.Tensor,
+    weight_scale: torch.Tensor,
+):
+    return torch.ops.auto_deploy.trtllm_hf_fp8_linear(
+        x,
+        w_fp8,
+        bias,
+        weight_scale,
+    )
+
+
+def _register_hf_fp8_linear_patterns(patterns: ADPatternMatcherPass) -> None:
+    """
+    Register HuggingFace FineGrained FP8 linear patterns.
+
+    HF FP8 uses block-wise weight quantization with per-block scales.
+    The replacement uses TRT-LLM's optimized fp8_block_scaling_gemm kernel.
+    """
+    # HF FP8 dummy tensors
+    # weight shape: [N, K], weight_scale shape: [N/128, K/128]
+    N, K = 256, 256  # Must be multiples of 128 for block quantization
+    x_hf_fp8 = torch.randn(3, K, device="meta", dtype=torch.bfloat16)
+    w_hf_fp8 = torch.randn(N, K, device="meta", dtype=torch.float8_e4m3fn)
+    bias_hf = torch.randn(N, device="meta", dtype=torch.bfloat16)
+    # Per-block weight scale: [N/128, K/128]
+    weight_scale_hf = torch.randn(N // 128, K // 128, device="meta", dtype=torch.float32)
+
+    # no-bias variant
+    dummy_args_hf_fp8_1 = [
+        x_hf_fp8,
+        w_hf_fp8,
+        weight_scale_hf,
+    ]
+    register_ad_pattern(
+        search_fn=_hf_fp8_ref_pattern_1,
+        replace_fn=_hf_fp8_ref_repl_1,
+        patterns=patterns,
+        dummy_args=dummy_args_hf_fp8_1,
+    )
+
+    # bias variant
+    dummy_args_hf_fp8_2 = [
+        x_hf_fp8,
+        w_hf_fp8,
+        bias_hf,
+        weight_scale_hf,
+    ]
+    register_ad_pattern(
+        search_fn=_hf_fp8_ref_pattern_2,
+        replace_fn=_hf_fp8_ref_repl_2,
+        patterns=patterns,
+        dummy_args=dummy_args_hf_fp8_2,
+    )
+
+
+class FuseHFFP8LinearConfig(TransformConfig):
+    """Configuration for HuggingFace FineGrained FP8 linear fusion transform."""
+
+    backend: str = Field(
+        default="trtllm",
+        description="Backend to use for HF FP8 linear computation (default: 'trtllm').",
+    )
+
+
+@TransformRegistry.register("fuse_hf_fp8_linear")
+class FuseHFFP8Linear(BaseTransform):
+    """Matches and replaces HF FineGrained FP8 fake quantized linear ops with TRT-LLM ops.
+
+    This transform replaces torch_fake_quant_hf_fp8_linear (which uses HuggingFace's
+    triton kernel) with trtllm_hf_fp8_linear (which uses TRT-LLM's optimized
+    fp8_block_scaling_gemm kernel).
+
+    Used for models like MiniMax M2 and DeepSeek that use HuggingFace's FineGrained FP8
+    quantization format with 128x128 block sizes.
+    """
+
+    config: FuseHFFP8LinearConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return FuseHFFP8LinearConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        if self.config.backend.lower() != "trtllm":
+            raise ValueError(f"Unsupported HF FP8 backend: {self.config.backend}")
+
+        patterns = ADPatternMatcherPass()
+        _register_hf_fp8_linear_patterns(patterns)
+        cnt = patterns.apply(gm.graph)
+
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2314,11 +2314,11 @@ class FuseNVFP4Moe(BaseTransform):
         return gm, info
 
 
-def _stack_hf_fp8_moe_weights(gm: GraphModule) -> int:
+def _stack_finegrained_fp8_moe_weights(gm: GraphModule) -> int:
     """
-    Stack per-expert HF FP8 block-scale weights and scales for the fused MoE kernel.
+    Stack per-expert FineGrained FP8 block-scale weights and scales for the fused MoE kernel.
 
-    HuggingFace FineGrainedFP8 uses:
+    FineGrainedFP8 uses:
     - FP8 weights with per-block scales (128x128 blocks)
     - Dynamic activation quantization at runtime (no pre-computed activation scales)
     """
@@ -2364,8 +2364,8 @@ def _stack_hf_fp8_moe_weights(gm: GraphModule) -> int:
     fused_key_counter = 0
     graph = gm.graph
 
-    replacement_op = torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused
-    replaced_op = torch.ops.auto_deploy.torch_quant_hf_fp8_moe
+    replacement_op = torch.ops.auto_deploy.trtllm_quant_finegrained_fp8_moe_fused
+    replaced_op = torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe
 
     matched_nodes = [node for node in graph.nodes if is_op(node, replaced_op)]
     for node in matched_nodes:
@@ -2407,10 +2407,10 @@ def _stack_hf_fp8_moe_weights(gm: GraphModule) -> int:
         fc2_weight_scale = w2_scale_stacked
 
         # Register stacked tensors as new parameters
-        new_key_fc1_weights = f"hf_fp8_moe_fc1_stacked_{fused_key_counter}"
-        new_key_fc2_weights = f"hf_fp8_moe_fc2_stacked_{fused_key_counter}"
-        new_key_fc1_scale = f"hf_fp8_moe_fc1_scale_stacked_{fused_key_counter}"
-        new_key_fc2_scale = f"hf_fp8_moe_fc2_scale_stacked_{fused_key_counter}"
+        new_key_fc1_weights = f"finegrained_fp8_moe_fc1_stacked_{fused_key_counter}"
+        new_key_fc2_weights = f"finegrained_fp8_moe_fc2_stacked_{fused_key_counter}"
+        new_key_fc1_scale = f"finegrained_fp8_moe_fc1_scale_stacked_{fused_key_counter}"
+        new_key_fc2_scale = f"finegrained_fp8_moe_fc2_scale_stacked_{fused_key_counter}"
 
         _register_parameter(gm, new_key_fc1_weights, fc1_expert_weights)
         _register_parameter(gm, new_key_fc2_weights, fc2_expert_weights)
@@ -2448,13 +2448,13 @@ def _stack_hf_fp8_moe_weights(gm: GraphModule) -> int:
     return fused_key_counter
 
 
-@TransformRegistry.register("fuse_hf_fp8_moe")
-class FuseHFFP8Moe(BaseTransform):
+@TransformRegistry.register("fuse_finegrained_fp8_moe")
+class FuseFineGrainedFP8Moe(BaseTransform):
     """
-    Stack per-expert HuggingFace FineGrainedFP8 MoE weights and block scales.
+    Stack per-expert FineGrainedFP8 MoE weights and block scales.
 
-    This transform replaces torch_quant_hf_fp8_moe ops with the fused
-    trtllm_quant_hf_fp8_block_scale_moe_fused kernel which is cudagraph-compatible.
+    This transform replaces torch_quant_finegrained_fp8_moe ops with the fused
+    trtllm_quant_finegrained_fp8_moe_fused kernel which is cudagraph-compatible.
     """
 
     def _apply(
@@ -2465,7 +2465,7 @@ class FuseHFFP8Moe(BaseTransform):
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
         with cuda_memory_tracker():
-            fused_key_counter = _stack_hf_fp8_moe_weights(gm)
+            fused_key_counter = _stack_finegrained_fp8_moe_weights(gm)
 
         info = TransformInfo(
             skipped=(fused_key_counter == 0),

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -419,11 +419,13 @@ def _process_moe_node(
     fused_w_down_experts = torch.stack([gm.get_parameter(n.target) for n in w2_list], dim=0)
     new_key_w_down = f"fused_moe_w2_stacked_{fused_key_counter}"
 
-    # Register the stacked weights as parameters
+    # Register the stacked weights as parameters and free intermediate tensors
     param_w_up = torch.nn.Parameter(fused_w_up_experts)
+    del fused_w_up_experts
     gm.register_parameter(new_key_w_up, param_w_up)
 
     param_w_down = torch.nn.Parameter(fused_w_down_experts)
+    del fused_w_down_experts
     gm.register_parameter(new_key_w_down, param_w_down)
 
     # Create fused MoE node - kernel applies routing to output
@@ -431,7 +433,7 @@ def _process_moe_node(
         w_up_arg = graph.get_attr(new_key_w_up)
         w_down_arg = graph.get_attr(new_key_w_down)
         # Get weight dtype for casting - fused kernel requires activation dtype to match weight dtype
-        weight_dtype = fused_w_up_experts.dtype
+        weight_dtype = param_w_up.dtype
 
         if apply_routing_on_input:
             # Scale input: hidden_states = hidden_states * routing_weights

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2312,3 +2312,165 @@ class FuseNVFP4Moe(BaseTransform):
             has_valid_shapes=fused_key_counter == 0,
         )
         return gm, info
+
+
+def _stack_hf_fp8_moe_weights(gm: GraphModule) -> int:
+    """
+    Stack per-expert HF FP8 block-scale weights and scales for the fused MoE kernel.
+
+    HuggingFace FineGrainedFP8 uses:
+    - FP8 weights with per-block scales (128x128 blocks)
+    - Dynamic activation quantization at runtime (no pre-computed activation scales)
+    """
+
+    def _register_parameter(gm: GraphModule, target, value):
+        gm.register_parameter(target, torch.nn.Parameter(value, requires_grad=False))
+
+    def get_param_or_buffer(target):
+        """Get parameter or buffer by target name."""
+        try:
+            return gm.get_parameter(target)
+        except AttributeError:
+            parts = target.rsplit(".", 1)
+            if len(parts) == 2:
+                mod = gm.get_submodule(parts[0])
+                return getattr(mod, parts[1])
+            else:
+                return getattr(gm, target)
+
+    def _extract_op_args(node):
+        return extract_op_args(
+            node,
+            "x",
+            "selected_experts",
+            "routing_weights",
+            "w1_weight",
+            "w2_weight",
+            "w3_weight",
+            "w1_weight_scale_inv",
+            "w2_weight_scale_inv",
+            "w3_weight_scale_inv",
+            "is_gated_mlp",
+        )
+
+    def _stack(param_list, dim=0, device=None, dtype=None):
+        if param_list:
+            return torch.stack(
+                [get_param_or_buffer(element.target) for element in param_list], dim=dim
+            ).contiguous()
+        else:
+            return torch.empty(0, device=device, dtype=dtype)
+
+    fused_key_counter = 0
+    graph = gm.graph
+
+    replacement_op = torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused
+    replaced_op = torch.ops.auto_deploy.torch_quant_hf_fp8_moe
+
+    matched_nodes = [node for node in graph.nodes if is_op(node, replaced_op)]
+    for node in matched_nodes:
+        (
+            hidden_states,
+            selected_experts,
+            routing_weights,
+            w1_list,
+            w2_list,
+            w3_list,
+            w1_scale_inv_list,
+            w2_scale_inv_list,
+            w3_scale_inv_list,
+            is_gated_mlp,
+        ) = _extract_op_args(node)
+
+        # Stack weights: [E, I, H] or [E, H, I]
+        w1_stacked = _stack(w1_list, dim=0)
+        w2_stacked = _stack(w2_list, dim=0)
+        device, dtype = (w1_stacked.device, w1_stacked.dtype)
+        w3_stacked = _stack(w3_list, dim=0, device=device, dtype=dtype)
+
+        # Stack block scales: [E, I/128, H/128] or [E, H/128, I/128]
+        w1_scale_stacked = _stack(w1_scale_inv_list, dim=0)
+        w2_scale_stacked = _stack(w2_scale_inv_list, dim=0)
+        w3_scale_stacked = _stack(w3_scale_inv_list, dim=0, device=device, dtype=torch.float32)
+
+        # Prepare stacked weights and scales for the fused kernel
+        if is_gated_mlp:
+            # For gated MLP, concatenate w3 and w1: [E, 2*I, H]
+            fc1_expert_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
+            # Concatenate scales: [E, 2*I/128, H/128]
+            fc1_weight_scale = torch.cat([w3_scale_stacked, w1_scale_stacked], dim=1).contiguous()
+        else:
+            fc1_expert_weights = w1_stacked
+            fc1_weight_scale = w1_scale_stacked
+
+        fc2_expert_weights = w2_stacked
+        fc2_weight_scale = w2_scale_stacked
+
+        # Register stacked tensors as new parameters
+        new_key_fc1_weights = f"hf_fp8_moe_fc1_stacked_{fused_key_counter}"
+        new_key_fc2_weights = f"hf_fp8_moe_fc2_stacked_{fused_key_counter}"
+        new_key_fc1_scale = f"hf_fp8_moe_fc1_scale_stacked_{fused_key_counter}"
+        new_key_fc2_scale = f"hf_fp8_moe_fc2_scale_stacked_{fused_key_counter}"
+
+        _register_parameter(gm, new_key_fc1_weights, fc1_expert_weights)
+        _register_parameter(gm, new_key_fc2_weights, fc2_expert_weights)
+        _register_parameter(gm, new_key_fc1_scale, fc1_weight_scale)
+        _register_parameter(gm, new_key_fc2_scale, fc2_weight_scale)
+
+        # Create new node with stacked parameters
+        with graph.inserting_before(node):
+            args = (
+                hidden_states,
+                selected_experts,
+                routing_weights,
+                graph.get_attr(new_key_fc1_weights),
+                graph.get_attr(new_key_fc2_weights),
+                graph.get_attr(new_key_fc1_scale),
+                graph.get_attr(new_key_fc2_scale),
+            )
+            new_node = graph.call_function(
+                replacement_op,
+                args,
+                kwargs={
+                    "is_gated_mlp": is_gated_mlp,
+                    "act_fn": node.kwargs.get("act_fn", int(ActivationType.Silu)),
+                },
+            )
+
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        fused_key_counter += 1
+
+    # Clean up unused nodes and parameters
+    gm.graph.eliminate_dead_code()
+    gm.delete_all_unused_submodules()
+
+    return fused_key_counter
+
+
+@TransformRegistry.register("fuse_hf_fp8_moe")
+class FuseHFFP8Moe(BaseTransform):
+    """
+    Stack per-expert HuggingFace FineGrainedFP8 MoE weights and block scales.
+
+    This transform replaces torch_quant_hf_fp8_moe ops with the fused
+    trtllm_quant_hf_fp8_block_scale_moe_fused kernel which is cudagraph-compatible.
+    """
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        with cuda_memory_tracker():
+            fused_key_counter = _stack_hf_fp8_moe_weights(gm)
+
+        info = TransformInfo(
+            skipped=(fused_key_counter == 0),
+            num_matches=fused_key_counter,
+            is_clean=fused_key_counter == 0,
+            has_valid_shapes=fused_key_counter == 0,
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2428,13 +2428,17 @@ def _stack_finegrained_fp8_moe_weights(gm: GraphModule) -> int:
                 graph.get_attr(new_key_fc1_scale),
                 graph.get_attr(new_key_fc2_scale),
             )
+            fused_kwargs = dict(node.kwargs) if node.kwargs else {}
+            fused_kwargs.update(
+                {
+                    "is_gated_mlp": is_gated_mlp,
+                    "act_fn": node.kwargs.get("act_fn", int(ActivationType.Silu)),
+                }
+            )
             new_node = graph.call_function(
                 replacement_op,
                 args,
-                kwargs={
-                    "is_gated_mlp": is_gated_mlp,
-                    "act_fn": node.kwargs.get("act_fn", int(ActivationType.Silu)),
-                },
+                kwargs=fused_kwargs,
             )
 
         node.replace_all_uses_with(new_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2408,6 +2408,9 @@ def _stack_finegrained_fp8_moe_weights(gm: GraphModule) -> int:
         fc2_expert_weights = w2_stacked
         fc2_weight_scale = w2_scale_stacked
 
+        del w1_stacked, w2_stacked, w3_stacked
+        del w1_scale_stacked, w2_scale_stacked, w3_scale_stacked
+
         # Register stacked tensors as new parameters
         new_key_fc1_weights = f"finegrained_fp8_moe_fc1_stacked_{fused_key_counter}"
         new_key_fc2_weights = f"finegrained_fp8_moe_fc2_stacked_{fused_key_counter}"
@@ -2447,9 +2450,8 @@ def _stack_finegrained_fp8_moe_weights(gm: GraphModule) -> int:
         graph.erase_node(node)
         fused_key_counter += 1
 
-    # Clean up unused nodes and parameters
-    gm.graph.eliminate_dead_code()
-    gm.delete_all_unused_submodules()
+        eliminate_dead_code(gm)
+        delete_all_unused_submodules(gm)
 
     return fused_key_counter
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -747,3 +747,93 @@ class INT4GPTQLinearQuantizationFromConfig(Quantization):
         state_dict[f"{mod_prefix}.qzeros"] = qzeros_v2  # [G, N/8] int32 (v2 format)
         # Remove the original qweight key to avoid "unexpected key" warnings
         del state_dict[qweight_ckpt]
+
+
+@TransformRegistry.register("quantize_hf_fp8_linear_from_config")
+class HFFineGrainedFP8LinearQuantization(Quantization):
+    """Quantization transform for HuggingFace FineGrainedFP8 (block-wise FP8) models.
+
+    This transform replaces linear ops with the HF FineGrainedFP8 quantized op.
+    The HF FP8 format uses per-block weight scales (weight_scale_inv) and
+    dynamic input quantization.
+
+    Config format (from HF config.json):
+        "quantization_config": {
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+            "modules_to_not_convert": ["lm_head"]
+        }
+    """
+
+    algo_name = "fp8"
+
+    def target_op(self):
+        return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear.default
+
+    def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(w, dtype=torch.float8_e4m3fn, device=w.device)
+
+    def scale_names(self) -> List[str]:
+        return ["weight_scale_inv"]
+
+    def default_scales(self, original_weight_shape: Tuple) -> Dict[str, torch.Tensor]:
+        # Default block size is 128x128 for HF FP8
+        N, K = original_weight_shape
+        block_n, block_k = 128, 128
+        scale_shape = (N // block_n, K // block_k)
+        return {"weight_scale_inv": torch.ones(scale_shape, dtype=torch.bfloat16)}
+
+    def build_custom_args_for_linear(self, scales: Dict[str, Node]) -> Tuple:
+        return ([], [scales["weight_scale_inv"]], [], [])
+
+    def load_hook(self, state_dict, prefix, *args, weight_name: str):
+        """Load hook to handle HF FineGrainedFP8 checkpoint format.
+
+        HF FP8 checkpoints store:
+        - weight: float8_e4m3fn tensor
+        - weight_scale_inv: per-block scale tensor
+        """
+        if weight_name not in state_dict:
+            return
+
+        weight = state_dict[weight_name]
+        if weight.dtype == torch.float8_e4m3fn:
+            scale_inv_name = weight_name + "_scale_inv"
+            if scale_inv_name in state_dict:
+                # Rename to match our buffer name
+                mod_prefix = weight_name.rsplit(".", 1)[0]
+                state_dict[mod_prefix + ".weight_scale_inv"] = state_dict[scale_inv_name]
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        qcfg = factory.get_quant_config()
+        if not qcfg:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        quant_method = str(qcfg.get("quant_method", "")).lower()
+        if quant_method != self.algo_name:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        excluded = qcfg.get("modules_to_not_convert", [])
+
+        cnt = 0
+        for n in gm.graph.nodes:
+            if not is_linear_op(n):
+                continue
+            if should_skip_quantization(n, excluded):
+                continue
+            self._insert_quantized_linear(gm, n, is_quantized_graph=False)
+            cnt += 1
+
+        return gm, TransformInfo(
+            skipped=False, num_matches=cnt, is_clean=False, has_valid_shapes=(cnt == 0)
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -749,12 +749,12 @@ class INT4GPTQLinearQuantizationFromConfig(Quantization):
         del state_dict[qweight_ckpt]
 
 
-@TransformRegistry.register("quantize_hf_fp8_linear_from_config")
-class HFFineGrainedFP8LinearQuantization(Quantization):
-    """Quantization transform for HuggingFace FineGrainedFP8 (block-wise FP8) models.
+@TransformRegistry.register("quantize_finegrained_fp8_linear_from_config")
+class FineGrainedFP8LinearQuantization(Quantization):
+    """Quantization transform for FineGrainedFP8 (block-wise FP8) models.
 
-    This transform replaces linear ops with the HF FineGrainedFP8 quantized op.
-    The HF FP8 format uses per-block weight scales (weight_scale_inv) and
+    This transform replaces linear ops with the FineGrainedFP8 quantized op.
+    The FineGrained FP8 format uses per-block weight scales (weight_scale_inv) and
     dynamic input quantization.
 
     Config format (from HF config.json):
@@ -768,7 +768,7 @@ class HFFineGrainedFP8LinearQuantization(Quantization):
     algo_name = "fp8"
 
     def target_op(self):
-        return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear.default
+        return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default
 
     def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(w, dtype=torch.float8_e4m3fn, device=w.device)
@@ -777,7 +777,7 @@ class HFFineGrainedFP8LinearQuantization(Quantization):
         return ["weight_scale_inv"]
 
     def default_scales(self, original_weight_shape: Tuple) -> Dict[str, torch.Tensor]:
-        # Default block size is 128x128 for HF FP8
+        # Default block size is 128x128 for FineGrained FP8
         N, K = original_weight_shape
         block_n, block_k = 128, 128
         scale_shape = (N // block_n, K // block_k)
@@ -787,9 +787,9 @@ class HFFineGrainedFP8LinearQuantization(Quantization):
         return ([], [scales["weight_scale_inv"]], [], [])
 
     def load_hook(self, state_dict, prefix, *args, weight_name: str):
-        """Load hook to handle HF FineGrainedFP8 checkpoint format.
+        """Load hook to handle FineGrainedFP8 checkpoint format.
 
-        HF FP8 checkpoints store:
+        FineGrained FP8 checkpoints store:
         - weight: float8_e4m3fn tensor
         - weight_scale_inv: per-block scale tensor
         """

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -313,6 +313,22 @@ class FP8LinearQuantizationFromConfig(Quantization):
             scale = amax / FP8_MAX
             state_dict[scale_name] = scale
 
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        qcfg = factory.get_quant_config()
+        # Skip if the config specifies block-wise (fine-grained) FP8 quantization via
+        # weight_block_size; those should be handled by FineGrainedFP8LinearQuantization.
+        if qcfg and qcfg.get("weight_block_size"):
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+        return super()._apply(gm, cm, factory, shared_config)
+
 
 @TransformRegistry.register("quantize_nvfp4_linear_from_config")
 class NVFP4LinearQuantizationFromConfig(Quantization):
@@ -780,7 +796,9 @@ class FineGrainedFP8LinearQuantization(Quantization):
         # Default block size is 128x128 for FineGrained FP8
         N, K = original_weight_shape
         block_n, block_k = 128, 128
-        scale_shape = (N // block_n, K // block_k)
+        # Use ceil to handle dimensions smaller than or not divisible by block size
+        # (e.g. after TP sharding or small projection weights).
+        scale_shape = (math.ceil(N / block_n), math.ceil(K / block_k))
         return {"weight_scale_inv": torch.ones(scale_shape, dtype=torch.bfloat16)}
 
     def build_custom_args_for_linear(self, scales: Dict[str, Node]) -> Tuple:
@@ -826,13 +844,14 @@ class FineGrainedFP8LinearQuantization(Quantization):
         excluded = qcfg.get("modules_to_not_convert", [])
 
         cnt = 0
-        for n in gm.graph.nodes:
-            if not is_linear_op(n):
-                continue
-            if should_skip_quantization(n, excluded):
-                continue
-            self._insert_quantized_linear(gm, n, is_quantized_graph=False)
-            cnt += 1
+        with WeightBiasInfoCache():
+            for n in gm.graph.nodes:
+                if not is_linear_op(n):
+                    continue
+                if should_skip_quantization(n, excluded):
+                    continue
+                self._insert_quantized_linear(gm, n, is_quantized_graph=False)
+                cnt += 1
 
         return gm, TransformInfo(
             skipped=False, num_matches=cnt, is_clean=False, has_valid_shapes=(cnt == 0)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
@@ -257,13 +257,13 @@ class QuantizeNVFP4MOE(NVFP4LinearQuantizationFromConfig):
         return gm, info
 
 
-@TransformRegistry.register("quantize_hf_fp8_moe")
-class QuantizeHFFP8MOE(Quantization):
+@TransformRegistry.register("quantize_finegrained_fp8_moe")
+class QuantizeFineGrainedFP8MOE(Quantization):
     """
     Traverse gm, find every torch.ops.auto_deploy.torch_moe, and replace it with the
-    HuggingFace FineGrainedFP8 quantized version.
+    FineGrainedFP8 quantized version.
 
-    This transform handles HF FP8 quantization config format:
+    This transform handles FineGrained FP8 quantization config format:
         "quantization_config": {
             "quant_method": "fp8",
             "weight_block_size": [128, 128],
@@ -274,7 +274,7 @@ class QuantizeHFFP8MOE(Quantization):
     algo_name = "fp8"
 
     def target_op(self):
-        return torch.ops.auto_deploy.torch_quant_hf_fp8_moe
+        return torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe
 
     def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(w, dtype=torch.float8_e4m3fn, device=w.device)
@@ -283,7 +283,7 @@ class QuantizeHFFP8MOE(Quantization):
         return ["weight_scale_inv"]
 
     def default_scales(self, original_weight_shape: Tuple) -> Dict[str, torch.Tensor]:
-        # Default block size is 128x128 for HF FP8
+        # Default block size is 128x128 for FineGrained FP8
         N, K = original_weight_shape
         block_n, block_k = 128, 128
         scale_shape = (N // block_n, K // block_k)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import math
 from functools import partial
 from typing import Callable, Dict, List, Tuple
 
@@ -286,7 +301,7 @@ class QuantizeFineGrainedFP8MOE(Quantization):
         # Default block size is 128x128 for FineGrained FP8
         N, K = original_weight_shape
         block_n, block_k = 128, 128
-        scale_shape = (N // block_n, K // block_k)
+        scale_shape = (math.ceil(N / block_n), math.ceil(K / block_k))
         return {"weight_scale_inv": torch.ones(scale_shape, dtype=torch.bfloat16)}
 
     def build_custom_args_for_linear(self, scales: Dict[str, "Node"]) -> Tuple:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -54,7 +54,6 @@ from ...utils.node_utils import (
     is_any_lin_op,
     is_any_moe_op,
     is_any_ssm_op,
-    is_fake_quantized_linear_op,
     is_op,
     is_weight_node,
     num_users_of_weight_node,
@@ -74,25 +73,9 @@ from ..interface import (
     TransformRegistry,
 )
 
-
 ########################################################
 #  Helper functions
 ########################################################
-def is_quantized_linear_scale_tensor(node: "Node", weight_node_key: str) -> bool:
-    """Check if a weight node is a scale tensor for a quantized linear op.
-
-    Scale tensors (e.g., weight_scale_inv for FineGrained FP8) are in "block space" and should
-    not be sharded with the same min_local_shape as the actual weight tensor.
-    They are handled separately by quantization_cb.
-
-    Args:
-        node: The linear operation node
-        weight_node_key: The parameter key of the weight node (e.g., "model.layers.0.self_attn.v_proj.weight_scale_inv")
-
-    Returns:
-        True if this is a scale tensor for a quantized linear op, False otherwise
-    """
-    return is_fake_quantized_linear_op(node) and "_scale" in weight_node_key
 
 
 ########################################################
@@ -524,6 +507,22 @@ class FineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightSharding
     def scale_names(self) -> List[str]:
         return ["weight_scale_inv"]
 
+    @staticmethod
+    def _split_scale(scale: torch.Tensor, dim: int, rank: int, world_size: int) -> torch.Tensor:
+        """Split a block-scale tensor along *dim*, handling the edge case where
+        ``scale.shape[dim] < world_size``.
+
+        When the scale dimension is smaller than world_size (e.g. a 2-row scale
+        shared across 8 GPUs), we group ranks that share the same scale row:
+        ``group = rank // (world_size // scale_dim)``.
+        """
+        scale_dim = scale.shape[dim]
+        if scale_dim >= world_size:
+            return torch.tensor_split(scale, world_size, dim=dim)[rank]
+        # More ranks than scale rows → group ranks that share a row
+        group = rank // (world_size // scale_dim)
+        return torch.tensor_split(scale, scale_dim, dim=dim)[group]
+
     def shard_scales(
         self,
         dim: int,
@@ -535,7 +534,7 @@ class FineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightSharding
     ) -> Dict[str, torch.Tensor]:
         # weight_scale_inv has shape [N/block_n, K/block_k]
         # When we shard weight along dim, we need to shard scale along the same dim
-        sharded_scale = torch.tensor_split(weight_scale_inv, world_size, dim=dim)[rank]
+        sharded_scale = self._split_scale(weight_scale_inv, dim, rank, world_size)
         return {"weight_scale_inv": sharded_scale}
 
     def shard_load_hook(
@@ -552,7 +551,7 @@ class FineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightSharding
         scale_key = weight_name + "_scale_inv"
         if scale_key in state_dict:
             scale = state_dict[scale_key]
-            state_dict[scale_key] = torch.tensor_split(scale, world_size, dim=dim)[rank]
+            state_dict[scale_key] = self._split_scale(scale, dim, rank, world_size)
 
 
 def _shard_fp4_weight_scale(weight_scale, sharded_uint8_weight_shape, dim, rank, world_size):
@@ -1370,7 +1369,10 @@ def shard_weight_tensor(
         min_d_shape: int = min_local_shape,
     ) -> torch.Tensor:
         # The local tensor shape has to be divisible by min_d_shape
-        max_split_size = t.shape[d] // min_d_shape
+        max_split_size = t.shape[d] // min_d_shape if min_d_shape > 0 else 0
+        if max_split_size == 0:
+            # Tensor dimension is smaller than min_d_shape; replicate instead of splitting
+            return t
         if ws > max_split_size:
             num_groups = math.ceil(ws / max_split_size)
             ad_logger.debug(
@@ -1471,12 +1473,6 @@ def _shard_parameter_node(
             min_local_shape=min_local_shape,
             fused_weight_dims=fused_weight_dims,
         )
-        if is_quantized_linear_scale_tensor(node, weight_node.node_key):
-            ad_logger.debug(
-                f"Skipping scale tensor {weight_node.node_key} in shard_weight_tensor - "
-                f"will be handled by weight's quantization_cb"
-            )
-            continue
         if quantization_cb is not None:
             quantization_cb(
                 gm=gm,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -493,6 +493,47 @@ class FP8WeightShardingInfo(QuantizationShardingMixin, WeightShardingInfo):
         return
 
 
+class HFFineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightShardingInfo):
+    """Tensor-parallel sharding for HuggingFace FineGrainedFP8 quantized linears.
+
+    HF FP8 uses per-block weight scales (weight_scale_inv) with shape [N/block_n, K/block_k].
+    When sharding the weight along a dimension, we also need to shard the scale tensor.
+    """
+
+    def scale_names(self) -> List[str]:
+        return ["weight_scale_inv"]
+
+    def shard_scales(
+        self,
+        dim: int,
+        rank: int,
+        world_size: int,
+        weight_shape: torch.Size,
+        *,
+        weight_scale_inv: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+        # weight_scale_inv has shape [N/block_n, K/block_k]
+        # When we shard weight along dim, we need to shard scale along the same dim
+        sharded_scale = torch.tensor_split(weight_scale_inv, world_size, dim=dim)[rank]
+        return {"weight_scale_inv": sharded_scale}
+
+    def shard_load_hook(
+        self,
+        state_dict,
+        prefix,
+        *args,
+        weight_name: str,
+        weight_shape: torch.Size,
+        dim: int,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        scale_key = weight_name + "_scale_inv"
+        if scale_key in state_dict:
+            scale = state_dict[scale_key]
+            state_dict[scale_key] = torch.tensor_split(scale, world_size, dim=dim)[rank]
+
+
 def _shard_fp4_weight_scale(weight_scale, sharded_uint8_weight_shape, dim, rank, world_size):
     # assert weight_scale.dim() == 1
     weight_shape_original = list(sharded_uint8_weight_shape)
@@ -723,9 +764,34 @@ class NVFP4EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
         _insert_sharded_moe(gm, node, self.config, scale_names=self.scale_names())
 
 
+class HFFP8EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
+    """HuggingFace FineGrainedFP8-specific EP sharding behavior.
+
+    HF FP8 MoE uses per-block weight scales (weight_scale_inv) for each expert's weights.
+    """
+
+    def validate(self, gm: GraphModule = None, node: Node = None) -> bool:
+        if not is_op(node, torch.ops.auto_deploy.torch_quant_hf_fp8_moe):
+            ad_logger.warning(f"EP sharding is only supported for MOE nodes. Skipping {self}.")
+            return False
+        return True
+
+    def scale_names(self) -> List[str]:
+        return ["weight_scale_inv"]
+
+    def apply(self, gm: GraphModule, node: Node) -> None:
+        _insert_sharded_moe(
+            gm,
+            node,
+            self.config,
+            scale_names=self.scale_names(),
+        )
+
+
 EP_SHARDING_RULES = [
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_fp8_moe), FP8EPShardingInfo),
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe), NVFP4EPShardingInfo),
+    (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe), HFFP8EPShardingInfo),
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_moe), EPShardingInfo),
     (lambda n: is_op(n, torch.ops.auto_deploy.triton_mxfp4_moe), MXFP4EPShardingInfo),
 ]
@@ -1221,6 +1287,10 @@ TP_SHARDING_RULES = [
     (
         lambda n: is_op(n, torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear),
         FP4WeightShardingInfo,
+    ),
+    (
+        lambda n: is_op(n, torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear),
+        HFFineGrainedFP8WeightShardingInfo,
     ),
 ]
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -54,6 +54,7 @@ from ...utils.node_utils import (
     is_any_lin_op,
     is_any_moe_op,
     is_any_ssm_op,
+    is_fake_quantized_linear_op,
     is_op,
     is_weight_node,
     num_users_of_weight_node,
@@ -72,6 +73,26 @@ from ..interface import (
     TransformInfo,
     TransformRegistry,
 )
+
+
+########################################################
+#  Helper functions
+########################################################
+def is_quantized_linear_scale_tensor(node: "Node", weight_node_key: str) -> bool:
+    """Check if a weight node is a scale tensor for a quantized linear op.
+
+    Scale tensors (e.g., weight_scale_inv for HF FP8) are in "block space" and should
+    not be sharded with the same min_local_shape as the actual weight tensor.
+    They are handled separately by quantization_cb.
+
+    Args:
+        node: The linear operation node
+        weight_node_key: The parameter key of the weight node (e.g., "model.layers.0.self_attn.v_proj.weight_scale_inv")
+
+    Returns:
+        True if this is a scale tensor for a quantized linear op, False otherwise
+    """
+    return is_fake_quantized_linear_op(node) and "_scale" in weight_node_key
 
 
 ########################################################
@@ -1447,6 +1468,12 @@ def _shard_parameter_node(
             min_local_shape=min_local_shape,
             fused_weight_dims=fused_weight_dims,
         )
+        if is_quantized_linear_scale_tensor(node, weight_node.node_key):
+            ad_logger.debug(
+                f"Skipping scale tensor {weight_node.node_key} in shard_weight_tensor - "
+                f"will be handled by weight's quantization_cb"
+            )
+            continue
         if quantization_cb is not None:
             quantization_cb(
                 gm=gm,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -81,7 +81,7 @@ from ..interface import (
 def is_quantized_linear_scale_tensor(node: "Node", weight_node_key: str) -> bool:
     """Check if a weight node is a scale tensor for a quantized linear op.
 
-    Scale tensors (e.g., weight_scale_inv for HF FP8) are in "block space" and should
+    Scale tensors (e.g., weight_scale_inv for FineGrained FP8) are in "block space" and should
     not be sharded with the same min_local_shape as the actual weight tensor.
     They are handled separately by quantization_cb.
 
@@ -514,10 +514,10 @@ class FP8WeightShardingInfo(QuantizationShardingMixin, WeightShardingInfo):
         return
 
 
-class HFFineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightShardingInfo):
-    """Tensor-parallel sharding for HuggingFace FineGrainedFP8 quantized linears.
+class FineGrainedFP8WeightShardingInfo(QuantizationShardingMixin, WeightShardingInfo):
+    """Tensor-parallel sharding for FineGrainedFP8 quantized linears.
 
-    HF FP8 uses per-block weight scales (weight_scale_inv) with shape [N/block_n, K/block_k].
+    FineGrained FP8 uses per-block weight scales (weight_scale_inv) with shape [N/block_n, K/block_k].
     When sharding the weight along a dimension, we also need to shard the scale tensor.
     """
 
@@ -785,14 +785,14 @@ class NVFP4EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
         _insert_sharded_moe(gm, node, self.config, scale_names=self.scale_names())
 
 
-class HFFP8EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
-    """HuggingFace FineGrainedFP8-specific EP sharding behavior.
+class FineGrainedFP8EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
+    """FineGrainedFP8-specific EP sharding behavior.
 
-    HF FP8 MoE uses per-block weight scales (weight_scale_inv) for each expert's weights.
+    FineGrained FP8 MoE uses per-block weight scales (weight_scale_inv) for each expert's weights.
     """
 
     def validate(self, gm: GraphModule = None, node: Node = None) -> bool:
-        if not is_op(node, torch.ops.auto_deploy.torch_quant_hf_fp8_moe):
+        if not is_op(node, torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe):
             ad_logger.warning(f"EP sharding is only supported for MOE nodes. Skipping {self}.")
             return False
         return True
@@ -812,7 +812,10 @@ class HFFP8EPShardingInfo(EPShardingInfo, QuantizationShardingMixin):
 EP_SHARDING_RULES = [
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_fp8_moe), FP8EPShardingInfo),
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe), NVFP4EPShardingInfo),
-    (lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe), HFFP8EPShardingInfo),
+    (
+        lambda n: is_op(n, torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe),
+        FineGrainedFP8EPShardingInfo,
+    ),
     (lambda n: is_op(n, torch.ops.auto_deploy.torch_moe), EPShardingInfo),
     (lambda n: is_op(n, torch.ops.auto_deploy.triton_mxfp4_moe), MXFP4EPShardingInfo),
 ]
@@ -1310,8 +1313,8 @@ TP_SHARDING_RULES = [
         FP4WeightShardingInfo,
     ),
     (
-        lambda n: is_op(n, torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear),
-        HFFineGrainedFP8WeightShardingInfo,
+        lambda n: is_op(n, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear),
+        FineGrainedFP8WeightShardingInfo,
     ),
 ]
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -551,7 +551,7 @@ def is_any_moe_op(node: Node) -> bool:
             torch.ops.auto_deploy.torch_moe,
             torch.ops.auto_deploy.torch_quant_fp8_moe,
             torch.ops.auto_deploy.torch_quant_nvfp4_moe,
-            torch.ops.auto_deploy.torch_quant_hf_fp8_moe,
+            torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe,
             torch.ops.auto_deploy.triton_mxfp4_moe,
         ],
     )
@@ -629,7 +629,7 @@ def is_fake_quantized_linear_op(node: Node) -> bool:
     quantized_linear_op = {
         torch.ops.auto_deploy.torch_fake_quant_fp8_linear,
         torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear,
-        torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear,
+        torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear,
     }
 
     return is_op(node, quantized_linear_op)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -551,6 +551,7 @@ def is_any_moe_op(node: Node) -> bool:
             torch.ops.auto_deploy.torch_moe,
             torch.ops.auto_deploy.torch_quant_fp8_moe,
             torch.ops.auto_deploy.torch_quant_nvfp4_moe,
+            torch.ops.auto_deploy.torch_quant_hf_fp8_moe,
             torch.ops.auto_deploy.triton_mxfp4_moe,
         ],
     )
@@ -628,6 +629,7 @@ def is_fake_quantized_linear_op(node: Node) -> bool:
     quantized_linear_op = {
         torch.ops.auto_deploy.torch_fake_quant_fp8_linear,
         torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear,
+        torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear,
     }
 
     return is_op(node, quantized_linear_op)

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -107,11 +107,30 @@ def get_quantization_from_linear_node(node: torch.fx.node.Node):
     return ""
 
 
+def _pattern_matches(modname: str, pattern: str) -> bool:
+    """Check if a pattern matches the module name.
+
+    Supports both:
+    - Glob patterns (with * or ?): use fnmatch
+    - Simple strings (no wildcards): use substring matching (HF style)
+    """
+    # If pattern contains wildcards, use fnmatch
+    if "*" in pattern or "?" in pattern:
+        return fnmatch(modname, pattern)
+    # Otherwise, use substring matching (HF modules_to_not_convert style)
+    # Check if pattern appears as a component in the module path
+    return pattern in modname.split(".")
+
+
 def should_skip_quantization(
     node_or_name: Union[Node, str],
     excluded_patterns: list[str],
 ) -> bool:
-    """Check if a node or parameter name should be skipped based on excluded patterns."""
+    """Check if a node or parameter name should be skipped based on excluded patterns.
+
+    Supports both glob patterns (e.g., "*gate*") and simple substring patterns
+    (e.g., "gate" matches "model.layers.0.block_sparse_moe.gate").
+    """
     if isinstance(node_or_name, str):
         modname, _, _ = node_or_name.rpartition(".")
     else:
@@ -124,7 +143,7 @@ def should_skip_quantization(
             return True
         modname = weight_name.rpartition(".")[0]
 
-    return any(fnmatch(modname, pattern) for pattern in excluded_patterns)
+    return any(_pattern_matches(modname, pattern) for pattern in excluded_patterns)
 
 
 def extract_scales_from_node(node: Node, scale_names: list[str]) -> Dict[str, Optional[Node]]:

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -108,18 +108,13 @@ def get_quantization_from_linear_node(node: torch.fx.node.Node):
 
 
 def _pattern_matches(modname: str, pattern: str) -> bool:
-    """Check if a pattern matches the module name.
+    """Check if an exclude pattern matches the module name.
 
-    Supports both:
-    - Glob patterns (with * or ?): use fnmatch
-    - Simple strings (no wildcards): use substring matching (HF style)
+    Keep behavior aligned with upstream: evaluate exclude entries via fnmatch.
+    This preserves exact module-path excludes (for example:
+    ``model.layers.0.self_attn.q_a_proj``) and wildcard entries.
     """
-    # If pattern contains wildcards, use fnmatch
-    if "*" in pattern or "?" in pattern:
-        return fnmatch(modname, pattern)
-    # Otherwise, use substring matching (HF modules_to_not_convert style)
-    # Check if pattern appears as a component in the module path
-    return pattern in modname.split(".")
+    return fnmatch(modname, pattern)
 
 
 def should_skip_quantization(

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -737,6 +737,57 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
+class TestMiniMaxM2(LlmapiAccuracyTestHarness):
+    """Accuracy regression tests for MiniMax M2.
+
+    Runs the model via AutoDeploy and verifies benchmark performance on MMLU and GSM8K.
+    """
+
+    MODEL_NAME = "MiniMaxAI/MiniMax-M2"
+    # Set minimum possible seq len + small buffer, for test speed & memory usage
+    MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
+                      GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
+
+    def get_default_kwargs(self):
+        return {
+            "skip_tokenizer_init":
+            False,
+            "trust_remote_code":
+            True,
+            "skip_loading_weights":
+            False,
+            "compile_backend":
+            "torch-cudagraph",
+            "free_mem_ratio":
+            0.88,
+            "max_batch_size":
+            64,
+            "max_seq_len":
+            self.MAX_SEQ_LEN,
+            "max_num_tokens":
+            self.MAX_SEQ_LEN,
+            "enable_chunked_prefill":
+            True,
+            "cuda_graph_batch_sizes":
+            [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 320, 384],
+            "model_kwargs": {
+                "torch_dtype": "bfloat16",
+            },
+        }
+
+    @pytest.mark.skip_less_device(8)
+    def test_finegrained_fp8(self):
+        kwargs = self.get_default_kwargs()
+        with AutoDeployLLM(model=self.MODEL_NAME,
+                           tokenizer=self.MODEL_NAME,
+                           world_size=8,
+                           **kwargs) as llm:
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+
 class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
     """Accuracy tests for models from the AutoDeploy model registry.
 

--- a/tests/integration/defs/common.py
+++ b/tests/integration/defs/common.py
@@ -303,7 +303,7 @@ def convert_weights(llm_venv,
                 "--use_weight_only", "--weight_only_precision=int4_awq",
                 "--group_size=128"
             ])
-        if 'hf_fp8' in model:
+        if 'finegrained_fp8' in model:
             convert_cmd.extend(["--use_fp8"])
 
     elif "draft_target_model" in model:

--- a/tests/integration/defs/examples/test_llama.py
+++ b/tests/integration/defs/examples/test_llama.py
@@ -538,7 +538,7 @@ def test_llm_llama_1gpu(run_type, data_type, fp8_cache, llama_example_root,
         model_dir = convert_weights(llm_venv=llm_venv,
                                     example_root=llama_example_root,
                                     cmodel_dir=cmodel_dir,
-                                    model="llama_v3_hf_fp8",
+                                    model="llama_v3_finegrained_fp8",
                                     model_path=llama_model_root,
                                     fp8_kv_cache=fp8_cache,
                                     data_type=data_type)

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -274,6 +274,46 @@ class FakeFP8Linear(nn.Linear):
         )
 
 
+class FakeHFFP8Linear(nn.Linear):
+    """Fake HuggingFace FineGrainedFP8 linear layer for testing.
+
+    Mimics the behavior of transformers.integrations.finegrained_fp8.FP8Linear
+    with per-block quantization (block_size = [128, 128] by default).
+    """
+
+    def __init__(self, in_features, out_features, bias=True, block_size=None):
+        super().__init__(in_features, out_features, bias)
+        device = self.weight.device
+
+        if block_size is None:
+            block_n = min(128, out_features)
+            block_k = min(128, in_features)
+            block_size = [block_n, block_k]
+        self.block_size = block_size
+
+        N, K = self.weight.shape
+        block_n, block_k = block_size
+
+        weight_reshaped = self.weight.detach().view(N // block_n, block_n, K // block_k, block_k)
+        amax = weight_reshaped.abs().amax(dim=(1, 3)).to(torch.float32)  # [N/block_n, K/block_k]
+
+        eps = torch.finfo(torch.float32).tiny
+        weight_scale_inv = torch.clamp(amax / FP8_MAX, min=eps).to(device)
+
+        weight_fp8 = (
+            self.weight.detach().float()
+            / weight_scale_inv.repeat_interleave(block_n, dim=0).repeat_interleave(block_k, dim=1)
+        ).to(torch.float8_e4m3fn)
+
+        self.weight = nn.Parameter(weight_fp8)
+        self.register_buffer("weight_scale_inv", weight_scale_inv)
+
+    def forward(self, x):
+        return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+            x, self.weight, self.bias, [], [self.weight_scale_inv], [], []
+        )
+
+
 def generate_dynamic_shapes(max_batch_size, max_seq_len):
     dynamic_shapes = (
         {

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -274,8 +274,8 @@ class FakeFP8Linear(nn.Linear):
         )
 
 
-class FakeHFFP8Linear(nn.Linear):
-    """Fake HuggingFace FineGrainedFP8 linear layer for testing.
+class FakeFineGrainedFP8Linear(nn.Linear):
+    """Fake FineGrainedFP8 linear layer for testing.
 
     Mimics the behavior of transformers.integrations.finegrained_fp8.FP8Linear
     with per-block quantization (block_size = [128, 128] by default).
@@ -309,7 +309,7 @@ class FakeHFFP8Linear(nn.Linear):
         self.register_buffer("weight_scale_inv", weight_scale_inv)
 
     def forward(self, x):
-        return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
             x, self.weight, self.bias, [], [self.weight_scale_inv], [], []
         )
 

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -507,13 +507,11 @@ def _run_sharding_execution_job(
         )
         # update the tp_plan in predefined_config to force simple sharding of the single linear layer
         predefined_config = {"tp_plan": {"*": "gather"}}
-    elif model_cls == HFFP8MLP:
-        # HFFP8MLP needs features divisible by 128 (block size)
-        model = model_cls(128, 128, bias=bias).to("cuda")
     elif model_cls == FineGrainedFP8MLP:
         # FineGrainedFP8MLP needs features divisible by 128 (block size)
         num_features = 128
         model = model_cls(num_features, num_features, bias=bias).to("cuda")
+        predefined_config = {"tp_plan": {"linear1": "colwise", "linear2": "rowwise"}}
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
@@ -623,6 +621,10 @@ def _run_sharding_execution_job(
         weight_sizes_valid = verify_local_weight_sizes(gm)
         return has_expected_dist_ops and weight_sizes_valid
 
+    # FineGrainedFP8 shard_load_hook always shards scales from the full state dict,
+    # so skip the round-trip load hook test (loading from already-sharded state dict).
+    test_load = model_cls != FineGrainedFP8MLP
+
     run_test_transformed_gm(
         model,
         x,
@@ -630,6 +632,8 @@ def _run_sharding_execution_job(
         check_transformed_graph=combined_graph_check,
         _get_expected_num_params=_get_expected_num_params,
         skip_output_assert=skip_output_assert,
+        test_load_hook=test_load,
+        strict_loading=test_load,
     )
 
 
@@ -730,6 +734,7 @@ def _run_pattern_detection_job(
         # FineGrainedFP8MLP needs features divisible by 128 (block size)
         num_features = 128
         model = model_cls(num_features, num_features, bias=bias).to("cuda")
+        predefined_config = {"tp_plan": {"linear1": "colwise", "linear2": "rowwise"}}
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
@@ -998,26 +1003,6 @@ def _run_pattern_detection_job(
                                 fused_weight_dims=fused_weight_dims,
                             )
                         )
-        elif model_cls == HFFP8MLP:
-            for node in gm.graph.nodes:
-                if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear):
-                    # linear1 should be sharded on dim=0, add_dist=False, min_local_shape=1
-                    # linear2 should be sharded on dim=1, add_dist=True, min_local_shape=1
-                    if "linear1" in node.args[1].name:
-                        dim = SplitDimension.COLUMN
-                        dist_op = None
-                    else:
-                        dim = SplitDimension.ROW
-                        dist_op = "all_reduce"
-                    expected_transformations.append(
-                        FineGrainedFP8WeightShardingInfo(
-                            target_node=node.name,
-                            split_dim=dim,
-                            config=config,
-                            dist_op=dist_op,
-                            min_local_shape=1,
-                        )
-                    )
         elif model_cls == FineGrainedFP8MLP:
             for node in gm.graph.nodes:
                 if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -10,14 +10,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 from _dist_test_utils import get_device_counts
 from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_transformed_gm
-from _model_test_utils import FakeFP8Linear, FakeHFFP8Linear
+from _model_test_utils import FakeFineGrainedFP8Linear, FakeFP8Linear
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_nemotron_h import NemotronHMamba2Mixer
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
+    FineGrainedFP8WeightShardingInfo,
     FP8WeightShardingInfo,
-    HFFineGrainedFP8WeightShardingInfo,
     LayerType,
     ShardingTransformConfig,
     SplitDimension,
@@ -187,8 +187,10 @@ class MLA_Block(nn.Module):
         # Output projection
         output = self.o_proj(attn_out)
         return output
-class HFFP8MLP(nn.Module):
-    """MLP using HuggingFace FineGrainedFP8 quantization for testing."""
+
+
+class FineGrainedFP8MLP(nn.Module):
+    """MLP using FineGrainedFP8 quantization for testing."""
 
     def __init__(self, in_features, out_features, bias=False):
         super().__init__()
@@ -196,8 +198,8 @@ class HFFP8MLP(nn.Module):
         self.out_features = out_features
         # Use larger features divisible by block size (128)
         hidden_features = max(4 * in_features, 128)
-        self.linear1 = FakeHFFP8Linear(in_features, hidden_features, bias=bias)
-        self.linear2 = FakeHFFP8Linear(hidden_features, out_features, bias=bias)
+        self.linear1 = FakeFineGrainedFP8Linear(in_features, hidden_features, bias=bias)
+        self.linear2 = FakeFineGrainedFP8Linear(hidden_features, out_features, bias=bias)
 
     def forward(self, x):
         y = F.relu(self.linear1(x))
@@ -508,6 +510,10 @@ def _run_sharding_execution_job(
     elif model_cls == HFFP8MLP:
         # HFFP8MLP needs features divisible by 128 (block size)
         model = model_cls(128, 128, bias=bias).to("cuda")
+    elif model_cls == FineGrainedFP8MLP:
+        # FineGrainedFP8MLP needs features divisible by 128 (block size)
+        num_features = 128
+        model = model_cls(num_features, num_features, bias=bias).to("cuda")
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
@@ -720,6 +726,10 @@ def _run_pattern_detection_job(
         )
         # update the tp_plan in predefined_config to force simple sharding of the single linear layer
         predefined_config = {"tp_plan": {"*": "gather"}}
+    elif model_cls == FineGrainedFP8MLP:
+        # FineGrainedFP8MLP needs features divisible by 128 (block size)
+        num_features = 128
+        model = model_cls(num_features, num_features, bias=bias).to("cuda")
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
@@ -990,7 +1000,7 @@ def _run_pattern_detection_job(
                         )
         elif model_cls == HFFP8MLP:
             for node in gm.graph.nodes:
-                if is_op(node, torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear):
+                if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear):
                     # linear1 should be sharded on dim=0, add_dist=False, min_local_shape=1
                     # linear2 should be sharded on dim=1, add_dist=True, min_local_shape=1
                     if "linear1" in node.args[1].name:
@@ -1000,7 +1010,27 @@ def _run_pattern_detection_job(
                         dim = SplitDimension.ROW
                         dist_op = "all_reduce"
                     expected_transformations.append(
-                        HFFineGrainedFP8WeightShardingInfo(
+                        FineGrainedFP8WeightShardingInfo(
+                            target_node=node.name,
+                            split_dim=dim,
+                            config=config,
+                            dist_op=dist_op,
+                            min_local_shape=1,
+                        )
+                    )
+        elif model_cls == FineGrainedFP8MLP:
+            for node in gm.graph.nodes:
+                if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear):
+                    # linear1 should be sharded on dim=0, add_dist=False, min_local_shape=1
+                    # linear2 should be sharded on dim=1, add_dist=True, min_local_shape=1
+                    if "linear1" in node.args[1].name:
+                        dim = SplitDimension.COLUMN
+                        dist_op = None
+                    else:
+                        dim = SplitDimension.ROW
+                        dist_op = "all_reduce"
+                    expected_transformations.append(
+                        FineGrainedFP8WeightShardingInfo(
                             target_node=node.name,
                             split_dim=dim,
                             config=config,
@@ -1044,7 +1074,7 @@ def _run_pattern_detection_job(
     (
         (MLP, "torch_dist_all_reduce"),
         (FP8MLP, "torch_dist_all_reduce"),
-        (HFFP8MLP, "torch_dist_all_reduce"),
+        (FineGrainedFP8MLP, "torch_dist_all_reduce"),
         (nn.Linear, "torch_dist_all_gather"),
         (GQA_Block, "torch_dist_all_reduce"),
         (NemotronHMamba2Mixer, "torch_dist_all_reduce"),
@@ -1074,7 +1104,7 @@ def test_sharding(
     (
         (MLP, "torch_dist_all_reduce"),
         (FP8MLP, "torch_dist_all_reduce"),
-        (HFFP8MLP, "torch_dist_all_reduce"),
+        (FineGrainedFP8MLP, "torch_dist_all_reduce"),
         (nn.Linear, "torch_dist_all_gather"),
         (GQA_Block, "torch_dist_all_reduce"),
         (NemotronHMamba2Mixer, "torch_dist_all_reduce"),

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -10,13 +10,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 from _dist_test_utils import get_device_counts
 from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_transformed_gm
-from _model_test_utils import FakeFP8Linear
+from _model_test_utils import FakeFP8Linear, FakeHFFP8Linear
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_nemotron_h import NemotronHMamba2Mixer
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     FP8WeightShardingInfo,
+    HFFineGrainedFP8WeightShardingInfo,
     LayerType,
     ShardingTransformConfig,
     SplitDimension,
@@ -186,6 +187,21 @@ class MLA_Block(nn.Module):
         # Output projection
         output = self.o_proj(attn_out)
         return output
+class HFFP8MLP(nn.Module):
+    """MLP using HuggingFace FineGrainedFP8 quantization for testing."""
+
+    def __init__(self, in_features, out_features, bias=False):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        # Use larger features divisible by block size (128)
+        hidden_features = max(4 * in_features, 128)
+        self.linear1 = FakeHFFP8Linear(in_features, hidden_features, bias=bias)
+        self.linear2 = FakeHFFP8Linear(hidden_features, out_features, bias=bias)
+
+    def forward(self, x):
+        y = F.relu(self.linear1(x))
+        return self.linear2(y)
 
 
 class GDN_Block(nn.Module):
@@ -489,6 +505,9 @@ def _run_sharding_execution_job(
         )
         # update the tp_plan in predefined_config to force simple sharding of the single linear layer
         predefined_config = {"tp_plan": {"*": "gather"}}
+    elif model_cls == HFFP8MLP:
+        # HFFP8MLP needs features divisible by 128 (block size)
+        model = model_cls(128, 128, bias=bias).to("cuda")
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
@@ -969,6 +988,26 @@ def _run_pattern_detection_job(
                                 fused_weight_dims=fused_weight_dims,
                             )
                         )
+        elif model_cls == HFFP8MLP:
+            for node in gm.graph.nodes:
+                if is_op(node, torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear):
+                    # linear1 should be sharded on dim=0, add_dist=False, min_local_shape=1
+                    # linear2 should be sharded on dim=1, add_dist=True, min_local_shape=1
+                    if "linear1" in node.args[1].name:
+                        dim = SplitDimension.COLUMN
+                        dist_op = None
+                    else:
+                        dim = SplitDimension.ROW
+                        dist_op = "all_reduce"
+                    expected_transformations.append(
+                        HFFineGrainedFP8WeightShardingInfo(
+                            target_node=node.name,
+                            split_dim=dim,
+                            config=config,
+                            dist_op=dist_op,
+                            min_local_shape=1,
+                        )
+                    )
 
     sharding_source = "heuristic" if from_config else "manual"
     # get detected transformations
@@ -1005,6 +1044,7 @@ def _run_pattern_detection_job(
     (
         (MLP, "torch_dist_all_reduce"),
         (FP8MLP, "torch_dist_all_reduce"),
+        (HFFP8MLP, "torch_dist_all_reduce"),
         (nn.Linear, "torch_dist_all_gather"),
         (GQA_Block, "torch_dist_all_reduce"),
         (NemotronHMamba2Mixer, "torch_dist_all_reduce"),
@@ -1034,6 +1074,7 @@ def test_sharding(
     (
         (MLP, "torch_dist_all_reduce"),
         (FP8MLP, "torch_dist_all_reduce"),
+        (HFFP8MLP, "torch_dist_all_reduce"),
         (nn.Linear, "torch_dist_all_gather"),
         (GQA_Block, "torch_dist_all_reduce"),
         (NemotronHMamba2Mixer, "torch_dist_all_reduce"),

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/moe/test_trtllm_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/moe/test_trtllm_moe.py
@@ -993,3 +993,253 @@ def test_stack_nvfp4_moe_weights_transform_relu2(hidden_size, intermediate_size)
 
     tol = 1e-3
     torch.testing.assert_close(ref_output, transformed_output, rtol=tol, atol=tol)
+
+
+# ============================================================================
+# HuggingFace FP8 Block Scale MoE Tests
+# ============================================================================
+
+HF_FP8_BLOCK_SIZE = 128  # HuggingFace FP8 uses 128x128 block scales
+
+
+def quantize_to_hf_fp8_block_scale(tensor: torch.Tensor, block_size: int = HF_FP8_BLOCK_SIZE):
+    """
+    Quantize tensor to FP8 with per-block scales (HuggingFace format).
+
+    Args:
+        tensor: Input tensor of shape [E, N, K] (experts, rows, cols)
+        block_size: Block size for quantization (default 128)
+
+    Returns:
+        tuple: (fp8_tensor, block_scales)
+    """
+    num_experts, n_dim, k_dim = tensor.shape
+
+    # Pad to multiple of block_size if needed
+    n_pad = (block_size - n_dim % block_size) % block_size
+    k_pad = (block_size - k_dim % block_size) % block_size
+
+    if n_pad > 0 or k_pad > 0:
+        tensor = F.pad(tensor, (0, k_pad, 0, n_pad))
+
+    padded_n, padded_k = tensor.shape[-2], tensor.shape[-1]
+    n_blocks = padded_n // block_size
+    k_blocks = padded_k // block_size
+
+    # Reshape to expose blocks: [E, n_blocks, block_size, k_blocks, block_size]
+    tensor_blocks = tensor.view(num_experts, n_blocks, block_size, k_blocks, block_size)
+    tensor_blocks = tensor_blocks.permute(
+        0, 1, 3, 2, 4
+    )  # [E, n_blocks, k_blocks, block_size, block_size]
+
+    # Compute per-block max for scaling
+    block_max = tensor_blocks.abs().amax(dim=(-2, -1), keepdim=True)
+    block_max = block_max.clamp(min=1e-12)
+
+    # Compute scales: [E, n_blocks, k_blocks]
+    scales = (block_max / FLOAT8_E4M3_MAX).squeeze(-1).squeeze(-1)
+
+    # Quantize
+    tensor_scaled = tensor_blocks / block_max * FLOAT8_E4M3_MAX
+    tensor_scaled = tensor_scaled.clamp(-FLOAT8_E4M3_MAX, FLOAT8_E4M3_MAX)
+
+    # Reshape back to [E, padded_n, padded_k]
+    tensor_fp8 = tensor_scaled.permute(
+        0, 1, 3, 2, 4
+    )  # [E, n_blocks, block_size, k_blocks, block_size]
+    tensor_fp8 = tensor_fp8.reshape(num_experts, padded_n, padded_k)
+
+    # Remove padding and convert to FP8
+    tensor_fp8 = tensor_fp8[:, :n_dim, :k_dim].to(FP8_DTYPE)
+
+    return tensor_fp8, scales.to(torch.float32)
+
+
+HF_FP8_BATCH_SIZES = [1, 4]
+HF_FP8_HIDDEN_SIZES = [256, 512]  # Must be multiple of 128
+HF_FP8_NUM_EXPERTS = [4, 8]
+HF_FP8_TOP_K = [2]
+HF_FP8_INTERMEDIATE_SIZES = [256, 512]  # Must be multiple of 128
+
+
+@pytest.mark.parametrize("batch_size", HF_FP8_BATCH_SIZES)
+@pytest.mark.parametrize("hidden_size", HF_FP8_HIDDEN_SIZES)
+@pytest.mark.parametrize("num_experts", HF_FP8_NUM_EXPERTS)
+@pytest.mark.parametrize("top_k", HF_FP8_TOP_K)
+@pytest.mark.parametrize("intermediate_size", HF_FP8_INTERMEDIATE_SIZES)
+@pytest.mark.skipif(
+    not fp8_compatible() or not trtllm_ops_available(),
+    reason="Requires FP8 and TensorRT-LLM ops support",
+)
+@skip_pre_hopper
+def test_trtllm_hf_fp8_block_scale_moe_hopper(
+    batch_size,
+    hidden_size,
+    num_experts,
+    top_k,
+    intermediate_size,
+):
+    """Test HF FP8 block scale MoE on Hopper (SM90) path.
+
+    This test verifies:
+    1. The op runs without error
+    2. Output shape and dtype are correct
+    3. Output values are finite (no NaN/Inf)
+
+    Note: Pure torch reference comparison has high error due to dynamic activation
+    quantization in the kernel. For functional correctness, see
+    test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness in test_moe_fusion.py
+    which compares fused vs unfused ops.
+    """
+    from tensorrt_llm._utils import is_sm_100f
+
+    if is_sm_100f():
+        pytest.skip("Hopper path test requires SM90 GPU (not SM100+)")
+
+    if top_k > num_experts:
+        pytest.skip(f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})")
+
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+
+    # Generate test data
+    x = gen_tensor((batch_size, hidden_size), dtype, scale=1.0)
+    router_logits = gen_tensor((batch_size, num_experts), dtype)
+    routing_weights, selected_experts = compute_routing(router_logits, top_k)
+
+    # FC1: [E, 2*I, H] for gated MLP
+    fc1_weights_bf16 = gen_tensor(
+        (num_experts, 2 * intermediate_size, hidden_size), dtype, scale=0.1
+    )
+    # FC2: [E, H, I]
+    fc2_weights_bf16 = gen_tensor((num_experts, hidden_size, intermediate_size), dtype, scale=0.1)
+
+    # Quantize to FP8 with block scales
+    fc1_weights_fp8, fc1_scales = quantize_to_hf_fp8_block_scale(fc1_weights_bf16)
+    fc2_weights_fp8, fc2_scales = quantize_to_hf_fp8_block_scale(fc2_weights_bf16)
+
+    # Run on Hopper (native path)
+    torch.cuda.synchronize()
+    test_output = torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused(
+        x,
+        selected_experts,
+        routing_weights,
+        fc1_weights_fp8,
+        fc2_weights_fp8,
+        fc1_scales,
+        fc2_scales,
+        is_gated_mlp=True,
+        act_fn=int(ActivationType.Silu),
+    )
+    torch.cuda.synchronize()
+
+    # Verify output shape matches input
+    assert test_output.shape == x.shape, (
+        f"Output shape {test_output.shape} != input shape {x.shape}"
+    )
+
+    # Verify output dtype
+    assert test_output.dtype == dtype, f"Output dtype {test_output.dtype} != expected {dtype}"
+
+    # Verify no NaN or Inf values
+    assert not torch.isnan(test_output).any(), "Output contains NaN values"
+    assert not torch.isinf(test_output).any(), "Output contains Inf values"
+
+    # Verify output is not all zeros (sanity check)
+    assert test_output.abs().sum() > 0, "Output is all zeros"
+
+    print(f"[Hopper] Output shape: {test_output.shape}, dtype: {test_output.dtype}")
+    print(
+        f"[Hopper] Output range: [{test_output.min().item():.4f}, {test_output.max().item():.4f}]"
+    )
+
+
+@pytest.mark.parametrize("batch_size", HF_FP8_BATCH_SIZES)
+@pytest.mark.parametrize("hidden_size", HF_FP8_HIDDEN_SIZES)
+@pytest.mark.parametrize("num_experts", HF_FP8_NUM_EXPERTS)
+@pytest.mark.parametrize("top_k", HF_FP8_TOP_K)
+@pytest.mark.parametrize("intermediate_size", HF_FP8_INTERMEDIATE_SIZES)
+@pytest.mark.skipif(
+    not fp8_compatible() or not trtllm_ops_available(),
+    reason="Requires FP8 and TensorRT-LLM ops support",
+)
+def test_trtllm_hf_fp8_block_scale_moe_blackwell(
+    batch_size,
+    hidden_size,
+    num_experts,
+    top_k,
+    intermediate_size,
+):
+    """Test HF FP8 block scale MoE on Blackwell (SM100+) path.
+
+    This test verifies:
+    1. The op runs without error
+    2. Output shape and dtype are correct
+    3. Output values are finite (no NaN/Inf)
+
+    Note: Pure torch reference comparison has high error due to dynamic activation
+    quantization in the kernel. For functional correctness, see
+    test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness in test_moe_fusion.py
+    which compares fused vs unfused ops.
+    """
+    from tensorrt_llm._utils import is_sm_100f
+
+    if not is_sm_100f():
+        pytest.skip("Blackwell path test requires SM100+ GPU")
+
+    if top_k > num_experts:
+        pytest.skip(f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})")
+
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+
+    # Generate test data
+    x = gen_tensor((batch_size, hidden_size), dtype, scale=1.0)
+    router_logits = gen_tensor((batch_size, num_experts), dtype)
+    routing_weights, selected_experts = compute_routing(router_logits, top_k)
+
+    # FC1: [E, 2*I, H] for gated MLP
+    fc1_weights_bf16 = gen_tensor(
+        (num_experts, 2 * intermediate_size, hidden_size), dtype, scale=0.1
+    )
+    # FC2: [E, H, I]
+    fc2_weights_bf16 = gen_tensor((num_experts, hidden_size, intermediate_size), dtype, scale=0.1)
+
+    # Quantize to FP8 with block scales
+    fc1_weights_fp8, fc1_scales = quantize_to_hf_fp8_block_scale(fc1_weights_bf16)
+    fc2_weights_fp8, fc2_scales = quantize_to_hf_fp8_block_scale(fc2_weights_bf16)
+
+    # Run on Blackwell (native path)
+    torch.cuda.synchronize()
+    test_output = torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused(
+        x,
+        selected_experts,
+        routing_weights,
+        fc1_weights_fp8,
+        fc2_weights_fp8,
+        fc1_scales,
+        fc2_scales,
+        is_gated_mlp=True,
+        act_fn=int(ActivationType.Silu),
+    )
+    torch.cuda.synchronize()
+
+    # Verify output shape matches input
+    assert test_output.shape == x.shape, (
+        f"Output shape {test_output.shape} != input shape {x.shape}"
+    )
+
+    # Verify output dtype
+    assert test_output.dtype == dtype, f"Output dtype {test_output.dtype} != expected {dtype}"
+
+    # Verify no NaN or Inf values
+    assert not torch.isnan(test_output).any(), "Output contains NaN values"
+    assert not torch.isinf(test_output).any(), "Output contains Inf values"
+
+    # Verify output is not all zeros (sanity check)
+    assert test_output.abs().sum() > 0, "Output is all zeros"
+
+    print(f"[Blackwell] Output shape: {test_output.shape}, dtype: {test_output.dtype}")
+    print(
+        f"[Blackwell] Output range: [{test_output.min().item():.4f}, {test_output.max().item():.4f}]"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -1241,7 +1241,7 @@ FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
 class BlockSparseTop2MLPFineGrainedFP8(nn.Module):
     """FineGrainedFP8 expert with per-block weight scales."""
 
-    def __init__(self, ffn_dim, hidden_dim, dtype=torch.bfloat16, device="cuda", block_size=None):
+    def __init__(self, ffn_dim, hidden_dim, device="cuda", block_size=None):
         super().__init__()
         self.ffn_dim = ffn_dim
         self.hidden_dim = hidden_dim

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -1232,14 +1232,14 @@ def test_split_moe_fused_for_sharding_load_hook():
 
 
 # =============================================================================
-# HuggingFace FineGrainedFP8 MoE Tests
+# FineGrainedFP8 MoE Tests
 # =============================================================================
 
 FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
 
 
-class BlockSparseTop2MLPHFFP8(nn.Module):
-    """HuggingFace FineGrainedFP8 expert with per-block weight scales."""
+class BlockSparseTop2MLPFineGrainedFP8(nn.Module):
+    """FineGrainedFP8 expert with per-block weight scales."""
 
     def __init__(self, ffn_dim, hidden_dim, dtype=torch.bfloat16, device="cuda", block_size=None):
         super().__init__()
@@ -1293,7 +1293,7 @@ class BlockSparseTop2MLPHFFP8(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor):
         x = hidden_states
-        w1_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        w1_out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
             x,
             self.w1_fp8,
             bias=None,
@@ -1302,7 +1302,7 @@ class BlockSparseTop2MLPHFFP8(nn.Module):
             input_zp=[],
             weight_zp=[],
         )
-        w3_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        w3_out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
             x,
             self.w3_fp8,
             bias=None,
@@ -1312,7 +1312,7 @@ class BlockSparseTop2MLPHFFP8(nn.Module):
             weight_zp=[],
         )
         fused = self.act_fn(w1_out) * w3_out
-        out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+        out = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
             fused,
             self.w2_fp8,
             bias=None,
@@ -1324,8 +1324,8 @@ class BlockSparseTop2MLPHFFP8(nn.Module):
         return out
 
 
-class HFFP8MoEOpModel(nn.Module):
-    """MoE model using HuggingFace FineGrainedFP8 quantized experts with torch_quant_hf_fp8_moe op."""
+class FineGrainedFP8MoEOpModel(nn.Module):
+    """MoE model using FineGrainedFP8 quantized experts with torch_quant_finegrained_fp8_moe op."""
 
     def __init__(
         self, hidden_size=256, intermediate_size=128, num_experts=4, top_k=2, device="cuda"
@@ -1338,10 +1338,10 @@ class HFFP8MoEOpModel(nn.Module):
 
         self.gate = nn.Linear(hidden_size, num_experts)
 
-        # Create HF FP8 experts
+        # Create FineGrained FP8 experts
         self.experts = nn.ModuleList(
             [
-                BlockSparseTop2MLPHFFP8(intermediate_size, hidden_size, device=device)
+                BlockSparseTop2MLPFineGrainedFP8(intermediate_size, hidden_size, device=device)
                 for _ in range(num_experts)
             ]
         )
@@ -1362,7 +1362,7 @@ class HFFP8MoEOpModel(nn.Module):
         w2_scale_list = [expert.w2_scale_inv for expert in self.experts]
         w3_scale_list = [expert.w3_scale_inv for expert in self.experts]
 
-        out = torch.ops.auto_deploy.torch_quant_hf_fp8_moe(
+        out = torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe(
             x,
             selected_experts,
             routing_weights,
@@ -1389,11 +1389,11 @@ class HFFP8MoEOpModel(nn.Module):
 
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
 @pytest.mark.skipif(not trtllm_ops_available(), reason="Requires TRTLLM ops")
-def test_fuse_hf_fp8_moe():
-    """Test that fuse_hf_fp8_moe transforms torch_quant_hf_fp8_moe to fused op."""
+def test_fuse_finegrained_fp8_moe():
+    """Test that fuse_finegrained_fp8_moe transforms torch_quant_finegrained_fp8_moe to fused op."""
     device = "cuda"
     # Use sizes divisible by 128 for block scales
-    model = HFFP8MoEOpModel(
+    model = FineGrainedFP8MoEOpModel(
         hidden_size=512, intermediate_size=1536, num_experts=72, device=device
     ).to(device=device)
     model.gate = model.gate.to(dtype=torch.bfloat16)
@@ -1403,17 +1403,17 @@ def test_fuse_hf_fp8_moe():
     with torch.inference_mode():
         gm = torch_export_to_gm(model, args=(x,), clone=True)
 
-        # Verify initial graph has torch_quant_hf_fp8_moe
+        # Verify initial graph has torch_quant_finegrained_fp8_moe
         has_unfused = any(
-            is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe) for n in gm.graph.nodes
+            is_op(n, torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe) for n in gm.graph.nodes
         )
-        assert has_unfused, "Expected torch_quant_hf_fp8_moe in initial graph"
+        assert has_unfused, "Expected torch_quant_finegrained_fp8_moe in initial graph"
 
         # Apply fusion transform
         gm_transformed = InferenceOptimizer(
             None,
             {
-                "fuse_hf_fp8_moe": {
+                "fuse_finegrained_fp8_moe": {
                     "stage": "post_load_fusion",
                 },
             },
@@ -1421,29 +1421,31 @@ def test_fuse_hf_fp8_moe():
 
         # Verify fused op is present
         has_fused = any(
-            is_op(n, torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused)
+            is_op(n, torch.ops.auto_deploy.trtllm_quant_finegrained_fp8_moe_fused)
             for n in gm_transformed.graph.nodes
         )
-        assert has_fused, "Expected trtllm_quant_hf_fp8_block_scale_moe_fused after fusion"
+        assert has_fused, "Expected trtllm_quant_finegrained_fp8_moe_fused after fusion"
 
         # Verify unfused op is removed
         still_has_unfused = any(
-            is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe)
+            is_op(n, torch.ops.auto_deploy.torch_quant_finegrained_fp8_moe)
             for n in gm_transformed.graph.nodes
         )
-        assert not still_has_unfused, "torch_quant_hf_fp8_moe should be replaced after fusion"
+        assert not still_has_unfused, (
+            "torch_quant_finegrained_fp8_moe should be replaced after fusion"
+        )
 
 
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
 @pytest.mark.skipif(not trtllm_ops_available(), reason="Requires TRTLLM ops")
-def test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness():
-    """Test functional correctness of fused HF FP8 MoE kernel vs unfused."""
+def test_trtllm_quant_finegrained_fp8_moe_fused_correctness():
+    """Test functional correctness of fused FineGrained FP8 MoE kernel vs unfused."""
     device = "cuda"
     dtype = torch.bfloat16
     torch.manual_seed(42)
 
     # Use sizes divisible by 128 for block scales
-    model = HFFP8MoEOpModel(
+    model = FineGrainedFP8MoEOpModel(
         hidden_size=512, intermediate_size=1536, num_experts=72, device=device
     ).to(device=device)
     model.gate = model.gate.to(dtype=dtype)
@@ -1459,7 +1461,7 @@ def test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness():
         gm_transformed = InferenceOptimizer(
             None,
             {
-                "fuse_hf_fp8_moe": {
+                "fuse_finegrained_fp8_moe": {
                     "stage": "post_load_fusion",
                 },
             },
@@ -1475,5 +1477,5 @@ def test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness():
             ref_output,
             atol=0.05,
             rtol=0.05,
-            msg="Fused HF FP8 MoE output differs from unfused reference",
+            msg="Fused FineGrained FP8 MoE output differs from unfused reference",
         )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -1229,3 +1229,251 @@ def test_split_moe_fused_for_sharding_load_hook():
     torch.testing.assert_close(actual_w1, expected_w1)
     torch.testing.assert_close(actual_w2, expected_w2)
     torch.testing.assert_close(actual_w3, expected_w3)
+
+
+# =============================================================================
+# HuggingFace FineGrainedFP8 MoE Tests
+# =============================================================================
+
+FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+class BlockSparseTop2MLPHFFP8(nn.Module):
+    """HuggingFace FineGrainedFP8 expert with per-block weight scales."""
+
+    def __init__(self, ffn_dim, hidden_dim, dtype=torch.bfloat16, device="cuda", block_size=None):
+        super().__init__()
+        self.ffn_dim = ffn_dim
+        self.hidden_dim = hidden_dim
+
+        if block_size is None:
+            block_n = min(128, ffn_dim)
+            block_k = min(128, hidden_dim)
+            block_size = [block_n, block_k]
+        self.block_size = block_size
+
+        # Create FP8 weights with per-block scales
+        self.w1_fp8, self.w1_scale_inv = self._create_fp8_weight(
+            ffn_dim, hidden_dim, block_size, device
+        )
+        self.w3_fp8, self.w3_scale_inv = self._create_fp8_weight(
+            ffn_dim, hidden_dim, block_size, device
+        )
+        # w2 has shape [hidden_dim, ffn_dim]
+        block_size_w2 = [min(128, hidden_dim), min(128, ffn_dim)]
+        self.w2_fp8, self.w2_scale_inv = self._create_fp8_weight(
+            hidden_dim, ffn_dim, block_size_w2, device
+        )
+
+        self.act_fn = F.silu
+
+    def _create_fp8_weight(self, out_features, in_features, block_size, device):
+        """Create FP8 weight with per-block scales."""
+        weight_fp32 = torch.randn(out_features, in_features, device=device) * 0.01
+
+        block_n, block_k = block_size
+        N, K = out_features, in_features
+
+        # Compute per-block scales
+        weight_reshaped = weight_fp32.view(N // block_n, block_n, K // block_k, block_k)
+        amax = weight_reshaped.abs().amax(dim=(1, 3)).to(torch.float32)
+        eps = torch.finfo(torch.float32).tiny
+        weight_scale_inv = torch.clamp(amax / FP8_MAX, min=eps)
+
+        # Quantize weight to FP8
+        weight_fp8 = (
+            weight_fp32.float()
+            / weight_scale_inv.repeat_interleave(block_n, dim=0).repeat_interleave(block_k, dim=1)
+        ).to(torch.float8_e4m3fn)
+
+        return (
+            nn.Parameter(weight_fp8, requires_grad=False),
+            weight_scale_inv,
+        )
+
+    def forward(self, hidden_states: torch.Tensor):
+        x = hidden_states
+        w1_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+            x,
+            self.w1_fp8,
+            bias=None,
+            input_scale=[],
+            weight_scale=[self.w1_scale_inv],
+            input_zp=[],
+            weight_zp=[],
+        )
+        w3_out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+            x,
+            self.w3_fp8,
+            bias=None,
+            input_scale=[],
+            weight_scale=[self.w3_scale_inv],
+            input_zp=[],
+            weight_zp=[],
+        )
+        fused = self.act_fn(w1_out) * w3_out
+        out = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+            fused,
+            self.w2_fp8,
+            bias=None,
+            input_scale=[],
+            weight_scale=[self.w2_scale_inv],
+            input_zp=[],
+            weight_zp=[],
+        )
+        return out
+
+
+class HFFP8MoEOpModel(nn.Module):
+    """MoE model using HuggingFace FineGrainedFP8 quantized experts with torch_quant_hf_fp8_moe op."""
+
+    def __init__(
+        self, hidden_size=256, intermediate_size=128, num_experts=4, top_k=2, device="cuda"
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+        self.gate = nn.Linear(hidden_size, num_experts)
+
+        # Create HF FP8 experts
+        self.experts = nn.ModuleList(
+            [
+                BlockSparseTop2MLPHFFP8(intermediate_size, hidden_size, device=device)
+                for _ in range(num_experts)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        router_logits = self.gate(x)
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        # Keep routing_weights as float32 - TRTLLM kernel expects this dtype
+        routing_weights = routing_weights.to(torch.float32)
+
+        # Collect per-expert weights and scales
+        w1_list = [expert.w1_fp8 for expert in self.experts]
+        w2_list = [expert.w2_fp8 for expert in self.experts]
+        w3_list = [expert.w3_fp8 for expert in self.experts]
+        w1_scale_list = [expert.w1_scale_inv for expert in self.experts]
+        w2_scale_list = [expert.w2_scale_inv for expert in self.experts]
+        w3_scale_list = [expert.w3_scale_inv for expert in self.experts]
+
+        out = torch.ops.auto_deploy.torch_quant_hf_fp8_moe(
+            x,
+            selected_experts,
+            routing_weights,
+            w1_list,
+            w2_list,
+            w3_list,
+            w1_scale_list,
+            w2_scale_list,
+            w3_scale_list,
+            is_gated_mlp=True,
+        )
+        return out
+
+    def get_input(self, device, dtype=torch.bfloat16):
+        """
+        fp8_blockscale_gemm_kernel requires expected_m > 64
+        expected_m = (num_tokens x top_k) / num_experts
+        min_num_tokens >=  kernel_threshold * num_experts / top_k
+        """
+        kernel_threshold = 64 * 2  # * 2 for cushion
+        num_tokens = int(kernel_threshold * self.num_experts / self.top_k)
+        return torch.randn(num_tokens, self.hidden_size, device=device, dtype=dtype)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+@pytest.mark.skipif(not trtllm_ops_available(), reason="Requires TRTLLM ops")
+def test_fuse_hf_fp8_moe():
+    """Test that fuse_hf_fp8_moe transforms torch_quant_hf_fp8_moe to fused op."""
+    device = "cuda"
+    # Use sizes divisible by 128 for block scales
+    model = HFFP8MoEOpModel(
+        hidden_size=512, intermediate_size=1536, num_experts=72, device=device
+    ).to(device=device)
+    model.gate = model.gate.to(dtype=torch.bfloat16)
+
+    x = model.get_input(device=device, dtype=torch.bfloat16)
+
+    with torch.inference_mode():
+        gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+        # Verify initial graph has torch_quant_hf_fp8_moe
+        has_unfused = any(
+            is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe) for n in gm.graph.nodes
+        )
+        assert has_unfused, "Expected torch_quant_hf_fp8_moe in initial graph"
+
+        # Apply fusion transform
+        gm_transformed = InferenceOptimizer(
+            None,
+            {
+                "fuse_hf_fp8_moe": {
+                    "stage": "post_load_fusion",
+                },
+            },
+        )(None, gm)
+
+        # Verify fused op is present
+        has_fused = any(
+            is_op(n, torch.ops.auto_deploy.trtllm_quant_hf_fp8_block_scale_moe_fused)
+            for n in gm_transformed.graph.nodes
+        )
+        assert has_fused, "Expected trtllm_quant_hf_fp8_block_scale_moe_fused after fusion"
+
+        # Verify unfused op is removed
+        still_has_unfused = any(
+            is_op(n, torch.ops.auto_deploy.torch_quant_hf_fp8_moe)
+            for n in gm_transformed.graph.nodes
+        )
+        assert not still_has_unfused, "torch_quant_hf_fp8_moe should be replaced after fusion"
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+@pytest.mark.skipif(not trtllm_ops_available(), reason="Requires TRTLLM ops")
+def test_trtllm_quant_hf_fp8_block_scale_moe_fused_correctness():
+    """Test functional correctness of fused HF FP8 MoE kernel vs unfused."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+
+    # Use sizes divisible by 128 for block scales
+    model = HFFP8MoEOpModel(
+        hidden_size=512, intermediate_size=1536, num_experts=72, device=device
+    ).to(device=device)
+    model.gate = model.gate.to(dtype=dtype)
+
+    x = model.get_input(device=device, dtype=dtype)
+
+    with torch.inference_mode():
+        # Get reference output from unfused model
+        ref_output = model(x)
+
+        # Export and apply fusion
+        gm = torch_export_to_gm(model, args=(x,), clone=True)
+        gm_transformed = InferenceOptimizer(
+            None,
+            {
+                "fuse_hf_fp8_moe": {
+                    "stage": "post_load_fusion",
+                },
+            },
+        )(None, gm)
+
+        # Get fused output
+        fused_output = gm_transformed(x)
+
+        # Compare outputs with tolerance for FP8 quantization
+        # FP8 with block scales can have ~5% relative error
+        torch.testing.assert_close(
+            fused_output,
+            ref_output,
+            atol=0.05,
+            rtol=0.05,
+            msg="Fused HF FP8 MoE output differs from unfused reference",
+        )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_fusion.py
@@ -22,6 +22,15 @@ def _has_fused_linear_fp8(gm):
     return found_fused and not found_ref
 
 
+def _has_fused_hf_fp8_linear(gm):
+    """Check if HF FP8 fake quant ops were replaced with TRT-LLM ops."""
+    found_fused = any(is_op(n, torch.ops.auto_deploy.trtllm_hf_fp8_linear) for n in gm.graph.nodes)
+    found_ref = any(
+        is_op(n, torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear) for n in gm.graph.nodes
+    )
+    return found_fused and not found_ref
+
+
 def _has_fused_linear_fp4(gm):
     found_fused = any(
         is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_linear) for n in gm.graph.nodes
@@ -115,6 +124,66 @@ class TinyFP4Ref(nn.Module):
         )
 
 
+class TinyHFFP8Ref(nn.Module):
+    """
+    A tiny module whose forward uses the HuggingFace FineGrained FP8 op:
+      torch_fake_quant_hf_fp8_linear(x, w_fp8, bias, [], [weight_scale_inv], [], [])
+
+    This simulates models like MiniMax M2 and DeepSeek that use HF's block-wise FP8.
+    """
+
+    def __init__(self, in_features=256, out_features=256, use_bias=True):
+        super().__init__()
+        # HF FP8 uses 128x128 block quantization, so dimensions must be multiples of 128
+        assert in_features % 128 == 0, "HF FP8 requires in_features % 128 == 0"
+        assert out_features % 128 == 0, "HF FP8 requires out_features % 128 == 0"
+        device = torch.device("cuda")
+
+        self.use_bias = use_bias
+        self.weight = nn.Parameter(
+            torch.rand(out_features, in_features, dtype=torch.bfloat16, device=device)
+        )
+        if use_bias:
+            self.bias = nn.Parameter(torch.rand(out_features, dtype=torch.bfloat16, device=device))
+        else:
+            self.register_parameter("bias", None)
+
+        # Compute block-wise FP8 quantization (128x128 blocks)
+        with torch.no_grad():
+            block_n, block_k = 128, 128
+            N, K = out_features, in_features
+
+            # Reshape to blocks and compute per-block max
+            weight_reshaped = self.weight.view(N // block_n, block_n, K // block_k, block_k)
+            amax = weight_reshaped.abs().amax(dim=(1, 3)).to(torch.float32)  # [N/128, K/128]
+
+            # Compute per-block scale (amax / 448 for FP8 E4M3)
+            FP8_MAX = 448.0
+            eps = torch.finfo(torch.float32).tiny
+            weight_scale_inv = torch.clamp(amax / FP8_MAX, min=eps)  # [N/128, K/128]
+
+            # Quantize weight to FP8
+            scale_expanded = weight_scale_inv.repeat_interleave(block_n, dim=0).repeat_interleave(
+                block_k, dim=1
+            )
+            w_fp8 = (self.weight.float() / scale_expanded).to(torch.float8_e4m3fn)
+
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale_inv", weight_scale_inv)
+
+    def forward(self, x):
+        bias = self.bias if self.use_bias else None
+        return torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear(
+            x,
+            self.weight_fp8,
+            bias,
+            [],  # input_scale unused
+            [self.weight_scale_inv],
+            [],  # input_zp unused
+            [],  # weight_zp unused
+        )
+
+
 @pytest.mark.parametrize("use_bias", [True, False])
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
 def test_fuse_quant_rewrites_fp8_linear(use_bias):
@@ -177,4 +246,43 @@ def test_fuse_quant_rewrites_fp4_linear(use_bias):
         False,  # strict_loading
         None,  # dynamic_shapes
         False,  # skip_output_assert
+    )
+
+
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.skipif(
+    not (fp8_compatible() and trtllm_ops_available()),
+    reason="Requires FP8 and TRT-LLM ops",
+)
+def test_fuse_quant_rewrites_hf_fp8_linear(use_bias):
+    """Test that torch_fake_quant_hf_fp8_linear is replaced with trtllm_hf_fp8_linear.
+
+    This tests the fusion transform for HuggingFace FineGrained FP8 models like
+    MiniMax M2 and DeepSeek, which use 128x128 block-wise FP8 quantization.
+    """
+    torch.manual_seed(0)
+    model = TinyHFFP8Ref(use_bias=use_bias).to("cuda")
+    x = torch.rand(3, 256, dtype=torch.bfloat16, device="cuda")
+
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm_transformed = InferenceOptimizer(
+        None,
+        {
+            "fuse_hf_fp8_linear": {"stage": "post_load_fusion", "backend": "trtllm"},
+        },
+    )(None, gm)
+    gm_transformed.to("cuda")
+
+    run_test_transformed_gm(
+        model,
+        x,
+        gm_transformed,
+        _has_fused_hf_fp8_linear,
+        lambda n: n,
+        0.1,  # atol - HF FP8 has some quantization error
+        0.05,  # rtol
+        False,  # test_load_hook
+        False,  # strict_loading
+        None,  # dynamic_shapes
+        True,  # skip_output_assert - skip numerical comparison for now
     )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -115,24 +115,24 @@ def test_quantization(quant_config, atol, rtol, num_p_og):
 
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
-def test_hf_fp8_quantization(bias):
-    """Test HuggingFace FineGrained FP8 quantization transform.
+def test_finegrained_fp8_quantization(bias):
+    """Test FineGrained FP8 quantization transform.
 
-    This tests the quantize_hf_fp8_linear_from_config transform which converts
-    linear layers to use the torch_fake_quant_hf_fp8_linear op with per-block
+    This tests the quantize_finegrained_fp8_linear_from_config transform which converts
+    linear layers to use the torch_fake_quant_finegrained_fp8_linear op with per-block
     quantization matching HuggingFace's FineGrainedFP8 format.
     """
     model = MLP(128, 256, 128).to(torch.float16).to("cuda")
     x = torch.randn(3, 128, dtype=torch.float16).to("cuda")
 
     quant_config = {"quant_method": "fp8"}
-    QUANT_OP = torch.ops.auto_deploy.torch_fake_quant_hf_fp8_linear
+    QUANT_OP = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear
 
     gm = torch_export_to_gm(model, args=(x,), clone=True)
     gm_transformed = InferenceOptimizer(
         DummyFactory(quant_config),
         {
-            "quantize_hf_fp8_linear_from_config": {
+            "quantize_finegrained_fp8_linear_from_config": {
                 "stage": "pattern_matcher",
             },
         },

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -113,9 +113,8 @@ def test_quantization(quant_config, atol, rtol, num_p_og):
     torch_export_to_gm(gm_transformed, args=(x,))
 
 
-@pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
-def test_finegrained_fp8_quantization(bias):
+def test_finegrained_fp8_quantization():
     """Test FineGrained FP8 quantization transform.
 
     This tests the quantize_finegrained_fp8_linear_from_config transform which converts


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added fine-grained FP8 quantization support for linear layers, enabling efficient inference on quantized models.
  * Introduced fine-grained FP8 Mixture of Experts (MoE) fusion for optimized kernel execution.
  * Extended tensor-parallel sharding support to handle fine-grained FP8 quantization.
  * Added checkpoint compatibility for fine-grained FP8 model formats.

* **Tests**
  * Added comprehensive test coverage for fine-grained FP8 quantization and MoE fusion across different hardware architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
