### PR TITLE
[None] [feat] Support DWDP for cuteDSL backend

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -205,17 +205,17 @@ class GatherGroupedGemmInputsHelper(GroupedGemmInputsHelper):
     - permuted_idx_to_expanded_idx specifies the gather pattern
     - Shape inference uses permuted_idx_to_expanded_idx size instead of a size
 
-    Input tensor layout:
-        0: a                       - Original input activation (not permuted)
-        1: b                       - Weight tensor
-        2: a_sf                    - Scale factor for a
-        3: b_sf                    - Scale factor for b
-        4: alpha                   - Per-expert scaling factor
-        5: tile_idx_to_group_idx   - Tile to expert mapping
-        6: tile_idx_to_mn_limit    - Tile M/N limits
-        7: permuted_idx_to_expanded_idx        - Token permutation mapping
-        8: num_non_exiting_tiles   - Number of valid tiles
-        9: global_sf               - Global scale factor
+    Input layout (positions 1, 3, 4 are lists for multi-B support):
+        0: a                               - tensor, original input activation
+        1: b_list                          - list of tensors, weight tensors
+        2: a_sf                            - tensor, scale factor for a
+        3: b_sf_list                       - list of tensors, scale factors for b
+        4: alpha_list                      - list of tensors, per-expert scaling factors
+        5: tile_idx_to_group_idx           - tensor, tile to expert mapping
+        6: tile_idx_to_mn_limit            - tensor, tile M/N limits
+        7: permuted_idx_to_expanded_idx    - tensor, token permutation mapping
+        8: num_non_exiting_tiles           - tensor, number of valid tiles
+        9: global_sf                       - tensor, global scale factor
     """
     # Override: use permuted_idx_to_expanded_idx for shape inference
     IDX_PERMUTED_IDX_TO_EXPANDED_IDX = 7
@@ -259,7 +259,7 @@ class GatherGroupedGemmInputsHelper(GroupedGemmInputsHelper):
             permuted_idx_to_expanded_idx.append(self.pad_val)
         return permuted_idx_to_expanded_idx
 
-    def inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+    def inputs_pre_hook(self, inputs: List) -> List:
         """Pre-hook for gather-based SwiGLU fusion kernel.
 
         Generates:
@@ -267,9 +267,22 @@ class GatherGroupedGemmInputsHelper(GroupedGemmInputsHelper):
             - tile_idx_to_mn_limit
             - permuted_idx_to_expanded_idx (for gather operation)
             - num_non_exiting_tiles
+
+        Input layout (positions 1, 3, 4 are lists):
+            0: a                               - tensor
+            1: b_list                          - list of tensors
+            2: a_sf                            - tensor
+            3: b_sf_list                       - list of tensors
+            4: alpha_list                      - list of tensors
+            5: tile_idx_to_group_idx           - tensor
+            6: tile_idx_to_mn_limit            - tensor
+            7: permuted_idx_to_expanded_idx    - tensor
+            8: num_non_exiting_tiles           - tensor
+            9: global_sf                       - tensor
         """
-        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, \
-            permuted_idx_to_expanded_idx, num_non_exiting_tiles, global_sf = inputs
+        a, b_list, a_sf, b_sf_list, alpha_list, tile_idx_to_group_idx, \
+            tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, \
+            num_non_exiting_tiles, global_sf = inputs
         # Verify permuted_idx_to_expanded_idx index matches the class constant
         assert inputs[
             self.
@@ -309,7 +322,7 @@ class GatherGroupedGemmInputsHelper(GroupedGemmInputsHelper):
             [num_non_exiting_tiles_val],
             dtype=num_non_exiting_tiles.dtype,
             device=num_non_exiting_tiles.device)
-        return (a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx,
+        return (a, b_list, a_sf, b_sf_list, alpha_list, tile_idx_to_group_idx,
                 tile_idx_to_mn_limit, permuted_idx_to_expanded_idx,
                 num_non_exiting_tiles, global_sf)
 
@@ -1825,13 +1838,23 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_cache = dict()
         tuning_config_cache = dict()
 
+        # Maximum number of B tensors supported (must match kernel's MAX_B_TENSORS)
+        MAX_B_TENSORS = 4
+
         def __init__(self,
                      num_experts: int,
                      top_k: int,
                      num_local_experts: int,
                      local_expert_offset: int,
                      tile_size: int,
-                     scaling_vector_size: int = 16):
+                     scaling_vector_size: int = 16,
+                     b_tensor_l_sizes: Optional[Tuple[int, ...]] = None):
+            """Initialize the runner.
+
+            Args:
+                b_tensor_l_sizes: Tuple of L sizes for each B tensor in multi-B mode.
+                    None for single-B mode. Used for kernel cache key.
+            """
             super().__init__()
             self.num_experts = num_experts
             self.top_k = top_k
@@ -1843,6 +1866,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 )
             self.tile_size = tile_size
             self.scaling_vector_size = scaling_vector_size
+            self.b_tensor_l_sizes = b_tensor_l_sizes
 
             if (sm_version := get_sm_version()) not in (100, 103):
                 raise ValueError(
@@ -1862,19 +1886,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.local_expert_offset,
                 self.tile_size,
                 self.scaling_vector_size,
+                self.b_tensor_l_sizes,
             )
 
         def get_valid_tactics(
             self,
-            inputs: List[torch.Tensor],
+            inputs: List,
             profile: OptimizationProfile,
             **kwargs,
         ) -> List[Tuple[int, int]]:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, *_ = inputs
+            # Tuning uses layout: a, b_list, a_sf, b_sf_list, alpha_list, ...
+            a = inputs[0]
+            b_list = inputs[1]  # List of B tensors
+            permuted_idx_to_expanded_idx = inputs[7]
             # m is the permuted size from permuted_idx_to_expanded_idx, not from a
             m = permuted_idx_to_expanded_idx.size(0)
             k = a.size(1) * 2
-            l, n = b.size(0), b.size(1)
+            l = sum(bi.size(0) for bi in b_list)
+            n = b_list[0].size(1)
 
             mma_tiler_mn_candidates = [(self.tile_size, 128),
                                        (self.tile_size, 256)]
@@ -1914,6 +1943,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                                        self.num_local_experts,
                                                        self.local_expert_offset,
                                                        self.tile_size)
+                # Tuning uses layout:
+                # a, b_list, a_sf, b_sf_list, alpha_list, tile_idx, tile_mn_limit, permuted_idx, ...
+                # Constraint indices adjusted for list inputs at positions 1, 3, 4
                 self.__class__.tuning_config_cache[key] = TuningConfig(
                     # Use permuted_idx_to_expanded_idx (IDX_SHAPE_INFER) for tuning
                     dynamic_tensor_specs=(DynamicTensorSpec(
@@ -1934,41 +1966,60 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 )
             return self.__class__.tuning_config_cache[key]
 
-        def forward(self, inputs: List[torch.Tensor],
+        def forward(self, inputs: List,
                     tactic: Optional[tuple]) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, global_sf = inputs
-            # Verify permuted_idx_to_expanded_idx index matches the class constant
-            assert inputs[
-                GatherGroupedGemmInputsHelper.
-                IDX_PERMUTED_IDX_TO_EXPANDED_IDX] is permuted_idx_to_expanded_idx
+            """Forward pass supporting both single tensor and list inputs.
+
+            Input layout (positions 1, 3, 4 are lists for multi-B support):
+                0: a                               - tensor
+                1: b_list                          - list of tensors
+                2: a_sf                            - tensor
+                3: b_sf_list                       - list of tensors
+                4: alpha_list                      - list of tensors
+                5: tile_idx_to_group_idx           - tensor
+                6: tile_idx_to_mn_limit            - tensor
+                7: permuted_idx_to_expanded_idx    - tensor
+                8: num_non_exiting_tiles           - tensor
+                9: global_sf                       - tensor
+            """
+            a, b_list, a_sf, b_sf_list, alpha_list, tile_idx_to_group_idx, \
+                tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, \
+                num_non_exiting_tiles, global_sf = inputs
+
+            num_b = len(b_list)
+            is_multi_b = num_b > 1
+            b_tensor_l_sizes = tuple(bi.size(0)
+                                     for bi in b_list) if is_multi_b else None
+
+            b0 = b_list[0]  # Use first B for shape inference
+
+            # Verify input dtypes and dimensions
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
-            assert b.dtype == torch.float4_e2m1fn_x2
-            assert b.dim() == 3
+            assert b0.dtype == torch.float4_e2m1fn_x2
+            assert b0.dim() == 3
             assert a_sf.dtype == torch.uint8
             assert a_sf.dim() == 2
-            assert b_sf.dtype == torch.uint8
-            assert b_sf.dim() == 3
-            assert alpha.dtype == torch.float32
-            assert alpha.dim() == 1
+            assert b_sf_list[0].dtype == torch.uint8
+            assert b_sf_list[0].dim() == 3
+            assert alpha_list[0].dtype == torch.float32
+            assert alpha_list[0].dim() == 1
 
             # a.size(0) is orig_m (original input size before gather)
             # permuted_idx_to_expanded_idx.size(0) is m (permuted size after gather)
             orig_m, k = a.size(0), a.size(1) * 2
             m = permuted_idx_to_expanded_idx.size(0)
-            l, n = b.size(0), b.size(1)
+            n = b0.size(1)
+            l = sum(bi.size(0) for bi in b_list)
             scale_k = k // self.scaling_vector_size
             interm_size = n // 2
+
             assert m % self.tile_size == 0
             assert k % (self.scaling_vector_size * 4) == 0
             assert n % (self.scaling_vector_size * 4 * 2) == 0
-            assert b.size(2) * 2 == k
+            assert b0.size(2) * 2 == k
             assert a_sf.size(0) == orig_m
             assert a_sf.size(1) == scale_k
-            assert b_sf.size(0) == l
-            assert b_sf.size(1) == n
-            assert b_sf.size(2) == scale_k
-            assert alpha.size(0) == l
 
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
@@ -1982,29 +2033,29 @@ if IS_CUTLASS_DSL_AVAILABLE:
             assert global_sf.dtype == torch.float32
             assert global_sf.numel() == 1
 
+            # Allocate output tensors
             c = torch.empty(m, interm_size // 2, dtype=a.dtype, device=a.device)
             c_sf = torch.empty(m * interm_size // self.scaling_vector_size,
                                dtype=a_sf.dtype,
                                device=a_sf.device)
 
+            # Create common pointers
             a_ptr = make_ptr(cutlass.Float4E2M1FN,
                              a.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            b_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             b.data_ptr(),
                              cute.AddressSpace.gmem,
                              assumed_align=32)
             a_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
                                 a_sf.data_ptr(),
                                 cute.AddressSpace.gmem,
                                 assumed_align=16)
-            b_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                b_sf.data_ptr(),
+            c_ptr = make_ptr(cutlass.Float4E2M1FN,
+                             c.data_ptr(),
+                             cute.AddressSpace.gmem,
+                             assumed_align=32)
+            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
+                                c_sf.data_ptr(),
                                 cute.AddressSpace.gmem,
                                 assumed_align=16)
-            alpha_ptr = make_ptr(cutlass.Float32, alpha.data_ptr(),
-                                 cute.AddressSpace.gmem)
             tile_idx_to_group_idx_ptr = make_ptr(
                 cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
                 cute.AddressSpace.gmem)
@@ -2019,14 +2070,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 cute.AddressSpace.gmem)
             global_sf_ptr = make_ptr(cutlass.Float32, global_sf.data_ptr(),
                                      cute.AddressSpace.gmem)
-            c_ptr = make_ptr(cutlass.Float4E2M1FN,
-                             c.data_ptr(),
-                             cute.AddressSpace.gmem,
-                             assumed_align=32)
-            c_sf_ptr = make_ptr(cutlass.Float8E4M3FN,
-                                c_sf.data_ptr(),
-                                cute.AddressSpace.gmem,
-                                assumed_align=16)
+
+            # Create B tensor pointers (tuple for multi-B, single for single-B)
+            b_ptr = tuple(
+                make_ptr(cutlass.Float4E2M1FN,
+                         bi.data_ptr(),
+                         cute.AddressSpace.gmem,
+                         assumed_align=32)
+                for bi in b_list) if is_multi_b else make_ptr(
+                    cutlass.Float4E2M1FN,
+                    b0.data_ptr(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=32)
+            b_sf_ptr = tuple(
+                make_ptr(cutlass.Float8E4M3FN,
+                         bsfi.data_ptr(),
+                         cute.AddressSpace.gmem,
+                         assumed_align=16)
+                for bsfi in b_sf_list) if is_multi_b else make_ptr(
+                    cutlass.Float8E4M3FN,
+                    b_sf_list[0].data_ptr(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=16)
+            alpha_ptr = tuple(
+                make_ptr(cutlass.Float32, ai.data_ptr(), cute.AddressSpace.gmem)
+                for ai in alpha_list) if is_multi_b else make_ptr(
+                    cutlass.Float32, alpha_list[0].data_ptr(),
+                    cute.AddressSpace.gmem)
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -2040,8 +2110,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
             assert mma_tiler_mn[
                 0] == self.tile_size, f"Tactic ({tactic}) is incompatible with tile size ({self.tile_size})"
 
+            # Cache key includes b_tensor_l_sizes (None for single-B, tuple for multi-B)
             cache_key = (self.scaling_vector_size, self.tile_size, self.top_k,
-                         mma_tiler_mn, cluster_shape_mn, raster_along_m)
+                         mma_tiler_mn, cluster_shape_mn, raster_along_m,
+                         b_tensor_l_sizes)
+
+            # Compile kernel if not cached
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
@@ -2050,31 +2124,28 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     vectorized_f32=True,
                     topk=self.top_k,
                     raster_along_m=raster_along_m,
+                    b_tensor_l_sizes=b_tensor_l_sizes,
                 )
-                # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
                     cluster_shape_mn[0] * cluster_shape_mn[1])
 
+                # Choose wrapper function based on mode
+                wrapper_fn = gemm.wrapper_multi_b if is_multi_b else gemm.wrapper
+
+                # Build compile arguments - differs only in B tensor args and l parameter
+                compile_args = [
+                    a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, c_sf_ptr,
+                    alpha_ptr, tile_idx_to_group_idx_ptr,
+                    tile_idx_to_mn_limit_ptr, permuted_idx_to_expanded_idx_ptr,
+                    num_non_exiting_tiles_ptr, global_sf_ptr, orig_m, m, n, k
+                ]
+                if not is_multi_b:
+                    compile_args.append(l)  # Single-B needs l parameter
+
                 compiled_gemm = cute.compile(
-                    gemm.wrapper,
-                    a_ptr,
-                    b_ptr,
-                    a_sf_ptr,
-                    b_sf_ptr,
-                    c_ptr,
-                    c_sf_ptr,
-                    alpha_ptr,
-                    tile_idx_to_group_idx_ptr,
-                    tile_idx_to_mn_limit_ptr,
-                    permuted_idx_to_expanded_idx_ptr,
-                    num_non_exiting_tiles_ptr,
-                    global_sf_ptr,
-                    orig_m,
-                    m,
-                    n,
-                    k,
-                    l,
+                    wrapper_fn,
+                    *compile_args,
                     tile_size=self.tile_size,
                     scaling_vector_size=self.scaling_vector_size,
                     max_active_clusters=max_active_clusters,
@@ -2084,26 +2155,18 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 compiled_gemm = self.__class__.kernel_cache[cache_key]
 
-            compiled_gemm(
-                a_ptr,
-                b_ptr,
-                a_sf_ptr,
-                b_sf_ptr,
-                c_ptr,
-                c_sf_ptr,
-                alpha_ptr,
-                tile_idx_to_group_idx_ptr,
-                tile_idx_to_mn_limit_ptr,
-                permuted_idx_to_expanded_idx_ptr,
-                num_non_exiting_tiles_ptr,
-                global_sf_ptr,
-                orig_m,
-                m,
-                n,
-                k,
-                l,
-                stream=stream,
-            )
+            # Execute kernel - same args as compile (without constexpr params)
+            exec_args = [
+                a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, c_sf_ptr, alpha_ptr,
+                tile_idx_to_group_idx_ptr, tile_idx_to_mn_limit_ptr,
+                permuted_idx_to_expanded_idx_ptr, num_non_exiting_tiles_ptr,
+                global_sf_ptr, orig_m, m, n, k
+            ]
+            if not is_multi_b:
+                exec_args.append(l)  # Single-B needs l parameter
+
+            compiled_gemm(*exec_args, stream=stream)
+
             return c, c_sf
 
     @torch.library.custom_op(
@@ -2112,10 +2175,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
         device_types="cuda")
     def cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell(
         input: torch.Tensor,
-        weight: torch.Tensor,
+        weight: List[torch.Tensor],
         input_scale: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
+        weight_scale: List[torch.Tensor],
+        alpha: List[torch.Tensor],
         tile_idx_to_group_idx: torch.Tensor,
         tile_idx_to_mn_limit: torch.Tensor,
         permuted_idx_to_expanded_idx: torch.Tensor,
@@ -2128,11 +2191,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
         tile_size: int,
         scaling_vector_size: int = 16,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """CuteDSL-based NVFP4 gather grouped GEMM with SwiGLU fusion.
+
+        Args:
+            weight: List of B tensors. Single-B mode: [b], multi-B mode: [b0, b1, ...].
+            weight_scale: List of scale tensors, matching weight.
+            alpha: List of alpha tensors, matching weight.
+        """
         tuner = AutoTuner.get()
+
+        # Infer b_tensor_l_sizes from weight
+        b_tensor_l_sizes = tuple(w.size(0)
+                                 for w in weight) if len(weight) > 1 else None
 
         runner = Sm100BlockScaledContiguousGatherGroupedGemmSwigluFusionRunner(
             num_experts, top_k, num_local_experts, local_expert_offset,
-            tile_size, scaling_vector_size)
+            tile_size, scaling_vector_size, b_tensor_l_sizes)
         inputs = [
             input, weight, input_scale, weight_scale, alpha,
             tile_idx_to_group_idx, tile_idx_to_mn_limit,
@@ -2145,17 +2219,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
             runner.get_tuning_config(),
             inputs,
         )
-        output = runner(inputs, tactic=best_tactic)
+
+        # Call forward with inputs list
+        output = runner.forward(inputs, tactic=best_tactic)
         return output
 
     @torch.library.register_fake(
         "trtllm::cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell")
     def _(
         input: torch.Tensor,
-        weight: torch.Tensor,
+        weight: List[torch.Tensor],
         input_scale: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
+        weight_scale: List[torch.Tensor],
+        alpha: List[torch.Tensor],
         tile_idx_to_group_idx: torch.Tensor,
         tile_idx_to_mn_limit: torch.Tensor,
         permuted_idx_to_expanded_idx: torch.Tensor,
@@ -2169,7 +2245,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         scaling_vector_size: int = 16,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         m = permuted_idx_to_expanded_idx.size(0)
-        n = weight.size(1)
+        n = weight[0].size(1)
         interm_size = n // 2
         output = torch.empty(m,
                              interm_size // 2,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
@@ -2074,84 +2074,220 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         )
                     else:
                         # Multi-B tensor - select based on expert_idx
-                        if expert_idx < self.b_tensor_l_offsets[1]:
-                            local_l = expert_idx - self.b_tensor_l_offsets[0]
-                            tBgB_slice = tBgB_0[(None, mma_tile_coord_mnl[1], None, local_l)]
-                            tBgSFB_slice = tBgSFB_0[(None, slice_n, None, local_l)]
-                            cute.copy(
-                                tma_atoms_b[0],
-                                tBgB_slice[(None, b_producer_state.count)],
-                                tBsB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=b_full_mcast_mask,
-                            )
-                            cute.copy(
-                                tma_atoms_sfb[0],
-                                tBgSFB_slice[(None, b_producer_state.count)],
-                                tBsSFB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=sfb_full_mcast_mask,
-                            )
-                        elif (
-                            cutlass.const_expr(self.num_b_tensors >= 2)
-                            and expert_idx < self.b_tensor_l_offsets[2]
-                        ):
-                            local_l = expert_idx - self.b_tensor_l_offsets[1]
-                            tBgB_slice = tBgB_1[(None, mma_tile_coord_mnl[1], None, local_l)]
-                            tBgSFB_slice = tBgSFB_1[(None, slice_n, None, local_l)]
-                            cute.copy(
-                                tma_atoms_b[1],
-                                tBgB_slice[(None, b_producer_state.count)],
-                                tBsB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=b_full_mcast_mask,
-                            )
-                            cute.copy(
-                                tma_atoms_sfb[1],
-                                tBgSFB_slice[(None, b_producer_state.count)],
-                                tBsSFB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=sfb_full_mcast_mask,
-                            )
-                        elif (
-                            cutlass.const_expr(self.num_b_tensors >= 3)
-                            and expert_idx < self.b_tensor_l_offsets[3]
-                        ):
-                            local_l = expert_idx - self.b_tensor_l_offsets[2]
-                            tBgB_slice = tBgB_2[(None, mma_tile_coord_mnl[1], None, local_l)]
-                            tBgSFB_slice = tBgSFB_2[(None, slice_n, None, local_l)]
-                            cute.copy(
-                                tma_atoms_b[2],
-                                tBgB_slice[(None, b_producer_state.count)],
-                                tBsB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=b_full_mcast_mask,
-                            )
-                            cute.copy(
-                                tma_atoms_sfb[2],
-                                tBgSFB_slice[(None, b_producer_state.count)],
-                                tBsSFB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=sfb_full_mcast_mask,
-                            )
+                        # Use nested const_expr ifs to avoid index out of range at compile time
+                        if cutlass.const_expr(self.num_b_tensors == 2):
+                            # Exactly 2 B tensors
+                            if expert_idx < self.b_tensor_l_offsets[1]:
+                                local_l_0 = expert_idx - self.b_tensor_l_offsets[0]
+                                cute.copy(
+                                    tma_atoms_b[0],
+                                    tBgB_0[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_0,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[0],
+                                    tBgSFB_0[(None, slice_n, b_producer_state.count, local_l_0)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            else:
+                                local_l_1 = expert_idx - self.b_tensor_l_offsets[1]
+                                cute.copy(
+                                    tma_atoms_b[1],
+                                    tBgB_1[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_1,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[1],
+                                    tBgSFB_1[(None, slice_n, b_producer_state.count, local_l_1)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                        elif cutlass.const_expr(self.num_b_tensors == 3):
+                            # Exactly 3 B tensors
+                            if expert_idx < self.b_tensor_l_offsets[1]:
+                                local_l_0 = expert_idx - self.b_tensor_l_offsets[0]
+                                cute.copy(
+                                    tma_atoms_b[0],
+                                    tBgB_0[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_0,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[0],
+                                    tBgSFB_0[(None, slice_n, b_producer_state.count, local_l_0)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            elif expert_idx < self.b_tensor_l_offsets[2]:
+                                local_l_1 = expert_idx - self.b_tensor_l_offsets[1]
+                                cute.copy(
+                                    tma_atoms_b[1],
+                                    tBgB_1[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_1,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[1],
+                                    tBgSFB_1[(None, slice_n, b_producer_state.count, local_l_1)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            else:
+                                local_l_2 = expert_idx - self.b_tensor_l_offsets[2]
+                                cute.copy(
+                                    tma_atoms_b[2],
+                                    tBgB_2[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_2,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[2],
+                                    tBgSFB_2[(None, slice_n, b_producer_state.count, local_l_2)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
                         else:
-                            local_l = expert_idx - self.b_tensor_l_offsets[3]
-                            tBgB_slice = tBgB_3[(None, mma_tile_coord_mnl[1], None, local_l)]
-                            tBgSFB_slice = tBgSFB_3[(None, slice_n, None, local_l)]
-                            cute.copy(
-                                tma_atoms_b[3],
-                                tBgB_slice[(None, b_producer_state.count)],
-                                tBsB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=b_full_mcast_mask,
-                            )
-                            cute.copy(
-                                tma_atoms_sfb[3],
-                                tBgSFB_slice[(None, b_producer_state.count)],
-                                tBsSFB_pipe,
-                                tma_bar_ptr=tma_bar,
-                                mcast_mask=sfb_full_mcast_mask,
-                            )
+                            # 4 B tensors
+                            if expert_idx < self.b_tensor_l_offsets[1]:
+                                local_l_0 = expert_idx - self.b_tensor_l_offsets[0]
+                                cute.copy(
+                                    tma_atoms_b[0],
+                                    tBgB_0[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_0,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[0],
+                                    tBgSFB_0[(None, slice_n, b_producer_state.count, local_l_0)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            elif expert_idx < self.b_tensor_l_offsets[2]:
+                                local_l_1 = expert_idx - self.b_tensor_l_offsets[1]
+                                cute.copy(
+                                    tma_atoms_b[1],
+                                    tBgB_1[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_1,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[1],
+                                    tBgSFB_1[(None, slice_n, b_producer_state.count, local_l_1)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            elif expert_idx < self.b_tensor_l_offsets[3]:
+                                local_l_2 = expert_idx - self.b_tensor_l_offsets[2]
+                                cute.copy(
+                                    tma_atoms_b[2],
+                                    tBgB_2[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_2,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[2],
+                                    tBgSFB_2[(None, slice_n, b_producer_state.count, local_l_2)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
+                            else:
+                                local_l_3 = expert_idx - self.b_tensor_l_offsets[3]
+                                cute.copy(
+                                    tma_atoms_b[3],
+                                    tBgB_3[
+                                        (
+                                            None,
+                                            mma_tile_coord_mnl[1],
+                                            b_producer_state.count,
+                                            local_l_3,
+                                        )
+                                    ],
+                                    tBsB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=b_full_mcast_mask,
+                                )
+                                cute.copy(
+                                    tma_atoms_sfb[3],
+                                    tBgSFB_3[(None, slice_n, b_producer_state.count, local_l_3)],
+                                    tBsSFB_pipe,
+                                    tma_bar_ptr=tma_bar,
+                                    mcast_mask=sfb_full_mcast_mask,
+                                )
 
                     b_producer_state.advance()
                     peek_ab_empty_status = cutlass.Boolean(1)
@@ -2598,27 +2734,35 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 expert_idx = mma_tile_coord_mnl[2]
 
                 # Select alpha from correct tensor based on expert_idx
+                # Initialize alpha_val first to avoid DSL "None prior to if" error
+                alpha_val = alpha_tuple[0][expert_idx - self.b_tensor_l_offsets[0]]
                 if cutlass.const_expr(self.num_b_tensors == 1):
-                    alpha_val = alpha_tuple[0][expert_idx]
-                else:
-                    if expert_idx < self.b_tensor_l_offsets[1]:
-                        local_idx = expert_idx - self.b_tensor_l_offsets[0]
-                        alpha_val = alpha_tuple[0][local_idx]
-                    elif (
-                        cutlass.const_expr(self.num_b_tensors >= 2)
+                    pass  # Already initialized above
+                elif cutlass.const_expr(self.num_b_tensors == 2):
+                    if expert_idx >= self.b_tensor_l_offsets[1]:
+                        alpha_val = alpha_tuple[1][expert_idx - self.b_tensor_l_offsets[1]]
+                elif cutlass.const_expr(self.num_b_tensors == 3):
+                    if (
+                        expert_idx >= self.b_tensor_l_offsets[1]
                         and expert_idx < self.b_tensor_l_offsets[2]
                     ):
-                        local_idx = expert_idx - self.b_tensor_l_offsets[1]
-                        alpha_val = alpha_tuple[1][local_idx]
+                        alpha_val = alpha_tuple[1][expert_idx - self.b_tensor_l_offsets[1]]
+                    elif expert_idx >= self.b_tensor_l_offsets[2]:
+                        alpha_val = alpha_tuple[2][expert_idx - self.b_tensor_l_offsets[2]]
+                else:
+                    # 4 B tensors
+                    if (
+                        expert_idx >= self.b_tensor_l_offsets[1]
+                        and expert_idx < self.b_tensor_l_offsets[2]
+                    ):
+                        alpha_val = alpha_tuple[1][expert_idx - self.b_tensor_l_offsets[1]]
                     elif (
-                        cutlass.const_expr(self.num_b_tensors >= 3)
+                        expert_idx >= self.b_tensor_l_offsets[2]
                         and expert_idx < self.b_tensor_l_offsets[3]
                     ):
-                        local_idx = expert_idx - self.b_tensor_l_offsets[2]
-                        alpha_val = alpha_tuple[2][local_idx]
-                    else:
-                        local_idx = expert_idx - self.b_tensor_l_offsets[3]
-                        alpha_val = alpha_tuple[3][local_idx]
+                        alpha_val = alpha_tuple[2][expert_idx - self.b_tensor_l_offsets[2]]
+                    elif expert_idx >= self.b_tensor_l_offsets[3]:
+                        alpha_val = alpha_tuple[3][expert_idx - self.b_tensor_l_offsets[3]]
 
                 #
                 # Slice to per mma tile index

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -519,11 +519,12 @@ class CuteDslFusedMoE(CutlassFusedMoE):
 
             torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_finalize_inplace_blackwell(
                 input=x.view(torch.float4_e2m1fn_x2),
-                weight=self.w2_weight.view(torch.float4_e2m1fn_x2),
+                weight=[self.w2_weight.view(torch.float4_e2m1fn_x2)],
                 input_scale=x_sf.view(torch.uint8),
-                weight_scale=self.quant_scales.fc2_weight_block.view(
-                    torch.uint8),
-                alpha=self.quant_scales.fc2_global,
+                weight_scale=[
+                    self.quant_scales.fc2_weight_block.view(torch.uint8)
+                ],
+                alpha=[self.quant_scales.fc2_global],
                 output=moe_output,
                 tile_idx_to_group_idx=tile_idx_to_expert_idx,
                 tile_idx_to_mn_limit=tile_idx_to_mn_limit,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -483,10 +483,10 @@ class CuteDslFusedMoE(CutlassFusedMoE):
 
         x, x_sf = torch.ops.trtllm.cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell(
             input=x.view(torch.float4_e2m1fn_x2),
-            weight=self.w3_w1_weight.view(torch.float4_e2m1fn_x2),
+            weight=[self.w3_w1_weight.view(torch.float4_e2m1fn_x2)],
             input_scale=x_sf.view(torch.uint8),
-            weight_scale=self.quant_scales.fc1_weight_block.view(torch.uint8),
-            alpha=self.quant_scales.fc1_global,
+            weight_scale=[self.quant_scales.fc1_weight_block.view(torch.uint8)],
+            alpha=[self.quant_scales.fc1_global],
             tile_idx_to_group_idx=tile_idx_to_expert_idx,
             tile_idx_to_mn_limit=tile_idx_to_mn_limit,
             permuted_idx_to_expanded_idx=permuted_idx_to_expanded_idx,

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -865,10 +865,10 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
     # Call gather kernel
     c, c_sf = torch.ops.trtllm.cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell(
         a,
-        b_interleaved,
+        [b_interleaved],
         a_sf_unswizzled,
-        b_sf_interleaved,
-        alpha,
+        [b_sf_interleaved],
+        [alpha],
         tile_idx_to_group_idx,
         tile_idx_to_mn_limit,
         permuted_idx_to_expanded_idx,

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -551,10 +551,10 @@ def test_nvfp4_grouped_gemm_finalize_blackwell(
 
     c = torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_finalize_blackwell(
         a,
-        b,
+        [b],
         a_sf,
-        b_sf,
-        alpha,
+        [b_sf],
+        [alpha],
         tile_idx_to_group_idx,
         tile_idx_to_mn_limit,
         permuted_idx_to_expanded_idx,

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -589,6 +589,35 @@ def test_nvfp4_grouped_gemm_finalize_blackwell(
     match_ratio = torch.isclose(c, c_ref, rtol=1.6e-2, atol=1e-5).sum().item() / c.numel()
     assert match_ratio > 0.99
 
+    if num_local_experts > 1:
+        split_sizes = (num_local_experts // 2, num_local_experts - num_local_experts // 2)
+        b_list = list(torch.split(b, split_sizes, dim=0))
+        b_sf_list = list(torch.split(b_sf, split_sizes, dim=0))
+        alpha_list = list(torch.split(alpha, split_sizes, dim=0))
+        c_multi = torch.ops.trtllm.cute_dsl_nvfp4_grouped_gemm_finalize_blackwell(
+            a,
+            b_list,
+            a_sf,
+            b_sf_list,
+            alpha_list,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            permuted_idx_to_expanded_idx,
+            num_non_exiting_tiles,
+            token_final_scales,
+            num_experts=num_experts,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+            local_expert_offset=0,
+            tile_size=tile_size,
+            output_dtype=torch.bfloat16,
+            scaling_vector_size=sf_vec_size,
+        )
+        multi_match_ratio = (
+            torch.isclose(c_multi, c_ref, rtol=1.6e-2, atol=1e-5).sum().item() / c_ref.numel()
+        )
+        assert multi_match_ratio > 0.99
+
 
 @pytest.mark.skipif(
     get_sm_version() not in (100, 103),
@@ -912,3 +941,44 @@ def test_nvfp4_gather_grouped_gemm_swiglu_blackwell(
         c_sf_valid = torch.cat(c_sf_valid)
         c_sf_ref_valid = torch.cat(c_sf_ref_valid)
         check_accuracy(c_sf_valid, c_sf_ref_valid, atol=1e-4, rtol=1e-4, percent=0.95)
+
+        if num_local_experts > 1:
+            split_sizes = (
+                num_local_experts // 2,
+                num_local_experts - num_local_experts // 2,
+            )
+            b_interleaved_list = list(torch.split(b_interleaved, split_sizes, dim=0))
+            b_sf_interleaved_list = list(torch.split(b_sf_interleaved, split_sizes, dim=0))
+            alpha_list = list(torch.split(alpha, split_sizes, dim=0))
+            c_multi, c_sf_multi = (
+                torch.ops.trtllm.cute_dsl_nvfp4_gather_grouped_gemm_swiglu_blackwell(
+                    a,
+                    b_interleaved_list,
+                    a_sf_unswizzled,
+                    b_sf_interleaved_list,
+                    alpha_list,
+                    tile_idx_to_group_idx,
+                    tile_idx_to_mn_limit,
+                    permuted_idx_to_expanded_idx,
+                    num_non_exiting_tiles,
+                    torch.tensor([1 / global_sf], dtype=torch.float32, device="cuda"),
+                    num_experts=num_experts,
+                    top_k=top_k,
+                    num_local_experts=num_local_experts,
+                    local_expert_offset=0,
+                    tile_size=tile_size,
+                    scaling_vector_size=sf_vec_size,
+                )
+            )
+            c_multi_valid = c_multi[:num_valid_permuted_tokens].view(torch.uint8)[valid_token_mask]
+            check_accuracy(c_multi_valid, c_ref_valid, atol=1e-4, rtol=1e-4, percent=0.95)
+
+            c_sf_multi_unswizzled = unswizzle_sf(
+                c_sf_multi, max_num_permuted_tokens, interm_size, sf_vec_size
+            )
+            c_sf_multi_valid = []
+            for i in range(num_valid_permuted_tokens):
+                if permuted_idx_to_expanded_idx[i].item() != helper.pad_val:
+                    c_sf_multi_valid.append(c_sf_multi_unswizzled[i])
+            c_sf_multi_valid = torch.cat(c_sf_multi_valid)
+            check_accuracy(c_sf_multi_valid, c_sf_ref_valid, atol=1e-4, rtol=1e-4, percent=0.95)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
