### PR TITLE
[TRTLLM-10308][feat] AutoTuner Cache: reorganize cache file for distributed tuning

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -356,10 +356,22 @@ class AutoTunerProfilingCache:
         - Use save_cache() to save the cache after tuning
         - Use load_cache() to restore cached results before inference
         - JSON format provides human-readable output and cross-platform compatibility
+
+    Cache organization:
+        - Ops with INDEPENDENT strategy are stored per-rank (rank_0, rank_1, ...)
+        - Ops with non-INDEPENDENT strategy (BROADCAST, MERGE, PARALLEL) are stored
+          in a shared dict since all ranks share the same tuning results
     """
+
+    # Key for shared cache entries (non-INDEPENDENT ops)
+    SHARED_CACHE_KEY = "shared"
 
     def __init__(self):
         self.cache: Dict[Tuple, Tuple] = dict()
+
+        # Track which ops use which distributed strategy
+        # Maps custom_op name -> DistributedTuningStrategy
+        self._op_strategy_map: Dict[str, DistributedTuningStrategy] = {}
 
         # Cache metadata for local storage and validation
         self.lib_version = tensorrt_llm.__version__
@@ -379,6 +391,7 @@ class AutoTunerProfilingCache:
 
     def clear(self) -> None:
         self.cache.clear()
+        self._op_strategy_map.clear()
 
     def fallback_entry(self) -> Tuple:
         # runner_id = 0, tactic = -1
@@ -443,11 +456,46 @@ class AutoTunerProfilingCache:
     def get_specific_custom_op(self, custom_op: str) -> Dict[Tuple, Tuple]:
         return {k: v for k, v in self.cache.items() if k[0] == custom_op}
 
+    def update_op_strategy(self, custom_op: str,
+                           strategy: DistributedTuningStrategy) -> None:
+        self._op_strategy_map[custom_op] = strategy
+
+    def _is_independent_op(self, custom_op: str) -> bool:
+        strategy = self._op_strategy_map.get(
+            custom_op, DistributedTuningStrategy.INDEPENDENT)
+        return strategy == DistributedTuningStrategy.INDEPENDENT
+
+    def _partition_cache_by_strategy(
+            self) -> Tuple[Dict[Tuple, Tuple], Dict[Tuple, Tuple]]:
+        """Partition cache entries into shared and rank-specific caches.
+
+        Returns:
+            A tuple of (shared_cache, rank_cache) where:
+            - shared_cache: entries for non-INDEPENDENT ops (BROADCAST, MERGE, PARALLEL)
+            - rank_cache: entries for INDEPENDENT ops
+        """
+        shared_cache = {}
+        rank_cache = {}
+
+        for key, value in self.cache.items():
+            custom_op = key[0]  # First element of cache key is custom_op name
+            if self._is_independent_op(custom_op):
+                rank_cache[key] = value
+            else:
+                shared_cache[key] = value
+
+        return shared_cache, rank_cache
+
     def save_cache(self, file_path: Union[str, Path], rank: int) -> None:
         """Save the profiling cache to disk in JSON format.
 
+        Cache entries are organized based on distributed strategy:
+        - INDEPENDENT ops are saved per-rank (rank_0, rank_1, ...)
+        - Non-INDEPENDENT ops (BROADCAST, MERGE, PARALLEL) are saved in a shared dict
+
         Args:
             file_path: Path where to save the cache
+            rank: The rank of the current process
 
         Raises:
             IOError: If file cannot be written
@@ -460,7 +508,12 @@ class AutoTunerProfilingCache:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            serialized_rank_cache_data = self._serialize_cache_data()
+            # Partition cache into shared (non-INDEPENDENT) and rank-specific (INDEPENDENT)
+            shared_cache, rank_cache = self._partition_cache_by_strategy()
+
+            serialized_shared_cache = self._serialize_cache_data(shared_cache)
+            serialized_rank_cache = self._serialize_cache_data(rank_cache)
+
             with open(file_path, 'a+') as f:
                 fcntl.flock(f, fcntl.LOCK_EX)
                 f.seek(0)
@@ -473,7 +526,16 @@ class AutoTunerProfilingCache:
                     }
                 f.seek(0)
                 f.truncate()
-                current_cache[f"rank_{rank}"] = serialized_rank_cache_data
+
+                # Merge shared cache entries (non-INDEPENDENT ops)
+                if self.SHARED_CACHE_KEY not in current_cache:
+                    current_cache[self.SHARED_CACHE_KEY] = {}
+                current_cache[self.SHARED_CACHE_KEY].update(
+                    serialized_shared_cache)
+
+                # Save rank-specific cache entries (INDEPENDENT ops)
+                current_cache[f"rank_{rank}"] = serialized_rank_cache
+
                 json.dump(current_cache, f, indent=2, default=str)
             logger.info(
                 f"[AutoTuner] Successfully saved cache to {file_path} using JSON format"
@@ -485,8 +547,12 @@ class AutoTunerProfilingCache:
     def load_cache(self, file_path: Union[str, Path], rank: int) -> None:
         """Load the profiling cache from disk in JSON format.
 
+        Loads both shared cache entries (non-INDEPENDENT ops) and rank-specific
+        entries (INDEPENDENT ops) and merges them into the current cache.
+
         Args:
             file_path: Path to the cache file
+            rank: The rank of the current process
 
         Raises:
             FileNotFoundError: If cache file doesn't exist
@@ -505,10 +571,31 @@ class AutoTunerProfilingCache:
                 fcntl.flock(f, fcntl.LOCK_SH)
                 current_cache_contents = json.load(f)
                 self._deserialize_metadata(current_cache_contents["metadata"])
-            self.cache = self._deserialize_cache_data(
-                current_cache_contents.get(f'rank_{rank}', {}))
+
+            # Start with empty cache
+            self.cache = {}
+
+            # Load shared cache entries (non-INDEPENDENT ops)
+            if self.SHARED_CACHE_KEY in current_cache_contents:
+                shared_cache = self._deserialize_cache_data(
+                    current_cache_contents[self.SHARED_CACHE_KEY])
+                self.cache.update(shared_cache)
+                logger.debug(
+                    f"[AutoTuner] Loaded {len(shared_cache)} shared cache entries"
+                )
+
+            # Load rank-specific cache entries (INDEPENDENT ops)
+            rank_key = f"rank_{rank}"
+            if rank_key in current_cache_contents:
+                rank_cache = self._deserialize_cache_data(
+                    current_cache_contents[rank_key])
+                self.cache.update(rank_cache)
+                logger.debug(
+                    f"[AutoTuner] Loaded {len(rank_cache)} rank-specific cache entries for rank {rank}"
+                )
+
             logger.info(
-                f"[AutoTuner] Successfully loaded cache from {file_path} using JSON format"
+                f"[AutoTuner] Successfully loaded cache from {file_path} using JSON format (total {len(self.cache)} entries)"
             )
         except Exception as e:
             logger.error(f"[AutoTuner] Failed to load cache with JSON: {e}")
@@ -528,8 +615,13 @@ class AutoTunerProfilingCache:
         self.device_name = metadata["device_name"]
         self.device_capability = metadata["device_capability"]
 
-    def _serialize_cache_data(self) -> Dict[str, Any]:
+    def _serialize_cache_data(self,
+                              cache: Optional[Dict[Tuple, Tuple]] = None
+                              ) -> Dict[str, Any]:
         """Convert the profiling cache to a JSON-serializable format.
+
+        Args:
+            cache: Optional cache dict to serialize. If None, uses self.cache.
 
         Returns:
             Dictionary that can be serialized to JSON
@@ -538,9 +630,12 @@ class AutoTunerProfilingCache:
             This method handles the conversion of complex objects to JSON-compatible
             representations. Some type information may be lost in the conversion.
         """
+        if cache is None:
+            cache = self.cache
+
         serializable_cache = {}
 
-        for key, value in self.cache.items():
+        for key, value in cache.items():
             # Convert any simple object to string for JSON compatibility
             key_str = str(key)
             runner_id, tactic, min_time = value
@@ -846,6 +941,9 @@ class AutoTuner:
         # Record the distributed tuning strategy for the custom_op
         self._map_op_to_distributed_strategy[
             custom_op] = tuning_config.distributed_tuning_strategy
+        # Also update the cache's strategy map for save/load partitioning
+        self.profiling_cache.update_op_strategy(
+            custom_op, tuning_config.distributed_tuning_strategy)
 
         tuning_start_time = time.perf_counter()
         profiles = self._optimization_profiles(tuning_config, inputs)

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 import os
 import pickle
 import sys
@@ -736,7 +737,10 @@ def _distributed_worker_function(world_size, strategy):
         # Each rank prefers different tactics
         prefer_tactics = [rank]
     runner = DistributedGemmRunner(prefer_tactics=prefer_tactics)
+    runner_independent = DistributedGemmRunner()
     config = TuningConfig(distributed_tuning_strategy=strategy)
+    config_independent = TuningConfig(
+        distributed_tuning_strategy=DistributedTuningStrategy.INDEPENDENT)
 
     # Keep temp_dir in function scope to prevent premature garbage collection
     temp_dir = None
@@ -749,40 +753,84 @@ def _distributed_worker_function(world_size, strategy):
         cache_path = dist.broadcast(None, root=0)
 
     with autotune(cache_path=cache_path):
-        tuner.choose_one(custom_op=f"test_distributed_{strategy}",
+        tuner.choose_one(custom_op=f"test_distributed_{strategy.value}",
                          runners=[runner],
                          tuning_config=config,
+                         inputs=inputs)
+        # run another normal gemm with INDEPENDENT strategy
+        tuner.choose_one(custom_op=f"test_distributed_normal_gemm",
+                         runners=[runner_independent],
+                         tuning_config=config_independent,
                          inputs=inputs)
 
     # Check only one file is created in the cache path
     assert len(os.listdir(os.path.dirname(
         cache_path))) == 1, "Only one rank file should be created"
 
+    dist.barrier()
+
     # Check cache for distributed tuning
     AutoTuner.get().profiling_cache.clear()
     AutoTuner.get().profiling_cache.load_cache(cache_path, rank)
 
     selected_runner, best_tactic = tuner.choose_one(
-        custom_op=f"test_distributed_{strategy}",
+        custom_op=f"test_distributed_{strategy.value}",
         runners=[runner],
         tuning_config=config,
         inputs=inputs)
 
+    # Verify cache file structure based on distributed strategy
+    with open(cache_path, 'r') as f:
+        cache_data = json.load(f)
+
+    # Helper to check if an op name appears in any cache key string
+    def has_op_in_section(section_data: dict, op_name: str) -> bool:
+        return any(op_name in key_str for key_str in section_data.keys())
+
+    assert 'metadata' in cache_data, "Metadata should be present"
+    assert f'rank_{rank}' in cache_data, f"rank {rank} should be present"
+
+    # The INDEPENDENT op "test_distributed_normal_gemm" should always be in rank-specific sections
+    assert has_op_in_section(cache_data[f'rank_{rank}'], 'test_distributed_normal_gemm'), \
+        f"rank {rank} should have test_distributed_normal_gemm"
+
+    if strategy == DistributedTuningStrategy.INDEPENDENT:
+        # Both ops use INDEPENDENT strategy, so no shared section
+        assert 'shared' not in cache_data or len(cache_data.get('shared', {})) == 0, \
+            "shared should not be present or be empty for INDEPENDENT strategy"
+        # Each rank should have 2 entries (the parameterized op + normal_gemm)
+        assert len(cache_data[f'rank_{rank}']) == 2, \
+            f"rank {rank} should have 2 entries, got {len(cache_data[f'rank_{rank}'])}"
+        assert has_op_in_section(cache_data[f'rank_{rank}'], f'test_distributed_{strategy.value}'), \
+            f"rank {rank} should have test_distributed_{strategy.value}"
+    else:
+        # Non-INDEPENDENT ops go to shared section
+        assert 'shared' in cache_data, "shared section should be present"
+        # Each rank should have only 1 entry (the normal_gemm with INDEPENDENT strategy)
+        assert len(cache_data[f'rank_{rank}']) == 1, \
+            f"rank {rank} should have 1 entry, got {len(cache_data[f'rank_{rank}'])}"
+        # The parameterized op should NOT be in rank-specific section
+        assert not has_op_in_section(cache_data[f'rank_{rank}'], f'test_distributed_{strategy.value}'), \
+            f"rank {rank} should not have test_distributed_{strategy.value}"
+        # The parameterized op should be in shared section
+        assert has_op_in_section(cache_data['shared'], f'test_distributed_{strategy.value}'), \
+            f"shared should have test_distributed_{strategy.value}"
+
     if strategy == DistributedTuningStrategy.BROADCAST:
         # All ranks should select tactic 0
-        assert best_tactic == 0
+        assert best_tactic == 0, f"Rank {rank} with {strategy} should select tactic 0, got {best_tactic}"
     elif strategy == DistributedTuningStrategy.INDEPENDENT:
         # Each rank should select the tactic it prefers
-        assert best_tactic == rank
+        assert best_tactic == rank, f"Rank {rank} with {strategy} should select tactic {rank}, got {best_tactic}"
     elif strategy == DistributedTuningStrategy.MERGE:
         # Because tactic 0 is slower, two ranks should always select tactic 1
-        assert best_tactic == 1
+        assert best_tactic == 1, f"Rank {rank} with {strategy} should select tactic 1, got {best_tactic}"
     elif strategy == DistributedTuningStrategy.PARALLEL:
         # Tactic 1 or 3 should be selected since they are faster.
         # TODO: This might not cover the case that rank1 tunes nothing
-        assert best_tactic % 2 == 1
+        assert best_tactic % 2 == 1, f"Rank {rank} with {strategy} should select tactic 1, got {best_tactic}"
     else:
-        assert False, f"Unknown strategy: {strategy}"
+        assert False, f"Rank {rank} got unknown strategy: {strategy}"
 
     dist.barrier()
     return True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced profiling cache with distributed-aware partitioning that automatically organizes and manages cache entries based on tuning strategies, improving performance optimization for distributed execution scenarios.

* **Tests**
  * Added comprehensive cache validation tests to verify correct organization and distribution of cached entries across distributed tuning configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
