### PR TITLE
[None][infra] Add source code pulse scan to PLC nightly pipeline

### DIFF
--- a/examples/scaffolding/contrib/mcp/weather/uv.lock
+++ b/examples/scaffolding/contrib/mcp/weather/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "mcp"
+version = "0.1.0"
+source = { virtual = "." }

--- a/jenkins/TensorRT_LLM_PLC.groovy
+++ b/jenkins/TensorRT_LLM_PLC.groovy
@@ -183,6 +183,12 @@ def pulseScan(llmRepo, branchName) {
         }
         sh "ls"
         sh "cat nspect_scan_report.json"
+        withCredentials([string(credentialsId: 'trtllm_plc_slack_webhook', variable: 'PLC_SLACK_WEBHOOK')]) {
+            def jobPath = env.JOB_NAME.replaceAll("/", "%2F")
+            def pipelineUrl = "${env.JENKINS_URL}blue/organizations/jenkins/${jobPath}/detail/${jobPath}/${env.BUILD_NUMBER}/pipeline"
+            sh "export TRTLLM_PLC_WEBHOOK=${PLC_SLACK_WEBHOOK}"
+            sh "python ./jenkins/scripts/submit_vulnerability_report.py --build-url ${pipelineUrl}"
+        }
     }
 }
 

--- a/jenkins/TensorRT_LLM_PLC.groovy
+++ b/jenkins/TensorRT_LLM_PLC.groovy
@@ -51,7 +51,6 @@ def createKubernetesPodConfig()
                 qosClass: Guaranteed
         """.stripIndent(),
     ]
-
     return podConfig
 }
 
@@ -75,8 +74,6 @@ def checkoutSource ()
 {
     def LLM_REPO = getLLMRepo()
     sh "git config --global --add safe.directory ${env.WORKSPACE}"
-    sh "git config --global user.email \"90828364+tensorrt-cicd@users.noreply.github.com\""
-    sh "git config --global user.name \"TensorRT LLM\""
     trtllm_utils.checkoutSource(LLM_REPO, params.branchName, env.WORKSPACE, false, true)
 }
 
@@ -102,6 +99,9 @@ def generateLockFiles(llmRepo, branchName)
         sh "python3 --version"
         sh "curl -sSL https://install.python-poetry.org | python3 -"
         sh "/root/.local/bin/poetry -h"
+        sh "git config --global --add safe.directory ${env.WORKSPACE}"
+        sh "git config --global user.email \"90828364+tensorrt-cicd@users.noreply.github.com\""
+        sh "git config --global user.name \"TensorRT LLM\""
         sh "export PATH=\"/root/.local/bin:\$PATH\" && python3 scripts/generate_lock_file.py"
         def count = sh(script: "git status --porcelain security_scanning/ | wc -l", returnStdout: true).trim()
         echo "Changed/untracked file count: ${count}"

--- a/jenkins/TensorRT_LLM_PLC.groovy
+++ b/jenkins/TensorRT_LLM_PLC.groovy
@@ -186,8 +186,13 @@ def pulseScan(llmRepo, branchName) {
         withCredentials([string(credentialsId: 'trtllm_plc_slack_webhook', variable: 'PLC_SLACK_WEBHOOK')]) {
             def jobPath = env.JOB_NAME.replaceAll("/", "%2F")
             def pipelineUrl = "${env.JENKINS_URL}blue/organizations/jenkins/${jobPath}/detail/${jobPath}/${env.BUILD_NUMBER}/pipeline"
-            sh "export TRTLLM_PLC_WEBHOOK=${PLC_SLACK_WEBHOOK}"
-            sh "python ./jenkins/scripts/submit_vulnerability_report.py --build-url ${pipelineUrl}"
+            sh """
+                export TRTLLM_PLC_WEBHOOK=${PLC_SLACK_WEBHOOK}
+                python3 -m venv venv
+                source venv/bin/activate
+                pip install requests
+                python ./jenkins/scripts/submit_vulnerability_report.py --build-url ${pipelineUrl}
+            """
         }
     }
 }

--- a/jenkins/TensorRT_LLM_PLC.groovy
+++ b/jenkins/TensorRT_LLM_PLC.groovy
@@ -163,22 +163,22 @@ def pulseScan(llmRepo, branchName) {
             ),
             string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')
         ]) {
-            trtllm_utils.llmExecStepWithRetry(this, script: "docker login gitlab-master.nvidia.com:5005 -u ${USERNAME} -p ${PASSWORD}")
-        }
-        docker.withRegistry('https://gitlab-master.nvidia.com:5005') {
-            docker.image("pstooling/pulse-group/pulse-open-source-scanner/pulse-oss-cli:stable")
-              .inside("--user 0 --privileged -v /var/run/docker.sock:/var/run/docker.sock") {
-                withEnv([
-                    "PULSE_NSPECT_ID=NSPECT-95LK-6FZF",
-                    "PULSE_BEARER_TOKEN=${token}",
-                    "PULSE_REPO_URL=${llmRepo}",
-                    "PULSE_SCAN_PROJECT=TRT-LLM",
-                    "PULSE_SCAN_PROJECT_VERSION=${branchName}",
-                    "PULSE_SCAN_VULNERABILITY_REPORT=nspect_scan_report.json"
-                ]) {
-                    sh 'pulse scan --no-fail .'
-                }
-              }
+            trtllm_utils.llmExecStepWithRetry(this, script: "docker login ${DEFAULT_GIT_URL}:5005 -u ${USERNAME} -p ${PASSWORD}")
+            docker.withRegistry("https://${DEFAULT_GIT_URL}:5005") {
+                docker.image("pstooling/pulse-group/pulse-open-source-scanner/pulse-oss-cli:stable")
+                  .inside("--user 0 --privileged -v /var/run/docker.sock:/var/run/docker.sock") {
+                    withEnv([
+                        "PULSE_NSPECT_ID=NSPECT-95LK-6FZF",
+                        "PULSE_BEARER_TOKEN=${token}",
+                        "PULSE_REPO_URL=${llmRepo}",
+                        "PULSE_SCAN_PROJECT=TRT-LLM",
+                        "PULSE_SCAN_PROJECT_VERSION=${branchName}",
+                        "PULSE_SCAN_VULNERABILITY_REPORT=nspect_scan_report.json"
+                    ]) {
+                        sh 'pulse scan --no-fail .'
+                    }
+                  }
+            }
         }
         sh "ls"
         sh "cat nspect_scan_report.json"

--- a/jenkins/TensorRT_LLM_PLC.groovy
+++ b/jenkins/TensorRT_LLM_PLC.groovy
@@ -14,7 +14,6 @@ def createKubernetesPodConfig()
             apiVersion: v1
             kind: Pod
             spec:
-                qosClass: Guaranteed
                 nodeSelector: ${selectors}
                 containers:
                   - name: alpine
@@ -89,7 +88,7 @@ def getPulseToken() {
         usernameVariable: 'SF_CLIENT_ID',
         passwordVariable: 'SF_CLIENT_SECRET'
     )]) {
-        AuthHeader = sh(script: "echo -n $SF_CLIENT_ID:$SF_CLIENT_SECRET | base64 -w0", returnStdout: true).trim()
+        def AuthHeader = sh(script: "set +x && echo -n $SF_CLIENT_ID:$SF_CLIENT_SECRET | base64 -w0", returnStdout: true).trim()
         token= sh(script: "curl -s --request POST --header \"Authorization: Basic ${AuthHeader}\" --header \"Content-Type: application/x-www-form-urlencoded\" \"https://4ubglassowmtsi7ogqwarmut7msn1q5ynts62fwnr1i.ssa.nvidia.com/token?grant_type=client_credentials&scope=verify:nspectid%20sourcecode:blackduck%20update:report\" | jq \".access_token\" |  tr -d '\"'", returnStdout: true).trim()
     }
     return token

--- a/jenkins/scripts/submit_vulnerability_report.py
+++ b/jenkins/scripts/submit_vulnerability_report.py
@@ -54,5 +54,5 @@ payload = {"report": message_text, "pipelineUrl": args.build_url}
 
 print(payload)
 # Send to Slack
-resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
+resp = requests.post(SLACK_WEBHOOK_URL, json=payload, timeout=60)
 resp.raise_for_status()

--- a/jenkins/scripts/submit_vulnerability_report.py
+++ b/jenkins/scripts/submit_vulnerability_report.py
@@ -17,7 +17,7 @@ args = parser.parse_args()
 
 # Throw error if not set
 if not SLACK_WEBHOOK_URL:
-    raise EnvironmentError("❌ Environment variable 'TRTLLM_PLC_WEBHOOK' is not set!")
+    raise EnvironmentError("Error: Environment variable 'TRTLLM_PLC_WEBHOOK' is not set!")
 
 # Read file
 raw_input = Path(INPUT_FILE).read_text()
@@ -29,7 +29,7 @@ def safe(value, default="N/A"):
 
 
 # Build attachment text
-message_lines = ["*🔐 TensorRT LLM Source Code Vulnerability Scan Report*\n"]
+message_lines = ["* TensorRT LLM Source Code Vulnerability Scan Report*\n"]
 
 severity_rank = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1}
 

--- a/jenkins/scripts/submit_vulnerability_report.py
+++ b/jenkins/scripts/submit_vulnerability_report.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import requests
 
+# slack workflow setting can be edited at https://slack.com/shortcuts/Ft0AAER075L3/a314cf6f4a81543cc37b75702c5d10f1
 SLACK_WEBHOOK_URL = os.environ.get("TRTLLM_PLC_WEBHOOK")
+# this json file will be generated from pulse in pipeline scanning
 INPUT_FILE = "./nspect_scan_report.json"
 
 parser = argparse.ArgumentParser()
@@ -27,7 +29,7 @@ def safe(value, default="N/A"):
 
 
 # Build attachment text
-message_lines = ["*🔐 Vulnerability Scan Report*\n"]
+message_lines = ["*🔐 TensorRT LLM Source Code Vulnerability Scan Report*\n"]
 
 severity_rank = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1}
 

--- a/jenkins/scripts/submit_vulnerability_report.py
+++ b/jenkins/scripts/submit_vulnerability_report.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+import requests
+
+SLACK_WEBHOOK_URL = os.environ.get("TRTLLM_PLC_WEBHOOK")
+INPUT_FILE = "./nspect_scan_report.json"
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--build-url", required=True, help="Jenkins build URL")
+
+args = parser.parse_args()
+
+# Throw error if not set
+if not SLACK_WEBHOOK_URL:
+    raise EnvironmentError("❌ Environment variable 'TRTLLM_PLC_WEBHOOK' is not set!")
+
+# Read file
+raw_input = Path(INPUT_FILE).read_text()
+vulnerabilities = json.loads(raw_input)
+
+
+def safe(value, default="N/A"):
+    return value if value else default
+
+
+# Build attachment text
+message_lines = ["*🔐 Vulnerability Scan Report*\n"]
+
+severity_rank = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1}
+
+for v in vulnerabilities:
+    sev = v.get("Severity", "Low")
+    if severity_rank.get(sev, 0) <= 2:
+        continue
+    shortTermVersion = safe(v.get("Upgrade-Guidance", {}).get("Short-Term"))
+    longTermVersion = safe(v.get("Upgrade-Guidance", {}).get("Long-Term"))
+    lines = [
+        f"🔴 *{safe(v.get('Severity'))}* — *{safe(v.get('Package Name'))}* `{safe(v.get('Package Version'))}`",
+        f"• *CVE:* {safe(v.get('Related Vuln'))} | *BDSA:* {safe(v.get('CVE ID'))}",
+        f"• *Score:* {safe(v.get('Score'))}",
+        f"• *Status:* {safe(v.get('Status'))}",
+        f"• *Published:* {safe(v.get('Vulnerability Published Date'))}",
+        f"• *Upgrade:* `{shortTermVersion}` → `{longTermVersion}`",
+        "─" * 40,  # separator line
+    ]
+    message_lines.extend(lines)
+
+message_text = "\n".join(message_lines)
+
+payload = {"report": message_text, "pipelineUrl": args.build_url}
+
+print(payload)
+# Send to Slack
+resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
+resp.raise_for_status()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Pulse OSS scanning for dependency vulnerability detection within the CI/CD pipeline.
  * Added automated vulnerability report generation and posting to Slack notifications.
  * Enhanced pipeline structure with explicit stages for environment preparation, lock file generation, and security scanning.
  * Improved Docker container runtime with expanded resource limits and enhanced capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add source code vulnerability scanning in TRTLLM PLC nightly pipeline

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
