### PR TITLE
[#9460][feat] AutoDeploy: Fully-fledged GPT-OSS support

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -122,7 +122,7 @@ transforms:
     backend: trtllm
   fuse_moe:
     stage: post_load_fusion
-    enabled: false
+    enabled: true
     backend: trtllm
   fuse_fp8_moe:
     stage: post_load_fusion

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -122,7 +122,7 @@ transforms:
     backend: trtllm
   fuse_moe:
     stage: post_load_fusion
-    enabled: true
+    enabled: false
     backend: trtllm
   fuse_fp8_moe:
     stage: post_load_fusion

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/gptoss.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/gptoss.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A patch for GPT-OSS MoE to make it compatible with torch.export.
+
+GPT-OSS uses a dense MoE pattern where all experts are computed for all tokens,
+with soft routing weights. This patch replaces the BMM-based forward with torch_moe
+using SwigluBias activation.
+"""
+
+import torch
+
+from tensorrt_llm._torch.utils import ActivationType
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+def _forward_gptoss_mlp(self, hidden_states: torch.Tensor):
+    """GPT-OSS MoE forward rewritten for torch.export compatibility.
+
+    Uses torch_moe with SwigluBias activation to match the original GPT-OSS
+    dense MoE computation: (up + 1) * (gate * sigmoid(alpha * gate)) with clamping.
+    """
+    batch_size, seq_len, hidden_size = hidden_states.shape
+    hidden_states_flat = hidden_states.view(-1, hidden_size)
+    num_tokens = hidden_states_flat.shape[0]
+
+    router_scores, _ = self.router(hidden_states)
+
+    experts = self.experts
+    num_experts = experts.num_experts
+
+    selected_experts = (
+        torch.arange(num_experts, device=hidden_states.device).unsqueeze(0).expand(num_tokens, -1)
+    )
+
+    # gate_up_proj: [E, H, 2*I] with interleaved gate/up
+    # Split into gate [E, H, I] and up [E, H, I], then transpose to [I, H] for F.linear
+    gate_proj = experts.gate_up_proj[..., ::2]  # [E, H, I] - gate
+    up_proj = experts.gate_up_proj[..., 1::2]  # [E, H, I] - up
+
+    # Create per-expert weight lists with shape [I, H] for F.linear
+    w1_weight = [gate_proj[i].T for i in range(num_experts)]  # gate: [I, H]
+    w3_weight = [up_proj[i].T for i in range(num_experts)]  # up: [I, H]
+    # down_proj: [E, I, H] -> transpose to [H, I] for F.linear
+    w2_weight = [experts.down_proj[i].T for i in range(num_experts)]  # down: [H, I]
+
+    # Biases: gate_up_proj_bias [E, 2*I] -> split into gate [E, I] and up [E, I]
+    w1_bias_stacked = experts.gate_up_proj_bias[..., ::2]  # [E, I] - gate bias
+    w3_bias_stacked = experts.gate_up_proj_bias[..., 1::2]  # [E, I] - up bias
+    w2_bias_stacked = experts.down_proj_bias  # [E, H] - down bias
+
+    final_hidden_states = torch.ops.auto_deploy.torch_moe(
+        hidden_states_flat,
+        selected_experts,
+        router_scores,  # [num_tokens, num_experts] - soft routing weights
+        w1_weight=w1_weight,
+        w2_weight=w2_weight,
+        w3_weight=w3_weight,
+        is_gated_mlp=True,
+        act_fn=int(ActivationType.SwigluBias),
+        w1_bias_stacked=w1_bias_stacked,
+        w2_bias_stacked=w2_bias_stacked,
+        w3_bias_stacked=w3_bias_stacked,
+    )
+
+    final_hidden_states = final_hidden_states.view(batch_size, seq_len, hidden_size)
+    return final_hidden_states, router_scores
+
+
+@ExportPatchRegistry.register("hf_gptoss_moe")
+class GptOssMoePatch(BaseExportPatch):
+    """Patch for GPT-OSS MoE to make it compatible with torch.export.
+
+    GPT-OSS uses a dense MoE pattern with:
+    - Soft routing over ALL experts (not top-k sparse)
+    - SwigluBias activation: (up + 1) * (gate * sigmoid(alpha * gate)) with clamping
+    - Biases on all projections
+
+    The original BMM-based forward is replaced with torch_moe custom op
+    which handles the computation in an export-compatible way.
+    """
+
+    def _apply_patch(self):
+        """Apply the GPT-OSS MoE patch."""
+        try:
+            from transformers.models.gpt_oss import modeling_gpt_oss
+
+            self.modeling_module = modeling_gpt_oss
+            self.original_values["GptOssMLP.forward"] = modeling_gpt_oss.GptOssMLP.forward
+            modeling_gpt_oss.GptOssMLP.forward = _forward_gptoss_mlp
+        except (ImportError, AttributeError):
+            pass
+
+    def _revert_patch(self):
+        """Revert the GPT-OSS MoE patch."""
+        if hasattr(self, "modeling_module") and "GptOssMLP.forward" in self.original_values:
+            self.modeling_module.GptOssMLP.forward = self.original_values["GptOssMLP.forward"]

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py
@@ -1,7 +1,7 @@
 """Transform for multi-stream execution of MoE layers that have shared experts and routed experts."""
 
 from threading import RLock
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 from torch.fx import GraphModule
@@ -127,6 +127,11 @@ def trtllm_moe_fused_aux(
     w2_stacked_weight: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    w3_w1_stacked_bias: Optional[torch.Tensor] = None,
+    w2_stacked_bias: Optional[torch.Tensor] = None,
+    swiglu_alpha: Optional[torch.Tensor] = None,
+    swiglu_beta: Optional[torch.Tensor] = None,
+    swiglu_limit: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     device = torch.cuda.current_device()
     with torch.cuda.stream(
@@ -141,6 +146,11 @@ def trtllm_moe_fused_aux(
             w2_stacked_weight,
             is_gated_mlp,
             act_fn,
+            w3_w1_stacked_bias,
+            w2_stacked_bias,
+            swiglu_alpha,
+            swiglu_beta,
+            swiglu_limit,
         )
         torch.ops.auto_deploy.record_event(device, cuda_stream_manager.AUX_STREAM_NAME)
     torch.ops.auto_deploy.wait_event(device, cuda_stream_manager.AUX_STREAM_NAME)
@@ -156,6 +166,11 @@ def trtllm_moe_fused_aux_fake(
     w2_stacked_weight: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    w3_w1_stacked_bias: Optional[torch.Tensor] = None,
+    w2_stacked_bias: Optional[torch.Tensor] = None,
+    swiglu_alpha: Optional[torch.Tensor] = None,
+    swiglu_beta: Optional[torch.Tensor] = None,
+    swiglu_limit: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 


### PR DESCRIPTION
closes #9460
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-expert bias support for MoE operations
  * Extended activation function support for gated and ungated MLP paths
  * Added GPT-OSS model patch for improved torch.export compatibility

* **Configuration Changes**
  * Disabled MOE fusion by default in post-load configuration

* **Tests**
  * Added test coverage for GPT-OSS style MoE operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- [X] Map BF16 model's MoE pattern to torch_moe and deprecate torch_moe_dense_mlp
Update torch_moe with:
1. Support expert bias
2. Add SwigluBias activation function

- [x] Map to optimized kernel

Tested with
```
model: unsloth/gpt-oss-20b-BF16
args:
  mode: graph
  world_size: 1
  runtime: trtllm
  compile_backend: torch-simple
  attn_backend: torch
  model_factory: AutoModelForCausalLM
  skip_loading_weights: false
  disable_overlap_scheduler: true
  kv_cache_config:
    enable_block_reuse: false
  model_kwargs:
    torch_dtype: bfloat16
benchmark:
  enabled: false
prompt:
  sp_kwargs:
    top_k: 0
    temperature: 0
dry_run: false

```
Outputs before/after are the same:
```
[01/30/2026-23:14:31] [TRT-LLM AUTO-DEPLOY] [I] [PROMPT 0] How big is the universe? : 1.3 trillion light years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8 billion years? 13.8? 13.8? 13.8? 
[01/30/2026-23:14:31] [TRT-LLM AUTO-DEPLOY] [I] [PROMPT 1] In simple words and a single sentence, explain the concept of gravity: : 1) The 2nd law of Newton's law?

The second law of Newton's law states that the force acting on an object is equal to the mass of the object multiplied by its acceleration.

The second law of

The second law of Newton's law states that the force acting on an object is equal to the mass of the object multiplied by its acceleration.

The second law of Newton's law states that the force acting on an object is equal to the mass of the object multiplied
```

This will break GPT-OSS mxfp4 model support in AutoDeploy, support will be added in follow-up PR.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
