### PR TITLE
[None][feat] Add flux kontext support

### DIFF
--- a/tensorrt_llm/visual_gen/examples/flux_kontext.py
+++ b/tensorrt_llm/visual_gen/examples/flux_kontext.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.distributed as dist
+from common import (
+    BaseArgumentParser,
+    autotuning,
+    benchmark_inference,
+    configure_cpu_offload,
+    create_dit_config,
+    generate_autotuner_dir,
+    generate_output_path,
+    log_args_and_timing,
+    save_output,
+    setup_distributed,
+    validate_parallel_config,
+)
+from PIL import Image
+from visual_gen import setup_configs
+from visual_gen.models.transformers.flux_transformer import ditFluxTransformer2DModel
+from visual_gen.pipelines.flux_kontext_pipeline import ditFluxKontextPipeline
+from visual_gen.utils import cudagraph_wrapper, get_logger
+
+logger = get_logger(__name__)
+
+
+def load_and_setup_pipeline(args):
+    """Load and configure the Flux Kontext pipeline."""
+    # Create dit configuration
+    dit_configs = create_dit_config(args)
+    setup_configs(**dit_configs)
+
+    # Load transformer
+    transformer = ditFluxTransformer2DModel.from_pretrained(
+        args.model_path, subfolder="transformer", torch_dtype=torch.bfloat16
+    )
+
+    # Create pipeline
+    pipe = ditFluxKontextPipeline.from_pretrained(
+        args.model_path, transformer=transformer, torch_dtype=torch.bfloat16, **dit_configs
+    )
+
+    # Setup distributed training and CPU offload
+    local_rank, world_size = setup_distributed()
+
+    # Flux CPU offload configuration
+    model_wise = None
+    block_wise = ["transformer"]
+
+    configure_cpu_offload(pipe, args, local_rank, model_wise=model_wise, block_wise=block_wise)
+
+    return pipe
+
+
+def run_inference(pipe, args, image, enable_autotuner: bool = False):
+    """Run warmup and actual inference."""
+
+    def inference_fn(warmup: bool = False):
+        if warmup:
+            num_inference_steps = 1
+        else:
+            num_inference_steps = args.num_inference_steps
+        return pipe(
+            prompt=args.prompt,
+            image=image,
+            guidance_scale=args.guidance_scale,
+            height=args.height,
+            width=args.width,
+            num_inference_steps=num_inference_steps,
+            max_sequence_length=args.max_sequence_length,
+        ).images[0]
+
+    autotuner_dir = args.autotuner_result_dir
+    if enable_autotuner and not args.skip_autotuning:
+        if autotuner_dir is None:
+            autotuner_dir = generate_autotuner_dir(args)
+        autotuning(inference_fn, autotuner_dir)
+
+    if args.enable_cuda_graph:
+        assert args.attn_type != "sage-attn", "sage-attn has accuracy issue when enable cudagraph"
+        assert not (
+            args.enable_async_cpu_offload
+            or args.enable_sequential_cpu_offload
+            or args.enable_model_cpu_offload
+        ), "CudaGraph is not supported when using cpu offload"
+
+        # === Text Encoders (prompt encode) ===
+        if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
+            pipe.text_encoder.forward = cudagraph_wrapper(pipe.text_encoder.forward)
+        if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
+            pipe.text_encoder_2.forward = cudagraph_wrapper(pipe.text_encoder_2.forward)
+
+        # === VAE Decode ===
+        if hasattr(pipe, "run_vae_decode"):
+            pipe.run_vae_decode = cudagraph_wrapper(pipe.run_vae_decode)
+
+        # === Transformer ===
+        if args.enable_teacache:
+            pipe.transformer.run_pre_processing = cudagraph_wrapper(
+                pipe.transformer.run_pre_processing
+            )
+            pipe.transformer.run_teacache_check = cudagraph_wrapper(
+                pipe.transformer.run_teacache_check
+            )
+            pipe.transformer.run_transformer_blocks = cudagraph_wrapper(
+                pipe.transformer.run_transformer_blocks
+            )
+            pipe.transformer.run_post_processing = cudagraph_wrapper(
+                pipe.transformer.run_post_processing
+            )
+        else:
+            pipe.transformer.forward = cudagraph_wrapper(pipe.transformer.forward)
+
+    result, elapsed_time = benchmark_inference(
+        inference_fn,
+        warmup=True,
+        random_seed=args.random_seed,
+        enable_autotuner=enable_autotuner,
+        autotuner_dir=autotuner_dir,
+    )
+    return result, elapsed_time
+
+
+def main():
+    """Main function for Flux Kontext."""
+    # Setup argument parser
+    parser = BaseArgumentParser("Flux Kontext (FLUX.1-Kontext)")
+
+    # Flux Kontext specific arguments
+    parser.parser.add_argument(
+        "--image", type=str, required=True, help="Path to the reference image"
+    )
+
+    # Set defaults for Flux Kontext
+    parser.set_defaults(
+        model_path="black-forest-labs/FLUX.1-Kontext-dev",
+        prompt="The same scene with different lighting",
+        negative_prompt="",
+        height=1024,
+        width=1024,
+        guidance_scale=3.5,
+        teacache_thresh=0.6,
+    )
+
+    args = parser.parse_args()
+
+    enable_autotuner = False
+    if args.linear_type == "auto" or args.attn_type == "auto":
+        enable_autotuner = True
+        if not args.disable_torch_compile:
+            logger.warning("Disable torch compile when using autotuner")
+            args.disable_torch_compile = True
+        if args.enable_async_cpu_offload:
+            logger.warning("Disable visual_gen cpu offload when using autotuner")
+            args.enable_async_cpu_offload = False
+
+    # Validate configuration
+    validate_parallel_config(args)
+
+    # Load reference image
+    logger.info(f"Loading reference image from: {args.image}")
+    image = Image.open(args.image).convert("RGB")
+
+    logger.info(f"Image size: {args.width}x{args.height}")
+    logger.info(f"Prompt: {args.prompt}")
+
+    # Generate output path
+    output_path = generate_output_path(args, save_type="png")
+
+    # Load pipeline
+    pipe = load_and_setup_pipeline(args)
+
+    # Run inference
+    result, elapsed_time = run_inference(pipe, args, image, enable_autotuner)
+
+    # Log results and save output
+    log_args_and_timing(args, elapsed_time)
+    save_output(result, output_path, output_type="image")
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/visual_gen/visual_gen/pipelines/__init__.py
+++ b/tensorrt_llm/visual_gen/visual_gen/pipelines/__init__.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .flux_kontext_pipeline import ditFluxKontextPipeline
 from .wan_pipeline import ditWanImageToVideoPipeline, ditWanPipeline
 
-__all__ = ["ditWanPipeline", "ditWanImageToVideoPipeline"]
+__all__ = [
+    "ditWanPipeline",
+    "ditWanImageToVideoPipeline",
+    "ditFluxKontextPipeline",
+]

--- a/tensorrt_llm/visual_gen/visual_gen/pipelines/flux_kontext_pipeline.py
+++ b/tensorrt_llm/visual_gen/visual_gen/pipelines/flux_kontext_pipeline.py
@@ -1,0 +1,107 @@
+# Adapted from: https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/flux/pipeline_flux_kontext.py
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+
+import torch
+from diffusers import FluxKontextPipeline
+from safetensors.torch import load_file
+
+from visual_gen.configs.diffusion_cache import TeaCacheConfig
+from visual_gen.configs.op_manager import LinearOpManager
+from visual_gen.configs.parallel import VAEParallelConfig
+from visual_gen.layers.linear import ditLinear
+from visual_gen.models.transformers.flux_transformer import ditFluxTransformer2DModel
+from visual_gen.pipelines.base_pipeline import ditBasePipeline
+from visual_gen.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ditFluxKontextPipeline(FluxKontextPipeline, ditBasePipeline):
+    """visual_gen Pipeline for Flux Kontext (reference image-based generation and editing)."""
+
+    def _after_load(self, pretrained_model_name_or_path, *args, **kwargs) -> None:
+        """Post-processing hook after load model checkpoints in 'from_pretrained' method."""
+        if not isinstance(self.transformer, ditFluxTransformer2DModel):
+            logger.debug("Loading ditFluxTransformer2DModel from diffusers transformer")
+            torch_dtype = kwargs.get("torch_dtype", torch.float32)
+            self.transformer = ditFluxTransformer2DModel.from_pretrained(
+                pretrained_model_name_or_path,
+                subfolder="transformer",
+                torch_dtype=torch_dtype,
+                low_cpu_mem_usage=True,
+            )
+            gc.collect()
+            torch.cuda.empty_cache()
+        else:
+            logger.debug("Using ditFluxTransformer2DModel from kwargs for transformer")
+
+        self._fuse_qkv(self.transformer)
+
+        linear_type = LinearOpManager.linear_type
+        if linear_type == "te-fp8-per-tensor":
+            self._fuse_gemm_gelu(self.transformer)
+
+        self.transformer.teacache_coefficients = [
+            2.57151496e05,
+            -3.54229917e04,
+            1.40286849e03,
+            -1.35890334e01,
+            1.32517977e-01,
+        ]
+
+        if not VAEParallelConfig.disable_parallel_vae:
+            logger.warning("VAE parallel is not supported for FluxKontextPipeline")
+
+    def load_fp4_weights(self, path, svd_weight_name_table):
+        """Load FP4 quantized weights."""
+        weights_table = load_file(path)
+        for name, module in self.transformer.named_modules():
+            if isinstance(module, ditLinear):
+                module.load_fp4_weight(weights_table, svd_weight_name_table)
+
+    def run_vae_decode(self, latents: torch.Tensor, height: int, width: int) -> torch.Tensor:
+        """VAE decode with latent unpacking and scaling.
+
+        This method can be wrapped with CUDA Graph for better performance.
+        """
+        latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+        latents = latents / self.vae.config.scaling_factor
+        if hasattr(self.vae.config, "shift_factor"):
+            latents = latents + self.vae.config.shift_factor
+        image = self.vae.decode(latents, return_dict=False)[0]
+        return image
+
+    def __call__(self, *args, num_inference_steps: int = 28, **kwargs):
+        """Override __call__ to initialize TeaCache before inference."""
+        if TeaCacheConfig.enable_teacache():
+            step_size = 1
+            if TeaCacheConfig.use_ret_steps():
+                TeaCacheConfig.set_config(
+                    cutoff_steps=num_inference_steps * step_size,
+                    num_steps=num_inference_steps * step_size,
+                    cnt=0,
+                )
+            else:
+                TeaCacheConfig.set_config(
+                    cutoff_steps=num_inference_steps * step_size - 2,
+                    num_steps=num_inference_steps * step_size,
+                    cnt=0,
+                )
+            logger.debug(f"TeaCache initialized: num_steps={num_inference_steps * step_size}")
+
+        return super().__call__(*args, num_inference_steps=num_inference_steps, **kwargs)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
