### PR TITLE
[None][fix] fix Qwen2/3 export for AutoDeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/export/library/unified_attn.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/unified_attn.py
@@ -22,7 +22,7 @@ HF_ATTN_KWARGS_MAPPING = {
 
 
 def torch_attention_hf_wrapper(
-    self: torch.nn.Module,
+    module: torch.nn.Module,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -39,6 +39,13 @@ def torch_attention_hf_wrapper(
     ad_attn_kwargs = {
         HF_ATTN_KWARGS_MAPPING[k]: v for k, v in kwargs.items() if k in HF_ATTN_KWARGS_MAPPING
     }
+
+    # Handle is_causal logic to match HF's SDPA behavior exactly.
+    # See: transformers.integrations.sdpa_attention.sdpa_attention_forward
+    is_causal = kwargs.get("is_causal", None)
+    if is_causal is None:
+        is_causal = getattr(module, "is_causal", True)
+    ad_attn_kwargs["is_causal"] = is_causal
 
     attn_output = torch.ops.auto_deploy.torch_attention(
         query_states,
@@ -70,6 +77,8 @@ class UnifiedAttnPatch(BaseExportPatch):
             # torch_export_to_gm is called at both export stage and attn matching stage
             # we only patch attn implementation for export stage
             if hasattr(model, "config") and hasattr(model.config, "_attn_implementation"):
+                self.original_values["model_config"] = model.config
+                self.original_values["_attn_implementation"] = model.config._attn_implementation
                 model.config._attn_implementation = "ad_unified_attn"
             return self.original_values["te.export"](model, *args, **kwargs)
 
@@ -79,3 +88,12 @@ class UnifiedAttnPatch(BaseExportPatch):
     def _revert_patch(self):
         """Revert the te.export patch."""
         te.export = self.original_values["te.export"]
+
+        # Restore original _attn_implementation if we modified it
+        if (
+            "model_config" in self.original_values
+            and "_attn_implementation" in self.original_values
+        ):
+            self.original_values["model_config"]._attn_implementation = self.original_values[
+                "_attn_implementation"
+            ]


### PR DESCRIPTION
@coderabbitai summary

`torch_export_to_gm` corrupts Qwen2/3 models.

An example to reproduce the bug:
```
import torch
from torch.export import Dim
from transformers import AutoModelForCausalLM, AutoTokenizer

import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
from tensorrt_llm._torch.auto_deploy.export.library.unified_attn import torch_attention_hf_wrapper
from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS


def extract_logits(output):
    if hasattr(output, 'logits'):
        return output.logits
    return output[0] if isinstance(output, tuple) else output


def generate_tokens(model, input_ids, num_tokens=5):
    """Generate tokens one by one (simulating decode phase)."""
    tokens = []
    current_ids = input_ids.clone()
    
    for i in range(num_tokens):
        with torch.no_grad():
            output = model(current_ids)
            logits = extract_logits(output)
            next_token = logits[0, -1].argmax().item()
            tokens.append(next_token)
            current_ids = torch.cat([
                current_ids,
                torch.tensor([[next_token]], device=current_ids.device)
            ], dim=1)
    
    return tokens


# Load model
# model_name = "meta-llama/Meta-Llama-3.1-8B-Instruct"
# model_name = "Qwen/Qwen2.5-0.5B-Instruct"
# model_name = "Qwen/Qwen2-0.5B-Instruct"
model_name = "Qwen/Qwen3-8B"
print(f"Loading {model_name}...")
model = AutoModelForCausalLM.from_pretrained(
    model_name, 
    torch_dtype=torch.float16, 
    use_cache=False
).to("cuda")
model.eval()

tokenizer = AutoTokenizer.from_pretrained(model_name)

# Register the wrapper
ALL_ATTENTION_FUNCTIONS.register("ad_unified_attn", torch_attention_hf_wrapper)

# Test prompt
prompt = "The capital of France is"
input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda")
print(f"\nPrompt: '{prompt}'")
print(f"Input shape: {input_ids.shape}")

num_gen_tokens = 5

# ============================================================
# Test 1: SDPA generation (baseline)
# ============================================================
print("\n" + "="*60)
print("=== TEST 1: SDPA BASELINE ===")
print("="*60)

model.config._attn_implementation = "sdpa"
sdpa_tokens = generate_tokens(model, input_ids, num_gen_tokens)
sdpa_text = tokenizer.decode(sdpa_tokens)
print(f"Generated tokens: {sdpa_tokens}")
print(f"Generated text: '{sdpa_text}'")

# ============================================================
# Test 2: Unified attention wrapper (direct use)
# ============================================================
print("\n" + "="*60)
print("=== TEST 2: UNIFIED ATTENTION (direct) ===")
print("="*60)

model.config._attn_implementation = "ad_unified_attn"
unified_tokens = generate_tokens(model, input_ids, num_gen_tokens)
unified_text = tokenizer.decode(unified_tokens)
print(f"Generated tokens: {unified_tokens}")
print(f"Generated text: '{unified_text}'")

# Restore
model.config._attn_implementation = "sdpa"

# ============================================================
# Test 3: Export and test GraphModule
# ============================================================
print("\n" + "="*60)
print("=== TEST 3: GRAPHMODULE (exported) ===")
print("="*60)

# Export with dynamic sequence length
dummy_input = torch.randint(0, 1000, input_ids.shape, device="cuda")
seq_len_dim = Dim("seq_len", min=1, max=2048)
dynamic_shapes = ({1: seq_len_dim},)


gm = torch_export_to_gm(model, (dummy_input,), dynamic_shapes=dynamic_shapes)
gm_tokens = generate_tokens(gm, input_ids, num_gen_tokens)
gm_text = tokenizer.decode(gm_tokens)
print(f"Generated tokens: {gm_tokens}")
print(f"Generated text: '{gm_text}'")

```
Before the fix:
```
============================================================
=== TEST 1: SDPA BASELINE ===
============================================================
Generated tokens: [12095, 13, 576, 6722, 315]
Generated text: ' Paris. The capital of'

============================================================
=== TEST 2: UNIFIED ATTENTION (direct) ===
============================================================
Generated tokens: [785, 785, 785, 785, 785]
Generated text: 'TheTheTheTheThe'

============================================================
=== TEST 3: GRAPHMODULE (exported) ===
============================================================
Export with dynamic shapes successful!
Generated tokens: [785, 785, 785, 785, 785]
Generated text: 'TheTheTheTheThe'
```
After the fix:
```
============================================================
=== TEST 1: SDPA BASELINE ===
============================================================
Generated tokens: [12095, 13, 576, 6722, 315]
Generated text: ' Paris. The capital of'

============================================================
=== TEST 2: UNIFIED ATTENTION (direct) ===
============================================================
Generated tokens: [12095, 13, 576, 6722, 315]
Generated text: ' Paris. The capital of'

============================================================
=== TEST 3: GRAPHMODULE (exported) ===
============================================================
Export with dynamic shapes successful!
Generated tokens: [12095, 13, 576, 6722, 315]
Generated text: ' Paris. The capital of'
```

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
