### PR TITLE
[#10826][feat] AutoDeploy: Eagle One-Model [2/n]: Prefill-Only Implementation

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
@@ -247,6 +247,7 @@ class Eagle3DecoderLayer(nn.Module):
 
     def __init__(self, config, layer_idx: int = 0):
         super().__init__()
+        self.dtype = config.torch_dtype
         self.self_attn = Eagle3Attention(config, layer_idx=layer_idx)
         self.hidden_norm = EagleRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.input_layernorm = EagleRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -259,6 +260,9 @@ class Eagle3DecoderLayer(nn.Module):
         embeds: torch.Tensor,
         position_embeds: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Embeddings could have a different dtype if they come from the target model.
+        embeds = embeds.to(self.dtype)
+
         residual = hidden_states
         hidden_states = self.hidden_norm(hidden_states)
 
@@ -287,7 +291,14 @@ class Eagle3Model(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.dtype = config.torch_dtype
+
+        load_embedding_from_target = getattr(config, "load_embedding_from_target", False)
+        self.embed_tokens = (
+            None
+            if load_embedding_from_target
+            else nn.Embedding(config.vocab_size, config.hidden_size)
+        )
 
         if config.draft_vocab_size is not None and config.draft_vocab_size != config.vocab_size:
             # Vocab mappings for draft <-> target token conversion
@@ -299,13 +310,17 @@ class Eagle3Model(nn.Module):
                 requires_grad=False,
             )
 
-        # Input feature fusion: 3 * hidden_size -> hidden_size for Eagle3.
-        # TODO: Can make this configurable based on number of capture layers.
-        self.fc = nn.Linear(
-            config.hidden_size * 3,
-            config.hidden_size,
-            bias=getattr(config, "bias", False),
-            dtype=config.torch_dtype,
+        # Hidden size compression for target hidden states.
+        # Assumption: No feedforward fusion needed if we have just one capture layer (valid for MTPEagle)
+        self.fc = (
+            nn.Linear(
+                config.hidden_size * config.num_capture_layers,
+                config.hidden_size,
+                bias=getattr(config, "bias", False),
+                dtype=self.dtype,
+            )
+            if config.num_capture_layers > 1
+            else None
         )
 
         self.head_dim = getattr(
@@ -328,12 +343,10 @@ class Eagle3Model(nn.Module):
     # Assumption: The hidden states are already fused if necessary
     def forward(
         self,
-        input_ids: torch.LongTensor,
+        inputs_embeds: torch.Tensor,
         position_ids: torch.LongTensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        input_embeds = self.embed_tokens(input_ids)
-
         cos, sin = self.rotary_emb(hidden_states, position_ids)
         position_embeds = (cos, sin)
 
@@ -341,25 +354,23 @@ class Eagle3Model(nn.Module):
             for layer in self.midlayer:
                 hidden_states = layer(
                     hidden_states=hidden_states,
-                    embeds=input_embeds,
+                    embeds=inputs_embeds,
                     position_embeds=position_embeds,
                 )
         else:
             hidden_states = self.midlayer(
                 hidden_states=hidden_states,
-                embeds=input_embeds,
+                embeds=inputs_embeds,
                 position_embeds=position_embeds,
             )
 
         return hidden_states
 
-    def apply_eagle3_fc(self, target_hidden_states: torch.Tensor) -> torch.Tensor:
-        return self.fc(target_hidden_states)
-
 
 @dataclass
 class Eagle3DraftOutput(ModelOutput):
     logits: Optional[torch.FloatTensor] = None
+    norm_hidden_state: Optional[torch.FloatTensor] = None
     last_hidden_state: Optional[torch.FloatTensor] = None
 
 
@@ -385,16 +396,24 @@ class Eagle3DrafterForCausalLM(PreTrainedModel):
 
     def __init__(self, config):
         super().__init__(config)
+
+        self.load_embedding_from_target = getattr(config, "load_embedding_from_target", False)
+        self.load_lm_head_from_target = getattr(config, "load_lm_head_from_target", False)
+
         self.model = Eagle3Model(config)
         self.norm = EagleRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.lm_head = nn.Linear(config.hidden_size, config.draft_vocab_size, bias=False)
+        self.lm_head = (
+            None
+            if self.load_lm_head_from_target
+            else nn.Linear(config.hidden_size, config.draft_vocab_size, bias=False)
+        )
 
         eagle_config = getattr(config, "eagle_config", {})
         self._return_hidden_post_norm = eagle_config.get("return_hidden_post_norm", False)
 
     def forward(
         self,
-        input_ids: torch.LongTensor,
+        inputs_embeds: torch.LongTensor,
         position_ids: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Eagle3DraftOutput:
@@ -405,8 +424,8 @@ class Eagle3DrafterForCausalLM(PreTrainedModel):
         Raises:
             ValueError: If hidden_states is not provided in kwargs.
         """
-        batch_size, seq_len = input_ids.shape
-        device = input_ids.device
+        batch_size, seq_len, _ = inputs_embeds.shape
+        device = inputs_embeds.device
 
         # Generate position_ids if not provided
         if position_ids is None:
@@ -418,17 +437,406 @@ class Eagle3DrafterForCausalLM(PreTrainedModel):
             raise ValueError("hidden_states must be provided.")
 
         hidden_states = self.model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            hidden_states=hidden_states,
+            inputs_embeds=inputs_embeds, position_ids=position_ids, hidden_states=hidden_states
         )
 
-        norm_hidden_states = self.norm(hidden_states)
-        logits = self.lm_head(norm_hidden_states)
+        norm_hidden_state = self.norm(hidden_states)
 
-        last_hidden_state = norm_hidden_states if self._return_hidden_post_norm else hidden_states
+        last_hidden_state = norm_hidden_state if self._return_hidden_post_norm else hidden_states
 
         return Eagle3DraftOutput(
-            logits=logits,
+            norm_hidden_state=norm_hidden_state,
             last_hidden_state=last_hidden_state,
+        )
+
+
+@dataclass
+class EagleWrapperOutput(ModelOutput):
+    """Output format compatible with Eagle3OneModelSampler/MTPSampler.
+
+    This output format allows the one-model speculative decoding flow to bypass
+    logits-based sampling in the sampler. The EagleWrapper performs all sampling
+    and verification internally, returning pre-computed tokens.
+    """
+
+    # logits: [batch_size, 1, vocab_size].  Used for compatibility.
+    logits: Optional[torch.Tensor] = None
+
+    # new_tokens: [batch_size, max_draft_len + 1]. Accepted tokens from verification.
+    # This is a 2D tensor where each row contains the accepted tokens for a request,
+    # padded if fewer tokens were accepted.
+    new_tokens: Optional[torch.Tensor] = None
+
+    # new_tokens_lens: [batch_size]. Number of newly accepted tokens per request in this iteration.
+    new_tokens_lens: Optional[torch.Tensor] = None
+
+    # next_draft_tokens: [batch_size, max_draft_len]. Draft tokens for the next iteration.
+    # These are the tokens predicted by the draft model, already converted via d2t.
+    next_draft_tokens: Optional[torch.Tensor] = None
+
+    # next_new_tokens: [batch_size, max_draft_len + 1]. Input tokens for the next iteration.
+    # Format: [last_accepted_token, draft_token_0, draft_token_1, ...]
+    next_new_tokens: Optional[torch.Tensor] = None
+
+
+@dataclass
+class EagleWrapperConfig:
+    max_draft_len: int
+    load_embedding_from_target: bool
+    load_lm_head_from_target: bool
+
+
+class EagleWrapper(nn.Module):
+    def __init__(self, config, target_model, draft_model, resource_manager):
+        super().__init__()
+        self.target_model = target_model
+        self.draft_model = draft_model
+        self.resource_manager = resource_manager
+        self.max_draft_len = config.max_draft_len
+        self.load_embedding_from_target = config.load_embedding_from_target
+        self.load_lm_head_from_target = config.load_lm_head_from_target
+
+    def apply_eagle3_fc(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply the fc layer that fuses hidden states from multiple target layers."""
+        draft_model = self.draft_model.model
+        hidden_states = hidden_states.to(draft_model.dtype)
+
+        fc = getattr(draft_model, "fc", None)
+        if fc is not None:
+            hidden_states = fc(hidden_states)
+        return hidden_states
+
+    def apply_d2t(self, draft_output_ids: torch.Tensor) -> torch.Tensor:
+        """Apply draft-to-target token mapping if available."""
+        d2t = getattr(self.draft_model.model, "d2t", None)
+        if d2t is not None:
+            draft_output_ids = d2t.data[draft_output_ids] + draft_output_ids
+        return draft_output_ids
+
+    def apply_draft_embedding(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Apply embedding to input_ids for the draft model."""
+        if self.load_embedding_from_target:
+            return self.target_model.get_input_embeddings()(input_ids)
+        else:
+            return self.draft_model.model.embed_tokens(input_ids)
+
+    def apply_lm_head(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply lm_head to get logits from hidden states."""
+        if self.load_lm_head_from_target:
+            return self.target_model.get_output_embeddings()(hidden_states)
+        else:
+            return self.draft_model.lm_head(hidden_states)
+
+    def sample_greedy(self, logits: torch.Tensor) -> torch.Tensor:
+        ret = torch.argmax(logits, dim=-1)
+        return ret
+
+    def sample_and_verify(
+        self, input_ids, target_logits: torch.Tensor, num_previously_accepted: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Args:
+            input_ids: [batch_size, seq_len]
+            target_logits: [batch_size, seq_len, vocab_size]
+            num_previously_accepted: [batch_size]. Number of input tokens accepted so far for each batch.
+
+        Returns:
+            output_ids: [batch_size, seq_len] (result of greedy sampling on input ids)
+            num_newly_accepted_tokens: [batch_size]. Number of newly accepted tokens in each batch.
+            num_accepted_tokens: [batch_size]. Number of tokens accepted in each batch, including previously accepted.
+                So num_accepted_tokens[i] = num_previously_accepted + num_newly_accepted_tokens.
+            last_logits_3d: [batch_size, 1, vocab_size]. The logit used to sample the bonus token.
+
+        How it works:
+        - Get input ids that were not previously accepted.
+        - Get the corresponding target logits to these input ids (target_logit[j-1] corresponds to input_ids[j])
+        - Sample a token from the logits for each batch and compare to input_ids to get the newly accepted tokens.
+        - The output_ids consist of the previously accepted tokens, the newly accepted tokens,
+        and a newly sampled token after the last accepted token.
+        """
+
+        batch_size, seq_len = input_ids.shape
+
+        # First, check that num_previously_accepted is <= seq_len for each batch
+        # Additionally, num_previously_accepted should be >= 1 for each batch,
+        # which corresponds to having some context tokens (context tokens are always accepted).
+        assert (num_previously_accepted >= 1).all(), (
+            "num_previously_accepted must be >= 1. Please provide non-empty context in each batch."
+        )
+        assert (num_previously_accepted <= seq_len).all(), (
+            "num_previously_accepted must be <= seq_len for each batch"
+        )
+
+        # We get input tokens that were not yet accepted.
+        unchecked_input_ids = [
+            input_ids[i, num_previously_accepted[i] : seq_len].unsqueeze(0)
+            for i in range(batch_size)
+        ]
+
+        # We get the corresponding target logits for the unchecked input tokens.
+        # logit j-1 corresponds to input j.
+        # Note that because of our check that num_previously_accepted is >= 1
+        # We also get the last output token for each batch, because we may need to append it
+        # at the end.
+        unchecked_target_logits = [
+            target_logits[i, (num_previously_accepted[i] - 1) : seq_len, :].unsqueeze(0)
+            for i in range(batch_size)
+        ]
+
+        unchecked_output_ids = [self.sample_greedy(x) for x in unchecked_target_logits]
+
+        # corresponding_output_ids: [batch_size, seq_len - 1]. The output ids that correspond to the unchecked input ids
+        # Omits the last index because that corresponds to a freshly sampled output model.
+        corresponding_output_ids = [output_id[:, :-1] for output_id in unchecked_output_ids]
+
+        # After sample_greedy, corresponding_output_ids should have same shape as unchecked_input_ids
+        assert [x.shape for x in unchecked_input_ids] == [
+            x.shape for x in corresponding_output_ids
+        ], "unchecked_input_ids and corresponding_output_ids must have the same shape"
+
+        matches = [
+            (corresponding_output_ids[i] == unchecked_input_ids[i]).int() for i in range(batch_size)
+        ]
+
+        # Compute num_newly_accepted_tokens per batch (handles different sizes across batches)
+        num_newly_accepted_tokens = []
+        for i in range(batch_size):
+            if matches[i].numel() == 0:
+                # No unchecked tokens for this batch (num_previously_accepted == seq_len)
+                num_newly_accepted_tokens.append(
+                    torch.tensor(0, dtype=torch.long, device=input_ids.device)
+                )
+            else:
+                # prefix_matches[j] is 1 if first j+1 tokens all matched
+                prefix_matches = matches[i].cumprod(dim=-1)
+                num_newly_accepted_tokens.append(prefix_matches.sum().long())
+        num_newly_accepted_tokens = torch.stack(num_newly_accepted_tokens)
+
+        # num_accepted_tokens: [batch_size]. The total number of accepted tokens in each batch,
+        # including previously accepted tokens.
+        num_accepted_tokens = num_previously_accepted + num_newly_accepted_tokens
+
+        assert (num_accepted_tokens <= seq_len).all(), (
+            "num_accepted_tokens must be <= seq_len for each batch"
+        )
+
+        # Construct draft_input_ids for the draft model
+        # For each sequence:
+        # 1. Take previously accepted tokens (skipping the first one)
+        # 2. Append newly accepted tokens directly from input_ids.
+        # 3. Append the sampled token for last accepted position: unchecked_output_ids[0][num_newly_accepted]
+        # 4. Fill the rest with zeros (padding)
+        # Total real tokens: (num_previously_accepted - 1) + num_newly_accepted + 1 = num_accepted_tokens
+
+        draft_input_ids = torch.zeros(
+            (batch_size, seq_len), dtype=input_ids.dtype, device=input_ids.device
+        )
+
+        for i in range(batch_size):
+            # 1. Previously accepted tokens (skip the first one in keeping with Eagle convention)
+            # Note that this potentially includes context tokens, but is structured this way because we
+            # want the output to contain the entire prefix of accepted tokens because the drafters have no KV cache.
+            prev_accepted = input_ids[i, 1 : num_previously_accepted[i]]
+
+            # 2. Newly accepted input tokens
+            newly_accepted = input_ids[
+                i,
+                num_previously_accepted[i] : num_previously_accepted[i]
+                + num_newly_accepted_tokens[i],
+            ]
+
+            # 3. The sampled output token for the last accepted position
+            # unchecked_output_ids[i][j] is the sampled token for position (num_previously_accepted + j)
+            # We want the token for position num_accepted_tokens, which is index num_newly_accepted_tokens
+            next_token = unchecked_output_ids[i][0][num_newly_accepted_tokens[i]].unsqueeze(0)
+
+            # Concatenate all parts
+            draft_prefix = torch.cat([prev_accepted, newly_accepted, next_token])
+
+            # Sanity check: draft_prefix length should equal num_accepted_tokens
+            assert draft_prefix.shape[0] == num_accepted_tokens[i], (
+                f"draft_prefix length {draft_prefix.shape[0]} != num_accepted_tokens {num_accepted_tokens[i]}"
+            )
+
+            # Fill into draft_input_ids (rest remains zeros as padding)
+            draft_input_ids[i, : num_accepted_tokens[i]] = draft_prefix
+
+        # Construct last_logits_3d: [batch_size, 1, vocab_size]
+        # This is the logit used to sample the bonus token for each sequence.
+        # The bonus token is sampled from unchecked_target_logits[i][0][num_newly_accepted_tokens[i]]
+        last_logits_list = []
+        for i in range(batch_size):
+            # unchecked_target_logits[i] has shape [1, num_unchecked + 1, vocab_size]
+            # Index num_newly_accepted_tokens[i] gives the logit for the bonus token
+            bonus_logit = unchecked_target_logits[i][0, num_newly_accepted_tokens[i], :].unsqueeze(
+                0
+            )
+            last_logits_list.append(bonus_logit)
+        last_logits_3d = torch.stack(last_logits_list, dim=0)  # [batch_size, 1, vocab_size]
+
+        return draft_input_ids, num_newly_accepted_tokens, num_accepted_tokens, last_logits_3d
+
+    def forward(self, input_ids, position_ids, **kwargs):
+        """Dispatch to appropriate forward implementation based on kwargs.
+
+        If num_previously_accepted is provided, use the prefill-only (no KV cache) implementation.
+        Otherwise, this is the KV cache case which is not yet implemented.
+        """
+        num_previously_accepted = kwargs.get("num_previously_accepted", None)
+
+        if num_previously_accepted is not None:
+            return self._forward_prefill_only(input_ids, position_ids, **kwargs)
+        else:
+            # KV cached case - not implemented yet
+            raise NotImplementedError(
+                "EagleWrapper forward with KV cache is not implemented. "
+                "This code path is reached when num_previously_accepted is not provided in kwargs."
+            )
+
+    def _forward_prefill_only(self, input_ids, position_ids, **kwargs):
+        """Forward pass without KV cache (prefill-only mode).
+
+        This is the original implementation that recomputes all attention
+        from scratch on every forward call.
+        """
+        batch_size, seq_len = input_ids.shape
+        device = input_ids.device
+
+        num_previously_accepted = kwargs.get("num_previously_accepted", None)
+        if num_previously_accepted is None:
+            raise ValueError("num_previously_accepted must be provided for prefill-only mode.")
+
+        if position_ids is None:
+            position_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
+            position_ids = position_ids.expand(batch_size, -1)
+
+        # Compute embeddings using the target embedding layer
+        # These embeddings will be passed to both target and draft models
+        inputs_embeds = self.apply_draft_embedding(input_ids)
+
+        # target_logits: [batch_size, seq_len, vocab_size]
+        # Pass embeddings to target model instead of input_ids
+        target_logits = self.target_model(
+            inputs_embeds=inputs_embeds, position_ids=position_ids
+        ).logits
+
+        # output_ids: [batch_size, seq_len]. Contains a prefix of accepted tokens from the target model,
+        # a generated token from the target model, and some padding to fill out the tensor.
+        # num_accepted_tokens: [batch_size]. The number of accepted tokens in each batch.
+        # num_newly_accepted_tokens: [batch_size]. The number of newly accepted tokens in each batch.
+
+        output_ids, num_newly_accepted_tokens, num_accepted_tokens, _ = self.sample_and_verify(
+            input_ids, target_logits, num_previously_accepted
+        )
+
+        # Get hidden states from the resource manager
+        # resource_manager.hidden_states is [max_tokens, hidden_size * num_capture_layers] (flattened)
+        # We slice to get [batch_size * seq_len, hidden_size * num_capture_layers]
+        hidden_states = self.resource_manager.hidden_states[: (batch_size * seq_len), :]
+
+        # Apply eagle3 fc to reduce hidden size.
+        # Note: Since we are in prefill-only mode, this is extremely wasteful - we will apply the eagle3 fc layer
+        # to hidden states that we have applied it to previously. But, this is generally the case in prefill-only mode.
+        # Input: [batch_size * seq_len, hidden_size * num_capture_layers]
+        # Output: [batch_size * seq_len, hidden_size]
+        hidden_states = self.apply_eagle3_fc(hidden_states)
+
+        # Reshape from [batch_size * seq_len, hidden_size] to [batch_size, seq_len, hidden_size]
+        hidden_size = hidden_states.shape[-1]
+        hidden_states = hidden_states.view(batch_size, seq_len, hidden_size)
+
+        # Create a working buffer for the drafting loop in [batch, seq + draft_len, hidden] format.
+        # This is separate from resource_manager.hidden_states which remains in flattened format.
+        all_hidden_states = torch.zeros(
+            (batch_size, seq_len + self.max_draft_len, hidden_size),
+            device=device,
+            dtype=hidden_states.dtype,
+        )
+        # Copy the initial hidden states from target model
+        all_hidden_states[:, :seq_len, :] = hidden_states
+
+        # Construct our inputs for the drafting loop.
+        # We want tensors that will be able to hold all the tokens we draft.
+
+        dummy_input_ids = torch.zeros(
+            (batch_size, self.max_draft_len), device=device, dtype=output_ids.dtype
+        )
+
+        # draft_input_ids: [batch_size, seq_len + self.max_draft_len]
+        draft_input_ids = torch.cat((output_ids, dummy_input_ids), dim=1)
+
+        draft_position_ids = 1 + torch.arange(
+            self.max_draft_len, device=device, dtype=torch.long
+        ).unsqueeze(0).expand(batch_size, -1)
+
+        draft_position_ids = draft_position_ids + position_ids[:, -1:].expand(
+            -1, self.max_draft_len
+        )
+
+        # draft_position_ids: [batch_size, seq_len + self.max_draft_len]
+        # These position ids will work throughout the drafting loop.
+        draft_position_ids = torch.cat((position_ids, draft_position_ids), dim=1)
+
+        # The number of tokens currently in the draft input ids. Possibly includes padding.
+        curr_num_tokens = seq_len
+
+        # [batch_size]
+        # The number of valid tokens currently in the draft input ids (does not include padding).
+        curr_valid_tokens = num_accepted_tokens.clone()
+
+        batch_indices = torch.arange(batch_size, device=device)
+
+        for _ in range(self.max_draft_len):
+            # Get the input ids, position ids, and hidden states for the current tokens.
+            # size of tensor is constant for the current iteration and constant across dimensions (curr_num_tokens)
+            # These tensors may correspond to padding tokens, but due to the causality of the draft model,
+            # we can extract the draft tokens and hidden states corresponding to the valid tokens.
+
+            input_ids = draft_input_ids[:, :curr_num_tokens]
+            position_ids = draft_position_ids[:, :curr_num_tokens]
+            hidden_states = all_hidden_states[:, :curr_num_tokens, :]
+
+            inputs_embeds = self.apply_draft_embedding(input_ids)
+            draft_output = self.draft_model(
+                inputs_embeds=inputs_embeds,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+            )
+
+            draft_output_logits = self.apply_lm_head(draft_output.norm_hidden_state)
+
+            # get the output logits for the latest valid token in each batch
+            # It is at curr_valid_tokens-1 due to 0-indexing.
+            latest_draft_logits = draft_output_logits[batch_indices, curr_valid_tokens - 1, :]
+
+            # draft_output_tokens: [batch_size, 1]
+            draft_output_tokens = self.sample_greedy(latest_draft_logits)
+
+            # if the lm_head outputs tokens from the draft vocab, we need to convert them to tokens
+            # from the target vocab before the next iteration.
+            draft_output_tokens = self.apply_d2t(draft_output_tokens)
+
+            # insert the draft output tokens into the draft input ids.
+            draft_input_ids[batch_indices, curr_valid_tokens] = draft_output_tokens
+
+            # Similarly, we want the hidden state for the latest drafted token in each batch.
+            # This is a draft hidden state for the token that was just created from the latest valid token.
+
+            # [batch_size, seq_len + self.max_draft_len, hidden_size]
+            all_hidden_states[batch_indices, curr_valid_tokens, :] = draft_output.last_hidden_state[
+                batch_indices, curr_valid_tokens - 1, :
+            ]
+
+            curr_valid_tokens = curr_valid_tokens + 1
+            curr_num_tokens = curr_num_tokens + 1
+
+        # Return the full draft_input_ids tensor for each batch element.
+        # The valid prefix within each tensor has length:
+        # num_previously_accepted[i] + num_newly_accepted_tokens[i] + max_draft_len
+        # Callers should use this to slice out the valid tokens if needed.
+        new_tokens = [draft_input_ids[i] for i in range(batch_size)]
+
+        return EagleWrapperOutput(
+            new_tokens=new_tokens,
+            new_tokens_lens=num_newly_accepted_tokens,
         )

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -443,3 +443,5 @@ l0_h100:
   - examples/test_ad_speculative_decoding.py::test_autodeploy_spec_dec_output[eagle3]
   - examples/test_ad_speculative_decoding.py::test_autodeploy_eagle3_acceptance_rate
   - examples/test_ad_speculative_decoding.py::test_eagle_model_with_weights
+  - examples/test_ad_speculative_decoding.py::test_eagle_wrapper_forward[1]
+  - examples/test_ad_speculative_decoding.py::test_eagle_wrapper_forward[2]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -21,6 +21,9 @@ from test_common.llm_data import with_mocked_hf_download
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
 
 
+@pytest.mark.skip(
+    reason="Skipping test_ad_speculative_decoding_smoke due to issues on CI for A30s."
+)
 @pytest.mark.parametrize("use_hf_speculative_model", [False])
 @with_mocked_hf_download
 def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -21,7 +21,9 @@ from test_common.llm_data import with_mocked_hf_download
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
 
 
-@pytest.mark.skip_less_device_memory(40000)
+@pytest.mark.skip(
+    reason="OOM on A30 GPUs on CI - speculative model loading does not support model_kwargs reduction"
+)
 @pytest.mark.parametrize("use_hf_speculative_model", [False])
 @with_mocked_hf_download
 def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -21,9 +21,7 @@ from test_common.llm_data import with_mocked_hf_download
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
 
 
-@pytest.mark.skip(
-    reason="Skipping test_ad_speculative_decoding_smoke due to issues on CI for A30s."
-)
+@pytest.mark.skip_less_device_memory(40000)
 @pytest.mark.parametrize("use_hf_speculative_model", [False])
 @with_mocked_hf_download
 def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):


### PR DESCRIPTION
fixes: #10826 

--Manual Summary--
Implements eagle one-model flow in prefill-only setting. This means no cached attention, so sequences are provided in full to the model. This is to be used for tracing and export in AutoDeploy.

Testing plan: Since this implements end-to-end Eagle support in the prefill-only setting, it can be tested by checking the acceptance rate of the model. This not only tests the correctness of the "glue code" (`EagleWrapper`) in this PR, but also verifies the correctness of the Eagle checkpoint architecture and model loading.

The test (`test_eagle_wrapper_forward()`) sets up a custom "target model with capture" that manually captures hidden states from preconfigured layers, creates a resource manager to store these target hidden states, then instantiates the EagleWrapper with the target model, resource manager, and draft model. Then it runs the EagleWrapper autoregressively and checks the acceptance rate for decode requests. This is done for batch sizes 1 and 2.

A note: The batch size 2 tests are quite hacky due to the fact that as we speculate, the sequences grow at different rates, and we are dealing with padded (not packed) representation here. To compensate, we discard all speculated tokens between each run, and calculate an acceptance rate by manually running these speculated tokens through the target model in a separate step. This makes the autoregressive loop identical to the normal decoding loop, but we check the accuracy of speculated tokens at each step.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced EagleWrapper for speculative decoding, enabling efficient token verification through draft and target model collaboration.
  * Added support for reusing target model embeddings and language head in draft models, reducing memory footprint.
  * Enhanced configuration management for Eagle-based drafting with improved model-type handling.

* **Tests**
  * Added comprehensive integration tests for speculative decoding workflows with multi-batch support and token verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
