### PR TITLE
[None][chore] KV Connector Refactor

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1563,7 +1563,9 @@ public:
     /// @param llmRequest Optional request to use for KV cache lookup.
     /// @details If llmRequest is supplied and KV cache reuse is enabled, try to recover KV cache blocks for
     /// inputLength - 1 tokens and populate prepopulatedPromptLen.
-    virtual void addSequence(LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
+    /// @return True if the sequence was added, False if the sequence was not added because it was already in the
+    /// manager.
+    virtual bool addSequence(LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         OptionalRef<LlmRequest> llmRequest = std::nullopt)
         = 0;
 
@@ -1913,7 +1915,9 @@ public:
     /// @param llmRequest Optional request to use for KV cache lookup.
     /// @details If llmRequest is supplied and KV cache reuse is enabled, try to recover KV cache blocks for
     /// inputLength - 1 tokens and populate prepopulatedPromptLen.
-    void addSequence(LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
+    /// @return True if the sequence was added, False if the sequence was not added because it was already in the
+    /// manager.
+    bool addSequence(LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         OptionalRef<LlmRequest> llmRequest = std::nullopt) override;
 
     [[nodiscard]] std::optional<KVCacheBlock::IdType> removeSequence(LlmRequest::RequestIdType requestId,

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -111,7 +111,7 @@ public:
         NB_OVERRIDE_PURE(addToken, requestId);
     }
 
-    void addSequence(tb::LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
+    bool addSequence(tb::LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest> llmRequest = std::nullopt) override
     {
         NB_OVERRIDE_PURE(addSequence, requestId, inputLength, beamWidth, llmRequest);

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
@@ -48,6 +48,7 @@ from tensorrt_llm.bindings.internal.batch_manager import \
     KvCacheConnectorManager as KvCacheConnectorManagerCpp
 from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
 from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+from tensorrt_llm.logger import logger
 
 from .llm_request import get_draft_token_length
 from .scheduler import ScheduledRequests
@@ -467,6 +468,11 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
                 # The req we get from the C++ call is different than the one in python.
                 # Replace it with the canonical request.
                 self.new_async_requests.loading[req.py_request_id] = req
+
+        logger.debug(
+            f"Marking {len(ready_requests)} requests with as ready IDs {list(map(lambda x: x.py_request_id, ready_requests))}."
+        )
+
         return ready_requests
 
     def handle_metadata(self) -> object:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
@@ -406,9 +406,6 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
         # Requests that have been returned from get_finished locally, but haven't yet been returned by all workers.
         self.local_finished_async_requests = AsyncRequests(dict(), dict())
 
-        # Requests that have finished loading asynchronously.
-        self.finished_async_loading_requests = dict()
-
         self._scheduler_output = None
         self.scheduler_output_manager = KvCacheConnectorSchedulerOutputManager()
 
@@ -437,10 +434,6 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
             raise RuntimeError(
                 "load_kv_async must be False when num_tokens is 0!")
 
-        # TODO(jthomson04): This part is a bit ugly.
-        # When the connector indicates that a request will be loaded asynchronously, we need to suspend it's execution.
-        # This is problematic, since at the point when this function is called, the request has already been scheduled!
-        # Because of this, we need to remove it from our list of scheduled requests (see `take_scheduled_requests_pending_load`).
         if load_kv_async:
             self.new_async_requests.loading[request.request_id] = request
 
@@ -449,42 +442,32 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
 
         return num_tokens
 
-    def should_add_sequence(self, request: LlmRequest) -> bool:
-        req_id = request.request_id
-        return req_id not in self.finished_async_loading_requests
-
     def build_scheduler_output(self, scheduled_batch: ScheduledRequests,
                                kv_cache_manager: "KVCacheManager"):
         self._scheduler_output = self.scheduler_output_manager.build_scheduler_output(
             scheduled_batch, self.new_async_requests, kv_cache_manager)
 
-    def take_scheduled_requests_pending_load(
-            self, scheduled_requests: ScheduledRequests):
+    def mark_ready_requests(
+            self, fitting_disagg_gen_init_requests: List[LlmRequest]
+    ) -> List[LlmRequest]:
         """
-        Remove context requests from our list of scheduled requests that are being loaded asynchronously.
-        This is done to prevent the runtime from attempting to load the KV cache for these requests.
-
-        Args:
-            scheduled_requests: The scheduled requests.
-
-        Returns:
-            The scheduled requests with the context requests that are being loaded asynchronously removed.
+        Mark scheduled KV connector requests as ready.
+        In the py executor, we mark ALL KV connector requests as async loading.
+        However, if we returned (_, False) from get_num_new_matched_tokens, we need to mark the request as ready for the upcoming context forward pass.
+        After we mark the request(s) as ready, we run scheduling again to account for the newly ready requests.
         """
-        allowed_context_requests = []
 
-        for req in scheduled_requests.context_requests:
-            # If this request is being loaded asynchronously, in addition to removing it from the list of scheduled requests,
-            # we also need to update it's state.
-            if req.request_id in self.new_async_requests.loading.keys():
-                req.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
-
-                # Replace the request with the canonical request.
-                self.new_async_requests.loading[req.request_id] = req
+        ready_requests = []
+        for req in fitting_disagg_gen_init_requests:
+            # If we're not loading this request asynchronously, mark it as ready for the upcoming forward pass.
+            if req.py_request_id not in self.new_async_requests.loading_ids:
+                ready_requests.append(req)
+                req.state = LlmRequestState.CONTEXT_INIT
             else:
-                allowed_context_requests.append(req)
-
-        # Update the list of scheduled requests.
-        scheduled_requests.context_requests = allowed_context_requests
+                # The req we get from the C++ call is different than the one in python.
+                # Replace it with the canonical request.
+                self.new_async_requests.loading[req.py_request_id] = req
+        return ready_requests
 
     def handle_metadata(self) -> object:
         metadata = self._run_on_leader(
@@ -506,14 +489,9 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
             Whether the request is performing asynchronous saving operations. If true, we do not immediately call free_resources on the request.
         """
 
-        if req.request_id in self.finished_async_loading_requests:
-            del self.finished_async_loading_requests[req.request_id]
-
         saving_async = self._run_on_leader(
             lambda: self.scheduler.request_finished(req, cache_block_ids))
 
-        # This is similar to take_scheduled_requests_pending_load.
-        # We need to update the request's state to indicate that it's still being used, but isn't schedulable.
         if saving_async:
             self.new_async_requests.saving[req.request_id] = req
             req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
@@ -565,7 +543,6 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
         # For requests that have finished loading, move them back to the context state.
         for id, req in all_finished.loading.items():
             req.state = LlmRequestState.CONTEXT_INIT
-            self.finished_async_loading_requests[id] = req
 
         # Return the requests that have finished saving.
         # The execution loop will call _terminate_request on these requests.

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2502,7 +2502,7 @@ class PyExecutor:
             if not _respond_if_invalid(request)
         ]
 
-        # When using a KV connector, mark new requests as disagg generation init.
+        # When using a KV connector, mark new requests as `DISAGG_GENERATION_INIT`
         # If the connector later decides not to load asynchronously, mark_ready_requests()
         # will move them back to CONTEXT_INIT.
         if self.kv_connector_manager:
@@ -2738,7 +2738,7 @@ class PyExecutor:
                     self.resource_manager.resource_managers[
                         resource_mgr_type].prepare_resources(
                             disagg_gen_init_to_prepare)
-            if self.kv_cache_transceiver and not self.kv_connector_manager:
+            if self.kv_cache_transceiver:
                 # Trigger KV cache exchange for new disagg_gen_init_requests
                 self._recv_disagg_gen_cache(fitting_disagg_gen_init_requests)
             elif self.kv_connector_manager:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -526,11 +526,8 @@ class KVCacheManager(BaseResourceManager):
                                        == self.mapping.cp_size - 1 else 0),
                             req_beam_width, req)
                 else:
-                    if req.is_first_context_chunk and self._kv_connector_should_add_sequence(
-                            req):
-                        self.impl.add_sequence(req.py_request_id,
-                                               req.prompt_len, req_beam_width,
-                                               req)
+                    if self.impl.add_sequence(req.py_request_id, req.prompt_len,
+                                              req_beam_width, req):
                         for _ in range(self.num_extra_kv_tokens):
                             self.impl.add_token(req.py_request_id)
                         for _ in range(get_draft_token_length(req)):
@@ -559,14 +556,6 @@ class KVCacheManager(BaseResourceManager):
 
             # prefill and generation kernels wait for scheduled offload/onboard/partial copy work before launching
             self.impl.refresh_blocks()
-
-        if self.kv_connector_manager is not None:
-            self.kv_connector_manager.build_scheduler_output(
-                scheduled_batch, self)
-
-    def _kv_connector_should_add_sequence(self, request: LlmRequest) -> bool:
-        return self.kv_connector_manager is None or self.kv_connector_manager.should_add_sequence(
-            request)
 
     def add_dummy_requests(
         self,

--- a/tests/unittest/_torch/test_connector.py
+++ b/tests/unittest/_torch/test_connector.py
@@ -25,8 +25,8 @@ from tensorrt_llm import mpi_rank
 from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
     AsyncRequests, KvCacheConnectorManager,
     KvCacheConnectorSchedulerOutputManager)
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
-from tensorrt_llm.bindings.internal.batch_manager import LlmRequestState
 
 cloudpickle.register_pickle_by_value(sys.modules[__name__])
 mpi4py.MPI.pickle.__init__(
@@ -113,6 +113,7 @@ def test_connector_manager_num_matched_tokens(mpi_pool_executor):
         req = MagicMock()
 
         req.request_id = 42
+        req.is_generation_only_request = False
 
         assert manager.get_num_new_matched_tokens(req, 32) == 16
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV cache sequence management with better error handling for resource allocation failures.

* **Refactor**
  * Enhanced KV cache connector integration workflow for more robust disaggregated generation support.
  * Streamlined internal KV cache resource management and state transitions.

* **Tests**
  * Updated integration and unit tests to reflect improved KV cache handling and connector workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Implements the remaining refactors from https://github.com/NVIDIA/TensorRT-LLM/pull/9186.

- Restructures the call to get_num_new_matched_tokens to be called before being added to the scheduled batch.
- Further unification of disagg and KV connector handling in the py executor
- Simplified state management in the kv connector manager

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
