### PR TITLE
[None][chore] Correct sorting order for attention DP scheduling to prioritize non-relaxed requests

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -445,7 +445,7 @@ class ExecutorRequestQueue:
                 return True
             return scheduling_params.attention_dp_relax
 
-        new_requests = sorted(new_requests, key=get_relax_value, reverse=True)
+        new_requests = sorted(new_requests, key=get_relax_value)
 
         # Try to put the requests to the target dp rank until the max_num_active_requests is reached
         remaining_unscheduled = []


### PR DESCRIPTION
Fix the sorting order in `schedule_attention_dp_requests` to correctly prioritize non-relaxed requests. The comment states "Prioritize the requests that are not in relax mode", but `reverse=True` causes relaxed requests (`get_relax_value=True`) 
to be processed first instead. Removing `reverse=True` ensures non-relaxed requests are scheduled to their target DP rank before slots fill up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized request scheduling prioritization in attention processing to improve system efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->