### PR TITLE
[None][fix] Reduce host memory usage during model loading

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -1,14 +1,79 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Dict, Iterator, Tuple, Union
 
 from tensorrt_llm.mapping import Mapping
+
+
+class ConsumableWeightsDict:
+    """
+    Wrapper around a weights dictionary that allows marking keys as consumed
+    to free memory during model loading.
+
+    This reduces peak memory usage by deleting weight tensors from the dictionary
+    after they have been copied to the model, rather than keeping all weights
+    in memory until loading completes.
+    """
+
+    def __init__(self, weights: Dict[str, Any]):
+        self._weights = weights
+
+    def __getitem__(self, key: str) -> Any:
+        return self._weights[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._weights[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._weights[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._weights
+
+    def __len__(self) -> int:
+        return len(self._weights)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._weights)
+
+    def keys(self):
+        return self._weights.keys()
+
+    def values(self):
+        return self._weights.values()
+
+    def items(self) -> Iterator[Tuple[str, Any]]:
+        return self._weights.items()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._weights.get(key, default)
+
+    def update(self, other: Dict[str, Any]) -> None:
+        self._weights.update(other)
+
+    def mark_consumed(self, prefix: str) -> int:
+        """
+        Delete all keys starting with the given prefix to free memory.
+
+        Args:
+            prefix: The prefix to match. Keys starting with "{prefix}." will be deleted.
+
+        Returns:
+            The number of keys deleted.
+        """
+        keys_to_delete = [
+            k for k in self._weights.keys() if k.startswith(prefix + ".")
+        ]
+        for key in keys_to_delete:
+            del self._weights[key]
+        return len(keys_to_delete)
 
 
 class BaseWeightLoader(ABC):
 
     @abstractmethod
-    def load_weights(self, checkpoint_dir: str,
-                     mapping: Mapping) -> dict[str, Any]:
+    def load_weights(
+            self, checkpoint_dir: str,
+            mapping: Mapping) -> Union[Dict[str, Any], ConsumableWeightsDict]:
         """
         Loads weights from a checkpoint directory.
 
@@ -17,7 +82,8 @@ class BaseWeightLoader(ABC):
             mapping: A mapping object containing the distributed configuration.
 
         Returns:
-            A dictionary where keys are tensor names and values are the tensors.
+            A dictionary (or ConsumableWeightsDict) where keys are tensor names
+            and values are the tensors.
         """
 
     def cleanup(self) -> None:

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
@@ -74,12 +74,18 @@ class BaseWeightMapper(ABC):
                 pattern_mapping = {
                     r'(.*?)out_proj(.*)': r'\1o_proj\2'
                 }
-            weights: A dictionary of weights
+            weights: A dictionary of weights (or ConsumableWeightsDict)
 
         Returns:
-            A dictionary of weights with renamed keys
+            A dictionary of weights with renamed keys (preserves ConsumableWeightsDict if input was one)
         """
         import re
+
+        from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+            ConsumableWeightsDict
+
+        # Check if input is a ConsumableWeightsDict to preserve the type
+        is_consumable = isinstance(weights, ConsumableWeightsDict)
 
         # Create a new dictionary to store the renamed weights
         renamed_weights = {}
@@ -103,6 +109,9 @@ class BaseWeightMapper(ABC):
             if key not in matched_keys:
                 renamed_weights[key] = weights[key]
 
+        # Preserve ConsumableWeightsDict type if that's what was passed in
+        if is_consumable:
+            return ConsumableWeightsDict(renamed_weights)
         return renamed_weights
 
     def preprocess_weights(self, weights: dict) -> dict:

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -9,8 +9,8 @@ import safetensors
 import torch
 import tqdm
 
-from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
-    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import (
+    BaseWeightLoader, ConsumableWeightsDict)
 from tensorrt_llm._torch.models.modeling_utils import (
     register_checkpoint_weight_loader, run_concurrently)
 from tensorrt_llm._utils import (local_mpi_barrier, local_mpi_rank,
@@ -70,7 +70,7 @@ class HfWeightLoader(BaseWeightLoader):
         raise RuntimeError(f"No weight files found in {checkpoint_dir}.")
 
     def _load_weights_in_parallel(self, weight_files: List[str], load_func,
-                                  description: str) -> dict[str, Any]:
+                                  description: str) -> ConsumableWeightsDict:
         """
         Load weight files in parallel using the specified loading function.
 
@@ -80,7 +80,7 @@ class HfWeightLoader(BaseWeightLoader):
             description: Description for the progress bar
 
         Returns:
-            Dictionary containing all loaded weights
+            ConsumableWeightsDict containing all loaded weights
         """
         weights = {}
         pbar = tqdm.tqdm(total=len(weight_files), desc=description)
@@ -91,7 +91,7 @@ class HfWeightLoader(BaseWeightLoader):
                          reduce_func=weights.update,
                          pbar=pbar)
 
-        return weights
+        return ConsumableWeightsDict(weights)
 
     @staticmethod
     def _load_safetensors_file(file):

--- a/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mistral/weight_mapper.py
@@ -49,6 +49,11 @@ class MistralWeightMapper(HfWeightMapper):
     # Adapted from:
     # https://github.com/vllm-project/vllm/blob/883b42896a9ed9791750d721fad26005b7569eba/vllm/model_executor/models/llama.py#L657
     def rename_by_params_map(self, params_map: dict[str, str], weights: dict) -> dict:
+        from tensorrt_llm._torch.models.checkpoints.base_weight_loader import ConsumableWeightsDict
+
+        # Check if input is a ConsumableWeightsDict to preserve the type
+        is_consumable = isinstance(weights, ConsumableWeightsDict)
+
         renamed_weights = {}
 
         for key in list(weights.keys()):
@@ -68,6 +73,9 @@ class MistralWeightMapper(HfWeightMapper):
 
             renamed_weights[new_key] = weights[key]
 
+        # Preserve ConsumableWeightsDict type if that's what was passed in
+        if is_consumable:
+            return ConsumableWeightsDict(renamed_weights)
         return renamed_weights
 
     def _permute_qk(self, module: nn.Module, new_name: str, weights: dict):

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -39,6 +39,8 @@ from transformers import PretrainedConfig
 
 import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 from tensorrt_llm._ipc_utils import can_access_peer
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    ConsumableWeightsDict
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.mapping import Mapping
@@ -147,7 +149,9 @@ class DeepseekV3WeightLoader:
         self.model_config = model.model_config
         self.is_draft_model = is_draft_model
 
-    def load_weights(self, weights: Dict, skip_modules: List[str] = []):
+    def load_weights(self,
+                     weights: ConsumableWeightsDict,
+                     skip_modules: List[str] = []):
 
         def requantize_weight_with_new_scale(weight, weight_scale, old_scale_2,
                                              new_scale_2, device):
@@ -324,6 +328,9 @@ class DeepseekV3WeightLoader:
         params_map = {'gate_up_proj': ['gate_proj', 'up_proj']}
         all_named_modules = dict(self.model.named_modules())
 
+        # Check if weights supports mark_consumed (ConsumableWeightsDict)
+        can_mark_consumed = hasattr(weights, 'mark_consumed')
+
         for name, module in tqdm(all_named_modules.items(),
                                  desc="Loading weights"):
             if len(module._parameters) <= 0 or name.startswith("draft_model"):
@@ -399,6 +406,9 @@ class DeepseekV3WeightLoader:
                                         -1, v_b_proj_scale.shape[-1]).cuda(),
                                 ).view(*attn_module.v_b_proj_dequant.shape).to(
                                     attn_module.v_b_proj_dequant.dtype))
+                    # Mark consumed kv_b_proj weights
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
                 elif names[-1] == "kv_a_proj_with_mqa":
                     nvfp4_fused_a = self.model_config.get_quant_config(
                     ).layer_quant_mode.has_nvfp4() and weights[
@@ -522,6 +532,13 @@ class DeepseekV3WeightLoader:
                         # For DeepseekV32: kv_a_proj_with_mqa is oversized
                         # to include indexer k weights, which is filled in post_load_weights.
                         module.weight.data[0:fused_a.shape[0]].copy_(fused_a)
+                    # Mark consumed kv_a_proj_with_mqa and q_a_proj weights
+                    if can_mark_consumed:
+                        parent_prefix = '.'.join(names[:-1])
+                        weights.mark_consumed(
+                            f"{parent_prefix}.kv_a_proj_with_mqa")
+                        if not is_lite:
+                            weights.mark_consumed(f"{parent_prefix}.q_a_proj")
                 elif names[-1] in params_map:
                     module_weights = []
                     for new_name in params_map[names[-1]]:
@@ -529,6 +546,11 @@ class DeepseekV3WeightLoader:
                             filter_weights('.'.join(names[:-1] + [new_name]),
                                            weights))
                     module.load_weights(weights=module_weights)
+                    # Mark consumed source weights (e.g., gate_proj, up_proj)
+                    if can_mark_consumed:
+                        for src_name in params_map[names[-1]]:
+                            weights.mark_consumed('.'.join(names[:-1] +
+                                                           [src_name]))
                 elif names[-1] == "experts":
                     module_weights = filter_weights(name, weights)
                     module_weights = rename_moe_weight(module_weights, {
@@ -537,6 +559,9 @@ class DeepseekV3WeightLoader:
                         "gate_proj": "w1",
                     })
                     module.load_weights(weights=[module_weights])
+                    # Mark consumed experts weights
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
                 elif names[-1] == "backend" and isinstance(module, MoE):
                     # Special case: ConfigurableMoE.backend (TRTLLMGenFusedMoE)
                     # Currently saved MoE weights don't include 'backend' in their names.
@@ -552,6 +577,9 @@ class DeepseekV3WeightLoader:
                         "gate_proj": "w1",
                     })
                     module.load_weights(weights=[module_weights])
+                    # Mark consumed MoE weights using parent name
+                    if can_mark_consumed:
+                        weights.mark_consumed(parent_name)
                 elif names[-1] == "self_attn":
                     continue
                 elif names[-1] == "next_layer_layernorm":
@@ -563,6 +591,9 @@ class DeepseekV3WeightLoader:
                     else:
                         for n, p in module.named_parameters():
                             p.data.copy_(module_weights[n][:])
+                    # Mark consumed weights
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
 
 
 class DeepseekV3MTPHead(nn.Module):
@@ -1805,7 +1836,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                return_context_logits=return_context_logits,
                                **kwargs)
 
-    def load_weights(self, weights: Dict):
+    def load_weights(self, weights: ConsumableWeightsDict):
         weight_loader = DeepseekV3WeightLoader(self)
         weight_loader.load_weights(weights)
 

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -12,8 +12,6 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_any_only
 from tqdm import tqdm
 
-from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
-    ConsumableWeightsDict
 from tensorrt_llm._utils import local_mpi_rank
 from tensorrt_llm.lora_manager import HfLoraLoader
 from tensorrt_llm.models.convert_utils import split_matrix_tp
@@ -971,7 +969,7 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
 
 
 def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],
-                          weights: ConsumableWeightsDict,
+                          weights,
                           weight_mapper: "BaseWeightMapper",
                           skip_modules: List[str] = [],
                           params_map: Optional[Dict[str, str]] = None,

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -748,11 +748,17 @@ def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
             pattern_mapping = {
                 r'(.*?)out_proj(.*)': r'\1o_proj\2'
             }
-        weights: A dictionary of weights
+        weights: A dictionary of weights (or ConsumableWeightsDict)
     Returns:
-        A dictionary of weights with renamed keys
+        A dictionary of weights with renamed keys (preserves ConsumableWeightsDict if input was one)
     """
     import re
+
+    from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+        ConsumableWeightsDict
+
+    # Check if input is a ConsumableWeightsDict to preserve the type
+    is_consumable = isinstance(weights, ConsumableWeightsDict)
 
     # Create a new dictionary to store the renamed weights
     renamed_weights = {}
@@ -776,6 +782,9 @@ def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
         if key not in matched_keys:
             renamed_weights[key] = weights[key]
 
+    # Preserve ConsumableWeightsDict type if that's what was passed in
+    if is_consumable:
+        return ConsumableWeightsDict(renamed_weights)
     return renamed_weights
 
 
@@ -913,6 +922,10 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                     module_weights.append(fw)
                 module.load_weights(weights=module_weights,
                                     allow_partial_loading=allow_partial_loading)
+                # Mark consumed source weights (e.g., q_proj, k_proj, v_proj for qkv_proj)
+                if hasattr(weights, 'mark_consumed'):
+                    for src_name in params_map[names[-1]]:
+                        weights.mark_consumed('.'.join(names[:-1] + [src_name]))
 
             else:
                 module_weights = filter_weights(name, weights)
@@ -933,6 +946,10 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                                 assert n in module_weights
                             if n in module_weights:
                                 p.data.copy_(module_weights[n][:])
+
+                    # Mark consumed weights
+                    if hasattr(weights, 'mark_consumed'):
+                        weights.mark_consumed(name)
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
                       "False") in ["True", "true", "1", "yes", "y"]:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced memory management during model weight loading across all supported architectures, enabling more efficient memory usage patterns during initialization.
  * Strengthened weight loading validation and tracking mechanisms to prevent redundant loading operations and improve initialization reliability across multiple model types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

TRTLLM doesn't delete the tensors in host memory after they've been copied to the GPU. This leads to massive host memory usage relative to the size of the checkpoint, leading to OOMs when loading large checkpoints.

Some testing on DSR1 FP4 (~350GB checkpoint)

Main branch: Peak at ~700GB
<img width="1260" height="540" alt="baseline" src="https://github.com/user-attachments/assets/7e82bd67-c4e4-4748-8a8b-a1dd37a16a2a" />

This branch: Peak at ~120GB
<img width="1260" height="540" alt="fixed" src="https://github.com/user-attachments/assets/6a16a0b8-7c3c-4b75-8e21-3623cab7551d" />


<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
