### PR TITLE
[None][chore] Print memory usage before/after accuracy test in CI

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -339,19 +339,16 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
     def test_bf16(self):
         kwargs = self.get_default_kwargs()
         sampling_params = self.get_default_sampling_params()
+        print_memory_usage("Before evaluation")
         with AutoDeployLLM(model=self.MODEL_PATH_BF16,
                            tokenizer=self.MODEL_PATH_BF16,
                            world_size=4,
                            **kwargs) as llm:
             task = MMLU(self.MODEL_NAME)
-            print_memory_usage("Before MMLU evaluation")
             task.evaluate(llm, sampling_params=sampling_params)
-            print_memory_usage("After MMLU evaluation")
-
             task = GSM8K(self.MODEL_NAME)
-            print_memory_usage("Before GSM8K evaluation")
             task.evaluate(llm)
-            print_memory_usage("After GSM8K evaluation")
+        print_memory_usage("After evaluation")
 
     @pytest.mark.skip("Skipping FP8 test until it is supported")
     @pytest.mark.skip_less_device_memory(180000)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+import torch
 from defs.conftest import skip_pre_blackwell
 from test_common.llm_data import hf_id_to_local_model_dir, llm_models_root
 
@@ -23,6 +24,34 @@ from tensorrt_llm.sampling_params import SamplingParams
 
 from ..conftest import get_device_count, llm_models_root
 from .accuracy_core import GSM8K, MMLU, CnnDailymail, LlmapiAccuracyTestHarness
+
+
+def print_memory_usage(label: str):
+    """Print detailed memory usage for all CUDA devices."""
+    print(f"\n{'=' * 60}")
+    print(f"Memory Usage: {label}")
+    print(f"{'=' * 60}")
+    num_devices = torch.cuda.device_count()
+    for device_id in range(num_devices):
+        allocated = torch.cuda.memory_allocated(device_id) / 1024**3
+        reserved = torch.cuda.memory_reserved(device_id) / 1024**3
+        peak_allocated = torch.cuda.max_memory_allocated(device_id) / 1024**3
+        peak_reserved = torch.cuda.max_memory_reserved(device_id) / 1024**3
+        cached_available = reserved - allocated  # Available in PyTorch's cache
+        free, total = torch.cuda.mem_get_info(device_id)
+        free_gb = free / 1024**3
+        total_gb = total / 1024**3
+        used_gb = total_gb - free_gb
+        print(f"  Device {device_id}:")
+        print(f"    Allocated:       {allocated:.2f} GB")
+        print(f"    Reserved:        {reserved:.2f} GB")
+        print(f"    Peak Allocated:  {peak_allocated:.2f} GB")
+        print(f"    Peak Reserved:   {peak_reserved:.2f} GB")
+        print(
+            f"    Available:       {cached_available:.2f} GB (in PyTorch cache) | {free_gb:.2f} GB (on GPU)"
+        )
+        print(f"    GPU Total:       {used_gb:.2f} / {total_gb:.2f} GB")
+    print(f"{'=' * 60}\n")
 
 
 class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
@@ -315,9 +344,14 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
                            world_size=4,
                            **kwargs) as llm:
             task = MMLU(self.MODEL_NAME)
+            print_memory_usage("Before MMLU evaluation")
             task.evaluate(llm, sampling_params=sampling_params)
+            print_memory_usage("After MMLU evaluation")
+
             task = GSM8K(self.MODEL_NAME)
+            print_memory_usage("Before GSM8K evaluation")
             task.evaluate(llm)
+            print_memory_usage("After GSM8K evaluation")
 
     @pytest.mark.skip("Skipping FP8 test until it is supported")
     @pytest.mark.skip_less_device_memory(180000)


### PR DESCRIPTION
Added print memory status in Nemotron SuperV3 accuracy test to monitor flaky CI failure. 

```
Before and after the test, it prints below info:
============================================================
Memory Usage: Before evaluation
============================================================
  Device 0:
    Allocated:       0.00 GB
    Reserved:        0.00 GB
    Peak Allocated:  0.00 GB
    Peak Reserved:   0.00 GB
    Available:       0.00 GB (in PyTorch cache) | 183.63 GB (on GPU)
    GPU Total:       0.68 / 184.31 GB
  Device 1:
    Allocated:       0.00 GB
    Reserved:        0.00 GB
    Peak Allocated:  0.00 GB
    Peak Reserved:   0.00 GB
    Available:       0.00 GB (in PyTorch cache) | 183.63 GB (on GPU)
    GPU Total:       0.68 / 184.31 GB
  Device 2:
    Allocated:       0.00 GB
    Reserved:        0.00 GB
    Peak Allocated:  0.00 GB
    Peak Reserved:   0.00 GB
    Available:       0.00 GB (in PyTorch cache) | 183.63 GB (on GPU)
    GPU Total:       0.68 / 184.31 GB
  Device 3:
    Allocated:       0.00 GB
    Reserved:        0.00 GB
    Peak Allocated:  0.00 GB
    Peak Reserved:   0.00 GB
    Available:       0.00 GB (in PyTorch cache) | 183.63 GB (on GPU)
    GPU Total:       0.68 / 184.31 GB
============================================================

[01/30/2026-15:41:04] [TRT-LLM] [I] Using LLM with AutoDeploy backend
```
 

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal testing infrastructure with memory profiling capabilities during model evaluations to monitor resource utilization across devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->