### PR TITLE
[None][chore] Align LlmArgs with some Pydantic best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ HuggingFace Model → LLM API → Executor (PyTorch/AutoDeploy/TensorRT)
 - **Avoid broad exception handling** — catch specific exceptions, not bare `except:` (see `CODING_GUIDELINES.md`).
 - **Python import style is enforced** — `from package.subpackage import module`, never `from module import Class`. Pre-commit will not catch this.
 - **One concern per PR** — avoid scope creep. If a PR touches unrelated areas, split it.
+- **User-facing configuration classes** - when editing or defining any user-facing configuration classes (particularly `LlmArgs` or any class used in its fields), you **MUST** follow the Pydantic guidelines in `CODING_GUIDELINES.md`.
 
 ## Development Workflow
 

--- a/examples/models/core/gemma/convert_checkpoint.py
+++ b/examples/models/core/gemma/convert_checkpoint.py
@@ -172,8 +172,9 @@ def compute_quant_algo(args: argparse.Namespace) -> Optional[QuantAlgo]:
 def create_quant_config(args: argparse.Namespace) -> QuantConfig:
     quant_algo = compute_quant_algo(args)
     GemmaForCausalLM.assert_valid_quant_algo(quant_algo)
-    quant_config = QuantConfig(quant_algo=quant_algo,
-                               smoothquant_val=args.smoothquant)
+    quant_config = QuantConfig(quant_algo=quant_algo)
+    if args.smoothquant is not None:
+        quant_config.smoothquant_val = args.smoothquant
 
     if args.fp8_kv_cache:
         quant_config.kv_cache_quant_algo = QuantAlgo.FP8

--- a/examples/models/core/llama/convert_checkpoint.py
+++ b/examples/models/core/llama/convert_checkpoint.py
@@ -443,7 +443,7 @@ def from_cli_args(args):
             'moe_ep_size': args.moe_ep_size,
             'cp_size': args.cp_size,
         },
-        'quantization': args_to_quant_config(args).to_dict()
+        'quantization': args_to_quant_config(args).model_dump()
     }
     config.update(args_to_build_options(args))
     return config

--- a/examples/models/core/mllama/convert_checkpoint.py
+++ b/examples/models/core/mllama/convert_checkpoint.py
@@ -350,7 +350,7 @@ def from_cli_args(args):
             'moe_tp_size': args.moe_tp_size,
             'moe_ep_size': args.moe_ep_size,
         },
-        'quantization': args_to_quant_config(args).to_dict()
+        'quantization': args_to_quant_config(args).model_dump()
     }
     config.update(args_to_build_options(args))
     return config

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -159,7 +159,7 @@ class DemoLLM(LLM):
     """
 
     def __init__(self, **kwargs):
-        self.args: LlmArgs = LlmArgs.from_kwargs(**kwargs)
+        self.args: LlmArgs = LlmArgs(**kwargs)
 
         self.mpi_session = None
         self.runtime_context = None

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -187,7 +187,12 @@ class LlmArgs(DynamicYamlMixInForSettings, TorchLlmArgs, BaseSettings):
         " no processes are spawned and the model is run on a single GPU (only for ``demollm``).",
     )
 
-    runtime: Literal["demollm", "trtllm"] = Field(default="trtllm")
+    runtime: Literal["demollm", "trtllm"] = Field(
+        default="trtllm",
+        description="The runtime backend to use. 'trtllm' is a production-grade runtime optimized for "
+        "high-performance inference. 'demollm' is a lightweight runtime for development and testing "
+        "with a simplified scheduler and KV-cache manager for easier debugging.",
+    )
 
     device: str = Field(default="cuda", description="The device to use for the model.", frozen=True)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3416,7 +3416,7 @@ class PyTorchModelEngine(ModelEngine):
                 return self._prepare_star_attention_inputs(
                     scheduled_requests, kv_cache_manager, attn_metadata,
                     resource_manager)
-            elif CpType.HELIX == cp_type:
+            elif cp_type in (CpType.HELIX, CpType.ULYSSES):
                 # Take the usual route of _prepare_tp_inputs.
                 pass
             else:

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import tensorrt as trt
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ._common import _is_building, check_max_num_tokens, serialize_engine
 from ._utils import (get_sm_version, np_bfloat16, np_float8, str_dtype_to_trt,
@@ -30,6 +30,7 @@ from ._utils import (get_sm_version, np_bfloat16, np_float8, str_dtype_to_trt,
 from .functional import PositionEmbeddingType
 from .graph_rewriting import optimize
 from .llmapi.kv_cache_type import KVCacheType
+from .llmapi.utils import StrictBaseModel
 from .logger import logger
 from .lora_helper import LoraConfig
 from .models import PretrainedConfig, PretrainedModel
@@ -450,7 +451,7 @@ class Builder():
         logger.info(f'Config saved to {config_path}.')
 
 
-class BuildConfig(BaseModel):
+class BuildConfig(StrictBaseModel):
     """Configuration class for TensorRT LLM engine building parameters.
 
     This class contains all the configuration parameters needed to build a TensorRT LLM engine,

--- a/tensorrt_llm/commands/build.py
+++ b/tensorrt_llm/commands/build.py
@@ -458,7 +458,6 @@ def main():
         )
 
     plugin_config = PluginConfig.from_arguments(args)
-    plugin_config.validate()
     if args.fast_build:
         plugin_config.manage_weights = True
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -189,7 +189,7 @@ def get_llm_args(
         KvCacheConfig(free_gpu_memory_fraction=free_gpu_memory_fraction)
         if free_gpu_memory_fraction != kv_cache_default_fraction else None,
         "cp_config":
-        cp_config if cp_config else {},
+        cp_config,
         "build_config":
         BuildConfig(max_batch_size=max_batch_size,
                     max_num_tokens=max_num_tokens,

--- a/tensorrt_llm/llmapi/build_cache.py
+++ b/tensorrt_llm/llmapi/build_cache.py
@@ -10,10 +10,12 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 import filelock
+from pydantic import Field, model_validator
 
 import tensorrt_llm
 from tensorrt_llm.builder import BuildConfig
-from tensorrt_llm.llmapi.utils import enable_llm_debug, print_colored
+from tensorrt_llm.llmapi.utils import (StrictBaseModel, enable_llm_debug,
+                                       print_colored)
 from tensorrt_llm.logger import logger
 
 
@@ -28,41 +30,36 @@ def get_build_cache_config_from_env() -> tuple[bool, str]:
     return build_cache_enabled, build_cache_root
 
 
-class BuildCacheConfig:
+class BuildCacheConfig(StrictBaseModel):
     """
     Configuration for the build cache.
-
-    Attributes:
-        cache_root (str): The root directory for the build cache.
-        max_records (int): The maximum number of records to store in the cache.
-        max_cache_storage_gb (float): The maximum amount of storage (in GB) to use for the cache.
 
     Note:
         The build-cache assumes the weights of the model are not changed during the execution. If the weights are
         changed, you should remove the caches manually.
     """
 
-    def __init__(self,
-                 cache_root: Optional[Path] = None,
-                 max_records: int = 10,
-                 max_cache_storage_gb: float = 256):
-        self._cache_root = cache_root
-        self._max_records = max_records
-        self._max_cache_storage_gb = max_cache_storage_gb
+    cache_root: Optional[Path] = Field(
+        default=None,
+        description=
+        "The root directory for the build cache. Falls back to env var if not provided."
+    )
+    max_records: int = Field(
+        default=10,
+        gt=0,
+        description="The maximum number of records to store in the cache.")
+    max_cache_storage_gb: float = Field(
+        default=256.0,
+        description="The maximum amount of storage (in GB) to use for the cache."
+    )
 
-    @property
-    def cache_root(self) -> Path:
-        _build_cache_enabled, _build_cache_root = get_build_cache_config_from_env(
-        )
-        return self._cache_root or Path(_build_cache_root)
-
-    @property
-    def max_records(self) -> int:
-        return self._max_records
-
-    @property
-    def max_cache_storage_gb(self) -> float:
-        return self._max_cache_storage_gb
+    @model_validator(mode="after")
+    def set_default_cache_root(self) -> "BuildCacheConfig":
+        """Set cache_root from environment variable if not provided."""
+        if self.cache_root is None:
+            _, default_cache_root = get_build_cache_config_from_env()
+            self.cache_root = Path(default_cache_root)
+        return self
 
 
 class BuildCache:
@@ -76,16 +73,10 @@ class BuildCache:
     CACHE_VERSION = 0
 
     def __init__(self, config: Optional[BuildCacheConfig] = None):
-
-        _, default_cache_root = get_build_cache_config_from_env()
         config = config or BuildCacheConfig()
-
-        self.cache_root = config.cache_root or Path(default_cache_root)
+        self.cache_root = config.cache_root
         self.max_records = config.max_records
         self.max_cache_storage_gb = config.max_cache_storage_gb
-
-        if config.max_records < 1:
-            raise ValueError("max_records should be greater than 0")
 
     def free_storage_in_gb(self) -> float:
         ''' Get the free storage capacity of the cache. '''

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -188,17 +188,16 @@ class BaseLLM:
                         f"{self.__class__.__name__} got invalid argument: {key}"
                     )
 
-            self.args = llm_args_cls.from_kwargs(
-                model=model,
-                tokenizer=tokenizer,
-                tokenizer_mode=tokenizer_mode,
-                skip_tokenizer_init=skip_tokenizer_init,
-                trust_remote_code=trust_remote_code,
-                tensor_parallel_size=tensor_parallel_size,
-                dtype=dtype,
-                revision=revision,
-                tokenizer_revision=tokenizer_revision,
-                **kwargs)
+            self.args = llm_args_cls(model=model,
+                                     tokenizer=tokenizer,
+                                     tokenizer_mode=tokenizer_mode,
+                                     skip_tokenizer_init=skip_tokenizer_init,
+                                     trust_remote_code=trust_remote_code,
+                                     tensor_parallel_size=tensor_parallel_size,
+                                     dtype=dtype,
+                                     revision=revision,
+                                     tokenizer_revision=tokenizer_revision,
+                                     **kwargs)
 
         except Exception as e:
             logger.error(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -136,8 +136,7 @@ class CudaGraphConfig(StrictBaseModel):
                     "max_batch_size must equal max(batch_sizes).\n"
                     f"CudaGraphConfig.batch_sizes: {self.batch_sizes}, "
                     f"max(batch_sizes): {derived_max}, "
-                    f"CudaGraphConfig.max_batch_size: {self.max_batch_size}"
-                )
+                    f"CudaGraphConfig.max_batch_size: {self.max_batch_size}")
         else:
             max_batch_size = self.max_batch_size or 128
             generated_sizes = CudaGraphConfig._generate_cuda_graph_batch_sizes(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -498,6 +498,8 @@ class CpConfig(StrictBaseModel):
     """
     Configuration for context parallelism.
     """
+    # TODO: given that multiple fields here are only used with specific cp_types, consider
+    # making this a Pydantic discriminated union.
     cp_type: CpType = Field(default=CpType.ULYSSES,
                             description="Context parallel type.")
     tokens_per_block: Optional[int] = Field(
@@ -507,6 +509,11 @@ class CpConfig(StrictBaseModel):
         default=None,
         description=
         "Whether to use NCCL for alltoall communication. Used in HELIX parallelism. Defaults to True."
+    )
+    fifo_version: Optional[int] = Field(
+        default=None,
+        description=
+        "FIFO version for alltoall communication. Used in HELIX parallelism. Defaults to 2."
     )
     cp_anchor_size: Optional[int] = Field(
         default=None, description="Anchor size for STAR attention.")
@@ -586,7 +593,8 @@ class _ParallelConfig(StrictBaseModel):
             pp_partition=self.pp_partition,
             cp_size=self.cp_size,
             # TODO: Mapping still uses cp_config as a dict; migrate to CpConfig
-            cp_config=self.cp_config.model_dump() if self.cp_config else {},
+            cp_config=self.cp_config.model_dump(
+                exclude_none=True) if self.cp_config else {},
             enable_attention_dp=self.enable_attention_dp,
             enable_lm_head_tp_in_adp=self.enable_lm_head_tp_in_adp,
             moe_cluster_size=self.moe_cluster_size,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -8,14 +8,15 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from pathlib import Path
-from typing import (Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple,
+from typing import (Annotated, Any, Dict, List, Literal, Optional, Set, Tuple,
                     Type, TypeAlias, TypeVar, Union, get_args, get_origin)
 
 import torch
 import yaml
-from pydantic import AliasChoices, BaseModel
+from pydantic import AliasChoices, BaseModel, ConfigDict
 from pydantic import Field as PydanticField
-from pydantic import PrivateAttr, field_validator, model_validator
+from pydantic import (NonNegativeFloat, NonNegativeInt, PositiveInt,
+                      PrivateAttr, field_validator, model_validator)
 from strenum import StrEnum
 from transformers import PreTrainedTokenizerBase
 
@@ -51,16 +52,15 @@ from ..bindings.executor import (BatchingType as _BatchingType,
 # yapf: enable
 from ..builder import BuildConfig, EngineConfig
 from ..logger import logger
-from ..mapping import Mapping
+from ..mapping import CpType, Mapping
 from ..models.automodel import AutoConfig
 from ..models.modeling_utils import (PretrainedConfig, QuantAlgo, QuantConfig,
                                      SpeculativeDecodingMode)
 from ..sampling_params import BatchedLogitsProcessor
 from .build_cache import BuildCacheConfig
 from .tokenizer import TokenizerBase, tokenizer_factory
-from .utils import generate_api_docs_as_docstring, get_type_repr
-
-# TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
+from .utils import (StrictBaseModel, generate_api_docs_as_docstring,
+                    get_type_repr)
 
 TypeBaseModel = TypeVar("T", bound=BaseModel)
 
@@ -95,15 +95,6 @@ def Field(default: Any = ...,
     return PydanticField(default, **kwargs)
 
 
-class StrictBaseModel(BaseModel):
-    """
-    A base model that forbids arbitrary fields.
-    """
-
-    class Config:
-        extra = "forbid"  # globally forbid arbitrary fields
-
-
 class CudaGraphConfig(StrictBaseModel):
     """
     Configuration for CUDA graphs.
@@ -113,7 +104,7 @@ class CudaGraphConfig(StrictBaseModel):
         default=None,
         description="List of batch sizes to create CUDA graphs for.")
 
-    max_batch_size: int = Field(
+    max_batch_size: NonNegativeInt = Field(
         default=0, description="Maximum batch size for CUDA graphs.")
 
     enable_padding: bool = Field(
@@ -122,14 +113,39 @@ class CudaGraphConfig(StrictBaseModel):
         "If true, batches are rounded up to the nearest cuda_graph_batch_size. This is usually a net win for performance."
     )
 
-    @field_validator('max_batch_size')
-    @classmethod
-    def validate_cuda_graph_max_batch_size(cls, v):
-        """Validate cuda_graph_config.max_batch_size is non-negative."""
-        if v < 0:
-            raise ValueError(
-                "cuda_graph_config.max_batch_size must be non-negative")
-        return v
+    @model_validator(mode='after')
+    def validate_cuda_graph_config(self) -> 'CudaGraphConfig':
+        """Validate CUDA graph configuration.
+
+        Ensures that:
+        1. If batch_sizes is provided, max_batch_size is derived as max(batch_sizes).
+           If max_batch_size was already set it must be compatible (equal to max(batch_sizes));
+           otherwise an error is raised.
+        2. If only max_batch_size is provided, batch_sizes is generated from it.
+        3. If neither is provided, a default max_batch_size of 128 is used.
+        """
+        if self.batch_sizes:
+            self.batch_sizes = sorted(self.batch_sizes)
+            derived_max = max(self.batch_sizes)
+            if self.max_batch_size == 0:
+                self.max_batch_size = derived_max
+            elif self.max_batch_size != derived_max:
+                raise ValueError(
+                    "CudaGraphConfig.max_batch_size is incompatible with "
+                    "CudaGraphConfig.batch_sizes. When both are provided, "
+                    "max_batch_size must equal max(batch_sizes).\n"
+                    f"CudaGraphConfig.batch_sizes: {self.batch_sizes}, "
+                    f"max(batch_sizes): {derived_max}, "
+                    f"CudaGraphConfig.max_batch_size: {self.max_batch_size}"
+                )
+        else:
+            max_batch_size = self.max_batch_size or 128
+            generated_sizes = CudaGraphConfig._generate_cuda_graph_batch_sizes(
+                max_batch_size, self.enable_padding)
+            self.batch_sizes = generated_sizes
+            self.max_batch_size = max_batch_size
+
+        return self
 
     @staticmethod
     def _generate_cuda_graph_batch_sizes(max_batch_size: int,
@@ -188,40 +204,13 @@ class BaseSparseAttentionConfig(StrictBaseModel):
     """
     Configuration for sparse attention.
     """
+    algorithm: str
+
     seq_len_threshold: Optional[int] = Field(
         default=None,
         description=
         "The sequence length threshold for separating short and long sequences."
     )
-
-    @property
-    def algorithm(self) -> str:
-        raise NotImplementedError("Algorithm must be implemented in subclasses")
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        # dispatch to the correct sparse attention config
-        config_classes = {
-            "rocket": RocketSparseAttentionConfig,
-            "dsa": DeepSeekSparseAttentionConfig,
-            "skip_softmax": SkipSoftmaxAttentionConfig,
-        }
-
-        algorithm = data.get("algorithm", None)
-        if algorithm is None:
-            raise ValueError(f"Sparse attention algorithm is required")
-
-        config_class = config_classes.get(algorithm.lower())
-        if config_class is None:
-            raise ValueError(f"Invalid algorithm: {algorithm}")
-
-        # Remove 'algorithm' before passing to subclass constructor
-        # It's a ClassVar in subclasses, and used for dispatching to the correct subclass
-        data = {k: v for k, v in data.items() if k != 'algorithm'}
-        return config_class(**data)
-
-    def _check_fields(self):
-        pass
 
     def supports_backend(self, backend: str) -> bool:
         """
@@ -247,7 +236,7 @@ class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
     """
     Configuration for RocketKV sparse attention.
     """
-    algorithm: ClassVar[str] = "rocket"
+    algorithm: Literal["rocket"] = "rocket"
     window_size: Optional[int] = Field(
         default=32, description="The window size for snap KV.")
     kernel_size: Optional[int] = Field(
@@ -263,10 +252,6 @@ class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
         description="KT cache dtype",
     )
 
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
 
@@ -278,7 +263,7 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
     """
     Configuration for DeepSeek Sparse Attention.
     """
-    algorithm: ClassVar[str] = "dsa"
+    algorithm: Literal["dsa"] = "dsa"
     index_n_heads: Optional[int] = Field(
         default=None, description="The number of heads for the indexer.")
     index_head_dim: Optional[int] = Field(
@@ -291,10 +276,6 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
         default=True,
         description=
         "Whether to skip the MQA and Top-K in the indexer for short sequences.")
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -312,14 +293,10 @@ class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
     """
     Configuration for skip softmax attention.
     """
-    algorithm: ClassVar[str] = "skip_softmax"
+    algorithm: Literal["skip_softmax"] = "skip_softmax"
     threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = Field(
         default=None,
         description="The threshold scale factor for skip softmax attention.")
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -475,37 +452,21 @@ class MoeConfig(StrictBaseModel):
         "Use low precision combine in MoE operations (only for NVFP4 quantization). When enabled, uses lower precision for combining expert outputs to improve performance."
     )
 
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
+
+Nvfp4Backend = Literal['cutlass', 'cublaslt', 'cutedsl', 'cuda_core']
 
 
 class Nvfp4GemmConfig(StrictBaseModel):
     """
     Configuration for NVFP4 GEMM backend selection.
     """
-    allowed_backends: List[str] = Field(
-        default=['cutlass', 'cublaslt', 'cuda_core'],
+    allowed_backends: List[Nvfp4Backend] = Field(
+        default_factory=lambda: ['cutlass', 'cublaslt', 'cuda_core'],
+        min_length=1,
         description="List of backends to consider for auto-selection. "
         "Default excludes 'cutedsl' for faster build time. "
-        "Add 'cutedsl' for extreme performance at the cost of longer server launch time. "
-        "Valid values: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.")
-
-    @model_validator(mode="after")
-    def validate_allowed_backends(self) -> 'Nvfp4GemmConfig':
-        valid_backends = {'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'}
-        invalid = set(self.allowed_backends) - valid_backends
-        if invalid:
-            raise ValueError(
-                f"Invalid backends in allowed_backends: {invalid}. "
-                f"Valid backends are: {sorted(valid_backends)}")
-        if not self.allowed_backends:
-            raise ValueError("allowed_backends cannot be empty.")
-        return self
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
+        "Add 'cutedsl' for extreme performance at the cost of longer server launch time."
+    )
 
 
 class AttentionDpConfig(StrictBaseModel):
@@ -520,9 +481,48 @@ class AttentionDpConfig(StrictBaseModel):
         default=10,
         description="The number of iterations to wait for batching.")
 
+    @model_validator(mode='after')
+    def validate_attention_dp_config(self) -> 'AttentionDpConfig':
+        if self.enable_balance:
+            if self.batching_wait_iters < 0:
+                raise ValueError(
+                    "attention_dp_config.batching_wait_iters must be greater or equal to 0 when enable_balance is true"
+                )
+            if self.timeout_iters < 0:
+                raise ValueError(
+                    "attention_dp_config.timeout_iters must be greater or equal to 0 when enable_balance is true"
+                )
+        return self
+
+
+class CpConfig(StrictBaseModel):
+    """
+    Configuration for context parallelism.
+    """
+    cp_type: CpType = Field(default=CpType.ULYSSES,
+                            description="Context parallel type.")
+    tokens_per_block: Optional[int] = Field(
+        default=None,
+        description="Number of tokens per block. Used in HELIX parallelism.")
+    use_nccl_for_alltoall: Optional[bool] = Field(
+        default=None,
+        description=
+        "Whether to use NCCL for alltoall communication. Used in HELIX parallelism. Defaults to True."
+    )
+    cp_anchor_size: Optional[int] = Field(
+        default=None, description="Anchor size for STAR attention.")
+    block_size: Optional[int] = Field(
+        default=None, description="Block size for STAR attention.")
+
+    @field_validator("cp_type", mode="before")
     @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
+    def validate_cp_type(cls, v):
+        """Normalize cp_type string to uppercase."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            return v.upper()
+        return v
 
 
 class _ParallelConfig(StrictBaseModel):
@@ -535,7 +535,7 @@ class _ParallelConfig(StrictBaseModel):
     moe_cluster_size: int = -1
     moe_tp_size: int = -1
     moe_ep_size: int = -1
-    cp_config: dict = Field(default_factory=dict)
+    cp_config: Optional[CpConfig] = Field(default=None)
     pp_partition: Optional[List[int]] = Field(default=None)
     enable_attention_dp: bool = False
     enable_lm_head_tp_in_adp: bool = False
@@ -578,19 +578,21 @@ class _ParallelConfig(StrictBaseModel):
         return self.world_size > 1
 
     def to_mapping(self) -> Mapping:
-        return Mapping(world_size=self.world_size,
-                       rank=mpi_rank(),
-                       gpus_per_node=self.gpus_per_node,
-                       tp_size=self.tp_size,
-                       pp_size=self.pp_size,
-                       pp_partition=self.pp_partition,
-                       cp_size=self.cp_size,
-                       cp_config=self.cp_config,
-                       enable_attention_dp=self.enable_attention_dp,
-                       enable_lm_head_tp_in_adp=self.enable_lm_head_tp_in_adp,
-                       moe_cluster_size=self.moe_cluster_size,
-                       moe_tp_size=self.moe_tp_size,
-                       moe_ep_size=self.moe_ep_size)
+        return Mapping(
+            world_size=self.world_size,
+            rank=mpi_rank(),
+            gpus_per_node=self.gpus_per_node,
+            tp_size=self.tp_size,
+            pp_size=self.pp_size,
+            pp_partition=self.pp_partition,
+            cp_size=self.cp_size,
+            # TODO: Mapping still uses cp_config as a dict; migrate to CpConfig
+            cp_config=self.cp_config.model_dump() if self.cp_config else {},
+            enable_attention_dp=self.enable_attention_dp,
+            enable_lm_head_tp_in_adp=self.enable_lm_head_tp_in_adp,
+            moe_cluster_size=self.moe_cluster_size,
+            moe_tp_size=self.moe_tp_size,
+            moe_ep_size=self.moe_ep_size)
 
 
 class CalibConfig(StrictBaseModel):
@@ -618,26 +620,6 @@ class CalibConfig(StrictBaseModel):
         description=
         "The maximum sequence length to initialize tokenizer for calibration.")
 
-    @classmethod
-    def from_dict(cls, config: dict) -> 'CalibConfig':
-        """Create a CalibConfig instance from a dict.
-
-        Args:
-            config (dict): The dict used to create CalibConfig.
-
-        Returns:
-            tensorrt_llm.llmapi.CalibConfig: The CalibConfig created from dict.
-        """
-        return cls(**config)
-
-    def to_dict(self) -> dict:
-        """Dump a CalibConfig instance to a dict.
-
-        Returns:
-            dict: The dict dumped from CalibConfig.
-        """
-        return self.model_dump()
-
 
 class _ModelFormatKind(Enum):
     HF = 0
@@ -646,73 +628,67 @@ class _ModelFormatKind(Enum):
 
 
 class DecodingBaseConfig(StrictBaseModel):
-    # The number of the drafter layers.
-    max_draft_len: Optional[int] = None
-    # The number of draft tokens in the draft tokens tree.
-    # If it's a linear tree, each draft layer will only generate one draft token.
-    # In this case, max_draft_len == max_total_draft_tokens.
-    # If it's a static or dynamic tree, each draft layer may generate more than one draft token.
-    # In this case, max_total_draft_tokens >= max_draft_len.
-    max_total_draft_tokens: Optional[int] = None
-    # The speculative (draft) model. Accepts either:
-    # - A HuggingFace Hub model ID (str), e.g., "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
-    #   which will be automatically downloaded.
-    # - A local filesystem path to a downloaded model directory.
+    max_draft_len: Optional[NonNegativeInt] = Field(
+        default=None, description="The number of drafter layers.")
+
+    max_total_draft_tokens: Optional[int] = Field(
+        default=None,
+        description=
+        "The number of draft tokens in the draft tokens tree. If it's a linear tree, each draft layer will "
+        "only generate one draft token. In this case, max_draft_len == max_total_draft_tokens. If it's a static or "
+        "dynamic tree, each draft layer may generate more than one draft token. In this case, "
+        "max_total_draft_tokens >= max_draft_len.")
+
     speculative_model: Optional[Union[str, Path]] = Field(
         default=None,
         validation_alias=AliasChoices("speculative_model",
-                                      "speculative_model_dir"))
+                                      "speculative_model_dir"),
+        description=
+        "The speculative (draft) model. Accepts either (1) a HuggingFace Hub model ID (e.g. 'yuhuili/EAGLE3-LLaMA3.1-Instruct-8B'),"
+        "which will be automatically downloaded, or (2) a local filesystem path to a downloaded model directory."
+    )
 
-    # PyTorch only.
-    # When specified, speculation will be disabled at batch sizes above
-    # this value. Otherwise, speculation will always be on.
-    max_concurrency: Optional[int] = None
+    max_concurrency: Optional[NonNegativeInt] = Field(
+        default=None,
+        description=
+        "When specified, speculation will be disabled at batch sizes above this value. Otherwise, "
+        "speculation will always be on. PyTorch backend only.")
 
-    # Developer interface: dynamically adjust draft length based on active batch size in runtime.
-    # Maps batch size to draft lengths. For example:
-    # {1: 4, 4: 2, 8: 0} means:
-    # - batch_size >= 1: use draft_len=4
-    # - batch_size >= 4: use draft_len=2
-    # - batch_size >= 8: use draft_len=0 (disable speculation)
-    # draft_len_schedule is enforced to contain batch_size=1 and its according draft_len equals max_draft_len for consistency
-    # for example, if max_draft_len=4, the schedule must contain {1: 4}
-    draft_len_schedule: Optional[dict[int, int]] = None
+    draft_len_schedule: Optional[dict[int, int]] = Field(
+        default=None,
+        description=
+        "Developer interface: dynamically adjust draft length based on active batch size in runtime. "
+        "Maps batch size to draft lengths. For example, {1: 4, 4: 2, 8: 0} means: "
+        "batch_size >= 1 uses draft_len=4, batch_size >= 4 uses draft_len=2, "
+        "batch_size >= 8 uses draft_len=0 (disable speculation). "
+        "draft_len_schedule is enforced to contain batch_size=1 and its according draft_len equals "
+        "max_draft_len for consistency; for example, if max_draft_len=4, the schedule must contain {1: 4}."
+    )
 
-    load_format: Optional[str] = None
-    # PyTorch only.
-    # Rolling average window size (N) for acceptance length across completed requests.
-    # If not set or set to 0, the feature is disabled.
-    acceptance_window: Optional[int] = None
-    # PyTorch only.
-    # Threshold for average acceptance length; speculation will be disabled
-    # permanently once the rolling average over the last N completed requests
-    # (N = acceptance_window) drops below this value.
-    acceptance_length_threshold: Optional[float] = None
+    load_format: Optional[str] = Field(
+        default=None, description="The load format of the speculative model.")
 
-    # Prototype. If true, allows non-greedy sampling when speculation is used. Only applicable
-    # to 1-model code paths; non-greedy sampling is always enabled on 2-model paths.
-    allow_advanced_sampling: bool = False
+    acceptance_window: Optional[NonNegativeInt] = Field(
+        default=None,
+        description=
+        "The rolling average window size (N) for acceptance length across completed requests. "
+        "If not set or set to 0, the feature is disabled. PyTorch backend only."
+    )
 
-    # Validate acceptance controls at field level so they run on model creation
-    @field_validator('acceptance_window')
-    @classmethod
-    def _validate_acceptance_window(cls, v: Optional[int]):
-        if v is None:
-            return v
-        if v < 0:
-            raise ValueError(
-                f"acceptance_window must be >= 0 (0 disables), got {v}")
-        return v
+    acceptance_length_threshold: Optional[NonNegativeFloat] = Field(
+        default=None,
+        description=
+        "The threshold for average acceptance length; speculation will be disabled permanently once the "
+        "rolling average over the last N completed requests (N = acceptance_window) drops below this value. "
+        "PyTorch backend only.")
 
-    @field_validator('acceptance_length_threshold')
-    @classmethod
-    def _validate_acceptance_length_threshold(cls, v: Optional[float]):
-        if v is None:
-            return v
-        if v < 0:
-            raise ValueError(
-                f"acceptance_length_threshold must be >= 0, got {v}")
-        return v
+    allow_advanced_sampling: bool = Field(
+        default=False,
+        status="prototype",
+        description=
+        "If true, allows non-greedy sampling when speculation is used. Only applicable "
+        "to 1-model code paths; non-greedy sampling is always enabled on 2-model paths."
+    )
 
     # If set, drafting is allowed to use chain drafter.
     _allow_chain_drafter: bool = PrivateAttr(True)
@@ -768,52 +744,12 @@ class DecodingBaseConfig(StrictBaseModel):
             return dict(sorted(v.items(), key=lambda x: x[0]))
         return v
 
-    @classmethod
-    def from_dict(cls, data: dict, backend: Optional[str] = None):
-        # dispatch to the correct decoding config
-        decoding_type = data.get("decoding_type")
-        config_classes = {
-            "MTP": MTPDecodingConfig,
-            "Medusa": MedusaDecodingConfig,
-            "Eagle": EagleDecodingConfig,
-            "Eagle3": Eagle3DecodingConfig,
-            "Lookahead": LookaheadDecodingConfig,
-            "NGram": NGramDecodingConfig,
-            "DraftTarget": DraftTargetDecodingConfig,
-            "SaveState": SaveHiddenStatesDecodingConfig,
-            "UserProvided": UserProvidedDecodingConfig,
-            "AUTO": AutoDecodingConfig,
-        }
-
-        backend = backend.lower() if isinstance(backend, str) else backend
-        if decoding_type == "Eagle" and backend in ("pytorch", "_autodeploy"):
-            data = dict(data)
-            data.pop("decoding_type")
-            spec_cfg = Eagle3DecodingConfig(**data)
-            spec_cfg._decoding_type_alias = "Eagle"
-            return spec_cfg
-
-        config_class = config_classes.get(decoding_type)
-        if config_class is None:
-            raise ValueError(f"Invalid decoding type: {decoding_type}")
-        data.pop("decoding_type")
-
-        return config_class(**data)
-
-    def _check_fields(self):
-        pass
-
     def supports_backend(self, backend: str) -> bool:
         """
         Override if the speculation algorithm does not support
         a subset of the possible backends.
         """
         return True
-
-    def validate(self) -> None:
-        """
-        Do any additional error checking here.
-        """
 
     @functools.cached_property
     def spec_dec_mode(self):
@@ -877,40 +813,74 @@ class LayerwiseBenchmarksConfig(StrictBaseModel):
 
 
 class MedusaDecodingConfig(DecodingBaseConfig):
-    medusa_choices: Optional[List[List[int]]] = None
-    num_medusa_heads: Optional[int] = None
+    decoding_type: Literal["Medusa"] = "Medusa"
+    medusa_choices: Optional[List[List[int]]] = Field(
+        default=None,
+        description=
+        "Tree structure for Medusa draft token generation. Each sublist represents a path in the tree where elements are token indices at each level. "
+        "For example, [[0], [0, 0], [1], [0, 1]] defines multiple branches.")
+    num_medusa_heads: Optional[int] = Field(
+        default=None,
+        description=
+        "Number of Medusa prediction heads to use. Each head predicts a draft token at a different position in parallel. "
+        "If not specified, defaults to the 'medusa_num_heads' value from the Medusa model's config.json."
+    )
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.max_total_draft_tokens = self.max_draft_len  # Current Medusa only support linear tree
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "Medusa"
+    @model_validator(mode="after")
+    def set_max_total_draft_tokens(self):
+        self.max_total_draft_tokens = self.max_draft_len  # Current Medusa only supports linear tree
+        return self
 
     def supports_backend(self, backend: str) -> bool:
         return backend not in ("pytorch", "_autodeploy")
 
 
 class EagleDecodingConfig(DecodingBaseConfig):
-    eagle_choices: Optional[List[List[int]]] = None
-    greedy_sampling: Optional[bool] = True
-    posterior_threshold: Optional[float] = None
-    # Whether to use dynamic tree.
-    use_dynamic_tree: Optional[bool] = False
-    # The topK value for each layer when enable dynamic tree.
-    dynamic_tree_max_topK: Optional[int] = None
-    # The number of eagle layer. will not be used in pytorch flow, just for compatibility with TRT flow
-    num_eagle_layers: Optional[int] = None
-    # The number of non-leaves in each layer.
-    max_non_leaves_per_layer: Optional[int] = None
-    eagle3_one_model: Optional[bool] = True
-    eagle3_layers_to_capture: Optional[Set[int]] = None
-    # The model architecture of the eagle3 model.
-    # choices: llama3, mistral_large3
-    eagle3_model_arch: str = "llama3"
+    decoding_type: Literal["Eagle"] = "Eagle"
+    eagle_choices: Optional[List[List[int]]] = Field(
+        default=None,
+        description=
+        "Static tree structure for draft token generation. Each sublist represents a path in the tree. Mutually exclusive with use_dynamic_tree."
+    )
+    greedy_sampling: Optional[bool] = Field(
+        default=True,
+        description=
+        "Whether to use greedy sampling (Top-1 with token equality acceptance) or typical acceptance with multinomial sampling."
+    )
+    posterior_threshold: Optional[float] = Field(
+        default=None,
+        description=
+        "Minimum token probability threshold for typical acceptance. Corresponds to epsilon in https://arxiv.org/pdf/2401.10774."
+    )
+    use_dynamic_tree: Optional[bool] = Field(
+        default=False,
+        description=
+        "Whether to use dynamic tree (Eagle-2 algorithm). Mutually exclusive with eagle_choices."
+    )
+    dynamic_tree_max_topK: Optional[int] = Field(
+        default=None,
+        description="The topK value for each layer when dynamic tree is enabled."
+    )
+    num_eagle_layers: Optional[int] = Field(
+        default=None,
+        description=
+        "The number of eagle layers. Will not be used in pytorch flow, just for compatibility with TRT flow."
+    )
+    max_non_leaves_per_layer: Optional[int] = Field(
+        default=None, description="The number of non-leaves in each layer.")
+    eagle3_one_model: Optional[bool] = Field(
+        default=True,
+        description=
+        "Whether to use the faster one-model implementation (draft as submodule) or the two-model implementation."
+    )
+    eagle3_layers_to_capture: Optional[Set[int]] = Field(
+        default=None,
+        description=
+        "Target model layer indices to capture hidden states from for the EAGLE3 draft model. Defaults to {1, num_layers//2-1, num_layers-4}."
+    )
+    eagle3_model_arch: Literal["llama3", "mistral_large3"] = Field(
+        default="llama3",
+        description="The model architecture of the eagle3 model.")
 
     @field_validator('eagle_choices', mode='before')
     @classmethod
@@ -930,8 +900,8 @@ class EagleDecodingConfig(DecodingBaseConfig):
 
     @model_validator(mode='after')
     def validate_eagle_config(self) -> 'EagleDecodingConfig':
-        if self.max_draft_len is None:
-            raise ValueError("max_draft_len is required for Eagle")
+        if self.max_draft_len is None or self.max_draft_len == 0:
+            raise ValueError("max_draft_len must be > 0 for Eagle")
         self.num_eagle_layers = self.max_draft_len
         self.max_total_draft_tokens = self.max_draft_len  # If using linear-tree, the max_total_draft_tokens is the same as max_draft_len
 
@@ -943,10 +913,9 @@ class EagleDecodingConfig(DecodingBaseConfig):
         # Checks whether the input eagle choices is valid
         # and reset the max_draft_len and num_eagle_layers if necessary
         if self.eagle_choices is not None:
-            # If eagle_choices is provided, use_dynamic_tree should not be used
             if self.use_dynamic_tree:
                 raise ValueError(
-                    "If eagle_choices is provided, use_dynamic_tree need to be False"
+                    "If eagle_choices is provided, use_dynamic_tree should be False"
                 )
 
             # Get num_eagle_layers from eagle_choices
@@ -982,15 +951,11 @@ class EagleDecodingConfig(DecodingBaseConfig):
 
         return self
 
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "Eagle"
-
-    def validate(self) -> None:
+    @model_validator(mode="after")
+    def validate_speculative_model(self) -> 'EagleDecodingConfig':
         if self.speculative_model is None:
             raise ValueError("Draft model must be provided for EAGLE")
+        return self
 
     def check_eagle_choices(self):
         # 1) Check connectivity
@@ -1038,17 +1003,47 @@ class EagleDecodingConfig(DecodingBaseConfig):
 
 
 class Eagle3DecodingConfig(EagleDecodingConfig):
-    decoding_type: ClassVar[str] = "Eagle3"
+    decoding_type: Literal["Eagle3"] = "Eagle3"
 
 
 class SaveHiddenStatesDecodingConfig(DecodingBaseConfig):
-    output_directory: str
-    write_interval: int = 20
-    file_prefix: str = "data"
-    eagle3_layers_to_capture: Optional[Set[int]] = None
+    decoding_type: Literal["SaveState"] = "SaveState"
+    output_directory: str = Field(
+        description=
+        "Directory path where hidden states data files will be saved. The directory is created if it does not exist."
+    )
+    write_interval: int = Field(
+        default=20,
+        description=
+        "Number of requests to process before writing accumulated hidden states to disk. Lower values write more frequently but may impact performance."
+    )
+    file_prefix: str = Field(
+        default="data",
+        description=
+        "Prefix for output filenames. Files are saved as '<file_prefix>_<iteration>.pt' containing input_ids and hidden_state tensors."
+    )
+    eagle3_layers_to_capture: Optional[Set[int]] = Field(
+        default=None,
+        description=
+        "Set of target model layer indices to capture hidden states from for EAGLE3 draft model training. "
+        "Use -1 to indicate the final post-norm hidden state. If not provided, defaults to capturing 3 intermediate layers "
+        "plus the post-norm hidden state. When provided, -1 is automatically added if not present."
+    )
 
-    max_total_draft_tokens: Optional[int] = Field(default=1, init=False)
-    eagle_choices: Optional[List[List[int]]] = Field(default=None, init=False)
+    max_total_draft_tokens: Optional[int] = Field(
+        default=1,
+        init=False,
+        description=
+        "Internal field, not user-configurable. Fixed to 1 since this mode captures hidden states without draft token generation."
+    )
+    eagle_choices: Optional[List[List[int]]] = Field(
+        default=None,
+        init=False,
+        description=
+        "Internal field, not user-configurable. Always None since this mode does not use tree-based draft token structures."
+    )
+
+    _last_hidden_in_save: bool = PrivateAttr(default=True)
 
     def model_post_init(self, __context):
         self._last_hidden_in_save = True
@@ -1056,17 +1051,9 @@ class SaveHiddenStatesDecodingConfig(DecodingBaseConfig):
             # This variable is queried to determine whether we should write the final hidden state
             # to the aux_hidden_states buffer.
             self._last_hidden_in_save = False
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "SaveState"
-
-    def validate(self) -> None:
-        if self.output_directory is None or not self.eagle3_layers_to_capture:
+        elif len(self.eagle3_layers_to_capture) == 0:
             raise ValueError(
-                "Save directory and layers to capture must be provided")
+                "eagle3_layers_to_capture must be non-empty if provided")
 
     @functools.cached_property
     def spec_dec_mode(self):
@@ -1097,115 +1084,146 @@ class SaveHiddenStatesDecodingConfig(DecodingBaseConfig):
 
 
 class UserProvidedDecodingConfig(DecodingBaseConfig):
+    decoding_type: Literal["User_Provided"] = "User_Provided"
     # Cannot use real type annotations due to circular imports
-    drafter: object  # Type is Drafter
-    resource_manager: object = None  # Type is Optional[ResourceManager]
+    drafter: object = Field(
+        description=
+        "User-provided Drafter instance implementing the prepare_draft_tokens() method for custom draft token generation. "
+        "See tensorrt_llm/_torch/speculative/drafter.py for the Drafter base class interface."
+    )  # Type is Drafter
+    resource_manager: object = Field(
+        default=None,
+        description=
+        "Optional user-provided BaseResourceManager instance for managing resources (memory, caches) during drafting. "
+        "Called to prepare/free resources before/after target model forward passes."
+    )  # Type is Optional[ResourceManager]
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.max_total_draft_tokens = self.max_draft_len  # Current UserProvided only support linear tree
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "User_Provided"
+    @model_validator(mode="after")
+    def set_max_total_draft_tokens(self):
+        self.max_total_draft_tokens = self.max_draft_len  # Current UserProvided only supports linear tree
+        return self
 
 
 class NGramDecodingConfig(DecodingBaseConfig):
     """
     Configuration for NGram drafter speculative decoding.
-
-    Arguments:
-        max_draft_len: int
-                The length maximum of draft tokens (can be understood as length maximum of output draft tokens).
-
-        max_matching_ngram_size: int
-            The length maximum of searching tokens (can be understood as length maximum of input tokens to search).
-
-        is_keep_all: bool = True
-            Whether to keep all candidate pattern-matches pairs, only one match is kept for each pattern if False.
-
-        is_use_oldest: bool = True
-            Whether to provide the oldest match when pattern is hit, the newest one is provided if False.
-
-        is_public_pool: bool = True
-            Whether to use a common pool for all requests, or the pool is private for each request if False.
     """
-    max_matching_ngram_size: int = 0
-    is_keep_all: bool = True
-    is_use_oldest: bool = True
-    is_public_pool: bool = True
+    decoding_type: Literal["NGram"] = "NGram"
+    max_matching_ngram_size: PositiveInt = Field(
+        default=2,
+        description=
+        "The length maximum of searching tokens (can be understood as length maximum of input tokens "
+        "to search).")
+    is_keep_all: bool = Field(
+        default=True,
+        description=
+        "Whether to keep all candidate pattern-matches pairs, only one "
+        "match is kept for each pattern if False.")
+    is_use_oldest: bool = Field(
+        default=True,
+        description="Whether to provide the oldest match when pattern is hit, "
+        "the newest one is provided if False.")
+    is_public_pool: bool = Field(
+        default=True,
+        description="Whether to use a common pool for all requests, or the pool "
+        "is private for each request if False.")
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.max_total_draft_tokens = self.max_draft_len  # Current NGram only support linear tree
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "NGram"
+    @model_validator(mode="after")
+    def validate_ngram_config(self):
+        if self.max_draft_len is None or self.max_draft_len <= 0:
+            raise ValueError("max_draft_len must be > 0 for NGram")
+        self.max_total_draft_tokens = self.max_draft_len  # Current NGram only supports linear tree
+        return self
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
 
 
 class DraftTargetDecodingConfig(DecodingBaseConfig):
+    decoding_type: Literal["Draft_Target"] = "Draft_Target"
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.max_total_draft_tokens = self.max_draft_len  # Current DraftTarget only support linear tree
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "Draft_Target"
+    @model_validator(mode="after")
+    def validate_draft_target_config(self):
+        if self.max_draft_len is None or self.max_draft_len <= 0:
+            raise ValueError("max_draft_len must be > 0 for DraftTarget")
+        if self.speculative_model is None:
+            raise ValueError(
+                "speculative_model must be specified for DraftTarget")
+        self.max_total_draft_tokens = self.max_draft_len  # Current DraftTarget only supports linear tree
+        return self
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch" or backend == "_autodeploy"
 
 
 class MTPDecodingConfig(DecodingBaseConfig):
-    num_nextn_predict_layers: int = 1
-    use_relaxed_acceptance_for_thinking: bool = False
-    relaxed_topk: int = 1
-    relaxed_delta: float = 0.
-    use_mtp_vanilla: bool = False
-    mtp_eagle_one_model: bool = True
+    decoding_type: Literal["MTP"] = "MTP"
+    num_nextn_predict_layers: PositiveInt = Field(
+        default=1,
+        description=
+        "Number of MTP modules. Each module predicts the next token, so N modules produce N draft tokens."
+    )
+    use_relaxed_acceptance_for_thinking: bool = Field(
+        default=False,
+        description=
+        "Enable relaxed acceptance during thinking phase for reasoning models. Accepts draft tokens matching any top-K candidate instead of exact top-1."
+    )
+    relaxed_topk: int = Field(
+        default=1,
+        description=
+        "Number of top candidate tokens to consider for relaxed acceptance. Draft token is accepted if it matches any of these."
+    )
+    relaxed_delta: float = Field(
+        default=0.,
+        description=
+        "Probability threshold for relaxed acceptance. Only candidates with prob >= (top-1 prob - delta) are kept."
+    )
+    use_mtp_vanilla: bool = Field(
+        default=False,
+        description=
+        "Force vanilla MTP mode (sequential MTP layers). When False, uses EAGLE-style MTP for single-layer checkpoints."
+    )
+    mtp_eagle_one_model: bool = Field(
+        default=True,
+        description=
+        "When using EAGLE-style MTP, use faster one-model implementation (drafter as submodule) vs two-model."
+    )
 
     # TODO: remove this after distinguishing `max_draft_len` and `num_nextn_predict_layers`
     # Now we need a flag when MTPDecodingConfig is updated by PyTorchModelEngine.
-    num_nextn_predict_layers_from_model_config: int = 1
+    num_nextn_predict_layers_from_model_config: int = Field(
+        default=1,
+        init=False,
+        description=
+        "Internal field storing MTP layer count from model config. Used to decide decoding mode: "
+        "when model has 1 layer and use_mtp_vanilla=False, uses faster EAGLE-style MTP instead of vanilla MTP."
+    )
 
-    # When encounter <think>, start thinking phase.
-    # When encounter </think>, end thinking phase.
-    # <think> [thinking phase] </think> [real output]
-    begin_thinking_phase_token: int = 128798
-    end_thinking_phase_token: int = 128799
+    begin_thinking_phase_token: int = Field(
+        default=128798,
+        description=
+        "Token ID marking start of thinking phase. Relaxed acceptance only applies within this phase."
+    )
+    end_thinking_phase_token: int = Field(
+        default=128799,
+        description=
+        "Token ID marking end of thinking phase. Strict acceptance resumes after this."
+    )
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        if 'num_nextn_predict_layers' in kwargs:
-            self.max_draft_len = kwargs['num_nextn_predict_layers']
-            self.max_total_draft_tokens = kwargs[
-                'num_nextn_predict_layers']  # Current MTP only support linear tree
+    @model_validator(mode="after")
+    def set_max_total_draft_tokens(self):
+        self.max_draft_len = self.num_nextn_predict_layers
+        self.max_total_draft_tokens = self.num_nextn_predict_layers  # Current MTP only supports linear tree
+        return self
 
+    @model_validator(mode="after")
+    def log_two_model_deprecation_warning(self):
         if not self.mtp_eagle_one_model:
             logger.warning(
                 "2-model style MTP is deprecated. The mtp_eagle_one_model flag will do nothing "
                 "in release 1.3. After that, the flag will be removed entirely."
             )
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        out = cls(**data)
-        out.max_draft_len = out.num_nextn_predict_layers
-        out.max_total_draft_tokens = out.num_nextn_predict_layers  # Current MTP only support linear tree
-        return out
-
-    decoding_type: ClassVar[str] = "MTP"
+        return self
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -1237,15 +1255,12 @@ class AutoDecodingConfig(DecodingBaseConfig):
     Attributes that are inherited from the base class are ignored.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.max_total_draft_tokens = self.max_draft_len  # Current Auto only support linear tree
+    decoding_type: Literal["AUTO"] = "AUTO"
 
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
-
-    decoding_type: ClassVar[str] = "AUTO"
+    @model_validator(mode="after")
+    def set_max_total_draft_tokens(self):
+        self.max_total_draft_tokens = self.max_draft_len  # Current Auto only supports linear tree
+        return self
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -1515,13 +1530,16 @@ class DynamicBatchConfig(StrictBaseModel, PybindMirror):
     Controls how batch size and token limits are dynamically adjusted at runtime.
     """
     enable_batch_size_tuning: bool = Field(
+        default=True,
         description="Controls if the batch size should be tuned dynamically")
 
     enable_max_num_tokens_tuning: bool = Field(
+        default=False,
         description="Controls if the max num tokens should be tuned dynamically"
     )
 
     dynamic_batch_moving_average_window: int = Field(
+        default=128,
         description=
         "The window size for moving average of input and output length which is used to calculate dynamic batch size and max num tokens"
     )
@@ -1544,7 +1562,10 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
         default=None, description="The context chunking policy to use")
 
     dynamic_batch_config: Optional[DynamicBatchConfig] = Field(
-        default=None, description="The dynamic batch config to use")
+        default=None,
+        description=
+        "The dynamic batch config to use. This only applies for the TensorRT backend and "
+        "cannot currently be used with the PyTorch backend.")
 
     waiting_queue_policy: WaitingQueuePolicy = Field(
         default=WaitingQueuePolicy.FCFS,
@@ -1636,39 +1657,28 @@ class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
     Configuration for lookahead speculative decoding.
     """
 
-    max_window_size: int = Field(
+    decoding_type: Literal["Lookahead"] = "Lookahead"
+    max_window_size: PositiveInt = Field(
         default=_LookaheadDecodingConfig.get_default_lookahead_decoding_window(
         ),
         description="Number of NGrams in lookahead branch per step.")
-    max_ngram_size: int = Field(
+    max_ngram_size: PositiveInt = Field(
         default=_LookaheadDecodingConfig.get_default_lookahead_decoding_ngram(),
         description="Number of tokens per NGram.")
-    max_verification_set_size: int = Field(
+    max_verification_set_size: PositiveInt = Field(
         default=_LookaheadDecodingConfig.
         get_default_lookahead_decoding_verification_set(),
         description="Number of NGrams in verification branch per step.")
 
-    @field_validator('max_window_size', 'max_ngram_size',
-                     'max_verification_set_size')
-    @classmethod
-    def validate_positive_values(cls, v):
-        if v <= 0:
-            raise ValueError(f"Value must be positive, got {v}")
-        return v
-
-    def __init__(self, **data):
-        super().__init__(**data)
-        self.max_total_draft_tokens = self.max_draft_len  # Current Lookahead only support linear tree
-        self._check_fields()
+    @model_validator(mode="after")
+    def set_max_total_draft_tokens(self):
+        self.max_total_draft_tokens = self.max_draft_len  # Current Lookahead only supports linear tree
+        return self
 
     def calculate_speculative_resource(self):
         return _LookaheadDecodingConfig.calculate_speculative_resource_tuple(
             self.max_window_size, self.max_ngram_size,
             self.max_verification_set_size)
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(**data)
 
     def _to_pybind(self):
         return _LookaheadDecodingConfig(self.max_window_size,
@@ -1678,25 +1688,30 @@ class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
     def supports_backend(self, backend: str) -> bool:
         return backend not in ("pytorch", "_autodeploy")
 
-    decoding_type: ClassVar[str] = "Lookahead"
 
+SpeculativeConfig: TypeAlias = Annotated[
+    Union[
+        DraftTargetDecodingConfig,
+        EagleDecodingConfig,
+        Eagle3DecodingConfig,
+        LookaheadDecodingConfig,
+        MedusaDecodingConfig,
+        MTPDecodingConfig,
+        NGramDecodingConfig,
+        UserProvidedDecodingConfig,
+        SaveHiddenStatesDecodingConfig,
+        AutoDecodingConfig,
+    ],
+    Field(discriminator="decoding_type"),
+]
 
-SpeculativeConfig: TypeAlias = Optional[Union[
-    DraftTargetDecodingConfig,
-    EagleDecodingConfig,
-    LookaheadDecodingConfig,
-    MedusaDecodingConfig,
-    MTPDecodingConfig,
-    NGramDecodingConfig,
-    UserProvidedDecodingConfig,
-    SaveHiddenStatesDecodingConfig,
-    AutoDecodingConfig,
-]]
-
-SparseAttentionConfig: TypeAlias = Union[
-    RocketSparseAttentionConfig,
-    DeepSeekSparseAttentionConfig,
-    SkipSoftmaxAttentionConfig,
+SparseAttentionConfig: TypeAlias = Annotated[
+    Union[
+        RocketSparseAttentionConfig,
+        DeepSeekSparseAttentionConfig,
+        SkipSoftmaxAttentionConfig,
+    ],
+    Field(discriminator="algorithm"),
 ]
 
 
@@ -1714,8 +1729,9 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         description=
         "The maximum number of tokens that should be stored in the KV cache. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used."
     )
-    max_attention_window: Optional[List[int]] = Field(
+    max_attention_window: Optional[List[PositiveInt]] = Field(
         default=None,
+        min_length=1,
         description=
         "Size of the attention window for each sequence. Only the last tokens will be stored in the KV cache. If the number of elements in `max_attention_window` is less than the number of layers, `max_attention_window` will be repeated multiple times to the number of layers."
     )
@@ -1725,6 +1741,8 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "Number of sink tokens (tokens to always keep in attention window).")
     free_gpu_memory_fraction: Optional[float] = Field(
         default=0.9,
+        ge=0,
+        le=1,
         description=
         "The fraction of GPU memory fraction that should be allocated for the KV cache. Default is 90%. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used."
     )
@@ -1766,7 +1784,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     )
     use_uvm: bool = Field(default=False,
                           description="Whether to use UVM for the KV cache.")
-    max_gpu_total_bytes: int = Field(
+    max_gpu_total_bytes: NonNegativeInt = Field(
         default=0,
         description=
         "The maximum size in bytes of GPU memory that can be allocated for the KV cache. If both `max_gpu_total_bytes` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be allocated."
@@ -1794,6 +1812,8 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
     max_util_for_resume: float = Field(
         default=0.95,
+        ge=0,
+        le=1,
         status="prototype",
         description=
         "The maximum utilization of the KV cache for resume. Default is 95%. Only used when using KV cache manager v2 (experimental)."
@@ -1817,55 +1837,6 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
             attention_dp_events_gather_period_ms=self.
             attention_dp_events_gather_period_ms,
             max_gpu_total_bytes=self.max_gpu_total_bytes)
-
-    @field_validator('free_gpu_memory_fraction')
-    @classmethod
-    def validate_free_gpu_memory_fraction(cls, v: float):
-        """Validates that the fraction is between 0.0 and 1.0."""
-        if not 0 <= v <= 1:
-            raise ValueError(
-                "kv_cache_config.free_gpu_memory_fraction must be a float between 0 and 1"
-            )
-        return v
-
-    @field_validator('max_gpu_total_bytes')
-    @classmethod
-    def validate_max_gpu_total_bytes(cls, v: int):
-        if v < 0:
-            raise ValueError(
-                "kv_cache_config.max_gpu_total_bytes must be non-negative")
-        return v
-
-    @field_validator('max_attention_window')
-    @classmethod
-    def validate_max_attention_window(cls, v: Optional[List[int]]):
-        # Allow unset
-        if v is None:
-            return v
-
-        # Must be a non-empty list of positive integers
-        if not isinstance(v, list) or len(v) == 0:
-            raise ValueError(
-                "kv_cache_config.max_attention_window must be a non-empty list of positive integers"
-            )
-        for i in v:
-            if not isinstance(i, int):
-                raise ValueError(
-                    "kv_cache_config.max_attention_window must contain only integers"
-                )
-            if i <= 0:
-                raise ValueError(
-                    "kv_cache_config.max_attention_window values must be positive"
-                )
-        return v
-
-    @field_validator('max_util_for_resume')
-    @classmethod
-    def validate_max_util_for_resume(cls, v: float):
-        if not 0 <= v <= 1:
-            raise ValueError(
-                "kv_cache_config.max_util_for_resume must be between 0 and 1")
-        return v
 
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
@@ -1915,16 +1886,14 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         default=None,
         description="The max number of tokens the transfer buffer can fit.")
 
-    kv_transfer_timeout_ms: Optional[int] = Field(
+    kv_transfer_timeout_ms: Optional[PositiveInt] = Field(
         default=None,
-        gt=0,
         description=
         "Timeout in milliseconds for KV cache transfer. Requests exceeding this timeout will be cancelled."
     )
 
-    kv_transfer_sender_future_timeout_ms: Optional[int] = Field(
+    kv_transfer_sender_future_timeout_ms: Optional[PositiveInt] = Field(
         default=1000,
-        gt=0,
         description=
         "Timeout in milliseconds to wait for the sender future to be ready when scheduled batch size is 0. This allows the request to be eventually cancelled by the user or because of kv_transfer_timeout_ms"
     )
@@ -1982,10 +1951,7 @@ class BaseLlmArgs(StrictBaseModel):
     """
     Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
     """
-    model_config = {
-        "arbitrary_types_allowed": True,
-        "extra": "forbid",
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     # Explicit arguments
     model: Union[str, Path] = Field(
@@ -2081,9 +2047,10 @@ class BaseLlmArgs(StrictBaseModel):
         "Pipeline parallel partition, a list of each rank's layer number.",
         status="prototype")
 
-    cp_config: Optional[dict] = Field(default_factory=dict,
-                                      description="Context parallel config.",
-                                      status="prototype")
+    cp_config: Optional[CpConfig] = Field(
+        default=None,
+        description="Context parallel config.",
+        status="prototype")
 
     load_format: Literal['auto', 'dummy'] = Field(
         default='auto',
@@ -2146,20 +2113,20 @@ class BaseLlmArgs(StrictBaseModel):
         status="prototype")
 
     # Speculative decoding parameters
-    speculative_config: SpeculativeConfig = Field(
+    speculative_config: Optional[SpeculativeConfig] = Field(
         default=None, description="Speculative decoding config.")
 
-    max_batch_size: Optional[int] = Field(default=None,
+    max_batch_size: Optional[int] = Field(default=2048,
                                           description="The maximum batch size.")
 
     # generation constraints
     max_input_len: Optional[int] = Field(
-        default=None, description="The maximum input length.")
+        default=1024, description="The maximum input length.")
 
     max_seq_len: Optional[int] = Field(
         default=None, description="The maximum sequence length.")
 
-    max_beam_width: Optional[int] = Field(default=None,
+    max_beam_width: Optional[int] = Field(default=1,
                                           description="The maximum beam width.")
 
     max_num_tokens: Optional[int] = Field(
@@ -2223,7 +2190,7 @@ class BaseLlmArgs(StrictBaseModel):
                                       description="Return perf metrics.",
                                       status="prototype")
 
-    perf_metrics_max_requests: int = Field(
+    perf_metrics_max_requests: NonNegativeInt = Field(
         default=0,
         description=
         "The maximum number of requests for perf metrics. Must also set return_perf_metrics to true to get perf metrics.",
@@ -2266,36 +2233,10 @@ class BaseLlmArgs(StrictBaseModel):
         return self.speculative_config.speculative_model if self.speculative_config is not None else None
 
     @classmethod
-    def from_kwargs(cls, **kwargs: Any) -> "BaseLlmArgs":
-        """Create `LlmArgs` instance from kwargs.
-
-        Args:
-            kwargs (Any): Arguments passed to `LlmArgs` constructor.
-
-        Returns:
-            tensorrt_llm.llmapi.llm_utils.BaseLlmArgs: The `BaseLlmArgs` instance.
-        """
-        kwargs = BaseLlmArgs._check_consistency(dict(kwargs))
-        ret = cls(**kwargs)
-        return ret
-
-    @staticmethod
-    def _check_consistency(kwargs_dict: Dict[str, Any]) -> Dict[str, Any]:
-        # max_beam_width is not included since vague behavior due to lacking the support for dynamic beam width during
-        # generation
-        black_list = set(["max_beam_width"])
-        executor_config_attrs = set(
-            attr for attr in dir(_ExecutorConfig) if not attr.startswith('_')
-            and callable(getattr(_ExecutorConfig, attr)))
-        executor_config_attrs -= black_list
-        llm_args_attr = set(BaseLlmArgs.model_fields.keys())
-        # NOTE: When cpp ExecutorConfig add new options, please add the new options into `LlmArgs` with docs as well
-        # ASK chunweiy for help if you are not sure about the new options.
-        assert executor_config_attrs.issubset(
-            llm_args_attr
-        ), f"New options found in underlying ExecutorConfig: {llm_args_attr - executor_config_attrs}"
-
-        return kwargs_dict
+    def from_yaml(cls, yaml_path: Union[str, Path]):
+        with open(yaml_path, "r") as f:
+            config_dict = yaml.safe_load(f)
+        return cls(**config_dict)
 
     @field_validator("dtype")
     @classmethod
@@ -2318,12 +2259,24 @@ class BaseLlmArgs(StrictBaseModel):
             v = torch.cuda.device_count()
         return v
 
-    @field_validator("model")
-    @classmethod
-    def validate_model(cls, v, info):
-        if not isinstance(v, (str, Path)):
-            raise ValueError(f"Invalid model: {v}")
-        return v
+    @model_validator(mode="after")
+    def normalize_optional_fields_to_defaults(self):
+        """Normalize certain fields to their declared default values in case a user explicitly sets them to None.
+
+        This is necessary because downstream code expects these fields to be non-None.
+        At the same time, we still need to accept None as a valid value to avoid a breaking change.
+        """
+        for field_name in (
+                "max_batch_size",
+                "max_input_len",
+                "max_beam_width",
+                "max_num_tokens",
+        ):
+            if getattr(self, field_name) is None:
+                field_info = self.__class__.model_fields.get(field_name)
+                if field_info is not None and field_info.default is not None:
+                    setattr(self, field_name, field_info.default)
+        return self
 
     @model_validator(mode="after")
     def validate_parallel_config(self):
@@ -2348,12 +2301,6 @@ class BaseLlmArgs(StrictBaseModel):
             enable_lm_head_tp_in_adp=self.enable_lm_head_tp_in_adp,
             pp_partition=self.pp_partition,
             cp_config=self.cp_config)
-        return self
-
-    @model_validator(mode="after")
-    def set_default_max_input_len(self):
-        if self.max_input_len is None:
-            self.max_input_len = 1024
         return self
 
     @model_validator(mode="after")
@@ -2472,27 +2419,25 @@ class TrtLlmArgs(BaseLlmArgs):
         status="prototype")
 
     # Once set, the model will reuse the build_cache
-    enable_build_cache: object = Field(
-        default=False,
-        description="Enable build cache.",
-        json_schema_extra={
-            "type": f"Union[{get_type_repr(BuildCacheConfig)}, bool]"
-        })
+    enable_build_cache: Union[BuildCacheConfig,
+                              bool] = Field(default=False,
+                                            description="Enable build cache.")
 
     extended_runtime_perf_knob_config: Optional[
         ExtendedRuntimePerfKnobConfig] = Field(
             default=None, description="Extended runtime perf knob config.")
 
-    calib_config: Optional[CalibConfig] = Field(
-        default=None, description="Calibration config.", validate_default=True)
-
     # Quantization and calibration configurations
-    quant_config: Optional[QuantConfig] = Field(
-        default=None, description="Quantization config.", validate_default=True)
+    calib_config: CalibConfig = Field(default_factory=CalibConfig,
+                                      description="Calibration config.")
 
-    embedding_parallel_mode: str = Field(
-        default='SHARDING_ALONG_VOCAB',
-        description="The embedding parallel mode.")
+    quant_config: QuantConfig = Field(default_factory=QuantConfig,
+                                      description="Quantization config.")
+
+    embedding_parallel_mode: Literal[
+        'NONE', 'SHARDING_ALONG_VOCAB', 'SHARDING_ALONG_HIDDEN'] = Field(
+            default='SHARDING_ALONG_VOCAB',
+            description="The embedding parallel mode.")
 
     fast_build: bool = Field(default=False, description="Enable fast build.")
 
@@ -2540,46 +2485,6 @@ class TrtLlmArgs(BaseLlmArgs):
         return self
 
     @model_validator(mode="after")
-    def validate_build_config_with_runtime_params(self):
-        # Note: max_batch_size and max_num_tokens in LlmArgs are for runtime,
-        # which will be passed to the C++ Executor API, overwriting the values
-        # from an built engine. In order to set build configuration, it is
-        # recommended to use build_config instead.
-        assert isinstance(
-            self.build_config, BuildConfig
-        ), f"build_config is not initialized: {self.build_config}"
-
-        if self.max_batch_size is not None:
-            if self.max_batch_size > self.build_config.max_batch_size:
-                self.max_batch_size = self.build_config.max_batch_size
-                logger.warning(
-                    f"max_batch_size [{self.max_batch_size}] is overridden by build_config.max_batch_size [{self.build_config.max_batch_size}] in build_config"
-                )
-        if self.max_num_tokens is not None:
-            if self.max_num_tokens > self.build_config.max_num_tokens:
-                self.max_num_tokens = self.build_config.max_num_tokens
-                logger.warning(
-                    f"max_num_tokens [{self.max_num_tokens}] is overridden by build_config.max_num_tokens [{self.build_config.max_num_tokens}] in build_config"
-                )
-        if self.max_seq_len is not None:
-            if self.max_seq_len != self.build_config.max_seq_len:
-                logger.warning(
-                    f"max_seq_len [{self.max_seq_len}] is overridden by build_config.max_seq_len [{self.build_config.max_seq_len}] in build_config"
-                )
-        if self.max_beam_width is not None:
-            if self.max_beam_width != self.build_config.max_beam_width:
-                logger.warning(
-                    f"max_beam_width [{self.max_beam_width}] is overridden by build_config.max_beam_width [{self.build_config.max_beam_width}] in build_config"
-                )
-        if self.max_input_len is not None:
-            if self.max_input_len != self.build_config.max_input_len:
-                logger.warning(
-                    f"max_input_len [{self.max_input_len}] is overridden by build_config.max_input_len [{self.build_config.max_input_len}] in build_config"
-                )
-
-        return self
-
-    @model_validator(mode="after")
     def validate_build_config_remaining(self):
         is_trt_llm_args = isinstance(self, TrtLlmArgs)
 
@@ -2599,12 +2504,6 @@ class TrtLlmArgs(BaseLlmArgs):
         if hasattr(self,
                    'enable_prompt_adapter') and self.enable_prompt_adapter:
             self.build_config.max_prompt_embedding_table_size = self.max_prompt_adapter_token * self.build_config.max_batch_size
-
-        if self.max_beam_width is None:
-            if self.build_config:
-                self.max_beam_width = self.build_config.max_beam_width
-            else:
-                self.max_beam_width = 1
 
         return self
 
@@ -2766,19 +2665,37 @@ class TrtLlmArgs(BaseLlmArgs):
         self._model_format = model_format
         return self
 
-    @field_validator('calib_config', mode='before')
-    @classmethod
-    def init_calib_config(cls, v):
-        if v is None:
-            return CalibConfig()
-        return v
+    @model_validator(mode="after")
+    def validate_build_config_with_runtime_params(self):
+        """Sync runtime parameters with build_config limits.
 
-    @field_validator("quant_config", mode='before')
-    @classmethod
-    def validate_quant_config(cls, v, info):
-        if v is None:
-            v = QuantConfig()
-        return v
+        This validator runs AFTER validate_model_format_misc so that when
+        loading from an engine, we have the real build_config loaded.
+        """
+        if self.build_config is None:
+            raise ValueError("build_config is not initialized")
+
+        # These can be lower than build_config limits
+        for field in ("max_batch_size", "max_num_tokens"):
+            runtime_val = getattr(self, field)
+            build_val = getattr(self.build_config, field)
+            if runtime_val is not None and runtime_val > build_val:
+                logger.warning(
+                    f"{field} [{runtime_val}] clamped to build_config.{field} [{build_val}]"
+                )
+                setattr(self, field, build_val)
+
+        # These must match build_config exactly
+        for field in ("max_seq_len", "max_beam_width", "max_input_len"):
+            runtime_val = getattr(self, field)
+            build_val = getattr(self.build_config, field)
+            if runtime_val is not None and runtime_val != build_val:
+                logger.warning(
+                    f"{field} [{runtime_val}] overridden by build_config.{field} [{build_val}]"
+                )
+                setattr(self, field, build_val)
+
+        return self
 
     @model_validator(mode="after")
     def setup_embedding_parallel_mode(self):
@@ -2799,9 +2716,6 @@ class TrtLlmArgs(BaseLlmArgs):
             return self
         self.enable_build_cache = BuildCacheConfig() if isinstance(
             self.enable_build_cache, bool) else self.enable_build_cache
-        if not isinstance(self.enable_build_cache, BuildCacheConfig):
-            raise ValueError(
-                f"Invalid build_cache_config: {self.enable_build_cache}")
         return self
 
     @model_validator(mode="after")
@@ -2840,7 +2754,7 @@ class TorchCompileConfig(StrictBaseModel):
         default=False,
         description="Enable piecewise CUDA graph in torch.compile.")
 
-    capture_num_tokens: Optional[List[int]] = Field(
+    capture_num_tokens: Optional[List[PositiveInt]] = Field(
         default=None,
         description=
         "List of num of tokens to capture the piecewise CUDA graph for. If not provided, the number of tokens will be the same as cuda_graph_config.batch_sizes."
@@ -2851,8 +2765,6 @@ class TorchCompileConfig(StrictBaseModel):
     def validate_capture_num_tokens(cls, v):
         if v is None:
             return v
-        if any(t <= 0 for t in v):
-            raise ValueError("capture_num_tokens must contain positive ints.")
         return sorted(set(v), reverse=True)
 
     enable_userbuffers: bool = Field(
@@ -2860,23 +2772,17 @@ class TorchCompileConfig(StrictBaseModel):
         description=
         "When torch compile is enabled, userbuffers is enabled by default.")
 
-    max_num_streams: int = Field(
+    max_num_streams: PositiveInt = Field(
         default=1,
         description=
         "The maximum number of CUDA streams to use for torch.compile.")
 
-    @field_validator('max_num_streams')
-    @classmethod
-    def validate_torch_compile_max_num_streams(cls, v):
-        """Validate torch_compile_config.max_num_streams >= 1."""
-        if v < 1:
-            raise ValueError(
-                "torch_compile_config.max_num_streams must be >= 1")
-        return v
-
-    @staticmethod
-    def _generate_capture_num_tokens() -> List[int]:
-        return [2**i for i in range(8)] + [i for i in range(256, 3073, 256)]
+    @model_validator(mode='after')
+    def set_default_capture_num_tokens(self) -> 'TorchCompileConfig':
+        if self.enable_piecewise_cuda_graph and self.capture_num_tokens is None:
+            self.capture_num_tokens = [2**i for i in range(8)
+                                       ] + [i for i in range(256, 3073, 256)]
+        return self
 
 
 class TorchLlmArgs(BaseLlmArgs):
@@ -2890,7 +2796,7 @@ class TorchLlmArgs(BaseLlmArgs):
 
     cuda_graph_config: Optional[CudaGraphConfig] = Field(
         default_factory=CudaGraphConfig,
-        description="CUDA graph config.If true, use CUDA graphs for decoding. \
+        description="CUDA graph config. If true, use CUDA graphs for decoding. \
         CUDA graphs are only created for the batch sizes in cuda_graph_config.batch_sizes, \
         and are enabled for batches that consist of decoding requests *only* \
         (the reason is that it's hard to capture a single graph with prefill requests \
@@ -2951,13 +2857,13 @@ class TorchLlmArgs(BaseLlmArgs):
                                  description="Print iteration logs.",
                                  status="beta")
 
-    batch_wait_timeout_ms: float = Field(
+    batch_wait_timeout_ms: NonNegativeFloat = Field(
         default=0,
         description=
         "If greater than 0, the request queue might wait up to batch_wait_timeout_ms to receive max_batch_size requests, if fewer than max_batch_size requests are currently available. If 0, no waiting occurs.",
         status="prototype")
 
-    batch_wait_timeout_iters: int = Field(
+    batch_wait_timeout_iters: NonNegativeInt = Field(
         default=0,
         description=
         "Maximum number of iterations the scheduler will wait to accumulate new coming requests for improved GPU utilization efficiency. If greater than 0, the scheduler will delay batch processing to gather more requests up to the specified iteration limit. If 0, disables timeout-iters-based batching delays.",
@@ -2965,6 +2871,8 @@ class TorchLlmArgs(BaseLlmArgs):
 
     batch_wait_max_tokens_ratio: float = Field(
         default=0,
+        ge=0,
+        le=1,
         description=
         "Token accumulation threshold ratio for batch scheduling optimization. If greater than 0, the scheduler will accumulate requests locally until the total token count reaches batch_wait_max_tokens_ratio * max_num_tokens. This mechanism enhances GPU utilization efficiency by ensuring adequate batch sizes.If 0 disables token-based batching delays.",
         status="prototype")
@@ -2997,7 +2905,7 @@ class TorchLlmArgs(BaseLlmArgs):
     )
 
     # TODO: make this a per-request parameter
-    stream_interval: int = Field(
+    stream_interval: PositiveInt = Field(
         default=1,
         description=
         "The iteration interval to create responses under the streaming mode. "
@@ -3121,11 +3029,11 @@ class TorchLlmArgs(BaseLlmArgs):
         self._quant_config = value
 
     # TODO: remove backend later
-    @field_validator('backend', mode='before')
-    def init_backend(cls, v):
-        if v is None:
-            return 'pytorch'
-        return v
+    backend: Literal["pytorch"] = Field(
+        default="pytorch",
+        description="The backend to use for this LLM instance.",
+        exclude_json_schema=True,
+        status="deprecated")
 
     @field_validator('load_format', mode='before')
     @classmethod
@@ -3154,12 +3062,8 @@ class TorchLlmArgs(BaseLlmArgs):
         self._extra_resource_managers = value
 
     @model_validator(mode="after")
-    def validate_misc(self):
+    def set_model_format(self):
         self._model_format = _ModelFormatKind.HF
-        if self.max_beam_width is None:
-            self.max_beam_width = 1
-        if self.max_batch_size is None:
-            self.max_batch_size = 2048
         return self
 
     @model_validator(mode="after")
@@ -3170,33 +3074,20 @@ class TorchLlmArgs(BaseLlmArgs):
                     f"Speculation type {self.speculative_config.decoding_type} does not "
                     f"support backend {self.backend}")
 
-            if isinstance(self.speculative_config, EagleDecodingConfig):
-                if (getattr(self.speculative_config, "_decoding_type_alias",
-                            None) == "Eagle" or type(self.speculative_config)
-                        is EagleDecodingConfig):
-                    logger.warning(
-                        "speculative_config.decoding_type 'Eagle' is not supported on the PyTorch backend; only 'Eagle3' is supported. "
-                        "'Eagle' is treated as 'Eagle3' for backward compatibility. "
-                        "EAGLE (v1/v2) draft checkpoints are incompatible with Eagle3—use an Eagle3 draft model."
-                    )
-                assert self.speculative_config.max_draft_len > 0
-                assert self.speculative_config.speculative_model is not None, "EAGLE3 draft model must be specified."
-            elif isinstance(self.speculative_config, NGramDecodingConfig):
-                assert self.speculative_config.max_draft_len > 0 and self.speculative_config.max_matching_ngram_size > 0
-            elif isinstance(self.speculative_config, DraftTargetDecodingConfig):
-                assert self.speculative_config.max_draft_len > 0
-                assert self.speculative_config.speculative_model is not None, "Draft model must be specified."
-            elif isinstance(self.speculative_config, MTPDecodingConfig):
-                assert self.speculative_config.num_nextn_predict_layers > 0
-                self.speculative_config.max_draft_len = self.speculative_config.num_nextn_predict_layers
-            elif isinstance(self.speculative_config,
-                            UserProvidedDecodingConfig):
-                pass
-            elif isinstance(self.speculative_config, AutoDecodingConfig):
-                pass
-            elif isinstance(self.speculative_config,
-                            SaveHiddenStatesDecodingConfig):
-                assert self.backend in ['pytorch']
+            # If user passed decoding_type: Eagle on pytorch, convert to Eagle3 with warning
+            if type(self.speculative_config) is EagleDecodingConfig:
+                logger.warning(
+                    "speculative_config.decoding_type 'Eagle' is not supported on the PyTorch backend; only 'Eagle3' is supported. "
+                    "'Eagle' is treated as 'Eagle3' for backward compatibility. "
+                    "EAGLE (v1/v2) draft checkpoints are incompatible with Eagle3—use an Eagle3 draft model."
+                )
+                # Convert EagleDecodingConfig to Eagle3DecodingConfig
+                eagle_data = self.speculative_config.model_dump(
+                    exclude={"decoding_type"})
+                self.speculative_config = Eagle3DecodingConfig(**eagle_data)
+
+            if isinstance(self.speculative_config,
+                          SaveHiddenStatesDecodingConfig):
                 logger.warning(
                     "SaveHiddenStatesDecodingConfig is active, setting max_batch_size to 1, disabling overlap scheduler, and setting cuda_graph_config to None"
                 )
@@ -3204,21 +3095,10 @@ class TorchLlmArgs(BaseLlmArgs):
                 self.disable_overlap_scheduler = True
                 self.cuda_graph_config = None
                 self.speculative_config.max_draft_len = 1
-            else:
-                raise ValueError(
-                    f"Unrecognized speculative config type {type(self.speculative_config)}"
-                )
 
         else:
             self.decoding_config = None
 
-        return self
-
-    @model_validator(mode="after")
-    def validate_stream_interval(self):
-        if self.stream_interval <= 0:
-            raise ValueError(
-                f"stream_interval must be positive, got {self.stream_interval}")
         return self
 
     @model_validator(mode="after")
@@ -3264,58 +3144,6 @@ class TorchLlmArgs(BaseLlmArgs):
         return self
 
     @model_validator(mode='after')
-    def validate_cuda_graph_config(self) -> 'TorchLlmArgs':
-        """Validate CUDA graph configuration.
-
-        Ensures that:
-        1. If cuda_graph_config.batch_sizes is provided, max_batch_size is
-           derived as max(batch_sizes).  If max_batch_size was already set it
-           must be compatible (equal to max(batch_sizes)); otherwise an error
-           is raised.
-        2. If only cuda_graph_config.max_batch_size is provided, batch_sizes
-           is generated from it.
-        3. If neither is provided, a default max_batch_size of 128 is used.
-        """
-        if self.cuda_graph_config is None:
-            return self
-
-        config = self.cuda_graph_config
-
-        if config.batch_sizes:
-            config.batch_sizes = sorted(config.batch_sizes)
-            derived_max = max(config.batch_sizes)
-            if config.max_batch_size != 0 and config.max_batch_size != derived_max:
-                raise ValueError(
-                    "cuda_graph_config.max_batch_size is incompatible with "
-                    "cuda_graph_config.batch_sizes. When both are provided, "
-                    "max_batch_size must equal max(batch_sizes).\n"
-                    f"cuda_graph_config.batch_sizes: {config.batch_sizes}, "
-                    f"max(batch_sizes): {derived_max}, "
-                    f"cuda_graph_config.max_batch_size: {config.max_batch_size}"
-                )
-            config.max_batch_size = derived_max
-        else:
-            max_batch_size = config.max_batch_size or 128
-            generated_sizes = CudaGraphConfig._generate_cuda_graph_batch_sizes(
-                max_batch_size, config.enable_padding)
-            config.batch_sizes = generated_sizes
-            config.max_batch_size = max_batch_size
-
-        return self
-
-    @model_validator(mode='after')
-    def validate_torch_compile_config(self) -> 'TorchLlmArgs':
-        if self.torch_compile_config is None:
-            return self
-
-        config = self.torch_compile_config
-        if config.enable_piecewise_cuda_graph:
-            if config.capture_num_tokens is None:
-                config.capture_num_tokens = TorchCompileConfig._generate_capture_num_tokens(
-                )
-        return self
-
-    @model_validator(mode='after')
     def sync_quant_config_with_kv_cache_config_dtype(self) -> 'TorchLlmArgs':
         if self.kv_cache_config is None:
             return self
@@ -3335,12 +3163,12 @@ class TorchLlmArgs(BaseLlmArgs):
     @model_validator(mode='after')
     def validate_helix_tokens_per_block(self) -> 'TorchLlmArgs':
         """Validate that cp_config.tokens_per_block matches kv_cache_config.tokens_per_block when HELIX parallelism is active."""
-        if self.context_parallel_size == 1 or self.cp_config is None or not self.cp_config:
+        if self.context_parallel_size == 1 or self.cp_config is None:
             return self
 
-        cp_type = self.cp_config.get('cp_type', None)
-        if cp_type is not None and str(cp_type).upper() == 'HELIX':
-            cp_tokens_per_block = self.cp_config.get('tokens_per_block', None)
+        cp_type = self.cp_config.cp_type
+        if cp_type == CpType.HELIX:
+            cp_tokens_per_block = self.cp_config.tokens_per_block
             if cp_tokens_per_block is not None:
                 kv_tokens_per_block = self.kv_cache_config.tokens_per_block
                 assert cp_tokens_per_block == kv_tokens_per_block, (
@@ -3368,52 +3196,6 @@ class TorchLlmArgs(BaseLlmArgs):
                     "It is not recommended for production use and may change or be removed.",
                 )
 
-        return self
-
-    @model_validator(mode='after')
-    def validate_attention_dp_config(self) -> 'TorchLlmArgs':
-        """Validate attention DP configuration.
-
-        Ensures that:
-        1. If attention_dp_config.enable_balance is true, attention_dp_config.batching_wait_iters must be greater or equal to 0
-        2. If attention_dp_config.enable_balance is true, attention_dp_config.timeout_iters must be greater or equal to 0
-        """
-        if self.attention_dp_config is None:
-            return self
-
-        config = self.attention_dp_config
-        if config.enable_balance:
-            if config.batching_wait_iters < 0:
-                raise ValueError(
-                    "attention_dp_config.batching_wait_iters must be greater or equal to 0 when enable_balance is true"
-                )
-            if config.timeout_iters < 0:
-                raise ValueError(
-                    "attention_dp_config.timeout_iters must be greater or equal to 0 when enable_balance is true"
-                )
-        return self
-
-    @model_validator(mode='after')
-    def validate_batch_wait_timeout_ms(self) -> 'TorchLlmArgs':
-        """Validate batch wait timeout."""
-        if self.batch_wait_timeout_ms < 0:
-            raise ValueError("batch_wait_timeout_ms must be greater than 0")
-        return self
-
-    @model_validator(mode='after')
-    def validate_batch_wait_timeout_iters(self) -> 'TorchLlmArgs':
-        if self.batch_wait_timeout_iters < 0:
-            raise ValueError(
-                f"batch_wait_timeout_iters must be >= 0, got {self.batch_wait_timeout_iters}"
-            )
-        return self
-
-    @model_validator(mode='after')
-    def validate_batch_wait_max_tokens_ratio(self) -> 'TorchLlmArgs':
-        if self.batch_wait_max_tokens_ratio < 0 or self.batch_wait_max_tokens_ratio > 1:
-            raise ValueError(
-                f"batch_wait_max_tokens_ratio must be in range [0, 1], got {self.batch_wait_max_tokens_ratio}"
-            )
         return self
 
     @model_validator(mode='after')
@@ -3462,29 +3244,15 @@ def update_llm_args_with_extra_dict(
         "build_config": BuildConfig,
         "decoding_config": DecodingConfig,
         "enable_build_cache": BuildCacheConfig,
-        "speculative_config": DecodingBaseConfig,
         "lora_config": LoraConfig,
         "moe_config": MoeConfig,
         "nvfp4_gemm_config": Nvfp4GemmConfig,
         "attention_dp_config": AttentionDpConfig,
-        "sparse_attention_config": BaseSparseAttentionConfig,
         "kv_cache_config": KvCacheConfig,
     }
     for field_name, field_type in field_mapping.items():
         if field_name in llm_args_dict:
-            # Some fields need to be converted manually.
-            if field_name in ["speculative_config", "sparse_attention_config"]:
-                if field_name == "speculative_config":
-                    backend = llm_args_dict.get("backend") or llm_args.get(
-                        "backend")
-                    llm_args_dict[field_name] = field_type.from_dict(
-                        llm_args_dict[field_name], backend=backend)
-                else:
-                    llm_args_dict[field_name] = field_type.from_dict(
-                        llm_args_dict[field_name])
-            else:
-                llm_args_dict[field_name] = field_type(
-                    **llm_args_dict[field_name])
+            llm_args_dict[field_name] = field_type(**llm_args_dict[field_name])
             extra_llm_str = f"because it's specified in {extra_llm_api_options}" if extra_llm_api_options else ""
             logger.warning(f"Overriding {field_name} {extra_llm_str}")
 

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -511,7 +511,7 @@ class ModelLoader:
                     dtype=self.llm_args.dtype,
                     mapping=self.mapping,
                     quant_config=self.llm_args.quant_config,
-                    **self.llm_args.calib_config.to_dict(),
+                    **self.llm_args.calib_config.model_dump(),
                     trust_remote_code=self.llm_args.trust_remote_code,
                 )
             if self.llm_args.parallel_config.is_multi_gpu:

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -32,6 +32,18 @@ from tqdm.auto import tqdm
 from tensorrt_llm.logger import Singleton, logger
 
 
+class StrictBaseModel(BaseModel):
+    """
+    A base model that forbids arbitrary fields.
+
+    All user-facing configuration classes should inherit from this to ensure
+    typos and invalid fields are caught at validation time.
+    """
+
+    class Config:
+        extra = "forbid"
+
+
 def print_traceback_on_error(func):
 
     @wraps(func)

--- a/tensorrt_llm/models/grok/convert.py
+++ b/tensorrt_llm/models/grok/convert.py
@@ -428,7 +428,7 @@ def create_config_from_xai(dtype,
         True,
     })
 
-    config['quantization'] = quantization.to_dict()
+    config['quantization'] = quantization.model_dump()
     config.update(override_fields)
 
     return config

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -136,7 +136,7 @@ class QuantConfig(StrictBaseModel):
         default=None, description="Quantization algorithm.")
     kv_cache_quant_algo: Optional[QuantAlgo] = Field(
         default=None, description="KV cache quantization algorithm.")
-    group_size: int = Field(
+    group_size: Optional[int] = Field(
         default=128, description="Group size for group-wise quantization.")
     smoothquant_val: float = Field(
         default=0.5,

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -14,6 +14,7 @@ from typing import (TYPE_CHECKING, Callable, Dict, Generator, List, Optional,
 import numpy as np
 import safetensors
 import torch
+from pydantic import Field, PrivateAttr
 
 from .._common import default_net
 from .._utils import (QuantModeWrapper, get_init_params, numpy_to_torch,
@@ -31,6 +32,7 @@ from ..layers.linear import ColumnLinear, Linear, RowLinear
 from ..layers.lora import Dora, Lora
 from ..layers.moe import MOE, MoeOOTB
 from ..llmapi.kv_cache_type import KVCacheType
+from ..llmapi.utils import StrictBaseModel
 from ..logger import logger
 from ..mapping import Mapping
 from ..module import Module, ModuleList
@@ -127,33 +129,36 @@ class SpeculativeDecodingMode(IntFlag):
             assert False, "Unknown speculative_decoding_mode " + args.speculative_decoding_mode
 
 
-@dataclasses.dataclass
-class QuantConfig:
-    """
-    Serializable quantization configuration class, part of the PretrainedConfig.
+class QuantConfig(StrictBaseModel):
+    """Serializable quantization configuration class, part of the PretrainedConfig."""
 
-    Args:
-        quant_algo (tensorrt_llm.quantization.mode.QuantAlgo, optional): Quantization algorithm. Defaults to None.
-        kv_cache_quant_algo (tensorrt_llm.quantization.mode.QuantAlgo, optional): KV cache quantization algorithm. Defaults to None.
-        group_size (int): The group size for group-wise quantization. Defaults to 128.
-        smoothquant_val (float): The smoothing parameter alpha used in smooth quant. Defaults to 0.5.
-        clamp_val (List[float], optional): The clamp values used in FP8 rowwise quantization. Defaults to None.
-        use_meta_recipe (bool): Whether to use Meta's recipe for FP8 rowwise quantization. Defaults to False.
-        has_zero_point (bool): Whether to use zero point for quantization. Defaults to False.
-        pre_quant_scale (bool): Whether to use pre-quant scale for quantization. Defaults to False.
-        exclude_modules (List[str], optional): The module name patterns that are skipped in quantization. Defaults to None.
-        mamba_ssm_cache_dtype (str, optional): The data type for mamba SSM cache. Defaults to None.
-    """
-    quant_algo: Optional[QuantAlgo] = None
-    kv_cache_quant_algo: Optional[QuantAlgo] = None
-    group_size: int = 128
-    smoothquant_val: float = 0.5
-    clamp_val: Optional[List[float]] = None
-    use_meta_recipe: bool = False
-    has_zero_point: bool = False
-    pre_quant_scale: bool = False
-    exclude_modules: Optional[List[str]] = None
-    mamba_ssm_cache_dtype: Optional[str] = None
+    quant_algo: Optional[QuantAlgo] = Field(
+        default=None, description="Quantization algorithm.")
+    kv_cache_quant_algo: Optional[QuantAlgo] = Field(
+        default=None, description="KV cache quantization algorithm.")
+    group_size: int = Field(
+        default=128, description="Group size for group-wise quantization.")
+    smoothquant_val: float = Field(
+        default=0.5,
+        description="Smoothing parameter alpha used in smooth quant.")
+    clamp_val: Optional[List[float]] = Field(
+        default=None,
+        description="Clamp values used in FP8 rowwise quantization.")
+    use_meta_recipe: bool = Field(
+        default=False,
+        description="Whether to use Meta's recipe for FP8 rowwise quantization."
+    )
+    has_zero_point: bool = Field(
+        default=False,
+        description="Whether to use zero point for quantization.")
+    pre_quant_scale: bool = Field(
+        default=False,
+        description="Whether to use pre-quant scale for quantization.")
+    exclude_modules: Optional[List[str]] = Field(
+        default=None,
+        description="Module name patterns that are skipped in quantization.")
+    mamba_ssm_cache_dtype: Optional[str] = Field(
+        default=None, description="Data type for mamba SSM cache.")
 
     @cached_property
     def quant_mode(self) -> QuantModeWrapper:
@@ -249,6 +254,8 @@ class QuantConfig:
                     return True
         return False
 
+    # NOTE: this is kept for backward compatibility with external libraries (e.g., modelopt).
+    # For new code, prefer directly using QuantConfig(**config) instead.
     @classmethod
     def from_dict(cls, config: dict) -> 'QuantConfig':
         """Create a QuantConfig instance from a dict.
@@ -262,86 +269,58 @@ class QuantConfig:
         obj = cls(**config)
         return obj
 
-    def to_dict(self) -> dict:
-        """Dump a QuantConfig instance to a dict.
 
-        Returns:
-            dict: The dict dumped from QuantConfig.
-        """
-        return dataclasses.asdict(self)
+class LayerQuantConfig(StrictBaseModel):
+    """Configuration for layer-wise/mixed-precision quantization."""
 
+    quant_algo: Optional[QuantAlgo] = Field(
+        default=None,
+        description="Quantization algorithm (typically MIXED_PRECISION).")
+    kv_cache_quant_algo: Optional[QuantAlgo] = Field(
+        default=None, description="KV cache quantization algorithm.")
+    quantized_layers: Dict[str, QuantConfig] = Field(
+        default_factory=dict,
+        description="Per-layer quantization configurations.")
 
-@dataclasses.dataclass
-class LayerQuantConfig(QuantConfig):
-    quant_algo: Optional[QuantConfig] = None
-    kv_cache_quant_algo: Optional[QuantConfig] = None
-    quantized_layers: Optional[Dict[str, QuantConfig]] = None
+    # Computed cache, not serialized
+    _auto_quant_mode: Dict[str, QuantMode] = PrivateAttr(default_factory=dict)
 
-    def __init__(self,
-                 *,
-                 quant_algo: Optional[QuantConfig] = None,
-                 kv_cache_quant_algo: Optional[QuantConfig] = None,
-                 quantized_layers: Optional[Dict[str, QuantConfig]] = None,
-                 **kwargs):
-        self.quant_algo = quant_algo
-        self.quantized_layers = quantized_layers
-        self.kv_cache_quant_algo = kv_cache_quant_algo
-        self.auto_quant_mode = {}
-        for name, layer_config in self.quantized_layers.items():
-            self.auto_quant_mode.update({
-                name:
-                QuantMode.from_quant_algo(
+    def model_post_init(self, __context) -> None:
+        """Compute auto_quant_mode after initialization."""
+        self._auto_quant_mode = {}
+        if self.quantized_layers:
+            for name, layer_config in self.quantized_layers.items():
+                self._auto_quant_mode[name] = QuantMode.from_quant_algo(
                     layer_config.quant_algo,
                     self.kv_cache_quant_algo,
                 )
-            })
-        for key in kwargs:
-            logger.warning(
-                f"Warning: Unrecognized parameter '{key}' with value '{kwargs[key]}'"
-            )
 
-    @cached_property
-    def quant_mode(self):
-        quant_mode_list = list(set(self.auto_quant_mode.values()))
+    @property
+    def auto_quant_mode(self) -> Dict[str, QuantMode]:
+        return self._auto_quant_mode
+
+    @property
+    def quant_mode(self) -> QuantModeWrapper:
+        quant_mode_list = list(set(self._auto_quant_mode.values()))
         return QuantModeWrapper(quant_mode_list)
 
-    #@lru_cache(maxsize=None)
     def layer_quant_mode(self, layer_name) -> QuantMode:
-
-        for name, quant_mode in self.auto_quant_mode.items():
+        for name, quant_mode in self._auto_quant_mode.items():
             if fnmatch.fnmatch(layer_name, name):
                 return quant_mode
-
         return QuantMode(0)
 
-    @cached_property
-    def auto_quant_list(self):
-        quant_list = []
-        for _, layer_config in self.quantized_layers.items():
-            quant_list.append(layer_config.quant_algo)
-        return list(set(quant_list))
+    @property
+    def auto_quant_list(self) -> List[QuantAlgo]:
+        if not self.quantized_layers:
+            return []
+        return list(set(lc.quant_algo for lc in self.quantized_layers.values()))
 
-    @classmethod
-    def from_dict(cls, config: dict):
-        quantized_layers = config.pop('quantized_layers', {})
-
-        quantized_layers_dict = {
-            layer_name: QuantConfig(**layer_config)
-            for layer_name, layer_config in quantized_layers.items()
-        }
-
-        obj = cls(quantized_layers=quantized_layers_dict, **config)
-        return obj
-
-    #@lru_cache(maxsize=None)
-    def _get_quant_cfg(self, module_name):
-        quant_res = QuantConfig()
-
+    def _get_quant_cfg(self, module_name) -> QuantConfig:
         for name, quant_cfg in self.quantized_layers.items():
             if fnmatch.fnmatch(module_name, name):
-                quant_res = quant_cfg
-                break
-        return quant_res
+                return quant_cfg
+        return QuantConfig()
 
     def _get_modelopt_qformat(self):
         algo_to_modelopt_map = {
@@ -351,19 +330,17 @@ class LayerQuantConfig(QuantConfig):
             QuantAlgo.W4A8_AWQ: "w4a8_awq",
             QuantAlgo.W8A8_SQ_PER_CHANNEL: "int8_sq",
         }
-        assert self.quant_algo == QuantAlgo.MIXED_PRECISION, f"We only support mixed precision quantization in LayerQuantConfig"
+        assert self.quant_algo == QuantAlgo.MIXED_PRECISION, \
+            "We only support mixed precision quantization in LayerQuantConfig"
         autoq_format = ','.join(
             [algo_to_modelopt_map[item] for item in self.auto_quant_list])
         return autoq_format
 
-    def to_dict(self):
-        output = copy.deepcopy(self.__dict__)
-        output.pop('auto_quant_mode', None)
-        output.pop('quant_mode', None)
-        for name, per_layer_config in output['quantized_layers'].items():
-            per_layer_config = per_layer_config.to_dict()
-            output['quantized_layers'][name] = per_layer_config
-        return output
+    # NOTE: this is kept for backward compatibility with external libraries (e.g., modelopt).
+    # For new code, prefer directly using LayerQuantConfig(**config) instead.
+    @classmethod
+    def from_dict(cls, config: dict) -> 'LayerQuantConfig':
+        return cls(**config)
 
 
 class PretrainedConfig:
@@ -432,8 +409,8 @@ class PretrainedConfig:
         if quantization is None:
             quantization = QuantConfig()
         elif isinstance(quantization, dict):
-            quantization = QuantConfig.from_dict(quantization)
-        assert isinstance(quantization, QuantConfig)
+            quantization = QuantConfig(**quantization)
+        assert isinstance(quantization, (QuantConfig, LayerQuantConfig))
         self.quantization = quantization
 
         self.use_parallel_embedding = use_parallel_embedding
@@ -497,7 +474,7 @@ class PretrainedConfig:
         output['position_embedding_type'] = str(self.position_embedding_type)
         output['mapping'] = self.mapping.to_dict()
         output['mapping'].pop('rank')
-        output['quantization'] = self.quantization.to_dict()
+        output['quantization'] = self.quantization.model_dump()
 
         return output
 
@@ -540,7 +517,7 @@ class PretrainedConfig:
                         assert quant_cfg == config["quantized_layers"][
                             moe_name], "MoE module needs to have the same quantization format for non-rounter sub-modules"
 
-        self.quantization = LayerQuantConfig.from_dict(config)
+        self.quantization = LayerQuantConfig.model_validate(config)
 
     @property
     def quant_mode(self):

--- a/tensorrt_llm/plugin/plugin.py
+++ b/tensorrt_llm/plugin/plugin.py
@@ -24,14 +24,15 @@ from typing import (Any, List, Literal, Optional, Tuple, Union, get_args,
                     get_origin)
 
 import tensorrt as trt
-from pydantic import (BaseModel, ConfigDict, Field, PrivateAttr, ValidationInfo,
-                      field_validator)
+from pydantic import (ConfigDict, Field, PrivateAttr, ValidationInfo,
+                      field_validator, model_validator)
 
 from .._ipc_utils import IpcMemory, can_access_peer
 from .._utils import get_sm_version
 from ..bindings.internal.runtime import (lamport_initialize,
                                          lamport_initialize_all,
                                          max_workspace_size_lowprecision)
+from ..llmapi.utils import StrictBaseModel
 from ..logger import logger
 from ..mapping import Mapping
 
@@ -85,7 +86,7 @@ DefaultPluginDtype = Literal["auto", "float16", "float32", "bfloat16", "int32",
                              None]
 
 
-class PluginConfig(BaseModel):
+class PluginConfig(StrictBaseModel):
     """The config that manages plugin-related options.
 
     There are two option categories:
@@ -97,7 +98,7 @@ class PluginConfig(BaseModel):
         * True, which means the plugin is enabled;
         * False, which means the plugin is disabled.
     """
-    model_config = ConfigDict(validate_assignment=True, extra="ignore")
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
     dtype: str = Field(default="float16",
                        description="Base dtype for the model and plugins")
@@ -339,7 +340,10 @@ class PluginConfig(BaseModel):
     def from_arguments(cls, args: argparse.Namespace):
         """Create a PluginConfig from argparse arguments."""
         args = vars(args)
-        obj = cls(**args)
+        # Filter to only include fields that are part of PluginConfig
+        valid_fields = set(cls.model_fields.keys())
+        filtered_args = {k: v for k, v in args.items() if k in valid_fields}
+        obj = cls(**filtered_args)
 
         # We want to know if the user explicitly disabled the gemm_plugin
         # because nvfp4 gemm uses plugin by default currently
@@ -364,7 +368,8 @@ class PluginConfig(BaseModel):
                             bool) or field_name == "paged_kv_cache":
                 setattr(self, field_name, False)
 
-    def validate(self):
+    @model_validator(mode="after")
+    def _validate_sm_compatibility(self) -> "PluginConfig":
         unsupported_plugins = {
             # bert_attention_plugin is handled within BertAttention
             100: [
@@ -378,8 +383,9 @@ class PluginConfig(BaseModel):
             for plugin in unsupported_plugins[sm]:
                 val = getattr(self, plugin, None)
                 if val is not None and val != False:
-                    raise NotImplementedError(
+                    raise ValueError(
                         f"{plugin}={val} is not supported on SM {sm}.")
+        return self
 
     @property
     def context_fmha_type(self):

--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -567,7 +567,8 @@ class CliFlowAccuracyTestHarness:
             if "quantization_config" in hf_config:
                 is_prequantized = True
 
-        quant_config = QuantConfig(self.quant_algo, self.kv_cache_quant_algo)
+        quant_config = QuantConfig(quant_algo=self.quant_algo,
+                                   kv_cache_quant_algo=self.kv_cache_quant_algo)
         if not is_prequantized and quant_config._requires_modelopt_quantization:
             script = f"{self.llm_root}/examples/quantization/quantize.py"
         else:

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -428,7 +428,8 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
     def test_lookahead(self, mocker):
         mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
 
-        self.run(spec_dec_algo=LookaheadDecodingConfig.decoding_type,
+        self.run(spec_dec_algo=LookaheadDecodingConfig.
+                 model_fields["decoding_type"].default,
                  extra_build_args=[
                      "--max_draft_len=83",
                      "--speculative_decoding_mode=lookahead_decoding"
@@ -448,7 +449,8 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
             extra_summarize_args.append("--cuda_graph_mode")
 
         self.run(dtype="float16",
-                 spec_dec_algo=MedusaDecodingConfig.decoding_type,
+                 spec_dec_algo=MedusaDecodingConfig.
+                 model_fields["decoding_type"].default,
                  extra_convert_args=[
                      f"--medusa_model_dir={self.MEDUSA_MODEL_PATH}",
                      "--num_medusa_heads=4"
@@ -476,7 +478,8 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
             extra_summarize_args.extend(
                 ["--eagle_posterior_threshold=0.09", "--temperature=0.7"])
 
-        self.run(spec_dec_algo=EagleDecodingConfig.decoding_type,
+        self.run(spec_dec_algo=EagleDecodingConfig.
+                 model_fields["decoding_type"].default,
                  extra_convert_args=[
                      f"--eagle_model_dir={self.EAGLE_MODEL_PATH}",
                      "--max_draft_len=63", "--num_eagle_layers=4",
@@ -503,7 +506,8 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
         if chunked_context:
             extra_summarize_args.append("--enable_chunked_context")
 
-        self.run(spec_dec_algo=EagleDecodingConfig.decoding_type,
+        self.run(spec_dec_algo=EagleDecodingConfig.
+                 model_fields["decoding_type"].default,
                  extra_convert_args=[
                      f"--eagle_model_dir={self.EAGLE_MODEL_PATH}",
                      "--max_draft_len=63", "--num_eagle_layers=4",
@@ -848,7 +852,8 @@ class TestLlama3_1_8BInstruct(CliFlowAccuracyTestHarness):
             "--medusa_choices=[[0], [0, 0], [1], [0, 1], [2], [0, 0, 0], [1, 0], [0, 2], [3], [0, 3], [4], [0, 4], [2, 0], [0, 5], [0, 0, 1], [5], [0, 6], [6], [0, 7], [0, 1, 0], [1, 1], [7], [0, 8], [0, 0, 2], [3, 0], [0, 9], [8], [9], [1, 0, 0], [0, 2, 0], [1, 2], [0, 0, 3], [4, 0], [2, 1], [0, 0, 4], [0, 0, 5], [0, 1, 1], [0, 0, 6], [0, 3, 0], [5, 0], [1, 3], [0, 0, 7], [0, 0, 8], [0, 0, 9], [6, 0], [0, 4, 0], [1, 4], [7, 0], [0, 1, 2], [2, 0, 0], [3, 1], [2, 2], [8, 0], [0, 5, 0], [1, 5], [1, 0, 1], [0, 2, 1], [9, 0], [0, 6, 0], [1, 6], [0, 7, 0]]"
         ]
         self.run(dtype="float16",
-                 spec_dec_algo=MedusaDecodingConfig.decoding_type,
+                 spec_dec_algo=MedusaDecodingConfig.
+                 model_fields["decoding_type"].default,
                  extra_build_args=["--speculative_decoding_mode=medusa"],
                  extra_summarize_args=extra_summarize_args)
 

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -184,8 +184,8 @@ def launch_disaggregated_llm(
     with open(gen_server_config_path, "w") as f:
         yaml.dump(gen_server_config, f)
 
-    args = LlmArgs.from_kwargs(model=model_name,
-                               tensor_parallel_size=tensor_parallel_size)
+    args = LlmArgs(model=model_name, tensor_parallel_size=tensor_parallel_size)
+
     if "FP4" in model_name:
         args.quant_config.quant_algo = "NVFP4"
 

--- a/tests/integration/defs/accuracy/test_llm_api.py
+++ b/tests/integration/defs/accuracy/test_llm_api.py
@@ -33,7 +33,8 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise(self):
-        quant_config = QuantConfig(QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
+        quant_config = QuantConfig(
+            quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
 
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
@@ -113,28 +114,28 @@ class TestLlama3_2_1B(LlmapiAccuracyTestHarness):
     @skip_post_blackwell
     def test_smooth_quant(self):
         quant_config = QuantConfig(
-            QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
+            quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb(self):
-        quant_config = QuantConfig(QuantAlgo.W8A8_SQ_PER_CHANNEL)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
 
     @skip_post_blackwell
     def test_int4_awq(self):
-        quant_config = QuantConfig(QuantAlgo.W4A16_AWQ)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_AWQ)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
 
     @skip_post_blackwell
     def test_int4_awq_int8_kv_cache(self):
-        quant_config = QuantConfig(QuantAlgo.W4A16_AWQ)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_AWQ)
         kv_cache_config = KvCacheConfig(quant_algo=QuantAlgo.INT8)
         with LLM(self.MODEL_PATH,
                  quant_config=quant_config,
@@ -144,7 +145,7 @@ class TestLlama3_2_1B(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         kv_cache_config = KvCacheConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH,
                  quant_config=quant_config,
@@ -155,7 +156,7 @@ class TestLlama3_2_1B(LlmapiAccuracyTestHarness):
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
     def test_fp8_pp2(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         kv_cache_config = KvCacheConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH,
                  pipeline_parallel_size=2,
@@ -168,7 +169,8 @@ class TestLlama3_2_1B(LlmapiAccuracyTestHarness):
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise(self):
-        quant_config = QuantConfig(QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
+        quant_config = QuantConfig(
+            quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
@@ -231,7 +233,7 @@ class TestMistralNemo12B(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device_memory(80000)
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8,
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8,
                                    kv_cache_quant_algo=QuantAlgo.FP8)
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.9)
 
@@ -313,7 +315,7 @@ class TestPhi4MiniInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
@@ -338,7 +340,7 @@ class TestQwen2_7BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_post_blackwell
     def test_weight_only(self):
-        quant_config = QuantConfig(QuantAlgo.W8A16)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W8A16)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -346,7 +348,7 @@ class TestQwen2_7BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -379,7 +381,7 @@ class TestQwen2_5_0_5BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -407,7 +409,7 @@ class TestQwen2_5_1_5BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_post_blackwell
     def test_weight_only(self):
-        quant_config = QuantConfig(QuantAlgo.W8A16)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W8A16)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -415,7 +417,7 @@ class TestQwen2_5_1_5BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -443,7 +445,7 @@ class TestQwen2_5_7BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_ada
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH, quant_config=quant_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
@@ -529,7 +531,7 @@ class TestStarCoder2_7B(LlmapiAccuracyTestHarness):
     @skip_pre_ada
     @pytest.mark.skip_less_device_memory(70000)
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH,
                  quant_config=quant_config,
                  kv_cache_config=self.kv_cache_config) as llm:
@@ -555,7 +557,7 @@ class TestCodestral_22B_V01(LlmapiAccuracyTestHarness):
     @skip_pre_ada
     @pytest.mark.skip_less_device_memory(80000)
     def test_fp8(self):
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
         with LLM(self.MODEL_PATH,
                  quant_config=quant_config,
                  kv_cache_config=self.kv_cache_config) as llm:

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_deepseek_v3_lite_empty_batch.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_deepseek_v3_lite_empty_batch.yaml
@@ -4,10 +4,6 @@ model: DeepSeek-V3-Lite/bf16
 backend: "pytorch"
 context_servers:
   num_instances: 1
-  build_config:
-    max_batch_size: 10
-    max_num_tokens: 512
-    max_seq_len: 768
   max_batch_size: 10
   max_num_tokens: 512
   max_seq_len: 768
@@ -27,10 +23,6 @@ context_servers:
       - "localhost:8001"
 generation_servers:
   num_instances: 1
-  build_config:
-    max_batch_size: 1
-    max_num_tokens: 2048
-    max_seq_len: 2560
   tensor_parallel_size: 1
   enable_attention_dp: false
   enable_lm_head_tp_in_adp: false

--- a/tests/microbenchmarks/build_time_benchmark.py
+++ b/tests/microbenchmarks/build_time_benchmark.py
@@ -197,7 +197,7 @@ def build_from_hf(args,
 
     quant_config = None
     if args.quant == 'fp8':
-        quant_config = QuantConfig(QuantAlgo.FP8)
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
 
     phase_and_time = []
     if load_weights:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
@@ -163,7 +163,7 @@ def test_non_registered_model_factory(model_factory: str):
         ("moe_tensor_parallel_size", 2),
         ("moe_expert_parallel_size", 2),
         ("enable_attention_dp", True),
-        ("cp_config", {"some_key": "some_value"}),
+        ("cp_config", {"cp_type": "HELIX"}),
     ],
 )
 def test_parallel_config_validation(parallel_field, invalid_value):

--- a/tests/unittest/api_stability/api_stability_core.py
+++ b/tests/unittest/api_stability/api_stability_core.py
@@ -265,7 +265,8 @@ class ClassSnapshot:
                         continue
                     parameters[field_name] = ParamSnapshot(
                         annotation=field.annotation,
-                        default=field.default or inspect._empty)
+                        default=inspect._empty
+                        if field.is_required() else field.default)
                 methods[method_name] = MethodSnapshot(parameters=parameters,
                                                       return_annotation=None)
             else:
@@ -300,7 +301,8 @@ class ClassSnapshot:
                             continue
                         parameters[field_name] = ParamSnapshot(
                             annotation=field.annotation,
-                            default=field.default or inspect._empty)
+                            default=inspect._empty
+                            if field.is_required() else field.default)
                     methods["__init__"] = MethodSnapshot(parameters=parameters,
                                                          return_annotation=None)
                 else:

--- a/tests/unittest/api_stability/references/calib_config.yaml
+++ b/tests/unittest/api_stability/references/calib_config.yaml
@@ -23,13 +23,4 @@ methods:
         annotation: int
         default: 2048
     return_annotation: None
-  from_dict:
-    parameters:
-      config:
-        annotation: dict
-        default: inspect._empty
-    return_annotation: tensorrt_llm.llmapi.llm_utils.CalibConfig
-  to_dict:
-    parameters: {}
-    return_annotation: dict
 properties: {}

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -15,7 +15,7 @@ methods:
         default: False
         status: beta
       cp_config:
-        annotation: Optional[dict]
+        annotation: Optional[tensorrt_llm.llmapi.llm_args.CpConfig]
         default: null
         status: prototype
       pp_partition:
@@ -76,12 +76,8 @@ methods:
         status: beta
       # Misc
       backend:
-        annotation: Optional[str]
-        default: null
-        status: deprecated
-      build_config:
-        annotation: Optional[tensorrt_llm.llmapi.llm_args.BuildConfig]
-        default: null
+        annotation: Literal["pytorch"]
+        default: pytorch
         status: deprecated
       cuda_graph_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.CudaGraphConfig]
@@ -200,7 +196,7 @@ methods:
         default: null
         status: prototype
       sparse_attention_config:
-        annotation: Optional[tensorrt_llm.llmapi.llm_args.SparseAttentionConfig]
+        annotation: Union[tensorrt_llm.llmapi.llm_args.RocketSparseAttentionConfig, tensorrt_llm.llmapi.llm_args.DeepSeekSparseAttentionConfig, tensorrt_llm.llmapi.llm_args.SkipSoftmaxAttentionConfig, NoneType]
         default: null
         status: prototype
       otlp_traces_endpoint:

--- a/tests/unittest/api_stability/references/quant_config.yaml
+++ b/tests/unittest/api_stability/references/quant_config.yaml
@@ -38,9 +38,6 @@ methods:
         annotation: dict
         default: inspect._empty
     return_annotation: tensorrt_llm.models.modeling_utils.QuantConfig
-  to_dict:
-    parameters: {}
-    return_annotation: dict
   is_module_excluded_from_quantization:
     parameters:
       name:

--- a/tests/unittest/api_stability/references/quant_config.yaml
+++ b/tests/unittest/api_stability/references/quant_config.yaml
@@ -8,7 +8,7 @@ methods:
         annotation: Optional[List[str]]
         default: null
       group_size:
-        annotation: int
+        annotation: Optional[int]
         default: 128
       has_zero_point:
         annotation: bool

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -59,21 +59,21 @@ methods:
         default: null
       # Speculative decoding
       speculative_config:
-        annotation: Union[tensorrt_llm.llmapi.llm_args.DraftTargetDecodingConfig, tensorrt_llm.llmapi.llm_args.EagleDecodingConfig,tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig, tensorrt_llm.llmapi.llm_args.MedusaDecodingConfig, tensorrt_llm.llmapi.llm_args.MTPDecodingConfig, tensorrt_llm.llmapi.llm_args.NGramDecodingConfig, tensorrt_llm.llmapi.llm_args.UserProvidedDecodingConfig, tensorrt_llm.llmapi.llm_args.AutoDecodingConfig, tensorrt_llm.llmapi.llm_args.SaveHiddenStatesDecodingConfig, NoneType]
+        annotation: Union[tensorrt_llm.llmapi.llm_args.DraftTargetDecodingConfig, tensorrt_llm.llmapi.llm_args.EagleDecodingConfig, tensorrt_llm.llmapi.llm_args.Eagle3DecodingConfig, tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig, tensorrt_llm.llmapi.llm_args.MedusaDecodingConfig, tensorrt_llm.llmapi.llm_args.MTPDecodingConfig, tensorrt_llm.llmapi.llm_args.NGramDecodingConfig, tensorrt_llm.llmapi.llm_args.UserProvidedDecodingConfig, tensorrt_llm.llmapi.llm_args.AutoDecodingConfig, tensorrt_llm.llmapi.llm_args.SaveHiddenStatesDecodingConfig, NoneType]
         default: null
       # generation constraints
       max_batch_size:
         annotation: Optional[int]
-        default: null
+        default: 2048
       max_input_len:
         annotation: Optional[int]
-        default: null
+        default: 1024
       max_seq_len:
         annotation: Optional[int]
         default: null
       max_beam_width:
         annotation: Optional[int]
-        default: null
+        default: 1
       max_num_tokens:
         annotation: Optional[int]
         default: 8192
@@ -81,9 +81,6 @@ methods:
       load_format:
         annotation: Union[str, tensorrt_llm.llmapi.llm_args.LoadFormat]
         default: 0
-      enable_tqdm:
-        annotation: bool
-        default: false
       enable_chunked_prefill:
         annotation: bool
         default: false

--- a/tests/unittest/llmapi/test_build_cache.py
+++ b/tests/unittest/llmapi/test_build_cache.py
@@ -8,7 +8,7 @@ from tensorrt_llm.llmapi.build_cache import BuildCache, BuildCacheConfig
 
 def test_BuildStep():
     with TemporaryDirectory() as tempdir:
-        build_cache = BuildCache(BuildCacheConfig(Path(tempdir)))
+        build_cache = BuildCache(BuildCacheConfig(cache_root=Path(tempdir)))
         build_step = build_cache.get_engine_building_cache_stage(
             build_config=BuildConfig(), hf_model_name="test")
         assert not build_step.is_cached()
@@ -27,7 +27,7 @@ def test_BuildStep():
 def test_BuildCache_clean_untracked_path():
     # The BuildCache could cleanup the untracked files/dirs within the cache_root
     with TemporaryDirectory() as tempdir:
-        build_cache = BuildCache(BuildCacheConfig(Path(tempdir)))
+        build_cache = BuildCache(BuildCacheConfig(cache_root=Path(tempdir)))
         (build_cache.cache_root / 'untracked').mkdir()
         (build_cache.cache_root / 'untracked_file').touch()
 
@@ -38,7 +38,8 @@ def test_BuildCache_clean_untracked_path():
 def test_BuildCache_clean_cache_exceed_record_limit():
     # The BuildCache could cleanup the cache if the number of records exceed the limit
     with TemporaryDirectory() as tempdir:
-        build_cache = BuildCache(BuildCacheConfig(Path(tempdir), max_records=2))
+        build_cache = BuildCache(
+            BuildCacheConfig(cache_root=Path(tempdir), max_records=2))
         build_config = BuildConfig()
 
         def create_cache(hf_model_name: str):

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -219,18 +219,18 @@ def test_llm_args_invalid_usage():
     runtime_max_num_tokens = 2
 
     # Update build_config with warning msg if runtime arguments are passed.
-    llm_args = LlmArgs.from_kwargs(model='test-model',
-                                   max_batch_size=runtime_max_batch_size,
-                                   max_num_tokens=runtime_max_num_tokens)
+    llm_args = LlmArgs(model='test-model',
+                       max_batch_size=runtime_max_batch_size,
+                       max_num_tokens=runtime_max_num_tokens)
     assert llm_args.build_config.max_batch_size == runtime_max_batch_size
     assert llm_args.build_config.max_num_tokens == runtime_max_num_tokens
 
     # Conflict between build_config and runtime_params
     build_config = BuildConfig(max_batch_size=5, max_num_tokens=7)
-    llm_args = LlmArgs.from_kwargs(model='test-model',
-                                   build_config=build_config,
-                                   max_batch_size=runtime_max_batch_size,
-                                   max_num_tokens=runtime_max_num_tokens)
+    llm_args = LlmArgs(model='test-model',
+                       build_config=build_config,
+                       max_batch_size=runtime_max_batch_size,
+                       max_num_tokens=runtime_max_num_tokens)
     assert llm_args.build_config.max_batch_size == build_config.max_batch_size
     assert llm_args.build_config.max_num_tokens == build_config.max_num_tokens
 

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1,5 +1,3 @@
-# fmt: off
-# isort: off
 import tempfile
 from dataclasses import is_dataclass
 from enum import Enum
@@ -9,32 +7,37 @@ from typing import Annotated, Any, Literal, get_args, get_origin
 import pydantic_core
 import pytest
 import yaml
-from pydantic import ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from utils.llm_data import llm_models_root
-from pydantic import BaseModel, TypeAdapter
 
 import tensorrt_llm.bindings.executor as tle
 import tensorrt_llm.llmapi.llm_args as llm_args_mod
 from tensorrt_llm import LLM as TorchLLM
 from tensorrt_llm._tensorrt_engine import LLM
+from tensorrt_llm._torch.auto_deploy.llm_args import \
+    LlmArgs as AutoDeployLlmArgs
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_llama import LlamaForCausalLM
 from tensorrt_llm.builder import LoraConfig
 from tensorrt_llm.commands.serve import get_llm_args, is_non_default_or_required
-from tensorrt_llm._torch.auto_deploy.llm_args import \
-    LlmArgs as AutoDeployLlmArgs
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
                                  SchedulerConfig)
-from tensorrt_llm.llmapi.llm_args import (
-    CacheTransceiverConfig, CalibConfig, ContextChunkingPolicy, CudaGraphConfig,
-    DecodingBaseConfig, DynamicBatchConfig, Eagle3DecodingConfig,
-    EagleDecodingConfig, ExtendedRuntimePerfKnobConfig, KvCacheConfig,
-    LookaheadDecodingConfig, MoeConfig, PeftCacheConfig, PybindMirror,
-    StrictBaseModel, TorchCompileConfig, TorchLlmArgs, TrtLlmArgs,
-    update_llm_args_with_extra_dict)
-from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
-# isort: on
+# fmt: off
+from tensorrt_llm.llmapi.llm_args import (CacheTransceiverConfig, CalibConfig,
+                                          ContextChunkingPolicy,
+                                          CudaGraphConfig, DecodingBaseConfig,
+                                          DynamicBatchConfig,
+                                          Eagle3DecodingConfig,
+                                          EagleDecodingConfig,
+                                          ExtendedRuntimePerfKnobConfig,
+                                          KvCacheConfig,
+                                          LookaheadDecodingConfig, MoeConfig,
+                                          PeftCacheConfig, PybindMirror,
+                                          StrictBaseModel, TorchCompileConfig,
+                                          TorchLlmArgs, TrtLlmArgs,
+                                          update_llm_args_with_extra_dict)
 # fmt: on
+from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
 from tensorrt_llm.llmapi.utils import print_traceback_on_error
 from tensorrt_llm.models.modeling_utils import LayerQuantConfig, QuantConfig
 from tensorrt_llm.plugin import PluginConfig

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -23,8 +23,8 @@ from tensorrt_llm.commands.serve import get_llm_args, is_non_default_or_required
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
                                  SchedulerConfig)
 # fmt: off
-from tensorrt_llm.llmapi.llm_args import (CacheTransceiverConfig, CalibConfig,
-                                          ContextChunkingPolicy,
+from tensorrt_llm.llmapi.llm_args import (BaseLlmArgs, CacheTransceiverConfig,
+                                          CalibConfig, ContextChunkingPolicy,
                                           CudaGraphConfig, DecodingBaseConfig,
                                           DynamicBatchConfig,
                                           Eagle3DecodingConfig,
@@ -33,8 +33,10 @@ from tensorrt_llm.llmapi.llm_args import (CacheTransceiverConfig, CalibConfig,
                                           KvCacheConfig,
                                           LookaheadDecodingConfig, MoeConfig,
                                           PeftCacheConfig, PybindMirror,
+                                          RayPlacementConfig, SpeculativeConfig,
                                           StrictBaseModel, TorchCompileConfig,
                                           TorchLlmArgs, TrtLlmArgs,
+                                          UserProvidedDecodingConfig,
                                           update_llm_args_with_extra_dict)
 # fmt: on
 from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1,12 +1,17 @@
 # fmt: off
 # isort: off
 import tempfile
+from dataclasses import is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Any, Literal, get_args, get_origin
 
 import pydantic_core
 import pytest
 import yaml
 from pydantic import ValidationError
 from utils.llm_data import llm_models_root
+from pydantic import BaseModel, TypeAdapter
 
 import tensorrt_llm.bindings.executor as tle
 import tensorrt_llm.llmapi.llm_args as llm_args_mod
@@ -16,6 +21,8 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_llama import LlamaForCausalLM
 from tensorrt_llm.builder import LoraConfig
 from tensorrt_llm.commands.serve import get_llm_args, is_non_default_or_required
+from tensorrt_llm._torch.auto_deploy.llm_args import \
+    LlmArgs as AutoDeployLlmArgs
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
                                  SchedulerConfig)
 from tensorrt_llm.llmapi.llm_args import (
@@ -29,6 +36,7 @@ from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
 # isort: on
 # fmt: on
 from tensorrt_llm.llmapi.utils import print_traceback_on_error
+from tensorrt_llm.models.modeling_utils import LayerQuantConfig, QuantConfig
 from tensorrt_llm.plugin import PluginConfig
 
 from .test_llm import llama_model_path
@@ -44,7 +52,7 @@ def test_LookaheadDecodingConfig():
     assert config.max_verification_set_size == 4
 
     # from dict
-    config = LookaheadDecodingConfig.from_dict({
+    config = LookaheadDecodingConfig(**{
         "max_window_size": 4,
         "max_ngram_size": 3,
         "max_verification_set_size": 4
@@ -71,19 +79,16 @@ class TestYaml:
             dict_content = yaml.safe_load(f)
         return dict_content
 
-    def test_update_llm_args_with_extra_dict_with_speculative_config(self):
+    def test_llm_args_yaml_with_speculative_config(self):
         yaml_content = """
 speculative_config:
     decoding_type: Lookahead
     max_window_size: 4
     max_ngram_size: 3
     """
-        dict_content = self._yaml_to_dict(yaml_content)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
 
-        llm_args = TrtLlmArgs(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
-        llm_args = TrtLlmArgs(**llm_args_dict)
+        llm_args = TrtLlmArgs(model=llama_model_path, **llm_args_dict)
         assert llm_args.speculative_config.max_window_size == 4
         assert llm_args.speculative_config.max_ngram_size == 3
         assert llm_args.speculative_config.max_verification_set_size == 4
@@ -94,28 +99,21 @@ pytorch_backend_config: # this is deprecated
     max_num_tokens: 1
     max_seq_len: 1
 """
-        dict_content = self._yaml_to_dict(yaml_content)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
 
-        llm_args = TrtLlmArgs(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
         with pytest.raises(ValueError):
-            llm_args = TrtLlmArgs(**llm_args_dict)
+            llm_args = TrtLlmArgs(model=llama_model_path, **llm_args_dict)
 
     def test_llm_args_with_build_config(self):
-        # build_config isn't a Pydantic
         yaml_content = """
 build_config:
     max_beam_width: 4
     max_batch_size: 8
     max_num_tokens: 256
     """
-        dict_content = self._yaml_to_dict(yaml_content)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
 
-        llm_args = TrtLlmArgs(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
-        llm_args = TrtLlmArgs(**llm_args_dict)
+        llm_args = TrtLlmArgs(model=llama_model_path, **llm_args_dict)
         assert llm_args.build_config.max_beam_width == 4
         assert llm_args.build_config.max_batch_size == 8
         assert llm_args.build_config.max_num_tokens == 256
@@ -127,12 +125,9 @@ kv_cache_config:
     max_tokens: 1024
     max_attention_window: [1024, 1024, 1024]
     """
-        dict_content = self._yaml_to_dict(yaml_content)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
 
-        llm_args = TrtLlmArgs(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
-        llm_args = TrtLlmArgs(**llm_args_dict)
+        llm_args = TrtLlmArgs(model=llama_model_path, **llm_args_dict)
         assert llm_args.kv_cache_config.enable_block_reuse == True
         assert llm_args.kv_cache_config.max_tokens == 1024
         assert llm_args.kv_cache_config.max_attention_window == [
@@ -145,12 +140,9 @@ max_batch_size: 16
 max_num_tokens: 256
 max_seq_len: 128
     """
-        dict_content = self._yaml_to_dict(yaml_content)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
 
-        llm_args = TrtLlmArgs(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
-        llm_args = TrtLlmArgs(**llm_args_dict)
+        llm_args = TrtLlmArgs(model=llama_model_path, **llm_args_dict)
         assert llm_args.max_batch_size == 16
         assert llm_args.max_num_tokens == 256
         assert llm_args.max_seq_len == 128
@@ -161,19 +153,17 @@ max_seq_len: 128
 model_kwargs:
     num_hidden_layers: 2
     """
-        dict_content = self._yaml_to_dict(yaml_content)
-        llm_args = llm_args_cls(model=llama_model_path)
-        llm_args_dict = update_llm_args_with_extra_dict(llm_args.model_dump(),
-                                                        dict_content)
-        llm_args = llm_args_cls(**llm_args_dict)
+        llm_args_dict = self._yaml_to_dict(yaml_content)
+        llm_args = llm_args_cls(model=llama_model_path, **llm_args_dict)
         assert llm_args.model_kwargs['num_hidden_layers'] == 2
 
 
 def test_decoding_type_eagle3_parses_to_eagle3_decoding_config():
-    spec_cfg = DecodingBaseConfig.from_dict(
+    adapter = TypeAdapter(SpeculativeConfig)
+    spec_cfg = adapter.validate_python(
         dict(decoding_type="Eagle3",
              max_draft_len=3,
-             speculative_model_dir="/path/to/draft/model"))
+             speculative_model="/path/to/draft/model"))
     assert isinstance(spec_cfg, Eagle3DecodingConfig)
 
 
@@ -185,12 +175,9 @@ def test_decoding_type_eagle_warns_on_pytorch_backend(monkeypatch):
 
     monkeypatch.setattr(llm_args_mod.logger, "warning", _capture_warning)
 
-    spec_cfg = DecodingBaseConfig.from_dict(dict(
-        decoding_type="Eagle",
-        max_draft_len=3,
-        speculative_model_dir="/path/to/draft/model"),
-                                            backend="pytorch")
-    assert isinstance(spec_cfg, Eagle3DecodingConfig)
+    spec_cfg = EagleDecodingConfig(decoding_type="Eagle",
+                                   max_draft_len=3,
+                                   speculative_model="/path/to/draft/model")
 
     TorchLlmArgs(model=llama_model_path, speculative_config=spec_cfg)
 
@@ -200,10 +187,9 @@ def test_decoding_type_eagle_warns_on_pytorch_backend(monkeypatch):
 
 
 def test_decoding_type_eagle3_errors_on_tensorrt_backend():
-    spec_cfg = DecodingBaseConfig.from_dict(
-        dict(decoding_type="Eagle3",
-             max_draft_len=3,
-             speculative_model_dir="/path/to/draft/model"))
+    spec_cfg = Eagle3DecodingConfig(decoding_type="Eagle3",
+                                    max_draft_len=3,
+                                    speculative_model="/path/to/draft/model")
     with pytest.raises(ValueError,
                        match="only supported on the PyTorch backend"):
         TrtLlmArgs(model=llama_model_path, speculative_config=spec_cfg)
@@ -675,7 +661,7 @@ class TestTrtLlmArgs:
         args = TrtLlmArgs(model=llama_model_path, build_config=build_config)
         args_dict = args.model_dump()
 
-        new_args = TrtLlmArgs.from_kwargs(**args_dict)
+        new_args = TrtLlmArgs(**args_dict)
 
         assert new_args.model_dump() == args_dict
 
@@ -734,9 +720,9 @@ class TestStrictBaseModelArbitraryArgs:
     def test_cuda_graph_config_arbitrary_args(self):
         """Test that CudaGraphConfig rejects arbitrary arguments."""
         # Valid arguments should work
-        config = CudaGraphConfig(batch_sizes=[1, 2, 4], max_batch_size=8)
+        config = CudaGraphConfig(batch_sizes=[1, 2, 4], max_batch_size=4)
         assert config.batch_sizes == [1, 2, 4]
-        assert config.max_batch_size == 8
+        assert config.max_batch_size == 4
 
         # Arbitrary arguments should be rejected
         with pytest.raises(
@@ -1169,3 +1155,344 @@ class TestPyTorchBackendModelDefaults:
             # should not prevent these from being applied.
             assert modified_args.kv_cache_config.enable_block_reuse == False
             assert modified_args.kv_cache_config.free_gpu_memory_fraction == 0.75
+
+
+def test_executor_config_consistency():
+    """Verify that BaseLlmArgs exposes all ExecutorConfig options."""
+    # max_beam_width is not included since vague behavior due to lacking the support for dynamic beam width during
+    # generation
+    black_list = set(["max_beam_width"])
+    executor_config_attrs = set(attr for attr in dir(tle.ExecutorConfig)
+                                if not attr.startswith('_')
+                                and callable(getattr(tle.ExecutorConfig, attr)))
+    executor_config_attrs -= black_list
+    llm_args_attr = set(BaseLlmArgs.model_fields.keys())
+    # NOTE: When cpp ExecutorConfig add new options, please add the new options into `LlmArgs` with docs as well
+    # ASK chunweiy for help if you are not sure about the new options.
+    assert executor_config_attrs.issubset(llm_args_attr), \
+        f"New options found in underlying ExecutorConfig: {executor_config_attrs - llm_args_attr}"
+
+
+def _get_all_llm_args_classes():
+    """Get all subclasses of BaseLlmArgs by traversing the class hierarchy."""
+    subclasses = []
+    to_visit = [BaseLlmArgs]
+    while to_visit:
+        cls = to_visit.pop()
+        for subclass in cls.__subclasses__():
+            subclasses.append(subclass)
+            to_visit.append(subclass)
+    return subclasses
+
+
+def _get_all_pydantic_models_from_llm_args():
+    """
+    Get all Pydantic models referenced by BaseLlmArgs and its subclasses,
+    including nested models.
+    """
+
+    visited = set()
+    models = []
+
+    def extract_types_from_annotation(annotation):
+        """Extract all concrete types from an annotation (handles Union, Optional, List, etc.)."""
+        args = get_args(annotation)
+        if args:
+            # Generic type - recurse into all type arguments
+            return [
+                t for arg in args if arg is not type(None)
+                for t in extract_types_from_annotation(arg)
+            ]
+        elif isinstance(annotation, type):
+            return [annotation]
+        return []
+
+    def visit_model(model_cls):
+        if model_cls in visited:
+            return
+        if not isinstance(model_cls, type) or not issubclass(
+                model_cls, BaseModel):
+            return
+
+        visited.add(model_cls)
+        models.append(model_cls)
+
+        # Visit all field types
+        for field_name, field_info in model_cls.model_fields.items():
+            annotation = field_info.annotation
+            if annotation is None:
+                continue
+
+            # Extract all types from the annotation
+            types_in_annotation = extract_types_from_annotation(annotation)
+            for type_cls in types_in_annotation:
+                if isinstance(type_cls, type) and issubclass(
+                        type_cls, BaseModel):
+                    visit_model(type_cls)
+
+    # Start with BaseLlmArgs and all its subclasses
+    for cls in [BaseLlmArgs] + _get_all_llm_args_classes():
+        visit_model(cls)
+
+    return models
+
+
+def _get_qualified_name(cls: type) -> str:
+    """Return the fully qualified name of a class."""
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+class TestPydanticBestPractices:
+    """
+    Ensure that the user-facing LlmArgs and its subfields follow Pydantic best practices.
+    """
+
+    # Fields exempt from Pydantic compatibility checks due to typing limitations or other edge cases.
+    # Avoid adding to this list unless absolutely necessary, especially if a field is user-facing.
+    # Keys are Pydantic model classes, values are lists of field names.
+    _COMPATIBILITY_EXEMPT_FIELDS: dict[type, list[str]] = {
+        BaseLlmArgs: [
+            "batched_logits_processor",  # abstract base class type
+            "decoding_config",  # deprecated field, typed as object
+            "model_kwargs",  # typed as Dict[str, Any] for flexibility
+            "mpi_session",  # abstract base class type
+            "tokenizer",  # uses PreTrainedTokenizerBase
+        ],
+        TorchLlmArgs: [
+            "checkpoint_loader",  # abstract base class type
+        ],
+        AutoDeployLlmArgs: [
+            "draft_checkpoint_loader",  # typed as object due to circular import
+            "transforms",  # typed as Dict[str, Dict[str, Any]] for flexibility
+            "model_kwargs",  # typed as Dict[str, Any] for flexibility
+            "tokenizer_kwargs",  # typed as Dict[str, Any] for flexibility
+        ],
+        UserProvidedDecodingConfig: [
+            "drafter",  # abstract base class type
+            "resource_manager",  # abstract base class type
+        ],
+        MoeConfig: ["load_balancer"],  # allows multiple types including dict
+        RayPlacementConfig: ["placement_groups"],  # contains Ray-specific types
+    }
+
+    def _is_allowed_type(self, annotation, model_cls: type,
+                         field_name: str) -> tuple[bool, str]:
+        """
+        Check if a type annotation is allowed for user-facing config fields.
+
+        Allowed:
+        - Pydantic models (must inherit from StrictBaseModel)
+        - Enums, primitives (str, int, float, bool, bytes, Path, type(None))
+        - Union/Optional/List/Dict of allowed types
+        Not allowed:
+        - object, Any, bare containers (dict, list without type parameters)
+        - dataclasses, non-Pydantic classes, Pydantic models not inheriting from StrictBaseModel
+
+        Returns (is_allowed, reason) tuple.
+        """
+
+        # Check if this field is exempt (check class and all parent classes)
+        for cls in model_cls.__mro__:
+            if field_name in self._COMPATIBILITY_EXEMPT_FIELDS.get(cls, []):
+                return True, "exempt"
+
+        # Check explicitly blocked types
+        if annotation is object:
+            return False, "bare 'object' type (use a specific type or Pydantic model)"
+        if annotation is Any:
+            return False, "'Any' type (use a specific type or Pydantic model)"
+
+        # Check for bare container types (missing type parameters)
+        if annotation in (dict, list, tuple, set, frozenset):
+            name = annotation.__name__
+            return False, f"bare '{name}' type (use {name}[...] with specific type parameters)"
+
+        # Check for dataclasses (should use Pydantic models instead)
+        if isinstance(annotation, type) and is_dataclass(annotation):
+            return False, f"class '{annotation.__name__}' is a dataclass (convert to a Pydantic StrictBaseModel instead)"
+
+        # Check for regular classes that aren't Pydantic models, enums, or primitives
+        _ALLOWED_CLASS_BASES = (BaseModel, Enum, str, int, float, bool, bytes,
+                                Path, type(None))
+        if isinstance(annotation, type) and not issubclass(
+                annotation, _ALLOWED_CLASS_BASES):
+            return False, f"class '{annotation.__name__}' is not a Pydantic model (convert to StrictBaseModel)"
+
+        # Require user-facing Pydantic models to inherit from StrictBaseModel
+        if isinstance(annotation, type) and issubclass(
+                annotation,
+                BaseModel) and not issubclass(annotation, StrictBaseModel):
+            return False, f"Pydantic model '{annotation.__name__}' is not a StrictBaseModel (convert to StrictBaseModel)"
+
+        # Recursively check generic type arguments for disallowed types
+        origin = get_origin(annotation)
+        if origin is not None:
+            # Skip Literal types - their args are values, not types
+            if origin is Literal:
+                return True, "Literal type"
+
+            # For Annotated types, only check the first arg (the actual type)
+            # The rest are metadata (validators, Field info, etc.)
+            if origin is Annotated:
+                args = get_args(annotation)
+                return self._is_allowed_type(args[0], model_cls, field_name)
+
+            # For other generic types (Union, List, Dict, etc.), check all type args
+            container_name = getattr(origin, "__name__", str(origin))
+            for arg in get_args(annotation):
+                if arg is type(None):
+                    continue
+                # Explicitly check for Any (it's a special form, not a type)
+                if arg is Any:
+                    return False, f"in {container_name}: 'Any' type (use a specific type)"
+                # Skip non-type args (e.g., Callable parameter specs)
+                if not isinstance(arg, type) and get_origin(arg) is None:
+                    continue
+                ok, reason = self._is_allowed_type(arg, model_cls, field_name)
+                if not ok:
+                    return False, f"in {container_name}: {reason}"
+
+        return True, "allowed"
+
+    def test_all_fields_have_descriptions(self):
+        """Test that all fields in LlmArgs classes (including subfields) have descriptions."""
+        violations = []
+
+        for cls in _get_all_pydantic_models_from_llm_args():
+            for field_name, field_info in cls.model_fields.items():
+                if field_name.startswith("_"):
+                    # Skip private / non user-facing fields
+                    continue
+                # Skip discriminator fields (single-value Literals)
+                annotation = field_info.annotation
+                if get_origin(annotation) is Literal and len(
+                        get_args(annotation)) == 1:
+                    continue
+                if field_info.description is None or field_info.description.strip(
+                ) == "":
+                    violations.append(
+                        f"{_get_qualified_name(cls)}.{field_name}: missing description"
+                    )
+
+        if violations:
+            pytest.fail(
+                f"The following fields are missing descriptions:\n" +
+                "\n".join(violations) +
+                "\n\nPlease add a description to each by using Field(description=\"...\")."
+            )
+
+    def test_all_fields_have_allowed_types(self):
+        """Test that all fields in LlmArgs classes (including subfields) have types that are allowed
+        (i.e. are Pydantic-compatible) according to the logic in _is_allowed_type."""
+        violations = []
+
+        for cls in _get_all_pydantic_models_from_llm_args():
+            for field_name, field_info in cls.model_fields.items():
+                if field_name.startswith("_"):
+                    # Skip private / non user-facing fields
+                    continue
+                is_compatible, reason = self._is_allowed_type(
+                    field_info.annotation, cls, field_name)
+                if not is_compatible:
+                    violations.append(
+                        f"{_get_qualified_name(cls)}.{field_name}: {reason}")
+
+        if violations:
+            pytest.fail(
+                f"The following user-facing fields have types that are not allowed:\n"
+                + "\n".join(violations) +
+                "\n\nPlease use Pydantic-compatible types (primitives, Pydantic models that inherit from StrictBaseModel, "
+                "or other compatible types). If this is intentional, add the field "
+                "to _COMPATIBILITY_EXEMPT_FIELDS.")
+
+    # Methods that shouldn't be manually defined on Pydantic models
+    # Keys are method names, values are suggestions for replacement
+    _FORBIDDEN_METHODS = {
+        "from_dict":
+        "Construct the class directly from the dict instead, i.e. MyModel(**my_dict).",
+        "from_kwargs":
+        "Construct the class directly from the kwargs instead, i.e. MyModel(**kwargs).",
+        "to_dict": "Use Pydantic's model_dump() instead.",
+        "validate":
+        "Use Pydantic's @field_validator or @model_validator instead.",
+        "is_valid":
+        "Use Pydantic's @field_validator or @model_validator instead.",
+    }
+
+    # Classes exempt from specific forbidden methods. Avoid adding to this list unless absolutely
+    # necessary, e.g. if needed to preserve backward compatibility with external libraries
+    # Keys are method names, values are sets of class names
+    _FORBIDDEN_METHODS_EXEMPT_CLASSES = {
+        "from_dict": {QuantConfig, LayerQuantConfig},
+    }
+
+    def test_no_manual_serialization_or_validation_methods(self):
+        """Test that LlmArgs and all nested Pydantic models do not define manual serialization/validation methods."""
+        violations = []
+
+        for cls in _get_all_pydantic_models_from_llm_args():
+            for method_name, suggestion in self._FORBIDDEN_METHODS.items():
+                if method_name in cls.__dict__:
+                    if cls in self._FORBIDDEN_METHODS_EXEMPT_CLASSES.get(
+                            method_name, set()):
+                        continue
+                    violations.append(
+                        f"{_get_qualified_name(cls)}.{method_name}(): {suggestion}"
+                    )
+
+        if violations:
+            pytest.fail(
+                f"The following models define forbidden methods:\n" +
+                "\n".join(violations) +
+                "\n\nPydantic models should follow the recommendations above instead."
+            )
+
+    def test_no_mutable_default_values(self):
+        """Test that LlmArgs and all nested Pydantic models do not use mutable default values directly."""
+        violations = []
+
+        for cls in _get_all_pydantic_models_from_llm_args():
+            for field_name, field_info in cls.model_fields.items():
+                if field_name.startswith("_"):
+                    continue
+                # Check if the default is a mutable type instance
+                default = field_info.default
+                if isinstance(default, (list, dict, set)):
+                    type_name = type(default).__name__
+                    violations.append(
+                        f"{_get_qualified_name(cls)}.{field_name}: uses mutable default {type_name}. "
+                        f"Use Field(default_factory={type_name}) instead.")
+
+        if violations:
+            pytest.fail(
+                f"The following fields use mutable default values:\n" +
+                "\n".join(violations) +
+                "\n\nMutable defaults are shared across instances and cause bugs. "
+                "Use Field(default_factory=...) instead.")
+
+    def test_no_custom_init_methods(self):
+        """Test that LlmArgs and all nested Pydantic models do not define custom __init__ methods.
+
+        Pydantic models should not override __init__ because:
+        - It bypasses Pydantic's validation and type coercion
+        - It can cause subtle bugs with model inheritance
+
+        There are better alternatives for all common use cases:
+        - For validation: use @field_validator or @model_validator
+        - For post-validation initialization: use model_post_init()
+        - For custom construction patterns: use classmethods (e.g. from_yaml())
+
+        See: https://docs.pydantic.dev/latest/concepts/models/#defining-a-custom-__init__
+        """
+        violations = []
+
+        for cls in _get_all_pydantic_models_from_llm_args():
+            if "__init__" in cls.__dict__:
+                violations.append(_get_qualified_name(cls))
+
+        if violations:
+            pytest.fail(
+                f"The following Pydantic models define custom __init__ methods:\n"
+                + "\n".join(violations) +
+                "\n\nThese should be replaced with alternatives like validators, model_post_init, or classmethods. See this test's docstring for more details."
+            )

--- a/tests/unittest/trt/model_api/test_model_quantization.py
+++ b/tests/unittest/trt/model_api/test_model_quantization.py
@@ -31,7 +31,7 @@ def test_int4_awq_quantization():
     cnn_dailymail_path = str(llm_models_root() / "datasets/cnn_dailymail")
 
     checkpoint_dir = tempfile.TemporaryDirectory("llama-checkpoint").name
-    quant_config = QuantConfig(QuantAlgo.W4A16_AWQ)
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_AWQ)
     LLaMAForCausalLM.quantize(hf_model_dir,
                               checkpoint_dir,
                               quant_config=quant_config,
@@ -74,7 +74,7 @@ def test_fp8_quantization():
     cnn_dailymail_path = str(llm_models_root() / "datasets/cnn_dailymail")
 
     checkpoint_dir = tempfile.TemporaryDirectory("llama-checkpoint").name
-    quant_config = QuantConfig(QuantAlgo.FP8)
+    quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
     LLaMAForCausalLM.quantize(hf_model_dir,
                               checkpoint_dir,
                               quant_config=quant_config,

--- a/tests/unittest/trt/quantization/test_quant.py
+++ b/tests/unittest/trt/quantization/test_quant.py
@@ -52,7 +52,7 @@ class TestQuant(unittest.TestCase):
         config = PretrainedConfig.from_dict(config)
         model = GPTForCausalLM(config)
 
-        quant_model = quantize(model, QuantConfig(quant_algo))
+        quant_model = quantize(model, QuantConfig(quant_algo=quant_algo))
 
         self.assertTrue(hasattr(quant_model, 'quant_mode'))
 
@@ -101,7 +101,7 @@ class TestQuant(unittest.TestCase):
 
         quant_model = quantize(
             model,
-            QuantConfig(quant_algo,
+            QuantConfig(quant_algo=quant_algo,
                         exclude_modules=[
                             'fc', 'dense', 'vocab_embedding',
                             'position_embedding', 'block_embedding'
@@ -138,7 +138,7 @@ class TestQuant(unittest.TestCase):
         model = GPTForCausalLM(config)
 
         quant_algo = QuantAlgo.W8A8_SQ_PER_TENSOR_PLUGIN
-        quant_config = QuantConfig(quant_algo)
+        quant_config = QuantConfig(quant_algo=quant_algo)
         quant_model = quantize(model, quant_config)
         for layer in quant_model.transformer.layers:
             assert isinstance(layer.input_layernorm, SmoothQuantLayerNorm)
@@ -167,7 +167,8 @@ class TestQuant(unittest.TestCase):
         model = LLaMAForCausalLM(config)
 
         quant_algo = QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN
-        quant_config = QuantConfig(quant_algo, use_meta_recipe=use_meta_recipe)
+        quant_config = QuantConfig(quant_algo=quant_algo,
+                                   use_meta_recipe=use_meta_recipe)
 
         quant_model = quantize(model, quant_config)
         local_num_hidden_layers = len(quant_model.transformer.layers)


### PR DESCRIPTION
## Motivation

`LlmArgs` is the main user-facing interface for configuring TRTLLM, and it uses [Pydantic](https://docs.pydantic.dev/latest/) for validating custom user configuration, including YAML files passed with `--config` / `--extra_llm_api_options`. It's important that `LlmArgs` follows Pydantic best practices so that (a) it's easier for users to understand how to configure the LLM API, and (b) we reduce the surface area for subtle bugs related to configuration parsing / validation.

This PR is also a preparatory change for #8331 which will significantly simplify the parsing of `LlmArgs` from config YAML files. The changes here would enable a variety of custom parsing logic (e.g. [`update_llm_args_with_extra_dict`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/llmapi/llm_args.py#L3402)) to be completely removed.

## Description

This PR aims to align `LlmArgs` with some Pydantic best practices that have been added to [`CODING_GUIDELINES.md`](https://github.com/anish-shanbhag/TensorRT-LLM/blob/ashanbhag/pydantic-best-practices/CODING_GUIDELINES.md#pydantic-guidelines).

The diff is unfortunately pretty large due to the interdependent nature of the changes here. ***To help with this, I recommend that reviewers read the changes in this order***:
1. Review the new Pydantic guidelines added to [`CODING_GUIDELINES.md`](https://github.com/anish-shanbhag/TensorRT-LLM/blob/ashanbhag/pydantic-best-practices/CODING_GUIDELINES.md#pydantic-guidelines). Some highlights include:
    - Ensuring that all fields have descriptions
    - Preferring built-in Pydantic features like `model_validator` / `model_dump` etc. instead of using custom methods like `validate()` or `to_dict()`
    - Using [discriminated unions](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions) when a field needs to accept one of several possible config classes
2. Review the new tests added in `test_llm_args.py::TestPydanticBestPractices`, which enforce a subset of the guidelines above.
3. Review the rest of the changes, which all aim to just bring `LlmArgs` into compliance with the above guidelines. Some highlights include:
    - Adding descriptions to fields in various config classes
    - Migrating the speculative decoding configs / sparse attention configs to [discriminated unions](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions)
    - Migrating `QuantConfig` to a Pydantic model
    - Changing various fields to use `PositiveInt` / `NonNegativeInt` / etc. instead of custom validators

The intention here is a pure refactoring PR that contains minimal to no behavior changes or user-facing breaking changes.

I've also added PR comments to many of the changes here to explain the motivation behind them.

At the time of writing this, all but 3 single GPU tests are passing (https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fmain%2FL0_Test-x86_64-Single-GPU/detail/L0_Test-x86_64-Single-GPU/16435/pipeline) and ARM multi-GPU tests are 100% passing (https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fmain%2FL0_Test-SBSA-Multi-GPU/detail/L0_Test-SBSA-Multi-GPU/6875/pipeline). Currently verifying fixes for the remaining tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
