### PR TITLE
[https://nvbugs/5435506][fix] Add optional InternVL2 any-res (dynamic tiling) image preprocessing

### DIFF
--- a/tensorrt_llm/runtime/multimodal_model_runner.py
+++ b/tensorrt_llm/runtime/multimodal_model_runner.py
@@ -47,6 +47,74 @@ if PYTHON_BINDINGS:
     from .model_runner_cpp import ModelRunnerCpp
 
 
+def _internvl_find_closest_aspect_ratio(aspect_ratio, target_ratios, width,
+                                       height, image_size):
+    """InternVL2 dynamic tiling helper (ported from InternVL2 HF README)."""
+    best_ratio_diff = float("inf")
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            # Prefer larger effective resolution
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+
+def _internvl_dynamic_preprocess_pil(image: Image.Image,
+                                     min_num: int = 1,
+                                     max_num: int = 12,
+                                     image_size: int = 448,
+                                     use_thumbnail: bool = True):
+    """Return (tiles, tile_grid_hw) where tiles are PIL 448x448 crops.
+
+    Notes:
+    - This matches InternVL2's "dynamic_preprocess" behavior: choose a grid that
+      best matches aspect ratio, split into fixed-size tiles, and optionally append
+      a 1x thumbnail tile when more than 1 tile exists.
+    - tile_grid_hw corresponds to the *grid tiles only* (excluding the optional thumbnail).
+    """
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / max(1, orig_height)
+
+    target_ratios = {
+        (i, j)
+        for n in range(min_num, max_num + 1) for i in range(1, n + 1)
+        for j in range(1, n + 1) if i * j <= max_num and i * j >= min_num
+    }
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+    target_aspect_ratio = _internvl_find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+
+    grid_w = int(target_aspect_ratio[0])
+    grid_h = int(target_aspect_ratio[1])
+    target_width = image_size * grid_w
+    target_height = image_size * grid_h
+    blocks = grid_w * grid_h
+
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size,
+        )
+        processed_images.append(resized_img.crop(box))
+
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+
+    return processed_images, (grid_h, grid_w)
+
+
 class LlavaNextUtils:
     # https://github.com/haotian-liu/LLaVA/blob/main/llava/mm_utils.py
 
@@ -374,6 +442,19 @@ class MultimodalModelRunner:
         with open(os.path.join(self.visual_engine_dir, "config.json"),
                   "r") as f:
             config = json.load(f)
+        # Cache vision engine max batch size (used to safely micro-batch InternVL
+        # any-res tiling without requiring users to rebuild the vision engine).
+        self.vision_max_batch_size = None
+        try:
+            builder_cfg = config.get("builder_config",
+                                     {}) if isinstance(config, dict) else {}
+            if isinstance(builder_cfg,
+                          dict) and builder_cfg.get("max_batch_size",
+                                                    None) is not None:
+                max_bs = int(builder_cfg.get("max_batch_size") or 0)
+                self.vision_max_batch_size = max_bs if max_bs > 0 else None
+        except Exception:
+            self.vision_max_batch_size = None
         if 'pretrained_config' in config:
             if config['pretrained_config'][
                     'architecture'] == 'LlavaNextForConditionalGeneration':
@@ -456,6 +537,16 @@ class MultimodalModelRunner:
         if self.cpp_e2e:
             self.visual_output_shape = config['builder_config'].get(
                 'output_shape', None)
+        # InternVL vision encoder outputs fixed tokens per input image/tile.
+        # Keep it for optional token-budgeting of dynamic tiling.
+        self.internvl_num_image_tokens = None
+        if self.model_type == "internvl":
+            try:
+                out_shape = config.get("builder_config", {}).get("output_shape", None)
+                if isinstance(out_shape, (list, tuple)) and len(out_shape) >= 2:
+                    self.internvl_num_image_tokens = int(out_shape[1])
+            except Exception:
+                self.internvl_num_image_tokens = None
         if self.decoder_llm:
             if not supports_inflight_batching(self.llm_engine_dir):
                 logger.warning(
@@ -648,7 +739,11 @@ class MultimodalModelRunner:
             from transformers import CLIPImageProcessor
             self.processor = CLIPImageProcessor.from_pretrained(
                 'OpenGVLab/InternViT-300M-448px'
-            )  # You can change the InternViT model type according to your InternVL type
+            )
+            logger.info(f"[internvl] resize/crop cfg: size={self.processor.size}, "
+                        f"crop_size={getattr(self.processor, 'crop_size', None)}, "
+                        f"do_resize={self.processor.do_resize}, "
+                        f"do_center_crop={self.processor.do_center_crop}")
 
         elif self.model_type == "neva":
             image_size = 384
@@ -759,11 +854,28 @@ class MultimodalModelRunner:
                            device=self.device) as f:
                 for k in f.keys():
                     self.image_newlines[k] = f.get_tensor(k)
+        elif self.model_type == "internvl":
+            # Optional (not required): some downstream code paths may provide
+            # newline vectors, but InternVL2's default behavior is to simply
+            # concatenate tile features (no newline tokens).
+            self.image_newlines = {}
+            image_newlines_path = os.path.join(self.visual_engine_dir,
+                                               'image_newlines.safetensors')
+            try:
+                if os.path.isfile(image_newlines_path):
+                    with safe_open(image_newlines_path,
+                                   framework="pt",
+                                   device=self.device) as f:
+                        for k in f.keys():
+                            self.image_newlines[k] = f.get_tensor(k)
+            except Exception:
+                # Keep optional newlines empty
+                self.image_newlines = {}
 
     def init_audio_encoder(self):
         assert self.model_type == "phi-4-multimodal"
         model = AutoModelForCausalLM.from_pretrained(self.args.hf_model_dir,
-                                                     dtype=torch.float16,
+                                                     torch_dtype=torch.float16,
                                                      trust_remote_code=True,
                                                      device_map='cpu')
         self.audio_model = model.model.embed_tokens_extend.audio_embed.to(
@@ -857,7 +969,7 @@ class MultimodalModelRunner:
 
         from transformers import CLIPImageProcessor
         processor = CLIPImageProcessor.from_pretrained(
-            "openai/clip-vit-large-patch14", dtype=torch.bfloat16)
+            "openai/clip-vit-large-patch14", torch_dtype=torch.bfloat16)
         frames = processor.preprocess(frames,
                                       return_tensors="pt")['pixel_values']
         # make dtype consistent with vision encoder
@@ -868,6 +980,13 @@ class MultimodalModelRunner:
     def preprocess(self, pre_prompt, post_prompt, image, other_vision_inputs,
                    other_audio_inputs):
         audio = None
+        # InternVL any-res: allow passing a list of tiles for native tiling/packing
+        internvl_tiles = None
+        internvl_tile_grid = None
+        if isinstance(other_vision_inputs, dict):
+            if 'tiles' in other_vision_inputs and 'internvl' in self.model_type:
+                internvl_tiles = other_vision_inputs.pop('tiles')
+                internvl_tile_grid = other_vision_inputs.pop('tile_grid_hw', None)
         # same prompt for single/multiple image(s)
         n_prompts_n_images = False
         if isinstance(post_prompt,
@@ -976,7 +1095,61 @@ class MultimodalModelRunner:
 
         profiler.start("Vision encoder")
         visual_features, visual_atts, model_runner_input = None, None, None
-        if image is not None:
+        # Hook: accept precomputed vision embeddings (e.g., any-res tiling) when provided
+        precomputed = None
+        try:
+            if isinstance(other_vision_inputs, dict) and 'precomputed_vision_emb' in other_vision_inputs:
+                precomputed = other_vision_inputs.pop('precomputed_vision_emb')
+        except Exception:
+            precomputed = None
+
+        if internvl_tiles is not None:
+            # Encode InternVL tiles with the vision engine, then concatenate them
+            # into a single long sequence (matching InternVL2 HF behavior).
+            tile_tensors = []
+            for t in internvl_tiles:
+                if isinstance(t, torch.Tensor):
+                    if t.dim() == 3:
+                        tile_tensors.append(t)
+                    elif t.dim() == 4:
+                        tile_tensors.append(t[0])
+                    else:
+                        raise ValueError("[internvl:anyres] unsupported tile tensor shape")
+                else:
+                    # Assume PIL Image
+                    tile_tensor = self.processor(images=t, return_tensors='pt').pixel_values[0]
+                    tile_tensors.append(tile_tensor)
+            dtype = str_dtype_to_torch(self.vision_precision)
+            tiles_batch = torch.stack(tile_tensors, dim=0).to(self.device).to(dtype)
+            # Vision encoder expects [N, 3, H, W]. Micro-batch to respect the
+            # vision engine's max batch size (common engines are built with max_bs=1).
+            max_bs = int(getattr(self, "vision_max_batch_size", 0) or 0)
+            if max_bs <= 0:
+                max_bs = tiles_batch.shape[0]
+            tile_embeds_chunks = []
+            for st in range(0, tiles_batch.shape[0], max_bs):
+                embeds, _ = self.get_visual_features(tiles_batch[st:st + max_bs],
+                                                     {})
+                tile_embeds_chunks.append(embeds)
+            tile_embeds = torch.cat(tile_embeds_chunks, dim=0)
+            # tile_embeds: [num_tiles, tokens_per_tile, hidden]
+            tile_embeds = tile_embeds.contiguous()
+            packed = tile_embeds.view(-1, tile_embeds.shape[-1])  # [T, hidden]
+            visual_features = packed.unsqueeze(0)  # [1, T, hidden]
+            visual_atts = torch.ones(visual_features.size()[:-1], dtype=torch.long, device=visual_features.device)
+            model_runner_input = None
+        elif precomputed is not None and image is None:
+            # precomputed expected shape: [batch, tokens, hidden]
+            if not torch.is_tensor(precomputed):
+                precomputed = torch.as_tensor(precomputed)
+            # Ensure device/dtype compatibility
+            dev = self.device if hasattr(self, 'device') else 'cuda'
+            dt = self.model.dtype if hasattr(self, 'model') and hasattr(self.model, 'dtype') else torch.float16
+            visual_features = precomputed.to(device=dev, dtype=dt)
+            atts_shape = visual_features.shape[:-1]
+            visual_atts = torch.ones(atts_shape, dtype=torch.long, device=visual_features.device)
+            model_runner_input = None
+        elif image is not None:
             model_runner_input = torch.stack(
                 image['image_patches'],
                 dim=0) if self.model_type == 'fuyu' else image
@@ -1252,6 +1425,9 @@ class MultimodalModelRunner:
                     length = pre_input_ids.shape[1] + post_input_ids.shape[
                         1] + visual_atts.shape[2] * visual_atts.shape[1]
                 elif self.model_type == 'internvl':
+                    # InternVL flattens visual tokens into a single sequence.
+                    # visual_atts can be [num_tiles, tokens_per_tile] (unpacked)
+                    # or [1, total_tokens] (packed any-res path).
                     length = pre_input_ids.shape[1] + post_input_ids.shape[
                         1] + visual_atts.shape[0] * visual_atts.shape[1]
                 else:
@@ -2493,8 +2669,102 @@ class MultimodalModelRunner:
                 input_text = "Please describe the image shortly."
             post_prompt = input_text + "<|end|><|assistant|>\n"
             prompt = pre_prompt + post_prompt
-            image = self.processor(images=raw_image,
-                                   return_tensors='pt').pixel_values
+            # InternVL2 supports dynamic tiling ("any-res") preprocessing. TRT-LLM
+            # can optionally enable it to improve detail-sensitive accuracy.
+            # Defaults: read from HF config.json if present; allow CLI overrides.
+            enable_dynamic = None
+            min_num = None
+            max_num = None
+            image_size = None
+            use_thumbnail = None
+            try:
+                cfg_path = os.path.join(self.args.hf_model_dir, "config.json")
+                if os.path.isfile(cfg_path):
+                    with open(cfg_path, "r") as f:
+                        cfg = json.load(f)
+                    if isinstance(cfg, dict):
+                        enable_dynamic = bool(cfg.get("dynamic_image_size", False))
+                        min_num = int(cfg.get("min_dynamic_patch", 1))
+                        max_num = int(cfg.get("max_dynamic_patch", 12))
+                        use_thumbnail = bool(cfg.get("use_thumbnail", True))
+                        if cfg.get("force_image_size", None) is not None:
+                            image_size = int(cfg["force_image_size"])
+                        else:
+                            vc = cfg.get("vision_config", {}) or {}
+                            if isinstance(vc, dict) and vc.get("image_size", None) is not None:
+                                image_size = int(vc["image_size"])
+            except Exception:
+                pass
+
+            # CLI overrides (optional, for backward compatibility)
+            if getattr(self.args, "internvl_dynamic_image_size", None) is not None:
+                enable_dynamic = bool(self.args.internvl_dynamic_image_size)
+            if getattr(self.args, "internvl_min_dynamic_patch", None) is not None:
+                min_num = int(self.args.internvl_min_dynamic_patch)
+            if getattr(self.args, "internvl_max_dynamic_patch", None) is not None:
+                max_num = int(self.args.internvl_max_dynamic_patch)
+            if getattr(self.args, "internvl_use_thumbnail", None) is not None:
+                use_thumbnail = bool(self.args.internvl_use_thumbnail)
+            if getattr(self.args, "internvl_image_size", None) is not None:
+                image_size = int(self.args.internvl_image_size)
+
+            # Final defaults
+            if enable_dynamic is None:
+                enable_dynamic = False
+            if min_num is None:
+                min_num = 1
+            if max_num is None:
+                max_num = 12
+            if image_size is None:
+                image_size = 448
+            if use_thumbnail is None:
+                use_thumbnail = True
+
+            if enable_dynamic and self.cpp_e2e:
+                logger.warning(
+                    "[internvl:anyres] dynamic_image_size is not supported in --session cpp (C++ E2E). "
+                    "Falling back to single-image preprocessing. Use --session cpp_llm_only or --session python to enable tiling."
+                )
+                enable_dynamic = False
+
+            if enable_dynamic:
+                tiles, grid_hw = _internvl_dynamic_preprocess_pil(
+                    raw_image,
+                    min_num=min_num,
+                    max_num=max_num,
+                    image_size=image_size,
+                    use_thumbnail=use_thumbnail,
+                )
+
+                # Best-effort cap by token budget (LLM max_input_len) so we don't
+                # exceed engine limits when too many tiles are produced.
+                try:
+                    max_input_len = int(
+                        getattr(self.model, "max_input_len", 0)
+                        or getattr(self.model_config, "max_input_len", 0) or 0)
+                    if max_input_len > 0 and self.internvl_num_image_tokens:
+                        pre_len = int(
+                            self.tokenizer(pre_prompt, return_tensors="pt").input_ids.shape[1])
+                        post_len = int(
+                            self.tokenizer(post_prompt, return_tensors="pt").input_ids.shape[1])
+                        budget = max_input_len - pre_len - post_len
+                        max_tiles_fit = max(1, int(budget // max(1, self.internvl_num_image_tokens)))
+                        if len(tiles) > max_tiles_fit:
+                            logger.warning(
+                                f"[internvl:anyres] Capping tiles from {len(tiles)} to {max_tiles_fit} "
+                                f"(max_input_len={max_input_len}, budget={budget}, "
+                                f"tokens_per_tile={self.internvl_num_image_tokens})."
+                            )
+                            tiles = tiles[:max_tiles_fit]
+                except Exception:
+                    pass
+
+                other_vision_inputs["tiles"] = tiles
+                other_vision_inputs["tile_grid_hw"] = grid_hw
+                image = None
+            else:
+                image = self.processor(images=raw_image,
+                                       return_tensors='pt').pixel_values
 
         elif self.model_type == "pix2struct":
             if input_text is None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic tiling support for InternVL image processing
  * Implemented batch processing for vision encoder tiles
  * Enhanced image preprocessing with flexible tile generation and optional thumbnail support
  * Added token budget capping to optimize tile usage based on model constraints

* **Chores**
  * Improved diagnostic logging for image processor configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR adds optional InternVL2 “any-resolution / dynamic tiling” image preprocessing to tensorrt_llm/runtime/multimodal_model_runner.py, gated to InternVL and opt-in via HuggingFace config.json.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
