### PR TITLE
[TRTLLM-11064][fix] Remove duplicated MoE Computation with Helix CP+DP

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -50,7 +50,8 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                           MoEAllReduce, MoEAllReduceParams, allgather)
+                           MoEAllReduce, MoEAllReduceParams, allgather,
+                           cp_allgather)
 from ..model_config import ModelConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
@@ -1368,12 +1369,13 @@ class DeepseekV3DecoderLayer(DecoderLayer):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         # Self Attention
-        hidden_states = self.self_attn(
+        hidden_states, residual = self.self_attn(
             position_ids=position_ids,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
             all_reduce_params=AllReduceParams(
                 enable_allreduce=not (self.disable_attn_allreduce)),
+            residual=residual,
             **kwargs,
         )
         if isinstance(self.mlp, Deepseekv3MoE):
@@ -1635,12 +1637,13 @@ class DeepseekV3MTP(DeepseekV3DecoderLayer):
         hidden_states = self.input_layernorm(hidden_states)
 
         # Self Attention
-        hidden_states = self.self_attn(
+        hidden_states, residual = self.self_attn(
             position_ids=position_ids,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
             all_reduce_params=AllReduceParams(
                 enable_allreduce=not (self.disable_attn_allreduce)),
+            residual=residual,
             **kwargs,
         )
 
@@ -1697,6 +1700,7 @@ class DeepseekV3Model(DecoderModel):
         config = model_config.pretrained_config
         self.vocab_size = config.vocab_size
         self.num_hidden_layers = config.num_hidden_layers
+        self.mapping_with_cp = mapping_with_cp
         aux_stream_list = [torch.cuda.Stream() for _ in range(4)]
         self.aux_stream_dict = {
             AuxStreamType.Attention: aux_stream_list[0],
@@ -1752,6 +1756,17 @@ class DeepseekV3Model(DecoderModel):
                 residual=residual,
                 spec_metadata=spec_metadata,
             )
+
+        # With CP helix, the last layer's reduce-scatter leaves each rank
+        # with only its chunk of tokens.  AllGather restores the full token
+        # count so the LM head (and norm) see every token.
+        if (self.mapping_with_cp is not None
+                and self.mapping_with_cp.has_cp_helix()
+                and self.mapping_with_cp.enable_attention_dp):
+            hidden_states = cp_allgather(hidden_states,
+                                         self.mapping_with_cp,
+                                         dim=0)
+            hidden_states = hidden_states[:attn_metadata.num_tokens]
 
         return hidden_states
 

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -175,8 +175,6 @@ class Eagle3DecoderLayer(DecoderLayer):
                                     and not is_first_layer) or eagle_config.get(
                                         "eh_proj_before_attn", False)
 
-        self._use_mla = use_mla
-
         # Select attention type based on config
         if use_mla:
             self.self_attn = Eagle3MLAttention(
@@ -238,19 +236,11 @@ class Eagle3DecoderLayer(DecoderLayer):
             embeds = self.input_layernorm(embeds)
             hidden_states = torch.cat([embeds, hidden_states], dim=-1)
 
-        if self._use_mla:
-            hidden_states, residual = self.self_attn(
-                position_ids=position_ids,
-                hidden_states=hidden_states,
-                attn_metadata=attn_metadata,
-                residual=residual,
-            )
-        else:
-            hidden_states = self.self_attn(
-                position_ids=position_ids,
-                hidden_states=hidden_states,
-                attn_metadata=attn_metadata,
-            )
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+        )
 
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1,6 +1,6 @@
 import math
 import weakref
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 import torch
 from torch import nn
@@ -21,7 +21,8 @@ from ..attention_backend.interface import (AttentionBackend, AttentionMask,
 from ..attention_backend.sparse.dsa import (
     DSAtrtllmAttentionMetadata, transform_local_topk_and_prepare_pool_view)
 from ..attention_backend.utils import create_attention, get_attention_backend
-from ..distributed import AllReduceParams, HelixAllToAllNative, alltoall_helix
+from ..distributed import (AllReduceParams, HelixAllToAllNative, alltoall_helix,
+                           cp_allgather, reducescatter)
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..utils import (Fp4QuantizedTensor, get_model_extra_attrs,
@@ -962,6 +963,7 @@ class MLA(nn.Module):
             gpus_per_node=self.mapping.gpus_per_node,
             enable_attention_dp=self.mapping.enable_attention_dp,
         )
+        self.mapping_o = mapping_o
         self.o_proj = Linear(
             self.num_key_value_heads * self.v_head_dim,
             self.hidden_size,
@@ -2278,6 +2280,96 @@ class MLA(nn.Module):
                 f"Missing bmm impl for dtype: {self.v_b_proj.dtype}.")
         return output
 
+    def _needs_cp_reduce_scatter(self) -> bool:
+        """Check if we should use CP reduce-scatter instead of AllReduce."""
+        return (self.mapping.has_cp_helix()
+                and self.mapping.enable_attention_dp)
+
+    def _maybe_allgather_input(
+            self, hidden_states: torch.Tensor,
+            attn_metadata: AttentionMetadata) -> torch.Tensor:
+        """AllGather input hidden states from CP group if needed.
+
+        For the first layer (Embed -> Attn), all CP ranks already have the
+        full input, so this is a no-op. For subsequent layers, the previous
+        layer's reduce-scatter left each rank with a portion that must be
+        reconstructed before attention.
+        """
+        if self._needs_cp_reduce_scatter() and self.layer_idx > 0:
+            hidden_states = cp_allgather(hidden_states, self.mapping, dim=0)
+            # Remove padding introduced by reduce-scatter alignment.
+            hidden_states = hidden_states[:attn_metadata.num_tokens]
+        return hidden_states
+
+    def _pad_for_cp(self, tensor: torch.Tensor,
+                    num_tokens: int) -> Tuple[torch.Tensor, int]:
+        """Pad tensor along dim-0 so its length is divisible by cp_size.
+
+        Returns the (possibly padded) tensor and the per-rank chunk size.
+        """
+        cp_size = self.mapping.cp_size
+        chunk_size = math.ceil(num_tokens / cp_size)
+        padded_size = chunk_size * cp_size
+
+        if num_tokens < padded_size:
+            pad = tensor.new_zeros(padded_size - num_tokens, tensor.shape[1])
+            tensor = torch.cat([tensor, pad], dim=0)
+
+        return tensor, chunk_size
+
+    def _slice_for_cp(self, tensor: torch.Tensor,
+                      attn_metadata: AttentionMetadata) -> torch.Tensor:
+        """Slice a tensor to this CP rank's chunk, matching post-RS size.
+
+        Used for the first layer's residual: since there is no prior RS to
+        divide it, we manually extract this rank's portion so it aligns with
+        the reduce-scattered attention output.
+        """
+        tensor, chunk_size = self._pad_for_cp(tensor, attn_metadata.num_tokens)
+        start = self.mapping.cp_rank * chunk_size
+        return tensor[start:start + chunk_size]
+
+    def _output_projection(
+        self,
+        attn_output: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        all_reduce_params: Optional[AllReduceParams],
+        residual: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply output projection (o_proj) and reduce across parallel ranks.
+
+        With CP reduce-scatter, o_proj produces partial sums (each CP rank
+        contributes from its head partition). Reduce-scatter sums these
+        and divides the result among CP ranks for subsequent MoE processing.
+        Otherwise, o_proj uses the standard AllReduce path.
+
+        The residual is passed through unchanged unless this is the first
+        layer with CP reduce-scatter, in which case it is sliced to match
+        the post-RS token count.
+        """
+        if self._needs_cp_reduce_scatter():
+            # Skip AllReduce in o_proj; use reduce-scatter instead.
+            attn_output = self.o_proj(
+                attn_output,
+                all_reduce_params=AllReduceParams(enable_allreduce=False))
+
+            # Pad to make token count divisible by cp_size for reduce-scatter.
+            attn_output, _ = self._pad_for_cp(attn_output,
+                                              attn_metadata.num_tokens)
+
+            # Reduce-scatter using mapping_o where tp_group = cp_group.
+            attn_output = reducescatter(attn_output, self.mapping_o, dim=0)
+
+            # For the first layer, the residual comes from the embedding and
+            # has not been through a prior RS. Slice it to match.
+            if self.layer_idx == 0:
+                residual = self._slice_for_cp(residual, attn_metadata)
+        else:
+            attn_output = self.o_proj(attn_output,
+                                      all_reduce_params=all_reduce_params)
+
+        return attn_output, residual
+
     def forward(
         self,
         position_ids: Optional[torch.Tensor],
@@ -2285,7 +2377,11 @@ class MLA(nn.Module):
         attn_metadata: AttentionMetadata,
         all_reduce_params: Optional[AllReduceParams] = None,
         latent_cache_gen: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+        residual: torch.Tensor = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+
+        hidden_states = self._maybe_allgather_input(hidden_states,
+                                                    attn_metadata)
 
         attn_output = self.create_output(hidden_states,
                                          attn_metadata.num_contexts)
@@ -2313,9 +2409,8 @@ class MLA(nn.Module):
             attn_output = attn_output[:, :self.num_heads_tp_cp *
                                       self.v_head_dim].contiguous()
 
-        attn_output = self.o_proj(attn_output,
-                                  all_reduce_params=all_reduce_params)
-        return attn_output
+        return self._output_projection(attn_output, attn_metadata,
+                                       all_reduce_params, residual)
 
     def resmooth_parameters(self,
                             module_weight,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1465,7 +1465,16 @@ class PyTorchModelEngine(ModelEngine):
 
     def _get_all_rank_num_tokens(self, attn_metadata: AttentionMetadata):
         if self.enable_attention_dp:
-            return list(self.dist.tp_cp_allgather(attn_metadata.num_tokens))
+            num_tokens = attn_metadata.num_tokens
+            if self.mapping.has_cp_helix():
+                # With CP, attention uses reduce-scatter to divide tokens
+                # among CP ranks. Report the post-RS token count.
+                # Use tp_cp_allgather so MoE (which sees the repurposed
+                # mapping where tp_size = original tp * cp) can index
+                # with its tp_rank.
+                num_tokens = math.ceil(num_tokens / self.mapping.cp_size)
+                return list(self.dist.tp_cp_allgather(num_tokens))
+            return list(self.dist.tp_allgather(num_tokens))
         return None
 
     def _get_all_rank_ctx_requests(self, num_ctx_requests: int):


### PR DESCRIPTION
## Description

### Background

When using Helix CP with Attention DP on the generation server, all CP ranks within the same DP group have identical data after attention computation. The MoE layer receives token counts from all ranks via `tp_cp_allgather` to coordinate expert routing and communication.

### Issue

MoE computation was being duplicated across CP ranks. Each CP rank was processing the same tokens independently, resulting in redundant computation and poor perf while maintaining accuracy.

### Root Cause

The `tp_cp_allgather` operation gathers token counts from all TP×CP ranks. In Helix mode, CP ranks hold identical data post-attention, so the gathered token counts included duplicates. For example, with CP=2:
- `[dp0cp0=128, dp0cp1=128, dp1cp0=64, dp1cp1=64]`

The MoE layer would then process 128 tokens on both `dp0cp0` and `dp0cp1`, doubling the computation.

### Fix

Allgather at the beginning of MLA layer and ReduceScatter at the end of it when AttentionDP is enabled.

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[fifo_v2-cudagraph:with_padding-pp1dp2cp2] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Helix Context Parallelism in DeepseekV3 models, enabling optimized distributed inference with automatic token deduplication across compute ranks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->