### PR TITLE
[None][feat] Extract embeding as .savetensors and support float8 quantized model

### DIFF
--- a/docs/source/features/auto_deploy/advanced/export_onnx.md
+++ b/docs/source/features/auto_deploy/advanced/export_onnx.md
@@ -4,10 +4,22 @@ AutoDeploy provides a mode to export PyTorch/HuggingFace models to ONNX format s
 
 ## Overview
 
-The `export_edgellm_onnx` mode differs from the standard AutoDeploy workflow in two key ways:
+The `export_edgellm_onnx` mode differs from the standard AutoDeploy workflow in several key ways:
 
 1. **Operation Fusion**: Fuses `torch_rope_with_explicit_cos_sin` and `torch_cached_attention_with_cache` into a single `AttentionPlugin` operation
+1. **Multimodal Input Support**: Rewrites the model to accept `inputs_embeds` instead of `input_ids`, enabling multimodal model support
+1. **Embedding Export**: Exports the embedding table as `embedding.safetensors` for runtime embedding lookup
 1. **ONNX Export**: Outputs an ONNX model file instead of a TensorRT Engine
+
+### Multimodal Input Changes
+
+To support multimodal models (e.g., vision-language models), the exported ONNX model now accepts `inputs_embeds` (float16 tensor of shape `[batch_size, seq_len, hidden_size]`) instead of `input_ids` (int32 tensor of shape `[batch_size, seq_len]`). This allows EdgeLLM runtime to:
+
+- Perform embedding lookup for text tokens using the exported `embedding.safetensors`
+- Fuse multimodal embeddings (from vision/audio encoders) with text embeddings
+- Pass the combined embeddings directly to the TensorRT engine
+
+The embedding table is exported separately so that the runtime can handle both text-only and multimodal inputs efficiently.
 
 ## Quick Start
 
@@ -55,6 +67,7 @@ The export process generates the following files in the output directory:
 | File | Description |
 |------|-------------|
 | `model.onnx` | The exported ONNX model with fused attention operations |
+| `embedding.safetensors` | Embedding table weights (for multimodal input support) |
 | `config.json` | Model configuration (architecture, hidden size, etc.) |
 | `tokenizer.json` | Tokenizer vocabulary and configuration |
 | `tokenizer_config.json` | Tokenizer settings |
@@ -81,6 +94,7 @@ ad_config = AutoDeployConfig(
 ad_config.attn_backend = "torch"
 
 # Optionally customize output location
+ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = "./my_output"
 ad_config.transforms["export_to_onnx"]["output_dir"] = "./my_output"
 
 # Run the export

--- a/examples/auto_deploy/onnx_export_llm.py
+++ b/examples/auto_deploy/onnx_export_llm.py
@@ -24,6 +24,7 @@ from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
 
 
 def main():
+    """CLI entry point for exporting HuggingFace models to ONNX format."""
     parser = argparse.ArgumentParser(
         description="Export HuggingFace model to ONNX format using AutoDeploy."
     )
@@ -69,6 +70,7 @@ def main():
     ad_config.attn_backend = "torch"
     if args.output_dir is not None:
         ad_config.transforms["export_to_onnx"]["output_dir"] = args.output_dir
+        ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = args.output_dir
 
     # Use direct InferenceOptimizer instead of LLM to avoid executor initialization
     export_onnx(ad_config)

--- a/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
@@ -120,6 +120,9 @@ transforms:
     stage: export_onnx
   adapt_to_edgellm:
     stage: export_onnx
+  rewrite_embedding_to_inputs_embeds:
+    stage: export_onnx
+    output_dir: "."
   export_to_onnx:
     stage: export_onnx
     output_dir: "."

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/adapt_to_edgellm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/adapt_to_edgellm.py
@@ -187,11 +187,15 @@ class AdaptToEdgeLLM(BaseTransform):
         # If we run shape inference with has_valid_shapes=True,
         # it will fail because it will lift some placeholder to meta
         # and cause a device mismatch error.
+        # TODO(yoco) See https://github.com/NVIDIA/TensorRT-LLM/pull/11180#discussion_r2789187355
+        # We actually has a function placeholders_on_meta(mod) to check if we need to lift.
+        # With that check, we should be able to run shape inference without lifting.
+        # However, it somehow does not work. We need to figure out why and fix it.
         run_shape_prop(gm)
 
         ad_logger.info(f"Changed {num_bfloat16_casts} bfloat16 casts to float16")
         ad_logger.info(f"Adapted EdgeLLM model (inserted {num_attn_casts} attention casts)")
 
         return gm, TransformInfo(
-            skipped=False, num_matches=num_attn_casts, is_clean=False, has_valid_shapes=False
+            skipped=False, num_matches=num_attn_casts, is_clean=False, has_valid_shapes=True
         )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/gather_last_token_ids.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/gather_last_token_ids.py
@@ -26,6 +26,8 @@ from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformReg
 
 @TransformRegistry.register("gather_last_token_ids")
 class GatherLastTokenIds(BaseTransform):
+    """Transform that inserts GatherND to select tokens by last_token_ids before logits computation."""
+
     def _find_last_linear_simple(self, gm: GraphModule) -> Node:
         """Find the final torch_linear_simple node that produces logits.
         This is the last matmul operation in the graph
@@ -136,6 +138,7 @@ class GatherLastTokenIds(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
+        """Apply the GatherND insertion transform to the graph."""
         ad_logger.info("Adding last_token_ids gather operation")
 
         # Step 1: Find last linear simple node
@@ -159,4 +162,6 @@ class GatherLastTokenIds(BaseTransform):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
-        return gm, TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
+        return gm, TransformInfo(
+            skipped=False, num_matches=1, is_clean=False, has_valid_shapes=False
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
@@ -47,6 +47,9 @@ class RewriteEmbeddingToInputsEmbedsConfig(TransformConfig):
 class RewriteEmbeddingToInputsEmbeds(BaseTransform):
     """Transform that rewrites the graph to accept inputs_embeds instead of input_ids.
 
+    NOTE(yoco) This is a temporary solution. We will change this after EdgeLLM
+    and TensorRT-LLM align on how to handle multimodal models.
+
     This transform performs the following operations:
     1. Detects the pattern: input_ids (placeholder) → embedding(weight, input_ids)
     2. Extracts the embedding weight tensor

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+import safetensors.torch
+import torch
+from pydantic import Field
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import add_graph_input, remove_graph_input
+from ...utils.logger import ad_logger
+from ...utils.node_utils import get_weight_tensor
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+class RewriteEmbeddingToInputsEmbedsConfig(TransformConfig):
+    """Configuration for the rewrite embedding to inputs_embeds transform."""
+
+    output_dir: Path = Field(
+        description="The directory to save the exported embedding weights.",
+        default=Path("."),
+    )
+
+
+@TransformRegistry.register("rewrite_embedding_to_inputs_embeds")
+class RewriteEmbeddingToInputsEmbeds(BaseTransform):
+    """Transform that rewrites the graph to accept inputs_embeds instead of input_ids.
+
+    This transform performs the following operations:
+    1. Detects the pattern: input_ids (placeholder) → embedding(weight, input_ids)
+    2. Extracts the embedding weight tensor
+    3. Exports the embedding weight to safetensors format
+    4. Removes the embedding node from the graph
+    5. Replaces the input_ids placeholder with inputs_embeds placeholder
+
+    This is necessary for EdgeLLM to support multimodal models where the embedding
+    lookup is performed at runtime before passing to the TensorRT engine.
+    """
+
+    config: RewriteEmbeddingToInputsEmbedsConfig
+
+    @classmethod
+    def get_config_class(cls):
+        """Return the configuration class for this transform."""
+        return RewriteEmbeddingToInputsEmbedsConfig
+
+    def _find_embedding_pattern(self, gm: GraphModule) -> Optional[Tuple[Node, Node, torch.Tensor]]:
+        """Find input_ids → embedding(weight, input_ids) pattern.
+
+        Returns:
+            (input_ids_node, embedding_node, weight_tensor) or None if pattern not found
+        """
+        graph = gm.graph
+
+        # Find input_ids placeholder
+        placeholder_nodes = graph.find_nodes(op="placeholder")
+        input_ids_node = next(
+            (node for node in placeholder_nodes if node.target == "input_ids"), None
+        )
+
+        if input_ids_node is None:
+            ad_logger.info("No input_ids placeholder found, skipping transform")
+            return None
+
+        # Find embedding node that uses input_ids
+        embedding_node = None
+        for user in input_ids_node.users:
+            if (
+                user.op == "call_function"
+                and user.target == torch.ops.aten.embedding.default
+                and user.args[1] == input_ids_node
+            ):
+                embedding_node = user
+                break
+
+        if embedding_node is None:
+            ad_logger.warning("input_ids placeholder found but no embedding node uses it directly")
+            return None
+
+        extra_users = [
+            u
+            for u in input_ids_node.users
+            if u is not embedding_node and u.target != torch.ops.aten.sym_size.int
+        ]
+        if extra_users:
+            ad_logger.warning(
+                "input_ids has non-embedding consumers; skipping rewrite to avoid breaking the graph"
+            )
+            return None
+
+        # Extract weight tensor
+        weight_tensor = get_weight_tensor(embedding_node)
+        ad_logger.info(
+            f"Found embedding pattern: {input_ids_node.name} → {embedding_node.name}, "
+            f"weight shape: {weight_tensor.shape}"
+        )
+        return (input_ids_node, embedding_node, weight_tensor)
+
+    def _export_embedding_weights(self, weight: torch.Tensor, output_path: Path):
+        """Export embedding weight to safetensors format.
+
+        The weight tensor should already be float16 after adapt_to_edgellm transform.
+
+        Args:
+            weight: The embedding weight tensor (should be float16)
+            output_path: Path to save the safetensors file
+        """
+        # Ensure the output directory exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Ensure the weight is on CPU and contiguous
+        weight_cpu = weight.detach().cpu().contiguous()
+
+        # Verify that the weight is already float16
+        if weight_cpu.dtype != torch.float16:
+            raise ValueError(
+                f"Embedding weight must be float16 (should be converted by adapt_to_edgellm), "
+                f"got {weight_cpu.dtype}"
+            )
+
+        # Create state dict
+        state_dict = {"weight": weight_cpu}
+
+        # Save to safetensors
+        safetensors.torch.save_file(state_dict, output_path)
+        ad_logger.info(
+            f"Exported embedding weights to {output_path} with dtype {weight_cpu.dtype} "
+            f"and shape {weight_cpu.shape}"
+        )
+
+    def _replace_with_inputs_embeds(
+        self,
+        gm: GraphModule,
+        input_ids_node: Node,
+        embedding_node: Node,
+    ):
+        """Replace input_ids placeholder with inputs_embeds and remove embedding node.
+
+        Args:
+            gm: The GraphModule to modify
+            input_ids_node: The input_ids placeholder node
+            embedding_node: The embedding node to remove
+        """
+        graph = gm.graph
+
+        # Get the embedding output meta, which has the correct shape and symbolic dimensions
+        # embedding_node output is [batch_size, seq_len, hidden_size] with symbolic dimensions
+        embedding_output_meta = embedding_node.meta.get("val")
+        if embedding_output_meta is None:
+            raise ValueError("embedding_node has no meta['val']")
+
+        ad_logger.info(
+            f"Creating inputs_embeds placeholder with shape {embedding_output_meta.shape} "
+            f"on device {embedding_output_meta.device}"
+        )
+
+        # Use the embedding output meta as template for inputs_embeds
+        # This preserves symbolic dimensions and device
+        # The dtype should already be float16 after adapt_to_edgellm transform
+        if embedding_output_meta.dtype != torch.float16:
+            raise ValueError(
+                f"Embedding output must be float16 (should be converted by adapt_to_edgellm), "
+                f"got {embedding_output_meta.dtype}"
+            )
+
+        # Add new inputs_embeds placeholder using add_graph_input utility
+        # We pass the embedding output meta directly to preserve symbolic dimensions
+        inputs_embeds_node = add_graph_input(
+            gm, name="inputs_embeds", val=embedding_output_meta, add_kwargs=True
+        )
+
+        # Verify the created placeholder has correct dtype
+        if inputs_embeds_node.meta.get("val") is None:
+            raise RuntimeError("inputs_embeds node should have meta['val']")
+        if inputs_embeds_node.meta["val"].dtype != torch.float16:
+            raise ValueError(
+                f"inputs_embeds dtype should be float16, got {inputs_embeds_node.meta['val'].dtype}"
+            )
+
+        ad_logger.info(f"Created inputs_embeds placeholder: {inputs_embeds_node.name}")
+
+        # Replace all uses of embedding_node with inputs_embeds_node
+        embedding_node.replace_all_uses_with(inputs_embeds_node)
+        ad_logger.info(f"Replaced {embedding_node.name} with {inputs_embeds_node.name}")
+
+        # Remove the embedding node from graph
+        graph.erase_node(embedding_node)
+        ad_logger.info(f"Removed {embedding_node.name} from graph")
+
+        # Handle input_ids users (e.g., sym_size operations for shape extraction)
+        # Replace them with equivalent operations on inputs_embeds
+        input_ids_users = list(input_ids_node.users.keys())
+        for user in input_ids_users:
+            if user.target == torch.ops.aten.sym_size.int:
+                # This is extracting a dimension from input_ids
+                # We need to replace it with the same dimension from inputs_embeds
+                dim_index = user.args[1]  # The dimension being extracted
+                with graph.inserting_after(inputs_embeds_node):
+                    new_sym_size = graph.call_function(
+                        torch.ops.aten.sym_size.int,
+                        args=(inputs_embeds_node, dim_index),
+                    )
+                user.replace_all_uses_with(new_sym_size)
+                graph.erase_node(user)
+                ad_logger.info(
+                    f"Replaced {user.name} (sym_size on input_ids dim {dim_index}) "
+                    f"with sym_size on inputs_embeds"
+                )
+
+        # Now we can safely remove input_ids node using remove_graph_input
+        # This properly maintains pytree_info and other metadata
+        removed_name = remove_graph_input(gm, input_ids_node)
+        ad_logger.info(f"Removed {removed_name} from graph")
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        _cm: CachedSequenceInterface,
+        _factory: ModelFactory,
+        _shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        """Apply the transform to rewrite embedding to inputs_embeds.
+
+        Args:
+            gm: The GraphModule to transform
+            cm: CachedSequenceInterface (unused)
+            factory: ModelFactory to get model config
+            shared_config: SharedConfig (unused)
+
+        Returns:
+            Tuple of (modified GraphModule, TransformInfo)
+        """
+        ad_logger.info("Rewriting embedding to inputs_embeds for EdgeLLM")
+
+        # Step 1: Find the embedding pattern
+        pattern_result = self._find_embedding_pattern(gm)
+
+        if pattern_result is None:
+            ad_logger.info("Embedding pattern not found, skipping transform")
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        input_ids_node, embedding_node, weight_tensor = pattern_result
+
+        # Step 2: Export embedding weights to safetensors
+        output_path = self.config.output_dir / "embedding.safetensors"
+        self._export_embedding_weights(weight_tensor, output_path)
+
+        # Step 3: Replace input_ids with inputs_embeds and remove embedding node
+        self._replace_with_inputs_embeds(gm, input_ids_node, embedding_node)
+
+        ad_logger.info("Successfully rewrote graph to use inputs_embeds")
+
+        gm.recompile()
+        return gm, TransformInfo(
+            skipped=False, num_matches=1, is_clean=False, has_valid_shapes=False
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/short_reshape_attention_output.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/short_reshape_attention_output.py
@@ -60,6 +60,7 @@ class ShortReshapeAttentionOutput(BaseTransform):
 
         # Helper function to check a single node
         def check_node(n):
+            """Recursively check node and return matching target if found."""
             if isinstance(n, Node):
                 result = self._lookup_ascending_node(n, target, max_depth - 1)
                 if result is not None:
@@ -127,6 +128,7 @@ class ShortReshapeAttentionOutput(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
+        """Apply reshape shortening to attention output reshape nodes."""
         num_matches = 0
         reshape_linear_pairs = self._find_reshape_attention_output(gm)
         self._log_info(f"Found {len(reshape_linear_pairs)} reshape_linear_pairs")
@@ -160,6 +162,6 @@ class ShortReshapeAttentionOutput(BaseTransform):
             num_matches += 1
 
         info = TransformInfo(
-            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=False
+            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=True
         )
         return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -118,6 +118,10 @@ def should_skip_quantization(
         if not (is_linear_op(node_or_name) or is_bmm_op(node_or_name)):
             return True
         weight_name = extract_weight_name(node_or_name)
+        # extract_weight_name can return False when weight node is not found (e.g. after
+        # PR 10718 get_weight_node uses forward mapping; some graph shapes may have no mapping).
+        if weight_name is False or not isinstance(weight_name, str):
+            return True
         modname = weight_name.rpartition(".")[0]
 
     return any(fnmatch(modname, pattern) for pattern in excluded_patterns)

--- a/tests/integration/defs/examples/test_ad_export_onnx.py
+++ b/tests/integration/defs/examples/test_ad_export_onnx.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import onnx
 import pytest
+import safetensors.torch
+import torch
 
 # Import utility from unittest directory
 sys.path.insert(
@@ -27,12 +29,16 @@ from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
     ],
 )
 def test_ad_export_onnx(model: str, output_dir: str, num_attn_ops: int):
+    """Test ONNX export pipeline for LLM models with attention operations."""
     ad_config = LlmArgs(
         model=get_small_model_config(model)["args"]["model"],
         mode="export_edgellm_onnx",
         max_batch_size=13,
         max_seq_len=4,
     )
+    # Set output directory for both transforms to ensure embedding.safetensors
+    # and model.onnx are in the same location
+    ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = output_dir
     ad_config.transforms["export_to_onnx"]["output_dir"] = output_dir
     export_onnx(ad_config)
 
@@ -51,7 +57,22 @@ def test_ad_export_onnx(model: str, output_dir: str, num_attn_ops: int):
     # check if the output onnx file exists
     assert os.path.exists(os.path.join(output_dir, "model.onnx"))
 
-    # check if the onnx file has 24 AttentionPlugin operators
+    # check if embedding.safetensors exists (new multimodal input support)
+    assert os.path.exists(os.path.join(output_dir, "embedding.safetensors"))
+
+    # verify embedding.safetensors content
+    embedding_weights = safetensors.torch.load_file(
+        os.path.join(output_dir, "embedding.safetensors")
+    )
+    assert "weight" in embedding_weights
+    assert embedding_weights["weight"].ndim == 2  # [vocab_size, hidden_size]
+    # Verify dtype is float16 as required by EdgeLLM
+
+    assert embedding_weights["weight"].dtype == torch.float16, (
+        f"Expected float16 dtype for embedding weights, got {embedding_weights['weight'].dtype}"
+    )
+
+    # check if the onnx file has the expected number of AttentionPlugin operators
     onnx_model = onnx.load(os.path.join(output_dir, "model.onnx"))
     attn_ops = [node for node in onnx_model.graph.node if node.op_type == "AttentionPlugin"]
     assert len(attn_ops) == num_attn_ops
@@ -59,8 +80,9 @@ def test_ad_export_onnx(model: str, output_dir: str, num_attn_ops: int):
     # check input and output names of the model
     actual_inputs_names = {input.name for input in onnx_model.graph.input}
     actual_outputs_names = {output.name for output in onnx_model.graph.output}
+    # Updated: expect inputs_embeds instead of input_ids (multimodal support)
     expect_inputs_names = {
-        "input_ids",
+        "inputs_embeds",  # Changed from "input_ids"
         "context_lengths",
         "rope_rotary_cos_sin",
         "kvcache_start_index",
@@ -71,3 +93,8 @@ def test_ad_export_onnx(model: str, output_dir: str, num_attn_ops: int):
     expect_outputs_names.update({f"present_key_values_{i}" for i in range(num_attn_ops)})
     assert actual_inputs_names == expect_inputs_names
     assert actual_outputs_names == expect_outputs_names
+
+    # Verify inputs_embeds has correct shape [batch, seq, hidden]
+    inputs_embeds_input = next(inp for inp in onnx_model.graph.input if inp.name == "inputs_embeds")
+    # Check it has 3 dimensions
+    assert len(inputs_embeds_input.type.tensor_type.shape.dim) == 3

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_export_fp8_linear_to_onnx.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_export_fp8_linear_to_onnx.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for FP8 fake quantized linear ONNX export.
+
+This tests the _translate_fake_quant_fp8_linear_op function which expands
+torch_fake_quant_fp8_linear into standard ONNX ops:
+- QuantizeLinear + DequantizeLinear (input fake quantization)
+- DequantizeLinear (weight dequantization)
+- Transpose + MatMul + Add (linear computation)
+"""
+
+import tempfile
+from pathlib import Path
+
+import onnx
+import pytest
+import torch
+
+# Import to register the custom op
+from tensorrt_llm._torch.auto_deploy.transform.library.export_to_onnx import (
+    _translate_fake_quant_fp8_linear_op,
+)
+
+torch.manual_seed(0)
+
+
+class FP8LinearModel(torch.nn.Module):
+    """
+    Simple model that uses torch_fake_quant_fp8_linear custom op.
+
+    This model is designed to test the ONNX export of FP8 fake quantized linear.
+    """
+
+    def __init__(self, in_features: int, out_features: int, use_bias: bool = True):
+        """Initialize FP8LinearModel with quantized weights and scales."""
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = use_bias
+
+        # FP8 quantized weight [out_features, in_features]
+        # Initialize with randn, then convert to FP8
+        weight_fp32 = torch.randn(out_features, in_features)
+        self.register_buffer("weight_fp8", weight_fp32.to(torch.float8_e4m3fn))
+
+        # Bias (optional)
+        if use_bias:
+            self.register_buffer("bias", torch.randn(out_features, dtype=torch.float16))
+        else:
+            self.bias = None
+
+        # Scales for quantization (per-tensor)
+        self.register_buffer("input_scale", torch.tensor([1.0], dtype=torch.float32))
+        self.register_buffer("weight_scale", torch.tensor([1.0], dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass using FP8 fake quantized linear operation."""
+        return torch.ops.auto_deploy.torch_fake_quant_fp8_linear(
+            x,
+            self.weight_fp8,
+            self.bias,
+            input_scale=[self.input_scale],
+            weight_scale=[self.weight_scale],
+            input_zp=[],
+            weight_zp=[],
+        )
+
+
+def _export_and_verify_onnx(
+    model: torch.nn.Module,
+    input_tensor: torch.Tensor,
+    use_bias: bool,
+) -> None:
+    """Helper function to export model to ONNX and verify the graph structure."""
+    model.eval()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_path = Path(tmp_dir) / "model.onnx"
+
+        # Build custom translation table
+        custom_translation_table = {
+            torch.ops.auto_deploy.torch_fake_quant_fp8_linear.default: _translate_fake_quant_fp8_linear_op,
+        }
+
+        # Export to ONNX
+        torch.onnx.export(
+            model,
+            (input_tensor,),
+            str(output_path),
+            opset_version=20,
+            dynamo=True,
+            custom_translation_table=custom_translation_table,
+        )
+
+        # Load and verify ONNX model
+        assert output_path.exists(), f"ONNX file should exist at {output_path}"
+        onnx_model = onnx.load(str(output_path))
+
+        # Collect op types in the graph
+        op_types = [node.op_type for node in onnx_model.graph.node]
+
+        # Verify expected ops are present
+        # 1. QuantizeLinear for input quantization
+        assert "QuantizeLinear" in op_types, (
+            f"QuantizeLinear should be in graph for input quantization, got ops: {op_types}"
+        )
+
+        # 2. DequantizeLinear for input and weight dequantization (at least 2)
+        dequantize_count = op_types.count("DequantizeLinear")
+        assert dequantize_count >= 2, (
+            f"Expected at least 2 DequantizeLinear ops (input + weight), got {dequantize_count}"
+        )
+
+        # 3. Transpose for weight transposition
+        assert "Transpose" in op_types, (
+            f"Transpose should be in graph for weight transposition, got ops: {op_types}"
+        )
+
+        # 4. MatMul for linear computation
+        assert "MatMul" in op_types, (
+            f"MatMul should be in graph for linear computation, got ops: {op_types}"
+        )
+
+        # 5. Add for bias (only if use_bias is True)
+        if use_bias:
+            assert "Add" in op_types, (
+                f"Add should be in graph for bias addition, got ops: {op_types}"
+            )
+
+
+@pytest.mark.parametrize(
+    "in_features,out_features,batch_size,seq_len",
+    [
+        pytest.param(64, 128, 2, 16, id="small"),
+        pytest.param(256, 512, 4, 32, id="medium"),
+    ],
+)
+@torch.inference_mode()
+def test_fp8_linear_with_bias(
+    in_features: int,
+    out_features: int,
+    batch_size: int,
+    seq_len: int,
+):
+    """Test FP8 linear ONNX export with bias."""
+    model = FP8LinearModel(
+        in_features=in_features,
+        out_features=out_features,
+        use_bias=True,
+    ).to("cuda")
+
+    input_tensor = torch.randn(batch_size, seq_len, in_features, device="cuda", dtype=torch.float16)
+
+    _export_and_verify_onnx(model, input_tensor, use_bias=True)
+
+
+@pytest.mark.parametrize(
+    "in_features,out_features,batch_size,seq_len",
+    [
+        pytest.param(64, 128, 2, 16, id="small"),
+    ],
+)
+@torch.inference_mode()
+def test_fp8_linear_without_bias(
+    in_features: int,
+    out_features: int,
+    batch_size: int,
+    seq_len: int,
+):
+    """Test FP8 linear ONNX export without bias."""
+    model = FP8LinearModel(
+        in_features=in_features,
+        out_features=out_features,
+        use_bias=False,
+    ).to("cuda")
+
+    input_tensor = torch.randn(batch_size, seq_len, in_features, device="cuda", dtype=torch.float16)
+
+    _export_and_verify_onnx(model, input_tensor, use_bias=False)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for rewrite_embedding_to_inputs_embeds transformation.
+
+This transform rewrites the graph to accept inputs_embeds instead of input_ids,
+which is necessary for EdgeLLM to support multimodal models where embedding
+lookup is performed at runtime.
+"""
+
+import inspect
+import tempfile
+from pathlib import Path
+
+import pytest
+import safetensors.torch
+import torch
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+
+torch.manual_seed(0)
+
+
+class EmbeddingModel(torch.nn.Module):
+    """
+    Simple model with embedding layer followed by a linear projection.
+
+    This model represents the minimal pattern that rewrite_embedding_to_inputs_embeds
+    expects to transform:
+        input_ids → embedding(weight, input_ids) → subsequent operations
+    """
+
+    def __init__(self, vocab_size: int, hidden_size: int):
+        """Initialize EmbeddingModel with embedding and linear projection layers."""
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.embed_tokens = torch.nn.Embedding(vocab_size, hidden_size)
+        self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            input_ids: [batch_size, seq_len] int tensor
+
+        Returns:
+            [batch_size, seq_len, hidden_size] float tensor
+        """
+        x = self.embed_tokens(input_ids)  # [batch, seq, hidden]
+        return self.proj(x)
+
+    def get_dynamic_shapes(self):
+        """Return dynamic shape specifications for torch.export."""
+        return [
+            {0: Dim("batch_size", max=8), 1: Dim("seq_len", max=128)},
+        ]
+
+
+def _run_test(
+    vocab_size: int,
+    hidden_size: int,
+    batch_size: int,
+    seq_len: int,
+):
+    """Helper function to run the transformation test."""
+    # Create model in fp16 (pre-condition for the transform)
+    model = EmbeddingModel(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+    ).to("cuda", torch.float16)
+
+    # Create input tensors
+    input_ids = torch.randint(
+        0, vocab_size, (batch_size, seq_len), device="cuda", dtype=torch.int32
+    )
+    dynamic_shapes = model.get_dynamic_shapes()
+
+    # Export to graph module
+    args = (input_ids,)
+    gm = torch_export_to_gm(model, args=args, dynamic_shapes=dynamic_shapes, clone=True)
+
+    # Verify pre-conditions: input_ids placeholder exists, embedding node exists
+    placeholder_nodes_before = gm.graph.find_nodes(op="placeholder")
+    placeholder_names_before = {node.target for node in placeholder_nodes_before}
+    assert "input_ids" in placeholder_names_before, "Pre-condition: input_ids should exist"
+
+    embedding_nodes_before = gm.graph.find_nodes(
+        op="call_function", target=torch.ops.aten.embedding.default
+    )
+    assert len(embedding_nodes_before) == 1, "Pre-condition: embedding node should exist"
+
+    # Create temp directory for safetensors output
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir)
+
+        # Apply rewrite_embedding_to_inputs_embeds transformation
+        # Note: factory=None because rewrite_embedding_to_inputs_embeds does not use it
+        optimizer = InferenceOptimizer(
+            None,
+            {
+                "rewrite_embedding_to_inputs_embeds": {
+                    "stage": "pattern_matcher",
+                    "output_dir": str(output_dir),
+                },
+            },
+        )
+        gm_transformed = optimizer(None, gm)
+
+        # =========================================================================
+        # Assertions
+        # =========================================================================
+
+        # 1. Verify input_ids placeholder is removed
+        placeholder_nodes_after = gm_transformed.graph.find_nodes(op="placeholder")
+        placeholder_names_after = {node.target for node in placeholder_nodes_after}
+        assert "input_ids" not in placeholder_names_after, (
+            f"input_ids should be removed, but found placeholders: {placeholder_names_after}"
+        )
+
+        # 2. Verify inputs_embeds placeholder is added
+        assert "inputs_embeds" in placeholder_names_after, (
+            f"inputs_embeds should be added, but found placeholders: {placeholder_names_after}"
+        )
+
+        # 3. Verify inputs_embeds has correct dtype and shape
+        inputs_embeds_node = None
+        for node in placeholder_nodes_after:
+            if node.target == "inputs_embeds":
+                inputs_embeds_node = node
+                break
+
+        assert inputs_embeds_node is not None, "inputs_embeds node not found"
+        inputs_embeds_meta = inputs_embeds_node.meta.get("val")
+        assert inputs_embeds_meta is not None, "inputs_embeds should have meta['val']"
+        assert inputs_embeds_meta.dtype == torch.float16, (
+            f"inputs_embeds dtype should be float16, got {inputs_embeds_meta.dtype}"
+        )
+        # Shape should be [batch_size, seq_len, hidden_size]
+        assert len(inputs_embeds_meta.shape) == 3, (
+            f"inputs_embeds should have 3 dimensions, got {len(inputs_embeds_meta.shape)}"
+        )
+
+        # 4. Verify embedding node is removed
+        embedding_nodes_after = gm_transformed.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.embedding.default
+        )
+        assert len(embedding_nodes_after) == 0, (
+            f"embedding node should be removed, but found {len(embedding_nodes_after)}"
+        )
+
+        # 5. Verify safetensors file is created with correct content
+        safetensors_path = output_dir / "embedding.safetensors"
+        assert safetensors_path.exists(), f"safetensors file should exist at {safetensors_path}"
+
+        # Load and verify the safetensors content
+        loaded_weights = safetensors.torch.load_file(str(safetensors_path))
+        assert "weight" in loaded_weights, "safetensors should contain 'weight' key"
+
+        weight_tensor = loaded_weights["weight"]
+        assert weight_tensor.dtype == torch.float16, (
+            f"weight dtype should be float16, got {weight_tensor.dtype}"
+        )
+        assert weight_tensor.shape == (vocab_size, hidden_size), (
+            f"weight shape should be ({vocab_size}, {hidden_size}), got {weight_tensor.shape}"
+        )
+
+        # 6. Verify the graph signature is updated (recompile was called)
+
+        sig = inspect.signature(gm_transformed.forward)
+        param_names = list(sig.parameters.keys())
+        assert "input_ids" not in param_names, "input_ids should not be in signature"
+        assert "inputs_embeds" in param_names, "inputs_embeds should be in signature"
+
+
+@pytest.mark.parametrize(
+    "vocab_size,hidden_size,batch_size,seq_len",
+    [
+        pytest.param(1000, 64, 2, 16, id="small_model"),
+        pytest.param(32000, 128, 4, 32, id="medium_model"),
+    ],
+)
+@torch.inference_mode()
+def test_rewrite_embedding_to_inputs_embeds(
+    vocab_size: int,
+    hidden_size: int,
+    batch_size: int,
+    seq_len: int,
+):
+    """Test rewrite_embedding_to_inputs_embeds transformation with various configurations."""
+    _run_test(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        batch_size=batch_size,
+        seq_len=seq_len,
+    )
+
+
+@torch.inference_mode()
+def test_rewrite_embedding_skips_when_no_input_ids():
+    """Test that the transform is skipped when input_ids placeholder doesn't exist."""
+
+    # Create a model that doesn't use input_ids naming
+    class NoInputIdsModel(torch.nn.Module):
+        """Simple model without input_ids placeholder to test skip behavior."""
+
+        def __init__(self, hidden_size: int):
+            """Initialize with a single linear projection layer."""
+            super().__init__()
+            self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass through the linear projection."""
+            return self.proj(x)
+
+    hidden_size = 64
+    batch_size = 2
+    seq_len = 16
+
+    model = NoInputIdsModel(hidden_size).to("cuda", torch.float16)
+    x = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=torch.float16)
+
+    # hidden_size is static, only batch and seq are dynamic
+    dynamic_shapes = [{0: Dim("batch_size", max=8), 1: Dim("seq_len", max=128)}]
+    gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=dynamic_shapes, clone=True)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir)
+
+        optimizer = InferenceOptimizer(
+            None,
+            {
+                "rewrite_embedding_to_inputs_embeds": {
+                    "stage": "pattern_matcher",
+                    "output_dir": str(output_dir),
+                },
+            },
+        )
+        gm_transformed = optimizer(None, gm)
+
+        # Should be skipped - no safetensors file created
+        safetensors_path = output_dir / "embedding.safetensors"
+        assert not safetensors_path.exists(), (
+            "safetensors should not be created when transform is skipped"
+        )
+
+        # Graph should remain unchanged
+        placeholder_nodes = gm_transformed.graph.find_nodes(op="placeholder")
+        placeholder_names = {node.target for node in placeholder_nodes}
+        assert "input_ids" not in placeholder_names
+        assert "inputs_embeds" not in placeholder_names


### PR DESCRIPTION
## Description

This PR enhances EdgeLLM ONNX export with two key features:

1. **Multimodal Input Support**: Replaces `input_ids` (int32) with `inputs_embeds` (float16) as model input. This enables multimodal models where embedding lookup is performed at runtime (e.g., for images/videos/audio). The embedding table is exported separately as safetensors.

2. **FP8 Quantization Export**: Adds ONNX translation for `torch_fake_quant_fp8_linear`, expanding it into standard ONNX ops (QuantizeLinear, DequantizeLinear, Transpose, MatMul, Add) for compatibility with ONNX runtime.


Key changes:
- New `rewrite_embedding_to_inputs_embeds` transform that removes embedding lookup from graph
- New `_translate_fake_quant_fp8_linear_op` for FP8 linear ONNX export
- `_sync_weight_meta_dtype` to fix dtype mismatch after quantization transforms

## Test Coverage

- `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py`
  - `test_rewrite_embedding_to_inputs_embeds[small_model]`
  - `test_rewrite_embedding_to_inputs_embeds[medium_model]`
  - `test_rewrite_embedding_skips_when_no_input_ids`
- `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_export_fp8_linear_to_onnx.py`
  - `test_fp8_linear_with_bias[small]`
  - `test_fp8_linear_with_bias[medium]`
  - `test_fp8_linear_without_bias[small]`


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.
- [x] Please check this after reviewing the above items as appropriate for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multimodal input support: Models now accept pre-computed embeddings directly, enabling flexible multimodal workflows.
  * Embedding export: Embedding tables are exported separately for efficient runtime lookup.
  * FP8 quantization: Added support for FP8 fake-quantized operations in ONNX export.

* **Bug Fixes**
  * Improved weight dtype synchronization in export pipelines.

* **Documentation**
  * Expanded ONNX export documentation with multimodal configuration and embedding handling details.

* **Tests**
  * Comprehensive test coverage for multimodal features and FP8 quantization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->