### PR TITLE
[None][fix] Use non-aligned version of barrier for fmha.

### DIFF
--- a/cpp/kernels/fmha_v2/src/fmha/hopper/arrive_wait.h
+++ b/cpp/kernels/fmha_v2/src/fmha/hopper/arrive_wait.h
@@ -73,7 +73,16 @@ inline __device__ void named_barrier_arrive(uint32_t BARRIER_ID, uint32_t NUM_TH
 {
     if (NUM_THREADS > 1)
     {
+        // Note: bar.arrive is an alias of barrier.arrive.aligned
         asm volatile("bar.arrive %0, %1;" : : "r"(BARRIER_ID), "r"(NUM_THREADS));
+    }
+}
+
+inline __device__ void named_barrier_arrive_unaligned(uint32_t BARRIER_ID, uint32_t NUM_THREADS)
+{
+    if (NUM_THREADS > 1)
+    {
+        asm volatile("barrier.arrive %0, %1;" : : "r"(BARRIER_ID), "r"(NUM_THREADS));
     }
 }
 
@@ -81,7 +90,16 @@ inline __device__ void named_barrier_wait(uint32_t BARRIER_ID, uint32_t NUM_THRE
 {
     if (NUM_THREADS > 1)
     {
+        // Note: bar.sync is an alias of barrier.sync.aligned
         asm volatile("bar.sync %0, %1;" ::"r"(BARRIER_ID), "r"(NUM_THREADS));
+    }
+}
+
+inline __device__ void named_barrier_wait_unaligned(uint32_t BARRIER_ID, uint32_t NUM_THREADS)
+{
+    if (NUM_THREADS > 1)
+    {
+        asm volatile("barrier.sync %0, %1;" ::"r"(BARRIER_ID), "r"(NUM_THREADS));
     }
 }
 

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/circular_buffer.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/circular_buffer.h
@@ -465,7 +465,7 @@ public:
         // Make sure barrier is not moving around
         if (_id == 0)
         {
-            named_barrier_wait(_barrier_id, 256);
+            named_barrier_arrive_unaligned(_barrier_id, 256);
         }
     }
 
@@ -474,7 +474,7 @@ public:
         // Make sure barrier is not moving around
         if (_id == 1)
         {
-            named_barrier_wait(_barrier_id, 256);
+            named_barrier_wait_unaligned(_barrier_id, 256);
         }
         // Softmax starts
         // ...

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/circular_buffer.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/circular_buffer.h
@@ -465,7 +465,10 @@ public:
         // Make sure barrier is not moving around
         if (_id == 0)
         {
-            named_barrier_arrive_unaligned(_barrier_id, 256);
+            // This is a *rendezvous* between the two compute warpgroups (256 threads total).
+            // Use the unaligned variant to avoid synccheck false positives when the two
+            // warpgroups reach this barrier from different control-flow paths / PCs.
+            named_barrier_wait_unaligned(_barrier_id, 256);
         }
     }
 


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
