### PR TITLE
[TRTLLM-9782][feat] Skip memory estimation process and calculate kv cache memory directly from fraction

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -259,7 +259,6 @@ def create_draft_kv_cache_manager_maybe(
         max_num_tokens=ad_config.max_num_tokens,
         max_beam_width=ad_config.max_beam_width,
         kv_connector_manager=None,  # KV connector manager not used in AutoDeploy (no disagg support)
-        estimating_kv_cache=False,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -217,7 +217,6 @@ class CachedSequenceInterface:
             # we don't rely on free_gpu_memory_fraction inside the KVCacheManager. This is similar
             # to _torch.pyexecutor._util.KVCacheCreator, which explicitly estimates the max_tokens
             # outside of the KVCacheManager.
-            "is_estimating_kv_cache": False,
         }
 
         # update args if we are just doing a dummy cache manager

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1,13 +1,11 @@
 import os
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import torch
 
 import tensorrt_llm
 import tensorrt_llm.bindings.executor as trtllm
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_utils import \
-    MODEL_CLASS_VISION_ENCODER_MAPPING
 from tensorrt_llm._utils import (confidential_compute_enabled,
                                  str_dtype_to_binding, torch_dtype_to_str)
 from tensorrt_llm.bindings.executor import DecodingMode
@@ -25,12 +23,11 @@ from tensorrt_llm.mapping import CpType, Mapping
 
 from ..attention_backend import get_sparse_attn_kv_cache_manager
 from ..model_config import ModelConfig
-from ..speculative import get_num_extra_kv_tokens, get_spec_decoder
+from ..speculative import get_spec_decoder
 from .config_utils import is_mla, is_nemotron_hybrid, is_qwen3_next
 from .guided_decoder import GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .kv_cache_transceiver import AttentionTypeCpp, create_kv_cache_transceiver
-from .llm_request import ExecutorResponse
 from .mamba_cache_manager import MambaHybridCacheManager
 from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
@@ -58,6 +55,12 @@ def get_kv_cache_manager_cls(model_config: ModelConfig):
         return KVCacheManager
 
 
+def is_vswa_enabled(kv_cache_config):
+    max_attention_window = kv_cache_config.max_attention_window
+    return max_attention_window is not None and len(
+        set(max_attention_window)) > 1
+
+
 class KvCacheCreator:
     """Groups together logic related to KV cache construction."""
 
@@ -67,7 +70,6 @@ class KvCacheCreator:
         model_engine: PyTorchModelEngine,
         draft_model_engine: Optional[PyTorchModelEngine],
         mapping: Mapping,
-        net_max_seq_len: int,
         kv_connector_manager: Optional[KvCacheConnectorManager],
         max_num_tokens: int,
         max_beam_width: int,
@@ -95,9 +97,6 @@ class KvCacheCreator:
         self._tokens_per_block = tokens_per_block
         self._max_seq_len = max_seq_len
         self._max_batch_size = max_batch_size
-        self._net_max_seq_len = net_max_seq_len
-        self._dummy_reqs = None
-        self._profiling_stage_data = profiling_stage_data
         self._kv_cache_manager_cls = get_kv_cache_manager_cls(
             model_engine.model.model_config)
         self._execution_stream = execution_stream
@@ -117,216 +116,21 @@ class KvCacheCreator:
                 tokens_per_block=self._tokens_per_block)
         return kv_size_per_token
 
-    def _cal_max_memory(self, peak_memory, total_gpu_memory, fraction,
-                        allocated_bytes: int) -> int:
+    def _cal_max_memory(self, peak_memory, total_gpu_memory, fraction) -> int:
         """
         Calculate the max KV cache capacity.
-
-        NOTE: `allocated_bytes` is the total KV-cache memory that must be pre-allocated during the estimation phase (for both the main and draft models) so the estimation run can complete successfully. When computing `available_kv_mem`, add this amount back in.
         """
         kv_size_per_token = self._get_kv_size_per_token()
 
-        available_kv_mem = (total_gpu_memory - peak_memory +
-                            allocated_bytes) * fraction
+        available_kv_mem = (total_gpu_memory - peak_memory) * fraction
         logger.info(
             f"Peak memory during memory usage profiling (torch + non-torch): {peak_memory / (GB):.2f} GiB, "
             f"available KV cache memory when calculating max tokens: {available_kv_mem / (GB):.2f} GiB, "
-            f"fraction is set {fraction}, kv size is {kv_size_per_token}. device total memory {total_gpu_memory / (GB):.2f} GiB, "
-            f", tmp kv_mem { (allocated_bytes) / (GB):.2f} GiB")
+            f"fraction is set {fraction}, kv size is {kv_size_per_token}. device total memory {total_gpu_memory / (GB):.2f} GiB"
+        )
         return int(available_kv_mem)
 
-    def _create_dummy_mm_context_request(
-            self, input_seq_len: int) -> List[trtllm.Request]:
-        requests = []
-        if isinstance(
-                self._profiling_stage_data,
-                dict) and not self._profiling_stage_data.get("enable_mm_reqs"):
-            return requests
-
-        input_processor = self._model_engine.input_processor
-        if not (hasattr(input_processor, "get_dummy_prompt")):
-            logger.warning("The input processor of the model does not have the method [get_dummy_prompt] implemented." \
-            "Profiling with the default input dummy context request. This may not take into account the memory consumption of " \
-            "the image encoder")
-            return requests
-
-        max_num_tokens = self._max_num_tokens
-        max_beam_width = self._max_beam_width
-        vocab_size = self._model_engine.model.model_config.pretrained_config.vocab_size
-
-        input_seq_len = min(max_num_tokens, input_seq_len)
-        remaining_tokens = max_num_tokens
-        while remaining_tokens > 0:
-            input_seq_len = min(input_seq_len, remaining_tokens)
-            dummy_mm_prompt = input_processor.get_dummy_prompt(input_seq_len)
-
-            if dummy_mm_prompt is not None:
-                prompt_token_ids, extra_processed_inputs = self._model_engine.input_processor_with_hash(
-                    dummy_mm_prompt, sampling_params=None)
-
-                multimodal_input = extra_processed_inputs.get(
-                    'multimodal_input')
-                multimodal_data = extra_processed_inputs.get('multimodal_data')
-                req_mm_input = trtllm.MultimodalInput(
-                    multimodal_hashes=multimodal_input.multimodal_hashes,
-                    multimodal_positions=multimodal_input.multimodal_positions,
-                    multimodal_lengths=multimodal_input.multimodal_lengths
-                ) if multimodal_input else None
-
-                request = trtllm.Request(prompt_token_ids,
-                                         max_tokens=1,
-                                         streaming=False,
-                                         sampling_config=trtllm.SamplingConfig(
-                                             beam_width=max_beam_width, ),
-                                         output_config=trtllm.OutputConfig(),
-                                         end_id=-1,
-                                         multimodal_input=req_mm_input)
-                request.py_multimodal_data = multimodal_data
-            else:
-                # Fall back to text-only prompt when we could not find the small image size.
-                prompt_token_ids = torch.randint(
-                    low=0, high=vocab_size, size=(input_seq_len, )).tolist()
-                request = trtllm.Request(prompt_token_ids,
-                                         max_tokens=1,
-                                         streaming=False,
-                                         sampling_config=trtllm.SamplingConfig(
-                                             beam_width=max_beam_width, ),
-                                         output_config=trtllm.OutputConfig(),
-                                         end_id=-1)
-                if self._model_engine.use_mrope:
-                    request.py_multimodal_data = {
-                        "mrope_config": {
-                            "mrope_position_ids":
-                            torch.zeros(3, 1, input_seq_len, dtype=torch.int32),
-                            "mrope_position_deltas":
-                            torch.zeros(1, 1, dtype=torch.int32)
-                        }
-                    }
-            remaining_tokens -= len(prompt_token_ids)
-            requests.append(request)
-
-        if self._mapping.enable_attention_dp:
-            requests = requests * self._mapping.tp_size
-
-        return requests
-
-    def _create_dummy_context_requests(
-            self, input_seq_len: int) -> List[trtllm.Request]:
-        requests = []
-        if hasattr(self._model_engine.model,
-                   "original_arch") and MODEL_CLASS_VISION_ENCODER_MAPPING.get(
-                       self._model_engine.model.original_arch, None):
-            requests = self._create_dummy_mm_context_request(input_seq_len)
-        # if succeed profiling with multimodal requests then return, otherwise profile
-        # with default case
-        if requests:
-            return requests
-        vocab_size = self._model_engine.model.model_config.pretrained_config.vocab_size
-        max_num_tokens = self._max_num_tokens
-        max_beam_width = self._max_beam_width
-
-        input_seq_len = min(max_num_tokens, input_seq_len)
-        remaining_tokens = max_num_tokens
-        while remaining_tokens > 0:
-            input_seq_len = min(input_seq_len, remaining_tokens)
-            input_tokens = torch.randint(low=0,
-                                         high=vocab_size,
-                                         size=(input_seq_len, )).tolist()
-            request = trtllm.Request(input_tokens,
-                                     max_tokens=1,
-                                     streaming=False,
-                                     sampling_config=trtllm.SamplingConfig(
-                                         beam_width=max_beam_width, ),
-                                     output_config=trtllm.OutputConfig(),
-                                     end_id=-1)
-            if self._model_engine.use_mrope:
-                request.py_multimodal_data = {
-                    "mrope_config": {
-                        "mrope_position_ids":
-                        torch.zeros(3, 1, input_seq_len, dtype=torch.int32),
-                        "mrope_position_deltas":
-                        torch.zeros(1, 1, dtype=torch.int32)
-                    }
-                }
-            requests.append(request)
-            remaining_tokens -= input_seq_len
-        if self._mapping.enable_attention_dp:
-            requests = requests * self._mapping.tp_size
-        return requests
-
-    def _get_token_num_for_estimation(self) -> int:
-        """Compute KV cache capacity required for estimate_max_kv_cache_tokens to succeed."""
-        if 'cp_type' in self._mapping.cp_config:
-            raise ValueError(
-                "KV cache size estimation not supported with context parallelism."
-            )
-        # estimate_max_kv_cache_tokens submits self._dummy_reqs
-        num_cache_blocks = 0
-        num_extra_tokens_per_seq = 1  # account for generated tokens
-        spec_cfg = self._speculative_config
-        if not self._llm_args.disable_overlap_scheduler:
-            num_extra_tokens_per_seq = num_extra_tokens_per_seq + 1
-            if spec_cfg is not None:
-                num_extra_tokens_per_seq += spec_cfg.max_total_draft_tokens
-
-        if spec_cfg is not None:
-            num_extra_tokens_per_seq += spec_cfg.max_total_draft_tokens
-            num_extra_tokens_per_seq += get_num_extra_kv_tokens(spec_cfg)
-
-        if self._dummy_reqs is None:
-            self._dummy_reqs = self._create_dummy_context_requests(
-                max(1, self._net_max_seq_len - 1))
-        for req in self._dummy_reqs:
-            num_req_tokens = len(req.input_token_ids) + num_extra_tokens_per_seq
-            # Requests cannot share KV cache blocks. Round up to nearest integer multiple of block size.
-            num_cache_blocks += (num_req_tokens + self._tokens_per_block -
-                                 1) // self._tokens_per_block
-
-        # Max cuda graph warmup required tokens
-        max_cuda_graph_bs = min(self._model_engine.batch_size,
-                                self._model_engine._max_cuda_graph_batch_size)
-        cuda_graph_warmup_block = (
-            self._model_engine.max_seq_len +
-            1) // self._tokens_per_block + max_cuda_graph_bs - 1
-        num_cache_blocks = max(cuda_graph_warmup_block, num_cache_blocks)
-
-        # This is the minimal blocks required to run with max bs
-        # If not able to allocate self._model_engine.batch_size blocks, the max batch size should be adjusted.
-        num_cache_blocks = max(num_cache_blocks, self._model_engine.batch_size)
-
-        free_mem, total_mem = torch.cuda.mem_get_info()
-        max_memory = self._kv_cache_config.free_gpu_memory_fraction * free_mem
-        max_num_tokens_in_memory = max_memory // self._get_kv_size_per_token(
-        ) // self._tokens_per_block * self._tokens_per_block
-
-        # Multiply by beam width, to prevent rescaling of the max_seq_len caused by the influence of beam width during the preparation for kv_cache_estimation
-        return min(
-            num_cache_blocks * self._tokens_per_block *
-            self._dummy_reqs[0].sampling_config.beam_width,
-            max_num_tokens_in_memory)
-
-    def try_prepare_estimation(self) -> bool:
-        """Prepare for possible KV cache capacity estimation.
-
-        This updates `kv_cache_config` and returns a boolean indicating whether KV cache
-        estimation is to be performend.
-        """
-        estimating_kv_cache = False
-        if 'cp_type' not in self._mapping.cp_config:
-            estimating_kv_cache = True
-            estimate_max_tokens = self._get_token_num_for_estimation()
-            self._kv_cache_config.max_tokens = min(
-                estimate_max_tokens, self._kv_cache_config.max_tokens
-            ) if self._kv_cache_config.max_tokens is not None else estimate_max_tokens
-        model_config = self._model_engine.model.model_config
-        if model_config.attn_backend == "VANILLA":
-            logger.info(
-                "KV cache size estimation is not supported for Vanilla attention backend, disable it."
-            )
-            estimating_kv_cache = False
-        return estimating_kv_cache
-
-    def configure_kv_cache_capacity(self, py_executor: PyExecutor) -> None:
+    def configure_kv_cache_capacity(self) -> None:
         """Perform KV cache capacity estimation.
         NOTE: for VSWA case, we calculate and set kv cache memory instead of using max_tokens in kv_cache_config.
 
@@ -351,67 +155,9 @@ class KvCacheCreator:
             f"Memory used after loading model weights (outside torch) in memory usage profiling: {((total_used_bytes - model_bytes) if total_used_bytes > model_bytes else 0) / (GB):.2f} GiB"
         )
 
-        py_executor.set_gather_responses(True)
-        origin_iter_stats = py_executor.enable_iter_perf_stats
-        py_executor.enable_iter_perf_stats = False
-        req_ids = []
-        if py_executor.dist.mapping.rank == 0:
-            req_ids = py_executor.enqueue_requests(self._dummy_reqs)
-        req_ids = py_executor.dist.broadcast(req_ids, root=0)
-        py_executor.is_warmup = True
-        py_executor.start_worker()
-        try:
-            responses = py_executor.await_responses(req_ids)
-            for response_or_list in responses:
-                response_list = [response_or_list] if isinstance(
-                    response_or_list, ExecutorResponse) else response_or_list
-                for response in response_list:
-                    if response.has_error():
-                        raise RuntimeError(response.error_msg)
-
-            torch_peak_memory = torch.cuda.memory_stats(
-            )["allocated_bytes.all.peak"]
-
-            # Clear the caching allocator before measuring the current memory usage
-            torch.cuda.empty_cache()
-            end, total_gpu_memory = torch.cuda.mem_get_info()
-            torch_used_bytes = torch.cuda.memory_stats(
-            )["allocated_bytes.all.current"]
-        finally:
-            py_executor.is_warmup = False
-            py_executor.shutdown()
-            py_executor.enable_iter_perf_stats = origin_iter_stats
-            py_executor.set_gather_responses(False)
-
-        total_used_bytes = total_gpu_memory - end
-        activation_bytes = torch_peak_memory - model_bytes
-        extra_cost = max(total_used_bytes - torch_used_bytes, 0)
-        peak_memory = torch_peak_memory + extra_cost
-        logger.info(
-            f"Memory dynamically allocated during inference (inside torch) in memory usage profiling: {activation_bytes / (GB):.2f} GiB"
-        )
-        logger.info(
-            f"Memory used outside torch (e.g., NCCL and CUDA graphs) in memory usage profiling: {extra_cost / (GB):.2f} GiB"
-        )
-
-        # get kv cache stats for both model and draft model
-        kv_stats = py_executor.resource_manager.resource_managers.get(
-            ResourceManagerType.KV_CACHE_MANAGER).get_kv_cache_stats()
-        kv_stats_draft = py_executor.resource_manager.resource_managers.get(
-            ResourceManagerType.DRAFT_KV_CACHE_MANAGER).get_kv_cache_stats(
-            ) if self._draft_model_engine is not None else None
-
-        # get total allocated bytes
-        allocated_bytes = kv_stats.allocated_bytes + (
-            kv_stats_draft.allocated_bytes if kv_stats_draft is not None else 0)
-
         # calculate max memory from peak memory and free gpu memory fraction
-        kv_cache_max_memory = self._cal_max_memory(peak_memory,
-                                                   total_gpu_memory, fraction,
-                                                   allocated_bytes)
-
-        max_attention_window = self._kv_cache_config.max_attention_window
-        is_vswa = max_attention_window and len(set(max_attention_window)) > 1
+        kv_cache_max_memory = self._cal_max_memory(total_used_bytes,
+                                                   total_gpu_memory, fraction)
 
         # NOTE:
         # KvCacheCreator currently controls KV-cache capacity using two parameters in KVCacheConfig:
@@ -423,6 +169,8 @@ class KvCacheCreator:
         # ---------------------------handle max_tokens---------------------------------
         # if user provided max_tokens, calculate max memory from max_tokens
         if self._max_kv_tokens_in is not None:
+            is_vswa = is_vswa_enabled(self._kv_cache_config)
+
             # raise error if it is VSWA case
             if is_vswa:
                 logger.warning(
@@ -455,14 +203,10 @@ class KvCacheCreator:
         )
         # set max_gpu_total_bytes
         self._kv_cache_config.max_gpu_total_bytes = kv_cache_max_memory
-        if isinstance(self._profiling_stage_data, dict):
-            self._profiling_stage_data["activation_bytes"] = activation_bytes
         # ---------------------------handle max_gpu_total_bytes---------------------------------
 
     def _create_kv_cache_manager(
-            self,
-            model_engine: PyTorchModelEngine,
-            estimating_kv_cache: bool = False) -> KVCacheManager:
+            self, model_engine: PyTorchModelEngine) -> KVCacheManager:
         mapping = self._mapping
         assert model_engine.model.model_config.is_generation, "Only construct KV cache for generation models."
 
@@ -479,58 +223,31 @@ class KvCacheCreator:
             max_num_tokens=self._max_num_tokens,
             max_beam_width=self._max_beam_width,
             kv_connector_manager=self._kv_connector_manager,
-            estimating_kv_cache=estimating_kv_cache,
             execution_stream=self._execution_stream,
         )
 
-        # KVCacheManager (Non-draft) modifies the max_seq_len field, update it to self
-        if model_engine.kv_cache_manager_key == ResourceManagerType.KV_CACHE_MANAGER:
-            # When SWA is enabled, max_seq_len is updated inside kv_cache_manager.
-            if kv_cache_manager is not None:
-                if kv_cache_manager.max_seq_len < self._max_seq_len:
-                    self._dummy_reqs = self._create_dummy_context_requests(
-                        max(
-                            1, self._net_max_seq_len - 1 -
-                            (self._max_seq_len - kv_cache_manager.max_seq_len)))
-                self._max_seq_len = kv_cache_manager.max_seq_len
-
         # When SWA is enabled, max_seq_len is updated inside kv_cache_manager.
         if kv_cache_manager is not None:
-            if kv_cache_manager.max_seq_len < self._max_seq_len:
-                self._dummy_reqs = self._create_dummy_context_requests(
-                    max(1, kv_cache_manager.max_seq_len - 1))
             self._max_seq_len = kv_cache_manager.max_seq_len
 
         return kv_cache_manager
 
-    def build_managers(self,
-                       resources: Dict,
-                       estimating_kv_cache: bool = False) -> None:
+    def build_managers(self, resources: Dict) -> None:
         """Construct KV caches for model and draft model (if applicable)."""
-        kv_cache_manager = self._create_kv_cache_manager(
-            self._model_engine, estimating_kv_cache)
+        self.configure_kv_cache_capacity()
+        kv_cache_manager = self._create_kv_cache_manager(self._model_engine, )
 
-        if not estimating_kv_cache and self._kv_connector_manager is not None and self._draft_model_engine is not None:
+        if self._kv_connector_manager is not None and self._draft_model_engine is not None:
             raise NotImplementedError(
                 "Connector manager is not supported for draft model.")
 
         draft_kv_cache_manager = self._create_kv_cache_manager(
-            self._draft_model_engine, estimating_kv_cache
+            self._draft_model_engine
         ) if self._draft_model_engine is not None else None
 
         resources[ResourceManagerType.KV_CACHE_MANAGER] = kv_cache_manager
         resources[
             ResourceManagerType.DRAFT_KV_CACHE_MANAGER] = draft_kv_cache_manager
-
-    def teardown_managers(self, resources: Dict) -> None:
-        """Clean up KV caches for model and draft model (if applicable)."""
-        resources[ResourceManagerType.KV_CACHE_MANAGER].shutdown()
-        del resources[ResourceManagerType.KV_CACHE_MANAGER]
-        draft_kv_cache_manager = resources[
-            ResourceManagerType.DRAFT_KV_CACHE_MANAGER]
-        if draft_kv_cache_manager:
-            draft_kv_cache_manager.shutdown()
-        del resources[ResourceManagerType.DRAFT_KV_CACHE_MANAGER]
 
 
 def _create_kv_cache_manager(
@@ -546,7 +263,6 @@ def _create_kv_cache_manager(
         max_num_tokens: int,
         max_beam_width: int,
         kv_connector_manager: Optional[KvCacheConnectorManager],
-        estimating_kv_cache: bool,
         execution_stream: Optional[torch.cuda.Stream] = None) -> KVCacheManager:
     """
     Returns:
@@ -590,10 +306,8 @@ def _create_kv_cache_manager(
             vocab_size=config.vocab_size,
             max_beam_width=max_beam_width,
             is_draft=model_engine.is_draft_model,
-            kv_connector_manager=kv_connector_manager
-            if not estimating_kv_cache else None,
+            kv_connector_manager=kv_connector_manager,
             sparse_attn_config=sparse_attn_config,
-            is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
         )
     elif is_nemotron_hybrid(config):
@@ -601,7 +315,7 @@ def _create_kv_cache_manager(
             raise ValueError(
                 "MambaHybridCacheManager + beam search is not supported yet.")
 
-        if not estimating_kv_cache and kv_connector_manager is not None:
+        if kv_connector_manager is not None:
             raise NotImplementedError(
                 "Connector manager is not supported for MambaHybridCacheManager."
             )
@@ -637,7 +351,6 @@ def _create_kv_cache_manager(
             mapping=mapping,
             dtype=kv_cache_dtype,
             spec_config=spec_config,
-            is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
         )
     elif is_qwen3_next(config):
@@ -645,7 +358,7 @@ def _create_kv_cache_manager(
             raise ValueError(
                 "MambaHybridCacheManager + beam search is not supported yet.")
 
-        if not estimating_kv_cache and kv_connector_manager is not None:
+        if kv_connector_manager is not None:
             raise NotImplementedError(
                 "Connector manager is not supported for MambaHybridCacheManager."
             )
@@ -687,13 +400,11 @@ def _create_kv_cache_manager(
             mapping=mapping,
             dtype=kv_cache_dtype,
             spec_config=spec_config,
-            is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
         )
     else:
         # NOTE: this is a workaround for VSWA to switch to calculate_max_num_blocks_from_cpp in KVCahceManager
-        is_vswa = kv_cache_config.max_attention_window is not None and len(
-            set(kv_cache_config.max_attention_window)) > 1
+        is_vswa = is_vswa_enabled(kv_cache_config)
         binding_model_config = model_engine.model.model_config.get_bindings_model_config(
             tokens_per_block=tokens_per_block) if is_vswa else None
 
@@ -714,10 +425,8 @@ def _create_kv_cache_manager(
             model_config=binding_model_config,
             max_beam_width=max_beam_width,
             is_draft=model_engine.is_draft_model,
-            kv_connector_manager=kv_connector_manager
-            if not estimating_kv_cache else None,
+            kv_connector_manager=kv_connector_manager,
             sparse_attn_config=sparse_attn_config,
-            is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
         )
     return kv_cache_manager
@@ -731,7 +440,6 @@ def create_py_executor_instance(
     llm_args,
     ctx_chunk_config,
     model_engine,
-    start_worker,
     sampler,
     drafter,
     guided_decoder: Optional[GuidedDecoder] = None,
@@ -915,7 +623,6 @@ def create_py_executor_instance(
         if spec_config is not None else 0,
         kv_cache_transceiver=kv_cache_transceiver,
         guided_decoder=guided_decoder,
-        start_worker=start_worker,
         garbage_collection_gen0_threshold=garbage_collection_gen0_threshold,
         kv_connector_manager=kv_connector_manager,
         max_seq_len=max_seq_len,
@@ -1060,53 +767,6 @@ def _try_infer_num_experts(model_config: ModelConfig) -> int:
         return 1
 
     return num_experts
-
-
-def _adjust_torch_mem_fraction():
-    # If true, adjust PyTorch CUDA memory fraction to correspond to the
-    # total GPU memory minus the statically allocated engine memory.
-    # If false, set the PyTorch CUDA memory fraction to 1.0.
-    _limit_torch_cuda_mem_fraction: bool = True
-
-    # FIXME: PyTorch only uses the garbage_collection_threshold setting
-    #        if a memory fraction is set, cf.
-    #   https://github.com/pytorch/pytorch/blob/cd995bfb2aac8891465809be3ce29543bd524287/c10/cuda/CUDACachingAllocator.cpp#L1357
-    logger.debug("Setting PyTorch memory fraction to 1.0")
-    torch.cuda.set_per_process_memory_fraction(1.0)
-
-    # FIXME: As soon as
-    #     torch.cuda._set_allocator_settings (added in PyTorch 2.8.0-rc1)
-    #   or a similar API is available, the warning below should be removed
-    #   and the allocator GC threshold be set via the new API instead.
-    torch_allocator_config = os.environ.get("PYTORCH_ALLOC_CONF", "")
-    torch_mem_threshold_advised = (
-        torch.cuda.get_allocator_backend() == "native"
-        and "expandable_segments:True" not in torch_allocator_config)
-    torch_mem_threshold_set = "garbage_collection_threshold:" in torch_allocator_config
-    if torch_mem_threshold_advised and not torch_mem_threshold_set:
-        logger.warning(
-            "It is recommended to incl. 'garbage_collection_threshold:0.???' or 'backend:cudaMallocAsync'"
-            " or 'expandable_segments:True' in PYTORCH_ALLOC_CONF.")
-
-    # NOTE: Even if a memory threshold was not set (cf. warning above), setting a memory
-    #       fraction < 1.0 is beneficial, because
-    #         https://github.com/pytorch/pytorch/blob/5228986c395dc79f90d2a2b991deea1eef188260/c10/cuda/CUDACachingAllocator.cpp#L2719
-    #       and
-    #         https://github.com/pytorch/pytorch/blob/5228986c395dc79f90d2a2b991deea1eef188260/c10/cuda/CUDACachingAllocator.cpp#L1240
-    #       lead PyTorch to release all unused memory before hitting the set fraction. This
-    #       still mitigates OOM, although at a higher performance impact, because it
-    #       effectively resets the allocator cache.
-    if not _limit_torch_cuda_mem_fraction:
-        return
-    mem_reserved = torch.cuda.memory_reserved()
-    mem_free, mem_total = torch.cuda.mem_get_info()
-    safety_margin = 32 * 1024**2
-    mem_torch_max = mem_free + mem_reserved - safety_margin
-    mem_torch_fraction = mem_torch_max / mem_total
-    logger.info(
-        f"Setting PyTorch memory fraction to {mem_torch_fraction} ({mem_torch_max / 1024**3} GiB)"
-    )
-    torch.cuda.set_per_process_memory_fraction(mem_torch_fraction)
 
 
 def validate_feature_combination(llm_args, model_engine, sampler_type):

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -377,7 +377,6 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         mapping: Mapping,
         dtype: DataType = DataType.HALF,
         spec_config: Optional["DecodingBaseConfig"] = None,
-        is_estimating_kv_cache: bool = False,
         execution_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
 
@@ -418,7 +417,6 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
             dtype=dtype,
             spec_config=spec_config,
             layer_mask=layer_mask,
-            is_estimating_kv_cache=is_estimating_kv_cache,
             execution_stream=execution_stream,
         )
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1329,7 +1329,9 @@ class PyTorchModelEngine(ModelEngine):
         self._init_max_num_tokens()
 
     def _release_cuda_graphs(self):
-        self.cuda_graph_runner.clear()
+        if hasattr(self,
+                   'cuda_graph_runner') and self.cuda_graph_runner is not None:
+            self.cuda_graph_runner.clear()
 
     def get_max_num_sequences(self) -> int:
         """

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -33,9 +33,8 @@ from ..speculative import (get_num_extra_kv_tokens, get_spec_drafter,
                            get_spec_resource_manager)
 from ..virtual_memory import ExecutorMemoryType, RestoreMode
 from ..virtual_memory import scope as virtual_memory_scope
-from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
-                    create_py_executor_instance, instantiate_sampler, is_mla,
-                    validate_feature_combination)
+from ._util import (KvCacheCreator, create_py_executor_instance,
+                    instantiate_sampler, validate_feature_combination)
 from .config_utils import is_mla
 from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
@@ -222,7 +221,6 @@ def create_py_executor(
     tokenizer: Optional[TokenizerBase] = None,
     profiling_stage_data: Optional[dict] = None,
 ) -> PyExecutor:
-    torch.cuda.set_per_process_memory_fraction(1.0)
     garbage_collection_gen0_threshold = llm_args.garbage_collection_gen0_threshold
     lora_config = llm_args.lora_config
     kv_connector_config = llm_args.kv_connector_config
@@ -430,7 +428,6 @@ def create_py_executor(
 
     # PyTorchModelEngine modifies these fields, update them
     model_engine_max_seq_len = model_engine.max_seq_len
-    net_max_seq_len = model_engine_max_seq_len
     if not llm_args.disable_overlap_scheduler:
         model_engine_max_seq_len = model_engine.max_seq_len + 1
         if spec_config is not None:
@@ -600,7 +597,6 @@ def create_py_executor(
         kv_connector_manager = None
 
     resources = {}
-    estimating_kv_cache = False
     kv_cache_creator = None
 
     # Create the execution stream for model forward operations
@@ -615,7 +611,6 @@ def create_py_executor(
             model_engine=model_engine,
             draft_model_engine=draft_model_engine,
             mapping=mapping,
-            net_max_seq_len=net_max_seq_len,
             kv_connector_manager=kv_connector_manager,
             max_num_tokens=max_num_tokens,
             max_beam_width=max_beam_width,
@@ -629,11 +624,8 @@ def create_py_executor(
             sparse_attention_config=sparse_attention_config,
             execution_stream=execution_stream,
         )
-        estimating_kv_cache = kv_cache_creator.try_prepare_estimation()
-        with allocation_scope(
-                ExecutorMemoryType.INIT_KV_CACHE if estimating_kv_cache else
-                ExecutorMemoryType.KV_CACHE, RestoreMode.NONE):
-            kv_cache_creator.build_managers(resources, estimating_kv_cache)
+        with allocation_scope(ExecutorMemoryType.KV_CACHE, RestoreMode.NONE):
+            kv_cache_creator.build_managers(resources)
             # Originally, max_seq_len might be mutated inside build_managers as field of executor config.
             # Since now, we are changing kv_cache_creator._max_seq_len instead. Restore max_seq_len here.
             max_seq_len = kv_cache_creator._max_seq_len
@@ -659,9 +651,11 @@ def create_py_executor(
                                    spec_resource_manager=spec_resource_manager,
                                    guided_decoder=guided_decoder)
 
-    with allocation_scope(
-            ExecutorMemoryType.INIT_EXTRA_RESOURCES if estimating_kv_cache else
-            ExecutorMemoryType.EXTRA_RESOURCES, RestoreMode.PINNED):
+    with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES,
+                          RestoreMode.PINNED):
+
+        # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
+        gc.collect()
         py_executor = create_py_executor_instance(
             dist=dist,
             resources=resources,
@@ -669,14 +663,12 @@ def create_py_executor(
             llm_args=llm_args,
             ctx_chunk_config=ctx_chunk_config,
             model_engine=model_engine,
-            start_worker=False,
             sampler=sampler,
             drafter=drafter,
             guided_decoder=guided_decoder,
             lora_config=lora_config,
             garbage_collection_gen0_threshold=garbage_collection_gen0_threshold,
-            kv_connector_manager=kv_connector_manager
-            if not estimating_kv_cache else None,
+            kv_connector_manager=kv_connector_manager,
             max_seq_len=max_seq_len,
             max_batch_size=max_batch_size,
             max_beam_width=max_beam_width,
@@ -684,75 +676,15 @@ def create_py_executor(
             peft_cache_config=peft_cache_config,
             scheduler_config=scheduler_config,
             cache_transceiver_config=cache_transceiver_config,
-            virtual_memory_pools=vm_pools if not estimating_kv_cache else None,
+            virtual_memory_pools=vm_pools,
             execution_stream=execution_stream,
         )
+
         # Originally, peft_cache_config might be mutated inside
         # create_py_executor_instance. Restore it here.
         peft_cache_config = py_executor.peft_cache_config
 
-    if estimating_kv_cache:
-        assert kv_cache_creator is not None
-        with allocation_scope(ExecutorMemoryType.MODEL_EXTRA,
-                              RestoreMode.PINNED):
-            kv_cache_creator.configure_kv_cache_capacity(py_executor)
-        kv_cache_creator.teardown_managers(resources)
-        del py_executor  # free before constructing new
-
-        with allocation_scope(ExecutorMemoryType.KV_CACHE, RestoreMode.NONE):
-            # Before estimating KV cache size, a minimal KV cache has been allocated using
-            # create_kv_cache_manager above, which caps kv_cache_creator.max_seq_len. Restoring
-            # the original value before creating the final KV cache.
-            kv_cache_creator._max_seq_len = model_engine_max_seq_len
-            kv_cache_creator.build_managers(resources, False)
-            # Originally, max_seq_len might be mutated inside build_managers as field of executor config.
-            # Since now, we are changing kv_cache_creator._max_seq_len instead. Restore max_seq_len here.
-            max_seq_len = kv_cache_creator._max_seq_len
-            update_sampler_max_seq_len(max_seq_len, sampler)
-
-            for eng in [model_engine, draft_model_engine]:
-                if eng is None:
-                    continue
-                if eng.attn_metadata is not None:
-                    if llm_args.cuda_graph_config is not None:
-                        eng._release_cuda_graphs()
-                    eng.attn_metadata = None
-
-        with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES,
-                              RestoreMode.PINNED):
-
-            # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
-            gc.collect()
-            py_executor = create_py_executor_instance(
-                dist=dist,
-                resources=resources,
-                mapping=mapping,
-                llm_args=llm_args,
-                ctx_chunk_config=ctx_chunk_config,
-                model_engine=model_engine,
-                start_worker=False,
-                sampler=sampler,
-                drafter=drafter,
-                guided_decoder=guided_decoder,
-                lora_config=lora_config,
-                garbage_collection_gen0_threshold=
-                garbage_collection_gen0_threshold,
-                kv_connector_manager=kv_connector_manager,
-                max_seq_len=max_seq_len,
-                max_batch_size=max_batch_size,
-                max_beam_width=max_beam_width,
-                max_num_tokens=max_num_tokens,
-                peft_cache_config=peft_cache_config,
-                scheduler_config=scheduler_config,
-                cache_transceiver_config=cache_transceiver_config,
-                virtual_memory_pools=vm_pools,
-                execution_stream=execution_stream,
-            )
-
-    _adjust_torch_mem_fraction()
-
     if mapping.rank == 0:
         logger.info(f"LLM Args:\n{llm_args}")
 
-    py_executor.start_worker()
     return py_executor

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -198,7 +198,6 @@ class KVCacheManager(BaseResourceManager):
         enable_indexer_k_cache: bool = False,
         indexer_k_cache_quant_block_size: int = 128,
         indexer_k_cache_index_head_dim: int = 0,
-        is_estimating_kv_cache: bool = False,
         execution_stream: Optional[torch.cuda.Stream] = None,
         **kwargs,
     ) -> None:
@@ -299,57 +298,34 @@ class KVCacheManager(BaseResourceManager):
         # FIXME: flashinfer.py accesses kv_cache_manager.blocks_in_primary_pool
         # This dependency should be adjusted as it only covers the single window
         # case and not VSWA scheme.
-        if is_estimating_kv_cache:
-            # If this is an estimation dry run, we have already calculated the
-            # max_tokens under _util.py::try_prepare_estimation
-            # Since this is a dry run, assigning the same max_tokens capacity
-            # to all window sizes as they are full attentions is enough.
-            self.blocks_in_primary_pool = int(kv_cache_config.max_tokens //
-                                              tokens_per_block)
-
-            host_cache_size = kv_cache_config.host_cache_size if kv_cache_config.host_cache_size else 0
-            max_tokens_secondary = host_cache_size // self.get_cache_bytes_per_token(
-            )
-            self.blocks_in_secondary_pool = int(max_tokens_secondary //
-                                                tokens_per_block)
-
-            blocks_per_window = {
-                window_size:
-                (self.blocks_in_primary_pool, self.blocks_in_secondary_pool)
-                for window_size in set(self.max_attention_window_vec)
-            }
-            logger.info(
-                f"[kv cache manager] Primary/secondary blocks for window sizes set to {blocks_per_window} for estimation dry run"
+        if self.is_vswa:
+            # VSWA case: use C++ implementation for variable window sizes
+            if model_config is None:
+                raise ValueError(
+                    "model_config is required for VSWA (Variable Sliding Window Attention)"
+                )
+            assert isinstance(
+                kv_cache_config, KvCacheConfig
+            ), "calculate_max_num_blocks_from_cpp only accepts KvCacheConfig"
+            blocks_per_window = self.calculate_max_num_blocks_from_cpp(
+                kv_cache_config=kv_cache_config,
+                model_config=model_config,
+                extra_cost_memory=0,
             )
         else:
-            if self.is_vswa:
-                # VSWA case: use C++ implementation for variable window sizes
-                if model_config is None:
-                    raise ValueError(
-                        "model_config is required for VSWA (Variable Sliding Window Attention)"
-                    )
-                assert isinstance(
-                    kv_cache_config, KvCacheConfig
-                ), "calculate_max_num_blocks_from_cpp only accepts KvCacheConfig"
-                blocks_per_window = self.calculate_max_num_blocks_from_cpp(
-                    kv_cache_config=kv_cache_config,
-                    model_config=model_config,
-                    extra_cost_memory=0,
-                )
-            else:
-                # Standard case: use original Python implementation
-                self.blocks_in_primary_pool, self.blocks_in_secondary_pool = self.calculate_max_num_blocks(
-                    kv_cache_config=kv_cache_config,
-                    head_dim=head_dim,
-                    tokens_per_block=tokens_per_block,
-                    mapping=mapping,
-                    dtype=dtype,
-                    kv_factor=self.kv_factor,
-                )
-                blocks_per_window = {
-                    self.max_attention_window_vec[0]:
-                    (self.blocks_in_primary_pool, self.blocks_in_secondary_pool)
-                }
+            # Standard case: use original Python implementation
+            self.blocks_in_primary_pool, self.blocks_in_secondary_pool = self.calculate_max_num_blocks(
+                kv_cache_config=kv_cache_config,
+                head_dim=head_dim,
+                tokens_per_block=tokens_per_block,
+                mapping=mapping,
+                dtype=dtype,
+                kv_factor=self.kv_factor,
+            )
+            blocks_per_window = {
+                self.max_attention_window_vec[0]:
+                (self.blocks_in_primary_pool, self.blocks_in_secondary_pool)
+            }
 
         # Validate and adjust attention windows against their upper bounds if needed
         blocks_per_window, self.max_seq_len, self.max_attention_window_vec = self._validate_and_adjust_attention_windows(

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -1399,7 +1399,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device_memory(60000)
     def test_bfloat16_2_model_mtp(self):
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.5)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
         pytorch_config = dict(
             disable_overlap_scheduler=True,
             cuda_graph_config=CudaGraphConfig(),
@@ -2280,7 +2280,7 @@ class TestDeepSeekR1(LlmapiAccuracyTestHarness):
         if moe_backend == "TRTLLM" and sm_version in (120, 121):
             pytest.skip(f"{moe_backend} backend does not support SM 120 or 121")
 
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.70)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.60)
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
             cuda_graph_config=CudaGraphConfig() if cuda_graph else None,
@@ -3786,12 +3786,15 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             disable_overlap_scheduler=not overlap_scheduler,
             cuda_graph_config=CudaGraphConfig() if cuda_graph else None)
 
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.5, )
+
         with LLM(f"{llm_models_root()}/Qwen3/Qwen3-8B"
                  if is_cached else "Qwen/Qwen3-8B",
                  tensor_parallel_size=tp_size,
                  pipeline_parallel_size=pp_size,
                  moe_expert_parallel_size=ep_size,
                  **pytorch_config,
+                 kv_cache_config=kv_cache_config,
                  enable_attention_dp=attention_dp) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -62,7 +62,7 @@ def nano_llm_model():
         tensor_parallel_size=1,
         max_batch_size=2,
         cuda_graph_config=CudaGraphConfig(),
-        kv_cache_config=KvCacheConfig(enable_block_reuse=False, mamba_ssm_cache_dtype="float32"),
+        kv_cache_config=KvCacheConfig(enable_block_reuse=False, mamba_ssm_cache_dtype="float32", free_gpu_memory_fraction=0.4),
     )
     yield nano_llm
 

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -62,7 +62,9 @@ def nano_llm_model():
         tensor_parallel_size=1,
         max_batch_size=2,
         cuda_graph_config=CudaGraphConfig(),
-        kv_cache_config=KvCacheConfig(enable_block_reuse=False, mamba_ssm_cache_dtype="float32", free_gpu_memory_fraction=0.4),
+        kv_cache_config=KvCacheConfig(
+            enable_block_reuse=False, mamba_ssm_cache_dtype="float32", free_gpu_memory_fraction=0.4
+        ),
     )
     yield nano_llm
 

--- a/tests/unittest/llmapi/apps/_test_openai_lora.py
+++ b/tests/unittest/llmapi/apps/_test_openai_lora.py
@@ -42,7 +42,10 @@ def temp_extra_llm_api_options_file():
             },
             # Disable CUDA graph
             # TODO: remove this once we have a proper fix for CUDA graph in LoRA
-            "cuda_graph_config": None
+            "cuda_graph_config": None,
+            "kv_cache_config": {
+                "free_gpu_memory_fraction": 0.5
+            },
         }
 
         with open(temp_file_path, 'w') as f:

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_lora.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_lora.py
@@ -28,7 +28,10 @@ def temp_extra_llm_api_options_file():
                 "max_lora_rank": 8,
                 "max_loras": 4,
                 "max_cpu_loras": 4,
-            }
+            },
+            "kv_cache_config": {
+                "free_gpu_memory_fraction": 0.5
+            },
         }
 
         with open(temp_file_path, 'w') as f:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Variable Sliding Window Attention (VSWA) detection for improved memory management.

* **Bug Fixes**
  * Fixed potential errors during CUDA graph cleanup.

* **Performance & Optimization**
  * Increased GPU memory allocation for KV caches across configurations, improving throughput.
  * Simplified KV cache memory management by removing estimation profiling logic.
  * Streamlined internal memory configuration flow for faster initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
