### PR TITLE
[TRTLLM-9687][feat] Improve are_stop_words performance

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1507,7 +1507,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             # Host Tensor for host access of self.store.num_accepted_draft_tokens
             stop_word_seq_slots_tensor_host = torch.tensor(
-                stop_word_seq_slots, device="cpu", dtype=torch.int32, pin_memory=True
+                stop_word_seq_slots, device="cpu", dtype=torch.int32, pin_memory=prefer_pinned()
             )
             # Device Tensor for device access of self.store.stop_words and self.store.past_tokens
             stop_word_seq_slots_tensor_cuda = stop_word_seq_slots_tensor_host.to(
@@ -1562,7 +1562,9 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             )
             _ = stop_words_host.fill_(self._EMPTY_STOP_WORD_TOKEN_ID)
             words, cumulative_stop_word_lengths = stop_words_list
-            words_host = torch.tensor(words, device="cpu", dtype=torch.int32, pin_memory=True)
+            words_host = torch.tensor(
+                words, device="cpu", dtype=torch.int32, pin_memory=prefer_pinned()
+            )
             begin = 0
             max_stop_word_length = 0
             num_stop_words = 0
@@ -1601,7 +1603,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 self._max_beam_width,
                 device="cpu",
                 dtype=torch.int32,
-                pin_memory=True,
+                pin_memory=prefer_pinned(),
             )
             tokens = request.get_tokens()
             for beam_idx in range(self._max_beam_width):

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -672,7 +672,6 @@ class TestFinishReasons:
                 num_accepted_tokens, stop_word_indices, single_token_stop_words_only = (
                     sampler._finish_reasons_handler._prepare_stop_word_handling_for_finish_reasons(
                         seq_slots_host,
-                        torch.zeros(len(requests), dtype=torch.bool),
                         torch.zeros((0,), dtype=torch.bool),
                     )
                 )

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -672,7 +672,6 @@ class TestFinishReasons:
                 sampler.store.new_tokens[:, seq_slots_cuda, cls.BEAM] = new_tokens_cuda
 
                 is_draft_batch = False
-                is_last_context_chunk = torch.zeros((0,), dtype=torch.bool)
                 # Capture return value of write_finish_reasons for use after _uut() runs.
                 write_finish_reasons_result: list[torch.Tensor] = []
 
@@ -681,7 +680,6 @@ class TestFinishReasons:
                         result = sampler._finish_reasons_handler.write_finish_reasons(
                             seq_slots_host=seq_slots_host,
                             is_draft_batch=is_draft_batch,
-                            is_last_context_chunk=is_last_context_chunk,
                             seq_slots_cuda=seq_slots_cuda,
                             seq_lens_cuda=seq_lens_cuda,
                             new_tokens_cuda=sampler.store.new_tokens,

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -647,13 +647,18 @@ class TestFinishReasons:
                     disable_overlap_scheduler=False,
                 )
                 sampler = TorchSampler(args=sampler_args)
+                # setup the sampler store for the requests
+                scheduled_requests = ScheduledRequests()
+                scheduled_requests.context_requests = [req.request for req in requests]
+                sampler.setup_sampler_step(scheduled_requests)
 
                 # fill with garbage value so we can observe that finish reasons are filled
                 # with NOT_FINISHED before we write to them.
                 sampler.store.finish_reasons.fill_(205)
-                seq_slots = torch.tensor(
-                    [req.request.py_seq_slot for req in requests], device="cuda", dtype=torch.int64
+                seq_slots_host = torch.tensor(
+                    [req.request.py_seq_slot for req in requests], device="cpu", dtype=torch.int64
                 )
+                seq_slots_device = seq_slots_host.to(device="cuda", non_blocking=True)
                 seq_lens = torch.tensor(
                     [req.request.max_beam_num_tokens for req in requests],
                     dtype=torch.int32,
@@ -662,42 +667,26 @@ class TestFinishReasons:
                 new_tokens = torch.tensor(
                     [req.new_tokens for req in requests], dtype=torch.int32, device="cuda"
                 ).T
-                sampler.store.new_tokens[:, seq_slots, cls.BEAM] = new_tokens
-                max_seq_lens = torch.tensor(
-                    [
-                        min(
-                            sampler.max_seq_len,
-                            req.request.orig_prompt_len + req.request.py_max_new_tokens,
-                        )
-                        for req in requests
-                    ],
-                    dtype=torch.int32,
-                    device="cuda",
+                sampler.store.new_tokens[:, seq_slots_device, cls.BEAM] = new_tokens
+                num_accepted_tokens, stop_word_indices, single_token_stop_words_only = (
+                    sampler._prepare_stop_word_handling_for_finish_reasons(seq_slots_host)
                 )
-                end_ids = torch.tensor(
-                    [
-                        req.request.py_end_id if req.request.py_end_id is not None else -1
-                        for req in requests
-                    ],
-                    dtype=torch.int32,
-                    device="cuda",
-                )
-                sampler.store.max_lengths_tensor[seq_slots] = max_seq_lens
-                sampler.store.end_ids[seq_slots] = end_ids
 
                 def _uut():
                     with extra_context() if extra_context is not None else nullcontext():
                         sampler._write_finish_reasons(
-                            [req.request for req in requests],
                             finish_reasons=sampler.store.finish_reasons,
                             new_tokens=sampler.store.new_tokens,
                             seq_lens=seq_lens,
-                            seq_slots=seq_slots,
+                            seq_slots=seq_slots_device,
+                            num_accepted_tokens=num_accepted_tokens,
+                            stop_word_indices=stop_word_indices,
+                            single_token_stop_words_only=single_token_stop_words_only,
                         )
 
                 yield _uut
 
-                reasons = sampler.store.finish_reasons[:, seq_slots, cls.BEAM].T.tolist()
+                reasons = sampler.store.finish_reasons[:, seq_slots_device, cls.BEAM].T.tolist()
 
                 for actual, request in zip(reasons, requests, strict=True):
                     expected = request.finish_reasons
@@ -723,15 +712,6 @@ class TestFinishReasons:
                     stop_words_list=[[12, 13]],
                     new_tokens=[12, 13, 60],
                     finish_reasons=[cls.NOT_FINISHED, cls.STOP_WORDS, cls.NOT_FINISHED],
-                ),
-                cls.RequestCase(
-                    prompt=[7, 8, 6],
-                    stop_words_list=[[12, 13]],
-                    new_tokens=[60, 12, 13],
-                    # The request has stop words, but no draft is created
-                    # Tokens at indices greater than 0 should be ignored
-                    num_draft_tokens=0,
-                    finish_reasons=[cls.NOT_FINISHED, cls.NOT_FINISHED, cls.NOT_FINISHED],
                 ),
                 cls.RequestCase(
                     prompt=[1, 2, 3, 4],
@@ -807,6 +787,58 @@ class TestFinishReasons:
         def raising_stop_words_ctx(expect_raise: bool) -> Generator[None, None, None]:
             with monkeypatch.context() as patch_ctx:
                 patch_ctx.setattr(TorchSampler, "_are_stop_words", stop_words_that_raises)
+                patch_ctx.setattr(
+                    TorchSampler, "_are_stop_words_single_token", stop_words_that_raises
+                )
+                with pytest.raises(AssertionError) if expect_raise else nullcontext():
+                    yield
+
+        uut_provider_with_stop_words = cls.RequestCase.build(
+            [
+                cls.RequestCase(
+                    prompt=[1],
+                    stop_words_list=[[1, 2]],
+                    new_tokens=[4],
+                    finish_reasons=[cls.NOT_FINISHED],
+                ),
+                cls.RequestCase(
+                    prompt=[1],
+                    stop_words_list=[[1]],
+                    new_tokens=[4],
+                    finish_reasons=[cls.NOT_FINISHED],
+                ),
+            ],
+            extra_context=lambda: raising_stop_words_ctx(True),
+        )
+        run_test_with_warmup(uut_provider_with_stop_words, max_sync_s=0.5)
+
+        uut_provider_with_stop_words = cls.RequestCase.build(
+            [
+                cls.RequestCase(
+                    prompt=[1],
+                    new_tokens=[4],
+                    finish_reasons=[cls.NOT_FINISHED],
+                )
+            ],
+            extra_context=lambda: raising_stop_words_ctx(False),
+        )
+        run_test_with_warmup(uut_provider_with_stop_words, max_sync_s=0.5)
+
+    @classmethod
+    def test_are_stop_words_single_token_is_called_when_single_token_stop_words_are_present(
+        cls, monkeypatch: pytest.MonkeyPatch
+    ):
+        """We don't want to call are_stop_words when there are only single token stop words because it's expensive"""
+
+        def stop_words_that_raises(*args, **kwargs):
+            raise AssertionError
+
+        @contextmanager
+        def raising_single_token_stop_words_ctx(expect_raise: bool) -> Generator[None, None, None]:
+            with monkeypatch.context() as patch_ctx:
+                patch_ctx.setattr(
+                    TorchSampler, "_are_stop_words_single_token", stop_words_that_raises
+                )
                 with pytest.raises(AssertionError) if expect_raise else nullcontext():
                     yield
 
@@ -819,15 +851,168 @@ class TestFinishReasons:
                     finish_reasons=[cls.NOT_FINISHED],
                 )
             ],
-            extra_context=lambda: raising_stop_words_ctx(True),
+            extra_context=lambda: raising_single_token_stop_words_ctx(True),
         )
         run_test_with_warmup(uut_provider_with_stop_words, max_sync_s=0.5)
 
-        uut_provider_without_stop_words = cls.RequestCase.build(
-            [cls.RequestCase(prompt=[1], new_tokens=[4], finish_reasons=[cls.NOT_FINISHED])],
-            extra_context=lambda: raising_stop_words_ctx(False),
+        uut_provider_with_stop_words = cls.RequestCase.build(
+            [
+                cls.RequestCase(
+                    prompt=[1],
+                    stop_words_list=[[1, 2]],
+                    new_tokens=[4],
+                    finish_reasons=[cls.NOT_FINISHED],
+                )
+            ],
+            extra_context=lambda: raising_single_token_stop_words_ctx(False),
         )
-        run_test_with_warmup(uut_provider_without_stop_words, max_sync_s=0.5)
+        run_test_with_warmup(uut_provider_with_stop_words, max_sync_s=0.5)
+
+    @classmethod
+    def check_resize_and_update_stop_words_buffer(
+        cls,
+        old_stop_words: torch.Tensor,
+        old_past_tokens: torch.Tensor,
+        new_stop_words: torch.Tensor,
+        new_past_tokens: torch.Tensor,
+        seq_slots_to_compare: torch.Tensor,
+        num_draft_tokens: int,
+    ):
+        old_num_stop_words = old_stop_words.shape[0]
+        old_stop_word_length = old_stop_words.shape[1]
+
+        old_past_token_length = old_past_tokens.shape[0]
+
+        # These sizes should not change after the resize
+        assert old_stop_words.shape[2] == new_stop_words.shape[2]
+        assert old_past_tokens.shape[1] == new_past_tokens.shape[1]
+        assert old_past_tokens.shape[2] == new_past_tokens.shape[2]
+
+        assert (
+            new_stop_words[-old_num_stop_words:, -old_stop_word_length:, seq_slots_to_compare]
+            == old_stop_words[..., seq_slots_to_compare]
+        ).all()
+        # initial fill has an offset of 1, as there will be a shift happening during sample_async
+        assert (
+            new_past_tokens[-old_past_token_length:-num_draft_tokens, seq_slots_to_compare, :]
+            == old_past_tokens[:-num_draft_tokens, seq_slots_to_compare, :]
+        ).all()
+
+    @classmethod
+    def test_stop_words_buffer_resize(cls, monkeypatch: pytest.MonkeyPatch):
+        @contextmanager
+        def check_resize_ctx() -> Generator[None, None, None]:
+            with monkeypatch.context() as patch_ctx:
+                setup_sampler_step_orig = TorchSampler.setup_sampler_step
+
+                def setup_sampler_step_with_size_check(self, scheduled_requests: ScheduledRequests):
+                    # RequestCase.build calls setup_sampler_step to fill the buffers for all context requests
+                    # Move the context requests to the generation requests
+                    scheduled_requests.generation_requests = scheduled_requests.context_requests
+                    # Add a request that enforces a resize
+                    scheduled_requests.context_requests = [
+                        cls.RequestCase(
+                            prompt=[1],
+                            stop_words_list=[
+                                [x for x in range(2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH)]
+                            ],
+                            new_tokens=[4],
+                            finish_reasons=[cls.NOT_FINISHED],
+                        ).request
+                    ]
+                    # Store the old stop words and past tokens for comparison
+                    old_stop_words = self.store.stop_words.clone()
+                    old_past_tokens = self.store.past_tokens.clone()
+                    # Call setup sampler step to trigger the resize
+                    setup_sampler_step_orig(self, scheduled_requests)
+
+                    # Check if sizes are correct
+                    assert self.store.stop_words.shape[0] == TorchSampler.DEFAULT_MAX_STOP_WORDS
+                    assert (
+                        self.store.stop_words.shape[1]
+                        == 2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH
+                    )
+                    assert self.max_tokens == 1
+                    assert (
+                        self.store.past_tokens.shape[0]
+                        == 2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH - 1 + self.max_tokens
+                    )
+                    # Check if values are added correctly
+                    seq_slots_to_compare_cuda = torch.Tensor(
+                        [
+                            scheduled_requests.generation_requests[x].py_seq_slot
+                            for x in range(len(scheduled_requests.generation_requests))
+                        ]
+                    ).to(device="cuda", dtype=torch.int32, non_blocking=True)
+                    cls.check_resize_and_update_stop_words_buffer(
+                        old_stop_words,
+                        old_past_tokens,
+                        self.store.stop_words,
+                        self.store.past_tokens,
+                        seq_slots_to_compare_cuda,
+                        self.max_draft_len,
+                    )
+
+                patch_ctx.setattr(
+                    TorchSampler, "setup_sampler_step", setup_sampler_step_with_size_check
+                )
+                yield
+
+        # The test adds one more request
+        num_requests = 8
+        uut_provider_with_resize_on_demand = cls.RequestCase.build(
+            [
+                cls.RequestCase(
+                    prompt=[1 + x],
+                    stop_words_list=[[x + 100]],
+                    new_tokens=[x + 4, x + 3, x + 2],
+                    finish_reasons=[cls.NOT_FINISHED, cls.NOT_FINISHED, cls.NOT_FINISHED],
+                )
+                for x in range(num_requests)
+            ],
+            extra_context=lambda: check_resize_ctx(),
+        )
+        run_test_with_warmup(uut_provider_with_resize_on_demand, max_sync_s=0.5)
+
+    @classmethod
+    def test_stop_words_buffer_resizes_on_demand(cls, monkeypatch: pytest.MonkeyPatch):
+        @contextmanager
+        def check_resize_ctx() -> Generator[None, None, None]:
+            with monkeypatch.context() as patch_ctx:
+                setup_sampler_step_orig = TorchSampler.setup_sampler_step
+
+                def setup_sampler_step_with_size_check(self, scheduled_requests: ScheduledRequests):
+                    setup_sampler_step_orig(self, scheduled_requests)
+                    assert self.store.stop_words.shape[0] == TorchSampler.DEFAULT_MAX_STOP_WORDS
+                    assert (
+                        self.store.stop_words.shape[1]
+                        == 2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH
+                    )
+                    assert self.max_tokens == 1
+                    assert (
+                        self.store.past_tokens.shape[0]
+                        == 2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH - 1 + self.max_tokens
+                    )
+
+                patch_ctx.setattr(
+                    TorchSampler, "setup_sampler_step", setup_sampler_step_with_size_check
+                )
+                yield
+
+        uut_provider_with_resize_on_demand = cls.RequestCase.build(
+            [
+                cls.RequestCase(
+                    prompt=[1],
+                    stop_words_list=[
+                        [x for x in range(2 * TorchSampler.DEFAULT_MAX_STOP_WORD_LENGTH)]
+                    ],
+                    new_tokens=[4],
+                    finish_reasons=[cls.NOT_FINISHED],
+                )
+            ],
+            extra_context=lambda: check_resize_ctx(),
+        )
+        run_test_with_warmup(uut_provider_with_resize_on_demand, max_sync_s=None)
 
 
 class TestBatchedSampling:
@@ -1139,12 +1324,19 @@ class TestBatchedSampling:
         use_flashinfer: bool,
         max_draft_len: int,
         seq_slot_assignment: tuple[list[int], int],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> TorchSampler:
-        return self._build_sampler(
-            use_flashinfer=use_flashinfer,
-            max_draft_len=max_draft_len,
-            seq_slot_assignment=seq_slot_assignment,
-        )
+        # Patch the sampler to setup every context request.
+        def always_true(*args, **kwargs) -> bool:
+            return True
+
+        with monkeypatch.context() as patch_ctx:
+            patch_ctx.setattr(TorchSampler, "_is_new_request", always_true)
+            return self._build_sampler(
+                use_flashinfer=use_flashinfer,
+                max_draft_len=max_draft_len,
+                seq_slot_assignment=seq_slot_assignment,
+            )
 
     def _build_sampler(
         self,

--- a/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
@@ -46,8 +46,9 @@ def run_test(eagle_model_dir, max_seq_len, beam_width, use_dynamic_tree,
             max_beam_width=beam_width,
         ))
     # fill with NOT_FINISHED to ensure that all finish reasons are NOT_FINISHED
-    torch_sampler.store.finish_reasons.fill_(FinishReason.NOT_FINISHED.value)
-    finish_reasons_list = torch_sampler.store.finish_reasons.to(
+    torch_sampler._finish_reasons_handler.store.finish_reasons_cuda.fill_(
+        FinishReason.NOT_FINISHED.value)
+    finish_reasons_list = torch_sampler._finish_reasons_handler.store.finish_reasons_cuda.to(
         device="cpu").permute(1, 0, 2).tolist()
     input_new_tokens_list = input_new_tokens.tolist()
     num_accepted_draft_tokens = torch_sampler._process_draft_tokens_tree(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the internal architecture of the sampling engine for improved efficiency and maintainability.
  * Enhanced stop-word recognition mechanisms and optimized buffer handling to reduce memory overhead during token generation.
  * Added comprehensive profiling support to enable detailed performance analysis and facilitate debugging.
  * Improved resource management through better buffer allocation and resizing strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Improve are_stop_words performance by caching stop words and past tokens in the TorchSampler Store.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
