### PR TITLE
[#10931][feat] AutoDeploy: Eagle One-Model [3/n]: E2E implementation for Llama-3.1-8B-Instruct

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -83,6 +83,7 @@ transforms:
     stage: pattern_matcher
   detect_hidden_states_for_capture:
     stage: pattern_matcher
+    run_per_gm: false
   detect_sharding:
     stage: sharding
     simple_shard_only: false

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
@@ -22,13 +22,16 @@ This file contains model definitions used for executing Eagle3 speculative decod
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.speculative.eagle3 import Eagle3ResourceManager
+from tensorrt_llm.llmapi.llm_args import EagleDecodingConfig
 
 from ...utils._config import deep_merge_dicts
 from ...utils.logger import ad_logger
@@ -575,7 +578,7 @@ class EagleWrapper(nn.Module):
         """Apply embedding to input_ids for the draft model."""
         if self.load_embedding_from_target:
             embeds = self.target_model.get_input_embeddings()(input_ids)
-            return embeds.to(self.draft_model.dtype)
+            return embeds.to(self.draft_model.model.dtype)
         else:
             return self.draft_model.get_input_embeddings()(input_ids)
 
@@ -583,15 +586,368 @@ class EagleWrapper(nn.Module):
         """Apply lm_head to get logits from hidden states."""
         if self.load_lm_head_from_target:
             lm_head_weights = self.target_model.get_output_embeddings()(hidden_states)
-            return lm_head_weights.to(self.draft_model.dtype)
+            return lm_head_weights.to(self.draft_model.model.dtype)
         else:
             return self.draft_model.get_output_embeddings()(hidden_states)
+
+    def _filter_kwargs_for_submodule(self, kwargs: dict, submodule: nn.Module) -> dict:
+        """Filter kwargs to only include those accepted by submodule's forward."""
+        # Get input names from GraphModule's placeholder nodes
+        expected_names = {node.name for node in submodule.graph.nodes if node.op == "placeholder"}
+        return {k: v for k, v in kwargs.items() if k in expected_names}
+
+    def _recompute_metadata_from_position_ids(
+        self,
+        kwargs: dict,
+        packed_position_ids: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> dict:
+        """Recompute all position-related metadata from packed position_ids and seq_lens.
+
+        This is the shared helper used by _prepare_next_draft_metadata to derive
+        all metadata from position_ids.
+
+        Args:
+            kwargs: Current kwargs dict (already filtered for submodule). Used to get
+                page_size from k_cache and to copy non-metadata keys.
+            packed_position_ids: Position IDs in packed format [1, total_tokens].
+            seq_lens: Number of tokens per sequence [num_seq]. Can be a tensor or list.
+
+        Returns:
+            New kwargs dict with all metadata recomputed from position_ids.
+        """
+        device = packed_position_ids.device
+
+        # Convert seq_lens to tensor if needed
+        if not isinstance(seq_lens, torch.Tensor):
+            seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.int32, device=device)
+        else:
+            seq_lens_tensor = seq_lens.int().to(device)
+
+        num_seq = len(seq_lens_tensor)
+
+        # Get page_size from kv_cache shape
+        # HND layout (default): [..., num_kv_heads, page_size, head_dim]
+        # page_size is always at index -2 (second to last)
+        page_size = None
+        for key, val in kwargs.items():
+            if key.startswith("kv_cache") and isinstance(val, torch.Tensor):
+                page_size = val.shape[-2]
+                break
+
+        if page_size is None:
+            raise ValueError(
+                f"Could not determine page_size from kv_cache in kwargs. Keys: {list(kwargs.keys())}"
+            )
+
+        # Compute cu_seqlen: cumulative sequence lengths [0, seq_len[0], seq_len[0]+seq_len[1], ...]
+        cu_seqlen = torch.zeros(num_seq + 1, dtype=torch.int32, device=device)
+        cu_seqlen[1:] = torch.cumsum(seq_lens_tensor, dim=0)
+        cu_seqlen_host = cu_seqlen.cpu()
+
+        # Compute batch_info: [num_prefill, num_prefill_tokens, num_decode]
+        # seq_len > 1 is "prefill" (multi-token), seq_len == 1 is "decode"
+        num_prefill = (seq_lens_tensor > 1).sum().item()
+        num_prefill_tokens = seq_lens_tensor[seq_lens_tensor > 1].sum().item()
+        num_decode = (seq_lens_tensor <= 1).sum().item()
+        batch_info_host = torch.tensor(
+            [num_prefill, num_prefill_tokens, num_decode], dtype=torch.int32, device="cpu"
+        )
+
+        # Compute seq_len_with_cache for each sequence
+        # seq_len_with_cache = last_position + 1 = position_ids[last_token_of_seq] + 1
+        # Last token of sequence i is at packed index cu_seqlen[i+1] - 1
+        last_token_indices = cu_seqlen[1:] - 1  # [num_seq]
+        last_positions = packed_position_ids[0, last_token_indices]  # [num_seq]
+        seq_len_with_cache = (last_positions + 1).int()
+        seq_len_with_cache_host = seq_len_with_cache.cpu()
+
+        # Compute last_page_len: (seq_len_with_cache - 1) % page_size + 1
+        last_page_len = ((seq_len_with_cache - 1) % page_size + 1).int()
+        last_page_len_host = last_page_len.cpu()
+
+        # Compute pages_per_seq: ceil(seq_len_with_cache / page_size) for each sequence
+        # Using integer math: (x + page_size - 1) // page_size = ceil(x / page_size)
+        pages_per_seq = ((seq_len_with_cache + page_size - 1) // page_size).int()
+        pages_per_seq_host = pages_per_seq.cpu()
+
+        # Compute cu_num_pages: cumulative sum [0, p0, p0+p1, p0+p1+p2, ...]
+        cu_num_pages = torch.zeros(num_seq + 1, dtype=torch.int32, device=device)
+        cu_num_pages[1:] = torch.cumsum(pages_per_seq, dim=0)
+        cu_num_pages_host = cu_num_pages.cpu()
+
+        # Build new kwargs with recomputed metadata
+        metadata_updates = {
+            "batch_info_host": batch_info_host,
+            "cu_seqlen_host": cu_seqlen_host,
+            "cu_seqlen": cu_seqlen,
+            "seq_len_with_cache": seq_len_with_cache,
+            "seq_len_with_cache_host": seq_len_with_cache_host,
+            "last_page_len": last_page_len,
+            "last_page_len_host": last_page_len_host,
+            "pages_per_seq": pages_per_seq,
+            "pages_per_seq_host": pages_per_seq_host,
+            "cu_num_pages": cu_num_pages,
+            "cu_num_pages_host": cu_num_pages_host,
+        }
+
+        new_kwargs = {}
+        for key, val in kwargs.items():
+            if key in metadata_updates:
+                new_kwargs[key] = metadata_updates[key]
+            else:
+                # Pass through unchanged (caches, cache_loc, etc.)
+                new_kwargs[key] = val
+
+        return new_kwargs
+
+    def _prepare_next_draft_metadata(
+        self,
+        kwargs: dict,
+        curr_position_ids: torch.Tensor,
+        curr_cu_seq_len: torch.Tensor,
+        num_sequences: int,
+        num_accepted: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict]:
+        """Prepare position_ids and metadata for the next draft iteration.
+
+        Extracts positions from each sequence at the last accepted token and increments
+        by 1, then recomputes all metadata including cu_num_pages for page boundary handling.
+
+        Args:
+            kwargs: Current kwargs dict
+            curr_position_ids: [1, total_tokens] - current position IDs
+            curr_cu_seq_len: [num_seq + 1] - cumulative sequence lengths (may be pre-allocated)
+            num_sequences: Actual number of sequences to process
+            num_accepted: [num_seq] - number of accepted tokens per sequence.
+                Extracts at cu_seqlen[i] + num_accepted[i] - 1 for each sequence.
+
+        Returns:
+            Tuple of:
+            - new_position_ids: [1, num_seq] - next position for each sequence
+            - new_kwargs: dict with recomputed metadata
+        """
+        # Compute extraction indices: cu_seqlen[i] + num_accepted[i] - 1
+        extraction_indices = (curr_cu_seq_len[:num_sequences] + num_accepted - 1).long()
+
+        # Get positions at extraction indices and increment by 1
+        extracted_positions = curr_position_ids[0, extraction_indices]
+        new_position_ids = (extracted_positions + 1).unsqueeze(0)  # [1, num_sequences]
+
+        # Each draft iteration is a standard decode step (1 token per sequence)
+        seq_lens = torch.ones(
+            new_position_ids.shape[1], dtype=torch.int32, device=curr_position_ids.device
+        )
+
+        # Recompute all metadata from the new packed position_ids
+        new_kwargs = self._recompute_metadata_from_position_ids(kwargs, new_position_ids, seq_lens)
+
+        return new_position_ids, new_kwargs
+
+    def _extract_draft_iteration_outputs(
+        self,
+        draft_idx: int,
+        draft_output: Any,
+        draft_output_logits: torch.Tensor,
+        draft_kwargs: dict,
+        num_sequences: int,
+        num_accepted: torch.Tensor = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Extract logits and hidden state from draft model output.
+
+        This helper encapsulates the iteration-dependent indexing logic:
+        - iter 0 (prefill-like): Extract at num_accepted-1 indices (leveraging causal attention)
+        - iter 1+ (decode-like): Each sequence has exactly 1 token, simple indexing
+
+        Args:
+            draft_idx: Current draft iteration index (0 = first/prefill-like, 1+ = decode-like)
+            draft_output: Output from draft model forward
+            draft_output_logits: Logits from lm_head, packed [1, total_tokens, vocab_size]
+            draft_kwargs: kwargs used for this iteration (contains cu_seqlen)
+            num_sequences: Actual number of sequences to process
+            num_accepted: [num_seq] - number of accepted tokens per sequence (required for iter 0)
+
+        Returns:
+            Tuple of:
+            - latest_draft_logits: [num_seq, vocab_size] - logits at extraction position
+            - last_draft_hidden_state: [num_seq, hidden_size] - hidden state at extraction position
+        """
+        if draft_idx == 0:
+            # First call: extract at num_accepted-1 indices (leveraging causal attention)
+            # With untruncated input, we ran full sequences through the draft model
+            # The output at position (num_accepted - 1) is equivalent to running truncated input
+            # cu_seqlen[i] gives the start of sequence i in the packed tensor
+            # We extract at cu_seqlen[i] + num_accepted[i] - 1
+            if num_accepted is None:
+                raise ValueError("num_accepted must be provided for draft_idx == 0")
+
+            cu_seqlen = draft_kwargs["cu_seqlen"]
+            # Compute extraction indices: cu_seqlen[i] + num_accepted[i] - 1 for each sequence
+            extraction_indices = cu_seqlen[:num_sequences] + num_accepted - 1  # [num_sequences]
+            extraction_indices = extraction_indices.long()
+
+            latest_draft_logits = draft_output_logits[0, extraction_indices, :]  # [num_seq, vocab]
+            last_draft_hidden_state = draft_output.last_hidden_state[
+                0, extraction_indices, :
+            ]  # [num_seq, hidden]
+        else:
+            # Subsequent calls: decode_cu_seqlen = [0, 1, 2, ..., num_sequences]
+            # Last token of seq i is at position i (since each seq has 1 token)
+            # Simplifies to taking all tokens: output[0, :, :] = [num_seq, ...]
+            latest_draft_logits = draft_output_logits[0, :, :]  # [num_seq, vocab]
+            last_draft_hidden_state = draft_output.last_hidden_state[0, :, :]  # [num_seq, hidden]
+
+        return latest_draft_logits, last_draft_hidden_state
 
     def sample_greedy(self, logits: torch.Tensor) -> torch.Tensor:
         ret = torch.argmax(logits, dim=-1)
         return ret
 
-    def sample_and_verify(
+    def prepare_draft_context(
+        self,
+        packed_input_ids: torch.Tensor,
+        packed_logits: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        num_context: int,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Sample new tokens for prefill sequences (no verification needed).
+
+        For prefill, all input tokens are the prompt (already "accepted").
+        We just sample a new token from the last logit position.
+
+        Args:
+            packed_input_ids: [1, total_tokens] - packed input token ids (full batch)
+            packed_logits: [1, total_tokens, vocab_size] - packed logits from target model (full batch)
+            cu_seqlen: [num_sequences + 1] - cumulative sequence lengths (full batch)
+            num_context: number of context (prefill) sequences
+
+        Returns:
+            packed_output_ids: [1, ctx_tokens] - shifted input + sampled token per context sequence,
+                or None if num_context == 0
+            num_accepted: [num_context] - always seq_len (all prompt tokens accepted),
+                or None if num_context == 0
+        """
+        if num_context == 0:
+            return None, None
+
+        # Slice to get only context sequences
+        ctx_cu_seqlen = cu_seqlen[: num_context + 1]
+        ctx_end_token = ctx_cu_seqlen[-1]
+        ctx_input_ids = packed_input_ids[:, :ctx_end_token]  # [1, ctx_tokens]
+        ctx_logits = packed_logits[:, :ctx_end_token, :]  # [1, ctx_tokens, vocab_size]
+
+        seq_lens = ctx_cu_seqlen[1:] - ctx_cu_seqlen[:-1]
+
+        # Squeeze batch dimension for processing
+        flat_input_ids = ctx_input_ids.squeeze(0)  # [ctx_tokens]
+        flat_logits = ctx_logits.squeeze(0)  # [ctx_tokens, vocab_size]
+
+        # Sample from last logit position of each sequence
+        last_positions = ctx_cu_seqlen[1:] - 1  # [num_context]
+        last_logits = flat_logits[last_positions]
+        sampled_tokens = self.sample_greedy(last_logits)  # [num_context]
+
+        # Construct output: for each sequence, output = input[1:] + sampled_token
+        # Vectorized: roll shifts all tokens left by 1, then scatter sampled tokens at sequence ends
+        flat_output_ids = flat_input_ids.roll(-1)  # output[i] = input[i+1] (with wraparound)
+        flat_output_ids[last_positions] = sampled_tokens.to(flat_output_ids.dtype)
+
+        packed_output_ids = flat_output_ids.unsqueeze(0)  # [1, ctx_tokens]
+        num_accepted = seq_lens.long()
+
+        return packed_output_ids, num_accepted
+
+    def _count_context_sequences(
+        self,
+        position_ids: torch.Tensor,
+        seq_starts: torch.Tensor,
+        num_sequences: int,
+    ) -> int:
+        """Count context (prefill) sequences and validate batch ordering.
+
+        Context sequences have first_position_id == 0 (start of a new sequence).
+        Spec_dec sequences have first_position_id > 0 (continuation).
+
+        Asserts that all context sequences come before all spec_dec sequences
+        (i.e., no interleaving).
+
+        TODO: This implementation inspects position_ids tensor values to classify sequences.
+        This should be refactored to receive num_context directly via batch_info_host / batch_info
+        from the runtime, avoiding tensor value inspection entirely.
+
+        Args:
+            position_ids: [1, total_tokens] packed position IDs
+            seq_starts: [num_sequences] tensor of start positions for each sequence in packed tensor
+            num_sequences: Total number of sequences in batch
+
+        Returns:
+            num_context: Count of context sequences (first num_context are context,
+                         remaining num_sequences - num_context are spec_dec)
+        """
+        if num_sequences == 0:
+            return 0
+
+        # Gather first position_id for each sequence (seq_starts is already on device)
+        first_positions = position_ids[0, seq_starts.long()]  # [num_sequences]
+        first_positions_cpu = first_positions.tolist()
+
+        # Count context sequences (first_position == 0) and validate ordering
+        # Context sequences must come first, then spec_dec sequences
+        num_context = 0
+        seen_spec_dec = False
+        for i in range(num_sequences):
+            is_context = first_positions_cpu[i] == 0
+            if is_context:
+                assert not seen_spec_dec, (
+                    f"Batch ordering violation: context sequence at index {i} found after "
+                    f"spec_dec sequence. Context sequences must come before spec_dec sequences."
+                )
+                num_context += 1
+            else:
+                seen_spec_dec = True
+
+        return num_context
+
+    def _store_target_hidden_states(
+        self,
+        kwargs: dict,
+        cu_seqlen: torch.Tensor,
+        num_sequences: int,
+    ) -> int:
+        """Store hidden states from target model forward pass.
+
+        Collects hidden_states_cache_* buffers from kwargs and stores
+        them in resource_manager for use by the draft model.
+
+        Args:
+            kwargs: Forward kwargs containing hidden_states_cache_* buffers
+            cu_seqlen: [num_sequences + 1] cumulative sequence lengths tensor (on device)
+            num_sequences: Total number of sequences in batch
+
+        Returns:
+            num_tokens: Total token count stored
+        """
+        # Collect hidden_states_cache buffers from kwargs (e.g., hidden_states_cache_0, _1, _2)
+        # Sort by name to ensure correct order: hidden_states_cache_0, _1, _2, etc.
+        hidden_state_items = sorted(
+            [
+                (name, tensor)
+                for name, tensor in kwargs.items()
+                if name.startswith("hidden_states_cache")
+            ],
+            key=lambda x: x[0],
+        )
+
+        hidden_state_buffers = [tensor for _, tensor in hidden_state_items]
+
+        # Compute num_tokens from cu_seqlen
+        # cu_seqlen[num_sequences] gives total tokens across all sequences
+        num_tokens = int(cu_seqlen[num_sequences].item())
+        self.resource_manager.store_hidden_states(hidden_state_buffers, num_tokens)
+
+        return num_tokens
+
+    def sample_and_verify_prefill_only(
         self, input_ids, target_logits: torch.Tensor, num_previously_accepted: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
@@ -616,6 +972,22 @@ class EagleWrapper(nn.Module):
         """
 
         batch_size, seq_len = input_ids.shape
+
+        # During export/tracing with meta tensors, we cannot perform actual verification
+        # because operations like .item(), .all(), and data-dependent indexing fail on meta tensors.
+        # Return simulated values with correct shapes instead.
+        if input_ids.device.type == "meta":
+            # Simulate accepting all tokens (optimistic case for shape tracing)
+            draft_input_ids = input_ids.clone()
+            num_newly_accepted_tokens = (
+                torch.full((batch_size,), seq_len, dtype=torch.long, device=input_ids.device)
+                - num_previously_accepted
+            )
+            num_accepted_tokens = torch.full(
+                (batch_size,), seq_len, dtype=torch.long, device=input_ids.device
+            )
+            last_logits_3d = target_logits[:, -1:, :]  # [batch_size, 1, vocab_size]
+            return draft_input_ids, num_newly_accepted_tokens, num_accepted_tokens, last_logits_3d
 
         # First, check that num_previously_accepted is <= seq_len for each batch
         # Additionally, num_previously_accepted should be >= 1 for each batch,
@@ -736,22 +1108,297 @@ class EagleWrapper(nn.Module):
 
         return draft_input_ids, num_newly_accepted_tokens, num_accepted_tokens, last_logits_3d
 
+    def sample_and_verify_decode(
+        self,
+        packed_input_ids: torch.Tensor,
+        packed_target_logits: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        num_context: int,
+        num_spec_dec: int,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Verify draft tokens for decode (spec_dec) sequences.
+
+        Uses packed representation with batch dimension 1 for both input and output.
+        Assumes all sequences have uniform length (1 + max_draft_len).
+
+        Args:
+            packed_input_ids: [1, total_tokens] - packed input token ids (full batch)
+            packed_target_logits: [1, total_tokens, vocab_size] - packed logits from target model (full batch)
+            cu_seqlen: [num_sequences + 1] - cumulative sequence lengths (full batch)
+            num_context: number of context (prefill) sequences
+            num_spec_dec: number of spec_dec (verification) sequences
+
+        Returns:
+            packed_output_ids: [1, sd_tokens] - greedy samples at ALL spec_dec positions,
+                or None if num_spec_dec == 0
+            num_accepted: [num_spec_dec] - total accepted tokens (verified + 1 bonus),
+                or None if num_spec_dec == 0
+        """
+        if num_spec_dec == 0:
+            return None, None
+
+        # Slice to get only spec_dec sequences
+        sd_cu_seqlen_raw = cu_seqlen[num_context : num_context + num_spec_dec + 1]
+        sd_start_token = sd_cu_seqlen_raw[0]
+        sd_end_token = sd_cu_seqlen_raw[-1]
+        sd_input_ids = packed_input_ids[:, sd_start_token:sd_end_token]  # [1, sd_tokens]
+        sd_logits = packed_target_logits[
+            :, sd_start_token:sd_end_token, :
+        ]  # [1, sd_tokens, vocab_size]
+
+        total_tokens = sd_input_ids.shape[1]
+        seq_len = total_tokens // num_spec_dec  # All spec_dec sequences have uniform length
+
+        # Squeeze batch dimension and greedy sample all positions
+        flat_input_ids = sd_input_ids.squeeze(0)  # [sd_tokens]
+        flat_logits = sd_logits.squeeze(0)  # [sd_tokens, vocab_size]
+        sampled_all = self.sample_greedy(flat_logits)  # [sd_tokens]
+
+        # Reshape to [num_spec_dec, seq_len] for per-sequence verification
+        flat_input_2d = flat_input_ids.view(num_spec_dec, seq_len)
+        sampled_2d = sampled_all.view(num_spec_dec, seq_len)
+
+        # Verify: compare draft tokens (input[:, 1:]) with what target would have sampled (sampled[:, :-1])
+        draft_tokens = flat_input_2d[:, 1:]  # [num_spec_dec, max_draft_len]
+        sampled_for_verification = sampled_2d[:, :-1]  # [num_spec_dec, max_draft_len]
+        matches = (sampled_for_verification == draft_tokens).int()
+
+        # Count consecutive matches from start using cumulative product
+        prefix_matches = matches.cumprod(dim=1)
+        num_accepted = prefix_matches.sum(dim=1) + 1  # +1 for bonus token
+
+        packed_output_ids = sampled_all.unsqueeze(0)  # [1, sd_tokens]
+        return packed_output_ids, num_accepted
+
     def forward(self, input_ids, position_ids, **kwargs):
         """Dispatch to appropriate forward implementation based on kwargs.
 
         If num_previously_accepted is provided, use the prefill-only (no KV cache) implementation.
-        Otherwise, this is the KV cache case which is not yet implemented.
+        Otherwise, use the KV cache implementation (for generation with cached attention).
         """
         num_previously_accepted = kwargs.get("num_previously_accepted", None)
 
         if num_previously_accepted is not None:
             return self._forward_prefill_only(input_ids, position_ids, **kwargs)
         else:
-            # KV cached case - not implemented yet
-            raise NotImplementedError(
-                "EagleWrapper forward with KV cache is not implemented. "
-                "This code path is reached when num_previously_accepted is not provided in kwargs."
+            return self._forward_with_kv_cache(input_ids, position_ids, **kwargs)
+
+    def _forward_with_kv_cache(self, input_ids, position_ids, **kwargs):
+        """Forward pass with KV cache support (for generation with cached attention).
+
+        TODO: We use input positions to distinguish prefill from spec-dec sequences (both are multi-token requests).
+        We should use a way that does not require us to inspect input positions.
+        """
+        # Extract batch_info from kwargs: [num_multi_token, num_multi_token_total, num_single_token]
+        batch_info_host = kwargs.get("batch_info_host", None)
+        if batch_info_host is None:
+            raise ValueError("batch_info_host must be provided in kwargs. ")
+
+        num_multi_token, _num_multi_token_total, num_single_token = batch_info_host.tolist()
+
+        # With spec dec enabled, all requests are multi-token (context or spec dec verification)
+        # Single-token decode doesn't happen in one-model spec dec flow
+        assert num_single_token == 0, (
+            f"Single-token requests not expected in spec dec flow. Got num_single_token={num_single_token}"
+        )
+
+        # Total number of sequences = num_multi_token (since num_single_token == 0)
+        num_sequences = num_multi_token
+
+        cu_seqlen = kwargs.get("cu_seqlen", None)
+        if cu_seqlen is None:
+            raise ValueError("cu_seqlen must be provided in kwargs for packed sequence format.")
+
+        seq_starts = cu_seqlen[:num_sequences]  # [num_sequences]
+
+        # Count context vs spec_dec sequences
+        # With ordered batches, context sequences are [:num_context], spec_dec are [num_context:]
+        num_context = self._count_context_sequences(position_ids, seq_starts, num_sequences)
+        num_spec_dec = num_sequences - num_context
+
+        inputs_embeds = self.target_model.get_input_embeddings()(input_ids)
+        target_kwargs = self._filter_kwargs_for_submodule(kwargs, self.target_model)
+
+        # target_logits: [batch_size, seq_len, vocab_size]
+        target_logits = self.target_model(
+            inputs_embeds=inputs_embeds, position_ids=position_ids, **target_kwargs
+        ).logits
+
+        # Capture and store hidden states from target model forward pass
+        num_tokens = self._store_target_hidden_states(kwargs, cu_seqlen, num_sequences)
+        hidden_states = self.resource_manager.hidden_states[:num_tokens, :]
+        hidden_states = self.apply_eagle3_fc(hidden_states)
+
+        # Get device from input_ids
+        device = input_ids.device
+
+        num_accepted_tokens = torch.zeros(num_sequences, dtype=torch.long, device=device)
+
+        # Process context and spec_dec sequences (methods return None if count is 0)
+        packed_output_chunks = []
+
+        ctx_output, ctx_accepted = self.prepare_draft_context(
+            input_ids, target_logits, cu_seqlen, num_context
+        )
+        if ctx_output is not None:
+            packed_output_chunks.append(ctx_output)
+            num_accepted_tokens[:num_context] = ctx_accepted
+
+        sd_output, sd_accepted = self.sample_and_verify_decode(
+            input_ids, target_logits, cu_seqlen, num_context, num_spec_dec
+        )
+        if sd_output is not None:
+            packed_output_chunks.append(sd_output)
+            num_accepted_tokens[num_context:] = sd_accepted
+
+        packed_output_ids = (
+            torch.cat(packed_output_chunks, dim=1) if packed_output_chunks else input_ids
+        )
+
+        # Filter kwargs for draft_model (exclude target_model caches)
+        draft_kwargs = self._filter_kwargs_for_submodule(kwargs, self.draft_model)
+
+        # We pass EVERYTHING to the first draft:
+        # - packed_output_ids: [1, total_tokens] - greedy samples at all positions
+        # - position_ids: [1, total_tokens] - full input position_ids (no truncation)
+        # - hidden_states: [total_tokens, hidden_size] - full hidden states (no truncation)
+        # After first draft, we extract at num_accepted-1 indices (leveraging causal attention)
+
+        draft_input_ids = packed_output_ids  # [1, total_tokens]
+        draft_position_ids = position_ids  # [1, total_tokens]
+        draft_hidden_states = hidden_states.unsqueeze(0)  # [1, total_tokens, hidden_size]
+
+        draft_tokens: list[torch.Tensor] = []  # List of tensors, each [num_sequences]
+
+        for draft_idx in range(self.max_draft_len):
+            inputs_embeds = self.apply_draft_embedding(draft_input_ids)
+            draft_output = self.draft_model(
+                inputs_embeds=inputs_embeds,
+                position_ids=draft_position_ids,
+                hidden_states=draft_hidden_states,
+                **draft_kwargs,
             )
+
+            # draft_output.norm_hidden_state is packed 3D: [1, total_tokens, hidden_size]
+            draft_output_logits = self.apply_lm_head(draft_output.norm_hidden_state)
+
+            # Extract logits and hidden state at appropriate positions:
+            # - iter 0: extract at num_accepted-1 indices (leveraging causal attention)
+            # - iter 1+: extract at last position (each seq has 1 token)
+            latest_draft_logits, last_draft_hidden_state = self._extract_draft_iteration_outputs(
+                draft_idx,
+                draft_output,
+                draft_output_logits,
+                draft_kwargs,
+                num_sequences,
+                num_accepted_tokens,
+            )
+
+            # Sample draft token from logits
+            draft_token = self.sample_greedy(latest_draft_logits)
+            draft_token = self.apply_d2t(draft_token)
+
+            # Store the draft token tensor for this iteration
+            # draft_token has shape [num_sequences]
+            draft_tokens.append(draft_token)
+
+            if draft_idx < self.max_draft_len - 1:
+                # For iter 0: use actual num_accepted from verification
+                # For iter 1+: we drafted 1 token per sequence, so num_accepted=1
+                num_accepted = (
+                    num_accepted_tokens if draft_idx == 0 else torch.ones_like(num_accepted_tokens)
+                )
+                draft_position_ids, draft_kwargs = self._prepare_next_draft_metadata(
+                    draft_kwargs,
+                    curr_position_ids=draft_position_ids,
+                    curr_cu_seq_len=draft_kwargs["cu_seqlen"],
+                    num_sequences=num_sequences,
+                    num_accepted=num_accepted,
+                )
+
+                # Prepare tensor inputs for next iteration
+                # last_draft_token: [num_sequences] -> [1, num_sequences]
+                draft_input_ids = draft_token.unsqueeze(0)
+                # last_draft_hidden_state: [num_sequences, hidden_size] -> [1, num_sequences, hidden_size]
+                draft_hidden_states = last_draft_hidden_state.unsqueeze(0)
+
+        # ============================================================
+        # End of Drafting Loop
+        # ============================================================
+
+        flat_output_ids = packed_output_ids.squeeze(0)  # [total_tokens]
+
+        new_tokens_2d = torch.zeros(
+            (num_sequences, self.max_draft_len + 1),
+            dtype=torch.int32,
+            device=device,
+        )
+        new_tokens_lens = torch.zeros(num_sequences, dtype=torch.int32, device=device)
+
+        # Convert draft_tokens list to tensor: [batch_size, max_draft_len]
+        # draft_tokens is a list of max_draft_len tensors, each of shape [num_sequences]
+        assert len(draft_tokens) == self.max_draft_len, (
+            f"Expected {self.max_draft_len} draft tokens, got {len(draft_tokens)}"
+        )
+        assert all(t.shape == (num_sequences,) for t in draft_tokens), (
+            f"All draft tokens should have shape [{num_sequences}]"
+        )
+        # Stack along dim=1 to get [num_sequences, max_draft_len]
+        next_draft_tokens = torch.stack(draft_tokens, dim=1).to(dtype=torch.int32, device=device)
+
+        # Prepare next_new_tokens: [batch_size, max_draft_len + 1]
+        # Format: [last_accepted_token, draft_token_0, draft_token_1, ...]
+        next_new_tokens = torch.zeros(
+            (num_sequences, self.max_draft_len + 1),
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # Process CONTEXT (prefill) requests - first num_context sequences (vectorized)
+        # prepare_draft_context() returns output_ids = [input_ids[1:], sampled_token]
+        # The sampled token is at the last position of each sequence
+        # Note: all operations are no-ops when num_context == 0 (empty slices)
+        ctx_last_positions = cu_seqlen[1 : num_context + 1] - 1  # [num_context]
+        ctx_sampled_tokens = flat_output_ids[ctx_last_positions].to(torch.int32)
+
+        new_tokens_2d[:num_context, 0] = ctx_sampled_tokens
+        new_tokens_lens[:num_context] = 1
+        next_new_tokens[:num_context, 0] = ctx_sampled_tokens
+        next_new_tokens[:num_context, 1:] = next_draft_tokens[:num_context]
+
+        # Process SPEC_DEC (verification) requests - sequences after context (vectorized)
+        # packed_output_ids contains greedy samples at ALL positions (same length as input)
+        # num_accepted_tokens: N + 1 (verified drafts + golden)
+        # Note: all operations are no-ops when num_spec_dec == 0 (empty slices)
+
+        # All spec_dec sequences have uniform length: 1 (accepted from prev round) + max_draft_len
+        sd_seq_len = 1 + self.max_draft_len
+        sd_start = cu_seqlen[num_context]
+        sd_flat = flat_output_ids[sd_start : cu_seqlen[num_sequences]]
+
+        # Copy to new_tokens_2d: reshape to [num_spec_dec, sd_seq_len] for block copy
+        new_tokens_2d[num_context:, :sd_seq_len] = sd_flat.view(-1, sd_seq_len).to(torch.int32)
+
+        # Set lengths from num_accepted_tokens
+        new_tokens_lens[num_context:] = num_accepted_tokens[num_context:].int()
+
+        # Get golden token (last accepted) for each sequence directly from flat format
+        # Golden token for sequence i is at flat index: sd_start + i * sd_seq_len + (num_accepted[i] - 1)
+        sd_num_accepted = num_accepted_tokens[num_context:]
+        seq_offsets = torch.arange(num_spec_dec, device=device) * sd_seq_len
+        golden_flat_indices = sd_start + seq_offsets + (sd_num_accepted - 1)
+        golden_tokens = flat_output_ids[golden_flat_indices].to(torch.int32)
+
+        next_new_tokens[num_context:, 0] = golden_tokens
+        next_new_tokens[num_context:, 1:] = next_draft_tokens[num_context:]
+
+        return EagleWrapperOutput(
+            logits=target_logits,
+            new_tokens=new_tokens_2d,
+            new_tokens_lens=new_tokens_lens,  # Use corrected value, not num_newly_accepted_tokens
+            next_draft_tokens=next_draft_tokens,
+            next_new_tokens=next_new_tokens,
+        )
 
     def _forward_prefill_only(self, input_ids, position_ids, **kwargs):
         """Forward pass without KV cache (prefill-only mode).
@@ -780,8 +1427,8 @@ class EagleWrapper(nn.Module):
         # num_accepted_tokens: [batch_size]. The number of accepted tokens in each batch.
         # num_newly_accepted_tokens: [batch_size]. The number of newly accepted tokens in each batch.
 
-        output_ids, num_newly_accepted_tokens, num_accepted_tokens, _ = self.sample_and_verify(
-            input_ids, target_logits, num_previously_accepted
+        output_ids, num_newly_accepted_tokens, num_accepted_tokens, _ = (
+            self.sample_and_verify_prefill_only(input_ids, target_logits, num_previously_accepted)
         )
 
         # Get hidden states from the resource manager
@@ -895,3 +1542,154 @@ class EagleWrapper(nn.Module):
             new_tokens=new_tokens,
             new_tokens_lens=num_newly_accepted_tokens,
         )
+
+
+class ADHiddenStateManager(Eagle3ResourceManager):
+    """AutoDeploy-specific hidden state manager for Eagle3 speculative decoding.
+
+    Stores hidden states for use by the draft model in EagleWrapper.forward().
+    This class extends Eagle3ResourceManager with functionality tailored to
+    how AutoDeploy captures hidden states.
+    """
+
+    def __init__(
+        self,
+        config: EagleDecodingConfig,
+        dtype: torch.dtype,
+        hidden_size: int,
+        max_num_requests: int,
+        max_seq_len: int,
+        max_num_tokens: int,
+    ):
+        super().__init__(config, dtype, hidden_size, max_num_requests, max_seq_len, max_num_tokens)
+
+        self.hidden_state_write_indices: torch.Tensor = torch.empty(
+            max_num_tokens, dtype=torch.long, device="cuda"
+        )
+
+    @classmethod
+    def build_from_target_engine(
+        cls,
+        engine,
+        config: EagleDecodingConfig,
+        max_num_requests: int,
+    ) -> "ADHiddenStateManager":
+        hidden_state_buffer = cls._get_hidden_state_buffers(engine.cache_seq_interface)[0]
+        dtype = hidden_state_buffer.dtype
+        hidden_size = hidden_state_buffer.shape[1]
+
+        return cls(
+            config=config,
+            dtype=dtype,
+            hidden_size=hidden_size,
+            max_num_requests=max_num_requests,
+            max_seq_len=engine.llm_args.max_seq_len,
+            max_num_tokens=engine.llm_args.max_num_tokens,
+        )
+
+    @classmethod
+    def build_from_target_factory(
+        cls,
+        target_factory,
+        config: EagleDecodingConfig,
+        max_num_requests: int,
+        max_num_tokens: int,
+    ) -> "ADHiddenStateManager":
+        hidden_size = target_factory.hidden_size
+        if hidden_size is None:
+            raise ValueError(
+                "Cannot determine hidden_size from target_factory. "
+                "Ensure the factory implements the hidden_size property."
+            )
+
+        dtype = target_factory.dtype
+        if dtype is None:
+            raise ValueError("dtype must be available in target factory.")
+
+        return cls(
+            config=config,
+            dtype=dtype,
+            hidden_size=hidden_size,
+            max_num_requests=max_num_requests,
+            max_seq_len=target_factory.max_seq_len,
+            max_num_tokens=max_num_tokens,
+        )
+
+    @staticmethod
+    def _get_hidden_state_buffers(
+        cache_seq_interface,
+    ) -> List[torch.Tensor]:
+        hidden_state_buffers = []
+        for name, tensor in cache_seq_interface.named_args.items():
+            if "hidden_states_cache" in name:
+                hidden_state_buffers.append(tensor)
+
+        if not hidden_state_buffers:
+            raise ValueError(
+                "No hidden_state_buffers found in cache_seq_interface. Check if we are actually running Eagle3."
+            )
+        return hidden_state_buffers
+
+    def prepare_hidden_states_capture(self, ordered_requests, cache_seq_interface) -> None:
+        """Prepare the hidden states for capture by establishing indices that the hidden states will be written to."""
+        seq_lens = cache_seq_interface.info.seq_len
+        num_tokens = sum(seq_lens)
+
+        start_idx = 0
+        hidden_states_write_indices = []
+        for request, seq_len in zip(ordered_requests, seq_lens):
+            request_id = request.request_id
+            slot_id = self.slot_manager.get_slot(request_id)
+            self.start_indices[slot_id] = start_idx
+            hidden_states_write_indices.extend(range(start_idx, start_idx + seq_len))
+            start_idx += max(seq_len, self.max_total_draft_tokens + 1)
+            assert start_idx < self.hidden_states.shape[0], (
+                f"start_idx {start_idx} exceeds hidden_states capacity {self.hidden_states.shape[0]}"
+            )
+
+        if len(hidden_states_write_indices) != num_tokens:
+            raise ValueError(
+                f"len(hidden_state_write_indices) ({len(hidden_states_write_indices)}) != num_tokens \
+                ({num_tokens}). Check whether ordered_requests matches up with seq_lens."
+            )
+
+        hidden_state_write_indices_host = torch.tensor(
+            hidden_states_write_indices, dtype=torch.long
+        )
+
+        self.hidden_state_write_indices[:num_tokens].copy_(
+            hidden_state_write_indices_host, non_blocking=True
+        )
+
+    def store_hidden_states(
+        self, hidden_state_buffers: List[torch.Tensor], num_tokens: int
+    ) -> None:
+        """Store hidden states from buffers into self.hidden_states.
+
+        This method takes a list of hidden state tensors (one per captured layer)
+        and copies them into the resource manager's hidden_states buffer using
+        the write indices set up by prepare_hidden_states_capture().
+
+        Args:
+            hidden_state_buffers: List of tensors, each of shape [max_num_tokens, hidden_size].
+                One tensor per captured layer.
+            num_tokens: Number of tokens to copy from each buffer.
+        """
+        if not hidden_state_buffers:
+            return
+
+        hidden_states = [buffer[:num_tokens] for buffer in hidden_state_buffers]
+        hidden_states = torch.cat(hidden_states, dim=1)
+        hidden_states = hidden_states.to(dtype=self.dtype)
+
+        # Use write indices to copy to the correct locations in self.hidden_states
+        token_idx = self.hidden_state_write_indices[:num_tokens]
+        self.hidden_states[:, : hidden_states.shape[1]].index_copy_(0, token_idx, hidden_states)
+
+    def capture_hidden_states(self, cache_seq_interface) -> None:
+        full_hidden_states = self._get_hidden_state_buffers(cache_seq_interface)
+        if not full_hidden_states:
+            return
+
+        num_tokens = sum(cache_seq_interface.info.seq_len)
+        self.store_hidden_states(full_hidden_states, num_tokens)

--- a/tensorrt_llm/_torch/auto_deploy/models/eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/eagle.py
@@ -15,22 +15,34 @@
 
 """Factory definitions for building models related to Eagle in AutoDeploy.
 
-This module provides EagleDrafterFactory, a specialized factory for building
-Eagle speculative decoding draft models. It extends AutoModelForCausalLMFactory
-to handle the mapping from base model types (e.g., "llama") to their corresponding
-Eagle drafter implementations.
+This module provides:
+- EagleDrafterFactory: A specialized factory for building Eagle speculative decoding draft models.
+  It extends AutoModelForCausalLMFactory to handle the mapping from base model types (e.g., "llama")
+  to their corresponding Eagle drafter implementations.
+- EagleOneModelFactory: A factory that composes target and draft model factories to build a combined
+  Eagle model that can be used for speculative decoding with a single engine/optimization pass.
 """
 
+import types
 from contextlib import nullcontext
-from typing import Dict
+from typing import Any, Dict, List, Optional
 
+import torch
 import torch.nn as nn
 from accelerate import init_empty_weights
 from torch._prims_common import DeviceLikeType
+from torch.export import Dim
+from torch.fx import GraphModule
 
 from ..utils.logger import ad_logger
-from .custom.modeling_eagle import Eagle3DrafterForCausalLM, EagleConfig
-from .factory import ModelFactoryRegistry
+from .custom.modeling_eagle import (
+    ADHiddenStateManager,
+    Eagle3DrafterForCausalLM,
+    EagleConfig,
+    EagleWrapper,
+    EagleWrapperConfig,
+)
+from .factory import DynamicShape, ModelFactory, ModelFactoryRegistry, SubModuleExportInfo
 from .hf import AutoModelForCausalLMFactory
 
 
@@ -93,3 +105,422 @@ class EagleDrafterFactory(AutoModelForCausalLMFactory):
             "EagleDrafterFactory does not support build_and_load_model(). "
             "Use build_model() + load_or_random_init() instead."
         )
+
+
+# =============================================================================
+# EagleOneModel classes for combined target+draft model support
+# =============================================================================
+@ModelFactoryRegistry.register("eagle_one_model")
+class EagleOneModelFactory(ModelFactory):
+    """A factory that composes target and draft model factories for Eagle speculative decoding.
+
+    This factory enables building a combined target+draft model as a single unit,
+    which can be optimized together through the AutoDeploy transform pipeline.
+
+    Args:
+        model: The model path (used as identifier, typically the target model path).
+        target_factory: The ModelFactory for the target (main) model.
+        draft_factory: The ModelFactory for the draft model.
+        speculative_config: The speculative decoding configuration (e.g., EagleDecodingConfig).
+        resource_manager: The resource manager for managing hidden states and other resources.
+        model_kwargs: Optional kwargs passed to the base ModelFactory.
+        tokenizer: Optional tokenizer path (defaults to target model's tokenizer).
+        tokenizer_kwargs: Optional kwargs for tokenizer initialization.
+        skip_loading_weights: Whether to skip loading weights.
+        max_seq_len: Maximum sequence length.
+        **kwargs: Additional keyword arguments.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        target_factory: ModelFactory,
+        draft_factory: ModelFactory,
+        speculative_config: Any,
+        resource_manager: Any,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        tokenizer: Optional[str] = None,
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        skip_loading_weights: bool = False,
+        max_seq_len: int = 512,
+        **kwargs,
+    ):
+        # Use target model's tokenizer by default if not specified
+        effective_tokenizer = tokenizer or target_factory.tokenizer
+
+        super().__init__(
+            model=model,
+            model_kwargs=model_kwargs,
+            tokenizer=effective_tokenizer,
+            tokenizer_kwargs=tokenizer_kwargs,
+            skip_loading_weights=skip_loading_weights,
+            max_seq_len=max_seq_len,
+            **kwargs,
+        )
+
+        self.target_factory = target_factory
+        self.draft_factory = draft_factory
+        self.speculative_config = speculative_config
+        self.resource_manager = resource_manager
+
+        # Sync skip_loading_weights with child factories
+        self.target_factory.skip_loading_weights = skip_loading_weights
+        self.draft_factory.skip_loading_weights = skip_loading_weights
+
+    @classmethod
+    def build_from_target(
+        cls,
+        target_factory: ModelFactory,
+        speculative_config: Any,
+        max_batch_size: int,
+        max_num_tokens: int,
+        draft_model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> "EagleOneModelFactory":
+        """Build an EagleOneModelFactory from a target factory and speculative config.
+
+        This convenience method creates the draft factory and resource manager automatically
+        from the speculative_config and target factory, then combines them.
+
+        Args:
+            target_factory: The ModelFactory for the target (main) model.
+            speculative_config: The speculative decoding configuration (e.g., EagleDecodingConfig).
+                Must have `speculative_model` attribute pointing to the draft model path.
+            max_batch_size: Maximum batch size (used as max_num_requests for resource manager).
+            max_num_tokens: Maximum number of tokens.
+            draft_model_kwargs: Optional kwargs to override the draft model's config (e.g., to
+                reduce model dimensions for testing). Passed as ``model_kwargs`` to
+                ``EagleDrafterFactory``.
+
+        Returns:
+            An EagleOneModelFactory configured with both target and draft factories.
+
+        Example:
+            >>> target_factory = AutoModelForCausalLMFactory(
+            ...     model="meta-llama/Llama-3.1-8B-Instruct"
+            ... )
+            >>> eagle_factory = EagleOneModelFactory.build_from_target(
+            ...     target_factory=target_factory,
+            ...     speculative_config=ad_config.speculative_config,
+            ...     max_batch_size=ad_config.max_batch_size,
+            ...     max_num_tokens=ad_config.max_num_tokens,
+            ... )
+        """
+        # Get draft model path from speculative config
+        draft_model_path = speculative_config.speculative_model
+        if draft_model_path is None:
+            raise ValueError(
+                "speculative_config.speculative_model must be set to the draft model path"
+            )
+
+        # Create draft factory using EagleDrafterFactory
+        # It maps from base model types (e.g., "llama") to Eagle drafter implementations
+        draft_factory = EagleDrafterFactory(
+            model=str(draft_model_path),
+            model_kwargs=draft_model_kwargs,
+            tokenizer=target_factory.tokenizer,  # Use target's tokenizer
+            skip_loading_weights=target_factory.skip_loading_weights,
+            max_seq_len=target_factory.max_seq_len,
+        )
+
+        # Build the resource manager from the target factory
+        resource_manager = ADHiddenStateManager.build_from_target_factory(
+            target_factory=target_factory,
+            config=speculative_config,
+            max_num_requests=max_batch_size,
+            max_num_tokens=max_num_tokens,
+        )
+
+        # Create and return the combined factory
+        return cls(
+            model=target_factory.model,
+            target_factory=target_factory,
+            draft_factory=draft_factory,
+            speculative_config=speculative_config,
+            resource_manager=resource_manager,
+            tokenizer=target_factory.tokenizer,
+            tokenizer_kwargs=target_factory.tokenizer_kwargs,
+            skip_loading_weights=target_factory.skip_loading_weights,
+            max_seq_len=target_factory.max_seq_len,
+        )
+
+    @property
+    def vocab_size_padded(self) -> Optional[int]:
+        """Return the padded vocabulary size from the target model factory."""
+        return self.target_factory.vocab_size_padded
+
+    @property
+    def hidden_size(self) -> Optional[int]:
+        """Return the hidden size from the target model factory."""
+        return self.target_factory.hidden_size
+
+    @property
+    def dtype(self) -> Optional[torch.dtype]:
+        """Return the dtype from the target model factory."""
+        return self.target_factory.dtype
+
+    def _build_model(self, device: str) -> nn.Module:
+        """Build both target and draft models and return a combined EagleWrapper module.
+
+        Args:
+            device: The device to build the models on.
+
+        Returns:
+            An EagleWrapper containing both target and draft models.
+        """
+        # Build target model
+        target_model = self.target_factory.build_model(device)
+
+        # Build draft model
+        draft_model = self.draft_factory.build_model(device)
+
+        # Create EagleWrapper config from speculative_config and draft model config
+        draft_config = draft_model.config
+        wrapper_config = EagleWrapperConfig(
+            max_draft_len=self.speculative_config.max_draft_len,
+            load_embedding_from_target=getattr(draft_config, "load_embedding_from_target", True),
+            load_lm_head_from_target=getattr(draft_config, "load_lm_head_from_target", True),
+        )
+
+        # Create combined model using EagleWrapper
+        return EagleWrapper(
+            config=wrapper_config,
+            target_model=target_model,
+            draft_model=draft_model,
+            resource_manager=self.resource_manager,
+        )
+
+    def _load_checkpoint(
+        self, model: nn.Module, device: DeviceLikeType, disable_preload: bool = False
+    ):
+        """Load checkpoints for both target and draft models.
+
+        Args:
+            model: The combined EagleWrapper.
+            device: The device to load the models on.
+            disable_preload: If True, disable preloading weights (passed to sub-factories).
+        """
+        if not isinstance(model, EagleWrapper):
+            raise ValueError(f"Expected EagleWrapper, got {type(model)}")
+
+        # Load target model weights
+        self.target_factory._load_checkpoint(model.target_model, device, disable_preload)
+
+        # Load draft model weights
+        self.draft_factory._load_checkpoint(model.draft_model, device, disable_preload)
+
+    def get_quant_config(self) -> Dict:
+        """Returns the quantization config from the target factory."""
+        return self.target_factory.get_quant_config()
+
+    def get_sharding_config(self) -> Dict:
+        """Returns the sharding config from the target model factory."""
+        # Use target model's sharding config as the primary config
+        return self.target_factory.get_sharding_config()
+
+    def get_cache_config_updates(self) -> Dict[str, Any]:
+        """Return the cache configuration updates from the target model factory."""
+        return self.target_factory.get_cache_config_updates()
+
+    def init_tokenizer(self) -> Optional[Any]:
+        """Initialize the tokenizer from the target model factory."""
+        return self.target_factory.init_tokenizer()
+
+    def init_processor(self) -> Optional[Any]:
+        """Initialize the processor from the target model factory."""
+        return self.target_factory.init_processor()
+
+    def prefetch_checkpoint(self, force: bool = False, skip_loading_weights: Optional[bool] = None):
+        """Prefetch checkpoints for both target and draft models.
+
+        Args:
+            force: Whether to force prefetching.
+            skip_loading_weights: Whether to skip loading weights.
+        """
+        # Prefetch for both factories
+        self.target_factory.prefetch_checkpoint(force, skip_loading_weights)
+        self.draft_factory.prefetch_checkpoint(force, skip_loading_weights)
+
+        # Also call parent's prefetch for any model-level prefetching
+        super().prefetch_checkpoint(force, skip_loading_weights)
+
+    def get_example_inputs(self) -> Dict[str, torch.Tensor]:
+        """Return example inputs including num_previously_accepted for EagleWrapper.
+
+        The EagleWrapper.forward() requires num_previously_accepted to be provided.
+        This tensor is passed via set_example_sequence's extra_args mechanism.
+
+        Returns:
+            A dictionary containing num_previously_accepted with shape [batch_size].
+        """
+        # Use batch_size >= 2 for export to prevent torch.export from specializing
+        # the batch dimension when max_batch_size=1
+        batch_size = 2
+        # num_previously_accepted must be >= 1 (at least context tokens are accepted)
+        # and should be reasonable for the example sequence length (4 by default)
+        num_previously_accepted = torch.ones(batch_size, dtype=torch.long)
+        return {"num_previously_accepted": num_previously_accepted}
+
+    def get_export_infos(self, model: nn.Module) -> List[SubModuleExportInfo]:
+        """Return export configurations for the target and draft models separately.
+
+        Args:
+            model: The combined EagleWrapper.
+
+        Returns:
+            A list of export configurations for both target and draft models.
+        """
+        draft_config = model.draft_model.config
+        load_embedding_from_target = getattr(draft_config, "load_embedding_from_target", True)
+        load_lm_head_from_target = getattr(draft_config, "load_lm_head_from_target", True)
+
+        return [
+            TargetModelExportInfo(load_lm_head_from_target),
+            DraftModelExportInfo(load_embedding_from_target, load_lm_head_from_target),
+        ]
+
+
+class TargetModelExportInfo(SubModuleExportInfo):
+    def __init__(self, load_lm_head_from_target: bool):
+        super().__init__("target_model")
+        self.load_lm_head_from_target = load_lm_head_from_target
+
+    def _init_dynamic_shape_lookup(self) -> Dict[str, DynamicShape]:
+        batch_size_dyn = Dim.DYNAMIC
+        seq_len_dyn = Dim.DYNAMIC
+        return {
+            "inputs_embeds": {0: batch_size_dyn, 1: seq_len_dyn},
+            "position_ids": {0: batch_size_dyn, 1: seq_len_dyn},
+        }
+
+    def post_process(self, sub_mod: nn.Module, sub_gm: GraphModule):
+        # Always save the embedding module
+        embed_tokens = sub_mod.get_input_embeddings()
+        sub_gm.get_input_embeddings = types.MethodType(
+            sub_mod.get_input_embeddings.__func__, sub_gm
+        )
+
+        # retrieve+replicate expected submodule hierarchy for where the embedding module is located
+        for embed_name, subsubmod in sub_mod.named_modules():
+            if subsubmod is embed_tokens:
+                break
+        else:
+            raise RuntimeError(
+                "Could not find embedding module in model. Expected embedding module to be a "
+                "submodule of the target model."
+            )
+        sub_gm.set_submodule(embed_name, embed_tokens)
+
+        # Add a dummy node to the graph for making the embedding module impure.
+        # Impure nodes won't be deleted from the graph during cleanup, ensuring the
+        # embedding module is not garbage collected from the GraphModule.
+        n_embed_tokens = sub_gm.graph.get_attr(f"{embed_name}.weight")
+        sub_gm.graph.call_function(
+            torch._assert, args=(n_embed_tokens, "Avoid embedding getting deleted from graph.")
+        )
+
+        # Save lm_head only if the draft model loads it from target
+        if self.load_lm_head_from_target:
+            lm_head = sub_mod.get_output_embeddings()
+            sub_gm.get_output_embeddings = types.MethodType(
+                sub_mod.get_output_embeddings.__func__, sub_gm
+            )
+            for lm_head_name, subsubmod in sub_mod.named_modules():
+                if subsubmod is lm_head:
+                    break
+            else:
+                raise RuntimeError(
+                    "Could not find lm_head module in model. Expected lm_head module to be a "
+                    "submodule of the target model."
+                )
+            sub_gm.set_submodule(lm_head_name, lm_head)
+
+            # Add dummy node to prevent lm_head from being garbage collected
+            n_lm_head = sub_gm.graph.get_attr(f"{lm_head_name}.weight")
+            sub_gm.graph.call_function(
+                torch._assert, args=(n_lm_head, "Avoid lm_head getting deleted from graph.")
+            )
+
+
+class DraftModelExportInfo(SubModuleExportInfo):
+    def __init__(self, load_embedding_from_target: bool, load_lm_head_from_target: bool):
+        super().__init__("draft_model")
+        self.load_embedding_from_target = load_embedding_from_target
+        self.load_lm_head_from_target = load_lm_head_from_target
+
+    def _init_dynamic_shape_lookup(self) -> Dict[str, DynamicShape]:
+        batch_size_dyn = Dim.DYNAMIC
+        seq_len_dyn = Dim.DYNAMIC
+        return {
+            "inputs_embeds": {0: batch_size_dyn, 1: seq_len_dyn},
+            "position_ids": {0: batch_size_dyn, 1: seq_len_dyn},
+            "hidden_states": {0: batch_size_dyn, 1: seq_len_dyn},
+        }
+
+    def post_process(self, sub_mod: nn.Module, sub_gm: GraphModule):
+        """Keep draft model modules available in the graph module for EagleWrapper utilities.
+
+        This preserves modules/parameters needed by EagleWrapper's utility methods:
+        - embedding (model.embed_tokens): for apply_token_embedding if draft has its own
+        - lm_head: for apply_lm_head
+        - fc (model.fc): for apply_eagle3_fc
+        - d2t (model.d2t): for apply_d2t
+        - model.dtype: for dtype conversion in apply_eagle3_fc
+
+        We also add dummy graph nodes (torch._assert) to make these modules "impure",
+        preventing them from being garbage collected during graph cleanup.
+        """
+        inner_model_mod = sub_mod.model
+
+        # Save embedding only if draft model has its own (not loading from target)
+        if not self.load_embedding_from_target:
+            sub_gm.set_submodule("model.embed_tokens", inner_model_mod.embed_tokens)
+            # Save get_input_embeddings method for EagleWrapper utilities
+            sub_gm.get_input_embeddings = types.MethodType(
+                sub_mod.get_input_embeddings.__func__, sub_gm
+            )
+            # Add dummy node to prevent embedding from being garbage collected
+            n_embed = sub_gm.graph.get_attr("model.embed_tokens.weight")
+            sub_gm.graph.call_function(
+                torch._assert, args=(n_embed, "Avoid draft embedding getting deleted from graph.")
+            )
+
+        # Save lm_head only if draft model has its own (not loading from target)
+        if not self.load_lm_head_from_target:
+            sub_gm.set_submodule("lm_head", sub_mod.lm_head)
+            # Save get_output_embeddings method for EagleWrapper utilities
+            sub_gm.get_output_embeddings = types.MethodType(
+                sub_mod.get_output_embeddings.__func__, sub_gm
+            )
+            # Add dummy node to prevent lm_head from being garbage collected
+            n_lm_head = sub_gm.graph.get_attr("lm_head.weight")
+            sub_gm.graph.call_function(
+                torch._assert, args=(n_lm_head, "Avoid draft lm_head getting deleted from graph.")
+            )
+
+        inner_model_gm = sub_gm.get_submodule("model")
+
+        # Save fc module if it exists (for fusing hidden states from multiple layers)
+        fc_module = getattr(inner_model_mod, "fc", None)
+        if fc_module is not None:
+            sub_gm.set_submodule("model.fc", fc_module)
+            # Add dummy node to prevent fc from being garbage collected
+            n_fc = sub_gm.graph.get_attr("model.fc.weight")
+            sub_gm.graph.call_function(
+                torch._assert, args=(n_fc, "Avoid fc getting deleted from graph.")
+            )
+
+        # Save d2t parameter and model dtype if they exist
+        # d2t is a Parameter (not a Module), so needs special handling
+        d2t = getattr(inner_model_mod, "d2t", None)
+        model_dtype = getattr(inner_model_mod, "dtype", None)
+
+        if d2t is not None:
+            inner_model_gm.register_parameter("d2t", d2t)
+            # Add dummy node to prevent d2t from being garbage collected
+            n_d2t = sub_gm.graph.get_attr("model.d2t")
+            sub_gm.graph.call_function(
+                torch._assert, args=(n_d2t, "Avoid d2t getting deleted from graph.")
+            )
+
+        if model_dtype is not None:
+            inner_model_gm.dtype = model_dtype

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -156,6 +156,14 @@ class ModelFactory(ABC):
         """
         return None
 
+    @property
+    def hidden_size(self) -> Optional[int]:
+        return None
+
+    @property
+    def dtype(self) -> Optional[torch.dtype]:
+        return None
+
     def build_model(self, device: str) -> nn.Module:
         """Build the model on the desired device.
 

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -142,6 +142,18 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
         model_config, _ = self._get_model_config()
         return getattr(model_config, "vocab_size", None)
 
+    @property
+    def hidden_size(self) -> Optional[int]:
+        """Return the hidden size from the model config."""
+        model_config, _ = self._get_model_config()
+        return getattr(model_config, "hidden_size", None)
+
+    @property
+    def dtype(self) -> Optional[torch.dtype]:
+        """Return the model dtype from the model config."""
+        model_config, _ = self._get_model_config()
+        return getattr(model_config, "torch_dtype", None)
+
     def _recursive_update_config(
         self, config: PretrainedConfig, update_dict: Dict[str, Any]
     ) -> Tuple[PretrainedConfig, Dict[str, Any]]:

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -445,6 +445,7 @@ l0_h100:
   - accuracy/test_llm_api_autodeploy.py::TestNemotronH::test_auto_dtype[triton_ssm-True]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_fp8[1]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronMOE::test_bf16[1]
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B_Instruct_Eagle3::test_eagle3_one_model
   - examples/test_ad_speculative_decoding.py::test_autodeploy_spec_dec_output[draft_target]
   - examples/test_ad_speculative_decoding.py::test_autodeploy_spec_dec_output[eagle3]
   - examples/test_ad_speculative_decoding.py::test_autodeploy_eagle3_acceptance_rate

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -488,7 +488,11 @@ _SMALL_MODEL_CONFIGS = {
     "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B": {
         "model_kwargs": {
             "hidden_size": 64,
-        }
+            "intermediate_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+        },
     },
 }
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_eagle.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_eagle.py
@@ -143,6 +143,7 @@ def test_build_ad_eagle(register_mock_eagle_factory):
     This test uses the MockEagleDrafterFactory which builds MockEagle3ModelForCausalLM,
     a mock model that generates random hidden states for standalone Eagle testing.
     """
+
     llm_extra_args = {
         "model_factory": "MockEagleDrafter",
         "transforms": {
@@ -177,13 +178,10 @@ def test_eagle_model_torch_export():
     print("=" * 80)
 
     eagle_model_path = hf_id_to_local_model_dir(EAGLE_MODEL_HUB_ID)
-    if eagle_model_path is None:
-        pytest.skip("Eagle model not found (LLM_MODELS_ROOT not set or model missing)")
-
     eagle_path = Path(eagle_model_path)
 
     # Setup
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda")
     dtype = torch.float16
 
     # Create model via EagleDrafterFactory (creates Eagle3DrafterForCausalLM)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -13,12 +13,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
+from unittest.mock import patch
+
 import pytest
 from _model_test_utils import get_small_model_config
 from build_and_run_ad import ExperimentConfig, main
 from test_common.llm_data import with_mocked_hf_download_for_single_gpu
 
-from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.llm import DemoLLM
+from tensorrt_llm._torch.auto_deploy.models import eagle as eagle_module
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_eagle import EagleConfig
+from tensorrt_llm._torch.auto_deploy.models.eagle import EagleDrafterFactory
+from tensorrt_llm.llmapi import DraftTargetDecodingConfig, Eagle3DecodingConfig, KvCacheConfig
+
+###############################################################################
+# Mock drafter factory for small-model testing
+#
+# The production EagleConfig defaults to num_capture_layers=3 for Llama-3.1-8B-Instruct.
+# When the target model is shrunk via model_kwargs (e.g. num_hidden_layers=1), we only capture 1 layer so
+# num_capture_layers must also be 1.
+
+# We patch the EagleDrafterFactory to use _SmallEagleConfig, which sets num_capture_layers=1.
+# This lets us avoid changes to the production code path that reads configs from the model type.
+
+
+# TODO: Consider passing custom EagleConfigs the same way we pass other model_kwargs.
+# This would make the test more robust, but would add more "test-only" code to handle this.
+# Though it could also be useful for production in the future if we want to support multiple Eagle architectures
+# for the same target model e.g. support both Eagle3 and MTPEagle.
+###############################################################################
+
+
+class _SmallEagleConfig(EagleConfig):
+    """EagleConfig override with num_capture_layers=1 for small-model tests."""
+
+    _drafter_defaults = {
+        "llama": {
+            "load_embedding_from_target": True,
+            "load_lm_head_from_target": False,
+            "num_capture_layers": 1,
+        },
+    }
+
+
+class _SmallEagleDrafterFactory(EagleDrafterFactory):
+    """EagleDrafterFactory that uses _SmallEagleConfig."""
+
+    def _build_model(self, device):
+        from accelerate import init_empty_weights
+
+        model_config, unused_kwargs = self._get_model_config()
+        drafter_cls = self._drafter_classes[model_config.model_type]
+        model_config = _SmallEagleConfig(model_config, model_config.model_type)
+
+        with (init_empty_weights if device == "meta" else nullcontext)():
+            model = drafter_cls._from_config(model_config, **unused_kwargs)
+
+        if device == "meta":
+            if hasattr(model, "post_init"):
+                model.post_init()
+        else:
+            model.to(device)
+
+        self._checkpoint_conversion_mapping = getattr(model, "_checkpoint_conversion_mapping", None)
+        model.eval()
+        return model
 
 
 @pytest.mark.skip(
@@ -84,3 +144,106 @@ def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):
     assert len(generated_text) > 0, "Generated text should not be empty"
 
     print("Speculative decoding smoke test passed!")
+
+
+# Maybe this test would be better checking a variety of settings of spec config and overlap scheduler
+# and being a test for the KV cache manager creation.
+def test_kv_cache_manager_spec_dec():
+    """Tests that KV cache manager is created correctly with spec decoding related parameters."""
+    print("\n" + "=" * 80)
+    print("Testing AutoDeploy KV cache manager creation with spec decoding related parameters.")
+    print("=" * 80)
+
+    base_model_id = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    eagle_model_id = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+
+    base_model_config = get_small_model_config(base_model_id)
+    eagle_model_config = get_small_model_config(eagle_model_id)
+
+    print(f"\nBase Model Config: {base_model_config}")
+    print(f"Eagle Model Config: {eagle_model_config}")
+
+    max_draft_len = 3
+    use_one_model_spec_dec = True
+
+    speculative_config = Eagle3DecodingConfig(
+        max_draft_len=max_draft_len,
+        speculative_model=eagle_model_config["args"]["model"],
+        eagle3_one_model=use_one_model_spec_dec,
+        # Must be valid layer indices for the (small) target model's num_hidden_layers.
+        eagle3_layers_to_capture={0},
+    )
+
+    # Use free_gpu_memory_fraction=0.0 so ResizeKVCache skips the forward pass (needs_resize()
+    # is False). This test only asserts KV cache manager creation and spec-dec fields; we don't need
+    # to run a forward pass.
+    kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.0)
+
+    # Patch EagleDrafterFactory with _SmallEagleDrafterFactory so that
+    # build_from_target() creates a drafter with num_capture_layers=1
+    # (matching the single layer captured from the small target model).
+    with patch.object(eagle_module, "EagleDrafterFactory", _SmallEagleDrafterFactory):
+        llm = DemoLLM(
+            model=base_model_config["args"]["model"],
+            model_kwargs=base_model_config["args"]["model_kwargs"],
+            speculative_model_kwargs=eagle_model_config["args"]["model_kwargs"],
+            skip_loading_weights=True,
+            world_size=0,
+            kv_cache_config=kv_cache_config,
+            speculative_config=speculative_config,
+            disable_overlap_scheduler=True,
+            max_num_tokens=128,
+        )
+
+    engine = llm._executor.engine_executor
+
+    print(f"engine type: {type(engine)}")
+    cache_interface = engine.cache_seq_interface
+    kv_cache_manager = cache_interface._kv_cache_manager
+
+    kv_num_extra_kv_tokens = getattr(kv_cache_manager, "num_extra_kv_tokens", None)
+    kv_max_draft_len = getattr(kv_cache_manager, "max_draft_len", None)
+    kv_max_total_draft_tokens = getattr(kv_cache_manager, "max_total_draft_tokens", None)
+
+    actual_extra_seq_len_for_kv_cache = getattr(
+        cache_interface, "_extra_seq_len_for_kv_cache", None
+    )
+    actual_spec_config = getattr(cache_interface, "_spec_config", None)
+
+    print("\n" + "=" * 60)
+    print("KVCacheManager Parameters:")
+    print("=" * 60)
+    print(f"  kv_num_extra_kv_tokens:     {kv_num_extra_kv_tokens}")
+    print(f"  kv_max_draft_len:           {kv_max_draft_len}")
+    print(f"  kv_max_total_draft_tokens:  {kv_max_total_draft_tokens}")
+    print("=" * 60)
+    print("\nCachedSequenceInterface Parameters:")
+    print("=" * 60)
+    print(f"  actual_extra_seq_len_for_kv_cache: {actual_extra_seq_len_for_kv_cache}")
+    print(f"  actual_spec_config:                {actual_spec_config}")
+    print("=" * 60)
+
+    assert kv_max_draft_len == max_draft_len, (
+        f"Expected kv_max_draft_len={max_draft_len}, got {kv_max_draft_len}"
+    )
+    assert kv_max_total_draft_tokens == max_draft_len, (
+        f"Expected kv_max_total_draft_tokens={max_draft_len}, got {kv_max_total_draft_tokens}"
+    )
+
+    expected_num_extra_kv_tokens = max_draft_len - 1 if use_one_model_spec_dec else 0
+    assert kv_num_extra_kv_tokens == expected_num_extra_kv_tokens, (
+        f"Expected kv_num_extra_kv_tokens={expected_num_extra_kv_tokens}, "
+        f"got {kv_num_extra_kv_tokens}"
+    )
+
+    # actual_extra_seq_len_for_kv_cache = max_total_draft_tokens + num_extra_kv_tokens
+    # (no overlap scheduler contribution since disable_overlap_scheduler=True)
+    expected_extra_seq_len = max_draft_len + expected_num_extra_kv_tokens  # 3 + 2 = 5
+    assert actual_extra_seq_len_for_kv_cache == expected_extra_seq_len, (
+        f"Expected actual_extra_seq_len_for_kv_cache={expected_extra_seq_len}, "
+        f"got {actual_extra_seq_len_for_kv_cache}"
+    )
+
+    print("\n" + "=" * 80)
+    print("SUCCESS! All KV cache spec-related assertions passed!")
+    print("=" * 80)


### PR DESCRIPTION
Summary:
* Added support for Eagle3 one-model speculative decoding mode alongside existing two-model configurations.


Testing Plan:
* Added accuracy test for GSM8K, where we verify that the output is accurate for the dataset and collect acceptance rate statistics. Acceptance rate looks good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Eagle3 one-model speculative decoding mode alongside existing two-model configurations.
  * Introduced acceptance rate metrics to track and verify speculative decoding performance.

* **Improvements**
  * Enhanced KV cache management with per-submodule support for improved resource handling.
  * Optimized hidden states capture during speculative decoding operations.
  * Refined metadata computation and token iteration management.

* **Bug Fixes**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
fixes: #10931 

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
