### PR TITLE
[TRTLLM-10803][fix] Fix mocking of HuggingFace downloads in `with_mocked_hf_download`

### DIFF
--- a/tests/test_common/llm_data.py
+++ b/tests/test_common/llm_data.py
@@ -104,11 +104,17 @@ def with_mocked_hf_download(func):
 
     When applied, any calls to snapshot_download will be redirected to use
     local model paths from LLM_MODELS_ROOT instead of downloading from HuggingFace.
+
+    NOTE: We must patch snapshot_download at the location where it's actually imported
+    with 'from huggingface_hub import snapshot_download', since that creates a
+    local binding that won't be affected by patching huggingface_hub.snapshot_download.
     """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        with patch("huggingface_hub.snapshot_download", side_effect=mock_snapshot_download):
+        with patch(
+            "tensorrt_llm.llmapi.utils.snapshot_download", side_effect=mock_snapshot_download
+        ):
             return func(*args, **kwargs)
 
     return wrapper

--- a/tests/test_common/llm_data.py
+++ b/tests/test_common/llm_data.py
@@ -115,18 +115,12 @@ def with_mocked_hf_download(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        original_offline = os.environ.get("HF_HUB_OFFLINE")
-        os.environ["HF_HUB_OFFLINE"] = "1"
-
-        try:
-            with patch(
+        with (
+            patch.dict(os.environ, {"HF_HUB_OFFLINE": "1"}),
+            patch(
                 "tensorrt_llm.llmapi.utils.snapshot_download", side_effect=mock_snapshot_download
-            ):
-                return func(*args, **kwargs)
-        finally:
-            if original_offline is None:
-                os.environ.pop("HF_HUB_OFFLINE", None)
-            else:
-                os.environ["HF_HUB_OFFLINE"] = original_offline
+            ),
+        ):
+            return func(*args, **kwargs)
 
     return wrapper

--- a/tests/test_common/llm_data.py
+++ b/tests/test_common/llm_data.py
@@ -99,7 +99,7 @@ def mock_snapshot_download(repo_id: str, **kwargs) -> str:
     return local_path
 
 
-def with_mocked_hf_download(func):
+def with_mocked_hf_download_for_single_gpu(func):
     """Decorator to mock huggingface_hub.snapshot_download for tests.
 
     When applied, any calls to snapshot_download will be redirected to use
@@ -111,6 +111,9 @@ def with_mocked_hf_download(func):
 
     Additionally sets HF_HUB_OFFLINE=1 to ensure no network requests are made to
     HuggingFace.
+
+    WARNING: This decorator only works for single-GPU tests. For multi-GPU tests, the
+    mock won't be applied in MPI worker processes.
     """
 
     @wraps(func)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -24,7 +24,7 @@ from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
 @pytest.mark.skip(
     reason="OOM on A30 GPUs on CI - speculative model loading does not support model_kwargs reduction"
 )
-@pytest.mark.parametrize("use_hf_speculative_model", [False])
+@pytest.mark.parametrize("use_hf_speculative_model", [False, True])
 @with_mocked_hf_download
 def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):
     """Test speculative decoding with AutoDeploy using the build_and_run_ad main()."""

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_speculative_decoding.py
@@ -16,7 +16,7 @@
 import pytest
 from _model_test_utils import get_small_model_config
 from build_and_run_ad import ExperimentConfig, main
-from test_common.llm_data import with_mocked_hf_download
+from test_common.llm_data import with_mocked_hf_download_for_single_gpu
 
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
 
@@ -25,7 +25,7 @@ from tensorrt_llm.llmapi import DraftTargetDecodingConfig, KvCacheConfig
     reason="OOM on A30 GPUs on CI - speculative model loading does not support model_kwargs reduction"
 )
 @pytest.mark.parametrize("use_hf_speculative_model", [False, True])
-@with_mocked_hf_download
+@with_mocked_hf_download_for_single_gpu
 def test_ad_speculative_decoding_smoke(use_hf_speculative_model: bool):
     """Test speculative decoding with AutoDeploy using the build_and_run_ad main()."""
 

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from test_common.llm_data import with_mocked_hf_download
+from test_common.llm_data import with_mocked_hf_download_for_single_gpu
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm import LLM, SamplingParams
@@ -150,7 +150,7 @@ def test_kv_lens_runtime_with_eagle3_one_model():
         [False, "TRTLLM", True, False, False, False, True, False, False, True],
     ])
 @pytest.mark.high_cuda_memory
-@with_mocked_hf_download
+@with_mocked_hf_download_for_single_gpu
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
                       disable_overlap_scheduler: bool, enable_block_reuse: bool,
                       use_one_model: bool, enable_chunked_prefill: bool,


### PR DESCRIPTION
## Description

`unittest/_torch/speculative/test_eagle3.py::test_llama_eagle3[False-TRTLLM-True-False-False-False-True-False-False-True]` and `test_ad_speculative_decoding_smoke[True]` are both intended to test the HuggingFace download codepath for speculative decoding which was introduced in #10099, but they were still supposed to mock out the actual download from HuggingFace, which was not actually being applied. This PR fixes the mocking behavior.

Note: `test_ad_speculative_decoding_smoke` is still waived due to https://nvbugs/5859869

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for HuggingFace model mocking with corrected patch targeting and documentation.
  * Expanded test coverage for speculative model scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->