### PR TITLE
[None][feat] Add support for bidirectional sliding window attention mask to fmha_v2

### DIFF
--- a/cpp/kernels/fmha_v2/README.md
+++ b/cpp/kernels/fmha_v2/README.md
@@ -20,7 +20,12 @@ the `setup.py` code:
 export TORCH_CUDA_ARCH_LIST=9.0 ENABLE_SM89_QMMA=1 ENABLE_HMMA_FP32=1 SCHEDULING_MODE=1 ENABLE_SM100=1 ENABLE_SM120=1
 ```
 
-To generate subset of kernels, you can add conditions in setup.py.
+To generate subset of kernels, you can add conditions in setup.py. Or set `FMHA_FILTER_ARCH` before calling setup.py:
+
+```
+# Build only for a specific arch (or list of architectures). Will not enable kernels that are disabled by default
+export FMHA_FILTER_ARCH=90
+```
 
 To generate the files and compile the kernels:
 ```

--- a/cpp/kernels/fmha_v2/fmha_test.py
+++ b/cpp/kernels/fmha_v2/fmha_test.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import subprocess
 
 import pytest
@@ -285,14 +299,12 @@ def test_trtllm_sliding_window_attention(sliding_window_size, mask_type):
     if mask_type == "-bidirectional-sliding-window-mask":
         sliding_window_size *= 2
 
-    subprocess.run(
-        f"bin/fmha.exe -d 128 -b 4 -h 5 -bf16 -s 8192 -min-s 4096 -bf16 \
+    subprocess.run(f"bin/fmha.exe -d 128 -b 4 -h 5 -s 8192 -min-s 4096 -bf16 \
         -sliding-window-size {sliding_window_size} {mask_type}",
-        shell=True,
-        check=True)
+                   shell=True,
+                   check=True)
 
-    subprocess.run(
-        f"bin/fmha.exe -d 64 -b 4 -h 5 -bf16 -s 8192 -min-s 4096 -bf16 \
+    subprocess.run(f"bin/fmha.exe -d 64 -b 4 -h 5 -s 8192 -min-s 4096 -bf16 \
         -sliding-window-size {sliding_window_size} {mask_type}",
-        shell=True,
-        check=True)
+                   shell=True,
+                   check=True)

--- a/cpp/kernels/fmha_v2/fmha_test.py
+++ b/cpp/kernels/fmha_v2/fmha_test.py
@@ -268,3 +268,31 @@ def test_trtllm_chunked_attention(chunked_attention_size, input_layout):
             -chunked-attention-size {chunked_attention_size} -paged-kv",
             shell=True,
             check=True)
+
+
+# The test cases for sliding window attention.
+@pytest.mark.parametrize(
+    'sliding_window_size', [64, 127, 128, 129, 256, 1024],
+    ids=[
+        "sliding-window-size-64", "sliding-window-size-127",
+        "sliding-window-size-128", "sliding-window-size-129",
+        "sliding-window-size-256", "sliding-window-size-1024"
+    ])
+@pytest.mark.parametrize(
+    'mask_type',
+    ["-sliding-or-chunked-causal-mask", "-bidirectional-sliding-window-mask"])
+def test_trtllm_sliding_window_attention(sliding_window_size, mask_type):
+    if mask_type == "-bidirectional-sliding-window-mask":
+        sliding_window_size *= 2
+
+    subprocess.run(
+        f"bin/fmha.exe -d 128 -b 4 -h 5 -bf16 -s 8192 -min-s 4096 -bf16 \
+        -sliding-window-size {sliding_window_size} {mask_type}",
+        shell=True,
+        check=True)
+
+    subprocess.run(
+        f"bin/fmha.exe -d 64 -b 4 -h 5 -bf16 -s 8192 -min-s 4096 -bf16 \
+        -sliding-window-size {sliding_window_size} {mask_type}",
+        shell=True,
+        check=True)

--- a/cpp/kernels/fmha_v2/fmha_test.py
+++ b/cpp/kernels/fmha_v2/fmha_test.py
@@ -286,11 +286,11 @@ def test_trtllm_chunked_attention(chunked_attention_size, input_layout):
 
 # The test cases for sliding window attention.
 @pytest.mark.parametrize(
-    'sliding_window_size', [64, 127, 128, 129, 256, 1024],
+    'sliding_window_size', [64, 127, 128, 129, 256, 512],
     ids=[
         "sliding-window-size-64", "sliding-window-size-127",
         "sliding-window-size-128", "sliding-window-size-129",
-        "sliding-window-size-256", "sliding-window-size-1024"
+        "sliding-window-size-256", "sliding-window-size-512"
     ])
 @pytest.mark.parametrize(
     'mask_type',
@@ -299,12 +299,12 @@ def test_trtllm_sliding_window_attention(sliding_window_size, mask_type):
     if mask_type == "-bidirectional-sliding-window-mask":
         sliding_window_size *= 2
 
-    subprocess.run(f"bin/fmha.exe -d 128 -b 4 -h 5 -s 8192 -min-s 4096 -bf16 \
+    subprocess.run(f"bin/fmha.exe -d 128 -b 2 -h 5 -s 2048 -min-s 1024 -bf16 \
         -sliding-window-size {sliding_window_size} {mask_type}",
                    shell=True,
                    check=True)
 
-    subprocess.run(f"bin/fmha.exe -d 64 -b 4 -h 5 -s 8192 -min-s 4096 -bf16 \
+    subprocess.run(f"bin/fmha.exe -d 64 -b 2 -h 5 -s 2048 -min-s 1024 -bf16 \
         -sliding-window-size {sliding_window_size} {mask_type}",
                    shell=True,
                    check=True)

--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -3523,7 +3523,9 @@ def get_cubin_header(kernel_traits, specs_names):
                         return 'nullptr'
                     lname = kname.replace('_kernel', '')
                     mask_types = [
-                        '_sliding_or_chunked_causal', '_custom_mask', '_causal'
+                        '_sliding_or_chunked_causal',
+                        '_bidirectional_sliding_window', '_custom_mask',
+                        '_causal'
                     ]
                     for mask_type in mask_types:
                         lname = lname.replace(mask_type, '')

--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -6943,6 +6943,11 @@ def enumerate_kernels():
                   and (kspec.head_size == 128 or kspec.head_size == 256 or not kspec.enable_attn_logit_softcapping)]
     # yapf: enable
 
+    # A separate more aggressive filter for building the fmha.exe binary. Can be ignored for building the cubins.
+    if "FMHA_FILTER_ARCH" in os.environ:
+        archs = [int(x) for x in os.environ["FMHA_FILTER_ARCH"].split(",")]
+        specs_names = [kspec for kspec in specs_names if kspec[0].sm in archs]
+
     generate_files(specs_names)
 
 

--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -749,7 +749,7 @@ using Kernel_traits_nl_bidirectional_sliding_window = fmha::{kernel_traits}<
     {warps_n},
     {ctas_per_head},
     {kernel_flags} | 0x200 /* no_loop flag */,
-    /*bidirectional_sliding_window mask*/ 5,
+    /*bidirectional sliding window mask*/ 5,
     /*bmm2_fp16_epilogue*/ true,
     {output_dtype_}>;
 
@@ -934,7 +934,7 @@ using Kernel_traits_nl_tiled_bidirectional_sliding_window = fmha::{kernel_traits
     {warps_n},
     {ctas_per_head},
     {kernel_flags} | 0x200 /* no_loop flag */,
-    /*bidirectional_sliding_window mask*/ 5,
+    /*bidirectional sliding window mask*/ 5,
     /*bmm2_fp16_epilogue*/ true,
     {output_dtype_}>;
 
@@ -2231,6 +2231,7 @@ def selected_mask_types(kspec):
         if kspec.enable_attn_logit_softcapping:
             padding_mask = '0'
             custom_mask = '0'
+            bidirectional_sliding_window_mask = '0'
 
         if kspec.head_size not in [32, 64, 128]:
             bidirectional_sliding_window_mask = '0'
@@ -3381,13 +3382,16 @@ def get_cubin_header(kernel_traits, specs_names):
                 '').replace('ldgsts_', '').replace('causal_', '').replace(
                     'alibi_', '').replace('softmax_', '').replace(
                         'sliding_or_chunked_', '').replace(
-                            'custom_mask_', '').replace('qkv_', '').replace(
-                                'q_kv_', '').replace('q_paged_kv_', '').replace(
-                                    'q_k_v_', '').replace('ws_', '').replace(
-                                        'softcapping_',
-                                        '').replace('sage_', '').replace(
-                                            'skipSoftmax_',
-                                            '').replace('output_', ''))
+                            'bidirectional_sliding_window_', '').replace(
+                                'custom_mask_', '').replace('qkv_', '').replace(
+                                    'q_kv_',
+                                    '').replace('q_paged_kv_', '').replace(
+                                        'q_k_v_',
+                                        '').replace('ws_', '').replace(
+                                            'softcapping_',
+                                            '').replace('sage_', '').replace(
+                                                'skipSoftmax_',
+                                                '').replace('output_', ''))
         flash_attention = 'flash_attention' in kname
         warp_specialization = 'tma_ws' in kname
         toks = tname.split('_')

--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -3182,7 +3182,7 @@ def get_kernel_traits_code(specs_names):
                                        replace('__use_tma_store__', 'false')
             snippet_ws_custom_mask = \
                 snippet_ws_template.replace('__placeholder__', '_custom_mask').\
-                                       replace('mask_type', '2').\
+                                       replace('mask_type', '4').\
                                        replace('__use_tma_store__', 'true')
         elif effective_sm >= 90:  #GMMA no flash yet
             snippet_template = '''    {{

--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -2233,9 +2233,6 @@ def selected_mask_types(kspec):
             custom_mask = '0'
             bidirectional_sliding_window_mask = '0'
 
-        if kspec.head_size not in [32, 64, 128]:
-            bidirectional_sliding_window_mask = '0'
-
     return padding_mask, causal_mask, sliding_or_chunked_causal_mask, bidirectional_sliding_window_mask, custom_mask
 
 

--- a/cpp/kernels/fmha_v2/src/fmha/hopper/kernel_traits.h
+++ b/cpp/kernels/fmha_v2/src/fmha/hopper/kernel_traits.h
@@ -49,7 +49,8 @@ template <
     int WARPS_N,
     // The version of the kernel.
     int VERSION_,
-    // The mask version of the kernel, (2 denotes dense mask, 3 denotes causal mask)
+    // The mask version of the kernel, (2 denotes dense mask, 3 denotes causal mask, 4 denotes sliding window causal
+    // mask, 5 denotes bidirectional sliding window mask)
     int MASK_VERSION_ = 2,
     // The flags to control the behaviour of LDGs.
     uint32_t FLAGS = 0x8u>
@@ -111,13 +112,19 @@ struct FMHA_kernel_traits_hopper
     // Whether use causal mask or not.
     enum
     {
-        CAUSAL_MASK = MASK_VERSION_ >= 3
+        CAUSAL_MASK = MASK_VERSION_ == 3 || MASK_VERSION_ == 4
     };
 
     // Whether use the sliding window attention mask or not.
     enum
     {
         SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 4
+    };
+
+    // Whether use the bidirectional sliding window attention mask or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 5
     };
 
     // Do we use LDGSTS for Q, K or V. If not, TMA is used!

--- a/cpp/kernels/fmha_v2/src/fmha/kernel_traits.h
+++ b/cpp/kernels/fmha_v2/src/fmha/kernel_traits.h
@@ -271,7 +271,8 @@ struct Kernel_traits_
         VERSION = VERSION_
     };
 
-    // The mask version: padding (2), causal (3), sliding_window_causal (4), custom_mask (5).
+    // The mask version: padding (2), causal (3), sliding_window_causal (4), bidirectional_sliding_window (5),
+    // custom_mask (6).
     enum
     {
         MASK_VERSION = MASK_VERSION_
@@ -289,10 +290,16 @@ struct Kernel_traits_
         SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 4
     };
 
+    // Whether use the bidirectional sliding window attention or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 5
+    };
+
     // Whether use the custom mask or not.
     enum
     {
-        CUSTOM_MASK = MASK_VERSION_ == 5
+        CUSTOM_MASK = MASK_VERSION_ == 6
     };
 
     // Do we use LDGSTS for Q, K or V.
@@ -551,13 +558,19 @@ struct Kernel_traits_fmhca_
     // Whether use causal mask or not.
     enum
     {
-        CAUSAL_MASK = MASK_VERSION >= 3
+        CAUSAL_MASK = MASK_VERSION == 3 || MASK_VERSION == 4
     };
 
     // Whether use the sliding window attention or not.
     enum
     {
         SLIDING_WINDOW_ATTENTION = MASK_VERSION == 4
+    };
+
+    // Whether use the bidirectional sliding window attention or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = MASK_VERSION == 5
     };
 
     // Do we use LDGSTS for Q, K or V.
@@ -745,13 +758,19 @@ struct Kernel_traits_interleaved_v2_
     // Whether use causal mask or not.
     enum
     {
-        CAUSAL_MASK = MASK_VERSION_ >= 3
+        CAUSAL_MASK = MASK_VERSION_ == 3 || MASK_VERSION_ == 4
     };
 
     // Whether use the sliding window attention or not.
     enum
     {
         SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 4
+    };
+
+    // Whether use the bidirectional sliding window attention or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = MASK_VERSION_ == 5
     };
 
     // The number of CTAs per head for Cta_tile_p; equivalent to BMM1 split-K

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/compute.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/compute.h
@@ -297,19 +297,19 @@ struct Compute
         // Handle sliding window or chunked attention masking
         if constexpr (SLIDING_OR_CHUNKED_ATTENTION)
         {
-            if (is_chunked_attention)
-            {
-                // Handle chunked attention
-                kv_left_mask_end = div_up(
-                    ((tile_offset_end >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size),
-                    STEP_KV);
-            }
-            else if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+            if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
             {
                 // Handle bidirectional sliding window attention
                 kv_left_mask_end = div_up(tile_offset_end - params.sliding_window_size / 2, STEP_KV);
                 kv_right_mask_start
                     = min(kv_idx_end - 1, (tile_offset_start + params.sliding_window_size / 2 + 1) / STEP_KV);
+            }
+            else if (is_chunked_attention)
+            {
+                // Handle chunked attention
+                kv_left_mask_end = div_up(
+                    ((tile_offset_end >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size),
+                    STEP_KV);
             }
             else
             {

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/compute.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/compute.h
@@ -116,6 +116,12 @@ struct Compute
         SLIDING_OR_CHUNKED_ATTENTION = Kernel_traits::SLIDING_OR_CHUNKED_ATTENTION
     };
 
+    // Whether use the bidirectional sliding window attention or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION
+    };
+
     // Are we applying alibi bias (drop FMA optimizations for accuracy reasons).
     enum
     {
@@ -288,17 +294,30 @@ struct Compute
         // Is the chunked_attention used ?
         bool is_chunked_attention = params.log2_chunked_attention_size > 0;
 
-        // The left mask is needed when we attend to a specific sliding window or chunk.
+        // Handle sliding window or chunked attention masking
         if constexpr (SLIDING_OR_CHUNKED_ATTENTION)
         {
-            // The kv_left_mask_end is the start of the chunk.
-            kv_left_mask_end = div_up(is_chunked_attention
-                    ? ((tile_offset_end >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size)
-                    : (tile_offset_end + 1 - params.sliding_window_size),
-                STEP_KV);
+            if (is_chunked_attention)
+            {
+                // Handle chunked attention
+                kv_left_mask_end = div_up(
+                    ((tile_offset_end >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size),
+                    STEP_KV);
+            }
+            else if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+            {
+                // Handle bidirectional sliding window attention
+                kv_left_mask_end = div_up(tile_offset_end - params.sliding_window_size / 2, STEP_KV);
+                kv_right_mask_start
+                    = min(kv_idx_end - 1, (tile_offset_start + params.sliding_window_size / 2 + 1) / STEP_KV);
+            }
+            else
+            {
+                kv_left_mask_end = div_up(tile_offset_end + 1 - params.sliding_window_size, STEP_KV);
+            }
         }
 
-        // The right mask is needed when causal mask (including sliding_window_attention or chunked attention) is used.
+        // The right mask is needed when causal mask is used.
         if constexpr (SKIP_CAUSAL_MASK_TILES)
         {
             kv_right_mask_start = tile_offset_start / STEP_KV;

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/dma.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/dma.h
@@ -207,13 +207,7 @@ struct DMA
             // Skip initial kv tiles due to sliding_window_size
             if (SLIDING_OR_CHUNKED_ATTENTION)
             {
-                if (is_chunked_attention)
-                {
-                    int kv_offset_start
-                        = ((q_step_offset >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size);
-                    kv_idx_start = kv_offset_start / STEP_KV;
-                }
-                else if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+                if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
                 {
                     int kv_offset_start = max(0, q_step_offset - params.sliding_window_size / 2);
                     int kv_offset_end = min(kv_steps * STEP_KV - 1, q_step_end + params.sliding_window_size / 2);
@@ -222,6 +216,12 @@ struct DMA
                     // exclusive
                     kv_idx_start = kv_offset_start / STEP_KV;
                     kv_idx_end = kv_offset_end / STEP_KV + 1;
+                }
+                else if (is_chunked_attention)
+                {
+                    int kv_offset_start
+                        = ((q_step_offset >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size);
+                    kv_idx_start = kv_offset_start / STEP_KV;
                 }
                 else
                 {

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/dma.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/dma.h
@@ -114,6 +114,12 @@ struct DMA
         SLIDING_OR_CHUNKED_ATTENTION = Kernel_traits::SLIDING_OR_CHUNKED_ATTENTION
     };
 
+    // Whether use the bidirectional sliding window attention or not.
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION
+    };
+
     // Is heads interleaved ?
     enum
     {
@@ -201,11 +207,27 @@ struct DMA
             // Skip initial kv tiles due to sliding_window_size
             if (SLIDING_OR_CHUNKED_ATTENTION)
             {
-                // The kv_offset_start.
-                int kv_offset_start = is_chunked_attention
-                    ? ((q_step_offset >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size)
-                    : max(0, q_step_offset + 1 - params.sliding_window_size);
-                kv_idx_start = kv_offset_start / STEP_KV;
+                if (is_chunked_attention)
+                {
+                    int kv_offset_start
+                        = ((q_step_offset >> params.log2_chunked_attention_size) << params.log2_chunked_attention_size);
+                    kv_idx_start = kv_offset_start / STEP_KV;
+                }
+                else if constexpr (BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+                {
+                    int kv_offset_start = max(0, q_step_offset - params.sliding_window_size / 2);
+                    int kv_offset_end = min(kv_steps * STEP_KV - 1, q_step_end + params.sliding_window_size / 2);
+
+                    // We do floor division plus 1 to get the correct kv_idx_end, this is because kv_idx_end is
+                    // exclusive
+                    kv_idx_start = kv_offset_start / STEP_KV;
+                    kv_idx_end = kv_offset_end / STEP_KV + 1;
+                }
+                else
+                {
+                    int kv_offset_start = max(0, q_step_offset + 1 - params.sliding_window_size);
+                    kv_idx_start = kv_offset_start / STEP_KV;
+                }
             }
 
             // Early stop when causal mask is enabled.

--- a/cpp/kernels/fmha_v2/src/fmha/warpspec/kernel_traits.h
+++ b/cpp/kernels/fmha_v2/src/fmha/warpspec/kernel_traits.h
@@ -51,8 +51,9 @@ template <
     int NUM_COMPUTE_GROUPS_,
     // The number of data warpgroups (TMA).
     int DMA2COMPUTE_DEPTH_,
-    // The attention mask type: padding (0), causal (1), sliding_window_causal (2), custom_mask (3).
-    // See fused_multihead_attention_kernel.h for description.
+    // The attention mask type: padding (0), causal (1), sliding_or_chunked_attention (2),
+    // bidirectional_sliding_window_attention (3), custom_mask (4). See fused_multihead_attention_kernel.h for
+    // description.
     int ATTENTION_MASK_TYPE_ = 0,
     // Is head interleaved ?
     // (head_interleaved means input [bxs, h, 3, d], otherwise [bx3, 3, h, d]).
@@ -250,7 +251,8 @@ struct Kernel_traits
         WARP_GROUP_K = 1
     };
 
-    // The attention mask type: padding (0), causal (1), sliding_or_chunked_attention (2), custom_mask (3).
+    // The attention mask type: padding (0), causal (1), sliding_or_chunked_attention (2),
+    // bidirectional_sliding_window_attention (3), custom_mask (4).
     enum
     {
         CAUSAL_MASK = (ATTENTION_MASK_TYPE_ == 1 || ATTENTION_MASK_TYPE_ == 2)
@@ -258,7 +260,12 @@ struct Kernel_traits
 
     enum
     {
-        SLIDING_OR_CHUNKED_ATTENTION = ATTENTION_MASK_TYPE_ == 2
+        SLIDING_OR_CHUNKED_ATTENTION = ATTENTION_MASK_TYPE_ == 2 || ATTENTION_MASK_TYPE_ == 3
+    };
+
+    enum
+    {
+        BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION = ATTENTION_MASK_TYPE_ == 3
     };
 
     // Is head interleaved ?
@@ -286,10 +293,10 @@ struct Kernel_traits
         ENABLE_BMM1_SOFTCAPPING_SCALE = ENABLE_BMM1_SOFTCAPPING_SCALE_
     };
 
-    // Use the custom mask input ( attention_mask_type == 3.)
+    // Use the custom mask input ( attention_mask_type == 4.)
     enum
     {
-        USE_CUSTOM_MASK = ATTENTION_MASK_TYPE_ == 3
+        USE_CUSTOM_MASK = ATTENTION_MASK_TYPE_ == 4
     };
 
     // Are we enabling skip softmax attention feature?

--- a/cpp/kernels/fmha_v2/src/fused_multihead_attention.h
+++ b/cpp/kernels/fmha_v2/src/fused_multihead_attention.h
@@ -49,6 +49,8 @@ enum class Attention_mask_type
     CAUSAL,
     // Causal mask + attend to the specific sliding window or chunk.
     SLIDING_OR_CHUNKED_CAUSAL,
+    // Bidirectional sliding window attention.
+    BIDIRECTIONAL_SLIDING_WINDOW,
     // The custom mask input.
     CUSTOM_MASK,
 };
@@ -62,6 +64,7 @@ static inline std::string mask_type_to_string(Attention_mask_type mask_type)
     case Attention_mask_type::PADDING: return "padding";
     case Attention_mask_type::CAUSAL: return "causal";
     case Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL: return "sliding_or_chunked_causal";
+    case Attention_mask_type::BIDIRECTIONAL_SLIDING_WINDOW: return "bidirectional_sliding_window";
     case Attention_mask_type::CUSTOM_MASK: return "custom_mask";
     default: assert(false); return "";
     }

--- a/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop.h
+++ b/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop.h
@@ -172,19 +172,43 @@ inline __device__ void device_flash_attention_nl(Params const& params)
     static_assert(MASK_LOOPS * Cta_tile_p::N == Cta_tile_p::M || Cta_tile_p::N >= Cta_tile_p::M, "");
 
     // The start/end step of kv loops.
-    // Do we need to mask out the tokens that is far away from the beginning.
+    // Do we need to mask out the tokens that is not in the sliding window.
     bool const mask_sliding_window
-        = Kernel_traits::SLIDING_WINDOW_ATTENTION && binfo.actual_kv_seqlen > params.sliding_window_size;
+        = (Kernel_traits::SLIDING_WINDOW_ATTENTION && binfo.actual_kv_seqlen > params.sliding_window_size)
+        || (Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION
+            && binfo.actual_kv_seqlen > params.sliding_window_size / 2 + 1); // +1 to include self token
+
     int const valid_seqlen = Kernel_traits::CAUSAL_MASK ? min(q_sequence_start + Cta_tile_p::M, binfo.actual_kv_seqlen)
                                                         : binfo.actual_kv_seqlen;
 
-    int const kv_loop_end = ((valid_seqlen + Cta_tile_p::N - 1) / Cta_tile_p::N) * Cta_tile_p::N;
-    int const kv_loop_start = mask_sliding_window
-        ? (max(0, q_sequence_start + 1 - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N
-        : 0;
-    int const sliding_window_mask_end = mask_sliding_window
-        ? (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N
-        : 0;
+    int kv_loop_start = 0;
+    int kv_loop_end = fmha::div_up(valid_seqlen, int(Cta_tile_p::N)) * int(Cta_tile_p::N);
+    int sliding_window_mask_left = 0;
+    int sliding_window_mask_right = kv_loop_end;
+    if (mask_sliding_window)
+    {
+        if constexpr (Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+        {
+            kv_loop_start = (max(0, q_sequence_start - params.sliding_window_size / 2) / Cta_tile_p::N) * Cta_tile_p::N;
+            sliding_window_mask_left
+                = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size / 2) / Cta_tile_p::N)
+                * Cta_tile_p::N;
+
+            // TODO I am not at all confident of this math
+            kv_loop_end = min(kv_loop_end,
+                (fmha::div_up(q_sequence_start + Cta_tile_p::M + params.sliding_window_size / 2, int(Cta_tile_p::N))
+                    * Cta_tile_p::N));
+            sliding_window_mask_right = min(sliding_window_mask_right,
+                ((q_sequence_start + params.sliding_window_size / 2) / int(Cta_tile_p::N)) * Cta_tile_p::N);
+        }
+        else
+        {
+            kv_loop_start = (max(0, q_sequence_start + 1 - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N;
+            sliding_window_mask_left
+                = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size) / Cta_tile_p::N)
+                * Cta_tile_p::N;
+        }
+    }
 
     static_assert(Cta_tile_p::M >= Cta_tile_p::N, "");
 
@@ -337,7 +361,8 @@ inline __device__ void device_flash_attention_nl(Params const& params)
     // Do we need to check if there are negative inf for softmax row_max ?
     enum
     {
-        CHECK_NEG_INF = Kernel_traits::SLIDING_WINDOW_ATTENTION || Kernel_traits::CUSTOM_MASK
+        CHECK_NEG_INF = Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION || Kernel_traits::SLIDING_WINDOW_ATTENTION
+            || Kernel_traits::CUSTOM_MASK
     };
 
     // Load the mask for that iteration.
@@ -363,7 +388,8 @@ inline __device__ void device_flash_attention_nl(Params const& params)
 
         bool const first_step = (kv_loop == kv_loop_start);
         // It is possible that all tokens are masked out (sliding-window-attention).
-        bool const apply_sliding_window_mask = (mask_sliding_window && kv_loop <= sliding_window_mask_end);
+        bool const apply_sliding_window_mask
+            = (mask_sliding_window && (kv_loop <= sliding_window_mask_left || kv_loop >= sliding_window_mask_right));
         bool const apply_mask = params.has_alibi || (kv_loop >= kv_mask_loop_start) || apply_sliding_window_mask;
 
         // Move mask offset.

--- a/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop.h
+++ b/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop.h
@@ -194,7 +194,6 @@ inline __device__ void device_flash_attention_nl(Params const& params)
                 = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size / 2) / Cta_tile_p::N)
                 * Cta_tile_p::N;
 
-            // TODO I am not at all confident of this math
             kv_loop_end = min(kv_loop_end,
                 (fmha::div_up(q_sequence_start + Cta_tile_p::M + params.sliding_window_size / 2, int(Cta_tile_p::N))
                     * Cta_tile_p::N));

--- a/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop_tiled.h
+++ b/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop_tiled.h
@@ -195,7 +195,6 @@ inline __device__ void device_flash_attention_nl_tiled(Params const& params)
                 = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size / 2) / Cta_tile_p::N)
                 * Cta_tile_p::N;
 
-            // TODO I am not at all confident of this math
             kv_loop_end = min(kv_loop_end,
                 (fmha::div_up(q_sequence_start + Cta_tile_p::M + params.sliding_window_size / 2, int(Cta_tile_p::N))
                     * Cta_tile_p::N));

--- a/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop_tiled.h
+++ b/cpp/kernels/fmha_v2/src/fused_multihead_flash_attention_kernel_noloop_tiled.h
@@ -175,17 +175,41 @@ inline __device__ void device_flash_attention_nl_tiled(Params const& params)
     // The start/end step of kv loops.
     // Do we need to mask out the tokens that is not in the sliding window.
     bool const mask_sliding_window
-        = Kernel_traits::SLIDING_WINDOW_ATTENTION && binfo.actual_kv_seqlen > params.sliding_window_size;
+        = (Kernel_traits::SLIDING_WINDOW_ATTENTION && binfo.actual_kv_seqlen > params.sliding_window_size)
+        || (Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION
+            && binfo.actual_kv_seqlen > params.sliding_window_size / 2 + 1); // +1 to include self token
+
     int const valid_seqlen = Kernel_traits::CAUSAL_MASK ? min(q_sequence_start + Cta_tile_p::M, binfo.actual_kv_seqlen)
                                                         : binfo.actual_kv_seqlen;
 
-    int const kv_loop_end = ((valid_seqlen + Cta_tile_p::N - 1) / Cta_tile_p::N) * Cta_tile_p::N;
-    int const kv_loop_start = mask_sliding_window
-        ? (max(0, q_sequence_start + 1 - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N
-        : 0;
-    int const sliding_window_mask_end = mask_sliding_window
-        ? (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N
-        : 0;
+    int kv_loop_start = 0;
+    int kv_loop_end = fmha::div_up(valid_seqlen, int(Cta_tile_p::N)) * int(Cta_tile_p::N);
+    int sliding_window_mask_left = 0;
+    int sliding_window_mask_right = kv_loop_end;
+    if (mask_sliding_window)
+    {
+        if constexpr (Kernel_traits::BIDIRECTIONAL_SLIDING_WINDOW_ATTENTION)
+        {
+            kv_loop_start = (max(0, q_sequence_start - params.sliding_window_size / 2) / Cta_tile_p::N) * Cta_tile_p::N;
+            sliding_window_mask_left
+                = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size / 2) / Cta_tile_p::N)
+                * Cta_tile_p::N;
+
+            // TODO I am not at all confident of this math
+            kv_loop_end = min(kv_loop_end,
+                (fmha::div_up(q_sequence_start + Cta_tile_p::M + params.sliding_window_size / 2, int(Cta_tile_p::N))
+                    * Cta_tile_p::N));
+            sliding_window_mask_right = min(sliding_window_mask_right,
+                ((q_sequence_start + params.sliding_window_size / 2) / int(Cta_tile_p::N)) * Cta_tile_p::N);
+        }
+        else
+        {
+            kv_loop_start = (max(0, q_sequence_start + 1 - params.sliding_window_size) / Cta_tile_p::N) * Cta_tile_p::N;
+            sliding_window_mask_left
+                = (max(0, q_sequence_start + Cta_tile_p::M - params.sliding_window_size) / Cta_tile_p::N)
+                * Cta_tile_p::N;
+        }
+    }
 
     // Move K and V tiles.
     // We need offset here since we split single k loops into finer granularity.
@@ -301,7 +325,8 @@ inline __device__ void device_flash_attention_nl_tiled(Params const& params)
 
         bool const first_step = (kv_loop == kv_loop_start);
         // It is possible that all tokens are masked out (sliding-window-attention).
-        bool const apply_sliding_window_mask = (mask_sliding_window && kv_loop <= sliding_window_mask_end);
+        bool const apply_sliding_window_mask
+            = (mask_sliding_window && (kv_loop <= sliding_window_mask_left || kv_loop >= sliding_window_mask_right));
         bool const apply_mask = params.has_alibi || (kv_loop >= kv_mask_loop_start) || apply_sliding_window_mask;
 
         // Declare the accumulators for the 1st gemm.

--- a/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fused_multihead_attention_common.h
+++ b/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fused_multihead_attention_common.h
@@ -69,6 +69,8 @@ enum class ContextAttentionMaskType
     CAUSAL,
     // Causal mask + attend to the specific sliding window or chunk.
     SLIDING_OR_CHUNKED_CAUSAL,
+    // Bidirectional sliding window attention.
+    BIDIRECTIONAL_SLIDING_WINDOW,
     // The custom mask input.
     CUSTOM_MASK
 };

--- a/tests/integration/defs/test_fmha.py
+++ b/tests/integration/defs/test_fmha.py
@@ -3,6 +3,8 @@ from functools import partial
 from pathlib import Path
 from subprocess import run
 
+from tests.unittest.utils.util import getSMVersion
+
 
 def test_fmha():
     build_run = partial(run, shell=True, check=True)
@@ -13,6 +15,15 @@ def test_fmha():
 
     try:
         os.chdir(fmha_v2_dir)
+
+        test_arch = getSMVersion()
+        # SM70 is deprecated in TRTLLM, so we don't need to test it
+        all_archs = [80, 86, 89, 90, 100, 120]
+
+        # Select the family we belong to (e.g. 103 -> 100)
+        test_arch = max(filter(lambda x: x < test_arch, all_archs))
+
+        build_only_on_archs = filter(lambda x: x != test_arch, all_archs)
 
         env = os.environ.copy()
         env.update({
@@ -26,10 +37,19 @@ def test_fmha():
             "1",  # Do not run tests with skip-softmax feature.
         })
 
-        build_run(
-            "rm -rf generated temp obj .pytest_cache __pycache__ bin cubin")
-        build_run("python3 setup.py", env=env)
-        build_run("make -j 16", env=env)
+        # The test executable is too large if we build all the architectures, so we must build architectures individually
+        def build_arch(arch):
+            env["FMHA_FILTER_ARCH"] = str(arch)
+            build_run(
+                "rm -rf generated temp obj .pytest_cache __pycache__ bin cubin")
+            build_run("python3 setup.py", env=env)
+            build_run("make -j 16", env=env)
+
+        # As part of the test we should compile all the architectures, even the ones we dont have executors for
+        for arch in build_only_on_archs:
+            build_arch(arch)
+
+        build_arch(test_arch)
         build_run("pytest fmha_test.py", env=env)
 
     finally:

--- a/tests/integration/defs/test_fmha.py
+++ b/tests/integration/defs/test_fmha.py
@@ -21,7 +21,7 @@ def test_fmha():
         all_archs = [80, 86, 89, 90, 100, 120]
 
         # Select the family we belong to (e.g. 103 -> 100)
-        test_arch = max(filter(lambda x: x < test_arch, all_archs))
+        test_arch = max(filter(lambda x: x <= test_arch, all_archs))
 
         build_only_on_archs = filter(lambda x: x != test_arch, all_archs)
 

--- a/tests/integration/defs/test_fmha.py
+++ b/tests/integration/defs/test_fmha.py
@@ -20,10 +20,12 @@ def test_fmha():
         # SM70 is deprecated in TRTLLM, so we don't need to test it
         all_archs = [80, 86, 89, 90, 100, 120]
 
+        # TODO Find a way to get this programmatically
+        # Filter out the architectures that are tested explicitly to not double up
+        tested_archs = [80, 86, 89, 90]
+
         # Select the family we belong to (e.g. 103 -> 100)
         test_arch = max(filter(lambda x: x <= test_arch, all_archs))
-
-        build_only_on_archs = filter(lambda x: x != test_arch, all_archs)
 
         env = os.environ.copy()
         env.update({
@@ -45,10 +47,14 @@ def test_fmha():
             build_run("python3 setup.py", env=env)
             build_run("make -j 16", env=env)
 
-        # As part of the test we should compile all the architectures, even the ones we dont have executors for
-        for arch in build_only_on_archs:
-            build_arch(arch)
+        # As part of the A100 test we compile all the architectures we dont have executors for, even if we dont run them
+        if test_arch == 80:
+            build_only_on_archs = set(all_archs) - set(tested_archs)
 
+            for arch in build_only_on_archs:
+                build_arch(arch)
+
+        # Run the test of our current architecture
         build_arch(test_arch)
         build_run("pytest fmha_test.py", env=env)
 

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -105,4 +105,4 @@ l0_a100:
       stage: post_merge
       backend: fmha
   tests:
-  - test_fmha.py::test_fmha TIMEOUT (90)
+  - test_fmha.py::test_fmha TIMEOUT (120) # Longer timeout for A100 as it builds all the architectures


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for bidirectional sliding window attention, extending available masking options for attention computation with configurable window sizes and mask types.

* **Tests**
  * Introduced new parametrized test suite for bidirectional sliding window attention with variable window sizes and mask configurations across multiple hardware setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
