### PR TITLE
[None][feat] Support disagg slurm jobs rescheduling

### DIFF
--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -56,14 +56,16 @@ cleanup_on_failure() {
 replace_placeholder() {
     file_path="$1"
     all_nodes_str="$2"
+    new_file_path="$3"
+    cp "$file_path" "$new_file_path"
     IFS=',' read -r -a node_array <<< "$all_nodes_str"
     for i in "${!node_array[@]}"; do
         current_val="${node_array[$i]}"
         placeholder="<node${i}_placeholder>"
 
         # Use sed to replace the placeholder with the value in-place
-        sed -i "s|$placeholder|$current_val|g" "${file_path}"
-        echo "Replaced $placeholder with $current_val in ${file_path}"
+        sed -i "s|$placeholder|$current_val|g" "${new_file_path}"
+        echo "Replaced $placeholder with $current_val in ${new_file_path}"
     done
 }
 
@@ -134,7 +136,18 @@ else
         cleanup_on_failure "Failed to get TensorRT-LLM environment variables. Check ${full_logdir}/2_get_env.log for details"
     fi
     echo "TensorRT-LLM environment variables saved to ${full_logdir}/env_vars.json"
+    # Install lm_eval[api]==0.4.9.1 if not installed
+    # if ! srun --container-name=${container_name} \
+    #     --container-mounts=${container_mount} --no-container-mount-home \
+    #     --mpi=pmix --overlap -N $SLURM_NNODES --ntasks-per-node=1 \
+    #     bash -c "pip install lm_eval[api]==0.4.9.1" \
+    #     &> ${full_logdir}/2_install_lm_eval.log; then
+    #     cleanup_on_failure "lm_eval installation failed. Check ${full_logdir}/2_install_lm_eval.log for details"
+    # fi
+    # echo "lm_eval installation completed successfully"
 fi
+
+
 
 # Get node lists and replace the placeholder with the actual node names
 echo "SLURM_NODELIST: ${SLURM_NODELIST}"
@@ -142,12 +155,15 @@ all_nodes=($(scontrol show hostname $SLURM_NODELIST | sort))
 all_nodes_str=$(IFS=','; echo "${all_nodes[*]}")
 echo "all_nodes_str: ${all_nodes_str}"
 
+start_server_cmds_base_file=${full_logdir}/start_server_cmds_base.sh
 start_server_cmds_file=${full_logdir}/start_server_cmds.sh
-replace_placeholder ${start_server_cmds_file} ${all_nodes_str}
+replace_placeholder ${start_server_cmds_base_file} ${all_nodes_str} ${start_server_cmds_file}
+server_config_base_file=${full_logdir}/server_config_base.yaml
 server_config_file=${full_logdir}/server_config.yaml
-replace_placeholder ${server_config_file} ${all_nodes_str}
+replace_placeholder ${server_config_base_file} ${all_nodes_str} ${server_config_file}
+client_cmds_base_file=${full_logdir}/client_cmds_base.sh
 client_cmds_file=${full_logdir}/client_cmds.sh
-replace_placeholder ${client_cmds_file} ${all_nodes_str}
+replace_placeholder ${client_cmds_base_file} ${all_nodes_str} ${client_cmds_file}
 
 # start the servers (skip ctx workers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set).
 echo "Starting worker commands from ${start_server_cmds_file}..."
@@ -164,7 +180,6 @@ done
 echo "Server is ready!"
 
 # Start client commands
-client_cmds_file=${full_logdir}/client_cmds.sh
 echo "Starting client commands from ${client_cmds_file}..."
 while read -r cmd <&3; do
     echo "Starting client command: ${cmd}"

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -136,18 +136,7 @@ else
         cleanup_on_failure "Failed to get TensorRT-LLM environment variables. Check ${full_logdir}/2_get_env.log for details"
     fi
     echo "TensorRT-LLM environment variables saved to ${full_logdir}/env_vars.json"
-    # Install lm_eval[api]==0.4.9.1 if not installed
-    # if ! srun --container-name=${container_name} \
-    #     --container-mounts=${container_mount} --no-container-mount-home \
-    #     --mpi=pmix --overlap -N $SLURM_NNODES --ntasks-per-node=1 \
-    #     bash -c "pip install lm_eval[api]==0.4.9.1" \
-    #     &> ${full_logdir}/2_install_lm_eval.log; then
-    #     cleanup_on_failure "lm_eval installation failed. Check ${full_logdir}/2_install_lm_eval.log for details"
-    # fi
-    # echo "lm_eval installation completed successfully"
 fi
-
-
 
 # Get node lists and replace the placeholder with the actual node names
 echo "SLURM_NODELIST: ${SLURM_NODELIST}"

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -146,13 +146,13 @@ echo "all_nodes_str: ${all_nodes_str}"
 
 start_server_cmds_base_file=${full_logdir}/start_server_cmds_base.sh
 start_server_cmds_file=${full_logdir}/start_server_cmds.sh
-replace_placeholder ${start_server_cmds_base_file} ${all_nodes_str} ${start_server_cmds_file}
+replace_placeholder "${start_server_cmds_base_file}" "${all_nodes_str}" "${start_server_cmds_file}"
 server_config_base_file=${full_logdir}/server_config_base.yaml
 server_config_file=${full_logdir}/server_config.yaml
-replace_placeholder ${server_config_base_file} ${all_nodes_str} ${server_config_file}
+replace_placeholder "${server_config_base_file}" "${all_nodes_str}" "${server_config_file}"
 client_cmds_base_file=${full_logdir}/client_cmds_base.sh
 client_cmds_file=${full_logdir}/client_cmds.sh
-replace_placeholder ${client_cmds_base_file} ${all_nodes_str} ${client_cmds_file}
+replace_placeholder "${client_cmds_base_file}" "${all_nodes_str}" "${client_cmds_file}"
 
 # start the servers (skip ctx workers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set).
 echo "Starting worker commands from ${start_server_cmds_file}..."

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -457,7 +457,7 @@ def submit_job(config, log_dir, dry_run):
 
     # Generate disagg server config
     server_config = convert_allocations_to_server_config(allocations)
-    with open(os.path.join(log_dir, "server_config.yaml"), "w") as f:
+    with open(os.path.join(log_dir, "server_config_base.yaml"), "w") as f:
         yaml.dump(server_config, f)
     disagg_server_hostname = server_config['hostname']
     disagg_server_port = server_config['port']
@@ -557,7 +557,7 @@ def submit_job(config, log_dir, dry_run):
     ]
     start_server_cmds.append(" ".join(cmd))
 
-    with open(os.path.join(log_dir, "start_server_cmds.sh"), "w") as f:
+    with open(os.path.join(log_dir, "start_server_cmds_base.sh"), "w") as f:
         f.write("\n".join(start_server_cmds) + "\n")
 
     # Generate client commands (use script_dir for benchmark scripts)
@@ -625,6 +625,12 @@ def submit_job(config, log_dir, dry_run):
             ]
             client_cmds.append(" ".join(accuracy_prefix + accuracy_cmd))
 
+    # post_process_cmd = [
+    #     f"bash /lustre/fsw/portfolios/coreai/users/xqiao/bench-disagg-r1/scripts/post_process.sh {log_dir} {gen_tp_size} {mtp_size} {log_dir}",
+    #     f"&> {log_dir}/8_post_process.log",
+    # ]
+    # client_cmds.append(" ".join(client_slurm_prefix + post_process_cmd))
+
     # record ${SLURM_JOB_NODELIST} to ${log_dir}/8_done_job_id.txt
     done_cmd = [
         "echo", "${SLURM_JOB_NODELIST}", ">",
@@ -632,7 +638,7 @@ def submit_job(config, log_dir, dry_run):
     ]
     client_cmds.append(" ".join(done_cmd))
 
-    with open(os.path.join(log_dir, "client_cmds.sh"), "w") as f:
+    with open(os.path.join(log_dir, "client_cmds_base.sh"), "w") as f:
         f.write("\n".join(client_cmds) + "\n")
 
     # Resolve slurm script_file path

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -625,12 +625,6 @@ def submit_job(config, log_dir, dry_run):
             ]
             client_cmds.append(" ".join(accuracy_prefix + accuracy_cmd))
 
-    # post_process_cmd = [
-    #     f"bash /lustre/fsw/portfolios/coreai/users/xqiao/bench-disagg-r1/scripts/post_process.sh {log_dir} {gen_tp_size} {mtp_size} {log_dir}",
-    #     f"&> {log_dir}/8_post_process.log",
-    # ]
-    # client_cmds.append(" ".join(client_slurm_prefix + post_process_cmd))
-
     # record ${SLURM_JOB_NODELIST} to ${log_dir}/8_done_job_id.txt
     done_cmd = [
         "echo", "${SLURM_JOB_NODELIST}", ">",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Original benchmark configuration and command files are now preserved; base files are used for per-run customization.
  * Enhanced placeholder substitution logic for generated configuration and command scripts.
  * Refined control flow for role-based benchmark execution settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
