### PR TITLE
[TRTLLM-10827][feat] Add KV Cache metrics to MetricsCollector for more Prometheus metrics

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -698,6 +698,7 @@ public:
         return mLogPrefix;
     }
 
+    // Get num free blocks in the primary memory pool
     [[nodiscard]] SizeType32 getNumFreeBlocks() const noexcept;
 
     [[nodiscard]] SizeType32 getNumAllocTotalBlocks() const
@@ -1016,7 +1017,7 @@ private:
     // Only be 1 or 2. If 2: general KV stored. If 1: K == V for any token, so only K is stored to optimize the
     // max_num_tokens(For DeepSeek). Controlled by mCacheType
     SizeType32 mKVFactor;
-    std::set<KVCacheBlock::IdType> reusedBlockIds;
+    std::set<KVCacheBlock::IdType> mReusedBlockIds;
     std::string const mLogPrefix;
     // Number of reused tokens
     double mReusedTokens;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1317,14 +1317,14 @@ SizeType32 WindowBlockManager::loadOrAllocateBlocks(std::vector<BlockKey> const&
             addBlockToAllBeams(matchingBlock, sequence);
             // TODO: only add once for reused blocks
             ++mReusedBlocks;
-            if (!reusedBlockIds.count(matchingBlockId))
+            if (!mReusedBlockIds.count(matchingBlockId))
             {
-                reusedBlockIds.insert(matchingBlockId);
+                mReusedBlockIds.insert(matchingBlockId);
                 ++mReusedUniqueBlocks;
             }
             ++blockItr;
         }
-        else
+        else // matchingBlock == nullptr || numMatchedTokens + numMatched > sequence.getCurrentPrepopulatedPromptLen()
         {
             // If we haven't set a priority, set it to the default priority level (low)
             auto freeBlock = getFreeBlock(sequence,

--- a/examples/serve/prometheus_metrics.py
+++ b/examples/serve/prometheus_metrics.py
@@ -1,0 +1,144 @@
+### :title Prometheus Metrics
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from urllib.request import urlopen
+
+from openai import OpenAI
+
+# Initialize the OpenAI client
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="tensorrt_llm",
+)
+
+# Prometheus metric prefix used by TensorRT-LLM
+METRIC_PREFIX = "trtllm_"
+
+# Base URL for the metrics endpoint
+METRICS_URL = "http://localhost:8000/prometheus/metrics"
+
+
+def fetch_metrics() -> dict | None:
+    """Fetch metrics from the Prometheus endpoint."""
+    try:
+        response = urlopen(METRICS_URL)
+        if response.status == 200:
+            return response.read().decode("utf-8")
+        else:
+            print(f"Error fetching metrics: HTTP {response.status}")
+            return None
+    except Exception as e:
+        print(f"Error fetching metrics: {e}")
+        return None
+
+
+def parse_and_display_metrics(metrics_data: dict) -> None:
+    """Parse and display relevant TensorRT-LLM metrics."""
+    if not metrics_data:
+        return
+
+    print("\n" + "=" * 80)
+    print("TensorRT-LLM Prometheus Metrics")
+    print("=" * 80)
+
+    # Define metrics to display with descriptions
+    metrics_of_interest = {
+        f"{METRIC_PREFIX}request_success_total": "Total successful requests",
+        f"{METRIC_PREFIX}e2e_request_latency_seconds": "End-to-end request latency",
+        f"{METRIC_PREFIX}time_to_first_token_seconds": "Time to first token",
+        f"{METRIC_PREFIX}request_queue_time_seconds": "Request queue time",
+        f"{METRIC_PREFIX}kv_cache_hit_rate": "KV cache hit rate",
+        f"{METRIC_PREFIX}kv_cache_utilization": "KV cache utilization",
+    }
+
+    found_metrics = []
+    missing_metrics = []
+
+    for metric_name, description in metrics_of_interest.items():
+        if metric_name in metrics_data:
+            found_metrics.append((metric_name, description))
+        else:
+            missing_metrics.append((metric_name, description))
+
+    # Display found metrics
+    if found_metrics:
+        print("\n✓ Available Metrics:")
+        print("-" * 80)
+        for metric_name, description in found_metrics:
+            # Extract the metric lines from the data
+            lines = [
+                line
+                for line in metrics_data.split("\n")
+                if line.startswith(metric_name) and not line.startswith("#")
+            ]
+            print(f"\n{description} ({metric_name}):")
+            for line in lines:
+                print(f"  {line}")
+
+    # Display missing metrics
+    if missing_metrics:
+        print("\n✗ Not Yet Available:")
+        print("-" * 80)
+        for metric_name, description in missing_metrics:
+            print(f"  {description} ({metric_name})")
+
+    print("\n" + "=" * 80)
+
+
+def main():
+    print("Prometheus Metrics Example")
+    print("=" * 80)
+    print("This script will:")
+    print("1. Send several completion requests to a running TensorRT-LLM server")
+    print(
+        "2. After each response, fetch and display Prometheus metrics from the /prometheus/metrics endpoint"
+    )
+    print()
+
+    # Make several completion requests to generate metrics
+    print("Sending completion requests...")
+    num_requests = 10
+    for i in range(num_requests):
+        try:
+            response = client.completions.create(
+                model="Server",
+                prompt=(
+                    f"Hello, this is request {i + 1}. "
+                    "Use your greatest imagination in this request. Tell me a lot about"
+                ),
+                max_tokens=1000,
+                stream=False,
+            )
+            print(
+                f"  Request {i + 1}/{num_requests} completed. Response: {response.choices[0].text[:50]}..."
+            )
+
+            # Fetch and display metrics after each response
+            print(f"\n  Fetching metrics after request {i + 1}...")
+            metrics_data = fetch_metrics()
+            if metrics_data:
+                parse_and_display_metrics(metrics_data)
+            else:
+                print("  ✗ Failed to fetch metrics")
+            print()
+        except Exception as e:
+            print(f"  Error on request {i + 1}: {e}")
+    print("All requests completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/metrics/collector.py
+++ b/tensorrt_llm/metrics/collector.py
@@ -184,8 +184,8 @@ class MetricsCollector:
         - kv_cache_utilization
 
         Args:
-            iteration_stats: A dictionary containing iteration-level statistics with the following
-                expected structure:
+            iteration_stats: A JSON dict returned from `BaseLLM.get_stats()` containing iteration-level statistics
+                with the following expected structure:
                 - "kvCacheStats" (dict): KV cache statistics containing:
                     - "cacheHitRate" (float): Cache hit rate (0.0 to 1.0). If present (including zero),
                       the kv_cache_hit_rate gauge is updated.

--- a/tensorrt_llm/metrics/collector.py
+++ b/tensorrt_llm/metrics/collector.py
@@ -1,17 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Utilities for Prometheus Metrics Collection."""
 
 import time
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 from .enums import MetricNames
 
 
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.10.0rc1/vllm/engine/metrics.py#L30
 class MetricsCollector:
+    """
+    Collects and logs metrics from TensorRT-LLM engine stats and request performance metrics to Prometheus.
+
+    Used by OpenAIServer in tensorrt_llm/serve/openai_server.py.
+
+    Args:
+        labels: A key-value dictionary of labels to add as metadata to all created Prometheus metrics. Useful for
+        distinguishing between multiple series of the same metric name. Example:
+        {"model_name": "nemotron-nano-3", "engine_type": "trtllm"}
+
+    Created Prometheus metrics:
+        trtllm_request_success_total
+        trtllm_e2e_request_latency_seconds
+        trtllm_time_to_first_token_seconds
+        trtllm_time_per_output_token_seconds
+        trtllm_request_queue_time_seconds
+        trtllm_kv_cache_hit_rate
+        trtllm_kv_cache_utilization
+    """
     labelname_finish_reason = "finished_reason"
 
     def __init__(self, labels: Dict[str, str]) -> None:
-        from prometheus_client import Counter, Histogram
+        from prometheus_client import Counter, Gauge, Histogram
         self.last_log_time = time.time()
         self.labels = labels
         self.metric_prefix = "trtllm_"
@@ -67,6 +100,15 @@ class MetricsCollector:
             ],
             labelnames=self.labels.keys())
 
+        self.kv_cache_hit_rate = Gauge(name=self.metric_prefix +
+                                       "kv_cache_hit_rate",
+                                       documentation="KV cache hit rate",
+                                       labelnames=self.labels.keys())
+        self.kv_cache_utilization = Gauge(name=self.metric_prefix +
+                                          "kv_cache_utilization",
+                                          documentation="KV cache utilization",
+                                          labelnames=self.labels.keys())
+
     def _label_merge(self, labels: Dict[str, str]) -> Dict[str, str]:
         if labels is None or len(labels) == 0:
             return self.labels
@@ -81,26 +123,90 @@ class MetricsCollector:
         # Convenience function for logging to histogram.
         histogram.labels(**self.labels).observe(data)
 
-    def log_request_success(self, data: Union[int, float],
-                            labels: Dict[str, str]) -> None:
-        self._log_counter(self.counter_request_success, labels, data)
-        self.last_log_time = time.time()
+    def _log_gauge(self, gauge, data: Union[int, float]) -> None:
+        # Convenience function for logging to gauge.
+        gauge.labels(**self.labels).set(data)
 
-    def log_histogram(self, data: Optional[dict[str, float]]) -> None:
-        if e2e := data.get(MetricNames.E2E, 0):
-            self._log_histogram(self.histogram_e2e_time_request, e2e)
-        if ttft := data.get(MetricNames.TTFT, 0):
-            self._log_histogram(self.histogram_time_to_first_token, ttft)
-        if tpot := data.get(MetricNames.TPOT, 0):
-            self._log_histogram(self.histogram_time_per_output_token, tpot)
-        if request_queue_time := data.get(MetricNames.REQUEST_QUEUE_TIME, 0):
-            self._log_histogram(self.histogram_queue_time_request,
-                                request_queue_time)
-        self.last_log_time = time.time()
+    def log_request_metrics_dict(self, metrics_dict: dict[str, float]) -> None:
+        """
+        Log per-request metrics from TRTLLM engine responses.
 
-    def log_metrics_dict(self, metrics_dict: dict[str, float]) -> None:
+        This method updates Prometheus metrics including:
+        - counter_request_success
+        - histogram_e2e_time_request
+        - histogram_time_to_first_token
+        - histogram_time_per_output_token
+        - histogram_queue_time_request
+
+        Args:
+            metrics_dict: A dictionary containing request metrics with the following expected keys:
+                - `MetricsCollector.labelname_finish_reason` (str): Finish reason string indicating
+                  request completion status.
+                - `MetricNames.E2E` (float): End-to-end request latency in seconds.
+                - `MetricNames.TTFT` (float): Time to first token in seconds.
+                - `MetricNames.TPOT` (float): Time per output token in seconds.
+                - `MetricNames.REQUEST_QUEUE_TIME` (float): Request queue time in seconds.
+
+        Returns:
+            None: Metrics are logged to Prometheus; nothing is returned.
+
+        Note:
+            - Needs to include `return_perf_metrics: true` in LLM args to populate the metrics_dict field
+            from the engine responses.
+            - Metrics are only recorded when MetricsCollector.labelname_finish_reason is present
+            in the metrics_dict, indicating the request has finished.
+
+        """
         if finish_reason := metrics_dict.get(
                 MetricsCollector.labelname_finish_reason):
-            self.log_request_success(
-                1, {MetricsCollector.labelname_finish_reason: finish_reason})
-            self.log_histogram(metrics_dict)
+            # If the request finishes, log per-request metrics
+            self._log_counter(
+                self.counter_request_success,
+                {MetricsCollector.labelname_finish_reason: finish_reason}, 1)
+            if e2e := metrics_dict.get(MetricNames.E2E, 0):
+                self._log_histogram(self.histogram_e2e_time_request, e2e)
+            if ttft := metrics_dict.get(MetricNames.TTFT, 0):
+                self._log_histogram(self.histogram_time_to_first_token, ttft)
+            if tpot := metrics_dict.get(MetricNames.TPOT, 0):
+                self._log_histogram(self.histogram_time_per_output_token, tpot)
+            if request_queue_time := metrics_dict.get(
+                    MetricNames.REQUEST_QUEUE_TIME, 0):
+                self._log_histogram(self.histogram_queue_time_request,
+                                    request_queue_time)
+            self.last_log_time = time.time()
+
+    def log_iteration_stats(self, iteration_stats: dict) -> None:
+        """
+        Log iteration-level statistics from TRTLLM engine.
+
+        This method updates Prometheus metrics including:
+        - kv_cache_hit_rate
+        - kv_cache_utilization
+
+        Args:
+            iteration_stats: A dictionary containing iteration-level statistics with the following
+                expected structure:
+                - "kvCacheStats" (dict): KV cache statistics containing:
+                    - "cacheHitRate" (float): Cache hit rate (0.0 to 1.0). If present (including zero),
+                      the kv_cache_hit_rate gauge is updated.
+                    - "usedNumBlocks" (int): Number of KV cache blocks currently in use.
+                    - "maxNumBlocks" (int): Maximum number of KV cache blocks available. Should always be
+                      non-zero.
+
+        Returns:
+            None: Metrics are logged to Prometheus; nothing is returned.
+
+        Note:
+            - Needs to include `enable_iter_perf_stats: true` in LLM args to collect iteration-level stats.
+            - KV cache utilization is only calculated and logged when both "usedNumBlocks" and
+              "maxNumBlocks" are present in kvCacheStats and "maxNumBlocks" is non-zero.
+        """
+        if kv_stats := iteration_stats.get("kvCacheStats"):
+            cache_hit_rate = kv_stats.get("cacheHitRate")
+            if cache_hit_rate is not None:
+                self._log_gauge(self.kv_cache_hit_rate, cache_hit_rate)
+            if "usedNumBlocks" in kv_stats and "maxNumBlocks" in kv_stats:
+                max_num_blocks = kv_stats["maxNumBlocks"]
+                if max_num_blocks:
+                    utilization = kv_stats["usedNumBlocks"] / max_num_blocks
+                    self._log_gauge(self.kv_cache_utilization, utilization)

--- a/tests/unittest/llmapi/apps/_test_openai_prometheus.py
+++ b/tests/unittest/llmapi/apps/_test_openai_prometheus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unittest/llmapi/apps/_test_openai_prometheus.py
+++ b/tests/unittest/llmapi/apps/_test_openai_prometheus.py
@@ -1,6 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 import os
 import tempfile
+import time
 from urllib.request import urlopen
 
 import pytest
@@ -24,7 +39,10 @@ def temp_extra_llm_api_options_file(request):
     temp_dir = tempfile.gettempdir()
     temp_file_path = os.path.join(temp_dir, "extra_llm_api_options.yaml")
     try:
-        extra_llm_api_options_dict = {"return_perf_metrics": True}
+        extra_llm_api_options_dict = {
+            "return_perf_metrics": True,
+            "enable_iter_perf_stats": True
+        }
 
         with open(temp_file_path, 'w') as f:
             yaml.dump(extra_llm_api_options_dict, f)
@@ -51,18 +69,53 @@ def test_metrics_endpoint(server: RemoteOpenAIServer):
     metric_prefix = "trtllm_"
 
     client = server.get_client()
-    client.completions.create(
-        model="Server",
-        prompt="Hello, my name is",
-        max_tokens=25,
-        stream=False,
-    )
+    # Need to send at least 2 requests to get iteration stats computed
+    # so kv_cache Prometheus metrics are available.
+    for _ in range(2):
+        client.completions.create(
+            model="Server",
+            prompt="Hello, my name is",
+            max_tokens=25,
+            stream=False,
+        )
 
+    # Wait for background iteration stats collector task to process and log metrics
+    # The _iteration_stats_collector_loop runs asynchronously, so we poll until
+    # the iteration stats metrics (kv_cache_hit_rate, kv_cache_utilization) appear
+    max_wait_time = 10.0  # seconds
+    poll_interval = 0.5  # seconds
+    start_time = time.time()
+
+    iteration_stats_metrics_found = False
+    while time.time() - start_time < max_wait_time:
+        response = urlopen(f'{server.url_root}/prometheus/metrics')
+        assert response.status == 200
+
+        data = response.read().decode("utf-8")
+
+        # Check if iteration stats metrics are present
+        if (metric_prefix + "kv_cache_hit_rate" in data
+                and metric_prefix + "kv_cache_utilization" in data):
+            iteration_stats_metrics_found = True
+            break
+
+        logger.info(
+            f"Iteration stats not yet available, waiting {poll_interval}s...")
+        time.sleep(poll_interval)
+
+    # Final check: fetch metrics one more time for assertions
     response = urlopen(f'{server.url_root}/prometheus/metrics')
-    assert response.status is 200
-
+    assert response.status == 200
     data = response.read().decode("utf-8")
+
+    # Assert request-level metrics (these should be available immediately)
     assert metric_prefix + "request_success_total" in data
     assert metric_prefix + "e2e_request_latency_seconds" in data
     assert metric_prefix + "time_to_first_token_seconds" in data
     assert metric_prefix + "request_queue_time_seconds" in data
+
+    # Assert iteration stats metrics (collected by background task)
+    assert iteration_stats_metrics_found, \
+        f"Iteration stats metrics not found after waiting {max_wait_time}s"
+    assert metric_prefix + "kv_cache_hit_rate" in data
+    assert metric_prefix + "kv_cache_utilization" in data


### PR DESCRIPTION
## Description

Current TRTLLM exposes too few Prometheus metrics. This PR adds KV cache utilization and hit rate metrics to Prometheus metrics. It will benefit Dynamo in monitoring TRTLLM. 

Minor clean-up:
- Rename a var in kvCacheManager to confirm to naming convention. Add more comments.
- Add more comments in MetricsCollector in tensorrt_llm/metrics/collector.py.
- Refactor some functions in MetricsCollector since the added functionality requires some existing functions to be renamed or refactored.

## Test Coverage

Modified tests/unittest/llmapi/apps/_test_openai_prometheus.py to cover the change

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added KV cache performance metrics: hit rate and utilization tracking via Prometheus gauges.
  * Enabled per-iteration performance statistics collection for more granular monitoring and diagnostics.

* **Improvements**
  * Enhanced metrics collection with better support for request-level and iteration-level performance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->