### PR TITLE
[None][fix] glm engine build dtype

### DIFF
--- a/examples/models/core/glm-4-9b/README.md
+++ b/examples/models/core/glm-4-9b/README.md
@@ -116,7 +116,7 @@ Normally, the `trtllm-build` command only requires a single GPU, but you can ena
 ```bash
 # GLM-4-9B: single-gpu engine with dtype float16, GPT Attention plugin, Gemm plugin
 trtllm-build --checkpoint_dir trt_ckpt/glm_4_9b/fp16/1-gpu \
-        --gemm_plugin float16 \
+        --gemm_plugin bfloat16 \
         --output_dir trt_engines/glm_4_9b/fp16/1-gpu
 ```
 


### PR DESCRIPTION
Currently GLM example uses `auto` for checkpoint_conversion step which results in a bfloat16 output dtype while the `trtllm-build` step assumed gemm is float16.

This change updates the `--gemm_plugin` to use bfloat16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example documentation to reflect the latest GEMM plugin data type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->