### PR TITLE
[https://nvbugs/5863464][fix] Fix port binding conflict in disagg benchmarking script

### DIFF
--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -35,6 +35,7 @@ l0_h100:
   - unittest/_torch/modeling -k "modeling_gpt_oss"
   - unittest/_torch/modeling/test_modeling_nemotron_h.py::test_nemotron_h_sanity
   - unittest/disaggregated/test_disagg_utils.py
+  - unittest/disaggregated/test_disagg_bench_submit.py
   - unittest/disaggregated/test_router.py
   - unittest/disaggregated/test_remoteDictionary.py
   - accuracy/test_llm_api_pytorch.py::TestGemma3_1BInstruct::test_auto_dtype

--- a/tests/unittest/disaggregated/test_disagg_bench_submit.py
+++ b/tests/unittest/disaggregated/test_disagg_bench_submit.py
@@ -1,0 +1,236 @@
+"""Tests for examples/disaggregated/slurm/benchmark/submit.py GPU allocation logic."""
+
+import os
+import sys
+
+# isort: off
+# Add the benchmark directory to path for imports.
+_BENCHMARK_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "..",
+    "examples",
+    "disaggregated",
+    "slurm",
+    "benchmark",
+)
+sys.path.insert(0, os.path.abspath(_BENCHMARK_DIR))
+
+from submit import allocate_gpus  # noqa: E402
+# isort: on
+
+
+class TestAllocateGpus:
+    """Test cases for the allocate_gpus function."""
+
+    def test_gen_and_ctx_on_separate_nodes(self):
+        """Test that GEN and CTX servers are allocated on separate nodes."""
+        allocations = allocate_gpus(
+            total_nodes=2,
+            gpus_per_node=8,
+            num_gen_servers=2,
+            num_ctx_servers=2,
+            gen_world_size=2,
+            ctx_world_size=2,
+            base_port=8000,
+        )
+
+        assert "GEN" in allocations
+        assert "CTX" in allocations
+        assert len(allocations["GEN"]) == 2
+        assert len(allocations["CTX"]) == 2
+
+        # Verify GEN and CTX are on separate nodes.
+        gen_nodes = set()
+        for server in allocations["GEN"].values():
+            gen_nodes.update(server["nodes"].keys())
+        ctx_nodes = set()
+        for server in allocations["CTX"].values():
+            ctx_nodes.update(server["nodes"].keys())
+        assert gen_nodes.isdisjoint(ctx_nodes)
+
+        # Verify port assignments.
+        assert allocations["GEN"][0]["port"] == 8000
+        assert allocations["GEN"][1]["port"] == 8001
+        assert allocations["CTX"][0]["port"] == 8000
+        assert allocations["CTX"][1]["port"] == 8001
+
+    def test_same_server_type_can_share_nodes(self):
+        """Test that multiple instances of the same server type can share nodes."""
+        # 2 GEN servers with world_size=2 each, 8 GPUs per node.
+        # Both GEN servers should fit on the same node.
+        allocations = allocate_gpus(
+            total_nodes=2,
+            gpus_per_node=8,
+            num_gen_servers=2,
+            num_ctx_servers=1,
+            gen_world_size=2,
+            ctx_world_size=2,
+            base_port=8000,
+        )
+
+        gen0_nodes = set(allocations["GEN"][0]["nodes"].keys())
+        gen1_nodes = set(allocations["GEN"][1]["nodes"].keys())
+
+        # Both GEN servers should be on the same node (node 0).
+        assert gen0_nodes == gen1_nodes, (
+            f"GEN servers should share nodes but got {gen0_nodes} and {gen1_nodes}."
+        )
+
+        # Servers on the same node must have different ports.
+        gen0_port = allocations["GEN"][0]["port"]
+        gen1_port = allocations["GEN"][1]["port"]
+        assert gen0_port != gen1_port, (
+            f"GEN servers on same node must have different ports but both have {gen0_port}."
+        )
+
+
+class TestPortConflictDetection:
+    """Test cases for port conflict detection."""
+
+    def test_port_conflict_raises_error(self):
+        """Test that allocating servers that would conflict raises an error.
+
+        This tests the validation logic, not the allocation itself.
+        In practice, the node boundary alignment should prevent most conflicts,
+        but the validation catches edge cases.
+        """
+        # With proper node separation, this should work without conflict.
+        # The port conflict detection is a safety net for edge cases.
+        try:
+            allocate_gpus(
+                total_nodes=2,
+                gpus_per_node=8,
+                num_gen_servers=2,
+                num_ctx_servers=2,
+                gen_world_size=4,
+                ctx_world_size=4,
+                base_port=8000,
+            )
+            # Should succeed - no conflict expected with proper allocation.
+        except RuntimeError as e:
+            # If there's a conflict, it should have a clear error message.
+            assert "bind to" in str(e).lower() or "conflict" in str(e).lower()
+
+    def test_multi_node_server_first_node_binding(self):
+        """Test that multi-node servers bind to their first node."""
+        allocations = allocate_gpus(
+            total_nodes=4,
+            gpus_per_node=4,
+            num_gen_servers=1,
+            num_ctx_servers=1,
+            gen_world_size=8,  # Spans 2 nodes.
+            ctx_world_size=8,  # Spans 2 nodes.
+            base_port=8000,
+        )
+
+        # GEN with world_size=8 on 4 GPUs/node spans 2 nodes.
+        gen_nodes = list(allocations["GEN"][0]["nodes"].keys())
+        assert len(gen_nodes) == 2, f"GEN should span 2 nodes, got {gen_nodes}."
+
+        # CTX should start on a fresh node boundary (node 2).
+        ctx_nodes = list(allocations["CTX"][0]["nodes"].keys())
+        assert len(ctx_nodes) == 2, f"CTX should span 2 nodes, got {ctx_nodes}."
+
+        # Verify no overlap.
+        assert set(gen_nodes).isdisjoint(set(ctx_nodes))
+
+
+class TestGpuAssignment:
+    """Test cases for GPU assignment within nodes."""
+
+    def test_gpu_ids_are_contiguous(self):
+        """Test that GPU IDs within a node are assigned contiguously."""
+        allocations = allocate_gpus(
+            total_nodes=1,
+            gpus_per_node=8,
+            num_gen_servers=1,
+            num_ctx_servers=0,
+            gen_world_size=4,
+            ctx_world_size=0,
+            base_port=8000,
+        )
+
+        gen_gpus = allocations["GEN"][0]["nodes"]["<node0_placeholder>"]
+        assert gen_gpus == [0, 1, 2, 3], f"Expected [0,1,2,3], got {gen_gpus}."
+
+    def test_multiple_servers_gpu_assignment(self):
+        """Test GPU assignment for multiple servers of the same type."""
+        allocations = allocate_gpus(
+            total_nodes=1,
+            gpus_per_node=8,
+            num_gen_servers=2,
+            num_ctx_servers=0,
+            gen_world_size=2,
+            ctx_world_size=0,
+            base_port=8000,
+        )
+
+        gen0_gpus = allocations["GEN"][0]["nodes"]["<node0_placeholder>"]
+        gen1_gpus = allocations["GEN"][1]["nodes"]["<node0_placeholder>"]
+
+        assert gen0_gpus == [0, 1], f"GEN 0 expected [0,1], got {gen0_gpus}."
+        assert gen1_gpus == [2, 3], f"GEN 1 expected [2,3], got {gen1_gpus}."
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_zero_ctx_servers(self):
+        """Test allocation with no CTX servers."""
+        allocations = allocate_gpus(
+            total_nodes=1,
+            gpus_per_node=8,
+            num_gen_servers=2,
+            num_ctx_servers=0,
+            gen_world_size=2,
+            ctx_world_size=1,  # Doesn't matter since num_ctx_servers=0.
+            base_port=8000,
+        )
+
+        assert "GEN" in allocations
+        assert len(allocations["GEN"]) == 2
+        # CTX key exists but is empty.
+        assert "CTX" in allocations
+        assert len(allocations["CTX"]) == 0
+
+    def test_zero_gen_servers(self):
+        """Test allocation with no GEN servers."""
+        allocations = allocate_gpus(
+            total_nodes=1,
+            gpus_per_node=8,
+            num_gen_servers=0,
+            num_ctx_servers=2,
+            gen_world_size=1,
+            ctx_world_size=2,
+            base_port=8000,
+        )
+
+        assert "GEN" in allocations
+        assert len(allocations["GEN"]) == 0
+        assert "CTX" in allocations
+        assert len(allocations["CTX"]) == 2
+
+    def test_exact_node_fill(self):
+        """Test allocation that exactly fills nodes."""
+        # 2 GEN servers with 4 GPUs each = 8 GPUs = exactly 1 node.
+        allocations = allocate_gpus(
+            total_nodes=2,
+            gpus_per_node=8,
+            num_gen_servers=2,
+            num_ctx_servers=1,
+            gen_world_size=4,
+            ctx_world_size=4,
+            base_port=8000,
+        )
+
+        # GEN servers fill node 0 exactly.
+        gen0_gpus = allocations["GEN"][0]["nodes"]["<node0_placeholder>"]
+        gen1_gpus = allocations["GEN"][1]["nodes"]["<node0_placeholder>"]
+        assert gen0_gpus == [0, 1, 2, 3]
+        assert gen1_gpus == [4, 5, 6, 7]
+
+        # CTX should be on node 1.
+        ctx_nodes = list(allocations["CTX"][0]["nodes"].keys())
+        assert "<node1_placeholder>" in ctx_nodes


### PR DESCRIPTION
## Description

### Issue

The current GPU allocation logic assigns GPUs contiguously across nodes without respecting node boundaries between different server types (ctx/gen). For example, when num_gen_gpus=2 and num_ctx_gpus=4, num_gen_instances=1, num_ctx_instances=1, num_nodes=2:

**Example of the bug (as shown in the allocation table):**
| GPU Cursor | Node       | Local GPU | Assigned To    |
|------------|------------|-----------|----------------|
| 0          | thria0237  | 0         | GEN            |
| 1          | thria0237  | 1         | GEN            |
| 2          | thria0237  | 2         | CTX ← wrong!   |
| 3          | thria0237  | 3         | CTX ← wrong!   |
| 4          | thria0239  | 0         | CTX            |
| 5          | thria0239  | 1         | CTX            |

CTX needs 4 GPUs and should be assigned `theia0239` after gen assignment, but the contiguous allocation caused it to straddle both nodes. This leads to port binding conflicts (between gen0 and ctx0 above).

### Fix

Add `align_cursor_to_node_boundary()` function that advances the GPU cursor to the start of the next node before allocating a new server type. This ensures:
   - Instances of different server types (CTX vs GEN) don't share nodes
   - Instances of the **same server type** can still share nodes with port id incremented

Also, added a preemptive check after gpu assignment to make sure issues are caught early.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced resource allocation alignment to prevent conflicts between server assignments
  * Added comprehensive conflict detection with detailed diagnostic reporting for better troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->