### PR TITLE
[https://nvbugs/5820874][fix] Adjust deepgemm tuning buckets to cover larger num_tokens's scope

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1525,10 +1525,12 @@ def fp8_swap_ab_gemm(
     # If tune_max_num_tokens is -1, set tune_max_num_tokens to None so that the autotuner will use curr_max_num_tokens.
     if tune_max_num_tokens > 0:
         fp8SwapABGemmRunner.tuning_config.tune_max_num_tokens = tune_max_num_tokens
-        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (DynamicTensorSpec(0, 0, deep_gemm_gen_tuning_buckets),)
+        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (
+            DynamicTensorSpec(0, 0, deep_gemm_gen_tuning_buckets), )
     else:
         fp8SwapABGemmRunner.tuning_config.tune_max_num_tokens = None
-        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (DynamicTensorSpec(0, 0, default_deep_gemm_gen_tuning_buckets),)
+        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (
+            DynamicTensorSpec(0, 0, default_deep_gemm_gen_tuning_buckets), )
 
     _, best_tactic = tuner.choose_one(
         "trtllm::fp8_swap_ab_gemm",

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1459,10 +1459,8 @@ def deep_gemm_gen_tuning_buckets(x: int):
 
 
 class fp8SwapABGemmRunner(TunableRunner):
-    tuning_config = TuningConfig(
-        dynamic_tensor_specs=(DynamicTensorSpec(
-            0, 0, deep_gemm_gen_tuning_buckets), ),
-    )
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        0, 0, deep_gemm_gen_tuning_buckets), ), )
 
     def __init__(self, output_dtype: torch.dtype, disable_ue8m0_cast: bool):
         self.output_dtype = output_dtype

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1459,8 +1459,10 @@ def deep_gemm_gen_tuning_buckets(x: int):
 
 
 class fp8SwapABGemmRunner(TunableRunner):
-    tuning_config = TuningConfig(dynamic_tensor_specs=(
-        DynamicTensorSpec(0, 0, deep_gemm_gen_tuning_buckets), ))
+    tuning_config = TuningConfig(
+        dynamic_tensor_specs=(DynamicTensorSpec(
+            0, 0, deep_gemm_gen_tuning_buckets), ),
+    )
 
     def __init__(self, output_dtype: torch.dtype, disable_ue8m0_cast: bool):
         self.output_dtype = output_dtype

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1455,7 +1455,7 @@ def deep_gemm_gen_tuning_buckets(x: int):
     return buckets
 
 
-def default_deep_gemm_tuning_buckets(x: int):
+def default_deep_gemm_gen_tuning_buckets(x: int):
     buckets = tuple(range(8, 128, 8))
     # Clamp x to be between 4096 and 8192.
     x = min(x, 8192)
@@ -1528,7 +1528,7 @@ def fp8_swap_ab_gemm(
         fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (DynamicTensorSpec(0, 0, deep_gemm_gen_tuning_buckets),)
     else:
         fp8SwapABGemmRunner.tuning_config.tune_max_num_tokens = None
-        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (DynamicTensorSpec(0, 0, default_deep_gemm_tuning_buckets),)
+        fp8SwapABGemmRunner.tuning_config.dynamic_tensor_specs = (DynamicTensorSpec(0, 0, default_deep_gemm_gen_tuning_buckets),)
 
     _, best_tactic = tuner.choose_one(
         "trtllm::fp8_swap_ab_gemm",

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -549,11 +549,15 @@ class AggrTestCmds(NamedTuple):
             server_cmd_with_port = add_host_port_to_cmd(server_cmd, server_hostname, server_port)
 
             server_file_path = os.path.join(self.output_dir, f"trtllm-serve.{server_idx}.log")
-            server_error_file_path = os.path.join(self.output_dir, f"trtllm-serve.{server_idx}.error.log")
+            server_error_file_path = os.path.join(
+                self.output_dir, f"trtllm-serve.{server_idx}.error.log"
+            )
 
             print_info(f"Starting server. cmd is {server_cmd_with_port}")
-            with open(server_file_path, "w") as server_ctx, \
-                 open(server_error_file_path, "w") as server_err_ctx:
+            with (
+                open(server_file_path, "w") as server_ctx,
+                open(server_error_file_path, "w") as server_err_ctx,
+            ):
                 server_proc = subprocess.Popen(
                     server_cmd_with_port,
                     stdout=server_ctx,
@@ -744,8 +748,10 @@ class DisaggTestCmds(NamedTuple):
                 print_info(
                     f"Starting server. disagg_serving_type: {self.disagg_serving_type} cmd is {server_cmd}"
                 )
-                with open(server_file_path, "w") as server_ctx, \
-                     open(server_error_file_path, "w") as server_err_ctx:
+                with (
+                    open(server_file_path, "w") as server_ctx,
+                    open(server_error_file_path, "w") as server_err_ctx,
+                ):
                     server_proc = subprocess.Popen(
                         server_cmd,
                         stdout=server_ctx,
@@ -768,8 +774,10 @@ class DisaggTestCmds(NamedTuple):
             try:
                 self._generate_disagg_server_config(server_idx, port)
                 print_info(f"Starting disagg server. cmd is {disagg_cmd}")
-                with open(disagg_server_file_path, "w") as disagg_server_ctx, \
-                     open(disagg_server_error_file_path, "w") as disagg_server_err_ctx:
+                with (
+                    open(disagg_server_file_path, "w") as disagg_server_ctx,
+                    open(disagg_server_error_file_path, "w") as disagg_server_err_ctx,
+                ):
                     disagg_server_proc = subprocess.Popen(
                         disagg_cmd,
                         stdout=disagg_server_ctx,

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -568,7 +568,7 @@ class AggrTestCmds(NamedTuple):
             wait_for_endpoint_ready(
                 f"http://{server_hostname}:{server_port}/health",
                 timeout=self.timeout,
-                check_files=[server_file_path],
+                check_files=[server_file_path, server_error_file_path],
                 server_proc=server_proc,
             )
 
@@ -797,19 +797,14 @@ class DisaggTestCmds(NamedTuple):
                 )
                 server_files = [
                     os.path.join(self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.log"),
+                    os.path.join(self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.error.log"),
+                ] + [
+                    os.path.join(self.output_dir, f"trtllm-serve.CTX_{ctx_idx}.{server_idx}.log")
+                    for ctx_idx in range(self.num_ctx_servers)
+                ] + [
+                    os.path.join(self.output_dir, f"trtllm-serve.GEN_{gen_idx}.{server_idx}.log")
+                    for gen_idx in range(self.num_gen_servers)
                 ]
-                for ctx_idx in range(self.num_ctx_servers):
-                    server_files.append(
-                        os.path.join(
-                            self.output_dir, f"trtllm-serve.CTX_{ctx_idx}.{server_idx}.log"
-                        )
-                    )
-                for gen_idx in range(self.num_gen_servers):
-                    server_files.append(
-                        os.path.join(
-                            self.output_dir, f"trtllm-serve.GEN_{gen_idx}.{server_idx}.log"
-                        )
-                    )
                 wait_for_endpoint_ready(
                     f"http://{disagg_server_hostname}:{disagg_server_port}/health",
                     timeout=self.timeout,

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -795,16 +795,28 @@ class DisaggTestCmds(NamedTuple):
                 disagg_server_hostname, disagg_server_port = (
                     self._get_disagg_server_hostname_and_port(server_idx)
                 )
-                server_files = [
-                    os.path.join(self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.log"),
-                    os.path.join(self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.error.log"),
-                ] + [
-                    os.path.join(self.output_dir, f"trtllm-serve.CTX_{ctx_idx}.{server_idx}.log")
-                    for ctx_idx in range(self.num_ctx_servers)
-                ] + [
-                    os.path.join(self.output_dir, f"trtllm-serve.GEN_{gen_idx}.{server_idx}.log")
-                    for gen_idx in range(self.num_gen_servers)
-                ]
+                server_files = (
+                    [
+                        os.path.join(
+                            self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.log"
+                        ),
+                        os.path.join(
+                            self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.error.log"
+                        ),
+                    ]
+                    + [
+                        os.path.join(
+                            self.output_dir, f"trtllm-serve.CTX_{ctx_idx}.{server_idx}.log"
+                        )
+                        for ctx_idx in range(self.num_ctx_servers)
+                    ]
+                    + [
+                        os.path.join(
+                            self.output_dir, f"trtllm-serve.GEN_{gen_idx}.{server_idx}.log"
+                        )
+                        for gen_idx in range(self.num_gen_servers)
+                    ]
+                )
                 wait_for_endpoint_ready(
                     f"http://{disagg_server_hostname}:{disagg_server_port}/health",
                     timeout=self.timeout,

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -549,13 +549,15 @@ class AggrTestCmds(NamedTuple):
             server_cmd_with_port = add_host_port_to_cmd(server_cmd, server_hostname, server_port)
 
             server_file_path = os.path.join(self.output_dir, f"trtllm-serve.{server_idx}.log")
+            server_error_file_path = os.path.join(self.output_dir, f"trtllm-serve.{server_idx}.error.log")
 
             print_info(f"Starting server. cmd is {server_cmd_with_port}")
-            with open(server_file_path, "w") as server_ctx:
+            with open(server_file_path, "w") as server_ctx, \
+                 open(server_error_file_path, "w") as server_err_ctx:
                 server_proc = subprocess.Popen(
                     server_cmd_with_port,
                     stdout=server_ctx,
-                    stderr=subprocess.STDOUT,
+                    stderr=server_err_ctx,
                     env=copy.deepcopy(os.environ),
                 )
 
@@ -571,20 +573,27 @@ class AggrTestCmds(NamedTuple):
                 client_file_path = os.path.join(
                     self.output_dir, f"trtllm-benchmark.{server_idx}.{client_idx}.log"
                 )
+                client_error_file_path = os.path.join(
+                    self.output_dir, f"trtllm-benchmark.{server_idx}.{client_idx}.error.log"
+                )
 
                 client_cmd_with_port = add_host_port_to_cmd(
                     client_cmd, server_hostname, server_port
                 )
                 print_info(f"Starting client. cmd is {client_cmd_with_port}")
 
-                output = subprocess.check_output(
+                result = subprocess.run(
                     client_cmd_with_port,
-                    stderr=subprocess.STDOUT,
+                    capture_output=True,
                     env=copy.deepcopy(os.environ),
-                ).decode()
+                    check=True,
+                )
+                output = result.stdout.decode()
 
                 with open(client_file_path, "w") as client_ctx:
                     client_ctx.write(output)
+                with open(client_error_file_path, "w") as client_err_ctx:
+                    client_err_ctx.write(result.stderr.decode())
 
                 outputs.append(output)
 
@@ -723,7 +732,10 @@ class DisaggTestCmds(NamedTuple):
         if "CTX" in self.disagg_serving_type or "GEN" in self.disagg_serving_type:
             self._generate_hostname_file(server_idx, port)
             server_file_path = os.path.join(
-                self.output_dir, f"trtllm-serve.{server_idx}.{self.disagg_serving_type}.log"
+                self.output_dir, f"trtllm-serve.{self.disagg_serving_type}.{server_idx}.log"
+            )
+            server_error_file_path = os.path.join(
+                self.output_dir, f"trtllm-serve.{self.disagg_serving_type}.{server_idx}.error.log"
             )
             is_ctx = "CTX" in self.disagg_serving_type
             server_cmd = ctx_cmd if is_ctx else gen_cmd
@@ -732,11 +744,12 @@ class DisaggTestCmds(NamedTuple):
                 print_info(
                     f"Starting server. disagg_serving_type: {self.disagg_serving_type} cmd is {server_cmd}"
                 )
-                with open(server_file_path, "w") as server_ctx:
+                with open(server_file_path, "w") as server_ctx, \
+                     open(server_error_file_path, "w") as server_err_ctx:
                     server_proc = subprocess.Popen(
                         server_cmd,
                         stdout=server_ctx,
-                        stderr=subprocess.STDOUT,
+                        stderr=server_err_ctx,
                         env=copy.deepcopy(os.environ),
                     )
                 self.wait_for_benchmark_ready(benchmark_status_file)
@@ -747,16 +760,20 @@ class DisaggTestCmds(NamedTuple):
 
         elif self.disagg_serving_type == "DISAGG_SERVER":
             disagg_server_file_path = os.path.join(
-                self.output_dir, f"trtllm-serve.{server_idx}.{self.disagg_serving_type}.log"
+                self.output_dir, f"trtllm-serve.{self.disagg_serving_type}.{server_idx}.log"
+            )
+            disagg_server_error_file_path = os.path.join(
+                self.output_dir, f"trtllm-serve.{self.disagg_serving_type}.{server_idx}.error.log"
             )
             try:
                 self._generate_disagg_server_config(server_idx, port)
                 print_info(f"Starting disagg server. cmd is {disagg_cmd}")
-                with open(disagg_server_file_path, "w") as disagg_server_ctx:
+                with open(disagg_server_file_path, "w") as disagg_server_ctx, \
+                     open(disagg_server_error_file_path, "w") as disagg_server_err_ctx:
                     disagg_server_proc = subprocess.Popen(
                         disagg_cmd,
                         stdout=disagg_server_ctx,
-                        stderr=subprocess.STDOUT,
+                        stderr=disagg_server_err_ctx,
                         env=copy.deepcopy(os.environ),
                     )
                 self.wait_for_benchmark_ready(benchmark_status_file)
@@ -771,18 +788,18 @@ class DisaggTestCmds(NamedTuple):
                     self._get_disagg_server_hostname_and_port(server_idx)
                 )
                 server_files = [
-                    os.path.join(self.output_dir, f"trtllm-serve.{server_idx}.DISAGG_SERVER.log"),
+                    os.path.join(self.output_dir, f"trtllm-serve.DISAGG_SERVER.{server_idx}.log"),
                 ]
                 for ctx_idx in range(self.num_ctx_servers):
                     server_files.append(
                         os.path.join(
-                            self.output_dir, f"trtllm-serve.{server_idx}.CTX_{ctx_idx}.log"
+                            self.output_dir, f"trtllm-serve.CTX_{ctx_idx}.{server_idx}.log"
                         )
                     )
                 for gen_idx in range(self.num_gen_servers):
                     server_files.append(
                         os.path.join(
-                            self.output_dir, f"trtllm-serve.{server_idx}.GEN_{gen_idx}.log"
+                            self.output_dir, f"trtllm-serve.GEN_{gen_idx}.{server_idx}.log"
                         )
                     )
                 wait_for_endpoint_ready(
@@ -796,20 +813,27 @@ class DisaggTestCmds(NamedTuple):
                     benchmark_file_path = os.path.join(
                         self.output_dir, f"trtllm-benchmark.{server_idx}.{client_idx}.log"
                     )
+                    benchmark_error_file_path = os.path.join(
+                        self.output_dir, f"trtllm-benchmark.{server_idx}.{client_idx}.error.log"
+                    )
 
                     client_cmd_with_port = add_host_port_to_cmd(
                         client_cmd, disagg_server_hostname, disagg_server_port
                     )
                     print_info(f"Starting benchmark. cmd is {client_cmd_with_port}")
 
-                    output = subprocess.check_output(
+                    result = subprocess.run(
                         client_cmd_with_port,
+                        capture_output=True,
                         env=copy.deepcopy(os.environ),
-                        stderr=subprocess.STDOUT,
-                    ).decode()
+                        check=True,
+                    )
+                    output = result.stdout.decode()
 
                     with open(benchmark_file_path, "w") as benchmark_ctx:
                         benchmark_ctx.write(output)
+                    with open(benchmark_error_file_path, "w") as benchmark_err_ctx:
+                        benchmark_err_ctx.write(result.stderr.decode())
                     outputs.append(output)
 
             finally:
@@ -1197,11 +1221,21 @@ class PerfSanityTestConfig:
 
             except Exception as e:
                 print_error(f"Test command failed for server {server_idx}. Error: {e}")
-                if isinstance(e, subprocess.CalledProcessError):
-                    print_error("--- stdout ---")
-                    if e.stdout:
-                        print_error(e.stdout.decode() if isinstance(e.stdout, bytes) else e.stdout)
-                    print_error("--------------")
+                # Print content of trtllm-serve error log files
+                error_log_pattern = os.path.join(
+                    commands.output_dir, f"trtllm-serve*{server_idx}.error.log"
+                )
+                error_log_files = glob.glob(error_log_pattern)
+                for error_log_file in error_log_files:
+                    if os.path.exists(error_log_file):
+                        print_error(f"--- {error_log_file} ---")
+                        with open(error_log_file, "r") as f:
+                            content = f.read()
+                            if content.strip():
+                                print_error(content)
+                            else:
+                                print_error("(empty)")
+                        print_error("-" * len(f"--- {error_log_file} ---"))
                 outputs[server_idx] = []
 
         return outputs

--- a/tests/integration/test_lists/test-db/l0_dgx_b200_perf_sanity.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200_perf_sanity.yml
@@ -20,6 +20,7 @@ l0_dgx_b200_perf_sanity:
   # - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_dep8_mtp1_1k1k] TIMEOUT (90) # failed
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_mtp3_8k1k]
   # - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_dep8_mtp1_8k1k] TIMEOUT (90) # failed
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_8k1k] TIMEOUT (90)
   # deepseek_r1_fp4_v2_blackwell
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_blackwell-r1_fp4_v2_tp4_mtp3_1k1k]
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_blackwell-r1_fp4_v2_tp4_mtp3_8k1k]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200_perf_sanity.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200_perf_sanity.yml
@@ -20,7 +20,7 @@ l0_dgx_b200_perf_sanity:
   # - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_dep8_mtp1_1k1k] TIMEOUT (90) # failed
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_mtp3_8k1k]
   # - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_dep8_mtp1_8k1k] TIMEOUT (90) # failed
-  - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_8k1k] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_6k1k] TIMEOUT (90)
   # deepseek_r1_fp4_v2_blackwell
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_blackwell-r1_fp4_v2_tp4_mtp3_1k1k]
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_blackwell-r1_fp4_v2_tp4_mtp3_8k1k]

--- a/tests/scripts/perf-sanity/deepseek_r1_fp8_blackwell.yaml
+++ b/tests/scripts/perf-sanity/deepseek_r1_fp8_blackwell.yaml
@@ -134,3 +134,31 @@ server_configs:
         osl: 1024
         backend: "openai"
         dataset_file: datasets/perf-ci/deepseek_r1-8k1k-20480-ratio-1_for_serve.json
+
+  # 8k1k configs - TP8 with TRTLLM, MTP1
+  - name: "r1_fp8_tp8_8k1k"
+    model_name: "deepseek_r1_0528_fp8"
+    tensor_parallel_size: 8
+    moe_expert_parallel_size: 1
+    pipeline_parallel_size: 1
+    max_batch_size: 512
+    max_num_tokens: 10240
+    attn_backend: "TRTLLM"
+    enable_attention_dp: false
+    moe_config:
+      backend: 'TRTLLM'
+    cuda_graph_config:
+      enable_padding: true
+      max_batch_size: 64
+    kv_cache_config:
+      dtype: 'fp8'
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.8
+    client_configs:
+      - name: "con64_iter10_8k1k"
+        concurrency: 64
+        iterations: 10
+        isl: 8192
+        osl: 1024
+        backend: "openai"
+        random_range_ratio: 0.2

--- a/tests/scripts/perf-sanity/deepseek_r1_fp8_blackwell.yaml
+++ b/tests/scripts/perf-sanity/deepseek_r1_fp8_blackwell.yaml
@@ -135,14 +135,14 @@ server_configs:
         backend: "openai"
         dataset_file: datasets/perf-ci/deepseek_r1-8k1k-20480-ratio-1_for_serve.json
 
-  # 8k1k configs - TP8 with TRTLLM, MTP1
-  - name: "r1_fp8_tp8_8k1k"
+  # 6k1k configs - TP8 with TRTLLM, MTP1
+  - name: "r1_fp8_tp8_6k1k"
     model_name: "deepseek_r1_0528_fp8"
     tensor_parallel_size: 8
     moe_expert_parallel_size: 1
     pipeline_parallel_size: 1
     max_batch_size: 512
-    max_num_tokens: 10240
+    max_num_tokens: 8192
     attn_backend: "TRTLLM"
     enable_attention_dp: false
     moe_config:
@@ -155,10 +155,10 @@ server_configs:
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.8
     client_configs:
-      - name: "con64_iter10_8k1k"
+      - name: "con64_iter10_6k1k"
         concurrency: 64
         iterations: 10
-        isl: 8192
+        isl: 6144
         osl: 1024
         backend: "openai"
         random_range_ratio: 0.2

--- a/tests/test_common/http_utils.py
+++ b/tests/test_common/http_utils.py
@@ -4,7 +4,7 @@ import time
 
 import requests
 
-ERROR_KEYWORDS = ["RuntimeError", "out of memory", "ValueError"]
+ERROR_KEYWORDS = ["RuntimeError", "out of memory", "ValueError", "FileNotFoundError"]
 
 
 def wait_for_endpoint_ready(


### PR DESCRIPTION
## Summary by CodeRabbit

* **Refactor**
  * In autotuner, SwapAB deepgemm kernel only uses tactic=0
  * Delete tune_max_num_tokens in DeepGemm SwapAB and use curr_max_num_tokens as default tune_max_num_tokens (but still clamp to [4096, 8192]) so that tuning bucket is more flexible.
  * Enhance test_perf_sanity.py to display server failure errors directly in the Jenkins pipeline, allowing developers to view them immediately.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
