### PR TITLE
[#11234][test] Move test_ad_export_onnx to integration examples

### DIFF
--- a/tests/integration/defs/examples/test_ad_export_onnx.py
+++ b/tests/integration/defs/examples/test_ad_export_onnx.py
@@ -1,7 +1,15 @@
 import os
+import sys
+from pathlib import Path
 
 import onnx
 import pytest
+
+# Import utility from unittest directory
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent.parent / "unittest/_torch/auto_deploy/_utils_test"),
+)
 from _model_test_utils import get_small_model_config
 
 from tensorrt_llm._torch.auto_deploy.export import export_onnx

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -445,3 +445,4 @@ l0_h100:
   - examples/test_ad_speculative_decoding.py::test_eagle_model_with_weights
   - examples/test_ad_speculative_decoding.py::test_eagle_wrapper_forward[1]
   - examples/test_ad_speculative_decoding.py::test_eagle_wrapper_forward[2]
+  - examples/test_ad_export_onnx.py::test_ad_export_onnx[Qwen/Qwen2.5-3B-Instruct-/tmp/test_ad_export_onnx_qwen2.5-3b-36]


### PR DESCRIPTION
## Description

Move `test_ad_export_onnx.py` from unittest folder to integration examples directory. This test is long-running (~83 seconds) and memory-intensive, making it more suitable for integration testing rather than unit testing. The test validates ONNX export functionality with Qwen2.5-3B model and verifies the exported model structure.

Changes:
- Moved test from `tests/unittest/_torch/auto_deploy/unit/singlegpu/` to `tests/integration/defs/examples/`
- Updated import paths to maintain compatibility with test utilities
- Registered test in `l0_h100.yml` test database for CI execution

Closes #11234

## Test Coverage

- `tests/integration/defs/examples/test_ad_export_onnx.py::test_ad_export_onnx` - Validates ONNX export pipeline with:
  - Model structure verification (input/output names, attention operators count)
  - Exported artifacts validation (tokenizer, config, model.onnx files)
  - Successful test run: PASSED in 83.46s

## PR Checklist

- [x] PR description clearly explains what and why
- [x] Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md)
- [x] Test cases provided for new code paths (test is the code path itself)
- [x] New dependencies scanned for license and vulnerabilities (no new dependencies)
- [x] CODEOWNERS updated if ownership changes (no ownership changes)
- [x] Documentation updated as needed (no user-facing changes)
- [x] Please check this after reviewing the above items as appropriate for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for ONNX export functionality on H100 hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->