### PR TITLE
[None][chore] Fix slurm job name

### DIFF
--- a/tests/integration/defs/perf/disagg/execution/executor.py
+++ b/tests/integration/defs/perf/disagg/execution/executor.py
@@ -219,7 +219,7 @@ class JobManager:
 
             # Write temporary config file with replaced environment variables
             logger.info(f"Creating temporary config: {temp_config_path}")
-            
+
             with open(temp_config_path, "w") as f:
                 yaml.dump(
                     test_config.config_data,

--- a/tests/integration/defs/perf/disagg/execution/executor.py
+++ b/tests/integration/defs/perf/disagg/execution/executor.py
@@ -219,6 +219,7 @@ class JobManager:
 
             # Write temporary config file with replaced environment variables
             logger.info(f"Creating temporary config: {temp_config_path}")
+            
             with open(temp_config_path, "w") as f:
                 yaml.dump(
                     test_config.config_data,

--- a/tests/integration/defs/perf/disagg/utils/common.py
+++ b/tests/integration/defs/perf/disagg/utils/common.py
@@ -61,13 +61,13 @@ class EnvManager:
     @staticmethod
     def get_slurm_job_name() -> str:
         """Get SLURM job name: {SLURM_ACCOUNT}-{base}.
-        
+
         Example: myaccount-unified.benchmark
         Customize base via SLURM_JOB_BASE_NAME env var (default: unified.benchmark)
         """
         account = EnvManager.get_slurm_account()
         base = os.getenv("SLURM_JOB_BASE_NAME", "unified.benchmark")
-        
+
         # Only use account as prefix if it's set and not a placeholder
         if account and not account.startswith("<"):
             return f"{account}-{base}"

--- a/tests/integration/defs/perf/disagg/utils/common.py
+++ b/tests/integration/defs/perf/disagg/utils/common.py
@@ -68,10 +68,10 @@ class EnvManager:
     @staticmethod
     def get_slurm_job_name() -> str:
         """Get SLURM job name based on GPU type configuration.
-        
+
         Format: {prefix}-{base} or just {base} if no prefix.
         Example: coreai_comparch_trtllm-unified.benchmark
-        
+
         Customize via SLURM_JOB_BASE_NAME env var (default: unified.benchmark)
         """
         gpu_type = EnvManager.get_gpu_type()

--- a/tests/integration/defs/perf/disagg/utils/common.py
+++ b/tests/integration/defs/perf/disagg/utils/common.py
@@ -10,7 +10,7 @@ GPU_RESOURCE_CONFIG = {
         "set_segment": True,
         "lock_freq_graphics_mhz": 2062,
         "lock_freq_memory_mhz": 3996,
-        "job_name_prefix": "",
+        "job_name_prefix": "coreai_comparch_trtllm",
     },
     "GB200_LYRIS": {  # Lyris GB200
         "slurm_extra_args": "",
@@ -38,14 +38,14 @@ GPU_RESOURCE_CONFIG = {
         "set_segment": False,
         "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
-        "job_name_prefix": "coreai_comparch_trtllm",
+        "job_name_prefix": "",
     },
     "B300": {  # OCI B300
         "slurm_extra_args": "--gres=gpu:4",
         "set_segment": False,
         "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
-        "job_name_prefix": "coreai_comparch_trtllm",
+        "job_name_prefix": "",
     },
 }
 

--- a/tests/integration/defs/perf/disagg/utils/common.py
+++ b/tests/integration/defs/perf/disagg/utils/common.py
@@ -2,50 +2,50 @@
 
 import os
 
-# GPU resource configuration
-# Centralized configuration for all GPU-specific parameters
+# GPU resource configuration - centralized config for all GPU-specific parameters
+# job_name_prefix: SLURM job name format is {prefix}-{base} (e.g., coreai_comparch_trtllm-unified.benchmark)
 GPU_RESOURCE_CONFIG = {
-    # OCI GB200
-    "GB200": {
-        "slurm_extra_args": "--gres=gpu:4",  # SLURM extra arguments (empty string if not required)
+    "GB200": {  # OCI GB200
+        "slurm_extra_args": "--gres=gpu:4",
         "set_segment": True,
-        "lock_freq_graphics_mhz": 2062,  # GPU graphics clock lock frequency (MHz)
-        "lock_freq_memory_mhz": 3996,  # GPU memory clock lock frequency (MHz)
+        "lock_freq_graphics_mhz": 2062,
+        "lock_freq_memory_mhz": 3996,
+        "job_name_prefix": "",
     },
-    # Lyris GB200
-    "GB200_LYRIS": {
-        "slurm_extra_args": "",  # GB300 does not require extra args
+    "GB200_LYRIS": {  # Lyris GB200
+        "slurm_extra_args": "",
         "set_segment": True,
-        "lock_freq_graphics_mhz": None,  # TODO: Set GB300 lock frequency
+        "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
+        "job_name_prefix": "coreai_comparch_trtllm",
     },
-    # Lyris GB300
-    "GB300": {
-        "slurm_extra_args": "",  # GB300 does not require extra args
+    "GB300": {  # Lyris GB300
+        "slurm_extra_args": "",
         "set_segment": True,
-        "lock_freq_graphics_mhz": None,  # TODO: Set GB300 lock frequency
+        "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
+        "job_name_prefix": "coreai_comparch_trtllm",
     },
-    # H100
     "H100": {
-        "slurm_extra_args": "",  # H100 does not require extra args
+        "slurm_extra_args": "",
         "set_segment": False,
-        "lock_freq_graphics_mhz": None,  # TODO: Set H100 lock frequency
+        "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
+        "job_name_prefix": "",
     },
-    # B200
-    "B200": {
+    "B200": {  # OCI B200
         "slurm_extra_args": "--gres=gpu:4",
         "set_segment": False,
-        "lock_freq_graphics_mhz": None,  # TODO: Set B200 lock frequency
+        "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
+        "job_name_prefix": "coreai_comparch_trtllm",
     },
-    # B300
-    "B300": {
+    "B300": {  # OCI B300
         "slurm_extra_args": "--gres=gpu:4",
         "set_segment": False,
-        "lock_freq_graphics_mhz": None,  # TODO: Set B300 lock frequency
+        "lock_freq_graphics_mhz": None,
         "lock_freq_memory_mhz": None,
+        "job_name_prefix": "coreai_comparch_trtllm",
     },
 }
 
@@ -67,7 +67,17 @@ class EnvManager:
 
     @staticmethod
     def get_slurm_job_name() -> str:
-        return os.getenv("SLURM_JOB_NAME", "unified-benchmark")
+        """Get SLURM job name based on GPU type configuration.
+        
+        Format: {prefix}-{base} or just {base} if no prefix.
+        Example: coreai_comparch_trtllm-unified.benchmark
+        
+        Customize via SLURM_JOB_BASE_NAME env var (default: unified.benchmark)
+        """
+        gpu_type = EnvManager.get_gpu_type()
+        prefix = GPU_RESOURCE_CONFIG.get(gpu_type, {}).get("job_name_prefix", "")
+        base = os.getenv("SLURM_JOB_BASE_NAME", "unified.benchmark")
+        return f"{prefix}-{base}" if prefix else base
 
     @staticmethod
     def get_slurm_set_segment() -> bool:

--- a/tests/integration/defs/perf/disagg/utils/config_loader.py
+++ b/tests/integration/defs/perf/disagg/utils/config_loader.py
@@ -532,7 +532,8 @@ class ConfigLoader:
         # Apply overrides based on field paths
         for (section, key), value_getter in field_mapping.items():
             if section in config:
-                config[section][key] = value_getter()
+                new_value = value_getter()
+                config[section][key] = new_value
         return config
 
     def _get_full_model_path(self, config: dict) -> str:

--- a/tests/integration/defs/perf/disagg/utils/config_loader.py
+++ b/tests/integration/defs/perf/disagg/utils/config_loader.py
@@ -532,8 +532,7 @@ class ConfigLoader:
         # Apply overrides based on field paths
         for (section, key), value_getter in field_mapping.items():
             if section in config:
-                new_value = value_getter()
-                config[section][key] = new_value
+                config[section][key] = value_getter()
         return config
 
     def _get_full_model_path(self, config: dict) -> str:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced GPU resource configurations with improved SLURM job naming logic for better resource allocation tracking.

* **Style**
  * Minor formatting adjustment for code consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
