### PR TITLE
[None][feat] Optimize super-v3 nvfp4 for better perf

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
@@ -15,6 +15,7 @@
  */
 
 #include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/fusedActivationQuant.h"
 #include "tensorrt_llm/kernels/quantization.cuh"
 #include "tensorrt_llm/kernels/quantization.h"
 

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/kernels/quantization.cuh"
 #include "tensorrt_llm/kernels/quantization.h"
 
+#include <cstdint>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
@@ -109,8 +110,8 @@ __global__ void fusedRelu2QuantizeKernel(T const* __restrict__ input, float cons
 }
 
 template <typename T>
-void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
-    int sfVecSize, cudaStream_t stream)
+void invokeFusedRelu2Quantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
+    int m, int n, int sfVecSize, cudaStream_t stream)
 {
     int numColThreads = n / kEltsPerThread;
     int threadsPerBlock = min(512, numColThreads);
@@ -121,11 +122,11 @@ void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* out
 }
 
 template void invokeFusedRelu2Quantize<half>(
-    half const*, float const*, uint8_t*, uint8_t*, int, int, int, cudaStream_t);
+    half const*, float const*, std::uint8_t*, std::uint8_t*, int, int, int, cudaStream_t);
 
 #ifdef ENABLE_BF16
 template void invokeFusedRelu2Quantize<__nv_bfloat16>(
-    __nv_bfloat16 const*, float const*, uint8_t*, uint8_t*, int, int, int, cudaStream_t);
+    __nv_bfloat16 const*, float const*, std::uint8_t*, std::uint8_t*, int, int, int, cudaStream_t);
 #endif
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
@@ -31,47 +31,89 @@ namespace kernels
 
 constexpr int kEltsPerThread = 8;
 
-__device__ __forceinline__ float relu2(float x)
+__device__ __forceinline__ float relu2_f32(float x)
 {
     float r = fmaxf(0.0f, x);
     return r * r;
 }
 
+// Fused relu2 + NVFP4 quantization kernel.
+//
+// To match the unfused path (PyTorch relu2 -> cvt_warp_fp16_to_fp4), relu2 is
+// computed in f32 then rounded back to native precision (bf16/fp16) before
+// quantization. Absmax and scale-factor math follow cvt_warp_fp16_to_fp4 exactly.
+// Column padding to a multiple of (4 * kSfVecSize) matches quantize_with_block_size
+// for the swizzled SF layout.
 template <typename T>
 __global__ void fusedRelu2QuantizeKernel(T const* __restrict__ input, float const* __restrict__ sfScale,
     uint32_t* __restrict__ outputFp4, uint32_t* __restrict__ outputSf, int m, int n)
 {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
     constexpr int kSfVecSize = 16;
+    constexpr int kNumThreadsPerSf = kSfVecSize / kEltsPerThread;
+    constexpr int kPackedPerThread = kEltsPerThread / 2;
+
+    using PackedType = std::conditional_t<std::is_same_v<T, half>, __half2, __nv_bfloat162>;
+
     float const SFScaleVal = sfScale[0];
-    int numColThreads = n / kEltsPerThread;
-    int numColVecs = n / kSfVecSize;
-    int rowIdx = blockIdx.x;
+    int const numColThreads = n / kEltsPerThread;
+    int const numColVecs = n / kSfVecSize;
+    int const numColThreadsPadded = ((n + 4 * kSfVecSize - 1) / (4 * kSfVecSize)) * (4 * kSfVecSize) / kEltsPerThread;
+    int const rowIdx = blockIdx.x;
 
     if (rowIdx >= m)
         return;
 
-    for (int colIdx = threadIdx.x; colIdx < numColThreads; colIdx += blockDim.x)
+    for (int colIdx = threadIdx.x; colIdx < numColThreadsPadded; colIdx += blockDim.x)
     {
-        int inputOffset = rowIdx * n + colIdx * kEltsPerThread;
-        float vals[kEltsPerThread];
+        bool const isValidCol = colIdx < numColThreads;
+        PackedType packedVals[kPackedPerThread];
 
-#pragma unroll
-        for (int i = 0; i < kEltsPerThread; i++)
+        if (isValidCol)
         {
-            vals[i] = relu2(static_cast<float>(input[inputOffset + i]));
+            int const inputOffset = rowIdx * n + colIdx * kEltsPerThread;
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                float f0 = relu2_f32(static_cast<float>(input[inputOffset + i * 2]));
+                float f1 = relu2_f32(static_cast<float>(input[inputOffset + i * 2 + 1]));
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    packedVals[i] = __floats2half2_rn(f0, f1);
+                }
+                else
+                {
+                    packedVals[i] = __floats2bfloat162_rn(f0, f1);
+                }
+            }
+        }
+        else
+        {
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    packedVals[i] = __float2half2_rn(0.0f);
+                }
+                else
+                {
+                    packedVals[i] = __float2bfloat162_rn(0.0f);
+                }
+            }
         }
 
-        float localMax = vals[0];
+        // Absmax in native precision, then reduce across the SF group (2 threads).
+        auto localMax = cuda_abs(packedVals[0]);
 #pragma unroll
-        for (int i = 1; i < kEltsPerThread; i++)
+        for (int i = 1; i < kPackedPerThread; i++)
         {
-            localMax = fmaxf(localMax, vals[i]);
+            localMax = cuda_max(localMax, cuda_abs(packedVals[i]));
         }
+        localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+        float vecMax = float(cuda_max(localMax.x, localMax.y));
 
-        localMax = fmaxf(localMax, __shfl_xor_sync(0xffffffff, localMax, 1));
-        float vecMax = localMax;
-
+        // Scale-factor computation (identical to cvt_warp_fp16_to_fp4).
         float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
         __nv_fp8_e4m3 fp8SF = __nv_fp8_e4m3(SFValue);
         uint8_t fp8SFVal = fp8SF.__x;
@@ -80,10 +122,9 @@ __global__ void fusedRelu2QuantizeKernel(T const* __restrict__ input, float cons
         float outputScale
             = vecMax != 0.0f ? reciprocal_approximate_ftz(SFValue * reciprocal_approximate_ftz(SFScaleVal)) : 0.0f;
 
-        constexpr int NUM_THREADS_PER_SF = kSfVecSize / kEltsPerThread;
-        if (colIdx % NUM_THREADS_PER_SF == 0)
+        if (colIdx % kNumThreadsPerSf == 0)
         {
-            auto sfOutPtr = cvt_quant_get_sf_out_offset<uint32_t, NUM_THREADS_PER_SF>(std::nullopt, rowIdx, colIdx,
+            auto sfOutPtr = cvt_quant_get_sf_out_offset<uint32_t, kNumThreadsPerSf>(std::nullopt, rowIdx, colIdx,
                 std::optional<int>(m), numColVecs, outputSf, QuantizationSFLayout::SWIZZLED);
             if (sfOutPtr != nullptr)
             {
@@ -91,15 +132,26 @@ __global__ void fusedRelu2QuantizeKernel(T const* __restrict__ input, float cons
             }
         }
 
-        float2 fp2Vals[kEltsPerThread / 2];
-#pragma unroll
-        for (int i = 0; i < kEltsPerThread / 2; i++)
+        if (isValidCol)
         {
-            fp2Vals[i].x = vals[i * 2] * outputScale;
-            fp2Vals[i].y = vals[i * 2 + 1] * outputScale;
-        }
+            float2 fp2Vals[kPackedPerThread];
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    fp2Vals[i] = __half22float2(packedVals[i]);
+                }
+                else
+                {
+                    fp2Vals[i] = __bfloat1622float2(packedVals[i]);
+                }
+                fp2Vals[i].x *= outputScale;
+                fp2Vals[i].y *= outputScale;
+            }
 
-        outputFp4[rowIdx * numColThreads + colIdx] = fp32_vec_to_e2m1(fp2Vals);
+            outputFp4[rowIdx * numColThreads + colIdx] = fp32_vec_to_e2m1(fp2Vals);
+        }
     }
 #else
     if (threadIdx.x == 0 && blockIdx.x == 0)
@@ -113,8 +165,9 @@ template <typename T>
 void invokeFusedRelu2Quantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
     int m, int n, int sfVecSize, cudaStream_t stream)
 {
-    int numColThreads = n / kEltsPerThread;
-    int threadsPerBlock = min(512, numColThreads);
+    constexpr int kSfVecSize = 16;
+    int const numColThreadsPadded = ((n + 4 * kSfVecSize - 1) / (4 * kSfVecSize)) * (4 * kSfVecSize) / kEltsPerThread;
+    int threadsPerBlock = min(512, numColThreadsPadded);
     threadsPerBlock = max(32, ((threadsPerBlock + 31) / 32) * 32);
 
     fusedRelu2QuantizeKernel<T><<<m, threadsPerBlock, 0, stream>>>(

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/quantization.cuh"
+#include "tensorrt_llm/kernels/quantization.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+constexpr int kEltsPerThread = 8;
+
+__device__ __forceinline__ float relu2(float x)
+{
+    float r = fmaxf(0.0f, x);
+    return r * r;
+}
+
+template <typename T>
+__global__ void fusedRelu2QuantizeKernel(T const* __restrict__ input, float const* __restrict__ sfScale,
+    uint32_t* __restrict__ outputFp4, uint32_t* __restrict__ outputSf, int m, int n)
+{
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+    constexpr int kSfVecSize = 16;
+    float const SFScaleVal = sfScale[0];
+    int numColThreads = n / kEltsPerThread;
+    int numColVecs = n / kSfVecSize;
+    int rowIdx = blockIdx.x;
+
+    if (rowIdx >= m)
+        return;
+
+    for (int colIdx = threadIdx.x; colIdx < numColThreads; colIdx += blockDim.x)
+    {
+        int inputOffset = rowIdx * n + colIdx * kEltsPerThread;
+        float vals[kEltsPerThread];
+
+#pragma unroll
+        for (int i = 0; i < kEltsPerThread; i++)
+        {
+            vals[i] = relu2(static_cast<float>(input[inputOffset + i]));
+        }
+
+        float localMax = vals[0];
+#pragma unroll
+        for (int i = 1; i < kEltsPerThread; i++)
+        {
+            localMax = fmaxf(localMax, vals[i]);
+        }
+
+        localMax = fmaxf(localMax, __shfl_xor_sync(0xffffffff, localMax, 1));
+        float vecMax = localMax;
+
+        float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+        __nv_fp8_e4m3 fp8SF = __nv_fp8_e4m3(SFValue);
+        uint8_t fp8SFVal = fp8SF.__x;
+        SFValue = static_cast<float>(fp8SF);
+
+        float outputScale
+            = vecMax != 0.0f ? reciprocal_approximate_ftz(SFValue * reciprocal_approximate_ftz(SFScaleVal)) : 0.0f;
+
+        constexpr int NUM_THREADS_PER_SF = kSfVecSize / kEltsPerThread;
+        if (colIdx % NUM_THREADS_PER_SF == 0)
+        {
+            auto sfOutPtr = cvt_quant_get_sf_out_offset<uint32_t, NUM_THREADS_PER_SF>(std::nullopt, rowIdx, colIdx,
+                std::optional<int>(m), numColVecs, outputSf, QuantizationSFLayout::SWIZZLED);
+            if (sfOutPtr != nullptr)
+            {
+                *sfOutPtr = fp8SFVal;
+            }
+        }
+
+        float2 fp2Vals[kEltsPerThread / 2];
+#pragma unroll
+        for (int i = 0; i < kEltsPerThread / 2; i++)
+        {
+            fp2Vals[i].x = vals[i * 2] * outputScale;
+            fp2Vals[i].y = vals[i * 2 + 1] * outputScale;
+        }
+
+        outputFp4[rowIdx * numColThreads + colIdx] = fp32_vec_to_e2m1(fp2Vals);
+    }
+#else
+    if (threadIdx.x == 0 && blockIdx.x == 0)
+    {
+        printf("FP4 quantization requires SM100 (Blackwell) or later!\n");
+    }
+#endif
+}
+
+template <typename T>
+void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
+    int sfVecSize, cudaStream_t stream)
+{
+    int numColThreads = n / kEltsPerThread;
+    int threadsPerBlock = min(512, numColThreads);
+    threadsPerBlock = max(32, ((threadsPerBlock + 31) / 32) * 32);
+
+    fusedRelu2QuantizeKernel<T><<<m, threadsPerBlock, 0, stream>>>(
+        input, sfScale, reinterpret_cast<uint32_t*>(outputFp4), reinterpret_cast<uint32_t*>(outputSf), m, n);
+}
+
+template void invokeFusedRelu2Quantize<half>(
+    half const*, float const*, uint8_t*, uint8_t*, int, int, int, cudaStream_t);
+
+#ifdef ENABLE_BF16
+template void invokeFusedRelu2Quantize<__nv_bfloat16>(
+    __nv_bfloat16 const*, float const*, uint8_t*, uint8_t*, int, int, int, cudaStream_t);
+#endif
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+template <typename T>
+void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
+    int sfVecSize, cudaStream_t stream);
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "tensorrt_llm/common/config.h"
+#include <cstdint>
 #include <cuda_runtime.h>
 
 TRTLLM_NAMESPACE_BEGIN
@@ -24,8 +25,8 @@ namespace kernels
 {
 
 template <typename T>
-void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
-    int sfVecSize, cudaStream_t stream);
+void invokeFusedRelu2Quantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
+    int m, int n, int sfVecSize, cudaStream_t stream);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/kernels/fusedLayernormKernels/layernorm_param.h
+++ b/cpp/tensorrt_llm/kernels/fusedLayernormKernels/layernorm_param.h
@@ -37,6 +37,7 @@ struct GeneralFP4AddBiasResidualPreLayerNormParam
     T const* bias = nullptr;
     T const* gamma = nullptr;
     T const* beta = nullptr;
+    T* high_precision_normed_output = nullptr;
 
     int m;
     int n;

--- a/cpp/tensorrt_llm/kernels/fusedLayernormKernels/low_latency_layernorm.cuh
+++ b/cpp/tensorrt_llm/kernels/fusedLayernormKernels/low_latency_layernorm.cuh
@@ -276,7 +276,7 @@ struct LowLatencyLayerNorm
             }
 
             typename PackType<typename Traits::OutputType, Traits::PACKED_ELEMS_PER_COMPUTE>::type normed_output;
-            typename PackType<typename Traits::AccumulatorType, Traits::PACKED_ELEMS_PER_COMPUTE>::type
+            typename PackType<typename Traits::InputType, Traits::PACKED_ELEMS_PER_COMPUTE>::type
                 high_precision_normed_output;
             for (int j = 0; j < Traits::PACKED_ELEMS_PER_COMPUTE; j++)
             {
@@ -300,7 +300,7 @@ struct LowLatencyLayerNorm
                 }
                 if constexpr (Traits::HIGH_PRECISION_NORMED_OUTPUT)
                 {
-                    high_precision_normed_output.array[j] = normed_out;
+                    high_precision_normed_output.array[j] = (typename Traits::InputType) normed_out;
                 }
                 if constexpr (Traits::OUTPUT_SCALE == SCALE_TYPE::SCALAR)
                 {

--- a/cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.cuh
+++ b/cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.cuh
@@ -690,7 +690,7 @@ struct WarpSpecializedLayerNorm
                     typename PackType<typename Traits::OutputType, Traits::PACKED_ELEMS_PER_COMPUTE>::type
                         normed_output;
                     typename PackType<typename Traits::InputType, Traits::PACKED_ELEMS_PER_COMPUTE>::type output;
-                    typename PackType<typename Traits::AccumulatorType, Traits::PACKED_ELEMS_PER_COMPUTE>::type
+                    typename PackType<typename Traits::InputType, Traits::PACKED_ELEMS_PER_COMPUTE>::type
                         high_precision_normed_output;
 
 #pragma unroll Traits::PACKED_ELEMS_PER_COMPUTE
@@ -719,6 +719,11 @@ struct WarpSpecializedLayerNorm
                             normed_out += beta[j];
                         }
 
+                        if constexpr (Traits::HIGH_PRECISION_NORMED_OUTPUT)
+                        {
+                            high_precision_normed_output.array[j] = (typename Traits::InputType) normed_out;
+                        }
+
                         if constexpr (Traits::OUTPUT_SCALE != SCALE_TYPE::NONE)
                         {
                             static_assert(Traits::OUTPUT_SCALE == SCALE_TYPE::SCALAR);
@@ -728,11 +733,6 @@ struct WarpSpecializedLayerNorm
                         if constexpr (Traits::UNNORMED_OUTPUT)
                         {
                             output.array[j] = (typename Traits::InputType) data[m_offset][i][j];
-                        }
-
-                        if constexpr (Traits::HIGH_PRECISION_NORMED_OUTPUT)
-                        {
-                            high_precision_normed_output.array[j] = normed_out;
                         }
 
                         normed_output.array[j] = (typename Traits::OutputType) normed_out;

--- a/cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.h
+++ b/cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.h
@@ -44,7 +44,7 @@ enum class SCALE_TYPE
 };
 
 template <typename T>
-void invokeWSLayerNorm(WarpSpecializedParam<T> param, bool use_rms_norm, int ctas);
+void invokeWSLayerNorm(WarpSpecializedParam<T> param, bool use_rms_norm, int ctas, bool output_hp_norm = false);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(
   dsv3FusedAGemmOp.cpp
   fusedQKNormRopeOp.cpp
   fusedAddRMSNormQuant.cpp
+  fusedActivationQuant.cpp
   fusedTopkSoftmax.cpp
   gatherTreeOp.cpp
   groupRmsNormOp.cpp

--- a/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
+++ b/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "tensorrt_llm/kernels/fusedActivationQuant.h"
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/kernels/quantization.h"
 #include "tensorrt_llm/thop/thUtils.h"
@@ -26,15 +27,6 @@
 #include <cuda_fp16.h>
 
 TRTLLM_NAMESPACE_BEGIN
-
-namespace kernels
-{
-
-template <typename T>
-void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
-    int sfVecSize, cudaStream_t stream);
-
-} // namespace kernels
 
 namespace torch_ext
 {

--- a/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
+++ b/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/quantization.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <ATen/Functions.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/EmptyTensor.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+template <typename T>
+void invokeFusedRelu2Quantize(T const* input, float const* sfScale, uint8_t* outputFp4, uint8_t* outputSf, int m, int n,
+    int sfVecSize, cudaStream_t stream);
+
+} // namespace kernels
+
+namespace torch_ext
+{
+
+std::tuple<at::Tensor, at::Tensor> fused_relu2_quantize(
+    at::Tensor const& input, at::Tensor const& sf_scale, int64_t sf_vec_size)
+{
+    CHECK_TH_CUDA(input);
+    CHECK_CONTIGUOUS(input);
+    CHECK_INPUT(sf_scale, torch::kFloat32);
+
+    auto const& inputShape = input.sizes();
+    TORCH_CHECK(inputShape.size() == 2, "input should be 2D tensor [M, N].");
+
+    int64_t const m = inputShape[0];
+    int64_t const n = inputShape[1];
+
+    TORCH_CHECK(sf_vec_size == 16, "sf_vec_size must be 16 for NVFP4.");
+    TORCH_CHECK(n % sf_vec_size == 0, "N must be divisible by sf_vec_size.");
+
+    auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
+
+    at::Tensor output_fp4 = at::detail::empty_cuda({m, n / 2}, torch::kUInt8, input.device(), std::nullopt);
+    int64_t const sfSize = tensorrt_llm::computeSwizzledLayoutSFSize(m, n / sf_vec_size);
+    at::Tensor output_sf = at::detail::empty_cuda({sfSize}, SF_DTYPE, input.device(), std::nullopt);
+
+    float const* sfScalePtr = sf_scale.data_ptr<float>();
+
+    if (input.scalar_type() == at::ScalarType::Half)
+    {
+        kernels::invokeFusedRelu2Quantize<half>(reinterpret_cast<half const*>(input.data_ptr()), sfScalePtr,
+            output_fp4.data_ptr<uint8_t>(), output_sf.data_ptr<uint8_t>(), static_cast<int>(m), static_cast<int>(n),
+            static_cast<int>(sf_vec_size), stream);
+    }
+    else if (input.scalar_type() == at::ScalarType::BFloat16)
+    {
+#ifdef ENABLE_BF16
+        kernels::invokeFusedRelu2Quantize<__nv_bfloat16>(reinterpret_cast<__nv_bfloat16 const*>(input.data_ptr()),
+            sfScalePtr, output_fp4.data_ptr<uint8_t>(), output_sf.data_ptr<uint8_t>(), static_cast<int>(m),
+            static_cast<int>(n), static_cast<int>(sf_vec_size), stream);
+#else
+        C10_THROW_ERROR(NotImplementedError, "BFloat16 not enabled.");
+#endif
+    }
+    else
+    {
+        C10_THROW_ERROR(NotImplementedError, "fused_relu2_quantize only supports fp16/bf16.");
+    }
+
+    return std::make_tuple(output_fp4, output_sf);
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("fused_relu2_quantize(Tensor input, Tensor sf_scale, int sf_vec_size=16) -> (Tensor, Tensor)");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("fused_relu2_quantize", &tensorrt_llm::torch_ext::fused_relu2_quantize);
+}

--- a/cpp/tensorrt_llm/thop/fusedAddRMSNormQuant.cpp
+++ b/cpp/tensorrt_llm/thop/fusedAddRMSNormQuant.cpp
@@ -43,16 +43,18 @@ namespace torch_ext
 // gamma: [N] - RMSNorm weight (fp16/bf16)
 // sf_scale: [1] - optional scale factor for FP4 quantization (float)
 // use_rms_norm: bool - if true use RMSNorm, else use LayerNorm
+// output_hp_norm: bool - if true, also output high precision normalized values (same dtype as input) for MoE gate.
 // Returns:
 //   normed_output: [M, N/8] - FP4 quantized normalized output (uint32_t, packed)
 //   output: [M, N] - pre-norm output (input + residual), same dtype as input
 //   sf_out: scale factors for FP4 (uint8_t), swizzled layout
+//   high_precision_normed_output: [M, N] - normalized output before quant (only if output_hp_norm=true, else empty)
 //
 // NOTE: This kernel requires SM90 (Hopper) or SM100 (Blackwell) GPU architecture.
 // NOTE: Hidden dimension N must be >= 2048 and <= 16384.
-std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_add_rms_norm_quant(at::Tensor const& input,
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> fused_add_rms_norm_quant(at::Tensor const& input,
     at::Tensor const& residual, at::Tensor const& gamma, std::optional<at::Tensor> const& sf_scale, bool use_rms_norm,
-    double eps)
+    double eps, bool output_hp_norm)
 {
     CHECK_TH_CUDA(input);
     CHECK_CONTIGUOUS(input);
@@ -116,6 +118,14 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_add_rms_norm_quant(at::Tens
     int64_t const sfSizePadded = tensorrt_llm::computeSwizzledLayoutSFSize(m_padded, n / sfVecSize);
     at::Tensor sf_out_padded = at::detail::empty_cuda({sfSizePadded}, SF_DTYPE, input.device(), std::nullopt);
     at::Tensor sf_out = (m_padded == m) ? sf_out_padded : sf_out_padded.narrow(0, 0, sfSize);
+    at::Tensor high_precision_normed_output;
+    if (output_hp_norm)
+    {
+        at::Tensor hp_normed_output_padded
+            = at::detail::empty_cuda({m_padded, n}, input.scalar_type(), input.device(), std::nullopt);
+        high_precision_normed_output
+            = (m_padded == m) ? hp_normed_output_padded : hp_normed_output_padded.narrow(0, 0, m);
+    }
 
     // Get number of SMs for persistent kernel
     static int const multiProcessorCount = tensorrt_llm::common::getMultiProcessorCount();
@@ -152,12 +162,14 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_add_rms_norm_quant(at::Tens
         param.bias = nullptr;                                                                                          \
         param.gamma = reinterpret_cast<T const*>(gamma.data_ptr());                                                    \
         param.beta = nullptr;                                                                                          \
+        param.high_precision_normed_output                                                                             \
+            = output_hp_norm ? reinterpret_cast<T*>(high_precision_normed_output.data_ptr()) : nullptr;                \
         param.m = static_cast<int>(m);                                                                                 \
         param.n = static_cast<int>(n);                                                                                 \
         param.layernorm_eps = static_cast<float>(eps);                                                                 \
         param.stream = stream;                                                                                         \
         param.counters = counters;                                                                                     \
-        tensorrt_llm::kernels::invokeWSLayerNorm<Param>(param, use_rms_norm, multiProcessorCount);                     \
+        tensorrt_llm::kernels::invokeWSLayerNorm<Param>(param, use_rms_norm, multiProcessorCount, output_hp_norm);     \
     } while (0)
 
     if (input.scalar_type() == at::ScalarType::Half)
@@ -180,7 +192,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_add_rms_norm_quant(at::Tens
 
 #undef LAUNCH_FUSED_ADD_RMS_NORM_QUANT
     // No explicit sync needed - kernel runs asynchronously on the stream
-    return std::make_tuple(normed_output, output, sf_out);
+    return std::make_tuple(normed_output, output, sf_out, high_precision_normed_output);
 }
 
 } // namespace torch_ext
@@ -191,7 +203,8 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "fused_add_rms_norm_quant(Tensor input, Tensor residual, Tensor gamma, "
-        "Tensor? sf_scale, bool use_rms_norm=True, float eps=1e-6) -> (Tensor, Tensor, Tensor)");
+        "Tensor? sf_scale, bool use_rms_norm=True, float eps=1e-6, bool output_hp_norm=False) -> (Tensor, Tensor, "
+        "Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -412,11 +412,13 @@ class NemotronHLayer(DecoderLayer):
         self,
         position_ids: torch.IntTensor,
         hidden_states: torch.Tensor,
-        residual: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        residual: Optional[torch.Tensor] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = torch.zeros_like(hidden_states)
 
         if self.norm.is_nvfp4 and not hasattr(self.norm, 'nvfp4_scale'):
             self._try_attach_nvfp4_scale()

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -37,7 +37,7 @@ from ..modules.mlp import MLP
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
-from ..utils import AuxStreamType, EventType
+from ..utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .modeling_deepseekv3 import DeepseekV3MTPHead
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, register_auto_model
@@ -242,13 +242,21 @@ class NemotronHMOE(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: Union[torch.Tensor, Fp4QuantizedTensor,
+                             Tuple[Union[torch.Tensor, Fp4QuantizedTensor],
+                                   torch.Tensor]],
         attn_metadata: AttentionMetadata,
         **kwargs,
     ) -> torch.Tensor:
-        assert hidden_states.shape[-1] == self.hidden_dim
-        orig_shape = hidden_states.shape
-        hidden_states = hidden_states.view(-1, self.hidden_dim)
+
+        if isinstance(hidden_states, tuple):
+            hidden_states, hidden_states_hp = hidden_states
+        else:
+            hidden_states_hp = hidden_states
+
+        assert hidden_states_hp.shape[-1] == self.hidden_dim
+        orig_shape = hidden_states_hp.shape
+        hidden_states_hp_2d = hidden_states_hp.view(-1, self.hidden_dim)
         all_rank_num_tokens = attn_metadata.all_rank_num_tokens
 
         def _compute_shared_output():
@@ -259,7 +267,8 @@ class NemotronHMOE(nn.Module):
             return shared_expert_output
 
         def _compute_routed_output():
-            router_logits = self.gate(hidden_states)
+            # Gate uses high precision input for accurate routing decisions.
+            router_logits = self.gate(hidden_states_hp_2d)
 
             routed_hidden_states = hidden_states
             if self.use_latent_moe:
@@ -321,6 +330,9 @@ class NemotronHLayer(DecoderLayer):
             # Enable fused NVFP4 quantization if possible.
             # It might be overridden in `_try_attach_nvfp4_scale` function.
             quantize_type="nvfp4" if self.is_nvfp4 else None,
+            # Enable high precision output for MoE layer.
+            # It might be overridden in `_try_attach_nvfp4_scale` function.
+            return_hp_output=layer_type == "E",
         )
 
         if layer_type == "M":
@@ -355,20 +367,34 @@ class NemotronHLayer(DecoderLayer):
 
         Called lazily on first forward (weights don't exist during __init__).
         """
-        # MoE layer is skipped for now since the gate needs high precision input.
+        # Normal handling for Mamba, MLP, and Attention layers.
         first_linear_attr = {
             'M': 'in_proj',
             '-': 'up_proj',
             '*': 'qkv_proj'
         }.get(self.layer_type)
-
         if first_linear_attr:
             first_linear = getattr(self.mixer, first_linear_attr, None)
             if first_linear and hasattr(first_linear, 'input_scale'):
                 self.norm.nvfp4_scale = first_linear.input_scale
                 return
 
+        # Special handling for MoE layer: fetch shared_expert.up_proj.input_scale
+        # as representation of the input scale.
+        if self.layer_type == 'E':
+            if (hasattr(self.mixer, 'shared_experts')
+                    and self.mixer.shared_experts is not None
+                    and hasattr(self.mixer.shared_experts, 'up_proj')
+                    and hasattr(self.mixer.shared_experts.up_proj,
+                                'input_scale') and
+                    self.mixer.shared_experts.up_proj.input_scale is not None):
+                self.norm.nvfp4_scale = self.mixer.shared_experts.up_proj.input_scale
+                # Enable high precision output for MoE layer.
+                self.norm.return_hp_output = True
+                return
+
         self.norm.is_nvfp4 = False
+        self.norm.return_hp_output = False
 
     def forward(
         self,
@@ -383,7 +409,12 @@ class NemotronHLayer(DecoderLayer):
         if self.norm.is_nvfp4 and not hasattr(self.norm, 'nvfp4_scale'):
             self._try_attach_nvfp4_scale()
 
-        hidden_states, residual = self.norm(hidden_states, residual)
+        if self.norm.return_hp_output:
+            hidden_states, residual, high_precision_normed_output = self.norm(
+                hidden_states, residual)
+            hidden_states = (hidden_states, high_precision_normed_output)
+        else:
+            hidden_states, residual = self.norm(hidden_states, residual)
         hidden_states = self.mixer(hidden_states,
                                    attn_metadata,
                                    spec_metadata=spec_metadata,

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -310,10 +310,17 @@ class NemotronHLayer(DecoderLayer):
         self.layer_idx = layer_idx
         self.layer_type = layer_type
 
+        self.is_nvfp4 = (model_config.quant_config is not None
+                         and model_config.quant_config.quant_mode is not None
+                         and model_config.quant_config.quant_mode.has_nvfp4())
+
         self.norm = RMSNorm(
             hidden_size=config.hidden_size,
             eps=config.rms_norm_eps,
             dtype=config.torch_dtype,
+            # Enable fused NVFP4 quantization if possible.
+            # It might be overridden in `_try_attach_nvfp4_scale` function.
+            quantize_type="nvfp4" if self.is_nvfp4 else None,
         )
 
         if layer_type == "M":
@@ -343,29 +350,51 @@ class NemotronHLayer(DecoderLayer):
         else:
             raise ValueError(f"{layer_type} is not supported")
 
+    def _try_attach_nvfp4_scale(self):
+        """Attach input_scale from mixer's first linear to norm for fused RMSNorm+Quant.
+
+        Called lazily on first forward (weights don't exist during __init__).
+        """
+        # MoE layer is skipped for now since the gate needs high precision input.
+        first_linear_attr = {
+            'M': 'in_proj',
+            '-': 'up_proj',
+            '*': 'qkv_proj'
+        }.get(self.layer_type)
+
+        if first_linear_attr:
+            first_linear = getattr(self.mixer, first_linear_attr, None)
+            if first_linear and hasattr(first_linear, 'input_scale'):
+                self.norm.nvfp4_scale = first_linear.input_scale
+                return
+
+        self.norm.is_nvfp4 = False
+
     def forward(
         self,
         position_ids: torch.IntTensor,
         hidden_states: torch.Tensor,
+        residual: torch.Tensor,
         attn_metadata: AttentionMetadata,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
 
-        residual = hidden_states
+        if self.norm.is_nvfp4 and not hasattr(self.norm, 'nvfp4_scale'):
+            self._try_attach_nvfp4_scale()
 
-        hidden_states = self.norm(hidden_states)
+        hidden_states, residual = self.norm(hidden_states, residual)
         hidden_states = self.mixer(hidden_states,
                                    attn_metadata,
                                    spec_metadata=spec_metadata,
                                    **kwargs)
-        hidden_states = torch.add(hidden_states, residual)
+
         if spec_metadata is not None and spec_metadata.is_layer_capture(
                 self.layer_idx):
             spec_metadata.maybe_capture_hidden_states(self.layer_idx,
                                                       hidden_states, None)
 
-        return hidden_states
+        return hidden_states, residual
 
 
 class NemotronHModel(DecoderModel):
@@ -443,16 +472,15 @@ class NemotronHModel(DecoderModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         hidden_states = inputs_embeds
-
+        residual = torch.zeros_like(hidden_states)
         for layer in self.layers[:self.num_hidden_layers]:
-            hidden_states = layer(position_ids,
-                                  hidden_states,
-                                  attn_metadata,
-                                  spec_metadata=spec_metadata,
-                                  mamba_metadata=mamba_metadata)
-
-        hidden_states = self.norm_f(hidden_states)
-
+            hidden_states, residual = layer(position_ids,
+                                            hidden_states,
+                                            residual=residual,
+                                            attn_metadata=attn_metadata,
+                                            spec_metadata=spec_metadata,
+                                            mamba_metadata=mamba_metadata)
+        hidden_states, _ = self.norm_f(hidden_states, residual)
         return hidden_states
 
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -243,9 +243,9 @@ class NemotronHMOE(nn.Module):
 
     def forward(
         self,
-        hidden_states: Union[torch.Tensor, Fp4QuantizedTensor,
-                             Tuple[Union[torch.Tensor, Fp4QuantizedTensor],
-                                   torch.Tensor]],
+        hidden_states: Union[torch.Tensor, Tuple[Union[torch.Tensor,
+                                                       Fp4QuantizedTensor],
+                                                 torch.Tensor]],
         attn_metadata: AttentionMetadata,
         **kwargs,
     ) -> torch.Tensor:
@@ -346,6 +346,9 @@ class NemotronHLayer(DecoderLayer):
             # It might be overridden in `_try_attach_nvfp4_scale` function.
             return_hp_output=layer_type == "E" and self.is_nvfp4,
         )
+        # Alias for compatibility with layer-wise benchmark runner.
+        self.input_layernorm = self.norm
+        self.next_layer_layernorm = None
 
         if layer_type == "M":
             self.mixer = Mamba2Mixer(d_model=config.hidden_size,

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -344,9 +344,6 @@ class NemotronHLayer(DecoderLayer):
             # It might be overridden in `_try_attach_nvfp4_scale` function.
             return_hp_output=layer_type == "E" and self.is_nvfp4,
         )
-        # Alias for compatibility with layer-wise benchmark runner.
-        self.input_layernorm = self.norm
-        self.next_layer_layernorm = None
 
         if layer_type == "M":
             self.mixer = Mamba2Mixer(d_model=config.hidden_size,

--- a/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
+++ b/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fused elementwise operations for Mamba2 prefill optimization."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _extract_transpose_prefill_kernel(
+    src_ptr,
+    dst_ptr,
+    num_prefill_tokens,
+    d_in_proj,
+    d_inner,
+    conv_dim,
+    BLOCK_SEQ: tl.constexpr,
+    BLOCK_CONV: tl.constexpr,
+):
+    """Extract src[0:num_prefill_tokens, d_inner:d_inner+conv_dim] and
+    transpose to dst[conv_dim, num_prefill_tokens]."""
+    pid_seq = tl.program_id(0)
+    pid_conv = tl.program_id(1)
+
+    seq_offsets = pid_seq * BLOCK_SEQ + tl.arange(0, BLOCK_SEQ)
+    conv_offsets = pid_conv * BLOCK_CONV + tl.arange(0, BLOCK_CONV)
+
+    seq_mask = seq_offsets < num_prefill_tokens
+    conv_mask = conv_offsets < conv_dim
+    mask = seq_mask[:, None] & conv_mask[None, :]
+
+    src_offsets = seq_offsets[:, None] * d_in_proj + (d_inner + conv_offsets[None, :])
+    data = tl.load(src_ptr + src_offsets, mask=mask, other=0.0)
+
+    dst_offsets = conv_offsets[:, None] * num_prefill_tokens + seq_offsets[None, :]
+    tl.store(dst_ptr + dst_offsets, tl.trans(data), mask=conv_mask[:, None] & seq_mask[None, :])
+
+
+def extract_transpose_xbc_prefill(
+    zxbcdt: torch.Tensor,
+    num_prefill_tokens: int,
+    d_inner: int,
+    conv_dim: int,
+) -> torch.Tensor:
+    """
+    Extract and transpose xbc slice from zxbcdt for causal_conv1d_fn.
+
+    Input:  zxbcdt[num_tokens, d_in_proj]
+    Output: [conv_dim, num_prefill_tokens]
+    """
+    out = torch.empty(conv_dim, num_prefill_tokens, dtype=zxbcdt.dtype, device=zxbcdt.device)
+
+    BLOCK_SEQ, BLOCK_CONV = 32, 128
+    grid = (triton.cdiv(num_prefill_tokens, BLOCK_SEQ), triton.cdiv(conv_dim, BLOCK_CONV))
+
+    _extract_transpose_prefill_kernel[grid](
+        zxbcdt,
+        out,
+        num_prefill_tokens,
+        zxbcdt.shape[1],
+        d_inner,
+        conv_dim,
+        BLOCK_SEQ,
+        BLOCK_CONV,
+    )
+    return out
+
+
+@triton.jit
+def _fused_conv_output_transpose_kernel(
+    src_ptr,
+    out_x_ptr,
+    out_B_ptr,
+    out_C_ptr,
+    num_prefill_tokens,
+    d_inner,
+    bc_size,
+    x_tiles,
+    bc_tiles,
+    BLOCK_SEQ: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """
+    Transpose and split conv1d output into x, B, C using linear grid mapping.
+
+    Grid: tiles [0, x_tiles) -> x, [x_tiles, x_tiles+bc_tiles) -> B, rest -> C
+    """
+    tile_id = tl.program_id(0)
+
+    is_x = tile_id < x_tiles
+    is_B = (tile_id >= x_tiles) & (tile_id < x_tiles + bc_tiles)
+
+    local_tile = tl.where(
+        is_x, tile_id, tl.where(is_B, tile_id - x_tiles, tile_id - x_tiles - bc_tiles)
+    )
+    dim_size = tl.where(is_x, d_inner, bc_size)
+    num_dim_blocks = tl.cdiv(dim_size, BLOCK_DIM)
+
+    pid_seq = local_tile // num_dim_blocks
+    pid_dim = local_tile % num_dim_blocks
+
+    seq_offsets = pid_seq * BLOCK_SEQ + tl.arange(0, BLOCK_SEQ)
+    dim_offsets = pid_dim * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+
+    seq_mask = seq_offsets < num_prefill_tokens
+    dim_mask = dim_offsets < dim_size
+
+    src_offset = tl.where(is_x, 0, tl.where(is_B, d_inner, d_inner + bc_size))
+    src_indices = (src_offset + dim_offsets[:, None]) * num_prefill_tokens + seq_offsets[None, :]
+    data = tl.load(src_ptr + src_indices, mask=dim_mask[:, None] & seq_mask[None, :], other=0.0)
+
+    out_ptr = tl.where(is_x, out_x_ptr, tl.where(is_B, out_B_ptr, out_C_ptr))
+    dst_indices = seq_offsets[:, None] * dim_size + dim_offsets[None, :]
+    tl.store(out_ptr + dst_indices, tl.trans(data), mask=seq_mask[:, None] & dim_mask[None, :])
+
+
+def fused_split_rearrange_after_conv1d(
+    xbc: torch.Tensor,
+    d_inner: int,
+    n_groups: int,
+    d_state: int,
+    nheads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Split and rearrange causal_conv1d output into contiguous x, B, C tensors.
+
+    Input:  xbc[conv_dim, num_prefill_tokens]
+    Output: x[1, num_prefill_tokens, nheads, head_dim],
+            B[1, num_prefill_tokens, n_groups, d_state],
+            C[1, num_prefill_tokens, n_groups, d_state]
+    """
+    conv_dim, num_prefill_tokens = xbc.shape
+    bc_size = n_groups * d_state
+
+    x_flat = torch.empty(num_prefill_tokens, d_inner, dtype=xbc.dtype, device=xbc.device)
+    B_flat = torch.empty(num_prefill_tokens, bc_size, dtype=xbc.dtype, device=xbc.device)
+    C_flat = torch.empty(num_prefill_tokens, bc_size, dtype=xbc.dtype, device=xbc.device)
+
+    BLOCK_SEQ, BLOCK_DIM = 64, 64
+    num_seq_blocks = triton.cdiv(num_prefill_tokens, BLOCK_SEQ)
+    x_tiles = num_seq_blocks * triton.cdiv(d_inner, BLOCK_DIM)
+    bc_tiles = num_seq_blocks * triton.cdiv(bc_size, BLOCK_DIM)
+
+    _fused_conv_output_transpose_kernel[(x_tiles + 2 * bc_tiles,)](
+        xbc,
+        x_flat,
+        B_flat,
+        C_flat,
+        num_prefill_tokens,
+        d_inner,
+        bc_size,
+        x_tiles,
+        bc_tiles,
+        BLOCK_SEQ,
+        BLOCK_DIM,
+    )
+
+    return (
+        x_flat.view(1, num_prefill_tokens, nheads, head_dim),
+        B_flat.view(1, num_prefill_tokens, n_groups, d_state),
+        C_flat.view(1, num_prefill_tokens, n_groups, d_state),
+    )

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -17,12 +17,94 @@ import math
 from typing import Tuple
 
 import torch
+import triton
+import triton.language as tl
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
 from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import \
     CUDA_GRAPH_DUMMY_REQUEST_ID
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
     use_cpp_mamba_cache_manager
+
+
+@triton.jit
+def _cu_seqlens_triton_kernel(
+    cu_seqlens_ptr,  # [num_seqs + 1]
+    chunk_indices_ptr,  # [N] output
+    chunk_offsets_ptr,  # [N] output
+    num_seqs: tl.constexpr,
+    chunk_size: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Computes chunk_indices and chunk_offsets in a single kernel launch."""
+    pid = tl.program_id(0)
+    chunk_start = pid * BLOCK_SIZE
+    offsets = chunk_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+    chunk_indices = offsets.to(tl.int64)
+    chunk_offsets = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    p = 0
+    for seq_idx in range(num_seqs - 1):
+        seq_start = tl.load(cu_seqlens_ptr + seq_idx + 1).to(tl.int64)
+        seq_end = tl.load(cu_seqlens_ptr + seq_idx + 2).to(tl.int64)
+        is_misaligned = (seq_start % chunk_size) > 0
+        p = p + is_misaligned
+        s_chunk = seq_start // chunk_size + p
+        e_chunk = seq_end // chunk_size + p + ((seq_end % chunk_size) > 0)
+        in_range = (offsets >= s_chunk) & (offsets < e_chunk)
+        chunk_indices = tl.where(in_range & mask, chunk_indices - p,
+                                 chunk_indices)
+        is_start = (offsets == s_chunk)
+        chunk_offsets = tl.where(is_start & mask, seq_start % chunk_size,
+                                 chunk_offsets)
+
+    tl.store(chunk_indices_ptr + offsets, chunk_indices.to(tl.int32), mask=mask)
+    tl.store(chunk_offsets_ptr + offsets, chunk_offsets.to(tl.int32), mask=mask)
+
+
+def cu_seqlens_to_chunk_indices_offsets_triton(
+        cu_seqlens: torch.Tensor,
+        chunk_size: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Optimized version of cu_seqlens_to_chunk_indices_offsets."""
+    device = cu_seqlens.device
+    num_seqs = cu_seqlens.numel() - 1
+
+    if num_seqs == 0:
+        return (torch.empty(0, dtype=torch.int, device=device),
+                torch.empty(0, dtype=torch.int, device=device))
+
+    cu = cu_seqlens.to(dtype=torch.int64)
+    total_seqlens = cu[-1].item()
+
+    if num_seqs == 1:
+        # Fast path for single sequence (no boundaries to process)
+        N = (total_seqlens + chunk_size - 1) // chunk_size
+        return (torch.arange(N, device=device, dtype=torch.int),
+                torch.zeros(N, device=device, dtype=torch.int))
+
+    seq_starts = cu[1:-1]
+    misaligned = ((seq_starts % chunk_size) > 0).to(torch.int64)
+    p = torch.cumsum(misaligned, dim=0)
+    extra_chunks = p[-1].item() if p.numel() > 0 else 0
+    N = (total_seqlens + chunk_size - 1) // chunk_size + extra_chunks
+    chunk_indices = torch.empty(N, device=device, dtype=torch.int)
+    chunk_offsets = torch.empty(N, device=device, dtype=torch.int)
+
+    BLOCK_SIZE = 256
+    grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE, )
+    _cu_seqlens_triton_kernel[grid](
+        cu,
+        chunk_indices,
+        chunk_offsets,
+        num_seqs=num_seqs,
+        chunk_size=chunk_size,
+        N=N,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return chunk_indices, chunk_offsets
 
 
 def cu_seqlens_to_chunk_indices_offsets(
@@ -117,15 +199,15 @@ class Mamba2Metadata:
         self.state_indices = torch.zeros(max_batch_size,
                                          dtype=torch.int32,
                                          device="cuda")
-        self._query_start_loc_long_buf = torch.arange(0,
-                                                      max_batch_size + 1,
-                                                      dtype=torch.long,
-                                                      device="cuda")
-        self._query_start_loc_buf = torch.zeros(max_batch_size + 1,
-                                                dtype=torch.int,
-                                                device="cuda")
-        self.query_start_loc_long = self._query_start_loc_long_buf
-        self.query_start_loc = self._query_start_loc_buf
+
+        # Pre-allocated buffers.
+        self._arange_buffer = torch.arange(max_batch_size + 1,
+                                           dtype=torch.int,
+                                           device="cuda")
+        self._arange_buffer_long = self._arange_buffer.to(torch.long)
+        self._cu_seqlens_long = torch.zeros(max_batch_size + 1,
+                                            dtype=torch.long,
+                                            device="cuda")
 
     def prepare(self, attn_metadata: AttentionMetadata):
         batch_size = attn_metadata.seq_lens.shape[0]
@@ -158,47 +240,32 @@ class Mamba2Metadata:
                          dtype=torch.int,
                          out=self.cu_seqlens[1:num_contexts + 1])
             torch.add(self.cu_seqlens[num_contexts],
-                      torch.arange(1,
-                                   batch_size - num_contexts + 1,
-                                   dtype=self.cu_seqlens.dtype,
-                                   device=self.cu_seqlens.device),
+                      self._arange_buffer[1:batch_size - num_contexts + 1],
                       out=self.cu_seqlens[num_contexts + 1:batch_size + 1])
             # Need both `query_start_loc` and `query_start_loc_long` because `causal_conv1d_fn`
             # accepts only `int32` while `chunk_gated_delta_rule` accepts only `long`.
-            self._query_start_loc_buf[:batch_size +
-                                      1] = self.cu_seqlens[:batch_size + 1]
-            self.query_start_loc = self._query_start_loc_buf[:batch_size + 1]
-            self._query_start_loc_long_buf[:batch_size + 1].copy_(
-                self.query_start_loc.to(torch.long), non_blocking=True)
-            self.query_start_loc_long = self._query_start_loc_long_buf[:
-                                                                       batch_size
-                                                                       + 1]
+            self.query_start_loc = self.cu_seqlens[:batch_size + 1]
+            self._cu_seqlens_long[:batch_size + 1].copy_(self.query_start_loc)
+            self.query_start_loc_long = self._cu_seqlens_long[:batch_size + 1]
             self.seq_idx = torch.repeat_interleave(
-                torch.arange(num_contexts,
-                             dtype=torch.int,
-                             device=self.cu_seqlens.device),
+                self._arange_buffer[:num_contexts],
                 repeats=context_lens,
                 output_size=num_ctx_tokens).unsqueeze(0)
 
             num_cached_tokens_per_seq = attn_metadata.kv_cache_params.num_cached_tokens_per_seq
-            self.has_initial_states[:num_contexts] = torch.tensor(
-                num_cached_tokens_per_seq[:num_contexts]) > 0
-            # precomputed bool to avoid host<->device syncs during forward pass
-            self.use_initial_states = torch.any(
-                self.has_initial_states[:num_contexts]).item()
+            initial_states = [
+                num_cached_tokens_per_seq[i] > 0 for i in range(num_contexts)
+            ]
+            self.use_initial_states = any(initial_states)
             if self.use_initial_states:
-                self.chunk_indices, self.chunk_offsets = cu_seqlens_to_chunk_indices_offsets(
+                self.has_initial_states[:num_contexts] = torch.tensor(
+                    initial_states, dtype=torch.bool)
+                self.chunk_indices, self.chunk_offsets = cu_seqlens_to_chunk_indices_offsets_triton(
                     self.cu_seqlens[:num_contexts + 1], self.chunk_size)
             else:
                 self.chunk_indices = None
                 self.chunk_offsets = None
         else:
             self.query_start_loc = None
-            torch.arange(0,
-                         batch_size + 1,
-                         dtype=torch.long,
-                         device=self.cu_seqlens.device,
-                         out=self._query_start_loc_long_buf[:batch_size + 1])
-            self.query_start_loc_long = self._query_start_loc_long_buf[:
-                                                                       batch_size
-                                                                       + 1]
+            self.query_start_loc_long = self._arange_buffer_long[:batch_size +
+                                                                 1]

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -33,6 +33,8 @@ from ..linear import Linear, TensorParallelMode
 from .causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 from .causal_conv1d_triton import \
     causal_conv1d_update as causal_conv1d_update_triton
+from .fuse_elementwise_ops import (extract_transpose_xbc_prefill,
+                                   fused_split_rearrange_after_conv1d)
 from .layernorm_gated import RMSNorm as RMSNormGated
 from .selective_state_update import \
     selective_state_update as selective_state_update_native
@@ -227,14 +229,16 @@ class Mamba2Mixer(nn.Module):
 
         # in_proj
         zxbcdt = self.in_proj(hidden_states)
-        z, xbc, dt = torch.split(
-            zxbcdt,
-            [self.tp_d_inner, self.tp_conv_dim, self.tp_nheads],
-            dim=-1,
-        )
+
+        # Split z and dt with views.
+        z = zxbcdt[:, :self.tp_d_inner]
+        dt = zxbcdt[:, self.tp_d_inner + self.tp_conv_dim:]
         z_p, z_d = torch.split(z, seqlen_split_size, dim=0)
-        xbc_p, xbc_d = torch.split(xbc, seqlen_split_size, dim=0)
         dt_p, dt_d = torch.split(dt, seqlen_split_size, dim=0)
+
+        # Decode path uses regular view since no transpose is needed.
+        xbc_d = zxbcdt[num_prefill_tokens:num_actual_tokens,
+                       self.tp_d_inner:self.tp_d_inner + self.tp_conv_dim]
 
         # Preallocate output tensor to avoid memcpy cost for merging prefill
         # and decode outputs
@@ -259,27 +263,29 @@ class Mamba2Mixer(nn.Module):
             has_initial_states = mamba_metadata.has_initial_states[:
                                                                    num_prefills]
 
-            xbc_p = causal_conv1d_fn(xbc_p.transpose(0, 1),
+            # Fused kernel to avoid expensive .contiguous() call in causal_conv1d_fn.
+            xbc_p_t = extract_transpose_xbc_prefill(zxbcdt, num_prefill_tokens,
+                                                    self.tp_d_inner,
+                                                    self.tp_conv_dim)
+            xbc_p = causal_conv1d_fn(xbc_p_t,
                                      self.conv1d.weight,
                                      self.conv1d.bias,
                                      activation="silu",
                                      conv_states=conv_states,
                                      has_initial_state=has_initial_states,
                                      query_start_loc=cu_seqlens,
-                                     cache_indices=state_indices_p).transpose(
-                                         0, 1)
+                                     cache_indices=state_indices_p)
 
-            x_p, B_p, C_p = torch.split(xbc_p.unsqueeze(0), [
+            # Fused kernel to avoid expensive .contiguous() calls after split/rearrange.
+            x_p, B_p, C_p = fused_split_rearrange_after_conv1d(
+                xbc_p,
                 self.tp_d_inner,
-                self.tp_ngroups * self.d_state,
-                self.tp_ngroups * self.d_state,
-            ],
-                                        dim=-1)
-
-            x_p = rearrange(x_p, "b l (h p) -> b l h p", h=self.tp_nheads)
+                self.tp_ngroups,
+                self.d_state,
+                self.tp_nheads,
+                self.head_dim,
+            )
             dt_p = dt_p.unsqueeze(0)
-            B_p = rearrange(B_p, "b l (g n) -> b l g n", g=self.tp_ngroups)
-            C_p = rearrange(C_p, "b l (g n) -> b l g n", g=self.tp_ngroups)
             z_p = rearrange(z_p.unsqueeze(0),
                             "b l (h p) -> b l h p",
                             h=self.tp_nheads)

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -247,8 +247,8 @@ class Mamba2Mixer(nn.Module):
                 zxbcdt.shape[0],
                 (self.num_heads * self.head_dim) // self.tp_size,
             ],
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
+            dtype=zxbcdt.dtype,
+            device=zxbcdt.device,
         )
         preallocated_ssm_out_p, preallocated_ssm_out_d = torch.split(
             preallocated_ssm_out,

--- a/tensorrt_llm/_torch/modules/mamba/ssd_bmm.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_bmm.py
@@ -25,36 +25,6 @@ import triton.language as tl
 
 @triton.autotune(
     configs=[
-        # Small chunk_size configs for better parallelism
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 32,
-                "BLOCK_SIZE_N": 32,
-                "BLOCK_SIZE_K": 32
-            },
-            num_stages=3,
-            num_warps=4,
-        ),
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 64,
-                "BLOCK_SIZE_N": 64,
-                "BLOCK_SIZE_K": 32
-            },
-            num_stages=3,
-            num_warps=4,
-        ),
-        # Low register pressure configs
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 64,
-                "BLOCK_SIZE_N": 64,
-                "BLOCK_SIZE_K": 64
-            },
-            num_stages=2,
-            num_warps=4,
-        ),
-        # Original configs for larger chunks
         triton.Config(
             {
                 "BLOCK_SIZE_M": 128,
@@ -102,12 +72,39 @@ import triton.language as tl
         ),
         triton.Config(
             {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 32
+            },
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 32
+            },
+            num_stages=5,
+            num_warps=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 32,
+                "BLOCK_SIZE_N": 64,
+                "BLOCK_SIZE_K": 32
+            },
+            num_stages=5,
+            num_warps=2,
+        ),
+        triton.Config(
+            {
                 "BLOCK_SIZE_M": 64,
                 "BLOCK_SIZE_N": 64,
                 "BLOCK_SIZE_K": 32
             },
             num_stages=4,
-            num_warps=4,
+            num_warps=2,
         ),
     ],
     key=["chunk_size", "K", "IS_CAUSAL"],

--- a/tensorrt_llm/_torch/modules/mamba/ssd_bmm.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_bmm.py
@@ -25,6 +25,36 @@ import triton.language as tl
 
 @triton.autotune(
     configs=[
+        # Small chunk_size configs for better parallelism
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 32,
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 32
+            },
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 64,
+                "BLOCK_SIZE_K": 32
+            },
+            num_stages=3,
+            num_warps=4,
+        ),
+        # Low register pressure configs
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 64,
+                "BLOCK_SIZE_K": 64
+            },
+            num_stages=2,
+            num_warps=4,
+        ),
+        # Original configs for larger chunks
         triton.Config(
             {
                 "BLOCK_SIZE_M": 128,
@@ -72,39 +102,12 @@ import triton.language as tl
         ),
         triton.Config(
             {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 64,
                 "BLOCK_SIZE_K": 32
             },
             num_stages=4,
             num_warps=4,
-        ),
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 64,
-                "BLOCK_SIZE_N": 32,
-                "BLOCK_SIZE_K": 32
-            },
-            num_stages=5,
-            num_warps=2,
-        ),
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 32,
-                "BLOCK_SIZE_N": 64,
-                "BLOCK_SIZE_K": 32
-            },
-            num_stages=5,
-            num_warps=2,
-        ),
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": 64,
-                "BLOCK_SIZE_N": 64,
-                "BLOCK_SIZE_K": 32
-            },
-            num_stages=4,
-            num_warps=2,
         ),
     ],
     key=["chunk_size", "K", "IS_CAUSAL"],

--- a/tensorrt_llm/_torch/modules/mamba/ssd_state_passing.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_state_passing.py
@@ -23,12 +23,21 @@ import triton.language as tl
 
 @triton.autotune(
     configs=[
+        # Small dim configs with higher parallelism
+        triton.Config({"BLOCK_SIZE": 64}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 128}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 256}, num_stages=2, num_warps=4),
+        # Medium dim configs
+        triton.Config({"BLOCK_SIZE": 512}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_stages=2, num_warps=8),
+        # Large dim configs
+        triton.Config({"BLOCK_SIZE": 1024}, num_stages=3, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_stages=3, num_warps=8),
+        # Original configs for fallback
         triton.Config({"BLOCK_SIZE": 64}),
         triton.Config({"BLOCK_SIZE": 128}),
         triton.Config({"BLOCK_SIZE": 256}),
         triton.Config({"BLOCK_SIZE": 512}),
-        triton.Config({"BLOCK_SIZE": 1024}),
-        triton.Config({"BLOCK_SIZE": 2048}),
     ],
     key=["dim"],
 )

--- a/tensorrt_llm/_torch/modules/mamba/ssd_state_passing.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_state_passing.py
@@ -23,21 +23,12 @@ import triton.language as tl
 
 @triton.autotune(
     configs=[
-        # Small dim configs with higher parallelism
-        triton.Config({"BLOCK_SIZE": 64}, num_stages=2, num_warps=4),
-        triton.Config({"BLOCK_SIZE": 128}, num_stages=2, num_warps=4),
-        triton.Config({"BLOCK_SIZE": 256}, num_stages=2, num_warps=4),
-        # Medium dim configs
-        triton.Config({"BLOCK_SIZE": 512}, num_stages=3, num_warps=4),
-        triton.Config({"BLOCK_SIZE": 512}, num_stages=2, num_warps=8),
-        # Large dim configs
-        triton.Config({"BLOCK_SIZE": 1024}, num_stages=3, num_warps=8),
-        triton.Config({"BLOCK_SIZE": 2048}, num_stages=3, num_warps=8),
-        # Original configs for fallback
         triton.Config({"BLOCK_SIZE": 64}),
         triton.Config({"BLOCK_SIZE": 128}),
         triton.Config({"BLOCK_SIZE": 256}),
         triton.Config({"BLOCK_SIZE": 512}),
+        triton.Config({"BLOCK_SIZE": 1024}),
+        triton.Config({"BLOCK_SIZE": 2048}),
     ],
     key=["dim"],
 )

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -86,13 +86,11 @@ class MLP(nn.Module):
             reduce_output=reduce_output,
         )
 
-        self._fused_checked = False
         self._use_fused_relu2_quant = False
 
-    def _init_fused_path(self):
-        if self._fused_checked:
-            return
-        self._fused_checked = True
+    def create_weights(self):
+        self.up_proj.create_weights()
+        self.down_proj.create_weights()
 
         has_nvfp4 = hasattr(self.down_proj,
                             'has_nvfp4') and self.down_proj.has_nvfp4
@@ -109,9 +107,6 @@ class MLP(nn.Module):
     ) -> torch.Tensor:
         if lora_params is not None:
             return self.forward_lora(x, lora_params=lora_params)
-
-        if not self._fused_checked:
-            self._init_fused_path()
 
         x_up = self.up_proj(x)
 

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -8,23 +8,25 @@ from tensorrt_llm.mapping import Mapping
 
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
+from ..utils import Fp4QuantizedTensor, relu2
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 
 
 class MLP(nn.Module):
 
-    def __init__(self,
-                 *,
-                 hidden_size: int,
-                 intermediate_size: int,
-                 bias: bool,
-                 activation: Callable[[torch.Tensor], torch.Tensor] = None,
-                 dtype: Optional[torch.dtype] = None,
-                 config: Optional[ModelConfig] = None,
-                 layer_idx: Optional[int] = None,
-                 reduce_output: bool = True,
-                 overridden_tp_size: Optional[int] = None):
-
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        intermediate_size: int,
+        bias: bool,
+        activation: Callable[[torch.Tensor], torch.Tensor] = None,
+        dtype: Optional[torch.dtype] = None,
+        config: Optional[ModelConfig] = None,
+        layer_idx: Optional[int] = None,
+        reduce_output: bool = True,
+        overridden_tp_size: Optional[int] = None,
+    ):
         super().__init__()
         self.layer_idx = layer_idx
         self.hidden_size = hidden_size
@@ -81,7 +83,24 @@ class MLP(nn.Module):
             lora=self.down_lora,
             allreduce_strategy=config.allreduce_strategy,
             force_dynamic_quantization=config.force_dynamic_quantization,
-            reduce_output=reduce_output)
+            reduce_output=reduce_output,
+        )
+
+        self._fused_checked = False
+        self._use_fused_relu2_quant = False
+
+    def _init_fused_path(self):
+        if self._fused_checked:
+            return
+        self._fused_checked = True
+
+        has_nvfp4 = hasattr(self.down_proj,
+                            'has_nvfp4') and self.down_proj.has_nvfp4
+        has_kernel = hasattr(torch.ops.trtllm, 'fused_relu2_quantize')
+        has_scale = hasattr(self.down_proj, 'input_scale')
+        is_relu2 = self.activation is relu2
+
+        self._use_fused_relu2_quant = has_nvfp4 and has_kernel and has_scale and is_relu2
 
     def forward(
         self,
@@ -91,11 +110,36 @@ class MLP(nn.Module):
         if lora_params is not None:
             return self.forward_lora(x, lora_params=lora_params)
 
+        if not self._fused_checked:
+            self._init_fused_path()
+
         x_up = self.up_proj(x)
-        x_act = self.activation(x_up)
+
+        if self._use_fused_relu2_quant:
+            x_act = self._fused_relu2_quant(x_up)
+        else:
+            x_act = self.activation(x_up)
+
         x_down = self.down_proj(x_act)
 
         return x_down
+
+    def _fused_relu2_quant(self, x: torch.Tensor) -> Fp4QuantizedTensor:
+        x_flat = x.view(-1, x.shape[-1])
+
+        if not x_flat.is_contiguous():
+            x_flat = x_flat.contiguous()
+        if x_flat.dtype != torch.bfloat16:
+            x_flat = x_flat.to(torch.bfloat16)
+
+        fp4_tensor, sf_tensor = torch.ops.trtllm.fused_relu2_quantize(
+            x_flat, self.down_proj.input_scale, 16)
+
+        return Fp4QuantizedTensor(
+            fp4_tensor=fp4_tensor,
+            scaling_factor=sf_tensor,
+            is_sf_swizzled=True,
+        )
 
     def forward_lora(
         self,

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -129,7 +129,8 @@ class MLP(nn.Module):
 
         if not x_flat.is_contiguous():
             x_flat = x_flat.contiguous()
-        if x_flat.dtype != torch.bfloat16:
+
+        if x_flat.dtype not in (torch.float16, torch.bfloat16):
             x_flat = x_flat.to(torch.bfloat16)
 
         fp4_tensor, sf_tensor = torch.ops.trtllm.fused_relu2_quantize(

--- a/tensorrt_llm/_torch/modules/rms_norm.py
+++ b/tensorrt_llm/_torch/modules/rms_norm.py
@@ -82,7 +82,8 @@ class RMSNorm(nn.Module):
             Optional[torch.Tensor],
             _ArgumentNotSpecifiedSentinelType] = _ARGUMENT_NOT_SPECIFIED_SENTINEL,
     ) -> Union[torch.Tensor, Fp4QuantizedTensor, Tuple[Union[
-            torch.Tensor, Fp4QuantizedTensor], Optional[torch.Tensor]]]:
+            torch.Tensor, Fp4QuantizedTensor], Optional[torch.Tensor]], Tuple[
+                Fp4QuantizedTensor, torch.Tensor, torch.Tensor]]:
         has_residual = residual is not self._ARGUMENT_NOT_SPECIFIED_SENTINEL
         if not has_residual:
             residual = None

--- a/tensorrt_llm/_torch/modules/rms_norm.py
+++ b/tensorrt_llm/_torch/modules/rms_norm.py
@@ -138,14 +138,13 @@ class RMSNorm(nn.Module):
 
             hidden_states_fused = Fp4QuantizedTensor(normed_fp4_u8, sf_fused)
 
-            if not self.return_hp_output:
-                return (hidden_states_fused,
-                        residual_out) if has_residual else hidden_states_fused
-            else:
+            outputs = [hidden_states_fused]
+            if has_residual:
+                outputs.append(residual_out)
+            if self.return_hp_output:
                 high_precision_normed_output = results[3].reshape(orig_shape)
-                return (hidden_states_fused, residual_out,
-                        high_precision_normed_output) if has_residual else (
-                            hidden_states_fused, high_precision_normed_output)
+                outputs.append(high_precision_normed_output)
+            return outputs[0] if len(outputs) == 1 else tuple(outputs)
 
         if self.return_hp_output:
             raise ValueError(

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -593,7 +593,9 @@ class MambaCacheManager(BaseResourceManager):
         return self._impl.get_intermediate_conv_states(layer_idx)
 
     def is_speculative(self) -> bool:
-        assert not self._use_cpp, "is_speculative is not supported in CppMambaCacheManager"
+        if self._use_cpp:
+            # CppMambaCacheManager does not support speculative decoding for now.
+            return False
         return self._impl.is_speculative()
 
     def mamba_layer_cache(

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -451,14 +451,7 @@ class Runner:
                         position_ids, hidden_states, attn_metadata, residual, **kwargs
                     )
                 else:
-                    result = layer(
-                        position_ids, hidden_states, attn_metadata, residual=residual, **kwargs
-                    )
-                    # Some layers (e.g., NemotronH) return (hidden_states, residual) tuple
-                    if isinstance(result, tuple):
-                        hidden_states, residual = result
-                    else:
-                        hidden_states = result
+                    hidden_states = layer(position_ids, hidden_states, attn_metadata, **kwargs)
             return hidden_states, residual
 
         model.forward = forward

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import inspect
 import itertools
 import os
 import unittest.mock
@@ -443,9 +444,9 @@ class Runner:
 
         def forward(position_ids, hidden_states, attn_metadata, residual, **kwargs):
             # TODO: to be more general, we should call DecoderModel.forward
-            residual_fusion = hasattr(model.model.layers[layer_indices[0]], "next_layer_layernorm")
             for layer_idx in layer_indices:
                 layer = model.model.layers[layer_idx]
+                residual_fusion = "residual" in inspect.signature(layer.forward).parameters
                 if residual_fusion:
                     hidden_states, residual = layer(
                         position_ids, hidden_states, attn_metadata, residual, **kwargs

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -451,7 +451,14 @@ class Runner:
                         position_ids, hidden_states, attn_metadata, residual, **kwargs
                     )
                 else:
-                    hidden_states = layer(position_ids, hidden_states, attn_metadata, **kwargs)
+                    result = layer(
+                        position_ids, hidden_states, attn_metadata, residual=residual, **kwargs
+                    )
+                    # Some layers (e.g., NemotronH) return (hidden_states, residual) tuple
+                    if isinstance(result, tuple):
+                        hidden_states, residual = result
+                    else:
+                        hidden_states = result
             return hidden_states, residual
 
         model.forward = forward

--- a/tests/unittest/_torch/modules/mamba/test_causal_conv1d.py
+++ b/tests/unittest/_torch/modules/mamba/test_causal_conv1d.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tensorrt_llm._torch.modules.mamba import PAD_SLOT_ID
+
+
+def mamba_conv1d_ref(x, past_conv_state, conv_weight, conv_bias, apply_silu):
+    """
+    Reference implementation for causal conv1d.
+
+    Arguments:
+        x: [batch_size, dim, seq_len]
+        past_conv_state: [batch_size, dim, dconv-1]
+        conv_weight: [dim, 1, dconv]
+        conv_bias: [dim]
+    Output:
+        y: [batch_size, dim, seq_len]
+        present_conv_state: [batch_size, dim, dconv-1]
+    """
+    assert x.dim() == 3
+    assert past_conv_state.dim() == 3
+    assert conv_weight.dim() == 3
+    assert conv_bias.dim() == 1
+    batch_size, dim, seq_len = x.shape
+    assert past_conv_state.shape[0] == batch_size
+    assert past_conv_state.shape[1] == dim
+    dconv = past_conv_state.shape[2] + 1
+    assert conv_weight.shape[0] == dim
+    assert conv_weight.shape[1] == 1
+    assert conv_weight.shape[2] == dconv
+    assert conv_weight.shape[0] == dim
+
+    padded_x = torch.cat([past_conv_state, x], dim=2)
+    present_conv_state = padded_x[:, :, -(dconv - 1) :]
+    x_conv = F.conv1d(padded_x, conv_weight, bias=conv_bias, groups=dim)
+
+    y = F.silu(x_conv) if apply_silu else x_conv
+    return y, present_conv_state
+
+
+def trtllm_causal_conv1d_available():
+    """Check if trtllm.causal_conv1d_fwd is available."""
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "causal_conv1d_fwd")
+
+
+skip_unsupported = pytest.mark.skipif(
+    not torch.cuda.is_available() or not trtllm_causal_conv1d_available(),
+    reason="Requires CUDA and trtllm.causal_conv1d_fwd op",
+)
+
+
+@skip_unsupported
+class TestCausalConv1d:
+    """Tests for the causal_conv1d CUDA kernel."""
+
+    @pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32"])
+    @pytest.mark.parametrize("apply_silu", [True, False])
+    @pytest.mark.parametrize("dim", [256, 512, 1024, 2048])
+    def test_basic_correctness(self, dtype, apply_silu, dim):
+        """Test basic correctness against reference implementation."""
+        torch.manual_seed(42)
+        device = "cuda"
+        torch_dtype = getattr(torch, dtype)
+
+        batch_size = 4
+        seq_len = 32
+        dconv = 4
+        std_dev = 0.5
+        x = torch.randn(batch_size, dim, seq_len, dtype=torch_dtype, device=device)
+        x = x * std_dev
+        conv_state = torch.zeros(batch_size, dim, dconv - 1, dtype=torch_dtype, device=device)
+        conv_weight = torch.randn(dim, 1, dconv, dtype=torch_dtype, device=device)
+        conv_bias = torch.randn(dim, dtype=torch_dtype, device=device)
+        x_kernel = x.clone()
+        conv_state_kernel = conv_state.clone()
+
+        conv_weight_input = conv_weight.squeeze(1).contiguous()
+        torch.ops.trtllm.causal_conv1d_fwd(
+            x_kernel,
+            conv_weight_input,
+            conv_bias,
+            conv_state_kernel,
+            None,  # query_start_loc
+            None,  # cache_indices
+            None,  # has_initial_state
+            apply_silu,
+            PAD_SLOT_ID,
+        )
+        out_ref, conv_state_ref = mamba_conv1d_ref(
+            x, conv_state, conv_weight, conv_bias, apply_silu
+        )
+
+        torch.testing.assert_close(x_kernel, out_ref, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(conv_state_kernel, conv_state_ref, rtol=1e-2, atol=1e-2)
+
+    @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
+    def test_various_batch_sizes(self, batch_size):
+        """Test with various batch sizes."""
+        torch.manual_seed(42)
+        device = "cuda"
+        dtype = torch.bfloat16
+        dim = 1024
+        seq_len = 64
+        dconv = 4
+        apply_silu = True
+
+        x = torch.randn(batch_size, dim, seq_len, dtype=dtype, device=device) * 0.5
+        conv_state = torch.zeros(batch_size, dim, dconv - 1, dtype=dtype, device=device)
+        conv_weight = torch.randn(dim, 1, dconv, dtype=dtype, device=device)
+        conv_bias = torch.randn(dim, dtype=dtype, device=device)
+        x_kernel = x.clone()
+        conv_state_kernel = conv_state.clone()
+
+        conv_weight_input = conv_weight.squeeze(1).contiguous()
+        torch.ops.trtllm.causal_conv1d_fwd(
+            x_kernel,
+            conv_weight_input,
+            conv_bias,
+            conv_state_kernel,
+            None,
+            None,
+            None,
+            apply_silu,
+            PAD_SLOT_ID,
+        )
+        out_ref, conv_state_ref = mamba_conv1d_ref(
+            x, conv_state, conv_weight, conv_bias, apply_silu
+        )
+
+        torch.testing.assert_close(x_kernel, out_ref, rtol=1e-2, atol=1e-1)
+        torch.testing.assert_close(conv_state_kernel, conv_state_ref, rtol=1e-2, atol=1e-1)
+
+    @pytest.mark.parametrize("dconv", [2, 3, 4])
+    def test_various_kernel_widths(self, dconv):
+        """Test with different convolution kernel widths."""
+        torch.manual_seed(42)
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        batch_size = 4
+        dim = 1024
+        seq_len = 64
+        apply_silu = True
+        x = torch.randn(batch_size, dim, seq_len, dtype=dtype, device=device) * 0.5
+        conv_state = torch.zeros(batch_size, dim, dconv - 1, dtype=dtype, device=device)
+        conv_weight = torch.randn(dim, 1, dconv, dtype=dtype, device=device)
+        conv_bias = torch.randn(dim, dtype=dtype, device=device)
+        x_kernel = x.clone()
+        conv_state_kernel = conv_state.clone()
+
+        conv_weight_input = conv_weight.squeeze(1).contiguous()
+        torch.ops.trtllm.causal_conv1d_fwd(
+            x_kernel,
+            conv_weight_input,
+            conv_bias,
+            conv_state_kernel,
+            None,
+            None,
+            None,
+            apply_silu,
+            PAD_SLOT_ID,
+        )
+        out_ref, conv_state_ref = mamba_conv1d_ref(
+            x, conv_state, conv_weight, conv_bias, apply_silu
+        )
+
+        torch.testing.assert_close(x_kernel, out_ref, rtol=1e-2, atol=1e-1)
+        torch.testing.assert_close(conv_state_kernel, conv_state_ref, rtol=1e-2, atol=1e-1)
+
+    def test_with_initial_state(self):
+        """Test with non-zero initial conv state."""
+        torch.manual_seed(42)
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        batch_size = 4
+        dim = 1024
+        seq_len = 32
+        dconv = 4
+        apply_silu = True
+
+        x = torch.randn(batch_size, dim, seq_len, dtype=dtype, device=device) * 0.5
+        # Non-zero initial state
+        conv_state = torch.randn(batch_size, dim, dconv - 1, dtype=dtype, device=device)
+        conv_state = conv_state * 0.5
+        conv_weight = torch.randn(dim, 1, dconv, dtype=dtype, device=device)
+        conv_bias = torch.randn(dim, dtype=dtype, device=device)
+        conv_state_kernel = conv_state.clone()
+        # Need to tell the kernel about initial state
+        has_initial_state = torch.ones(batch_size, dtype=torch.bool, device=device)
+        query_start_loc = torch.tensor(
+            [0] + [seq_len * (i + 1) for i in range(batch_size)],
+            dtype=torch.int32,
+            device=device,
+        )
+        # Reshape for varlen format
+        x_varlen = x.transpose(1, 2).reshape(-1, dim).T.contiguous()
+
+        conv_weight_input = conv_weight.squeeze(1).contiguous()
+        torch.ops.trtllm.causal_conv1d_fwd(
+            x_varlen,
+            conv_weight_input,
+            conv_bias,
+            conv_state_kernel,
+            query_start_loc,
+            None,  # cache_indices
+            has_initial_state,
+            apply_silu,
+            PAD_SLOT_ID,
+        )
+
+        out_ref_list = []
+        conv_state_ref_list = []
+        for b in range(batch_size):
+            out_b, state_b = mamba_conv1d_ref(
+                x[b : b + 1],
+                conv_state[b : b + 1],
+                conv_weight,
+                conv_bias,
+                apply_silu,
+            )
+            out_ref_list.append(out_b)
+            conv_state_ref_list.append(state_b)
+        out_ref = torch.cat(out_ref_list, dim=0)
+        conv_state_ref = torch.cat(conv_state_ref_list, dim=0)
+        x_kernel_reshaped = (
+            x_varlen.T.reshape(batch_size, seq_len, dim).transpose(1, 2).contiguous()
+        )
+
+        torch.testing.assert_close(x_kernel_reshaped, out_ref, rtol=1e-2, atol=1e-1)
+        torch.testing.assert_close(conv_state_kernel, conv_state_ref, rtol=1e-2, atol=1e-1)

--- a/tests/unittest/_torch/modules/mamba/test_causal_conv1d.py
+++ b/tests/unittest/_torch/modules/mamba/test_causal_conv1d.py
@@ -44,7 +44,6 @@ def mamba_conv1d_ref(x, past_conv_state, conv_weight, conv_bias, apply_silu):
     assert conv_weight.shape[0] == dim
     assert conv_weight.shape[1] == 1
     assert conv_weight.shape[2] == dconv
-    assert conv_weight.shape[0] == dim
 
     padded_x = torch.cat([past_conv_state, x], dim=2)
     present_conv_state = padded_x[:, :, -(dconv - 1) :]

--- a/tests/unittest/_torch/modules/mamba/test_fuse_elementwise_ops.py
+++ b/tests/unittest/_torch/modules/mamba/test_fuse_elementwise_ops.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fused elementwise operations in Mamba2 prefill."""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import (
+    extract_transpose_xbc_prefill,
+    fused_split_rearrange_after_conv1d,
+)
+
+skip_no_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for triton kernels",
+)
+
+
+def extract_transpose_xbc_prefill_ref(
+    zxbcdt: torch.Tensor,
+    num_prefill_tokens: int,
+    d_inner: int,
+    conv_dim: int,
+) -> torch.Tensor:
+    """Reference implementation for extract_transpose_xbc_prefill."""
+    # Extract the xbc slice and transpose
+    xbc = zxbcdt[:num_prefill_tokens, d_inner : d_inner + conv_dim]
+    return xbc.transpose(0, 1).contiguous()
+
+
+def fused_split_rearrange_after_conv1d_ref(
+    xbc: torch.Tensor,
+    d_inner: int,
+    n_groups: int,
+    d_state: int,
+    nheads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reference implementation for fused_split_rearrange_after_conv1d."""
+    conv_dim, num_prefill_tokens = xbc.shape
+    bc_size = n_groups * d_state
+
+    # Transpose and split
+    xbc_t = xbc.transpose(0, 1).contiguous()  # [num_prefill_tokens, conv_dim]
+    x, B, C = torch.split(xbc_t, [d_inner, bc_size, bc_size], dim=-1)
+    x = x.contiguous().view(1, num_prefill_tokens, nheads, head_dim)
+    B = B.contiguous().view(1, num_prefill_tokens, n_groups, d_state)
+    C = C.contiguous().view(1, num_prefill_tokens, n_groups, d_state)
+    return x, B, C
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("num_prefill_tokens", [1, 32, 128, 1024])
+@pytest.mark.parametrize(
+    "d_inner,conv_dim,d_in_proj", [(256, 512, 800), (512, 1024, 1600), (1024, 2048, 3200)]
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_extract_transpose_xbc_prefill(num_prefill_tokens, d_inner, conv_dim, d_in_proj, dtype):
+    """Test extract_transpose_xbc_prefill matches reference implementation."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    num_total_tokens = num_prefill_tokens + 16
+    zxbcdt = torch.randn(num_total_tokens, d_in_proj, dtype=dtype, device=device)
+    out_ref = extract_transpose_xbc_prefill_ref(zxbcdt, num_prefill_tokens, d_inner, conv_dim)
+    out_fused = extract_transpose_xbc_prefill(zxbcdt, num_prefill_tokens, d_inner, conv_dim)
+
+    assert out_fused.shape == out_ref.shape, f"Shape mismatch: {out_fused.shape} vs {out_ref.shape}"
+    torch.testing.assert_close(out_fused, out_ref, rtol=1e-3, atol=1e-3)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize("num_prefill_tokens", [1, 32, 128, 1024])
+@pytest.mark.parametrize(
+    "nheads,head_dim,n_groups,d_state", [(8, 64, 1, 128), (16, 64, 2, 64), (32, 64, 4, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_split_rearrange_after_conv1d(
+    num_prefill_tokens, nheads, head_dim, n_groups, d_state, dtype
+):
+    """Test fused_split_rearrange_after_conv1d matches reference implementation."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    d_inner = nheads * head_dim
+    bc_size = n_groups * d_state
+    conv_dim = d_inner + 2 * bc_size
+    xbc = torch.randn(conv_dim, num_prefill_tokens, dtype=dtype, device=device)
+    x_ref, B_ref, C_ref = fused_split_rearrange_after_conv1d_ref(
+        xbc, d_inner, n_groups, d_state, nheads, head_dim
+    )
+    x_fused, B_fused, C_fused = fused_split_rearrange_after_conv1d(
+        xbc, d_inner, n_groups, d_state, nheads, head_dim
+    )
+
+    assert x_fused.shape == x_ref.shape, f"x shape mismatch: {x_fused.shape} vs {x_ref.shape}"
+    assert B_fused.shape == B_ref.shape, f"B shape mismatch: {B_fused.shape} vs {B_ref.shape}"
+    assert C_fused.shape == C_ref.shape, f"C shape mismatch: {C_fused.shape} vs {C_ref.shape}"
+    torch.testing.assert_close(x_fused, x_ref, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(B_fused, B_ref, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(C_fused, C_ref, rtol=1e-3, atol=1e-3)

--- a/tests/unittest/_torch/modules/mamba/test_mamba2_metadata.py
+++ b/tests/unittest/_torch/modules/mamba/test_mamba2_metadata.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for Mamba2 metadata preparation optimizations."""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.mamba.mamba2_metadata import (
+    cu_seqlens_to_chunk_indices_offsets,
+    cu_seqlens_to_chunk_indices_offsets_triton,
+)
+
+skip_no_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for triton kernels",
+)
+
+
+@skip_no_cuda
+class TestCuSeqlensToChunkIndicesOffsets:
+    """Tests for cu_seqlens_to_chunk_indices_offsets_triton function."""
+
+    def test_empty_sequence(self):
+        """Test with empty cu_seqlens (no sequences)."""
+        cu_seqlens = torch.tensor([0], dtype=torch.int, device="cuda")
+        chunk_size = 8
+
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        assert indices_triton.numel() == 0
+        assert offsets_triton.numel() == 0
+
+    def test_single_sequence_aligned(self):
+        """Test with a single sequence that aligns with chunk size."""
+        cu_seqlens = torch.tensor([0, 16], dtype=torch.int, device="cuda")
+        chunk_size = 8
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)
+
+    def test_single_sequence_unaligned(self):
+        """Test with a single sequence that doesn't align with chunk size."""
+        cu_seqlens = torch.tensor([0, 10], dtype=torch.int, device="cuda")
+        chunk_size = 8
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)
+
+    def test_two_sequences_aligned(self):
+        """Test with two sequences, both aligned with chunk boundaries."""
+        cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int, device="cuda")
+        chunk_size = 8
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)
+
+    def test_two_sequences_misaligned(self):
+        """Test with two sequences where second starts at misaligned position."""
+        # Example from docstring: cu_seqlens = [0, 5, 10], chunk_size = 8
+        # -> chunk_indices = [0, 0, 1], chunk_offsets = [0, 5, 0]
+        cu_seqlens = torch.tensor([0, 5, 10], dtype=torch.int, device="cuda")
+        chunk_size = 8
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        # Verify against expected values from docstring
+        expected_indices = torch.tensor([0, 0, 1], dtype=torch.int, device="cuda")
+        expected_offsets = torch.tensor([0, 5, 0], dtype=torch.int, device="cuda")
+
+        torch.testing.assert_close(indices_ref, expected_indices)
+        torch.testing.assert_close(offsets_ref, expected_offsets)
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)
+
+    @pytest.mark.parametrize("chunk_size", [8, 16, 32, 64, 128])
+    def test_multiple_sequences_various_chunk_sizes(self, chunk_size):
+        """Test with multiple sequences and various chunk sizes."""
+        # Create sequences with varying lengths
+        cu_seqlens = torch.tensor([0, 10, 25, 40, 60, 75], dtype=torch.int, device="cuda")
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)
+
+    def test_all_sequences_within_one_chunk(self):
+        """Test when all sequences fit within a single chunk."""
+        cu_seqlens = torch.tensor([0, 2, 4, 6], dtype=torch.int, device="cuda")
+        chunk_size = 64  # Large chunk size
+
+        indices_ref, offsets_ref = cu_seqlens_to_chunk_indices_offsets(cu_seqlens, chunk_size)
+        indices_triton, offsets_triton = cu_seqlens_to_chunk_indices_offsets_triton(
+            cu_seqlens, chunk_size
+        )
+
+        torch.testing.assert_close(indices_triton, indices_ref)
+        torch.testing.assert_close(offsets_triton, offsets_ref)

--- a/tests/unittest/_torch/modules/test_fused_activation_quant.py
+++ b/tests/unittest/_torch/modules/test_fused_activation_quant.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fused relu2 + NVFP4 quantization kernel."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tests.unittest.utils.util import getSMVersion
+
+
+def fused_relu2_quantize_available():
+    """Check if the fused_relu2_quantize op is available."""
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fused_relu2_quantize")
+
+
+def fp4_quantize_available():
+    """Check if the fp4_quantize op is available."""
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fp4_quantize")
+
+
+skip_unless_fused_relu2_quantize = pytest.mark.skipif(
+    getSMVersion() < 100 or not fused_relu2_quantize_available(),
+    reason="Requires SM100+ (Blackwell) and trtllm.fused_relu2_quantize op",
+)
+
+skip_unless_fused_relu2_and_fp4_quantize = pytest.mark.skipif(
+    getSMVersion() < 100 or not fused_relu2_quantize_available() or not fp4_quantize_available(),
+    reason="Requires SM100+ (Blackwell) and trtllm fused_relu2_quantize + fp4_quantize ops",
+)
+
+
+# FP4 E2M1 lookup tables for reference implementation
+E2M1_BOUNDS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5])
+E2M1_VALUES = torch.tensor([0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
+
+
+def relu2(x: torch.Tensor) -> torch.Tensor:
+    """Reference relu2 activation: square(relu(x))."""
+    return torch.square(F.relu(x))
+
+
+def cast_to_fp4(weight: torch.Tensor) -> torch.Tensor:
+    """Cast tensor values to FP4 E2M1 format (as uint8)."""
+    device = weight.device
+
+    mask = torch.tensor([0, 1, 0, 1, 0, 1, 0], dtype=torch.uint8).to(device)
+    mask_shape = list(weight.shape)
+    mask = mask.expand([*mask_shape, 7])
+
+    sign_bit = (weight < 0).to(torch.uint8)
+    weight_abs = weight.abs()
+
+    ord_val = torch.searchsorted(E2M1_BOUNDS.to(device), weight_abs, out_int32=True).to(torch.uint8)
+    round_val = torch.any((weight_abs.unsqueeze(-1) == E2M1_BOUNDS.to(device)) * mask, dim=-1)
+    fp4_val = (sign_bit * 0b1000 + ord_val + round_val).to(torch.uint8)
+    return fp4_val
+
+
+def dequantize_fp4(
+    packed: torch.Tensor, scale: torch.Tensor, scale2: torch.Tensor, m: int, n: int
+) -> torch.Tensor:
+    """Dequantize FP4 packed tensor back to float for comparison."""
+    device = packed.device
+
+    # Unpack FP4 values
+    high = (packed >> 4) & 0x0F
+    low = packed & 0x0F
+
+    idx = torch.empty(m, n, dtype=torch.long, device=device)
+    idx[..., 0::2] = low.long()
+    idx[..., 1::2] = high.long()
+
+    vals = E2M1_VALUES.to(device)[idx]
+    return vals
+
+
+def quantize_nvfp4_ref(
+    input: torch.Tensor, sf_scale: torch.Tensor, sf_vec_size: int = 16
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference NVFP4 quantization implementation.
+
+    Args:
+        input: Input tensor [M, N], already activated (e.g., after relu2)
+        sf_scale: Per-tensor scaling factor (sf_scale = amax / (6 * 448))
+        sf_vec_size: Block size for per-block scaling (default 16)
+
+    Returns:
+        Tuple of (fp4_packed, scale_factors)
+    """
+    m, n = input.shape
+    assert n % sf_vec_size == 0, f"N ({n}) must be divisible by sf_vec_size ({sf_vec_size})"
+
+    # Reshape for block-wise quantization
+    input_blocked = input.view(m, n // sf_vec_size, sf_vec_size)
+
+    # Compute per-block amax
+    per_block_amax = input_blocked.abs().amax(dim=-1).float()
+
+    # Compute per-block scale: amax / 6.0
+    per_block_scale = per_block_amax / 6.0
+
+    # Quantize per-block scale to FP8
+    q_per_block_scale = per_block_scale / sf_scale
+    q_per_block_scale[per_block_scale == 0] = 1.0
+    q_per_block_scale_fp8 = q_per_block_scale.to(torch.float8_e4m3fn)
+
+    # Dequantize scale for actual quantization
+    scale_dequant = q_per_block_scale_fp8.float() * sf_scale
+
+    # Scale the input
+    scale_expanded = scale_dequant.unsqueeze(-1).expand_as(input_blocked)
+    scaled_input = input_blocked / (scale_expanded + 1e-12)
+    scaled_input = scaled_input.view(m, n)
+
+    # Cast to FP4
+    fp4_vals = cast_to_fp4(scaled_input)
+
+    # Pack two FP4 values into one uint8
+    packed = (fp4_vals[..., 1::2] << 4) | fp4_vals[..., 0::2]
+
+    return packed, q_per_block_scale_fp8
+
+
+def fused_relu2_quantize_ref(
+    input: torch.Tensor, sf_scale: torch.Tensor, sf_vec_size: int = 16
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference implementation for fused relu2 + NVFP4 quantization.
+
+    Args:
+        input: Input tensor [M, N]
+        sf_scale: Per-tensor scaling factor
+        sf_vec_size: Block size for per-block scaling (default 16)
+
+    Returns:
+        Tuple of (fp4_packed, scale_factors)
+    """
+    # Apply relu2 activation
+    activated = relu2(input)
+    # Quantize to NVFP4
+    return quantize_nvfp4_ref(activated, sf_scale, sf_vec_size)
+
+
+@skip_unless_fused_relu2_quantize
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_relu2_quantize_zeros(dtype):
+    """Test fused_relu2_quantize with inputs that produce zeros after relu2."""
+    device = torch.device("cuda")
+
+    # All negative inputs -> relu2 produces all zeros
+    m, n = 32, 64
+    input_tensor = -torch.abs(torch.randn(m, n, dtype=dtype, device=device))
+    sf_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    fp4_fused, sf_fused = torch.ops.trtllm.fused_relu2_quantize(input_tensor, sf_scale, 16)
+
+    assert fp4_fused.shape == (m, n // 2)
+    assert (fp4_fused == 0).all(), "All negative inputs should produce zero output"
+
+
+@skip_unless_fused_relu2_and_fp4_quantize
+@pytest.mark.parametrize("m", [1, 16, 64, 128])
+@pytest.mark.parametrize("n", [32, 64, 128, 256])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_relu2_quantize_vs_separate_ops(m, n, dtype):
+    """
+    Compare fused_relu2_quantize kernel output against separate relu2 + fp4_quantize.
+
+    This test verifies that the fused CUDA kernel produces FP4 packed values that
+    closely match running relu2 activation followed by fp4_quantize separately.
+
+    Note: Due to floating point precision differences in intermediate calculations
+    (e.g., FMA vs separate mul+add), a small percentage of values at quantization
+    boundaries may differ. We require >= 99% match rate.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    input_tensor = torch.randn(m, n, dtype=dtype, device=device)
+    activated = relu2(input_tensor)
+    sf_scale = (activated.abs().amax().float() / (6.0 * 448.0)).to(device)
+    sf_scale = sf_scale.view(1)
+
+    fp4_separate, sf_separate = torch.ops.trtllm.fp4_quantize(
+        activated,
+        sf_scale,
+        16,
+        False,
+        True,  # use_ue8m0=False, is_sf_swizzled_layout=True
+    )
+    fp4_fused, sf_fused = torch.ops.trtllm.fused_relu2_quantize(
+        input_tensor.contiguous(), sf_scale, 16
+    )
+
+    match_rate = (fp4_fused == fp4_separate).float().mean().item()
+    assert match_rate >= 0.99, (
+        f"FP4 values match rate {match_rate:.4f} < 0.99 for shape ({m}, {n}), dtype {dtype}"
+    )
+
+
+@skip_unless_fused_relu2_and_fp4_quantize
+def test_fused_relu2_quantize_vs_separate_ops_various_sf_scales():
+    """
+    Test with various sf_scale values to ensure consistent behavior.
+    """
+    device = torch.device("cuda")
+    m, n = 64, 128
+    dtype = torch.bfloat16
+
+    torch.manual_seed(123)
+    input_tensor = torch.randn(m, n, dtype=dtype, device=device)
+    activated = relu2(input_tensor)
+
+    # Test with different sf_scale values
+    for scale_multiplier in [0.1, 1.0, 10.0]:
+        sf_scale = (
+            (activated.abs().amax().float() / (6.0 * 448.0) * scale_multiplier).to(device).view(1)
+        )
+        fp4_separate, sf_separate = torch.ops.trtllm.fp4_quantize(
+            activated, sf_scale, 16, False, True
+        )
+        fp4_fused, sf_fused = torch.ops.trtllm.fused_relu2_quantize(
+            input_tensor.contiguous(), sf_scale, 16
+        )
+
+        match_rate = (fp4_fused == fp4_separate).float().mean().item()
+        assert match_rate >= 0.99, (
+            f"FP4 values match rate {match_rate:.4f} < 0.99 with scale_multiplier={scale_multiplier}"
+        )

--- a/tests/unittest/_torch/modules/test_fused_add_rms_norm_quant.py
+++ b/tests/unittest/_torch/modules/test_fused_add_rms_norm_quant.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fused_add_rms_norm_quant with/without output_hp_norm support."""
+
+import pytest
+import torch
+
+from tests.unittest.utils.util import getSMVersion
+
+
+def fused_add_rms_norm_quant_available():
+    """Check if the fused_add_rms_norm_quant op is available."""
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fused_add_rms_norm_quant")
+
+
+skip_unsupported = pytest.mark.skipif(
+    getSMVersion() < 100 or not fused_add_rms_norm_quant_available(),
+    reason="Requires Blackwell+ (SM100+) and trtllm.fused_add_rms_norm_quant op",
+)
+
+
+def rms_norm_ref(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    gamma: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference RMSNorm implementation with residual addition.
+
+    Args:
+        hidden_states: Input tensor [M, N]
+        residual: Residual tensor [M, N]
+        gamma: Weight tensor [N]
+        eps: Epsilon for numerical stability
+
+    Returns:
+        Tuple of (normalized_output, residual_output)
+    """
+    input_dtype = hidden_states.dtype
+
+    # Add residual
+    hidden_states_fp32 = hidden_states.float() + residual.float()
+    residual_out = hidden_states_fp32.to(input_dtype)
+
+    # RMSNorm
+    variance = hidden_states_fp32.pow(2).mean(-1, keepdim=True)
+    normed = hidden_states_fp32 * torch.rsqrt(variance + eps)
+    normed_output = (gamma.float() * normed).to(input_dtype)
+
+    return normed_output, residual_out
+
+
+def get_swizzled_sf_indices(m: int, n: int, sf_vec_size: int = 16) -> list[int]:
+    """
+    Compute the valid indices in swizzled SF layout for given m and n.
+
+    The swizzled layout uses 128x4 tiles:
+    - SF layout: [numMTiles, numKTiles, 32 (outerM), 4 (innerM), 4 (innerK)]
+    - Each SF block has 128 rows, padded to multiple of 128
+    - Each SF block has columns padded to multiple of 4
+
+    Args:
+        m: Number of rows
+        n: Hidden dimension
+        sf_vec_size: Number of elements sharing one scale factor (default 16)
+
+    Returns:
+        List of valid indices in the swizzled buffer
+    """
+    num_col_vecs = n // sf_vec_size  # Number of SF columns
+    indices = []
+
+    for m_idx in range(m):
+        for k_idx in range(num_col_vecs):
+            # Compute swizzled offset using 128x4 tile layout
+            inner_k_idx = k_idx % 4
+            inner_k_stride = 1
+
+            inner_m_idx = (m_idx % 128) // 32
+            inner_m_stride = 4 * inner_k_stride  # 4
+
+            outer_m_idx = m_idx % 32
+            outer_m_stride = 4 * inner_m_stride  # 16
+
+            k_tile_idx = k_idx // 4
+            k_tile_stride = 32 * outer_m_stride  # 512
+
+            num_k_tiles = (num_col_vecs + 3) // 4
+            m_tile_idx = m_idx // 128
+            m_tile_stride = num_k_tiles * k_tile_stride
+
+            offset = (
+                m_tile_idx * m_tile_stride
+                + k_tile_idx * k_tile_stride
+                + outer_m_idx * outer_m_stride
+                + inner_m_idx * inner_m_stride
+                + inner_k_idx * inner_k_stride
+            )
+            indices.append(offset)
+
+    return indices
+
+
+@skip_unsupported
+@pytest.mark.parametrize("m", [1, 16, 64, 128])
+@pytest.mark.parametrize("n", [2048, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rms_norm_quant_basic(m, n, dtype):
+    """Test basic functionality of fused_add_rms_norm_quant without hp_output."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    # Create input tensors
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    gamma = torch.ones(n, dtype=dtype, device=device)
+
+    # Compute sf_scale (per-tensor scale)
+    eps = 1e-6
+    normed_ref, _ = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    # Run fused kernel without hp_output
+    normed_fp4, residual_out, sf_out, dummy_output = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps
+    )
+    assert dummy_output is None
+
+    # Verify output shapes
+    assert normed_fp4.shape[0] == m
+    assert residual_out.shape == (m, n)
+    assert residual_out.dtype == dtype
+
+
+@skip_unsupported
+@pytest.mark.parametrize("m", [1, 16, 64, 128])
+@pytest.mark.parametrize("n", [2048, 4096])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rms_norm_quant_with_hp_output(m, n, dtype):
+    """Test fused_add_rms_norm_quant with output_hp_norm=True."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    # Create input tensors
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    gamma = torch.ones(n, dtype=dtype, device=device)
+
+    # Compute sf_scale
+    eps = 1e-6
+    normed_ref, residual_ref = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    # Run fused kernel with hp_output
+    results = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=True
+    )
+
+    # Should return 4 tensors when output_hp_norm=True
+    assert len(results) == 4, f"Expected 4 outputs, got {len(results)}"
+
+    normed_fp4, residual_out, sf_out, hp_normed_output = results
+
+    # Verify output shapes
+    assert normed_fp4.shape[0] == m
+    assert residual_out.shape == (m, n)
+    assert hp_normed_output.shape == (m, n)
+
+    # Verify dtypes
+    assert residual_out.dtype == dtype
+    assert hp_normed_output.dtype == dtype
+
+    # Verify high precision output matches reference
+    torch.testing.assert_close(hp_normed_output, normed_ref, rtol=1e-2, atol=1e-2)
+
+    # Verify residual output matches reference
+    torch.testing.assert_close(residual_out, residual_ref, rtol=1e-3, atol=1e-3)
+
+
+@skip_unsupported
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rms_norm_quant_hp_output_consistency(dtype):
+    """Test that hp_output is consistent with the quantized output."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    m, n = 64, 4096
+
+    # Create input tensors
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    gamma = torch.ones(n, dtype=dtype, device=device)
+
+    eps = 1e-6
+    normed_ref, _ = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    # Run without hp_output
+    results_no_hp = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=False
+    )
+    assert results_no_hp[3] is None
+    normed_fp4_no_hp, residual_out_no_hp, sf_out_no_hp = results_no_hp[:3]
+
+    # Run with hp_output
+    results_hp = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=True
+    )
+    normed_fp4_hp, residual_out_hp, sf_out_hp, hp_normed_output = results_hp
+
+    # The quantized outputs should be identical regardless of hp_output flag
+    torch.testing.assert_close(normed_fp4_hp, normed_fp4_no_hp, rtol=0, atol=0)
+    torch.testing.assert_close(residual_out_hp, residual_out_no_hp, rtol=0, atol=0)
+    # Compare only valid SF indices (swizzled layout pads rows to 128)
+    valid_sf_indices = get_swizzled_sf_indices(m, n)
+    sf_out_hp_valid = sf_out_hp[valid_sf_indices]
+    sf_out_no_hp_valid = sf_out_no_hp[valid_sf_indices]
+    torch.testing.assert_close(sf_out_hp_valid, sf_out_no_hp_valid, rtol=0, atol=0)
+
+
+@skip_unsupported
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rms_norm_quant_gamma_weight(dtype):
+    """Test fused_add_rms_norm_quant with non-trivial gamma weights."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    m, n = 32, 2048
+
+    # Create input tensors
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    # Non-trivial gamma weights
+    gamma = torch.randn(n, dtype=dtype, device=device) * 0.5 + 1.0
+
+    eps = 1e-6
+    normed_ref, residual_ref = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    # Run with hp_output
+    results = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=True
+    )
+    normed_fp4, residual_out, sf_out, hp_normed_output = results
+
+    # Verify high precision output matches reference
+    torch.testing.assert_close(hp_normed_output, normed_ref, rtol=1e-2, atol=1e-2)
+
+    # Verify residual output matches reference
+    torch.testing.assert_close(residual_out, residual_ref, rtol=1e-3, atol=1e-3)
+
+
+@skip_unsupported
+def test_fused_add_rms_norm_quant_large_batch():
+    """Test fused_add_rms_norm_quant with larger batch size."""
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    m, n = 512, 4096
+    dtype = torch.bfloat16
+
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    gamma = torch.ones(n, dtype=dtype, device=device)
+
+    eps = 1e-6
+    normed_ref, residual_ref = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    results = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=True
+    )
+    normed_fp4, residual_out, sf_out, hp_normed_output = results
+
+    assert hp_normed_output.shape == (m, n)
+    torch.testing.assert_close(hp_normed_output, normed_ref, rtol=1e-2, atol=1e-2)
+
+
+@skip_unsupported
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_low_latency_layernorm_hp_output_consistency(dtype):
+    """
+    Test that low_latency_layernorm hp_output is consistent with/without the flag.
+
+    The quantized outputs should be identical regardless of output_hp_norm flag.
+    Uses m=1 to trigger the low_latency_layernorm path.
+    """
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    m, n = 1, 4096  # m=1 triggers low_latency_layernorm path
+
+    hidden_states = torch.randn(m, n, dtype=dtype, device=device)
+    residual = torch.randn(m, n, dtype=dtype, device=device)
+    gamma = torch.ones(n, dtype=dtype, device=device)
+
+    eps = 1e-6
+    normed_ref, _ = rms_norm_ref(hidden_states, residual, gamma, eps)
+    sf_scale = (normed_ref.abs().amax().float() / (6.0 * 448.0)).view(1)
+
+    # Run without hp_output
+    results_no_hp = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps
+    )
+    assert len(results_no_hp) == 4, f"Expected 4 outputs, got {len(results_no_hp)}"
+    assert results_no_hp[3] is None, "Expected 4th output to be None when output_hp_norm=False"
+    normed_fp4_no_hp, residual_out_no_hp, sf_out_no_hp = results_no_hp[:3]
+
+    # Run with hp_output
+    results_hp = torch.ops.trtllm.fused_add_rms_norm_quant(
+        hidden_states, residual, gamma, sf_scale, True, eps=eps, output_hp_norm=True
+    )
+    assert len(results_hp) == 4, f"Expected 4 outputs, got {len(results_hp)}"
+    normed_fp4_hp, residual_out_hp, sf_out_hp, hp_normed_output = results_hp
+
+    # The quantized outputs should be identical regardless of hp_output flag
+    torch.testing.assert_close(normed_fp4_hp, normed_fp4_no_hp, rtol=0, atol=0)
+    torch.testing.assert_close(residual_out_hp, residual_out_no_hp, rtol=0, atol=0)
+    # Compare only valid SF indices (swizzled layout pads rows to 128)
+    valid_sf_indices = get_swizzled_sf_indices(m, n)
+    sf_out_hp_valid = sf_out_hp[valid_sf_indices]
+    sf_out_no_hp_valid = sf_out_no_hp[valid_sf_indices]
+    torch.testing.assert_close(sf_out_hp_valid, sf_out_no_hp_valid, rtol=0, atol=0)


### PR DESCRIPTION

## Detailed Kernel Analysis

### 1. Kernels Completely Removed (Optimized Out)

These kernels were present in the base profile but are absent from the optimized version:

| Kernel | Instances (Base) | Total Time (Base) | Notes |
|--------|------------------|-------------------|-------|
| `elementwise_kernel (direct_copy BFloat16)` | 960 | 860.73 ms | Memory copy operations eliminated |
| `cutlass FP4 GEMM (4_4_1_2SM, 256x256x256)` | 320 | 113.77 ms | Kernel variant consolidated |
| `cutlass3x_sm100 bias_bf16_relu` | 320 | 164.30 ms | Fused into other operations |
| `flashinfer RMSNormKernel` | 712 | 162.15 ms | Replaced by fused variant |
| `vectorized_elementwise_kernel (clamp)` | 320 | 57.09 ms | Fused into other operations |
| `vectorized_elementwise_kernel (pow)` | 320 | 52.72 ms | Fused into other operations |

**Total time saved from removed kernels: ~1,410.76 ms**

### 2. Kernels Added (New in Optimized Version)

These kernels appear only in the optimized profile:

| Kernel | Instances | Total Time | Purpose |
|--------|-----------|------------|---------|
| `_fused_conv_output_transpose_kernel` | 320 | 102.86 ms | Fused convolution + transpose |
| `_extract_transpose_prefill_kernel` | 320 | 100.99 ms | Optimized transpose for prefill |
| `warpSpecializedInvoker (FP4AddBiasResidualPreLayerNorm, variant 1)` | 320 | 98.01 ms | Fused LN + bias + residual |
| `warpSpecializedInvoker (FP4AddBiasResidualPreLayerNorm, variant 2)` | 320 | 87.52 ms | Fused LN + bias + residual |
| `fusedRelu2QuantizeKernel` | 320 | 69.22 ms | Fused ReLU + quantize |
| `FusedAddRMSNormKernel` | 8 | 2.45 ms | Fused add + RMS norm |
| `FillFunctor` | 8 | 0.93 ms | Memory initialization |

**Total time for new kernels: ~462.00 ms**

**Net savings from kernel fusion: ~948.76 ms**

### 3. Kernels with Significant Time Changes

| Kernel | Base (ms) | Opt (ms) | Change (ms) | % Change | Instances |
|--------|-----------|----------|-------------|----------|-----------|
| **_chunk_scan_fwd_kernel** | 670.56 | 476.10 | -194.46 | -29.0% | 320 |
| **quantize_with_block_size** | 398.67 | 134.05 | -264.62 | -66.4% | 2304/960 |
| **vectorized_elementwise (add)** | 183.62 | 58.38 | -125.24 | -68.2% | 1024/320 |
| **_layer_norm_fwd_1pass_kernel**  (codes not changed) | 164.13 | 171.13 | +6.99 | +4.3% | 320 |
| **_state_passing_fwd_kernel** | 127.91 | 128.88 | +0.97 | +0.8% | 320 |
| **_chunk_state_fwd_kernel** | 323.61 | 312.06 | -11.55 | -3.6% | 320 |
| **routingMainKernel (DeepSeek)** (codes not changed) | 225.77 | 237.02 | +11.25 | +5.0% | 320 |
| **bmm_Bfloat16_E2m1E2m1** (codes not changed) | 413.52 | 424.28 | +10.76 | +2.6% | 320 |
| **causal_conv1d_fwd_kernel** | 321.42 | 317.19 | -4.24 | -1.3% | 320 |
| **finalizeKernelVecLoad** (codes not changed) | 139.88 | 142.41 | +2.52 | +1.8% | 320 |
| **nvjet_sm100_tss** (codes not changed) | 48.17 | 50.06 | +1.89 | +3.9% | 320 |
| **_bmm_chunk_fwd_kernel** | 31.09 | 38.20 | +7.11 | +22.9% | 320 |

### 4. Core GEMM Operations (We did not touch it, the regression might be from run variances.)

| Kernel | Base (ms) | Opt (ms) | Change | Notes |
|--------|-----------|----------|--------|-------|
| bmm_E2m1_E2m1E2m1 (Mamba BMM) | 865.87 | 910.97 | +5.2% | Slight regression |
| fmhaSm100f (Flash Attention) | 775.96 | 818.86 | +5.5% | Slight regression |
| FP4 GEMM 2_1_1_2SM | 568.28 | 571.95 | +0.6% | Stable |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added fused ReLU2 activation with FP4 quantization for efficient inference.
  * Extended layer normalization with optional high-precision output mode.

* **Performance Improvements**
  * Optimized causal convolution with CUDA enhancements and warp-level operations.
  * Improved Mamba2 prefill with fused elementwise operations and Triton acceleration.
  * Enhanced Triton kernel configurations for better parallelism and reduced register pressure.
  * Nemotron model now supports FP4 fused quantization paths.

* **Tests**
  * Added comprehensive test coverage for causal convolution, fused activation quantization, and layer normalization features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
