### PR TITLE
[None][fix] Better error message for mismatched MPI world size

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -20,7 +20,8 @@ from tensorrt_llm._mnnvl_utils import init_helix_cp_comm
 from tensorrt_llm._utils import (mpi_allgather, mpi_barrier, mpi_comm,
                                  mpi_disabled, mpi_isend, mpi_isend_object,
                                  mpi_recv, mpi_recv_object, mpi_send,
-                                 mpi_send_object, torch_pybind11_abi)
+                                 mpi_send_object, mpi_world_size,
+                                 torch_pybind11_abi)
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.bindings.internal.process_group import init_pg
 from tensorrt_llm.logger import logger
@@ -455,6 +456,18 @@ class MPIDist(Distributed):
         self._cp_comm = None
         self._tp_comm = None
         self._pp_comm = None
+
+        # Validate that all ranks in the mapping are within the MPI world size
+        # to prevent segfaults when creating sub-communicators
+        if ENABLE_MULTI_DEVICE:
+            actual_world_size = mpi_world_size()
+            max_rank_needed = mapping.world_size
+
+            if max_rank_needed > actual_world_size:
+                raise RuntimeError(
+                    f"Mapping requires world_size={max_rank_needed} "
+                    f"(tp_size={mapping.tp_size} * pp_size={mapping.pp_size} * cp_size={mapping.cp_size}), "
+                    f"but MPI world size is only {actual_world_size}. ")
 
     def broadcast(self, obj, root=0, chunk_size: int = 4 * 1024 * 1024):
         comm = mpi_comm()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for multi-device distributed training configurations. The system now verifies MPI world size requirements upfront and provides clear error messages when the requested configuration exceeds available resources, preventing downstream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

If the mpi world size TRTLLM launches into is smaller than the `tensor_parallel_size`, you get a segfault like this:
```
  !!!!!!! Segfault encountered !!!!!!!                                                                                                                                                                                                                                                                                                                                  
    File "../ompi/group/group.h", line 405, in ompi_group_get_proc_name                                                                                                                                                                                                                                                                                                 
    File "dpm/dpm.c", line 1268, in ompi_dpm_group_is_dyn                                                                                                                                                                                                                                                                                                               
    File "dpm/dpm.c", line 1299, in ompi_dpm_mark_dyncomm                                                                                                                                                                                                                                                                                                               
    File "communicator/comm.c", line 215, in ompi_comm_set_nb                                                                                                                                                                                                                                                                                                           
    File "communicator/comm.c", line 116, in ompi_comm_set                                                                                                                                                                                                                                                                                                              
    File "communicator/comm.c", line 1205, in ompi_comm_create_group                                                                                                                                                                                                                                                                                                    
    File "/build-result/src/hpcx-v2.25.1-gcc-inbox-ubuntu24.04-cuda13-x86_64/ompi-ad48c462ffb305748641c267af6c1be683fd73ef/ompi/mpi/c/profile/pcomm_create_group.c", line 78, in PMPI_Comm_create_group                                                                                                                                                                 
    File "src/mpi4py.MPI.c", line 111198, in __pyx_pf_6mpi4py_3MPI_4Comm_26Create_group                                                                                                                                                                                                                                                                                 
    File "src/mpi4py.MPI.c", line 111091, in __pyx_pw_6mpi4py_3MPI_4Comm_27Create_group                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in PyObject_Vectorcall                                                                                                                                                                                                                                                                                                                    
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in PyObject_CallOneArg                                                                                                                                                                                                                                                                                                                    
    File "<unknown>", line 0, in _PyObject_GenericGetAttrWithDict                                                                                                                                                                                                                                                                                                       
    File "<unknown>", line 0, in PyObject_GetAttr                                                                                                                                                                                                                                                                                                                       
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in PyObject_Call                                                                                                                                                                                                                                                                                                                          
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in PyObject_Call                                                                                                                                                                                                                                                                                                                          
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in _PyObject_Call_Prepend                                                                                                                                                                                                                                                                                                                 
    File "<unknown>", line 0, in _PyObject_MakeTpCall                                                                                                                                                                                                                                                                                                                   
    File "<unknown>", line 0, in _PyEval_EvalFrameDefault                                                                                                                                                                                                                                                                                                               
    File "<unknown>", line 0, in __clone                                                                                                                                                                                                                                                                                                                                
    File "<unknown>", line 0, in 0xffffffffffffffff                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                        
  /code/tensorrt_llm/.venv-3.12/bin/trtllm-llmapi-launch: line 129:  7806 Segmentation fault      (core dumped) python3 -m tensorrt_llm.llmapi.mgmn_leader_node                                                                                                                                                                                                         
  Rank0 MGMN leader node exit code: 139                                                                                                                                                                                                                                                                                                                                 
```

This MR checks the MPI world size in advance to provide a clearer error message.

```
RuntimeError: Mapping requires world_size=2 (tp_size=2 * pp_size=1 * cp_size=1), but MPI world size is only 1.
```

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
