### PR TITLE
Introduce the BOLT_COMPATIBLE option to CMake and make it available u…

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ option(ENABLE_MULTI_DEVICE
        "Enable building with multi device support (requires NCCL, MPI,...)" ON)
 option(ENABLE_UCX "Enable building with UCX (Uniform Communication X) support"
        ON)
+option(BOLT_COMPATIBLE "Ensure that TRT-LLM libraries are BOLT-compatible" OFF)
 option(NVRTC_DYNAMIC_LINKING "Link against the dynamic NVRTC libraries" OFF)
 option(CUBLAS_DYNAMIC_LINKING
        "Link against the dynamic cublas/cublasLt libraries" ON)
@@ -196,6 +197,59 @@ else()
 
   set(CURAND_LIB CUDA::curand_static)
   list(APPEND CUDA_TOOLKIT_COMPONENTS curand_static)
+endif()
+
+if(BOLT_COMPATIBLE AND NOT WIN32)
+  message(STATUS "BOLT-compatible flags enabled")
+
+  #
+  # Add extra CFLAGS
+  #
+  include(CheckCCompilerFlag)
+
+  # Add -fno-plt if supported
+  check_c_compiler_flag("-fno-plt" HAS_C_FNO_PLT)
+  if(HAS_C_FNO_PLT)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fno-plt>)
+  endif()
+
+  # Add -fno-reorder-blocks-and-partition if supported
+  check_c_compiler_flag("-fno-reorder-blocks-and-partition"
+                        HAS_C_FNO_REORDER_BLOCKS_AND_PARTITION)
+  if(HAS_C_FNO_REORDER_BLOCKS_AND_PARTITION)
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:C>:-fno-reorder-blocks-and-partition>)
+  endif()
+
+  #
+  # Add extra CXXFLAGS
+  #
+  include(CheckCXXCompilerFlag)
+
+  # Add -fno-plt if supported
+  check_cxx_compiler_flag("-fno-plt" HAS_CXX_FNO_PLT)
+  if(HAS_CXX_FNO_PLT)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-plt>)
+  endif()
+
+  # Add -fno-reorder-blocks-and-partition if supported
+  check_cxx_compiler_flag("-fno-reorder-blocks-and-partition"
+                          HAS_CXX_FNO_REORDER_BLOCKS_AND_PARTITION)
+  if(HAS_CXX_FNO_REORDER_BLOCKS_AND_PARTITION)
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-reorder-blocks-and-partition>)
+  endif()
+
+  #
+  # Add extra LDFLAGS
+  #
+  include(CheckLinkerFlag)
+
+  # Add -Wl,-q if supported
+  check_linker_flag(CXX "-Wl,-q" HAS_LINK_WL_Q)
+  if(HAS_LINK_WL_Q)
+    add_link_options("-Wl,-q")
+  endif()
 endif()
 
 if(NVRTC_DYNAMIC_LINKING)

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/CMakeLists.txt
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/CMakeLists.txt
@@ -67,7 +67,17 @@ if(NIXL_ENABLED OR MOONCAKE_ENABLED)
   set(AGENT_BINDING_SOURCES "")
   list(APPEND AGENT_BINDING_SOURCES agentBindings.cpp)
 
-  nanobind_add_module(${TRANSFER_AGENT_BINDING_TARGET} ${AGENT_BINDING_SOURCES})
+  set(TRANSFER_AGENT_BINDING_ARGS ${TRANSFER_AGENT_BINDING_TARGET})
+
+  if(BOLT_COMPATIBLE AND NOT WIN32)
+    # BOLT-compatible libraries need to not be stripped and should not be
+    # optimized for size
+    list(APPEND TRANSFER_AGENT_BINDING_ARGS NOSTRIP NOMINSIZE)
+  endif()
+
+  list(APPEND TRANSFER_AGENT_BINDING_ARGS ${AGENT_BINDING_SOURCES})
+
+  nanobind_add_module(${TRANSFER_AGENT_BINDING_ARGS})
   message(STATUS "Building tensorrt_llm_transfer_agent_binding with nanobind")
 
   target_compile_options(${TRANSFER_AGENT_BINDING_TARGET} PRIVATE -Wno-error)

--- a/cpp/tensorrt_llm/nanobind/CMakeLists.txt
+++ b/cpp/tensorrt_llm/nanobind/CMakeLists.txt
@@ -29,7 +29,17 @@ set(SRCS
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-nanobind_add_module(${TRTLLM_NB_MODULE} ${SRCS})
+set(TRTLLM_NB_MODULE_ARGS ${TRTLLM_NB_MODULE})
+
+if(BOLT_COMPATIBLE AND NOT WIN32)
+  # BOLT-compatible libraries need to not be stripped and should not be
+  # optimized for size
+  list(APPEND TRTLLM_NB_MODULE_ARGS NOSTRIP NOMINSIZE)
+endif()
+
+list(APPEND TRTLLM_NB_MODULE_ARGS ${SRCS})
+
+nanobind_add_module(${TRTLLM_NB_MODULE_ARGS})
 
 set_property(TARGET ${TRTLLM_NB_MODULE} PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -491,6 +491,7 @@ def main(*,
          generate_fmha: bool = False,
          no_venv: bool = False,
          nvrtc_dynamic_linking: bool = False,
+         bolt_compatible: bool = False,
          mypyc: bool = False):
 
     if clean:
@@ -594,6 +595,11 @@ def main(*,
 
     if fast_build:
         cmake_def_args.append(f"-DFAST_BUILD=ON")
+
+    if bolt_compatible:
+        # bolt_compatible implies nvrtc_dynamic_linking
+        nvrtc_dynamic_linking = True
+        cmake_def_args.append(f'-DBOLT_COMPATIBLE=ON')
 
     if nvrtc_dynamic_linking:
         cmake_def_args.append(f"-DNVRTC_DYNAMIC_LINKING=ON")
@@ -1110,6 +1116,10 @@ def add_arguments(parser: ArgumentParser):
         "--nvrtc_dynamic_linking",
         action="store_true",
         help="Link against dynamic NVRTC libraries instead of static ones")
+    parser.add_argument(
+        "--bolt_compatible",
+        action="store_true",
+        help="Ensure that TRT-LLM libraries are BOLT-compatible")
     parser.add_argument("--mypyc",
                         action="store_true",
                         help="Compile kv_cache_manager_v2 with mypyc")


### PR DESCRIPTION
…nder the --bolt_compatible switch to build_wheel.py

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
