### PR TITLE
[visual_gen] Support Cosmos Predict2.5 via diffusers

### DIFF
--- a/tensorrt_llm/visual_gen/.gitignore
+++ b/tensorrt_llm/visual_gen/.gitignore
@@ -1,0 +1,4 @@
+# Library files compiled by `pip install -e`
+*.cpython-*.so
+# Output videos from running examples
+*.mp4

--- a/tensorrt_llm/visual_gen/README.md
+++ b/tensorrt_llm/visual_gen/README.md
@@ -57,6 +57,7 @@ Given a diffusion model implemented in native PyTorch or HuggingFace Diffusers p
 ### Cosmos
 | Model Name | Resolution | Parameters | Description |
 |------------|------------|------------|-------------|
+| nvidia/Cosmos-Predict2.5-2B | - | 2B | Video/text-to-world |
 | nvidia/Cosmos-Predict2.5-2B-Base | - | 2B | Text-to-image |
 | nvidia/Cosmos-Predict2-2B-Video2World | - | 2B | Video-to-world |
 | nvidia/Cosmos-Predict2-14B-Video2World | - | 14B | Video-to-world |

--- a/tensorrt_llm/visual_gen/examples/README.md
+++ b/tensorrt_llm/visual_gen/examples/README.md
@@ -19,6 +19,7 @@ We provides state-of-the-art diffusion model capabilities with optimized inferen
 | Flux.1 [dev] | `black-forest-labs/FLUX.1-dev` | 12B | **Text-to-Image** |
 | FLUX.2 [dev] | `black-forest-labs/FLUX.2-dev` | 32B | **Text-to-Image** |
 | HunyuanImage2.1 | `tencent/HunyuanImage-2.1` | 17B | **Text-to-Image** |
+| Cosmos | `nvidia/Cosmos-Predict2.5-2B` | 2B | **Video/text-to-World** |
 | Cosmos | `nvidia/Cosmos-Predict2-2B-Video2World` | 2B | **Video-to-World** |
 | Cosmos | `nvidia/Cosmos-Predict2-14B-Video2World` | 14B | **Video-to-World** |
 | Cosmos | `nvidia/Cosmos-Predict2-2B-Text2Image` | 2B | **Text-to-Image** |
@@ -91,6 +92,16 @@ torchrun --nproc-per-node 4 hunyuan_image2.1.py  --attn_type flash-attn3 --linea
 ```
 
 #### Cosmos
+
+**Cosmos Predict2.5 2B Image2World**
+```bash
+python cosmos2_5_predict.py --model_path "nvidia/Cosmos-Predict2.5-2B" --height 704 --width 1280 --num_frames 93 --enable_teacache
+```
+
+**Cosmos Predict2.5 2B Text2World**
+```bash
+python cosmos2_5_predict.py --model_path "nvidia/Cosmos-Predict2.5-2B" --image "" --height 704 --width 1280 --num_frames 93 --enable_teacache
+```
 
 **Cosmos Predict2 2B Video2World**
 ```bash

--- a/tensorrt_llm/visual_gen/examples/cosmos2_5_predict.py
+++ b/tensorrt_llm/visual_gen/examples/cosmos2_5_predict.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.distributed as dist
+from common import BaseArgumentParser
+from common import (
+    autotuning,
+    configure_cpu_offload,
+    create_dit_config,
+    generate_autotuner_dir,
+    generate_output_path,
+    save_output,
+    setup_distributed,
+    validate_parallel_config,
+)
+from diffusers.utils import load_image
+
+from visual_gen import setup_configs
+from visual_gen.pipelines.cosmos_pipeline import ditCosmos2_5_PredictBasePipeline
+from visual_gen.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def load_and_setup_pipeline(args):
+    """Load and configure the Cosmos pipeline."""
+    # Create visual_gen configuration
+    pipe_cfg = create_dit_config(args)
+    setup_configs(**pipe_cfg)
+
+    logger.info(f"Loading 2VideoToWorldPipeline with extra configs {pipe_cfg}...")
+    pipe = ditCosmos2_5_PredictBasePipeline.from_pretrained(
+        args.model_path,
+        revision=args.revision,
+        torch_dtype=torch.bfloat16,
+        **pipe_cfg,
+    )
+
+    # Setup distributed training and CPU offload
+    local_rank, _world_size = setup_distributed()
+    configure_cpu_offload(pipe, args, local_rank)
+
+    return pipe
+
+
+def run_inference(pipe, args, image, enable_autotuner: bool = False):
+    """Run warmup and actual inference."""
+
+    def inference_fn(warmup: bool = False):
+        if warmup:
+            num_inference_steps = args.num_warmup_steps
+        else:
+            num_inference_steps = args.num_inference_steps
+        return pipe(
+            image=image,
+            prompt=args.prompt,
+            negative_prompt=args.negative_prompt,
+            height=args.height,
+            width=args.width,
+            num_frames=args.num_frames,
+            guidance_scale=args.guidance_scale,
+            num_inference_steps=num_inference_steps,
+            max_sequence_length=args.max_sequence_length,
+        ).frames[0]  # List of PIL frames (T x H x W x C)
+
+    autotuner_dir = args.autotuner_result_dir
+    if enable_autotuner and not args.skip_autotuning:
+        if autotuner_dir is None:
+            autotuner_dir = generate_autotuner_dir(args)
+        autotuning(inference_fn, autotuner_dir)
+
+    frames = inference_fn(warmup=False)
+    return frames, None
+
+
+def main():
+    """Main function for Cosmos image-to-video generation."""
+    # Setup argument parser
+    parser = BaseArgumentParser("Cosmos Image-to-Video Generation")
+    parser.add_image_input_args(
+        default_image="https://media.githubusercontent.com/media/nvidia-cosmos/cosmos-predict2.5/refs/heads/main/assets/base/bus_terminal.jpg"
+    )
+    parser.add_video_args(default_num_frames=93, default_fps=16)
+    parser.parser.add_argument(
+        "--revision",
+        type=str,
+        default="diffusers/base/post-trained",
+        help="HuggingFace model branch",
+    )
+
+    # Set defaults for Cosmos I2V
+    parser.parser.set_defaults(
+        model_path="nvidia/Cosmos-Predict2.5-2B",
+        revision="diffusers/base/post-trained",
+        prompt=(
+            "A nighttime city bus terminal gradually shifts from stillness to subtle movement. "
+            "At first, multiple double-decker buses are parked under the glow of overhead lights, "
+            "with a central bus labeled '87D' facing forward and stationary. "
+            "As the video progresses, the bus in the middle moves ahead slowly, its headlights brightening the surrounding area "
+            "and casting reflections onto adjacent vehicles. "
+            "The motion creates space in the lineup, signaling activity within the otherwise quiet station. "
+            "It then comes to a smooth stop, resuming its position in line. "
+            "Overhead signage in Chinese characters remains illuminated, enhancing the vibrant, urban night scene."
+        ),
+        negative_prompt=(
+            "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, "
+            "over-saturation, shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, "
+            "underexposed and overexposed scenes, poor color balance, washed out colors, choppy sequences, jerky movements, "
+            "low frame rate, artifacting, color banding, unnatural transitions, outdated special effects, fake elements, "
+            "unconvincing visuals, poorly edited content, jump cuts, visual noise, and flickering. "
+            "Overall, the video is of poor quality."
+        ),
+        height=704,
+        width=1280,
+        num_frames=93,
+        guidance_scale=7.0,
+        num_inference_steps=36,
+        max_sequence_length=512,
+        teacache_thresh=0.13,
+    )
+    args = parser.parse_args()
+
+    enable_autotuner = False
+    if args.linear_type == "auto" or args.attn_type == "auto":
+        enable_autotuner = True
+    if enable_autotuner:
+        raise RuntimeError("Autotuner not supported by Cosmos 2.5.")
+
+    if not args.disable_parallel_vae:
+        logger.warning("Parallel VAE is not supported for Cosmos I2V, disable parallel VAE")
+        args.disable_parallel_vae = True
+
+    # Validate configuration
+    validate_parallel_config(args)
+
+    # Generate output path
+    output_path = generate_output_path(args, save_type="mp4")
+
+    # Load pipeline and prepare inputs
+    pipe = load_and_setup_pipeline(args)
+
+    # Load and resize the image
+    if len(args.image) > 0:
+        image = load_image(args.image)
+        image = image.resize((args.width, args.height))
+    else:
+        image = None
+
+    # Run inference
+    frames, _ = run_inference(pipe, args, image, enable_autotuner)
+
+    # Log results and save output
+    save_output(frames, output_path, output_type="video")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/tensorrt_llm/visual_gen/examples/cosmos_predict2.5/README.md
+++ b/tensorrt_llm/visual_gen/examples/cosmos_predict2.5/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This example shows how to integrate our plug-and-play feature to quickly support Cosmos Predict2.5, which is not a diffusers dependent model.
+This example shows how to integrate our plug-and-play feature to quickly support the non-diffusers version of Cosmos Predict2.5. For the diffusers version of Cosmos-Predict2.5 will full feature support, please try `examples/cosmos2_5_predict.py` instead.
 
 ## APIs
 We supported it with a few APIs. 

--- a/tensorrt_llm/visual_gen/requirements-cosmos.txt
+++ b/tensorrt_llm/visual_gen/requirements-cosmos.txt
@@ -1,0 +1,3 @@
+cosmos-guardrail @ git+https://github.com/codeJRV/cosmos-guardrail.git
+diffusers @ git+https://github.com/huggingface/diffusers.git
+transformers~=4.57

--- a/tensorrt_llm/visual_gen/requirements.txt
+++ b/tensorrt_llm/visual_gen/requirements.txt
@@ -1,4 +1,4 @@
-diffusers==0.36.0
+diffusers>=0.36.0
 peft==0.17.0
 transformers>=4.52.1
 sentencepiece

--- a/tensorrt_llm/visual_gen/setup.py
+++ b/tensorrt_llm/visual_gen/setup.py
@@ -217,6 +217,10 @@ if compile_svd:
 if compile_fused_qk_norm_rope:
     ext_modules.append(fused_qk_norm_rope_extension())
 requirements = load_requirements()
+requirements_ext = {
+    "cosmos": load_requirements("requirements-cosmos.txt"),
+    "dev": [],
+}
 setup(
     name="visual_gen",
     version=get_version(),
@@ -226,9 +230,7 @@ setup(
     packages=find_packages(include=["visual_gen*"]),
     python_requires=">=3.8",
     install_requires=requirements,
-    extras_require={
-        "dev": [],
-    },
+    extras_require=requirements_ext,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",

--- a/tensorrt_llm/visual_gen/visual_gen/models/vaes/__init__.py
+++ b/tensorrt_llm/visual_gen/visual_gen/models/vaes/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This change targets TRTLLM/visual_gen Python variant code:

New capabilities compared to library mode:

- TeaCache
- Support more native functionalities

<!--
## Test Coverage

Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
