### PR TITLE
[None][fix] Pre-Allocation for Auto-Tuning NCCL_SYMMETRIC

### DIFF
--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -626,8 +626,10 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
     // Check for buffers still in use - this shouldn't happen if cleanup is called properly,
     // but we log a warning if it does
     size_t inUseCount = 0;
+    size_t totalBytes = 0;
     for (auto const& entry : commIt->second)
     {
+        totalBytes += entry.buffer.size;
         if (entry.inUse)
         {
             ++inUseCount;
@@ -640,6 +642,8 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
             "This may indicate buffers weren't properly released before cleanup.",
             inUseCount, static_cast<void*>(comm));
     }
+    TLLM_LOG_DEBUG("[NCCLUtil] NCCL window allocator teardown for comm %p: %zu buffers, %zu bytes total",
+        static_cast<void*>(comm), commIt->second.size(), totalBytes);
 
     for (auto& entry : commIt->second)
     {

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1455,6 +1455,8 @@ void preallocateNCCLWindowBuffer(torch::List<int64_t> const& group, int64_t size
     ncclComm_t comm = *comm_ptr;
 
     auto const size = static_cast<size_t>(size_bytes);
+    TLLM_LOG_DEBUG("[preallocateNCCLWindowBuffer] Pre-allocating %ld buffer(s) of %zu bytes for comm %p",
+        buffers_per_size, size, static_cast<void*>(comm));
     for (int64_t i = 0; i < buffers_per_size; ++i)
     {
         try
@@ -1462,6 +1464,9 @@ void preallocateNCCLWindowBuffer(torch::List<int64_t> const& group, int64_t size
             NCCLWindowBuffer buffer = allocator.requestBuffer(comm, size);
             if (buffer.isValid())
             {
+                TLLM_LOG_DEBUG(
+                    "[preallocateNCCLWindowBuffer] Allocated buffer %ld/%ld: handle=%d ptr=%p size=%zu window=%p",
+                    i + 1, buffers_per_size, buffer.handle, buffer.ptr, buffer.size, buffer.window);
                 allocator.releaseBuffer(comm, buffer.ptr);
             }
         }

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -733,6 +733,7 @@ class AutoTuner:
         self._active_capture: Optional['AutoTuner.TacticsCapture'] = None
         # Last captured choose_one() contexts
         self._last_capture: Optional['AutoTuner.TacticsCapture'] = None
+        self._is_preparation = False
 
         # Dsitributed tuning state
         self._dist: Optional[Distributed] = None
@@ -1033,12 +1034,16 @@ class AutoTuner:
             valid_tactics = self._maybe_parallelize_tactics(
                 all_valid_tactics, tuning_config.distributed_tuning_strategy)
             if "do_preparation" in runner_arg_names and len(valid_tactics) > 0:
-                runner(
-                    input_tensors,
-                    tactic=-1,
-                    do_preparation=True,
-                    **kwargs,
-                )
+                self._is_preparation = True
+                try:
+                    runner(
+                        input_tensors,
+                        tactic=-1,
+                        do_preparation=True,
+                        **kwargs,
+                    )
+                finally:
+                    self._is_preparation = False
 
             for tac in valid_tactics:
                 try:

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -733,7 +733,6 @@ class AutoTuner:
         self._active_capture: Optional['AutoTuner.TacticsCapture'] = None
         # Last captured choose_one() contexts
         self._last_capture: Optional['AutoTuner.TacticsCapture'] = None
-        self._is_preparation = False
 
         # Dsitributed tuning state
         self._dist: Optional[Distributed] = None
@@ -1034,16 +1033,12 @@ class AutoTuner:
             valid_tactics = self._maybe_parallelize_tactics(
                 all_valid_tactics, tuning_config.distributed_tuning_strategy)
             if "do_preparation" in runner_arg_names and len(valid_tactics) > 0:
-                self._is_preparation = True
-                try:
-                    runner(
-                        input_tensors,
-                        tactic=-1,
-                        do_preparation=True,
-                        **kwargs,
-                    )
-                finally:
-                    self._is_preparation = False
+                runner(
+                    input_tensors,
+                    tactic=-1,
+                    do_preparation=True,
+                    **kwargs,
+                )
 
             for tac in valid_tactics:
                 try:

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1782,6 +1782,15 @@ class AllReduceRunner(TunableRunner):
         )
 
 
+@torch.library.register_fake("trtllm::preallocate_nccl_window_buffer")
+def _(
+    input: torch.Tensor,
+    group: List[int],
+    count: int,
+) -> None:
+    return None
+
+
 @torch.library.custom_op("trtllm::tunable_allreduce", mutates_args=())
 def tunable_allreduce(
     input: torch.Tensor,

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1786,6 +1786,10 @@ def tunable_allreduce(
                 element_size = input.element_size()
                 for tokens in sorted([int(v) for v in opt_shapes if v > 0]):
                     size_bytes = int(tokens * elements_per_token * element_size)
+                    logger.debug(
+                        "[tunable_allreduce] Pre-allocating NCCL window buffers: "
+                        "tokens=%d size_bytes=%d group=%s", tokens, size_bytes,
+                        list(group))
                     torch.ops.trtllm.preallocate_nccl_window_buffer(
                         group, size_bytes, 2)
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1687,10 +1687,11 @@ class AllReduceRunner(TunableRunner):
         )
 
     @classmethod
-    def _maybe_preallocate_buffers(cls, input_tensor: torch.Tensor,
-                                   group: List[int]) -> None:
-        if not AutoTuner.get().is_tuning_mode or not AutoTuner.get(
-        )._is_preparation:
+    def _maybe_preallocate_buffers(cls,
+                                   input_tensor: torch.Tensor,
+                                   group: List[int],
+                                   do_preparation: bool = False) -> None:
+        if not do_preparation:
             return
         if not hasattr(torch.ops.trtllm, "preallocate_nccl_window_buffer"):
             return
@@ -1762,7 +1763,9 @@ class AllReduceRunner(TunableRunner):
                                                    OptimizationProfile(),
                                                    **kwargs)
             if AllReduceStrategy.NCCL_SYMMETRIC.value in valid_tactics:
-                self._maybe_preallocate_buffers(input, self.group)
+                self._maybe_preallocate_buffers(input,
+                                                self.group,
+                                                do_preparation=True)
             return input
         if tactic == -1:
             tactic = AllReduceStrategy.NCCL_SYMMETRIC.value

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1,6 +1,6 @@
 import threading
 from functools import lru_cache
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import ClassVar, List, Mapping, Optional, Tuple, Union
 
 import torch
 import triton  # type: ignore[import]
@@ -1656,8 +1656,8 @@ def _(
 
 
 class AllReduceRunner(TunableRunner):
-    _prealloc_lock = threading.Lock()
-    _prealloc_done = set()
+    _prealloc_lock: ClassVar[threading.Lock] = threading.Lock()
+    _prealloc_done: ClassVar[set] = set()
     tuning_config = TuningConfig(
         dynamic_tensor_specs=(DynamicTensorSpec(
             0, 0, get_last_power_of_2_num_tokens_buckets(8192),
@@ -1700,7 +1700,7 @@ class AllReduceRunner(TunableRunner):
             try:
                 if torch.cuda.is_current_stream_capturing():
                     return
-            except Exception:
+            except (RuntimeError, AssertionError):
                 # If capture status can't be queried, avoid prealloc to be safe.
                 return
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NCCL window buffer preallocation capability to enhance collective communication performance.
  * Extended AllReduceRunner with a preparation phase for advanced optimization capabilities.

* **Improvements**
  * Implemented intelligent buffer caching with safety checks for improved resource management.
  * Enhanced NCCL cleanup operations with better tracking and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Description

This is a follow-up to https://github.com/NVIDIA/TensorRT-LLM/pull/11042

This PR introduces pre-allocations of the tensor sizes for Auto-Tuning NCCL_SYMMETRIC.
This doesn't add memory allocation, it just moves allocation from possibly within a graph capture to outside an earlier time.
When the Auto-Tuning for AR is setup, we now pre-allocated symmetric buffers, that the auto-tuning can use during execution.

It also helps to have some buffers allocated that can be used during the regular run later, re-use of the pre-allocated buffers is implemented.

## Test Coverage

Covered in existing CI.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
