### PR TITLE
[#11318][infra] AutoDeploy: Add fused rope kernel - triton_rope_on_interleaved_qk_inputs

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -4,4 +4,131 @@ All AutoDeploy custom operators follow the following naming convention:
 
 `torch.ops.auto_deploy.<kernel_backend>_<op_category>_<op_name>`
 
-The table below lists the operators ordered by their backend.
+The table below lists the operators grouped by category.
+
+### Available Custom Operators
+
+#### Attention
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_attention` | Grouped SDPA implementation with `bsnd` and `bnsd` layout supported |
+| `torch.ops.auto_deploy.torch_attention_sdpa` | Standard scaled dot-product attention (SDPA) implementation |
+| `torch.ops.auto_deploy.torch_attention_repeat_kv` | KV repetition for grouped-query attention |
+| `torch.ops.auto_deploy.torch_cached_attention_with_cache` | PyTorch backend attention with KV cache management |
+| `torch.ops.auto_deploy.flashinfer_attention_mha_with_cache` | FlashInfer multi-head attention with KV cache support |
+| `torch.ops.auto_deploy.flashinfer_attention_prepare_metadata` | FlashInfer attention metadata preparation |
+| `torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache` | Triton flattened MHA with cache |
+| `torch.ops.auto_deploy.torch_onnx_attention_plugin` | Fused attention with RoPE placeholder for ONNX export |
+| `torch.ops.auto_deploy.torch_onnx_gather_nd` | N-dimensional gather operation for ONNX export |
+
+#### MLA (Multi-head Latent Attention)
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_mla` | Multi-head Latent Attention (MLA) implementation |
+| `torch.ops.auto_deploy.torch_cached_mla_with_cache` | PyTorch backend cached MLA with KV cache |
+| `torch.ops.auto_deploy.flashinfer_mla_with_cache` | FlashInfer MLA with cache |
+| `torch.ops.auto_deploy.flashinfer_mla_prepare_metadata` | FlashInfer MLA metadata preparation |
+
+#### RoPE (Rotary Position Embedding)
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin` | RoPE with explicit cosine/sine |
+| `torch.ops.auto_deploy.torch_rope_with_complex_freqs` | RoPE with complex frequencies |
+| `torch.ops.auto_deploy.torch_rope_with_qk_interleaving` | RoPE with QK interleaving |
+| `torch.ops.auto_deploy.triton_rope_with_input_pos` | Triton RoPE with input positions |
+| `torch.ops.auto_deploy.triton_rope_on_flattened_inputs` | Triton RoPE on flattened inputs |
+| `torch.ops.auto_deploy.triton_rope_on_interleaved_qk_inputs` | Triton fused RoPE on interleaved QK inputs (position lookup + de-interleave + RoPE) |
+| `torch.ops.auto_deploy.flashinfer_rope` | FlashInfer RoPE implementation |
+
+#### Linear
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_linear_simple` | Simple linear layer wrapper (avoids view ops in export graph) |
+| `torch.ops.auto_deploy.torch_moe_router` | MoE router: linear projection + top-k + softmax + scatter |
+
+#### MoE (Mixture of Experts)
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_moe` | Mixture of Experts implementation (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_moe_fused` | Fused Mixture of Experts implementation (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_moe_dense_mlp` | Dense MLP implementation for MoE (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_quant_fp8_moe` | FP8 quantized MoE (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_quant_nvfp4_moe` | NVFP4 quantized MoE (PyTorch backend) |
+| `torch.ops.auto_deploy.triton_moe_fused` | Fused MoE (Triton backend) |
+| `torch.ops.auto_deploy.triton_quant_fp8_moe` | FP8 quantized MoE (Triton backend) |
+| `torch.ops.auto_deploy.triton_mxfp4_moe` | MXFP4 MoE with triton-kernels matmul_ogs |
+| `torch.ops.auto_deploy.triton_mxfp4_moe_ep` | MXFP4 MoE with Expert Parallelism (triton-kernels) |
+| `torch.ops.auto_deploy.trtllm_moe_fused` | Fused MoE (TRT-LLM backend) |
+| `torch.ops.auto_deploy.trtllm_quant_fp8_moe_fused` | FP8 quantized fused MoE (TRT-LLM backend) |
+| `torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused` | NVFP4 quantized fused MoE (TRT-LLM backend) |
+
+#### Quantization
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_quant_fn` | Generic quantization function that scales, rounds, and clamps input values |
+| `torch.ops.auto_deploy.torch_quant_fp8_linear` | FP8 quantized linear layer (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_quant_nvfp4_linear` | NVFP4 quantized linear layer (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_quant_fp8_bmm` | FP8 quantized batch matrix multiply (PyTorch backend) |
+| `torch.ops.auto_deploy.trtllm_quant_fp8_linear` | FP8 quantized linear layer (TRT-LLM backend) |
+| `torch.ops.auto_deploy.torch_fake_quant_fp8_linear` | Fake FP8 quantized linear (for calibration/simulation) |
+| `torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear` | Fake NVFP4 quantized linear (for calibration/simulation) |
+| `torch.ops.auto_deploy.torch_fake_quant_int4_linear` | Fake INT4 quantized linear (for calibration/simulation) |
+| `torch.ops.auto_deploy.torch_fake_quant_int4_gptq_linear` | Fake INT4 GPTQ quantized linear (for calibration/simulation) |
+
+#### Normalization
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_rmsnorm` | RMSNorm (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_rmsnorm_gated` | Gated RMSNorm with optional SiLU gating (PyTorch backend) |
+| `torch.ops.auto_deploy.triton_rms_norm` | RMSNorm (Triton backend) |
+| `torch.ops.auto_deploy.triton_rmsnorm_gated` | Gated RMSNorm with optional SiLU gating (Triton backend) |
+| `torch.ops.auto_deploy.flashinfer_rms_norm` | RMSNorm (FlashInfer backend) |
+| `torch.ops.auto_deploy.flashinfer_fused_add_rms_norm_inplace` | Fused residual add + RMSNorm in-place (FlashInfer backend) |
+| `torch.ops.auto_deploy.sharded_rmsnorm` | RMSNorm for tensor-parallel sharded activations (uses all-reduce) |
+| `torch.ops.auto_deploy.torch_l2norm` | L2 normalization (PyTorch backend) |
+| `torch.ops.auto_deploy.fla_l2norm` | L2 normalization (FLA Triton kernel backend) |
+
+#### Mamba (SSM + Causal Conv)
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_ssm` | State Space Model (SSM) computation (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_cached_ssm` | Cached SSM with state management (PyTorch backend) |
+| `torch.ops.auto_deploy.triton_cached_ssm` | Cached SSM with state management (Triton backend) |
+| `torch.ops.auto_deploy.flashinfer_cached_ssm` | Cached SSM with state management (FlashInfer backend) |
+| `torch.ops.auto_deploy.mamba_ssm_prepare_metadata` | Mamba SSM metadata preparation (chunk indices, offsets, seq_idx) |
+| `torch.ops.auto_deploy.torch_causal_conv1d` | Causal 1D convolution (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_cached_causal_conv1d` | Cached causal 1D convolution (PyTorch backend) |
+| `torch.ops.auto_deploy.triton_cached_causal_conv1d` | Cached causal 1D convolution (Triton backend) |
+| `torch.ops.auto_deploy.cuda_cached_causal_conv1d` | Cached causal 1D convolution (CUDA backend) |
+
+#### FLA (Flash Linear Attention)
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.fla_delta_rule` | FLA chunked delta rule computation |
+| `torch.ops.auto_deploy.fla_cached_delta_rule` | FLA cached delta rule with state management |
+
+#### Distributed
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.torch_dist_all_gather` | All-gather (PyTorch backend, demollm mode) |
+| `torch.ops.auto_deploy.torch_dist_all_reduce` | All-reduce (PyTorch backend, demollm mode) |
+| `torch.ops.auto_deploy.trtllm_dist_all_gather` | All-gather (TRT-LLM backend, MPI mode) |
+| `torch.ops.auto_deploy.trtllm_dist_all_reduce` | All-reduce (TRT-LLM backend, MPI mode) |
+| `torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm` | Fused all-reduce + residual add + RMSNorm (TRT-LLM backend, MPI mode) |
+
+#### Utilities
+
+| Operator Name | Description |
+|--------------|-------------|
+| `torch.ops.auto_deploy.triton_utils_fused_gather_scatter` | Triton fused gather + scatter for overlap scheduling input_ids reordering |
+| `torch.ops.auto_deploy.gather_logits_before_lm_head` | Gather hidden states using logits indices before LM head |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/triton_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/triton_rope.py
@@ -17,7 +17,7 @@ from typing import Tuple
 import torch
 import triton
 
-from .triton_kernels.rope import (
+from .triton_rope_kernel import (
     rope_fwd_flattened_kernel,
     rope_fwd_interleaved_kernel,
     rope_fwd_kernel,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/rope/test_triton_rope.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/rope/test_triton_rope.py
@@ -5,7 +5,7 @@ import torch
 from _custom_op_utils import torch_rope_reference
 
 # Import after we've imported torch (to ensure custom ops are registered)
-from tensorrt_llm._torch.auto_deploy.custom_ops import triton_rope  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.rope import triton_rope  # noqa: F401
 
 
 def _precompute_cos_sin_cache(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/rope/test_triton_rope.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/rope/test_triton_rope.py
@@ -1,11 +1,24 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import pytest
 import torch
 from _custom_op_utils import torch_rope_reference
 
 # Import after we've imported torch (to ensure custom ops are registered)
-from tensorrt_llm._torch.auto_deploy.custom_ops.rope import triton_rope  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops import triton_rope  # noqa: F401
+
+
+def _precompute_cos_sin_cache(
+    max_seq_len: int, head_dim: int, rope_theta: float = 10000.0, dtype: torch.dtype = torch.float16
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Precompute cos and sin cache for RoPE (DeepSeek-style)."""
+    inv_freq = 1.0 / (rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    positions = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = positions.unsqueeze(1) * inv_freq.unsqueeze(0)  # [max_seq_len, head_dim//2]
+    emb = torch.cat((freqs, freqs), dim=-1)  # [max_seq_len, head_dim]
+    cos_cache = emb.cos().to(dtype)
+    sin_cache = emb.sin().to(dtype)
+    return cos_cache, sin_cache
 
 
 def _precompute_freqs_cis(
@@ -73,3 +86,105 @@ def test_rope_flattened(d_head):
     y_reshaped = y.unflatten(-1, (2, N_ELEM // 2)).transpose(-2, -1).flatten(-2).contiguous()
 
     assert torch.allclose(y_ref.cpu(), y_reshaped.cpu(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,num_q_heads,num_k_heads,head_dim",
+    [
+        (1, 4, 8, 8, 64),  # Standard case
+        (2, 16, 20, 1, 128),  # GLM-4 style: non-power-of-2 heads, MQA
+        (1, 1, 8, 8, 64),  # Single token (decode)
+        (4, 32, 16, 2, 96),  # GQA with non-standard head_dim
+    ],
+)
+def test_triton_rope_on_interleaved_qk_inputs(
+    batch_size: int, seq_len: int, num_q_heads: int, num_k_heads: int, head_dim: int
+):
+    """
+    Test that triton_rope_on_interleaved_qk_inputs produces the same output as
+    the PyTorch reference (index + torch_rope_with_qk_interleaving).
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    max_seq_len = 1024
+
+    # Create random inputs with interleaved layout [B, S, H, D]
+    q = torch.randn(batch_size, seq_len, num_q_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seq_len, num_k_heads, head_dim, device=device, dtype=dtype)
+
+    # Precompute cos/sin cache
+    cos_cache, sin_cache = _precompute_cos_sin_cache(max_seq_len, head_dim, dtype=dtype)
+    cos_cache = cos_cache.to(device)
+    sin_cache = sin_cache.to(device)
+
+    # Random position IDs (not necessarily sequential)
+    position_ids = torch.randint(0, max_seq_len - seq_len, (batch_size,), device=device)
+    position_ids = position_ids.unsqueeze(1) + torch.arange(seq_len, device=device).unsqueeze(0)
+    # position_ids: [B, S]
+
+    # ========== PyTorch Reference ==========
+    # Step 1: Index cos/sin with position_ids
+    cos_indexed = cos_cache[position_ids]  # [B, S, D]
+    sin_indexed = sin_cache[position_ids]  # [B, S, D]
+
+    # Step 2: Apply PyTorch rope with qk interleaving
+    # unsqueeze_dim=2 for [B, S, H, D] layout
+    q_ref, k_ref = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
+        q, k, cos_indexed, sin_indexed, unsqueeze_dim=2
+    )
+
+    # ========== Triton Implementation ==========
+    q_triton, k_triton = torch.ops.auto_deploy.triton_rope_on_interleaved_qk_inputs(
+        q, k, cos_cache, sin_cache, position_ids
+    )
+
+    # ========== Compare Outputs ==========
+    # Use relative tolerance for bf16
+    atol = 1e-2
+    rtol = 1e-2
+
+    assert torch.allclose(q_ref, q_triton, atol=atol, rtol=rtol), (
+        f"Q mismatch: max diff = {(q_ref - q_triton).abs().max().item()}"
+    )
+    assert torch.allclose(k_ref, k_triton, atol=atol, rtol=rtol), (
+        f"K mismatch: max diff = {(k_ref - k_triton).abs().max().item()}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_triton_rope_interleaved_dtype_consistency(dtype):
+    """Test that the Triton kernel works correctly with different dtypes."""
+    device = "cuda"
+    batch_size, seq_len, num_heads, head_dim = 2, 8, 8, 64
+    max_seq_len = 1024
+
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+
+    cos_cache, sin_cache = _precompute_cos_sin_cache(max_seq_len, head_dim, dtype=dtype)
+    cos_cache = cos_cache.to(device)
+    sin_cache = sin_cache.to(device)
+
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    # PyTorch reference
+    cos_indexed = cos_cache[position_ids]
+    sin_indexed = sin_cache[position_ids]
+    q_ref, k_ref = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
+        q, k, cos_indexed, sin_indexed, unsqueeze_dim=2
+    )
+
+    # Triton
+    q_triton, k_triton = torch.ops.auto_deploy.triton_rope_on_interleaved_qk_inputs(
+        q, k, cos_cache, sin_cache, position_ids
+    )
+
+    # Verify outputs match
+    atol = 1e-2
+    rtol = 1e-2
+    assert torch.allclose(q_ref, q_triton, atol=atol, rtol=rtol)
+    assert torch.allclose(k_ref, k_triton, atol=atol, rtol=rtol)
+
+    # Verify output dtype is preserved
+    assert q_triton.dtype == dtype
+    assert k_triton.dtype == dtype


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fused RoPE operator and runtime kernel for interleaved query/key layouts, plus an optimizer path that replaces the original RoPE with this high-performance variant.

* **Tests**
  * Added unit tests validating correctness across batch/sequence sizes, head configurations (including MQA), and dtypes (FP16/BF16).

* **Documentation**
  * Documented the new fused interleaved Q/K RoPE operator in the custom-ops README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
