### PR TITLE
[#11146][feat] AutoDeploy: Add triton paged attention

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
@@ -21,16 +21,10 @@ This module provides various attention implementations and backends:
 - flashinfer_attention: FlashInfer-based optimized attention
 - triton_attention: Triton-based attention implementations
 - triton_attention_with_kv_cache: Triton attention with KV cache support
-- triton_attention_with_paged_kv_cache: Triton attention with paged KV cache
+- triton_paged_attention: Triton paged attention (two-stage flash-decode) with HND layout
+- triton_paged_attention_one_stage: Triton paged attention (single-stage) with HND layout
 - onnx_attention: Placeholder ops for ONNX export of attention mechanisms
-"""
 
-__all__ = [
-    "torch_attention",
-    "torch_backend_attention",
-    "flashinfer_attention",
-    "triton_attention",
-    "triton_attention_with_kv_cache",
-    "triton_attention_with_paged_kv_cache",
-    "onnx_attention",
-]
+All modules are auto-imported by the parent custom_ops/__init__.py via pkgutil.walk_packages,
+so no explicit imports are needed here.
+"""

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1,0 +1,971 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton Paged Attention
+
+This module provides a Triton-based paged attention implementation with:
+- Combined KV cache with HND layout: [num_blocks, 2, num_kv_heads, page_size, head_dim]
+- Context/prefill kernel with causal masking
+"""
+
+import math
+from typing import List, Literal, Optional, Tuple
+
+import flashinfer
+import torch
+import triton
+import triton.language as tl
+from torch._ops import OpOverloadPacket
+from torch._subclasses import FakeTensor
+from torch.fx import Node
+
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+from ...utils.logger import ad_logger
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    Constant,
+    KVPagedResourceHandler,
+    MHACallable,
+    PrepareMetadataCallable,
+    ResourceHandlerDict,
+)
+
+KV_LAYOUT: Literal["HND", "NHD"] = "HND"
+
+
+def _get_sm_scale(head_dim: int, scale: Optional[float]) -> float:
+    """Get softmax scale, computing default if not provided."""
+    return scale if scale is not None else 1.0 / math.sqrt(head_dim)
+
+
+@triton.jit
+def _update_paged_kv_cache_kernel(
+    # Input K, V
+    k_ptr,
+    v_ptr,
+    # Metadata
+    batch_indices_ptr,
+    positions_ptr,
+    # KV cache
+    kv_cache_ptr,
+    # Page table
+    kv_indices_ptr,
+    kv_indptr_ptr,
+    # Constants
+    NUM_TOKENS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    # Strides for kv_cache: [num_blocks, 2, num_kv_heads, page_size, head_dim]
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+):
+    """Update combined KV cache with new tokens."""
+    token_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+
+    if token_id >= NUM_TOKENS:
+        return
+
+    batch_idx = tl.load(batch_indices_ptr + token_id)
+    position = tl.load(positions_ptr + token_id)
+
+    page_idx_in_seq = position // PAGE_SIZE
+    offset_in_page = position % PAGE_SIZE
+
+    page_start = tl.load(kv_indptr_ptr + batch_idx)
+    physical_page = tl.load(kv_indices_ptr + page_start + page_idx_in_seq)
+
+    head_offsets = tl.arange(0, HEAD_DIM)
+    kv_offset = token_id * N_KV_HEADS * HEAD_DIM + head_id * HEAD_DIM + head_offsets
+
+    k = tl.load(k_ptr + kv_offset)
+    v = tl.load(v_ptr + kv_offset)
+
+    # Compute cache offset (use int64 to avoid overflow when physical_page * stride > 2^31)
+    cache_base = (
+        physical_page.to(tl.int64) * cache_stride_block
+        + head_id * cache_stride_head
+        + offset_in_page.to(tl.int64) * cache_stride_token
+        + head_offsets
+    )
+
+    tl.store(kv_cache_ptr + cache_base, k)
+    tl.store(kv_cache_ptr + cache_base + cache_stride_kv, v)
+
+
+def update_paged_kv_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_indices: torch.Tensor,
+    positions: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+) -> None:
+    """Update the combined paged KV cache with new K, V tensors."""
+    num_tokens, n_kv_heads, head_dim = k.shape
+    page_size = kv_cache.shape[3]
+
+    if num_tokens == 0:
+        return
+
+    grid = (num_tokens, n_kv_heads)
+    _update_paged_kv_cache_kernel[grid](
+        k,
+        v,
+        batch_indices,
+        positions,
+        kv_cache,
+        kv_indices,
+        kv_indptr,
+        NUM_TOKENS=num_tokens,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+        cache_stride_block=kv_cache.stride(0),
+        cache_stride_kv=kv_cache.stride(1),
+        cache_stride_head=kv_cache.stride(2),
+        cache_stride_token=kv_cache.stride(3),
+    )
+
+
+# =============================================================================
+# FLASH DECODE - HELPERS
+# =============================================================================
+
+
+def _get_num_splits(max_seq_len: int, batch_size: int, n_kv_heads: int, page_size: int) -> int:
+    """Compute optimal number of KV splits for FlashDecoding.
+
+    With GQA batching, the grid is (batch, n_kv_heads, num_splits).
+    We want enough blocks to saturate the GPU.
+    """
+    if max_seq_len <= 0:
+        return 1
+
+    num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+    existing_parallelism = batch_size * n_kv_heads
+
+    # Already enough parallelism
+    if existing_parallelism >= num_sms * 2:
+        return 1
+
+    # Target ~4 waves of thread blocks
+    target_blocks = num_sms * 4
+    num_splits = max(1, (target_blocks + existing_parallelism - 1) // existing_parallelism)
+
+    # Cap splits so each block has at least 2 pages of work.
+    # With fewer pages, the per-block overhead (Q load, accumulator init,
+    # partial_o/lse store, plus stage2 reduction cost) dominates the useful
+    # compute (page-loop iterations). 2 pages is a conservative lower bound
+    # to keep the overhead-to-work ratio acceptable.
+    max_pages = max_seq_len // page_size
+    max_splits = max(1, max_pages // 2)
+    num_splits = min(num_splits, max_splits)
+
+    # Round to next power of 2 for Triton compile caching
+    if num_splits > 1:
+        num_splits = 2 ** math.ceil(math.log2(num_splits))
+
+    return min(num_splits, 128)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=3),
+    ],
+    key=["HEAD_DIM", "PAGE_SIZE", "HEAD_RATIO"],
+)
+@triton.jit
+def _flash_decode_stage1_kernel(
+    # Query input
+    q_ptr,
+    # KV cache (combined)
+    kv_cache_ptr,
+    # Page table
+    kv_indices_ptr,
+    kv_indptr_ptr,
+    kv_last_page_len_ptr,
+    # Intermediate outputs
+    partial_o_ptr,
+    partial_lse_ptr,
+    # Q strides: [batch, n_heads, head_dim]
+    q_stride_batch: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    # Partial output strides: [batch, n_heads, num_splits, head_dim]
+    po_stride_batch: tl.constexpr,
+    po_stride_head: tl.constexpr,
+    po_stride_split: tl.constexpr,
+    # Partial LSE strides: [batch, n_heads, num_splits]
+    plse_stride_batch: tl.constexpr,
+    plse_stride_head: tl.constexpr,
+    plse_stride_split: tl.constexpr,
+    # Cache strides: [num_blocks, 2, n_kv_heads, page_size, head_dim]
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    HEAD_RATIO: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+):
+    """
+    Key optimizations:
+    - Loads KV once for HEAD_RATIO Q heads
+    - Iterates by page for contiguous memory access
+    - Splits KV sequence across blocks for GPU utilization
+    """
+    batch_id = tl.program_id(axis=0)
+    kv_head_id = tl.program_id(axis=1)
+    split_id = tl.program_id(axis=2)
+
+    # Get sequence info from page table
+    kv_page_start = tl.load(kv_indptr_ptr + batch_id)
+    kv_page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_pages = kv_page_end - kv_page_start
+    last_page_len = tl.load(kv_last_page_len_ptr + batch_id)
+
+    # Compute this split's page range (page-aligned splits)
+    pages_per_split = (num_pages + NUM_SPLITS - 1) // NUM_SPLITS
+    page_split_start = split_id * pages_per_split
+    page_split_end = tl.minimum(page_split_start + pages_per_split, num_pages)
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+    head_ids = kv_head_id * HEAD_RATIO + tl.arange(0, HEAD_RATIO)
+
+    # Handle inactive splits (beyond the sequence's pages)
+    if page_split_start >= num_pages:
+        # Store zeros + -inf LSE for all HEAD_RATIO Q heads
+        po_offsets = (
+            batch_id * po_stride_batch
+            + head_ids[:, None] * po_stride_head
+            + split_id * po_stride_split
+            + dhead_offsets[None, :]
+        )
+        tl.store(
+            partial_o_ptr + po_offsets,
+            tl.zeros([HEAD_RATIO, HEAD_DIM], dtype=tl.float32),
+        )
+        plse_offsets = (
+            batch_id * plse_stride_batch
+            + head_ids * plse_stride_head
+            + split_id * plse_stride_split
+        )
+        tl.store(
+            partial_lse_ptr + plse_offsets,
+            tl.zeros([HEAD_RATIO], dtype=tl.float32) + float("-inf"),
+        )
+        return
+
+    # Load Q for all HEAD_RATIO heads sharing this KV head: [HEAD_RATIO, HEAD_DIM]
+    q_offsets = (
+        batch_id * q_stride_batch + head_ids[:, None] * q_stride_head + dhead_offsets[None, :]
+    )
+    q_all = tl.load(q_ptr + q_offsets)  # [HEAD_RATIO, HEAD_DIM]
+
+    acc = tl.zeros([HEAD_RATIO, HEAD_DIM], dtype=tl.float32)
+    m_i = tl.zeros([HEAD_RATIO], dtype=tl.float32) + float("-inf")
+    l_i = tl.zeros([HEAD_RATIO], dtype=tl.float32)
+
+    num_pages_this_split = page_split_end - page_split_start
+    for local_page_idx in range(num_pages_this_split):
+        page_idx = page_split_start + local_page_idx
+        physical_page = tl.load(kv_indices_ptr + kv_page_start + page_idx)
+
+        # Determine valid tokens in this page
+        is_last_page_of_seq = page_idx == (num_pages - 1)
+        valid_tokens = tl.where(is_last_page_of_seq, last_page_len, PAGE_SIZE)
+
+        page_offsets = tl.arange(0, PAGE_SIZE)
+        page_mask = page_offsets < valid_tokens
+
+        # Compute cache offset (use int64 to avoid overflow when physical_page * stride > 2^31)
+        cache_base = (
+            physical_page.to(tl.int64) * cache_stride_block
+            + kv_head_id * cache_stride_head
+            + page_offsets[:, None] * cache_stride_token
+            + dhead_offsets[None, :]
+        )
+        page_mask_2d = page_mask[:, None]
+
+        k = tl.load(
+            kv_cache_ptr + cache_base, mask=page_mask_2d, other=0.0
+        )  # [PAGE_SIZE, HEAD_DIM]
+        v = tl.load(
+            kv_cache_ptr + cache_base + cache_stride_kv,
+            mask=page_mask_2d,
+            other=0.0,
+        )  # [PAGE_SIZE, HEAD_DIM]
+
+        # [HEAD_RATIO, HEAD_DIM] @ [HEAD_DIM, PAGE_SIZE] -> [HEAD_RATIO, PAGE_SIZE]
+        attn = tl.dot(q_all, tl.trans(k)) * SM_SCALE
+        attn = tl.where(page_mask[None, :], attn, float("-inf"))
+
+        # Online softmax update (vectorized over HEAD_RATIO)
+        m_ij = tl.max(attn, axis=1)  # [HEAD_RATIO]
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(attn - m_i_new[:, None])  # [HEAD_RATIO, PAGE_SIZE]
+
+        # [HEAD_RATIO, PAGE_SIZE] @ [PAGE_SIZE, HEAD_DIM] -> [HEAD_RATIO, HEAD_DIM]
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+
+    # Finalize: normalize and compute LSE
+    l_i_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    partial_o_val = acc / l_i_safe[:, None]  # [HEAD_RATIO, HEAD_DIM]
+    lse_val = m_i + tl.log(l_i_safe)  # [HEAD_RATIO]
+
+    # Store results for all HEAD_RATIO Q heads at once (2D store)
+    po_offsets = (
+        batch_id * po_stride_batch
+        + head_ids[:, None] * po_stride_head
+        + split_id * po_stride_split
+        + dhead_offsets[None, :]
+    )
+    tl.store(partial_o_ptr + po_offsets, partial_o_val)
+
+    plse_offsets = (
+        batch_id * plse_stride_batch + head_ids * plse_stride_head + split_id * plse_stride_split
+    )
+    tl.store(partial_lse_ptr + plse_offsets, lse_val)
+
+
+@triton.jit
+def _flash_decode_stage2_kernel(
+    # Partial results
+    partial_o_ptr,
+    partial_lse_ptr,
+    # Final output
+    o_ptr,
+    # Partial output strides: [batch, n_heads, num_splits, head_dim]
+    po_stride_batch: tl.constexpr,
+    po_stride_head: tl.constexpr,
+    po_stride_split: tl.constexpr,
+    # Partial LSE strides: [batch, n_heads, num_splits]
+    plse_stride_batch: tl.constexpr,
+    plse_stride_head: tl.constexpr,
+    plse_stride_split: tl.constexpr,
+    # Output strides: [batch, n_heads, head_dim]
+    o_stride_batch: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    # Constants
+    HEAD_DIM: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+):
+    """
+    Each program combines results from all splits for one (batch, head) pair.
+    """
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+
+    # Find global maximum LSE across splits for numerical stability
+    global_max_lse = float("-inf")
+    for split_id in range(NUM_SPLITS):
+        plse_offset = (
+            batch_id * plse_stride_batch + head_id * plse_stride_head + split_id * plse_stride_split
+        )
+        lse = tl.load(partial_lse_ptr + plse_offset)
+        global_max_lse = tl.maximum(global_max_lse, lse)
+
+    # Guard: if all splits had -inf LSE (empty sequence), output zeros
+    o_offset = batch_id * o_stride_batch + head_id * o_stride_head + dhead_offsets
+    if global_max_lse == float("-inf"):
+        tl.store(o_ptr + o_offset, tl.zeros([HEAD_DIM], dtype=tl.float32))
+        return
+
+    # Weighted combination: weight_i = exp(lse_i - global_max)
+    acc = tl.zeros([HEAD_DIM], dtype=tl.float32)
+    total_weight = 0.0
+
+    for split_id in range(NUM_SPLITS):
+        plse_offset = (
+            batch_id * plse_stride_batch + head_id * plse_stride_head + split_id * plse_stride_split
+        )
+        lse = tl.load(partial_lse_ptr + plse_offset)
+        weight = tl.exp(lse - global_max_lse)
+
+        po_base = batch_id * po_stride_batch + head_id * po_stride_head + split_id * po_stride_split
+        partial_o = tl.load(partial_o_ptr + po_base + dhead_offsets)
+
+        acc += weight * partial_o
+        total_weight += weight
+
+    # Normalize and store
+    total_weight = tl.where(total_weight == 0.0, 1.0, total_weight)
+    o = acc / total_weight
+    tl.store(o_ptr + o_offset, o)
+
+
+def triton_paged_decode(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Optimized paged decode with GQA batching + FlashDecoding + page-aligned iteration.
+
+    Args:
+        q: Query tensor [batch_size, n_heads, head_dim]
+        kv_cache: Combined cache [num_blocks, 2, n_kv_heads, page_size, head_dim]
+        kv_indices: Physical page indices (flattened)
+        kv_indptr: Cumulative page counts [batch_size + 1]
+        kv_last_page_len: Valid tokens in last page [batch_size]
+        sm_scale: Softmax scale factor
+        out: Optional output tensor [batch_size, n_heads, head_dim]
+
+    Returns:
+        Output tensor [batch_size, n_heads, head_dim]
+    """
+    batch_size, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
+    head_ratio = n_heads // n_kv_heads
+
+    max_pages = kv_indices.shape[0]
+    max_seq_len = max_pages * page_size
+
+    output = out if out is not None else torch.empty_like(q)
+
+    if batch_size == 0:
+        return output
+
+    num_splits = _get_num_splits(max_seq_len, batch_size, n_kv_heads, page_size)
+
+    # Allocate intermediate buffers for split-K
+    partial_o = torch.empty(
+        batch_size,
+        n_heads,
+        num_splits,
+        head_dim,
+        dtype=torch.float32,
+        device=q.device,
+    )
+    partial_lse = torch.empty(
+        batch_size,
+        n_heads,
+        num_splits,
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    # Stage 1: GQA-batched parallel KV processing
+    _flash_decode_stage1_kernel[(batch_size, n_kv_heads, num_splits)](
+        q,
+        kv_cache,
+        kv_indices,
+        kv_indptr,
+        kv_last_page_len,
+        partial_o,
+        partial_lse,
+        # Q strides
+        q.stride(0),
+        q.stride(1),
+        # Partial output strides
+        partial_o.stride(0),
+        partial_o.stride(1),
+        partial_o.stride(2),
+        # Partial LSE strides
+        partial_lse.stride(0),
+        partial_lse.stride(1),
+        partial_lse.stride(2),
+        # Cache strides
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        # Constants
+        SM_SCALE=sm_scale,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+        HEAD_RATIO=head_ratio,
+        NUM_SPLITS=num_splits,
+    )
+
+    # Stage 2: Combine partial results
+    _flash_decode_stage2_kernel[(batch_size, n_heads)](
+        partial_o,
+        partial_lse,
+        output,
+        # Partial output strides
+        partial_o.stride(0),
+        partial_o.stride(1),
+        partial_o.stride(2),
+        # Partial LSE strides
+        partial_lse.stride(0),
+        partial_lse.stride(1),
+        partial_lse.stride(2),
+        # Output strides
+        output.stride(0),
+        output.stride(1),
+        # Constants
+        HEAD_DIM=head_dim,
+        NUM_SPLITS=num_splits,
+    )
+
+    return output
+
+
+# =============================================================================
+# TRITON KERNELS - CONTEXT/PREFILL (page-aligned)
+# =============================================================================
+@triton.jit
+def _paged_context_kernel(
+    # Inputs
+    q_ptr,
+    kv_cache_ptr,
+    # Metadata
+    qo_indptr_ptr,
+    kv_indptr_ptr,
+    kv_indices_ptr,
+    kv_last_page_len_ptr,
+    seq_len_with_cache_ptr,
+    # Output
+    o_ptr,
+    # Strides
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    o_stride_token: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    Q_BLOCK: tl.constexpr,
+):
+    """Context/prefill attention with paged KV cache, causal masking, and page-aligned iteration.
+
+    Page-aligned iteration benefits over arbitrary KV_BLOCK:
+    - 1 scalar page table load per page
+    """
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    q_block_id = tl.program_id(axis=2)
+
+    HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS
+    kv_head_id = head_id // HEAD_RATIO
+
+    q_start = tl.load(qo_indptr_ptr + batch_id)
+    q_end = tl.load(qo_indptr_ptr + batch_id + 1)
+    q_len = q_end - q_start
+
+    kv_page_start = tl.load(kv_indptr_ptr + batch_id)
+    kv_page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_kv_pages = kv_page_end - kv_page_start
+    total_kv_len = tl.load(seq_len_with_cache_ptr + batch_id)
+
+    cache_len = total_kv_len - q_len
+
+    q_block_start = q_block_id * Q_BLOCK
+    q_offsets = q_block_start + tl.arange(0, Q_BLOCK)
+    q_mask = q_offsets < q_len
+
+    if tl.sum(q_mask.to(tl.int32)) == 0:
+        return
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+    q_load_offsets = (
+        (q_start + q_offsets[:, None]) * q_stride_token
+        + head_id * q_stride_head
+        + dhead_offsets[None, :]
+    )
+    q_load_mask = q_mask[:, None]
+    q = tl.load(q_ptr + q_load_offsets, mask=q_load_mask, other=0.0)
+
+    acc = tl.zeros([Q_BLOCK, HEAD_DIM], dtype=tl.float32)
+    m_i = tl.zeros([Q_BLOCK], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([Q_BLOCK], dtype=tl.float32)
+
+    page_offsets = tl.arange(0, PAGE_SIZE)
+
+    # Page-aligned iteration: one page per loop iteration
+    for page_idx in range(num_kv_pages):
+        # Single scalar page table load (vs vector load of KV_BLOCK entries)
+        physical_page = tl.load(kv_indices_ptr + kv_page_start + page_idx)
+
+        # Valid tokens in this page
+        kv_base_pos = page_idx * PAGE_SIZE
+        valid_tokens = tl.minimum(PAGE_SIZE, total_kv_len - kv_base_pos)
+        page_mask = page_offsets < valid_tokens
+
+        # Contiguous KV load: all tokens in a page are adjacent in memory
+        cache_base = (
+            physical_page.to(tl.int64) * cache_stride_block
+            + kv_head_id * cache_stride_head
+            + page_offsets[:, None] * cache_stride_token
+            + dhead_offsets[None, :]
+        )
+        page_mask_2d = page_mask[:, None]
+
+        k = tl.load(kv_cache_ptr + cache_base, mask=page_mask_2d, other=0.0)
+        v = tl.load(
+            kv_cache_ptr + cache_base + cache_stride_kv,
+            mask=page_mask_2d,
+            other=0.0,
+        )
+
+        # QK^T: [Q_BLOCK, HEAD_DIM] @ [HEAD_DIM, PAGE_SIZE] -> [Q_BLOCK, PAGE_SIZE]
+        qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+
+        # Causal mask: q_pos (in full sequence) >= kv_pos
+        q_positions = q_offsets[:, None] + cache_len
+        kv_positions = kv_base_pos + page_offsets[None, :]
+        causal_mask = q_positions >= kv_positions
+
+        full_mask = q_mask[:, None] & causal_mask & page_mask[None, :]
+        qk = tl.where(full_mask, qk, float("-inf"))
+
+        # Online softmax update
+        m_ij = tl.max(qk, axis=1)
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(qk - m_i_new[:, None])
+
+        # P@V: [Q_BLOCK, PAGE_SIZE] @ [PAGE_SIZE, HEAD_DIM] -> [Q_BLOCK, HEAD_DIM]
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+
+    l_i = tl.where(l_i == 0.0, 1.0, l_i)
+    o = acc / l_i[:, None]
+
+    o_store_offsets = (
+        (q_start + q_offsets[:, None]) * o_stride_token
+        + head_id * o_stride_head
+        + dhead_offsets[None, :]
+    )
+    tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
+
+
+def triton_paged_context(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Context/prefill attention with paged KV cache."""
+    total_tokens, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
+    num_seq = qo_indptr.shape[0] - 1
+
+    output = out if out is not None else torch.empty_like(q)
+
+    Q_BLOCK = 32
+
+    q_lens = qo_indptr[1:] - qo_indptr[:-1]
+    max_q_len = int(q_lens.max().item()) if num_seq > 0 else 0
+    num_q_blocks = (max_q_len + Q_BLOCK - 1) // Q_BLOCK
+
+    if num_seq == 0 or max_q_len == 0:
+        return output
+
+    grid = (num_seq, n_heads, num_q_blocks)
+
+    _paged_context_kernel[grid](
+        q,
+        kv_cache,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        seq_len_with_cache,
+        output,
+        q.stride(0),
+        q.stride(1),
+        output.stride(0),
+        output.stride(1),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        SM_SCALE=sm_scale,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+        Q_BLOCK=Q_BLOCK,
+    )
+
+    return output
+
+
+@torch.library.custom_op("auto_deploy::triton_paged_prepare_metadata", mutates_args=())
+def prepare_triton_paged_metadata(
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+) -> List[torch.Tensor]:
+    """Prepare metadata for Triton paged attention."""
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    num_tokens = num_prefill_tokens + num_decode
+
+    qo_indptr = cu_seqlen[: num_seq + 1]
+
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        qo_indptr, seq_len_with_cache[:num_seq], num_tokens
+    )
+
+    return batch_indices, positions
+
+
+@prepare_triton_paged_metadata.register_fake
+def prepare_triton_paged_metadata_fake(
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+):
+    num_tokens = position_ids.shape[0] * position_ids.shape[1]
+    return (
+        torch.empty(num_tokens, dtype=torch.int32, device=position_ids.device),
+        torch.empty(num_tokens, dtype=torch.int32, device=position_ids.device),
+    )
+
+
+@torch.library.custom_op("auto_deploy::triton_paged_mha_with_cache", mutates_args=())
+def triton_paged_mha_with_cache(
+    # Q, K, V
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    # STANDARD METADATA
+    batch_info_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    last_page_len_host: torch.Tensor,
+    seq_len_with_cache_host: torch.Tensor,
+    # EXTRA METADATA
+    triton_batch_indices: torch.Tensor,
+    triton_positions: torch.Tensor,
+    # CACHES - combined KV cache
+    kv_cache: torch.Tensor,
+    # CONSTANTS
+    scale: Optional[float],
+) -> torch.Tensor:
+    """Triton paged attention with mixed batch support."""
+    head_dim = kv_cache.shape[-1]
+    q_shape_og = q.shape
+    b, s = q_shape_og[:2]
+
+    q = q.reshape(b * s, -1, head_dim).contiguous()
+    k = k.reshape(b * s, -1, head_dim).contiguous()
+    v = v.reshape(b * s, -1, head_dim).contiguous()
+
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    num_total_tokens = num_prefill_tokens + num_decode
+
+    sm_scale = _get_sm_scale(head_dim, scale)
+
+    # Update KV cache with new tokens
+    update_paged_kv_cache(
+        k[:num_total_tokens],
+        v[:num_total_tokens],
+        triton_batch_indices[:num_total_tokens],
+        triton_positions[:num_total_tokens],
+        kv_cache,
+        cache_loc,
+        cu_num_pages[: num_seq + 1],
+    )
+
+    y = torch.empty_like(q)
+
+    # Process prefill tokens if any
+    if num_prefill > 0:
+        cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
+        seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
+        triton_paged_context(
+            q[:num_prefill_tokens],
+            kv_cache,
+            cu_seqlen,
+            cu_num_pages[: num_prefill + 1],
+            cache_loc,
+            last_page_len[:num_prefill],
+            seq_len_with_cache,
+            sm_scale,
+            out=y[:num_prefill_tokens],
+        )
+
+    # Process decode tokens if any
+    if num_decode > 0:
+        triton_paged_decode(
+            q[num_prefill_tokens:num_total_tokens],
+            kv_cache,
+            cache_loc,
+            cu_num_pages[num_prefill : num_seq + 1],
+            last_page_len[num_prefill:num_seq],
+            sm_scale,
+            out=y[num_prefill_tokens:num_total_tokens],
+        )
+
+    return y.view(q_shape_og)
+
+
+@triton_paged_mha_with_cache.register_fake
+def triton_paged_mha_with_cache_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    last_page_len_host: torch.Tensor,
+    seq_len_with_cache_host: torch.Tensor,
+    triton_batch_indices: torch.Tensor,
+    triton_positions: torch.Tensor,
+    kv_cache: torch.Tensor,
+    scale: Optional[float],
+) -> torch.Tensor:
+    return torch.empty_like(q.contiguous())
+
+
+@AttentionRegistry.register("triton_paged")
+class TritonPagedAttention(AttentionDescriptor):
+    """Descriptor for Triton Paged Attention backend.
+
+    Optimized with GQA head batching, FlashDecoding, and page-aligned iteration.
+    """
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        return 3
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_attention
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.triton_paged_mha_with_cache.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        return [
+            "batch_info_host",
+            "cu_seqlen_host",
+            "cu_num_pages",
+            "cu_num_pages_host",
+            "cache_loc",
+            "last_page_len",
+            "last_page_len_host",
+            "seq_len_with_cache_host",
+        ]
+
+    @classmethod
+    def get_prepare_extra_metadata_info(
+        cls, any_source_attn_node: Node
+    ) -> Tuple[Optional[PrepareMetadataCallable], int, List[Constant]]:
+        return (
+            torch.ops.auto_deploy.triton_paged_prepare_metadata.default,
+            2,
+            [],
+        )
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
+        num_kv_heads = k_fake.shape[2]
+        head_dim = k_fake.shape[3]
+
+        return {
+            "kv_cache": KVPagedResourceHandler(
+                num_kv_heads,
+                head_dim,
+                dtype=cls.resolve_cache_dtype(cache_config.dtype, k_fake.dtype),
+                kv_factor=2,
+                kv_layout=KV_LAYOUT,
+            )
+        }
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        layout = source_attn_node.kwargs.get("layout", None)
+        if (
+            layout is None
+            and len(source_attn_node.args) > 0
+            and isinstance(source_attn_node.args[-1], str)
+        ):
+            layout = source_attn_node.args[-1]
+        if layout != "bsnd":
+            raise RuntimeError(
+                f"Expected torch_attention layout='bsnd' but got {layout!r} "
+                f"for node: {source_attn_node.format_node()}"
+            )
+
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
+        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+            ad_logger.debug(
+                "Unsupported attention arguments for "
+                f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
+            )
+
+        if len(source_attn_node.args) > 6:
+            scale = source_attn_node.args[6]
+        else:
+            scale = source_attn_node.kwargs.get("scale", None)
+
+        if not (isinstance(scale, float) or scale is None):
+            ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
+            scale = None
+
+        return [scale]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention_one_stage.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention_one_stage.py
@@ -1,0 +1,890 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton Paged Attention
+
+This module provides a Triton-based paged attention implementation with:
+- Combined KV cache with HND layout: [num_blocks, 2, num_kv_heads, page_size, head_dim]
+- Context/prefill kernel with causal masking
+"""
+
+import math
+from typing import List, Literal, Optional, Tuple
+
+import flashinfer
+import torch
+import triton
+import triton.language as tl
+from torch._ops import OpOverloadPacket
+from torch._subclasses import FakeTensor
+from torch.fx import Node
+
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+from ...utils.logger import ad_logger
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    Constant,
+    KVPagedResourceHandler,
+    MHACallable,
+    PrepareMetadataCallable,
+    ResourceHandlerDict,
+)
+
+# =============================================================================
+# MODULE CONSTANTS
+# =============================================================================
+
+# KV cache layout: "HND" to match FlashInfer
+# Shape: [num_blocks, 2, num_kv_heads, page_size, head_dim]
+# Dimension 1: 0 = K, 1 = V
+KV_LAYOUT: Literal["HND", "NHD"] = "HND"
+
+
+def _get_sm_scale(head_dim: int, scale: Optional[float]) -> float:
+    """Get softmax scale, computing default if not provided."""
+    return scale if scale is not None else 1.0 / math.sqrt(head_dim)
+
+
+# =============================================================================
+# TRITON KERNELS - CACHE UPDATE
+# =============================================================================
+
+
+# TODO: add num_warps for auto-tuning?
+# TODO: what about Instead of 1 token per kernel instance, process multiple tokens together?
+@triton.jit
+def _update_paged_kv_cache_kernel(
+    # Input K, V
+    k_ptr,
+    v_ptr,
+    # Metadata
+    batch_indices_ptr,
+    positions_ptr,
+    # KV cache (combined)
+    kv_cache_ptr,
+    # Page table
+    kv_indices_ptr,
+    kv_indptr_ptr,
+    # Constants
+    NUM_TOKENS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    # Strides for kv_cache: [num_blocks, 2, num_kv_heads, page_size, head_dim]
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+):
+    """Update combined KV cache with new tokens.
+
+    Cache layout (HND): [num_blocks, 2, num_kv_heads, page_size, head_dim]
+    - Dimension 1: 0 = K, 1 = V
+    """
+    token_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+
+    if token_id >= NUM_TOKENS:
+        return
+
+    # Load metadata for the token
+    batch_idx = tl.load(batch_indices_ptr + token_id)
+    position = tl.load(positions_ptr + token_id)
+
+    # Compute page and offset within page
+    page_idx_in_seq = position // PAGE_SIZE
+    offset_in_page = position % PAGE_SIZE
+
+    # Get physical page from page table
+    page_start = tl.load(kv_indptr_ptr + batch_idx)
+    physical_page = tl.load(kv_indices_ptr + page_start + page_idx_in_seq)
+
+    # Load K, V for the token and head
+    head_offsets = tl.arange(0, HEAD_DIM)
+    kv_offset = token_id * N_KV_HEADS * HEAD_DIM + head_id * HEAD_DIM + head_offsets
+
+    k = tl.load(k_ptr + kv_offset)
+    v = tl.load(v_ptr + kv_offset)
+
+    # Compute cache offset (use int64 to avoid overflow when physical_page * stride > 2^31)
+    cache_base = (
+        physical_page.to(tl.int64) * cache_stride_block
+        + head_id * cache_stride_head
+        + offset_in_page.to(tl.int64) * cache_stride_token
+        + head_offsets
+    )
+
+    # Store K (kv_idx=0) and V (kv_idx=1)
+    tl.store(kv_cache_ptr + cache_base, k)
+    tl.store(kv_cache_ptr + cache_base + cache_stride_kv, v)
+
+
+def update_paged_kv_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_indices: torch.Tensor,
+    positions: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+) -> None:
+    """Update the combined paged KV cache with new K, V tensors.
+
+    Args:
+        k: Key tensor [num_tokens, n_kv_heads, head_dim]
+        v: Value tensor [num_tokens, n_kv_heads, head_dim]
+        batch_indices: Batch index for each token [num_tokens]
+        positions: Position in sequence for each token [num_tokens]
+        kv_cache: Combined cache [num_blocks, 2, n_kv_heads, page_size, head_dim]
+        kv_indices: Physical page indices (flattened)
+        kv_indptr: Cumulative page counts per sequence [num_seq + 1]
+    """
+    num_tokens, n_kv_heads, head_dim = k.shape
+    page_size = kv_cache.shape[3]
+
+    if num_tokens == 0:
+        return
+
+    grid = (num_tokens, n_kv_heads)
+
+    _update_paged_kv_cache_kernel[grid](
+        k,
+        v,
+        batch_indices,
+        positions,
+        kv_cache,
+        kv_indices,
+        kv_indptr,
+        NUM_TOKENS=num_tokens,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+        cache_stride_block=kv_cache.stride(0),
+        cache_stride_kv=kv_cache.stride(1),
+        cache_stride_head=kv_cache.stride(2),
+        cache_stride_token=kv_cache.stride(3),
+    )
+
+
+# =============================================================================
+# TRITON KERNELS - SINGLE-STAGE DECODE
+# =============================================================================
+# TODO(perf): Consider FlashDecoding-style two-phase approach for both decode and context:
+#             Phase 1: Parallelize across KV blocks (each computes local_max, local_sum, local_acc)
+#             Phase 2: Reduction kernel to combine results with max corrections.
+#             This enables parallelism over the KV sequence dimension for long sequences.
+@triton.autotune(
+    configs=[
+        triton.Config({"SEQ_BLOCK_SIZE": 32}, num_warps=4, num_stages=2),
+        triton.Config({"SEQ_BLOCK_SIZE": 64}, num_warps=4, num_stages=3),
+        triton.Config({"SEQ_BLOCK_SIZE": 128}, num_warps=8, num_stages=3),
+        triton.Config({"SEQ_BLOCK_SIZE": 256}, num_warps=8, num_stages=4),
+    ],
+    key=["HEAD_DIM", "MAX_SEQ_LEN", "PAGE_SIZE"],
+)
+@triton.jit
+def _single_stage_paged_decode_kernel(
+    # Query input
+    q_ptr,
+    # KV cache (combined)
+    kv_cache_ptr,
+    # Page table
+    kv_indices_ptr,
+    kv_indptr_ptr,
+    kv_last_page_len_ptr,
+    # Output
+    o_ptr,
+    # Strides
+    q_stride_batch: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    o_stride_batch: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    MAX_SEQ_LEN: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    SEQ_BLOCK_SIZE: tl.constexpr,
+):
+    """Single-stage paged decode with paged KV cache.
+
+    Grid: (batch_size, n_heads)
+    Each program processes one (batch, head) pair using online softmax.
+    """
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+
+    # GQA: Map query head to KV head
+    HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS
+    kv_head_id = head_id // HEAD_RATIO
+
+    # Get sequence length from page table
+    page_start = tl.load(kv_indptr_ptr + batch_id)
+    page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_pages = page_end - page_start
+    last_page_len = tl.load(kv_last_page_len_ptr + batch_id)
+    seq_len = (num_pages - 1) * PAGE_SIZE + last_page_len
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+
+    if seq_len <= 0:
+        # Zero output for empty sequence
+        o_offset = batch_id * o_stride_batch + head_id * o_stride_head + dhead_offsets
+        tl.store(o_ptr + o_offset, tl.zeros([HEAD_DIM], dtype=tl.float32))
+        return
+
+    # Load Q (stays in registers)
+    q_offset = batch_id * q_stride_batch + head_id * q_stride_head + dhead_offsets
+    q = tl.load(q_ptr + q_offset)
+
+    # Initialize online softmax accumulators
+    acc = tl.zeros([HEAD_DIM], dtype=tl.float32)
+    m_i = float("-inf")
+    l_i = 0.0
+
+    # Process KV in blocks
+    # TODO(perf): Iterate by page instead of by block to eliminate div/mod for page indexing.
+    #             Use page-aligned iteration: for page_idx in range(num_pages), then load
+    #             physical_page directly from page table. Handle last_page_len for partial pages.
+    num_blocks = (seq_len + SEQ_BLOCK_SIZE - 1) // SEQ_BLOCK_SIZE
+
+    for block_idx in range(num_blocks):
+        seq_start = block_idx * SEQ_BLOCK_SIZE
+        seq_offsets = seq_start + tl.arange(0, SEQ_BLOCK_SIZE)
+        seq_mask = seq_offsets < seq_len
+
+        # Compute page indices and offsets
+        page_idx_in_seq = seq_offsets // PAGE_SIZE
+        offset_in_page = seq_offsets % PAGE_SIZE
+
+        # Load physical page indices
+        physical_pages = tl.load(
+            kv_indices_ptr + page_start + page_idx_in_seq,
+            mask=seq_mask & (page_idx_in_seq < num_pages),
+            other=0,
+        )
+
+        # Compute cache offsets for K and V (int64 to avoid overflow)
+        cache_base = (
+            physical_pages[:, None].to(tl.int64) * cache_stride_block
+            + kv_head_id * cache_stride_head
+            + offset_in_page[:, None].to(tl.int64) * cache_stride_token
+            + dhead_offsets[None, :]
+        )
+
+        kv_mask = seq_mask[:, None]
+
+        # Load K and V
+        k = tl.load(kv_cache_ptr + cache_base, mask=kv_mask, other=0.0)
+        v = tl.load(kv_cache_ptr + cache_base + cache_stride_kv, mask=kv_mask, other=0.0)
+
+        # Compute attention scores
+        attn = tl.sum(q[None, :] * k, axis=1) * SM_SCALE
+        attn = tl.where(seq_mask, attn, float("-inf"))
+
+        # Online softmax update
+        m_ij = tl.max(attn, axis=0)
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(attn - m_i_new)
+
+        # Update accumulator
+        acc = acc * alpha + tl.sum(p[:, None] * v, axis=0)
+        l_i = l_i * alpha + tl.sum(p, axis=0)
+        m_i = m_i_new
+
+    # Finalize
+    l_i = tl.where(l_i == 0.0, 1.0, l_i)
+    o = acc / l_i
+
+    # Store output
+    o_offset = batch_id * o_stride_batch + head_id * o_stride_head + dhead_offsets
+    tl.store(o_ptr + o_offset, o)
+
+
+def triton_paged_decode(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Single-stage paged decode with paged KV cache.
+
+    Args:
+        q: Query tensor [batch_size, n_heads, head_dim]
+        kv_cache: Combined cache [num_blocks, 2, n_kv_heads, page_size, head_dim]
+        kv_indices: Physical page indices (flattened)
+        kv_indptr: Cumulative page counts [batch_size + 1]
+        kv_last_page_len: Valid tokens in last page [batch_size]
+        sm_scale: Softmax scale factor
+        out: Optional output tensor [batch_size, n_heads, head_dim]
+
+    Returns:
+        Output tensor [batch_size, n_heads, head_dim]
+    """
+    batch_size, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
+    max_pages = kv_indices.shape[0]
+    max_seq_len = max_pages * page_size
+
+    output = out if out is not None else torch.empty_like(q)
+
+    grid = (batch_size, n_heads)
+
+    _single_stage_paged_decode_kernel[grid](
+        q,
+        kv_cache,
+        kv_indices,
+        kv_indptr,
+        kv_last_page_len,
+        output,
+        q.stride(0),
+        q.stride(1),
+        output.stride(0),
+        output.stride(1),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        SM_SCALE=sm_scale,
+        MAX_SEQ_LEN=max_seq_len,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+    )
+
+    return output
+
+
+# =============================================================================
+# TRITON KERNELS - CONTEXT/PREFILL
+# =============================================================================
+
+
+# TODO: add auto-tuning? And consider tune the Q_BLOCK and KV_BLOCK?
+@triton.jit
+def _paged_context_kernel(
+    # Inputs
+    q_ptr,
+    kv_cache_ptr,
+    # Metadata
+    qo_indptr_ptr,
+    kv_indptr_ptr,
+    kv_indices_ptr,
+    kv_last_page_len_ptr,
+    seq_len_with_cache_ptr,
+    # Output
+    o_ptr,
+    # Strides
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    o_stride_token: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    Q_BLOCK: tl.constexpr,
+    KV_BLOCK: tl.constexpr,
+):
+    """Context/prefill attention with paged KV cache and causal masking.
+
+    Grid: (num_seq, n_heads, num_q_blocks)
+    """
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    q_block_id = tl.program_id(axis=2)
+
+    # GQA
+    HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS
+    kv_head_id = head_id // HEAD_RATIO
+
+    # Load metadata
+    q_start = tl.load(qo_indptr_ptr + batch_id)
+    q_end = tl.load(qo_indptr_ptr + batch_id + 1)
+    q_len = q_end - q_start
+
+    kv_page_start = tl.load(kv_indptr_ptr + batch_id)
+    kv_page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_kv_pages = kv_page_end - kv_page_start
+    total_kv_len = tl.load(seq_len_with_cache_ptr + batch_id)
+
+    cache_len = total_kv_len - q_len
+
+    # Q block range
+    q_block_start = q_block_id * Q_BLOCK
+    q_offsets = q_block_start + tl.arange(0, Q_BLOCK)
+    q_mask = q_offsets < q_len
+
+    if tl.sum(q_mask.to(tl.int32)) == 0:
+        return
+
+    # Load Q block
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+    q_load_offsets = (
+        (q_start + q_offsets[:, None]) * q_stride_token
+        + head_id * q_stride_head
+        + dhead_offsets[None, :]
+    )
+    q_load_mask = q_mask[:, None]
+    q = tl.load(q_ptr + q_load_offsets, mask=q_load_mask, other=0.0)
+
+    # Initialize accumulators
+    acc = tl.zeros([Q_BLOCK, HEAD_DIM], dtype=tl.float32)
+    m_i = tl.zeros([Q_BLOCK], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([Q_BLOCK], dtype=tl.float32)
+
+    # Loop over KV blocks
+    num_kv_blocks = (total_kv_len + KV_BLOCK - 1) // KV_BLOCK
+
+    # TODO: Instead of iterating by KV_BLOCK, iterate by page?
+    for kv_block_id in range(num_kv_blocks):
+        kv_block_start = kv_block_id * KV_BLOCK
+        kv_offsets = kv_block_start + tl.arange(0, KV_BLOCK)
+        kv_mask = kv_offsets < total_kv_len
+
+        # Map to physical pages
+        page_idx = kv_offsets // PAGE_SIZE
+        offset_in_page = kv_offsets % PAGE_SIZE
+
+        physical_pages = tl.load(
+            kv_indices_ptr + kv_page_start + page_idx,
+            mask=kv_mask & (page_idx < num_kv_pages),
+            other=0,
+        )
+
+        # Compute cache offsets (int64 to avoid overflow)
+        cache_offsets = (
+            physical_pages[:, None].to(tl.int64) * cache_stride_block
+            + kv_head_id * cache_stride_head
+            + offset_in_page[:, None].to(tl.int64) * cache_stride_token
+            + dhead_offsets[None, :]
+        )
+
+        kv_load_mask = kv_mask[:, None]
+
+        # Load K, V
+        k = tl.load(kv_cache_ptr + cache_offsets, mask=kv_load_mask, other=0.0)
+        v = tl.load(
+            kv_cache_ptr + cache_offsets + cache_stride_kv,
+            mask=kv_load_mask,
+            other=0.0,
+        )
+
+        # Compute QK^T
+        qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+
+        # Causal mask: q_pos + cache_len >= kv_pos
+        q_positions = q_offsets[:, None] + cache_len
+        kv_positions = kv_offsets[None, :]
+        causal_mask = q_positions >= kv_positions
+
+        # Combined mask
+        full_mask = q_mask[:, None] & causal_mask & kv_mask[None, :]
+        qk = tl.where(full_mask, qk, float("-inf"))
+
+        # Online softmax
+        m_ij = tl.max(qk, axis=1)
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(qk - m_i_new[:, None])
+
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+
+    # Finalize
+    l_i = tl.where(l_i == 0.0, 1.0, l_i)
+    o = acc / l_i[:, None]
+
+    # Store output
+    o_store_offsets = (
+        (q_start + q_offsets[:, None]) * o_stride_token
+        + head_id * o_stride_head
+        + dhead_offsets[None, :]
+    )
+    tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
+
+
+def triton_paged_context(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Context/prefill attention with paged KV cache.
+
+    Args:
+        q: Query tensor [total_tokens, n_heads, head_dim]
+        kv_cache: Combined cache [num_blocks, 2, n_kv_heads, page_size, head_dim]
+        qo_indptr: Cumulative token counts [num_seq + 1]
+        kv_indptr: Cumulative page counts [num_seq + 1]
+        kv_indices: Physical page indices
+        kv_last_page_len: Valid tokens in last page [num_seq]
+        seq_len_with_cache: Total sequence length including cache [num_seq]
+        sm_scale: Softmax scale
+        out: Optional output tensor [total_tokens, n_heads, head_dim]
+
+    Returns:
+        Output tensor [total_tokens, n_heads, head_dim]
+    """
+    total_tokens, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
+    num_seq = qo_indptr.shape[0] - 1
+
+    output = out if out is not None else torch.empty_like(q)
+
+    # TODO: make these configurable?
+    Q_BLOCK = 32
+    KV_BLOCK = 32
+
+    # Compute max q_len for grid sizing
+    q_lens = qo_indptr[1:] - qo_indptr[:-1]
+    max_q_len = int(q_lens.max().item()) if num_seq > 0 else 0
+    num_q_blocks = (max_q_len + Q_BLOCK - 1) // Q_BLOCK
+
+    if num_seq == 0 or max_q_len == 0:
+        return output
+
+    grid = (num_seq, n_heads, num_q_blocks)
+
+    _paged_context_kernel[grid](
+        q,
+        kv_cache,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        seq_len_with_cache,
+        output,
+        q.stride(0),
+        q.stride(1),
+        output.stride(0),
+        output.stride(1),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        SM_SCALE=sm_scale,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+        Q_BLOCK=Q_BLOCK,
+        KV_BLOCK=KV_BLOCK,
+    )
+
+    return output
+
+
+# =============================================================================
+# METADATA PREPARATION
+# =============================================================================
+
+
+@torch.library.custom_op("auto_deploy::triton_paged_one_stage_prepare_metadata", mutates_args=())
+def prepare_triton_paged_one_stage_metadata(
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+) -> List[torch.Tensor]:
+    """Prepare metadata for Triton paged attention.
+
+    Computes batch_indices and positions for cache updates.
+    """
+
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    num_tokens = num_prefill_tokens + num_decode
+
+    qo_indptr = cu_seqlen[: num_seq + 1]
+
+    # Use FlashInfer's optimized Triton kernel for batch indices and positions
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        qo_indptr, seq_len_with_cache[:num_seq], num_tokens
+    )
+
+    return batch_indices, positions
+
+
+@prepare_triton_paged_one_stage_metadata.register_fake
+def prepare_triton_paged_one_stage_metadata_fake(
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+):
+    num_tokens = position_ids.shape[0] * position_ids.shape[1]
+    return (
+        torch.empty(num_tokens, dtype=torch.int32, device=position_ids.device),
+        torch.empty(num_tokens, dtype=torch.int32, device=position_ids.device),
+    )
+
+
+@torch.library.custom_op("auto_deploy::triton_paged_one_stage_mha_with_cache", mutates_args=())
+def triton_paged_one_stage_mha_with_cache(
+    # Q, K, V
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    # STANDARD METADATA
+    batch_info_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    last_page_len_host: torch.Tensor,
+    seq_len_with_cache_host: torch.Tensor,
+    # EXTRA METADATA
+    triton_batch_indices: torch.Tensor,
+    triton_positions: torch.Tensor,
+    # CACHES - combined KV cache
+    kv_cache: torch.Tensor,
+    # CONSTANTS
+    scale: Optional[float],
+) -> torch.Tensor:
+    """Triton paged attention with mixed batch support.
+
+    Handles prefill, decode, or mixed batches by checking batch_info_host
+    and dispatching to the appropriate kernel.
+
+    Args:
+        q, k, v: Query, Key, Value tensors [batch, seq, heads, head_dim]
+        batch_info_host: [num_prefill, num_prefill_tokens, num_decode]
+        kv_cache: Combined cache [num_blocks, 2, n_kv_heads, page_size, head_dim]
+        scale: Softmax scale (default: 1/sqrt(head_dim))
+
+    Returns:
+        Attention output with same shape as q
+    """
+    # Extract shapes
+    head_dim = kv_cache.shape[-1]
+    q_shape_og = q.shape
+    b, s = q_shape_og[:2]
+
+    # Reshape to [total_tokens, heads, head_dim]
+    q = q.reshape(b * s, -1, head_dim).contiguous()
+    k = k.reshape(b * s, -1, head_dim).contiguous()
+    v = v.reshape(b * s, -1, head_dim).contiguous()
+
+    # Extract batch info
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    num_total_tokens = num_prefill_tokens + num_decode
+
+    sm_scale = _get_sm_scale(head_dim, scale)
+
+    # Update KV cache with new tokens
+    update_paged_kv_cache(
+        k[:num_total_tokens],
+        v[:num_total_tokens],
+        triton_batch_indices[:num_total_tokens],
+        triton_positions[:num_total_tokens],
+        kv_cache,
+        cache_loc,
+        cu_num_pages[: num_seq + 1],
+    )
+
+    # Allocate output tensor once
+    y = torch.empty_like(q)
+
+    # Process prefill tokens if any
+    if num_prefill > 0:
+        cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
+        seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
+        triton_paged_context(
+            q[:num_prefill_tokens],
+            kv_cache,
+            cu_seqlen,
+            cu_num_pages[: num_prefill + 1],
+            cache_loc,
+            last_page_len[:num_prefill],
+            seq_len_with_cache,
+            sm_scale,
+            out=y[:num_prefill_tokens],
+        )
+
+    # Process decode tokens if any
+    if num_decode > 0:
+        triton_paged_decode(
+            q[num_prefill_tokens:num_total_tokens],
+            kv_cache,
+            cache_loc,
+            cu_num_pages[num_prefill : num_seq + 1],
+            last_page_len[num_prefill:num_seq],
+            sm_scale,
+            out=y[num_prefill_tokens:num_total_tokens],
+        )
+
+    return y.view(q_shape_og)
+
+
+@triton_paged_one_stage_mha_with_cache.register_fake
+def triton_paged_one_stage_mha_with_cache_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    cache_loc: torch.Tensor,
+    last_page_len: torch.Tensor,
+    last_page_len_host: torch.Tensor,
+    seq_len_with_cache_host: torch.Tensor,
+    triton_batch_indices: torch.Tensor,
+    triton_positions: torch.Tensor,
+    kv_cache: torch.Tensor,
+    scale: Optional[float],
+) -> torch.Tensor:
+    return torch.empty_like(q.contiguous())
+
+
+# =============================================================================
+# DESCRIPTOR CLASS
+# =============================================================================
+
+
+@AttentionRegistry.register("triton_paged_one_stage")
+class TritonPagedAttentionOneStage(AttentionDescriptor):
+    """Descriptor for Triton Paged Attention backend."""
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        """Get the attention layout expected by the backend."""
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        """Get the number of qkv arguments expected by the source op."""
+        return 3
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        """Get the source attention op that we target for replacement."""
+        return torch.ops.auto_deploy.torch_attention
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.triton_paged_one_stage_mha_with_cache.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        """Standard metadata args - matching FlashInfer for consistency."""
+        return [
+            "batch_info_host",
+            "cu_seqlen_host",
+            "cu_num_pages",
+            "cu_num_pages_host",
+            "cache_loc",
+            "last_page_len",
+            "last_page_len_host",
+            "seq_len_with_cache_host",
+        ]
+
+    @classmethod
+    def get_prepare_extra_metadata_info(
+        cls, any_source_attn_node: Node
+    ) -> Tuple[Optional[PrepareMetadataCallable], int, List[Constant]]:
+        return (
+            torch.ops.auto_deploy.triton_paged_one_stage_prepare_metadata.default,
+            2,
+            [],
+        )
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        """Create paged resource handler for combined KV cache."""
+        k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
+        num_kv_heads = k_fake.shape[2]
+        head_dim = k_fake.shape[3]
+
+        return {
+            "kv_cache": KVPagedResourceHandler(
+                num_kv_heads,
+                head_dim,
+                dtype=cls.resolve_cache_dtype(cache_config.dtype, k_fake.dtype),
+                kv_factor=2,
+                kv_layout=KV_LAYOUT,
+            )
+        }
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        """Extract constants from the source attention node."""
+        # Sanity check: layout == "bsnd"
+        layout = source_attn_node.kwargs.get("layout", None)
+        if (
+            layout is None
+            and len(source_attn_node.args) > 0
+            and isinstance(source_attn_node.args[-1], str)
+        ):
+            layout = source_attn_node.args[-1]
+        if layout != "bsnd":
+            raise RuntimeError(
+                f"Expected torch_attention layout='bsnd' but got {layout!r} "
+                f"for node: {source_attn_node.format_node()}"
+            )
+
+        # Check other arguments
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
+        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+            ad_logger.debug(
+                "Unsupported attention arguments for "
+                f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
+            )
+
+        # Get scale
+        if len(source_attn_node.args) > 6:
+            scale = source_attn_node.args[6]
+        else:
+            scale = source_attn_node.kwargs.get("scale", None)
+
+        if not (isinstance(scale, float) or scale is None):
+            ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
+            scale = None
+
+        return [scale]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -1,0 +1,574 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Triton Paged Attention.
+
+Tests the Triton paged attention kernels and compares against FlashInfer for correctness.
+"""
+
+import math
+
+import pytest
+import torch
+
+# Skip all tests if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+
+def create_paged_kv_cache(
+    num_blocks: int,
+    page_size: int,
+    n_kv_heads: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.float16,
+    device: str = "cuda",
+) -> torch.Tensor:
+    """Create an empty paged KV cache with HND layout.
+
+    Shape: [num_blocks, 2, n_kv_heads, page_size, head_dim]
+    """
+    return torch.zeros(num_blocks, 2, n_kv_heads, page_size, head_dim, dtype=dtype, device=device)
+
+
+def create_page_table(
+    batch_size: int,
+    max_pages_per_seq: int,
+    num_blocks: int,
+    device: str = "cuda",
+) -> tuple:
+    """Create page table metadata.
+
+    Returns:
+        kv_indices: Flattened page indices
+        kv_indptr: Cumulative page counts [batch_size + 1]
+        kv_last_page_len: Valid tokens in last page [batch_size]
+    """
+    # Assign sequential pages to each sequence
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    all_indices = []
+
+    for i in range(batch_size):
+        num_pages = min(max_pages_per_seq, num_blocks - sum(kv_indptr[: i + 1].tolist()))
+        pages = list(range(int(kv_indptr[i].item()), int(kv_indptr[i].item()) + num_pages))
+        all_indices.extend(pages)
+        kv_indptr[i + 1] = kv_indptr[i] + num_pages
+
+    kv_indices = torch.tensor(all_indices, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    return kv_indices, kv_indptr, kv_last_page_len
+
+
+class TestTritonPagedDecodeKernel:
+    """Tests for the single-stage paged decode kernel."""
+
+    @pytest.mark.parametrize("batch_size", [1, 4, 8])
+    @pytest.mark.parametrize("n_heads,n_kv_heads", [(8, 8), (32, 8)])
+    @pytest.mark.parametrize("head_dim", [64, 128])
+    @pytest.mark.parametrize("seq_len", [64, 256, 512])
+    def test_decode_kernel_basic(
+        self, batch_size: int, n_heads: int, n_kv_heads: int, head_dim: int, seq_len: int
+    ):
+        """Test decode kernel produces valid output shapes and no NaNs."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_decode,
+        )
+
+        page_size = 16
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 10
+
+        # Create inputs
+        q = torch.randn(batch_size, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+
+        # Fill cache with random data
+        kv_cache.normal_()
+
+        # Create page table
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        kv_last_page_len = torch.full(
+            (batch_size,), seq_len % page_size or page_size, dtype=torch.int32, device="cuda"
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        # Run kernel
+        output = triton_paged_decode(q, kv_cache, kv_indices, kv_indptr, kv_last_page_len, sm_scale)
+
+        # Check output
+        assert output.shape == q.shape
+        assert not torch.isnan(output).any(), "Output contains NaN"
+        assert not torch.isinf(output).any(), "Output contains Inf"
+
+    def test_decode_kernel_vs_pytorch_reference(self):
+        """Test decode kernel against PyTorch SDPA reference."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_decode,
+            update_paged_kv_cache,
+        )
+
+        batch_size = 2
+        n_heads = 8
+        n_kv_heads = 8
+        head_dim = 64
+        seq_len = 32
+        page_size = 16
+
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 5
+
+        # Create Q for decode (single token per sequence)
+        q = torch.randn(batch_size, n_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        # Create K, V for the full sequence
+        k = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        v = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+
+        # Flatten for cache update
+        k_flat = k.reshape(batch_size * seq_len, n_kv_heads, head_dim)
+        v_flat = v.reshape(batch_size * seq_len, n_kv_heads, head_dim)
+
+        # Create metadata for cache update
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+
+        # Create page table
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        last_token_in_page = seq_len % page_size
+        kv_last_page_len = torch.full(
+            (batch_size,),
+            last_token_in_page if last_token_in_page > 0 else page_size,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        # Create and fill cache
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(
+            k_flat, v_flat, batch_indices, positions, kv_cache, kv_indices, kv_indptr
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        # Run Triton kernel
+        output_triton = triton_paged_decode(
+            q, kv_cache, kv_indices, kv_indptr, kv_last_page_len, sm_scale
+        )
+
+        # Compute PyTorch reference
+        # Q: [B, n_heads, head_dim] -> [B, n_heads, 1, head_dim]
+        # K: [B, seq_len, n_kv_heads, head_dim] -> [B, n_kv_heads, seq_len, head_dim]
+        # V: [B, seq_len, n_kv_heads, head_dim] -> [B, n_kv_heads, seq_len, head_dim]
+        q_ref = q.unsqueeze(2)  # [B, n_heads, 1, head_dim]
+        k_ref = k.transpose(1, 2)  # [B, n_kv_heads, seq_len, head_dim]
+        v_ref = v.transpose(1, 2)  # [B, n_kv_heads, seq_len, head_dim]
+
+        # Handle GQA by expanding K, V
+        head_ratio = n_heads // n_kv_heads
+        if head_ratio > 1:
+            k_ref = k_ref.repeat_interleave(head_ratio, dim=1)
+            v_ref = v_ref.repeat_interleave(head_ratio, dim=1)
+
+        output_ref = torch.nn.functional.scaled_dot_product_attention(
+            q_ref, k_ref, v_ref, scale=sm_scale, is_causal=False
+        )
+        output_ref = output_ref.squeeze(2)  # [B, n_heads, head_dim]
+
+        # Compare
+        torch.testing.assert_close(output_triton.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
+
+
+class TestTritonPagedContextKernel:
+    """Tests for the context/prefill kernel."""
+
+    @pytest.mark.parametrize("batch_size", [1, 2])
+    @pytest.mark.parametrize("seq_len", [32, 64, 128])
+    def test_context_kernel_basic(self, batch_size: int, seq_len: int):
+        """Test context kernel produces valid output."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context,
+            update_paged_kv_cache,
+        )
+
+        n_heads = 8
+        n_kv_heads = 8
+        head_dim = 64
+        page_size = 16
+
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 5
+        total_tokens = batch_size * seq_len
+
+        # Create inputs (flattened)
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        # Create metadata
+        qo_indptr = torch.arange(
+            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        )[: batch_size + 1]
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        last_token_in_page = seq_len % page_size
+        kv_last_page_len = torch.full(
+            (batch_size,),
+            last_token_in_page if last_token_in_page > 0 else page_size,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        seq_len_with_cache = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+
+        # Create batch_indices and positions for cache update
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+
+        # Create and fill cache
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        # Run kernel
+        output = triton_paged_context(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            seq_len_with_cache,
+            sm_scale,
+        )
+
+        # Check output
+        assert output.shape == q.shape
+        assert not torch.isnan(output).any(), "Output contains NaN"
+        assert not torch.isinf(output).any(), "Output contains Inf"
+
+
+class TestCacheUpdate:
+    """Tests for the KV cache update kernel."""
+
+    def test_cache_update_writes_correct_values(self):
+        """Test that cache update writes K, V to correct locations."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            update_paged_kv_cache,
+        )
+
+        batch_size = 2
+        seq_len = 8
+        n_kv_heads = 4
+        head_dim = 32
+        page_size = 4
+        num_blocks = 10
+
+        # Create K, V with known values
+        k = torch.arange(
+            batch_size * seq_len * n_kv_heads * head_dim, dtype=torch.float16, device="cuda"
+        ).reshape(batch_size * seq_len, n_kv_heads, head_dim)
+        v = k + 1000  # Offset to distinguish K from V
+
+        # Create metadata
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+
+        kv_indptr = torch.tensor([0, 2, 4], dtype=torch.int32, device="cuda")
+        kv_indices = torch.tensor([0, 1, 2, 3], dtype=torch.int32, device="cuda")
+
+        # Create empty cache
+        kv_cache = torch.zeros(
+            num_blocks, 2, n_kv_heads, page_size, head_dim, dtype=torch.float16, device="cuda"
+        )
+
+        # Run update
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        # Verify: check first token of sequence 0
+        # Token 0 should be at page 0, offset 0
+        expected_k = k[0]  # First token's K
+        actual_k = kv_cache[0, 0, :, 0, :]  # Page 0, K (idx 0), all heads, offset 0
+        torch.testing.assert_close(actual_k, expected_k)
+
+        expected_v = v[0]  # First token's V
+        actual_v = kv_cache[0, 1, :, 0, :]  # Page 0, V (idx 1), all heads, offset 0
+        torch.testing.assert_close(actual_v, expected_v)
+
+
+class TestFlashInferComparison:
+    """Tests comparing Triton implementation against FlashInfer."""
+
+    @pytest.mark.parametrize("batch_size", [1, 4])
+    @pytest.mark.parametrize("seq_len", [64, 128])
+    def test_decode_vs_flashinfer(self, batch_size: int, seq_len: int):
+        """Compare decode output against FlashInfer."""
+        import flashinfer
+
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_decode,
+            update_paged_kv_cache,
+        )
+
+        n_heads = 32
+        n_kv_heads = 8
+        head_dim = 128
+        page_size = 16
+
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 10
+
+        # Create shared K, V data
+        k = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        v = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+
+        # Query for decode
+        q = torch.randn(batch_size, n_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        # Page table metadata
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        last_token_in_page = seq_len % page_size
+        kv_last_page_len = torch.full(
+            (batch_size,),
+            last_token_in_page if last_token_in_page > 0 else page_size,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        # ===== Triton =====
+        kv_cache_triton = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        k_flat = k.reshape(batch_size * seq_len, n_kv_heads, head_dim)
+        v_flat = v.reshape(batch_size * seq_len, n_kv_heads, head_dim)
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+        update_paged_kv_cache(
+            k_flat, v_flat, batch_indices, positions, kv_cache_triton, kv_indices, kv_indptr
+        )
+        output_triton = triton_paged_decode(
+            q, kv_cache_triton, kv_indices, kv_indptr, kv_last_page_len, sm_scale
+        )
+
+        # ===== FlashInfer =====
+        kv_cache_fi = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        # Use FlashInfer's cache append
+        fi_batch_indices = batch_indices.clone()
+        fi_positions = positions.clone()
+        flashinfer.page.append_paged_kv_cache(
+            append_key=k_flat,
+            append_value=v_flat,
+            batch_indices=fi_batch_indices,
+            positions=fi_positions,
+            paged_kv_cache=kv_cache_fi,
+            kv_indices=kv_indices,
+            kv_indptr=kv_indptr,
+            kv_last_page_len=kv_last_page_len,
+            kv_layout="HND",
+        )
+
+        # Use FlashInfer decode
+        workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace, "HND", use_tensor_cores=True
+        )
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            page_size,
+            q_data_type=q.dtype,
+            kv_data_type=kv_cache_fi.dtype,
+            sm_scale=sm_scale,
+        )
+        output_fi = wrapper.run(q, kv_cache_fi)
+
+        # Compare
+        torch.testing.assert_close(output_triton.float(), output_fi.float(), rtol=1e-2, atol=1e-2)
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("flashinfer", reason="FlashInfer not installed"),
+        reason="FlashInfer not installed",
+    )
+    def test_prefill_vs_flashinfer(self):
+        """Compare prefill output against FlashInfer."""
+        import flashinfer
+
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context,
+            update_paged_kv_cache,
+        )
+
+        batch_size = 2
+        seq_len = 64
+        n_heads = 32
+        n_kv_heads = 8
+        head_dim = 128
+        page_size = 16
+
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 10
+        total_tokens = batch_size * seq_len
+
+        # Create inputs
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        # Metadata
+        qo_indptr = torch.arange(
+            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        )[: batch_size + 1]
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        last_token_in_page = seq_len % page_size
+        kv_last_page_len = torch.full(
+            (batch_size,),
+            last_token_in_page if last_token_in_page > 0 else page_size,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        seq_len_with_cache = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        # ===== Triton =====
+        kv_cache_triton = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(
+            k, v, batch_indices, positions, kv_cache_triton, kv_indices, kv_indptr
+        )
+        output_triton = triton_paged_context(
+            q,
+            kv_cache_triton,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            seq_len_with_cache,
+            sm_scale,
+        )
+
+        # ===== FlashInfer =====
+        kv_cache_fi = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        flashinfer.page.append_paged_kv_cache(
+            append_key=k,
+            append_value=v,
+            batch_indices=batch_indices.clone(),
+            positions=positions.clone(),
+            paged_kv_cache=kv_cache_fi,
+            kv_indices=kv_indices,
+            kv_indptr=kv_indptr,
+            kv_last_page_len=kv_last_page_len,
+            kv_layout="HND",
+        )
+
+        workspace = torch.empty(320 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, "HND")
+        wrapper.plan(
+            qo_indptr.cpu(),
+            kv_indptr.cpu(),
+            kv_indices,
+            kv_last_page_len.cpu(),
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            page_size,
+            causal=True,
+            q_data_type=q.dtype,
+            kv_data_type=kv_cache_fi.dtype,
+            sm_scale=sm_scale,
+            seq_lens=seq_len_with_cache.cpu(),
+        )
+        output_fi = wrapper.run(q, kv_cache_fi)
+
+        # Compare
+        torch.testing.assert_close(output_triton.float(), output_fi.float(), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
This is the part 1 to add the triton paged attention as the AutoDeploy attention backend. #11146 

The changes in this PR:
1. Add the two stage (Flash Attention Style) triton implementation for paged attention
2. Add a single stage triton implementation for paged attention (the perf for the single stage attention is not good but might be good for fast onboarding. We can delete this if the value is limited)
3. Add the related tests for two stage triton attention. 

The perf for Llama-3.1-8B-Instruct for triton_paged vs. flashinfer

<img width="2964" height="1764" alt="image" src="https://github.com/user-attachments/assets/a4ddf5c6-40fc-4f36-81f4-e624a3d4b853" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two Triton-based paged attention backends with KV cache support: a two-stage implementation with FlashDecoding and a one-stage implementation for efficient attention computation.

* **Tests**
  * Added comprehensive unit tests validating paged attention functionality across decode, context/prefill paths, and cache updates with comparisons against PyTorch and FlashInfer implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
