### PR TITLE
[TRTC-265][chore] Add CODEOWNERS coverage for serve/ and commands/ directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,6 +154,8 @@ docs/source/performance/perf-benchmarking.md @NVIDIA/trtllm-bench-reviewers
 ## TensorRT-LLM LLM API
 /tensorrt_llm/llmapi @NVIDIA/trt-llm-llmapi-devs
 /tensorrt_llm/executor @NVIDIA/trt-llm-llmapi-devs
+/tensorrt_llm/serve @NVIDIA/trt-llm-llmapi-devs
+/tensorrt_llm/commands @NVIDIA/trt-llm-llmapi-devs
 
 ## TensorRT-LLM LLM Disaggregated
 /examples/disaggregated @NVIDIA/trt-llm-disagg-devs @NVIDIA/trt-llm-doc-owners


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for internal development team organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add `trt-llm-llmapi-devs` as code owners for `/tensorrt_llm/serve/` and `/tensorrt_llm/commands/` directories, which previously had no broad CODEOWNERS coverage. Existing specific overrides (`commands/bench.py` → `trtllm-bench-reviewers`, `serve/openai_disagg_server.py` → `trt-llm-disagg-devs`) continue to take precedence via last-match-wins.

## Test Coverage

N/A — CODEOWNERS-only change, no code logic modified.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.