### PR TITLE
[None][feat] Integrate all reduce from flashinfer

### DIFF
--- a/tensorrt_llm/_torch/distributed/__init__.py
+++ b/tensorrt_llm/_torch/distributed/__init__.py
@@ -3,9 +3,9 @@ from tensorrt_llm.functional import AllReduceFusionOp
 from .communicator import Distributed, MPIDist, TorchDist
 from .moe_alltoall import MoeAlltoAll
 from .ops import (AllReduce, AllReduceParams, AllReduceStrategy,
-                  HelixAllToAllNative, MoEAllReduce, MoEAllReduceParams,
-                  allgather, alltoall_helix, cp_allgather, reducescatter,
-                  userbuffers_allreduce_finalize, FlashInferVLLMAllReduce)
+                  FlashInferVLLMAllReduce, HelixAllToAllNative, MoEAllReduce,
+                  MoEAllReduceParams, allgather, alltoall_helix, cp_allgather,
+                  reducescatter, userbuffers_allreduce_finalize)
 
 __all__ = [
     "allgather",
@@ -24,4 +24,5 @@ __all__ = [
     "TorchDist",
     "MPIDist",
     "Distributed",
+    "FlashInferVLLMAllReduce",
 ]

--- a/tensorrt_llm/_torch/distributed/__init__.py
+++ b/tensorrt_llm/_torch/distributed/__init__.py
@@ -5,7 +5,7 @@ from .moe_alltoall import MoeAlltoAll
 from .ops import (AllReduce, AllReduceParams, AllReduceStrategy,
                   HelixAllToAllNative, MoEAllReduce, MoEAllReduceParams,
                   allgather, alltoall_helix, cp_allgather, reducescatter,
-                  userbuffers_allreduce_finalize)
+                  userbuffers_allreduce_finalize, FlashInferVLLMAllReduce)
 
 __all__ = [
     "allgather",

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -21,6 +21,16 @@ from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
 
 _thread_local = threading.local()
 
+from ..flashinfer_utils import current_flashinfer_allreduce_workspace
+
+try:
+    import flashinfer.comm as flashinfer_comm
+except ImportError:
+    print(
+        "FlashInfer comm module not found. Follow readme to install Flashinfer >=2.8.0."
+    )
+    exit(1)
+
 
 def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
     if not hasattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}'):
@@ -959,3 +969,60 @@ class MoEAllReduce(nn.Module):
                 nranks=self.mapping.tp_size,
                 eps=all_reduce_params.eps,
             )
+
+
+class FlashInferVLLMAllReduce(nn.Module):
+
+    def __init__(self, mapping: Mapping, dtype: torch.dtype):
+        super().__init__()
+        self.mapping = mapping
+        self.dtype = dtype
+
+        self.reg_buffer_size = 8192 * 8192 * 2
+        self.workspace = current_flashinfer_allreduce_workspace()
+
+    def custom_all_reduce(self, input: torch.Tensor, registered: bool = False):
+        input_tensor = input.contiguous()
+        output_tensor = torch.empty_like(input_tensor)
+
+        try:
+            if registered:
+                flashinfer_comm.vllm_all_reduce(self.workspace.fa, input_tensor,
+                                                output_tensor, 0, 0, 36)
+            else:
+                flashinfer_comm.vllm_all_reduce(
+                    self.workspace.fa,
+                    input_tensor,
+                    output_tensor,
+                    self.workspace.buffer_ptrs_ipc.peer_ptrs[
+                        self.mapping.tp_rank],
+                    self.reg_buffer_size,
+                    36,  # CTA upper bounds: 36 as mentioned in the API
+                )
+        except Exception as e:
+            logger.error(f"FlashInferVLLMAllReduce failed: {e}")
+            raise
+
+        return output_tensor
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        *,
+        all_reduce_params: Optional[AllReduceParams] = None,
+    ) -> torch.Tensor:
+        """
+        Forward pass for vLLM custom AllReduce.
+        Args:
+            input (torch.Tensor): Input tensor to be reduced
+            all_reduce_params (Optional[AllReduceParams]): Parameters for fused operations
+        Returns:
+            torch.Tensor: Reduced tensor
+        """
+        if self.workspace._is_capturing:
+            if torch.cuda.is_current_stream_capturing():
+                return self.custom_all_reduce(input, registered=True)
+            else:
+                return torch.empty_like(input)
+        else:
+            return self.custom_all_reduce(input, registered=False)

--- a/tensorrt_llm/_torch/flashinfer_utils.py
+++ b/tensorrt_llm/_torch/flashinfer_utils.py
@@ -5,7 +5,7 @@ import traceback
 
 import torch
 
-from tensorrt_llm._ipc_utils import IpcMemory
+from tensorrt_llm._ipc_utils import IpcMemory, can_access_peer
 from tensorrt_llm._utils import mpi_comm
 from tensorrt_llm.mapping import Mapping
 
@@ -34,6 +34,8 @@ if platform.system() != "Windows":
             "flashinfer is not installed properly, please try pip install or building from source codes"
         )
 
+_MiB = 1024 * 1024
+
 
 class FlashInferAllReduceWorkspace:
 
@@ -45,22 +47,33 @@ class FlashInferAllReduceWorkspace:
 
         self.mapping = mapping
 
-        max_size = 8192 * 8192 * 2  # 2 bytes for bfloat16
-        logger.info(
-            f"Opening IPC memory for meta with size {flashinfer_comm.vllm_meta_size() + max_size}"
-        )
+        if mapping.tp_size not in (2, 4, 6, 8):
+            raise ValueError(
+                f"FlashInfer vLLM custom allreduce only supports tp_size in (2,4,6,8), "
+                f"got {mapping.tp_size}")
+
+        if not can_access_peer(mapping):
+            raise RuntimeError(
+                "FlashInfer vLLM custom allreduce requires NVLink peer access "
+                "between all TP ranks")
+
+        self.max_size = self._get_max_size()
+        meta_alloc_size = flashinfer_comm.vllm_meta_size() + self.max_size
+        logger.info(f"FlashInfer AR: meta_alloc={meta_alloc_size}, "
+                    f"buffer_alloc={self.max_size}, rank_data=8MB")
         try:
             self.meta_ptrs_ipc = IpcMemory(
                 mapping,
-                flashinfer_comm.vllm_meta_size() + max_size)
+                flashinfer_comm.vllm_meta_size() + self.max_size)
 
-            # Create rank data buffer (8MB as in test)
+            # Create rank data buffer. 8MB is for 131072 elements.
+            # Most models use < 10000 elements.
             self.rank_data = torch.empty(8 * 1024 * 1024,
                                          dtype=torch.uint8,
                                          device=f"cuda:{mapping.local_rank}")
 
             # Create buffer pointers for IPC communication
-            self.buffer_ptrs_ipc = IpcMemory(mapping, max_size)
+            self.buffer_ptrs_ipc = IpcMemory(mapping, self.max_size)
 
             # Initialize custom allreduce
             self.fa = flashinfer_comm.vllm_init_custom_ar(
@@ -81,6 +94,51 @@ class FlashInferAllReduceWorkspace:
             f"FlashInferAllReduceWorkspace initialized for rank {mapping.tp_rank}"
         )
 
+    def _get_max_size(self):
+        # Per-architecture max input sizes for custom allreduce.
+        # Keys are (SM major, SM minor).
+        # Values are dicts of {tp_size: max_bytes}.
+        # Based on empirical testing.
+        custom_ar_max_sizes = {
+            (8, 0): {
+                2: 8 * _MiB,
+                4: 8 * _MiB,
+                6: 8 * _MiB,
+                8: 8 * _MiB
+            },
+            (8, 9): {
+                2: 8 * _MiB,
+                4: 8 * _MiB,
+                6: 8 * _MiB,
+                8: 8 * _MiB
+            },
+            (9, 0): {
+                2: 8 * _MiB,
+                4: 8 * _MiB,
+                6: 4 * _MiB,
+                8: 4 * _MiB
+            },
+            (10, 0): {
+                2: 4 * _MiB,
+                4: 4 * _MiB,
+                6: 4 * _MiB,
+                8: 4 * _MiB
+            },
+        }
+
+        default_max_size = 8 * _MiB  # 8 MB — safe default for unknown architectures
+
+        if not torch.cuda.is_available():
+            return default_max_size
+
+        device = torch.device(f"cuda:{self.mapping.tp_rank}")
+        cap = torch.cuda.get_device_capability(device)
+        arch_sizes = custom_ar_max_sizes.get(cap)
+        if arch_sizes is not None and self.mapping.tp_size in arch_sizes:
+            size = arch_sizes[self.mapping.tp_size]
+            return min(size, default_max_size)
+        return default_max_size
+
     @contextlib.contextmanager
     def capture(self):
         try:
@@ -92,9 +150,12 @@ class FlashInferAllReduceWorkspace:
             self.register_graph_buffers()
 
     def register_graph_buffers(self):
-        # add error handling
-        handle, offsets = flashinfer_comm.vllm_get_graph_buffer_ipc_meta(
-            self.fa)
+        try:
+            handle, offsets = flashinfer_comm.vllm_get_graph_buffer_ipc_meta(
+                self.fa)
+        except Exception as e:
+            logger.error(f"Failed to get graph buffer IPC meta: {e}")
+            raise e
 
         world_size = self.mapping.tp_size
         tp_rank = self.mapping.tp_rank
@@ -121,11 +182,22 @@ flashinfer_allreduce_workspace = None
 
 def init_flashinfer_allreduce_workspace(mapping: Mapping):
     global flashinfer_allreduce_workspace
-    if flashinfer_allreduce_workspace is None:
+    if flashinfer_allreduce_workspace is None and IS_FLASHINFER_AVAILABLE:
         flashinfer_allreduce_workspace = FlashInferAllReduceWorkspace(mapping)
 
 
-def current_flashinfer_allreduce_workspace():
+def get_current_flashinfer_allreduce_workspace(
+) -> FlashInferAllReduceWorkspace:
     global flashinfer_allreduce_workspace
     assert flashinfer_allreduce_workspace is not None, "You must call `init_flashinfer_allreduce_workspace` first"
     return flashinfer_allreduce_workspace
+
+
+def cleanup_flashinfer_allreduce_workspace():
+    global flashinfer_allreduce_workspace
+    if flashinfer_allreduce_workspace is not None and IS_FLASHINFER_AVAILABLE:
+        try:
+            flashinfer_comm.vllm_dispose(flashinfer_allreduce_workspace.fa)
+        except Exception as e:
+            logger.warning(f"Error disposing FlashInfer AR workspace: {e}")
+        flashinfer_allreduce_workspace = None

--- a/tensorrt_llm/_torch/flashinfer_utils.py
+++ b/tensorrt_llm/_torch/flashinfer_utils.py
@@ -1,6 +1,13 @@
+import contextlib
 import os
 import platform
 import traceback
+
+import torch
+
+from tensorrt_llm._ipc_utils import IpcMemory
+from tensorrt_llm._utils import mpi_comm
+from tensorrt_llm.mapping import Mapping
 
 from ..logger import logger
 
@@ -18,6 +25,7 @@ def get_env_enable_pdl():
 if platform.system() != "Windows":
     try:
         import flashinfer
+        import flashinfer.comm as flashinfer_comm
         logger.info(f"flashinfer is available: {flashinfer.__version__}")
         IS_FLASHINFER_AVAILABLE = True
     except ImportError:
@@ -25,3 +33,99 @@ if platform.system() != "Windows":
         print(
             "flashinfer is not installed properly, please try pip install or building from source codes"
         )
+
+
+class FlashInferAllReduceWorkspace:
+
+    def __init__(self, mapping: Mapping):
+        if not IS_FLASHINFER_AVAILABLE:
+            raise RuntimeError(
+                "flashinfer is not installed properly, please try pip install or building from source codes"
+            )
+
+        self.mapping = mapping
+
+        max_size = 8192 * 8192 * 2  # 2 bytes for bfloat16
+        logger.info(
+            f"Opening IPC memory for meta with size {flashinfer_comm.vllm_meta_size() + max_size}"
+        )
+        try:
+            self.meta_ptrs_ipc = IpcMemory(
+                mapping,
+                flashinfer_comm.vllm_meta_size() + max_size)
+
+            # Create rank data buffer (8MB as in test)
+            self.rank_data = torch.empty(8 * 1024 * 1024,
+                                         dtype=torch.uint8,
+                                         device=f"cuda:{mapping.local_rank}")
+
+            # Create buffer pointers for IPC communication
+            self.buffer_ptrs_ipc = IpcMemory(mapping, max_size)
+
+            # Initialize custom allreduce
+            self.fa = flashinfer_comm.vllm_init_custom_ar(
+                ipc_tensors=self.meta_ptrs_ipc.peer_ptrs,
+                rank_data=self.rank_data,
+                rank=mapping.tp_rank,
+                full_nvlink=True)
+
+            flashinfer_comm.vllm_register_buffer(self.fa,
+                                                 self.buffer_ptrs_ipc.peer_ptrs)
+        except Exception:
+            traceback.print_exc()
+            logger.error(f"Error initializing FlashInferAllReduceWorkspace")
+            raise
+
+        self._is_capturing = False
+        logger.info(
+            f"FlashInferAllReduceWorkspace initialized for rank {mapping.tp_rank}"
+        )
+
+    @contextlib.contextmanager
+    def capture(self):
+        try:
+            self._is_capturing = True
+            yield
+        finally:
+            self._is_capturing = False
+            # Register graph buffers after capture if not already done
+            self.register_graph_buffers()
+
+    def register_graph_buffers(self):
+        # add error handling
+        handle, offsets = flashinfer_comm.vllm_get_graph_buffer_ipc_meta(
+            self.fa)
+
+        world_size = self.mapping.tp_size
+        tp_rank = self.mapping.tp_rank
+
+        all_data = [[None, None] for _ in range(world_size)]
+        all_data[tp_rank] = [handle, offsets]
+
+        comm = mpi_comm().Split(
+            self.mapping.pp_rank * self.mapping.cp_size + self.mapping.cp_rank,
+            self.mapping.tp_rank)
+
+        for i in range(world_size):
+            all_data[i] = comm.bcast(all_data[i], i)
+
+        handles = [d[0] for d in all_data]
+        offsets_list = [d[1] for d in all_data]
+
+        flashinfer_comm.vllm_register_graph_buffers(self.fa, handles,
+                                                    offsets_list)
+
+
+flashinfer_allreduce_workspace = None
+
+
+def init_flashinfer_allreduce_workspace(mapping: Mapping):
+    global flashinfer_allreduce_workspace
+    if flashinfer_allreduce_workspace is None:
+        flashinfer_allreduce_workspace = FlashInferAllReduceWorkspace(mapping)
+
+
+def current_flashinfer_allreduce_workspace():
+    global flashinfer_allreduce_workspace
+    assert flashinfer_allreduce_workspace is not None, "You must call `init_flashinfer_allreduce_workspace` first"
+    return flashinfer_allreduce_workspace

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -66,6 +66,7 @@ class LMHead(Linear):
             gather_output=gather_output,
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
+            use_flashinfer_allreduce=False,
         )
 
         if tensor_parallel_mode == TensorParallelMode.ROW:

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -66,7 +66,6 @@ class LMHead(Linear):
             gather_output=gather_output,
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
-            use_flashinfer_allreduce=False,
         )
 
         if tensor_parallel_mode == TensorParallelMode.ROW:

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2352,6 +2352,7 @@ class Linear(nn.Module):
         disable_deep_gemm: bool = False,
         fused_weight_shard_indices_mapping: Optional[dict] = None,
         nvfp4_allowed_backends: Optional[List[str]] = None,
+        enable_gemm_allreduce_fusion: bool = True,
     ):
         """
         Args:

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2352,7 +2352,6 @@ class Linear(nn.Module):
         disable_deep_gemm: bool = False,
         fused_weight_shard_indices_mapping: Optional[dict] = None,
         nvfp4_allowed_backends: Optional[List[str]] = None,
-        use_flashinfer_allreduce: bool = True,
     ):
         """
         Args:
@@ -2362,7 +2361,7 @@ class Linear(nn.Module):
                 Valid backends: 'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'.
                 Configure via nvfp4_gemm_config.allowed_backends in extra_llm_api_options.yaml.
         """
-        from ..distributed import AllReduce, FlashInferVLLMAllReduce
+        from ..distributed import AllReduce
 
         super().__init__()
         self.has_bias = bias
@@ -2415,17 +2414,6 @@ class Linear(nn.Module):
         self.all_reduce = AllReduce(mapping=self.mapping,
                                     strategy=allreduce_strategy,
                                     dtype=self.dtype) if reduce_output else None
-
-        self.use_flashinfer_allreduce = use_flashinfer_allreduce
-        self.flashinfer_vllm = self.use_flashinfer_allreduce and os.getenv(
-            "_USE_FLASHINFER_VLLM_ALLREDUCE", "0") == "1"
-        self.flashinfer_token_threshold = int(
-            os.getenv("_FLASHINFER_TOKEN_THRESHOLD", "256"))
-
-        if self.flashinfer_vllm:
-            self.flash_infer_all_reduce = FlashInferVLLMAllReduce(
-                mapping=self.mapping,
-                dtype=self.dtype) if reduce_output else None
 
         self._weights_created = False
         self.reduce_output = reduce_output
@@ -2599,17 +2587,10 @@ class Linear(nn.Module):
                     bias = None if fuse_bias else bias
                     output = self.apply_linear(input, bias, lora_params,
                                                layer_idx)
-                    if self.flashinfer_vllm and output.size(
-                            0) <= self.flashinfer_token_threshold:
-                        output = self.flash_infer_all_reduce(
-                            output,
-                            all_reduce_params=None,
-                        )
-                    else:
-                        output = self.all_reduce(
-                            output,
-                            all_reduce_params=all_reduce_params,
-                        )
+                    output = self.all_reduce(
+                        output,
+                        all_reduce_params=all_reduce_params,
+                    )
             else:
                 output = self.apply_linear(input, bias, lora_params, layer_idx)
         elif self.tp_mode == TensorParallelMode.COLUMN:

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -79,6 +79,7 @@ class CUDAGraphRunnerConfig:
     dist: Optional[Distributed]
     kv_cache_manager_key: Any
     sparse_attention_config: Optional[BaseSparseAttentionConfig] = None
+    capture_flashinfer_allreduce_workspace: bool = False
 
 
 class CUDAGraphRunner:
@@ -344,12 +345,10 @@ class CUDAGraphRunner:
             return forward_fn(capture_inputs)
 
         def _maybe_add_flashinfer_allreduce_context():
-            #Use self.config here
-            import os
-            if os.getenv("_USE_FLASHINFER_VLLM_ALLREDUCE", "0") == "1":
+            if self.config.capture_flashinfer_allreduce_workspace:
                 from ..flashinfer_utils import \
-                    current_flashinfer_allreduce_workspace
-                return current_flashinfer_allreduce_workspace().capture()
+                    get_current_flashinfer_allreduce_workspace
+                return get_current_flashinfer_allreduce_workspace().capture()
             else:
                 return contextlib.nullcontext()
 

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -343,12 +343,23 @@ class CUDAGraphRunner:
                 capture_inputs['attn_metadata'].use_spec_decoding = True
             return forward_fn(capture_inputs)
 
+        def _maybe_add_flashinfer_allreduce_context():
+            #Use self.config here
+            import os
+            if os.getenv("_USE_FLASHINFER_VLLM_ALLREDUCE", "0") == "1":
+                from ..flashinfer_utils import \
+                    current_flashinfer_allreduce_workspace
+                return current_flashinfer_allreduce_workspace().capture()
+            else:
+                return contextlib.nullcontext()
+
         # We have to do warm up runs to initialize PyTorch's
         # internal states according to the docs:
         # https://pytorch.org/docs/stable/notes/cuda.html#cuda-graph-semantics
         # This also lets us initialize states in the attn_metadata.
         graph = torch.cuda.CUDAGraph()
-        with with_multi_stream(True), piecewise_cuda_graph(False):
+        with with_multi_stream(True), piecewise_cuda_graph(
+                False), _maybe_add_flashinfer_allreduce_context():
             for _ in range(self.WARMUP_STEPS):
                 _setup_spec_decoding_and_forward(key, forward_fn,
                                                  capture_inputs)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -39,6 +39,7 @@ from ..compilation.utils import capture_piecewise_cuda_graph
 from ..distributed import Distributed
 from ..distributed.communicator import init_pp_comm
 from ..expert_statistic import ExpertStatistic
+from ..flashinfer_utils import init_flashinfer_allreduce_workspace
 from ..memory_buffer_utils import with_shared_pool
 from ..metadata import KVCacheParams
 from ..models.modeling_multimodal_utils import filter_mm_token_from_input_ids
@@ -184,6 +185,11 @@ class PyTorchModelEngine(ModelEngine):
 
         self.attn_runtime_features = attn_runtime_features or AttentionRuntimeFeatures(
         )
+
+        self._enable_flashinfer_allreduce = False
+        if os.getenv("_USE_FLASHINFER_VLLM_ALLREDUCE", "0") == "1":
+            init_flashinfer_allreduce_workspace(mapping)
+            self._enable_flashinfer_allreduce = True
 
         self.input_processor = create_input_processor(
             model_path,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -40,8 +40,8 @@ from ..distributed import Distributed
 from ..distributed.communicator import init_pp_comm
 from ..expert_statistic import ExpertStatistic
 from ..flashinfer_utils import (IS_FLASHINFER_AVAILABLE,
-                                cleanup_flashinfer_allreduce_workspace,
-                                init_flashinfer_allreduce_workspace)
+                                init_flashinfer_allreduce_workspace,
+                                release_flashinfer_allreduce_workspace)
 from ..memory_buffer_utils import with_shared_pool
 from ..metadata import KVCacheParams
 from ..models.modeling_multimodal_utils import filter_mm_token_from_input_ids
@@ -195,9 +195,9 @@ class PyTorchModelEngine(ModelEngine):
                     "FlashInfer is not installed. Falling back to AUTO AllReduce strategy."
                 )
                 self.llm_args.allreduce_strategy = 'AUTO'
-                return
-            init_flashinfer_allreduce_workspace(mapping)
-            self._enable_flashinfer_allreduce = True
+            else:
+                init_flashinfer_allreduce_workspace(mapping)
+                self._enable_flashinfer_allreduce = True
 
         self.input_processor = create_input_processor(
             model_path,
@@ -1286,7 +1286,7 @@ class PyTorchModelEngine(ModelEngine):
 
         # Clean up FlashInfer AllReduce workspace (IPC memory + CUDA buffers)
         if self._enable_flashinfer_allreduce:
-            cleanup_flashinfer_allreduce_workspace()
+            release_flashinfer_allreduce_workspace()
 
         # Release model weights.
         release_gc()

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -3882,6 +3882,7 @@ class AllReduceStrategy(IntEnum):
     MNNVL = 7
     NCCL_SYMMETRIC = 8
     SYMM_MEM = 9  # PyTorch symmetric memory with MULTIMEM
+    FLASHINFER = 10  # Custom AR from FLASHINFER
 
 
 class AllReduceFusionOp(IntEnum):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2985,13 +2985,13 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
-    allreduce_strategy: Optional[Literal[
-        'AUTO', 'NCCL', 'UB', 'MINLATENCY', 'ONESHOT', 'TWOSHOT',
-        'LOWPRECISION', 'MNNVL',
-        'NCCL_SYMMETRIC']] = Field(default='AUTO',
-                                   description="Allreduce strategy to use.",
-                                   status="beta")
-
+    allreduce_strategy: Optional[
+        Literal['AUTO', 'NCCL', 'UB', 'MINLATENCY', 'ONESHOT', 'TWOSHOT',
+                'LOWPRECISION', 'MNNVL', 'NCCL_SYMMETRIC',
+                'FLASHINFER']] = Field(default='AUTO',
+                                       description="Allreduce strategy to use.",
+                                       status="beta")
+    
     checkpoint_loader: Optional[object] = Field(
         default=None,
         description=

--- a/tests/unittest/_torch/multi_gpu/test_flashinfer_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_flashinfer_allreduce.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import pickle
+import sys
+import traceback
+
+import cloudpickle
+import pytest
+import torch
+from mpi4py import MPI
+
+import tensorrt_llm
+from tensorrt_llm._torch.distributed import (
+    AllReduce,
+    AllReduceFusionOp,
+    AllReduceParams,
+    AllReduceStrategy,
+)
+from tensorrt_llm._torch.flashinfer_utils import (
+    IS_FLASHINFER_AVAILABLE,
+    FlashInferAllReduceWorkspace,
+    init_flashinfer_allreduce_workspace,
+)
+from tensorrt_llm.mapping import Mapping
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+MPI.pickle.__init__(
+    cloudpickle.dumps,
+    cloudpickle.loads,
+    pickle.HIGHEST_PROTOCOL,
+)
+
+# needed since we reuse the mpi executor pool, first test running will leak a thread
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+skip_no_flashinfer = pytest.mark.skipif(
+    not IS_FLASHINFER_AVAILABLE, reason="FlashInfer is not installed"
+)
+
+
+def _run_single_rank(tensor_parallel_size, worker_fn, *args):
+    rank = tensorrt_llm.mpi_rank()
+    torch.cuda.set_device(rank)
+    try:
+        return worker_fn(*args, tensor_parallel_size=tensor_parallel_size, rank=rank)
+    except Exception:
+        traceback.print_exc()
+        raise
+
+
+@torch.inference_mode()
+def _flashinfer_allreduce_worker(
+    x: torch.Tensor,
+    hidden_size: int,
+    dtype: torch.dtype,
+    *,
+    tensor_parallel_size: int,
+    rank: int,
+):
+    x = x.cuda()
+    mapping = Mapping(
+        world_size=tensor_parallel_size,
+        tp_size=tensor_parallel_size,
+        rank=rank,
+    )
+
+    # Initialize the workspace (idempotent — only first call creates it)
+    init_flashinfer_allreduce_workspace(mapping)
+
+    allreduce = AllReduce(
+        mapping=mapping,
+        strategy=AllReduceStrategy.FLASHINFER,
+        dtype=dtype,
+    ).cuda()
+
+    # Shard the input across TP ranks (simulates row-parallel linear output)
+    xs = torch.chunk(x.clone(), tensor_parallel_size, dim=-1)
+    shard = xs[rank]
+
+    # Run FlashInfer custom allreduce
+    output = allreduce(shard, all_reduce_params=AllReduceParams())
+
+    # Reference: NCCL allreduce
+    ref_allreduce = AllReduce(mapping=mapping, strategy=AllReduceStrategy.AUTO).cuda()
+    ref_output = ref_allreduce(shard, all_reduce_params=AllReduceParams())
+
+    torch.testing.assert_close(output, ref_output, rtol=1e-3, atol=1e-3)
+    return True
+
+
+@skip_no_flashinfer
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs")
+@pytest.mark.parametrize("seq_len", [1, 16, 128, 256], ids=lambda x: f"seqlen:{x}")
+@pytest.mark.parametrize("hidden_size", [4096, 8192], ids=lambda x: f"hidden:{x}")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=lambda x: f"dtype:{x}")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_flashinfer_allreduce_correctness(seq_len, hidden_size, dtype, mpi_pool_executor):
+    """Verify FlashInfer custom allreduce matches NCCL reference."""
+    torch.manual_seed(42)
+    tp = mpi_pool_executor.num_workers
+    x = torch.randn((seq_len, hidden_size), dtype=dtype)
+    results = mpi_pool_executor.map(
+        _run_single_rank,
+        *zip(*[(tp, _flashinfer_allreduce_worker, x, hidden_size, dtype)] * tp),
+    )
+    for r in results:
+        assert r is True
+
+
+@torch.inference_mode()
+def _flashinfer_fallback_worker(
+    x: torch.Tensor,
+    hidden_size: int,
+    dtype: torch.dtype,
+    *,
+    tensor_parallel_size: int,
+    rank: int,
+):
+    x = x.cuda()
+    mapping = Mapping(
+        world_size=tensor_parallel_size,
+        tp_size=tensor_parallel_size,
+        rank=rank,
+    )
+
+    init_flashinfer_allreduce_workspace(mapping)
+
+    allreduce = AllReduce(
+        mapping=mapping,
+        strategy=AllReduceStrategy.FLASHINFER,
+        dtype=dtype,
+    ).cuda()
+
+    xs = torch.chunk(x.clone(), tensor_parallel_size, dim=-1)
+    shard = xs[rank]
+
+    # This input is large enough to exceed the max_size buffer,
+    # so should_custom_ar returns False and it falls back to AUTO.
+    output = allreduce(shard, all_reduce_params=AllReduceParams())
+
+    # Reference
+    ref_allreduce = AllReduce(mapping=mapping, strategy=AllReduceStrategy.AUTO).cuda()
+    ref_output = ref_allreduce(shard, all_reduce_params=AllReduceParams())
+
+    torch.testing.assert_close(output, ref_output, rtol=1e-3, atol=1e-3)
+    return True
+
+
+@skip_no_flashinfer
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_flashinfer_allreduce_fallback_large_input(mpi_pool_executor):
+    """Verify large inputs fall back to AUTO without crashing."""
+    torch.manual_seed(42)
+    tp = mpi_pool_executor.num_workers
+    dtype = torch.bfloat16
+    # seq_len=8192, hidden=8192 => 8192*8192*2 = 128 MB >> max_size
+    # This guarantees should_custom_ar returns False
+    seq_len = 8192
+    hidden_size = 8192
+    x = torch.randn((seq_len, hidden_size), dtype=dtype)
+    results = mpi_pool_executor.map(
+        _run_single_rank,
+        *zip(*[(tp, _flashinfer_fallback_worker, x, hidden_size, dtype)] * tp),
+    )
+    for r in results:
+        assert r is True
+
+
+@skip_no_flashinfer
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for workspace init"
+)
+class TestShouldCustomAR:
+    """Unit tests for FlashInferVLLMAllReduce.should_custom_ar (logic only)."""
+
+    @staticmethod
+    def _make_module(tp_size=2):
+        """Create a FlashInferVLLMAllReduce for testing should_custom_ar logic."""
+        from tensorrt_llm._torch.distributed.ops import FlashInferVLLMAllReduce
+
+        mapping = Mapping(world_size=tp_size, tp_size=tp_size, rank=0)
+        init_flashinfer_allreduce_workspace(mapping)
+        return FlashInferVLLMAllReduce(mapping=mapping, dtype=torch.bfloat16)
+
+    def test_within_buffer(self):
+        mod = self._make_module()
+        # Small tensor that fits in buffer
+        inp = torch.randn(16, 4096, dtype=torch.bfloat16, device="cuda")
+        assert mod.should_custom_ar(inp) is True
+
+    def test_exceeds_buffer(self):
+        mod = self._make_module()
+        # Tensor larger than max_size
+        num_elements = (mod.reg_buffer_size // 2) + 1  # +1 element over limit
+        inp = torch.randn(num_elements, dtype=torch.bfloat16, device="cuda")
+        assert mod.should_custom_ar(inp) is False
+
+    def test_alignment_16_bytes(self):
+        mod = self._make_module()
+        # 5 bf16 elements = 10 bytes, not a multiple of 16
+        inp = torch.randn(5, dtype=torch.bfloat16, device="cuda")
+        assert mod.should_custom_ar(inp) is False
+
+    def test_alignment_passes(self):
+        mod = self._make_module()
+        # 8 bf16 elements = 16 bytes, multiple of 16
+        inp = torch.randn(8, dtype=torch.bfloat16, device="cuda")
+        assert mod.should_custom_ar(inp) is True
+
+    def test_non_contiguous(self):
+        mod = self._make_module()
+        inp = torch.randn(16, 4096, dtype=torch.bfloat16, device="cuda")
+        non_contig = inp[:, ::2]  # non-contiguous slice
+        assert not non_contig.is_contiguous()
+        assert mod.should_custom_ar(non_contig) is False
+
+    def test_unsupported_dtype_fp64(self):
+        mod = self._make_module()
+        inp = torch.randn(16, 4096, dtype=torch.float64, device="cuda")
+        assert mod.should_custom_ar(inp) is False
+
+    def test_unsupported_dtype_int(self):
+        mod = self._make_module()
+        inp = torch.randint(0, 100, (16, 4096), dtype=torch.int32, device="cuda")
+        assert mod.should_custom_ar(inp) is False
+
+    def test_supported_dtypes(self):
+        mod = self._make_module()
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            inp = torch.randn(8, 1024, dtype=dtype, device="cuda")
+            assert mod.should_custom_ar(inp) is True, f"Failed for {dtype}"
+
+    def test_fusion_op_not_none(self):
+        mod = self._make_module()
+        inp = torch.randn(16, 4096, dtype=torch.bfloat16, device="cuda")
+        params = AllReduceParams(
+            fusion_op=AllReduceFusionOp.RESIDUAL_RMS_NORM,
+            residual=torch.randn_like(inp),
+            norm_weight=torch.randn(4096, dtype=torch.bfloat16, device="cuda"),
+            eps=1e-5,
+        )
+        assert mod.should_custom_ar(inp, params) is False
+
+    def test_fusion_op_none_passes(self):
+        mod = self._make_module()
+        inp = torch.randn(16, 4096, dtype=torch.bfloat16, device="cuda")
+        params = AllReduceParams(fusion_op=AllReduceFusionOp.NONE)
+        assert mod.should_custom_ar(inp, params) is True
+
+
+@skip_no_flashinfer
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for workspace init"
+)
+class TestGetMaxSize:
+    """Unit tests for FlashInferAllReduceWorkspace._get_max_size."""
+
+    def _make_workspace(self, tp_size=2):
+        mapping = Mapping(world_size=tp_size, tp_size=tp_size, rank=0)
+        init_flashinfer_allreduce_workspace(mapping)
+        return FlashInferAllReduceWorkspace(mapping)
+
+    def test_max_size_is_positive(self):
+        ws = self._make_workspace()
+        assert ws.max_size > 0
+
+    def test_max_size_does_not_exceed_default(self):
+        ws = self._make_workspace()
+        default = 8 * 1024 * 1024  # 8 MiB
+        assert ws.max_size <= default
+
+    def test_max_size_is_power_of_two_aligned(self):
+        """max_size should be at least 256 KiB (smallest arch entry)."""
+        ws = self._make_workspace()
+        assert ws.max_size >= 256 * 1024


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced FlashInfer-based AllReduce implementation with IPC kernel support for distributed operations.
  * Added FLASHINFER as a new AllReduce strategy option with automatic fallback to existing methods.
  * Added configuration option to enable FlashInfer AllReduce in TorchLlmArgs.

* **Tests**
  * Added comprehensive multi-GPU test suite validating FlashInfer AllReduce correctness, fallback behavior, input constraints, and edge cases across multiple data types and sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Integrates all reduce from flashinfer. Improves output token throughput / GPU in the low-mid concurrency range for multiple SKUs across concurrencies ranging from 1 - 256 and TP sizes ranging from 2-8. 
- A100 SXM: ~10% 
- H100 SXM: 8%
- B200: TODO
Numbers above were collected on models with hidden size = 8192 (e.g. Llama3.3).

<!--

-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
