### PR TITLE
[#11440] [feat] AutoDeploy : Support Qwen3.5

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -3,6 +3,7 @@ compile_backend: torch-cudagraph
 max_seq_len: 4096
 max_num_tokens: 4096
 max_batch_size: 512
+world_size: 2
 enable_chunked_prefill: true
 model_factory: AutoModelForCausalLM
 kv_cache_config:
@@ -11,3 +12,7 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
+  # text_config:
+  #   num_hidden_layers: 6
+  # vision_config:
+  #   depth: 2

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -7,7 +7,7 @@ enable_chunked_prefill: true
 model_factory: AutoModelForCausalLM
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.7
+  free_gpu_memory_fraction: 0.95
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -1,0 +1,13 @@
+runtime: trtllm
+compile_backend: torch-cudagraph
+max_seq_len: 4096
+max_num_tokens: 4096
+max_batch_size: 512
+enable_chunked_prefill: true
+model_factory: AutoModelForCausalLM
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.7
+  tokens_per_block: 64
+model_kwargs:
+  torch_dtype: bfloat16

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -3,6 +3,7 @@ compile_backend: torch-cudagraph
 max_seq_len: 2048
 max_num_tokens: 2048
 max_batch_size: 512
+cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 world_size: 8
 enable_chunked_prefill: true
 model_factory: AutoModelForCausalLM
@@ -12,4 +13,6 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
-# skip_loading_weights: true
+transforms:
+  export_to_gm:
+    num_moe_experts_for_export: 2

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -2,7 +2,7 @@ runtime: trtllm
 compile_backend: torch-cudagraph
 max_seq_len: 2048
 max_num_tokens: 2048
-max_batch_size: 512
+max_batch_size: 64
 world_size: 8
 enable_chunked_prefill: true
 model_factory: AutoModelForCausalLM

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -12,3 +12,4 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
+# skip_loading_weights: true

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -2,7 +2,7 @@ runtime: trtllm
 compile_backend: torch-cudagraph
 max_seq_len: 2048
 max_num_tokens: 2048
-max_batch_size: 64
+max_batch_size: 512
 world_size: 8
 enable_chunked_prefill: true
 model_factory: AutoModelForCausalLM

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -1,0 +1,14 @@
+runtime: trtllm
+compile_backend: torch-cudagraph
+max_seq_len: 2048
+max_num_tokens: 2048
+max_batch_size: 512
+world_size: 8
+enable_chunked_prefill: true
+model_factory: AutoModelForCausalLM
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.95
+  tokens_per_block: 64
+model_kwargs:
+  torch_dtype: bfloat16

--- a/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
@@ -1,5 +1,6 @@
 runtime: trtllm
 compile_backend: torch-simple
+attn_backend: torch
 max_seq_len: 4096
 max_num_tokens: 4096
 max_batch_size: 64
@@ -14,3 +15,6 @@ kv_cache_config:
 model_kwargs:
   torch_dtype: bfloat16
   # num_hidden_layers: 6
+transforms:
+  export_to_gm:
+    num_moe_experts_for_export: 2

--- a/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
@@ -1,0 +1,15 @@
+runtime: trtllm
+compile_backend: torch-simple
+max_seq_len: 4096
+max_num_tokens: 4096
+max_batch_size: 64
+enable_chunked_prefill: true
+model_factory: AutoModelForCausalLM
+# disable_overlap_scheduler: false
+# cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.7
+  tokens_per_block: 64
+model_kwargs:
+  torch_dtype: bfloat16

--- a/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
@@ -1,6 +1,5 @@
 runtime: trtllm
 compile_backend: torch-simple
-attn_backend: torch
 max_seq_len: 4096
 max_num_tokens: 4096
 max_batch_size: 64

--- a/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3Next.yaml
@@ -1,5 +1,6 @@
 runtime: trtllm
 compile_backend: torch-simple
+attn_backend: torch
 max_seq_len: 4096
 max_num_tokens: 4096
 max_batch_size: 64
@@ -13,3 +14,4 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
+  # num_hidden_layers: 6

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -30,6 +30,8 @@ transforms:
     stage: pattern_matcher
   match_bmm_moe_pattern:
     stage: pattern_matcher
+  split_moe_fused_for_sharding:
+    stage: pattern_matcher
   match_repeat_kv:
     stage: pattern_matcher
     run_shape_prop: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -202,7 +202,7 @@ transforms:
     backend: fla_delta
   insert_cached_gated_delta_rule:
     stage: cache_init
-    backend: torch_gated_delta
+    backend: fla_gated_delta
     enabled: true
   insert_cached_residual_add:
     stage: cache_init

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -200,6 +200,10 @@ transforms:
   insert_cached_delta_rule:
     stage: cache_init
     backend: fla_delta
+  insert_cached_gated_delta_rule:
+    stage: cache_init
+    backend: torch_gated_delta
+    enabled: true
   insert_cached_residual_add:
     stage: cache_init
     backend: cached_residual_add

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -102,7 +102,7 @@ transforms:
     sharding_source: ['manual', 'factory', 'heuristic']
     support_partial_config: true
     sharding_dims: ['tp', 'ep', 'bmm']
-    shard_all_unprocessed: true
+    shard_all_unprocessed: false
     enable_attention_dp: false
     allreduce_strategy: 'NCCL'
     dist_backend: auto

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_gated_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_backend_gated_delta.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cached attention op for the gated delta rule using fla kernels.
+
+Gated Delta Rule is based on this paper: https://arxiv.org/abs/2412.06464
+
+Kernels are based on this repo: https://github.com/fla-org/flash-linear-attention
+"""
+
+from typing import List
+
+import torch
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from .....llmapi.llm_args import KvCacheConfig
+from ....modules.fla.chunk import chunk_gated_delta_rule
+from ....modules.fla.fused_recurrent import fused_recurrent_gated_delta_rule_fwd
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    Constant,
+    MHACallable,
+    ResourceHandlerDict,
+    StateResourceHandler,
+)
+
+
+@torch.library.custom_op("auto_deploy::fla_cached_gated_delta_rule", mutates_args=())
+def fla_cached_gated_delta_rule(
+    # INPUTS (dense but may be flattened across sequences)
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    # STANDARD METADATA
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
+    # CACHES
+    delta_cache: torch.Tensor,  # [max_batch_size, H, K, V]
+    # CONSTANTS
+    scale: float,
+) -> torch.Tensor:
+    b, s, num_heads, _ = q.shape
+
+    # flatten batch and sequence dims
+    q_flat = q.view(b * s, num_heads, -1)
+    k_flat = k.view(b * s, num_heads, -1)
+    v_flat = v.view(b * s, num_heads, -1)
+    g_flat = g.view(b * s, num_heads)
+    beta_flat = beta.view(b * s, num_heads)
+
+    # pre-allocate output
+    y = torch.empty_like(v, memory_format=torch.contiguous_format)
+    y_flat = y.view(b * s, num_heads, -1)
+
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+
+    # clean up metadata
+    cu_seqlen_prefill = cu_seqlen[: num_prefill + 1]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
+
+    if num_prefill > 0:
+        initial_states = None
+        if torch.any(use_initial_states[:num_prefill]):
+            initial_states = torch.where(
+                use_initial_states[:num_prefill, None, None, None],
+                delta_cache[slot_idx[:num_prefill]],
+                0,
+            )
+
+        y_prefill, final_state = chunk_gated_delta_rule(
+            q=q_flat[None, :num_prefill_tokens],
+            k=k_flat[None, :num_prefill_tokens],
+            v=v_flat[None, :num_prefill_tokens],
+            g=g_flat[None, :num_prefill_tokens],
+            beta=beta_flat[None, :num_prefill_tokens],
+            scale=scale,
+            initial_state=initial_states,
+            output_final_state=True,
+            cu_seqlens=cu_seqlen_prefill,
+        )
+
+        y_flat[None, :num_prefill_tokens] = y_prefill.to(y_flat.dtype)
+        delta_cache.index_copy_(0, slot_idx[:num_prefill], final_state.to(delta_cache.dtype))
+
+        del y_prefill, initial_states, final_state
+
+    if num_decode > 0:
+        # NOTE: avoiding state clone here and adopting the kernel to handle
+        # indexed initial states would give a boost
+        y_decode, final_state = fused_recurrent_gated_delta_rule_fwd(
+            q=q_flat[num_prefill_tokens:, None],
+            k=k_flat[num_prefill_tokens:, None],
+            v=v_flat[num_prefill_tokens:, None],
+            g=g_flat[num_prefill_tokens:, None],
+            beta=beta_flat[num_prefill_tokens:, None],
+            scale=scale,
+            initial_state=delta_cache[slot_idx[num_prefill:]].clone(),
+            output_final_state=True,
+        )
+
+        y_flat[num_prefill_tokens:, None] = y_decode.to(y_flat.dtype)
+        delta_cache.index_copy_(0, slot_idx[num_prefill:], final_state.to(delta_cache.dtype))
+
+        del y_decode, final_state
+
+    return y
+
+
+@fla_cached_gated_delta_rule.register_fake
+def fla_cached_gated_delta_rule_fake(
+    # INPUTS (dense but may be flattened across sequences)
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    # STANDARD METADATA
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # EXTRA METADATA
+    #
+    # CACHES
+    delta_cache: torch.Tensor,  # [max_batch_size, H, K, V]
+    # CONSTANTS
+    scale: float,
+) -> torch.Tensor:
+    return torch.empty_like(v)
+
+
+@AttentionRegistry.register("fla_gated_delta")
+class FlaGatedDeltaBackend(AttentionDescriptor):
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # q, k, v, g, beta
+        return 5
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_gated_delta_rule
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.fla_cached_gated_delta_rule.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info_host", "cu_seqlen", "slot_idx", "use_initial_states"]
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        key_node = source_attn_node.args[1]
+        value_node = source_attn_node.args[2]
+        num_heads = key_node.meta["val"].shape[-2]
+        key_dim = key_node.meta["val"].shape[-1]
+        value_dim = value_node.meta["val"].shape[-1]
+        key_dtype = key_node.meta["val"].dtype
+
+        return {
+            "delta_cache": StateResourceHandler(
+                num_heads,
+                key_dim,
+                value_dim,
+                # NOTE: not configurable at the moment, using auto to match the key dtype
+                dtype=cls.resolve_cache_dtype("auto", key_dtype),
+            )
+        }
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        scale = extract_op_args(source_attn_node, "scale")[0]
+        if scale is None:
+            key_node = source_attn_node.args[1]
+            key_dim = key_node.meta["val"].shape[-1]
+            scale = key_dim**-0.5
+        return [scale]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_gated_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/fla_gated_delta.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Torch reference implementation of the Gated Delta Rule for linear attention.
+
+The Gated Delta Rule extends the basic Delta Rule with an exponential decay gate `g`:
+  Basic:  S = S + k * (v - S*k) * beta
+  Gated:  S = S * exp(g) + k * (v - S*k) * beta
+
+This op is used by Qwen3Next's GatedDeltaNet layers.
+
+Reference:
+  - HF transformers v4.57.1 `torch_chunk_gated_delta_rule`:
+    https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L309-L397
+  - Gated Delta Networks paper: https://arxiv.org/abs/2412.06464
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+def _torch_chunk_gated_delta_rule_impl(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int = 64,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Pure-torch chunked gated delta rule computation.
+
+    Adapted from HF transformers v4.57.1 modeling_qwen3_next.py `torch_chunk_gated_delta_rule`.
+
+    Args:
+        query: [B, H, S, K] - query states (already l2-normalized externally)
+        key:   [B, H, S, K] - key states (already l2-normalized externally)
+        value: [B, H, S, V] - value states
+        g:     [B, H, S]    - gating/decay values (negative log-space)
+        beta:  [B, H, S]    - beta scaling values (sigmoid-activated)
+        chunk_size: chunk size for chunked processing
+        scale: optional scaling factor for queries (defaults to K^-0.5)
+
+    Returns:
+        output: [B, H, S, V]
+    """
+    initial_dtype = query.dtype
+    query, key, value = [x.contiguous().to(torch.float32) for x in (query, key, value)]
+    beta = beta.contiguous().to(torch.float32)
+    g = g.contiguous().to(torch.float32)
+
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+
+    if scale is None:
+        scale = 1.0 / (k_head_dim**0.5)
+    query = query * scale
+
+    # Pad sequence to be divisible by chunk_size
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+    total_sequence_length = sequence_length + pad_size
+
+    v_beta = value * beta.unsqueeze(-1)
+    k_beta = key * beta.unsqueeze(-1)
+
+    # Reshape to chunks: [B, H, num_chunks, chunk_size, D]
+    query, key, value, k_beta, v_beta = [
+        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
+        for x in (query, key, value, k_beta, v_beta)
+    ]
+    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
+    )
+
+    # Chunk decay
+    g = g.cumsum(dim=-1)
+    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+    for i in range(1, chunk_size):
+        row = attn[..., i, :i].clone()
+        sub = attn[..., :i, :i].clone()
+        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+    value = attn @ v_beta
+    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
+
+    last_recurrent_state = torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
+    core_attn_out = torch.zeros_like(value)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+    )
+
+    # Process each chunk recurrently
+    for i in range(0, total_sequence_length // chunk_size):
+        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
+        attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
+        v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
+        v_new = v_i - v_prime
+        attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
+        core_attn_out[:, :, i] = attn_inter + attn @ v_new
+        last_recurrent_state = (
+            last_recurrent_state * g[:, :, i, -1, None, None].exp()
+            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+        )
+
+    # Remove padding and reshape back
+    core_attn_out = core_attn_out.reshape(
+        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
+    )
+    core_attn_out = core_attn_out[:, :, :sequence_length]
+    return core_attn_out.to(initial_dtype)
+
+
+@torch.library.custom_op("auto_deploy::torch_gated_delta_rule", mutates_args=())
+def torch_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Gated Delta Rule custom op for linear attention (torch reference implementation).
+
+    All inputs use the autodeploy [B, S, H, D] (bsnd) layout convention.
+
+    Args:
+        q:    [B, S, H, K] - query states (should be l2-normalized before calling)
+        k:    [B, S, H, K] - key states (should be l2-normalized before calling)
+        v:    [B, S, H, V] - value states
+        g:    [B, S, H]    - gating/decay values
+        beta: [B, S, H]    - beta scaling values
+        scale: optional query scaling factor (defaults to K^-0.5)
+
+    Returns:
+        output: [B, S, H, V]
+    """
+    # Transpose from bsnd -> bhsd for internal computation
+    q_t = q.transpose(1, 2)
+    k_t = k.transpose(1, 2)
+    v_t = v.transpose(1, 2)
+    g_t = g.transpose(1, 2)
+    beta_t = beta.transpose(1, 2)
+
+    out = _torch_chunk_gated_delta_rule_impl(q_t, k_t, v_t, g_t, beta_t, scale=scale)
+
+    # Transpose back from bhsd -> bsnd
+    return out.transpose(1, 2).contiguous()
+
+
+@torch_gated_delta_rule.register_fake
+def torch_gated_delta_rule_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    return torch.empty_like(v)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/torch_backend_gated_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/torch_backend_gated_delta.py
@@ -153,7 +153,9 @@ def _torch_gated_delta_prefill(
 # ---------------------------------------------------------------------------
 
 
-@torch.library.custom_op("auto_deploy::torch_cached_gated_delta_rule", mutates_args=())
+@torch.library.custom_op(
+    "auto_deploy::torch_cached_gated_delta_rule", mutates_args=("delta_cache",)
+)
 def torch_cached_gated_delta_rule(
     # INPUTS (dense but may be flattened across sequences)
     q: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/torch_backend_gated_delta.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fla/torch_backend_gated_delta.py
@@ -1,0 +1,375 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-torch cached backend for the Gated Delta Rule.
+
+The Gated Delta Rule extends the basic Delta Rule with an exponential decay gate ``g``:
+  S = S * exp(g) + k * (v - S^T @ k) * beta
+
+This module provides:
+  - ``_torch_gated_delta_step``:   single-token recurrence (decode)
+  - ``_torch_gated_delta_prefill``: loop-based prefill over the sequence dimension
+  - ``torch_cached_gated_delta_rule``: cached custom op dispatching prefill / decode
+  - ``TorchGatedDeltaBackend``: AttentionDescriptor registered as ``"torch_gated_delta"``
+
+Reference:
+  - Gated Delta Networks paper: https://arxiv.org/abs/2412.06464
+"""
+
+from typing import List, Tuple
+
+import torch
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from .....llmapi.llm_args import KvCacheConfig
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    Constant,
+    MHACallable,
+    ResourceHandlerDict,
+    StateResourceHandler,
+)
+
+# ---------------------------------------------------------------------------
+# Core recurrence helpers
+# ---------------------------------------------------------------------------
+
+
+def _torch_gated_delta_step(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    state: torch.Tensor,
+    scale: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Single-token gated delta rule recurrence.
+
+    All computation is performed in float32 for numerical stability.
+
+    Args:
+        q:     [B, H, K]
+        k:     [B, H, K]
+        v:     [B, H, V]
+        g:     [B, H]          gating / decay values (negative, log-space)
+        beta:  [B, H]          beta scaling values
+        state: [B, H, K, V]    recurrent state
+        scale: query scaling factor
+
+    Returns:
+        output:    [B, H, V]
+        new_state: [B, H, K, V]
+    """
+    q = q.float()
+    k = k.float()
+    v = v.float()
+    g = g.float()
+    beta = beta.float()
+    state = state.float()
+
+    # Apply decay gate to state
+    state = state * torch.exp(g[..., None, None])  # [B, H, K, V]
+
+    # Delta update: v' = v - S^T @ k
+    v_prime = v - torch.einsum("bhk,bhkv->bhv", k, state)  # [B, H, V]
+    v_prime = v_prime * beta[..., None]  # [B, H, V]
+
+    # Update state: S = S + k outer v'
+    state = state + torch.einsum("bhk,bhv->bhkv", k, v_prime)  # [B, H, K, V]
+
+    # Output: o = (q * scale) @ S
+    output = torch.einsum("bhk,bhkv->bhv", q * scale, state)  # [B, H, V]
+
+    return output, state
+
+
+def _torch_gated_delta_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Loop-based prefill for the gated delta rule.
+
+    Iterates ``_torch_gated_delta_step`` over the sequence dimension.
+
+    Args:
+        q:     [B, S, H, K]  (bsnd layout)
+        k:     [B, S, H, K]
+        v:     [B, S, H, V]
+        g:     [B, S, H]
+        beta:  [B, S, H]
+        scale: query scaling factor
+        initial_state: [B, H, K, V]
+
+    Returns:
+        output:      [B, S, H, V]
+        final_state: [B, H, K, V]
+    """
+    B, S, H, V = v.shape
+    state = initial_state.float()
+    outputs = []
+
+    for t in range(S):
+        # Slice at time t from bsnd: q[:, t] gives [B, H, K]
+        o_t, state = _torch_gated_delta_step(
+            q[:, t],  # [B, H, K]
+            k[:, t],  # [B, H, K]
+            v[:, t],  # [B, H, V]
+            g[:, t],  # [B, H]
+            beta[:, t],  # [B, H]
+            state,  # [B, H, K, V]
+            scale,
+        )
+        outputs.append(o_t)  # [B, H, V]
+
+    # Stack along seq dim: [B, S, H, V]
+    output = torch.stack(outputs, dim=1)
+    return output, state
+
+
+# ---------------------------------------------------------------------------
+# Cached custom op
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_gated_delta_rule", mutates_args=())
+def torch_cached_gated_delta_rule(
+    # INPUTS (dense but may be flattened across sequences)
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    # STANDARD METADATA
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    # CACHES
+    delta_cache: torch.Tensor,  # [max_batch_size, H, K, V]
+    # CONSTANTS
+    scale: float,
+) -> torch.Tensor:
+    """Cached gated delta rule using pure-torch recurrence.
+
+    Handles mixed prefill + decode batches. Inputs use the autodeploy bsnd layout.
+
+    Args:
+        q:    [B, S, H, K]
+        k:    [B, S, H, K]
+        v:    [B, S, H, V]
+        g:    [B, S, H]
+        beta: [B, S, H]
+        batch_info_host: [num_prefill, num_prefill_tokens, num_decode] on host
+        cu_seqlen:       cumulative sequence lengths for prefill sequences
+        slot_idx:        per-sequence slot indices into delta_cache
+        use_initial_states: per-sequence bool (True if cache history exists)
+        delta_cache:     [max_slots, H, K, V] recurrent state cache
+        scale:           query scaling factor
+
+    Returns:
+        output: [B, S, H, V]
+    """
+    b, s, num_heads, _ = q.shape
+
+    # Pre-allocate output
+    y = torch.empty_like(v, memory_format=torch.contiguous_format)
+
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+
+    # Clean up metadata
+    cu_seqlen_prefill = cu_seqlen[: num_prefill + 1]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
+
+    # Flatten for indexing: [B*S, H, D]
+    q_flat = q.reshape(b * s, num_heads, -1)
+    k_flat = k.reshape(b * s, num_heads, -1)
+    v_flat = v.reshape(b * s, num_heads, -1)
+    g_flat = g.reshape(b * s, num_heads)
+    beta_flat = beta.reshape(b * s, num_heads)
+    y_flat = y.reshape(b * s, num_heads, -1)
+
+    key_dim = q.shape[-1]
+    value_dim = v.shape[-1]
+
+    # ---- PREFILL ----
+    if num_prefill > 0:
+        for seq_idx in range(num_prefill):
+            start = cu_seqlen_prefill[seq_idx].item()
+            end = cu_seqlen_prefill[seq_idx + 1].item()
+            slot = slot_idx[seq_idx]
+
+            # Gather per-sequence tensors: [1, seq_len, H, D]
+            q_seq = q_flat[start:end].unsqueeze(0)  # [1, S, H, K]
+            k_seq = k_flat[start:end].unsqueeze(0)  # [1, S, H, K]
+            v_seq = v_flat[start:end].unsqueeze(0)  # [1, S, H, V]
+            g_seq = g_flat[start:end].unsqueeze(0)  # [1, S, H]
+            beta_seq = beta_flat[start:end].unsqueeze(0)  # [1, S, H]
+
+            # Initial state for this sequence
+            if use_initial_states[seq_idx]:
+                init_state = delta_cache[slot].unsqueeze(0).clone()  # [1, H, K, V]
+            else:
+                init_state = torch.zeros(
+                    1,
+                    num_heads,
+                    key_dim,
+                    value_dim,
+                    dtype=torch.float32,
+                    device=q.device,
+                )
+
+            y_seq, final_state = _torch_gated_delta_prefill(
+                q_seq,
+                k_seq,
+                v_seq,
+                g_seq,
+                beta_seq,
+                scale,
+                init_state,
+            )
+
+            # Write output
+            y_flat[start:end] = y_seq.squeeze(0).to(y_flat.dtype)
+
+            # Write final state back to cache
+            delta_cache[slot] = final_state.squeeze(0).to(delta_cache.dtype)
+
+    # ---- DECODE ----
+    if num_decode > 0:
+        for i in range(num_decode):
+            token_idx = num_prefill_tokens + i
+            seq_idx = num_prefill + i
+            slot = slot_idx[seq_idx]
+
+            # Single token: [H, D]
+            q_tok = q_flat[token_idx]  # [H, K]
+            k_tok = k_flat[token_idx]  # [H, K]
+            v_tok = v_flat[token_idx]  # [H, V]
+            g_tok = g_flat[token_idx]  # [H]
+            beta_tok = beta_flat[token_idx]  # [H]
+
+            # Load state from cache
+            state = delta_cache[slot].unsqueeze(0).clone()  # [1, H, K, V]
+
+            o_tok, new_state = _torch_gated_delta_step(
+                q_tok.unsqueeze(0),  # [1, H, K]
+                k_tok.unsqueeze(0),  # [1, H, K]
+                v_tok.unsqueeze(0),  # [1, H, V]
+                g_tok.unsqueeze(0),  # [1, H]
+                beta_tok.unsqueeze(0),  # [1, H]
+                state,  # [1, H, K, V]
+                scale,
+            )
+
+            # Write output
+            y_flat[token_idx] = o_tok.squeeze(0).to(y_flat.dtype)
+
+            # Write state back to cache
+            delta_cache[slot] = new_state.squeeze(0).to(delta_cache.dtype)
+
+    return y
+
+
+@torch_cached_gated_delta_rule.register_fake
+def torch_cached_gated_delta_rule_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    delta_cache: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    return torch.empty_like(v)
+
+
+# ---------------------------------------------------------------------------
+# AttentionDescriptor backend
+# ---------------------------------------------------------------------------
+
+
+@AttentionRegistry.register("torch_gated_delta")
+class TorchGatedDeltaBackend(AttentionDescriptor):
+    """Pure-torch cached backend for the Gated Delta Rule.
+
+    Registered as ``"torch_gated_delta"`` in the AttentionRegistry.
+    """
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # q, k, v, g, beta
+        return 5
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_gated_delta_rule
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_cached_gated_delta_rule.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info_host", "cu_seqlen", "slot_idx", "use_initial_states"]
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        key_node = source_attn_node.args[1]
+        value_node = source_attn_node.args[2]
+        num_heads = key_node.meta["val"].shape[-2]
+        key_dim = key_node.meta["val"].shape[-1]
+        value_dim = value_node.meta["val"].shape[-1]
+
+        return {
+            "delta_cache": StateResourceHandler(
+                num_heads,
+                key_dim,
+                value_dim,
+                # NOTE: torch backend uses float32 cache to avoid bfloat16 quantization
+                # errors that accumulate across autoregressive decode steps.
+                dtype=torch.float32,
+            )
+        }
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        scale = extract_op_args(source_attn_node, "scale")[0]
+        if scale is None:
+            key_node = source_attn_node.args[1]
+            key_dim = key_node.meta["val"].shape[-1]
+            scale = key_dim**-0.5
+        return [scale]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/l2norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/l2norm.py
@@ -42,7 +42,7 @@ def _torch_l2norm_fake(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
 
 @torch.library.custom_op("auto_deploy::fla_l2norm", mutates_args=())
 def fla_l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    y = l2norm_fwd(x, eps)
+    y = l2norm_fwd(x.contiguous(), eps)
     return y
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/flashinfer_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/flashinfer_rope.py
@@ -56,14 +56,14 @@ def apply_rope_with_input_pos_flashinfer(
     position_ids = position_ids.view(-1).to(q.device).int()  # flashinfer requires int
     num_nnz = position_ids.shape[0]
 
-    q_flat = q.view(num_nnz, -1)
-    k_flat = k.view(num_nnz, -1)
+    q_flat = q.reshape(num_nnz, -1)
+    k_flat = k.reshape(num_nnz, -1)
 
     query_rotated_flash, key_rotated_flash = flashinfer.rope.apply_rope_with_cos_sin_cache(
         position_ids, q_flat, k_flat, head_dim, cos_sin_cache, is_neox=is_neox
     )
-    query_rotated_flash = query_rotated_flash.view(q_shape)
-    key_rotated_flash = key_rotated_flash.view(k_shape)
+    query_rotated_flash = query_rotated_flash.reshape(q_shape)
+    key_rotated_flash = key_rotated_flash.reshape(k_shape)
     return query_rotated_flash, key_rotated_flash
 
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -2,6 +2,7 @@ from .modeling_deepseek import DeepSeekV3ForCausalLM
 from .modeling_glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .modeling_nemotron_flash import NemotronFlashForCausalLM, NemotronFlashPreTrainedTokenizerFast
 from .modeling_nemotron_h import NemotronHForCausalLM
+from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM
 
 __all__ = (
     "DeepSeekV3ForCausalLM",
@@ -9,4 +10,5 @@ __all__ = (
     "NemotronFlashForCausalLM",
     "NemotronFlashPreTrainedTokenizerFast",
     "NemotronHForCausalLM",
+    "Qwen3_5MoeForCausalLM",
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -2,7 +2,7 @@ from .modeling_deepseek import DeepSeekV3ForCausalLM
 from .modeling_glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .modeling_nemotron_flash import NemotronFlashForCausalLM, NemotronFlashPreTrainedTokenizerFast
 from .modeling_nemotron_h import NemotronHForCausalLM
-from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM
+from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM, Qwen3_5MoeForConditionalGeneration
 
 __all__ = (
     "DeepSeekV3ForCausalLM",
@@ -11,4 +11,5 @@ __all__ = (
     "NemotronFlashPreTrainedTokenizerFast",
     "NemotronHForCausalLM",
     "Qwen3_5MoeForCausalLM",
+    "Qwen3_5MoeForConditionalGeneration",
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
-"""Slimmed-down, prefill-only Qwen3.5 MoE text model for auto_deploy.
+"""Qwen3.5 MoE model for auto_deploy (text + vision).
 
 Reference HF modeling file (not yet in a released transformers version):
   transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -10,18 +10,20 @@ This implementation differs from the HuggingFace original in the following ways:
     autodeploy custom ops.
   * Cache-related code paths have been removed (prefill-only).
   * Training-related code paths have been removed.
-  * Vision model components have been removed (text-only).
   * Unnecessary output fields have been removed.
   * The GatedDeltaNet forward is adapted from the Qwen3Next GDN patch
     (tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py).
   * The MoE forward is adapted from the Qwen3Next MoE patch.
+  * mRoPE cos/sin can be computed outside the export boundary (Option 3) and
+    passed in as ``position_embeddings`` to allow 3D spatial position IDs for
+    multimodal inputs without requiring the export graph to handle mRoPE internally.
 
 This allows us to have a "pytorch" native reference implementation decoupled from bugs and
 dependency issues in the source, while remaining weight-compatible with HF checkpoints.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -29,6 +31,7 @@ from torch import nn
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
+from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
@@ -728,23 +731,40 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        rope_cos: Optional[torch.Tensor] = None,
+        rope_sin: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[Tuple, Qwen3_5MoeOutput]:
+        """Forward pass.
+
+        There are three ways to provide position information (checked in order):
+
+        1. ``rope_cos`` + ``rope_sin``: separate tensors, each ``(B, S, rotary_dim)``.
+           Export-friendly -- each is a proper graph input with its own dynamic shape.
+        2. ``position_embeddings``: pre-computed ``(cos, sin)`` tuple. Convenient for
+           the multimodal wrapper calling at the plain-PyTorch level.
+        3. ``position_ids`` (or ``None``): standard 2D ``(B, S)`` or 3D ``(3, B, S)``
+           position IDs.  The internal ``rotary_emb`` computes cos/sin.  This is the
+           default text-only path.
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        # Compute position_ids for mRoPE (3, B, S)
-        if position_ids is None:
-            seq_len = inputs_embeds.shape[1]
-            position_ids = torch.arange(seq_len, device=inputs_embeds.device)
-            position_ids = position_ids.view(1, 1, -1).expand(3, inputs_embeds.shape[0], -1)
-        elif position_ids.ndim == 2:
-            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-
-        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
+        # Resolve position embeddings from one of the three input modes.
+        if rope_cos is not None and rope_sin is not None:
+            position_embeddings = (rope_cos, rope_sin)
+        elif position_embeddings is None:
+            if position_ids is None:
+                seq_len = inputs_embeds.shape[1]
+                position_ids = torch.arange(seq_len, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, 1, -1).expand(3, inputs_embeds.shape[0], -1)
+            elif position_ids.ndim == 2:
+                position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+            position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
 
         hidden_states = inputs_embeds
         for decoder_layer in self.layers:
@@ -785,12 +805,756 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         input_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        rope_cos: Optional[torch.Tensor] = None,
+        rope_sin: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[Tuple, Qwen3_5MoeCausalLMOutput]:
-        outputs = self.model(input_ids, inputs_embeds=inputs_embeds, position_ids=position_ids)
+        outputs = self.model(
+            input_ids,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            rope_cos=rope_cos,
+            rope_sin=rope_sin,
+        )
         hidden_states = outputs[0]
         logits = self.lm_head(hidden_states.to(self.lm_head.weight.dtype)).float()
         return Qwen3_5MoeCausalLMOutput(logits=logits)
+
+
+# =============================================================================
+# Vision Configuration
+# =============================================================================
+
+
+class Qwen3_5MoeVisionConfig(PretrainedConfig):
+    """Config class for the Qwen3.5 MoE vision tower.
+
+    Mirrors the upstream ``Qwen3_5MoeVisionConfig``.
+    """
+
+    model_type = "qwen3_5_moe_vision"
+
+    def __init__(
+        self,
+        depth: int = 27,
+        hidden_size: int = 1152,
+        hidden_act: str = "gelu_pytorch_tanh",
+        intermediate_size: int = 4304,
+        num_heads: int = 16,
+        in_channels: int = 3,
+        patch_size: int = 16,
+        spatial_merge_size: int = 2,
+        temporal_patch_size: int = 2,
+        out_hidden_size: int = 3584,
+        num_position_embeddings: int = 2304,
+        initializer_range: float = 0.02,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.depth = depth
+        self.hidden_size = hidden_size
+        self.hidden_act = hidden_act
+        self.intermediate_size = intermediate_size
+        self.num_heads = num_heads
+        self.in_channels = in_channels
+        self.patch_size = patch_size
+        self.spatial_merge_size = spatial_merge_size
+        self.temporal_patch_size = temporal_patch_size
+        self.out_hidden_size = out_hidden_size
+        self.num_position_embeddings = num_position_embeddings
+        self.initializer_range = initializer_range
+
+
+class Qwen3_5MoeConfig(PretrainedConfig):
+    """Composite config containing both text and vision configs.
+
+    Mirrors the upstream ``Qwen3_5MoeConfig``.
+    """
+
+    model_type = "qwen3_5_moe"
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        image_token_id: int = 248056,
+        video_token_id: int = 248057,
+        vision_start_token_id: int = 248053,
+        vision_end_token_id: int = 248054,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ):
+        if isinstance(vision_config, dict):
+            self.vision_config = Qwen3_5MoeVisionConfig(**vision_config)
+        elif vision_config is None:
+            self.vision_config = Qwen3_5MoeVisionConfig()
+        else:
+            self.vision_config = vision_config
+
+        if isinstance(text_config, dict):
+            self.text_config = Qwen3_5MoeTextConfig(**text_config)
+        elif text_config is None:
+            self.text_config = Qwen3_5MoeTextConfig()
+        else:
+            self.text_config = text_config
+
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+# =============================================================================
+# Vision Tower Components (plain PyTorch -- NOT exported)
+# =============================================================================
+
+
+class Qwen3_5MoeVisionRotaryEmbedding(nn.Module):
+    """Simple rotary embedding for the vision tower (not mRoPE)."""
+
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        freqs = torch.outer(seq, self.inv_freq)
+        return freqs
+
+
+def apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply RoPE to vision Q/K tensors. Layout: (seq, heads, dim)."""
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
+
+
+class Qwen3_5MoeVisionPatchEmbed(nn.Module):
+    """3D convolution patch embedding for images/videos."""
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+        self.embed_dim = config.hidden_size
+
+        kernel_size = [self.temporal_patch_size, self.patch_size, self.patch_size]
+        self.proj = nn.Conv3d(
+            self.in_channels, self.embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=True
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        target_dtype = self.proj.weight.dtype
+        hidden_states = hidden_states.view(
+            -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(-1, self.embed_dim)
+        return hidden_states
+
+
+class Qwen3_5MoeVisionMLP(nn.Module):
+    """Feed-forward network for vision blocks."""
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(self.intermediate_size, self.hidden_size, bias=True)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act_fn(self.linear_fc1(hidden_state)))
+
+
+class Qwen3_5MoeVisionAttention(nn.Module):
+    """Bidirectional attention for vision tokens with cu_seqlens support.
+
+    Uses either:
+      - Eager path: splits by sequence lengths, runs attention per chunk.
+      - (Future) Flash Attention: single call with cu_seqlens.
+
+    Always non-causal (is_causal=False).
+    """
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.dim = config.hidden_size
+        self.num_heads = config.num_heads
+        self.head_dim = self.dim // self.num_heads
+        self.qkv = nn.Linear(self.dim, self.dim * 3, bias=True)
+        self.proj = nn.Linear(self.dim, self.dim)
+        self.scaling = self.head_dim**-0.5
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        query_states, key_states, value_states = (
+            self.qkv(hidden_states)
+            .reshape(seq_length, 3, self.num_heads, -1)
+            .permute(1, 0, 2, 3)
+            .unbind(0)
+        )
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb_vision(query_states, key_states, cos, sin)
+
+        # Eager path: process each variable-length sequence separately
+        # Layout: (1, num_heads, seq_len, head_dim) per chunk
+        query_states = query_states.transpose(0, 1).unsqueeze(0)  # (1, H, S, D)
+        key_states = key_states.transpose(0, 1).unsqueeze(0)
+        value_states = value_states.transpose(0, 1).unsqueeze(0)
+
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        q_splits = torch.split(query_states, lengths, dim=2)
+        k_splits = torch.split(key_states, lengths, dim=2)
+        v_splits = torch.split(value_states, lengths, dim=2)
+
+        attn_outputs = []
+        for q, k, v in zip(q_splits, k_splits, v_splits):
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_outputs.append(torch.matmul(attn_weights, v))
+
+        attn_output = torch.cat(attn_outputs, dim=2)  # (1, H, total_S, D)
+        attn_output = attn_output.squeeze(0).transpose(0, 1)  # (S, H, D)
+        attn_output = attn_output.reshape(seq_length, -1).contiguous()
+        attn_output = self.proj(attn_output)
+        return attn_output
+
+
+class Qwen3_5MoeVisionBlock(nn.Module):
+    """Vision transformer block: LayerNorm -> Attention -> Residual -> LayerNorm -> MLP -> Residual."""
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.attn = Qwen3_5MoeVisionAttention(config=config)
+        self.mlp = Qwen3_5MoeVisionMLP(config=config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+        return hidden_states
+
+
+class Qwen3_5MoeVisionPatchMerger(nn.Module):
+    """Merges spatial_merge_size^2 patches into one token and projects to LLM hidden size."""
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.norm = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size)
+        self.act_fn = nn.GELU()
+        self.linear_fc2 = nn.Linear(self.hidden_size, config.out_hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm(x).view(-1, self.hidden_size)
+        x = self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+        return x
+
+
+class Qwen3_5MoeVisionModel(nn.Module):
+    """Complete vision tower: PatchEmbed + PositionEmbed + VisionBlocks + PatchMerger.
+
+    This module is NOT exported -- it runs in plain PyTorch.
+    """
+
+    def __init__(self, config: Qwen3_5MoeVisionConfig):
+        super().__init__()
+        self.config = config
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+        self.dtype = None  # set after loading weights
+
+        self.patch_embed = Qwen3_5MoeVisionPatchEmbed(config=config)
+        self.pos_embed = nn.Embedding(config.num_position_embeddings, config.hidden_size)
+        self.num_grid_per_side = int(config.num_position_embeddings**0.5)
+
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Qwen3_5MoeVisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList([Qwen3_5MoeVisionBlock(config) for _ in range(config.depth)])
+        self.merger = Qwen3_5MoeVisionPatchMerger(config=config)
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        """Compute rotary position embeddings for vision tokens."""
+        merge_size = self.spatial_merge_size
+        max_hw = int(grid_thw[:, 1:].max().item())
+        freq_table = self.rotary_pos_emb(max_hw)  # (max_hw, dim//2)
+        device = freq_table.device
+
+        total_tokens = int(torch.prod(grid_thw, dim=1).sum().item())
+        pos_ids = torch.empty((total_tokens, 2), dtype=torch.long, device=device)
+
+        offset = 0
+        for num_frames, height, width in grid_thw:
+            merged_h, merged_w = height // merge_size, width // merge_size
+
+            block_rows = torch.arange(merged_h, device=device)
+            block_cols = torch.arange(merged_w, device=device)
+            intra_row = torch.arange(merge_size, device=device)
+            intra_col = torch.arange(merge_size, device=device)
+
+            row_idx = block_rows[:, None, None, None] * merge_size + intra_row[None, None, :, None]
+            col_idx = block_cols[None, :, None, None] * merge_size + intra_col[None, None, None, :]
+
+            row_idx = row_idx.expand(merged_h, merged_w, merge_size, merge_size).reshape(-1)
+            col_idx = col_idx.expand(merged_h, merged_w, merge_size, merge_size).reshape(-1)
+
+            coords = torch.stack((row_idx, col_idx), dim=-1)
+            if num_frames > 1:
+                coords = coords.repeat(num_frames, 1)
+
+            num_tokens = coords.shape[0]
+            pos_ids[offset : offset + num_tokens] = coords
+            offset += num_tokens
+
+        embeddings = freq_table[pos_ids]
+        embeddings = embeddings.flatten(1)
+        return embeddings
+
+    def fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        """Bilinear interpolation of learned positional embeddings for variable image sizes."""
+        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
+        device = self.pos_embed.weight.device
+
+        idx_list: List[List[int]] = [[] for _ in range(4)]
+        weight_list: List[List[float]] = [[] for _ in range(4)]
+
+        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
+            h_idxs = torch.linspace(0, self.num_grid_per_side - 1, int(h.item()))
+            w_idxs = torch.linspace(0, self.num_grid_per_side - 1, int(w.item()))
+
+            h_idxs_floor = h_idxs.int()
+            w_idxs_floor = w_idxs.int()
+            h_idxs_ceil = (h_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+            w_idxs_ceil = (w_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+
+            dh = h_idxs - h_idxs_floor
+            dw = w_idxs - w_idxs_floor
+
+            base_h = h_idxs_floor * self.num_grid_per_side
+            base_h_ceil = h_idxs_ceil * self.num_grid_per_side
+
+            indices = [
+                (base_h[None].T + w_idxs_floor[None]).flatten(),
+                (base_h[None].T + w_idxs_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+
+        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(weight_list, dtype=self.pos_embed.weight.dtype, device=device)
+        pos_embeds = self.pos_embed(idx_tensor).to(device) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+
+        patch_pos_embeds = patch_pos_embeds.split(
+            [int(h.item()) * int(w.item()) for h, w in zip(grid_hs, grid_ws)]
+        )
+
+        merge_size = self.config.spatial_merge_size
+        patch_pos_embeds_permute = []
+        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+            t, h, w = int(t.item()), int(h.item()), int(w.item())
+            pos_embed = pos_embed.repeat(t, 1)
+            pos_embed = (
+                pos_embed.view(t, h // merge_size, merge_size, w // merge_size, merge_size, -1)
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            patch_pos_embeds_permute.append(pos_embed)
+
+        return torch.cat(patch_pos_embeds_permute)
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> BaseModelOutputWithPooling:
+        """Run the vision tower.
+
+        Args:
+            hidden_states: Raw pixel values reshaped for patch embedding.
+            grid_thw: Shape ``(num_images_or_videos, 3)`` -- temporal, height, width.
+
+        Returns:
+            ``BaseModelOutputWithPooling`` with ``pooler_output`` containing merged features.
+        """
+        hidden_states = self.patch_embed(hidden_states)
+
+        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + pos_embeds
+
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+
+        seq_len, _ = hidden_states.size()
+        hidden_states = hidden_states.reshape(seq_len, -1)
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        cu_seqlens = torch.repeat_interleave(
+            grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
+        ).cumsum(dim=0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+
+        for blk in self.blocks:
+            hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+            )
+
+        merged_hidden_states = self.merger(hidden_states)
+
+        return BaseModelOutputWithPooling(
+            last_hidden_state=hidden_states,
+            pooler_output=merged_hidden_states,
+        )
+
+
+# =============================================================================
+# Multimodal Wrapper (plain PyTorch -- NOT exported)
+# =============================================================================
+
+
+@dataclass
+class Qwen3_5MoeConditionalOutput(ModelOutput):
+    """Output of the Qwen3.5 MoE conditional generation model."""
+
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Qwen3_5MoeModel(nn.Module):
+    """Multimodal wrapper: vision tower + embedding merge + mRoPE + language model.
+
+    This module is NOT exported. It orchestrates the vision pipeline in plain
+    PyTorch and calls the (potentially exported) language model with pre-computed
+    ``(cos, sin)`` position embeddings (Option 3 for mRoPE).
+    """
+
+    def __init__(self, config: Qwen3_5MoeConfig):
+        super().__init__()
+        self.config = config
+        self.visual = Qwen3_5MoeVisionModel(config.vision_config)
+        self.language_model = Qwen3_5MoeForCausalLM(config.text_config)
+
+        # mRoPE embedding -- computed in this wrapper, passed to language model
+        self.rotary_emb = Qwen3_5MoeTextRotaryEmbedding(config.text_config)
+
+        # Cache rope_deltas for decode steps
+        self.rope_deltas: Optional[torch.Tensor] = None
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def get_rope_index(
+        self,
+        input_ids: torch.LongTensor,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute 3D mRoPE position IDs for multimodal sequences.
+
+        For each sample in the batch, scans for vision placeholder tokens and
+        assigns spatial (T, H, W) positions to vision tokens while text tokens
+        get sequential positions.
+
+        Returns:
+            ``(position_ids, mrope_position_deltas)`` where ``position_ids`` has
+            shape ``(3, B, S)`` and ``mrope_position_deltas`` has shape ``(B, 1)``.
+        """
+        # Split multi-frame videos into per-frame entries
+        if video_grid_thw is not None:
+            video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+            video_grid_thw[:, 0] = 1
+
+        spatial_merge_size = self.config.vision_config.spatial_merge_size
+        image_token_id = self.config.image_token_id
+        video_token_id = self.config.video_token_id
+        vision_start_token_id = self.config.vision_start_token_id
+        mrope_position_deltas = []
+
+        if input_ids is not None and (image_grid_thw is not None or video_grid_thw is not None):
+            total_input_ids = input_ids
+            if attention_mask is None:
+                attention_mask = torch.ones_like(total_input_ids)
+            position_ids = torch.ones(
+                3,
+                input_ids.shape[0],
+                input_ids.shape[1],
+                dtype=input_ids.dtype,
+                device=input_ids.device,
+            )
+            image_index, video_index = 0, 0
+            attention_mask = attention_mask.to(total_input_ids.device)
+
+            for i, ids in enumerate(total_input_ids):
+                ids = ids[attention_mask[i] == 1]
+                vision_start_indices = torch.argwhere(ids == vision_start_token_id).squeeze(1)
+                vision_tokens = ids[vision_start_indices + 1]
+                image_nums = int((vision_tokens == image_token_id).sum().item())
+                video_nums = int((vision_tokens == video_token_id).sum().item())
+                input_tokens = ids.tolist()
+                llm_pos_ids_list: list = []
+                st = 0
+                remain_images, remain_videos = image_nums, video_nums
+
+                for _ in range(image_nums + video_nums):
+                    ed_image = (
+                        input_tokens.index(image_token_id, st)
+                        if image_token_id in input_tokens and remain_images > 0
+                        else len(input_tokens) + 1
+                    )
+                    ed_video = (
+                        input_tokens.index(video_token_id, st)
+                        if video_token_id in input_tokens and remain_videos > 0
+                        else len(input_tokens) + 1
+                    )
+
+                    if ed_image < ed_video:
+                        t, h, w = image_grid_thw[image_index].tolist()
+                        image_index += 1
+                        remain_images -= 1
+                        ed = ed_image
+                    else:
+                        t, h, w = video_grid_thw[video_index].tolist()
+                        video_index += 1
+                        remain_videos -= 1
+                        ed = ed_video
+
+                    llm_grid_t = int(t)
+                    llm_grid_h = int(h) // spatial_merge_size
+                    llm_grid_w = int(w) // spatial_merge_size
+                    text_len = ed - st
+
+                    st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    )
+
+                    # Vision token spatial positions
+                    t_index = (
+                        torch.arange(llm_grid_t)
+                        .view(-1, 1)
+                        .expand(-1, llm_grid_h * llm_grid_w)
+                        .flatten()
+                    )
+                    h_index = (
+                        torch.arange(llm_grid_h)
+                        .view(1, -1, 1)
+                        .expand(llm_grid_t, -1, llm_grid_w)
+                        .flatten()
+                    )
+                    w_index = (
+                        torch.arange(llm_grid_w)
+                        .view(1, 1, -1)
+                        .expand(llm_grid_t, llm_grid_h, -1)
+                        .flatten()
+                    )
+                    llm_pos_ids_list.append(
+                        torch.stack([t_index, h_index, w_index]) + text_len + st_idx
+                    )
+                    st = ed + llm_grid_t * llm_grid_h * llm_grid_w
+
+                # Trailing text
+                if st < len(input_tokens):
+                    st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
+                    text_len = len(input_tokens) - st
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    )
+
+                llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+                position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(position_ids.device)
+                mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
+
+            mrope_position_deltas = torch.tensor(
+                mrope_position_deltas, device=input_ids.device
+            ).unsqueeze(1)
+            return position_ids, mrope_position_deltas
+        else:
+            # Text-only path
+            if attention_mask is not None:
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+                position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+                max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
+                mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+            else:
+                position_ids = (
+                    torch.arange(input_ids.shape[1], device=input_ids.device)
+                    .view(1, 1, -1)
+                    .expand(3, input_ids.shape[0], -1)
+                )
+                mrope_position_deltas = torch.zeros(
+                    [input_ids.shape[0], 1], device=input_ids.device, dtype=input_ids.dtype
+                )
+
+            return position_ids, mrope_position_deltas
+
+    def get_image_features(
+        self, pixel_values: torch.Tensor, image_grid_thw: torch.LongTensor
+    ) -> List[torch.Tensor]:
+        """Run vision tower on images and split by grid dimensions."""
+        vision_output: BaseModelOutputWithPooling = self.visual(
+            pixel_values, grid_thw=image_grid_thw
+        )
+        image_embeds = vision_output.pooler_output
+        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
+        return list(torch.split(image_embeds, split_sizes))
+
+    def get_video_features(
+        self, pixel_values_videos: torch.Tensor, video_grid_thw: torch.LongTensor
+    ) -> List[torch.Tensor]:
+        """Run vision tower on videos (same as images)."""
+        return self.get_image_features(pixel_values_videos, video_grid_thw)
+
+    def get_placeholder_mask(
+        self,
+        input_ids: torch.LongTensor,
+        inputs_embeds: torch.FloatTensor,
+        image_features: Optional[torch.Tensor] = None,
+        video_features: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Find image/video placeholder token positions in the embedding sequence."""
+        special_image_mask = (
+            (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        )
+        special_video_mask = (
+            (input_ids == self.config.video_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        )
+        return special_image_mask, special_video_mask
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_values_videos: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Qwen3_5MoeCausalLMOutput:
+        """Multimodal forward: vision encoding + embedding merge + mRoPE + LM.
+
+        Steps:
+            1. Embed input_ids -> inputs_embeds
+            2. Run vision tower on pixel_values -> masked_scatter into embeds
+            3. Compute mRoPE position_ids via get_rope_index
+            4. Compute (cos, sin) from rotary_emb
+            5. Call language_model with (inputs_embeds, position_embeddings)
+        """
+        inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        # Image embedding merge
+        if pixel_values is not None and image_grid_thw is not None:
+            image_embeds_list = self.get_image_features(pixel_values, image_grid_thw)
+            image_embeds = torch.cat(image_embeds_list, dim=0).to(
+                inputs_embeds.device, inputs_embeds.dtype
+            )
+            image_mask, _ = self.get_placeholder_mask(
+                input_ids, inputs_embeds, image_features=image_embeds
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        # Video embedding merge
+        if pixel_values_videos is not None and video_grid_thw is not None:
+            video_embeds_list = self.get_video_features(pixel_values_videos, video_grid_thw)
+            video_embeds = torch.cat(video_embeds_list, dim=0).to(
+                inputs_embeds.device, inputs_embeds.dtype
+            )
+            _, video_mask = self.get_placeholder_mask(
+                input_ids, inputs_embeds, video_features=video_embeds
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+        # Compute 3D position IDs and mRoPE cos/sin
+        position_ids, self.rope_deltas = self.get_rope_index(
+            input_ids,
+            image_grid_thw,
+            video_grid_thw,
+            attention_mask=attention_mask,
+        )
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
+
+        # Call language model with pre-computed position embeddings
+        return self.language_model(
+            inputs_embeds=inputs_embeds,
+            position_embeddings=position_embeddings,
+        )
+
+
+class Qwen3_5MoeForConditionalGeneration(nn.Module):
+    """Top-level multimodal model: vision + language + lm_head.
+
+    This wraps ``Qwen3_5MoeModel`` and is registered for the composite config.
+    """
+
+    def __init__(self, config: Qwen3_5MoeConfig):
+        super().__init__()
+        self.config = config
+        self.model = Qwen3_5MoeModel(config)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_values_videos: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Qwen3_5MoeConditionalOutput:
+        return Qwen3_5MoeConditionalOutput(
+            logits=self.model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values=pixel_values,
+                pixel_values_videos=pixel_values_videos,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                **kwargs,
+            ).logits
+        )
 
 
 # =============================================================================
@@ -798,3 +1562,6 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 # =============================================================================
 
 AutoModelForCausalLMFactory.register_custom_model_cls("Qwen3_5MoeTextConfig", Qwen3_5MoeForCausalLM)
+AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Qwen3_5MoeConfig", Qwen3_5MoeForConditionalGeneration
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1,0 +1,800 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Slimmed-down, prefill-only Qwen3.5 MoE text model for auto_deploy.
+
+Reference HF modeling file (not yet in a released transformers version):
+  transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+
+This implementation differs from the HuggingFace original in the following ways:
+  * External kernel dependencies (flash-linear-attention, causal_conv1d) are replaced with
+    autodeploy custom ops.
+  * Cache-related code paths have been removed (prefill-only).
+  * Training-related code paths have been removed.
+  * Vision model components have been removed (text-only).
+  * Unnecessary output fields have been removed.
+  * The GatedDeltaNet forward is adapted from the Qwen3Next GDN patch
+    (tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py).
+  * The MoE forward is adapted from the Qwen3Next MoE patch.
+
+This allows us to have a "pytorch" native reference implementation decoupled from bugs and
+dependency issues in the source, while remaining weight-compatible with HF checkpoints.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.configuration_utils import PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+class Qwen3_5MoeTextConfig(PretrainedConfig):
+    """Minimal config class for Qwen3.5 MoE text model.
+
+    Mirrors the attributes of the upstream Qwen3_5MoeTextConfig. Only attributes
+    needed by the slimmed-down prefill model are included.
+    """
+
+    model_type = "qwen3_5_moe_text"
+
+    def __init__(
+        self,
+        vocab_size=248320,
+        hidden_size=2048,
+        num_hidden_layers=40,
+        num_attention_heads=16,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        tie_word_embeddings=False,
+        rope_parameters=None,
+        attention_bias=False,
+        attention_dropout=0.0,
+        head_dim=256,
+        # linear attention (GatedDeltaNet) params
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_num_key_heads=16,
+        linear_num_value_heads=32,
+        # MoE params
+        moe_intermediate_size=512,
+        shared_expert_intermediate_size=512,
+        num_experts_per_tok=8,
+        num_experts=256,
+        # layer types
+        layer_types=None,
+        pad_token_id=None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.head_dim = head_dim
+
+        if rope_parameters is None:
+            rope_parameters = {
+                "rope_type": "default",
+                "rope_theta": 1000000.0,
+                "partial_rotary_factor": 0.25,
+                "mrope_section": [11, 11, 10],
+            }
+        self.rope_parameters = rope_parameters
+
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_key_head_dim = linear_key_head_dim
+        self.linear_value_head_dim = linear_value_head_dim
+        self.linear_num_key_heads = linear_num_key_heads
+        self.linear_num_value_heads = linear_num_value_heads
+
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_experts = num_experts
+
+        self.layer_types = layer_types
+        if self.layer_types is None:
+            # Default pattern: every 4th layer is full_attention, rest are linear_attention
+            interval_pattern = kwargs.pop("full_attention_interval", 4)
+            self.layer_types = [
+                "linear_attention" if bool((i + 1) % interval_pattern) else "full_attention"
+                for i in range(self.num_hidden_layers)
+            ]
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+
+# =============================================================================
+# Normalization
+# =============================================================================
+
+
+class Qwen3_5MoeRMSNorm(nn.Module):
+    """RMSNorm with (1 + weight) scaling. Weight is initialized to zeros."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output = x.float()
+        output = output * torch.rsqrt(output.pow(2).mean(-1, keepdim=True) + self.eps)
+        output = output * (1.0 + self.weight.float())
+        return output.type_as(x)
+
+
+class Qwen3_5MoeRMSNormGated(nn.Module):
+    """Gated RMSNorm: norm(x) * weight * silu(gate). Weight is initialized to ones."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        hidden_states = self.weight * hidden_states.to(input_dtype)
+        hidden_states = hidden_states * F.silu(gate.to(torch.float32))
+        return hidden_states.to(input_dtype)
+
+
+# =============================================================================
+# Rotary Position Embedding (mRoPE)
+# =============================================================================
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply partial RoPE to query and key tensors.
+
+    Supports partial rotary where only the first `rotary_dim` dimensions are rotated.
+    Default unsqueeze_dim=2 is for bsnd layout (B, S, N, D).
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+
+    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
+    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
+
+    q_embed = torch.cat([q_embed, q_pass], dim=-1)
+    k_embed = torch.cat([k_embed, k_pass], dim=-1)
+    return q_embed, k_embed
+
+
+class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
+    """Simplified mRoPE for text-only prefill. Supports only the "default" rope type."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__()
+        rope_params = config.rope_parameters
+        base = rope_params["rope_theta"]
+        partial_rotary_factor = rope_params.get("partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        dim = int(head_dim * partial_rotary_factor)
+
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.mrope_section = rope_params.get("mrope_section", [11, 11, 10])
+
+    @torch.no_grad()
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute cos/sin embeddings.
+
+        Args:
+            x: Hidden states tensor, used only for dtype/device.
+            position_ids: Shape (3, B, S) for mRoPE or (B, S) for plain.
+        """
+        if position_ids.ndim == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+
+        # inv_freq: (dim/2,) -> (3, B, dim/2, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        )
+        # position_ids: (3, B, S) -> (3, B, 1, S)
+        position_ids_expanded = position_ids[:, :, None, :].float()
+
+        # freqs: (3, B, S, dim/2)
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(2, 3)
+        # Apply interleaved mRoPE: (3, B, S, dim/2) -> (B, S, dim/2)
+        freqs = self._apply_interleaved_mrope(freqs)
+        # Double for cos/sin: (B, S, dim)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+    def _apply_interleaved_mrope(self, freqs: torch.Tensor) -> torch.Tensor:
+        """Apply interleaved mRoPE. Merges T/H/W frequency channels into one tensor."""
+        freqs_t = freqs[0].clone()
+        for dim_idx, offset in enumerate((1, 2), start=1):
+            length = self.mrope_section[dim_idx] * 3
+            idx = slice(offset, length, 3)
+            freqs_t[..., idx] = freqs[dim_idx, ..., idx]
+        return freqs_t
+
+
+# =============================================================================
+# GatedDeltaNet (Linear Attention)
+# =============================================================================
+# Adapted from the Qwen3Next GDN patch:
+#   tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py
+# Uses autodeploy custom ops: torch_causal_conv1d, torch_l2norm, torch_gated_delta_rule
+
+
+class Qwen3_5MoeGatedDeltaNet(nn.Module):
+    """Prefill-only GatedDeltaNet using autodeploy custom ops."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_v_heads = config.linear_num_value_heads
+        self.num_k_heads = config.linear_num_key_heads
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.layer_idx = layer_idx
+
+        # QKV convolution
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            padding=self.conv_kernel_size - 1,
+        )
+
+        # dt_bias and A_log for gated delta rule
+        self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
+        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        self.A_log = nn.Parameter(torch.log(A))
+
+        # Gated RMSNorm (per head_v_dim)
+        self.norm = Qwen3_5MoeRMSNormGated(self.head_v_dim, eps=config.rms_norm_eps)
+
+        # Projections
+        self.in_proj_qkv = nn.Linear(
+            self.hidden_size, self.key_dim * 2 + self.value_dim, bias=False
+        )
+        self.in_proj_z = nn.Linear(self.hidden_size, self.value_dim, bias=False)
+        self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+
+        # 1. Projections (separate, unlike Qwen3Next which uses combined in_proj_qkvz)
+        mixed_qkv = self.in_proj_qkv(hidden_states)  # [B, S, conv_dim]
+        z = self.in_proj_z(hidden_states)  # [B, S, value_dim]
+        z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)  # [B, S, num_v_heads, head_v_dim]
+        b = self.in_proj_b(hidden_states)  # [B, S, num_v_heads]
+        a = self.in_proj_a(hidden_states)  # [B, S, num_v_heads]
+
+        # 2. Causal Conv1d via autodeploy op
+        # torch_causal_conv1d expects [B, S, C] input, handles transpose internally
+        mixed_qkv = torch.ops.auto_deploy.torch_causal_conv1d(
+            mixed_qkv,
+            self.conv1d.weight,
+            self.conv1d.bias,
+            self.conv1d.stride[0],
+            self.conv1d.padding[0],
+            self.conv1d.dilation[0],
+            self.conv1d.groups,
+            self.conv1d.padding_mode,
+        )
+        mixed_qkv = F.silu(mixed_qkv)
+
+        # Split back into Q, K, V
+        query, key, value = torch.split(
+            mixed_qkv,
+            [self.key_dim, self.key_dim, self.value_dim],
+            dim=-1,
+        )
+
+        # Reshape to per-head: [B, S, num_heads, head_dim]
+        query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        # 3. L2 normalize Q and K via autodeploy op
+        query = torch.ops.auto_deploy.torch_l2norm(query)
+        key = torch.ops.auto_deploy.torch_l2norm(key)
+
+        # 4. Compute beta and gating
+        beta = b.sigmoid()  # [B, S, num_v_heads]
+        # If the model is loaded in fp16, without the .float() here, A might be -inf
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)  # [B, S, num_v_heads]
+
+        # Repeat-interleave Q, K if num_v_heads > num_k_heads (GQA for linear attention)
+        if self.num_v_heads // self.num_k_heads > 1:
+            query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+            key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+        # 5. Gated Delta Rule via autodeploy custom op
+        # Op expects [B, S, H, D] layout (bsnd convention)
+        core_attn_out = torch.ops.auto_deploy.torch_gated_delta_rule(query, key, value, g, beta)
+
+        # 6. Gated RMSNorm
+        z_shape_og = z.shape
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+        # 7. Output projection
+        output = self.out_proj(core_attn_out)
+        return output
+
+
+# =============================================================================
+# Attention
+# =============================================================================
+
+
+class Qwen3_5MoeAttention(nn.Module):
+    """Multi-headed attention with gating, Q/K norms, and partial RoPE.
+
+    Key differences from standard attention:
+      - q_proj outputs 2x (query + gate), gating applied to attention output.
+      - q_norm / k_norm applied per-head before RoPE.
+      - Partial RoPE: only first rotary_dim dimensions are rotated.
+    """
+
+    def __init__(self, config: Qwen3_5MoeTextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+
+        # q_proj outputs 2x for query + gate
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim * 2,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        # Per-head Q/K norms
+        self.q_norm = Qwen3_5MoeRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen3_5MoeRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        bsz, q_len, _ = hidden_states.size()
+
+        # Q projection with gate: output shape (B, S, N, 2*D)
+        qg = self.q_proj(hidden_states).view(bsz, q_len, -1, self.head_dim * 2)
+        query_states, gate = torch.chunk(qg, 2, dim=-1)  # each (B, S, N, D)
+        gate = gate.reshape(bsz, q_len, -1)  # (B, S, N*D)
+
+        # K, V projections in bsnd layout
+        key_states = self.k_proj(hidden_states).view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        )
+        value_states = self.v_proj(hidden_states).view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        )
+
+        # Per-head Q/K norms (norm operates on last dim = head_dim)
+        query_states = self.q_norm(query_states)
+        key_states = self.k_norm(key_states)
+
+        # Partial RoPE in bsnd layout (unsqueeze_dim=2 for the N dimension)
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, unsqueeze_dim=2
+        )
+
+        # Attention via autodeploy op (bsnd layout)
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            layout="bsnd",
+        )
+        attn_output = attn_output.view(bsz, q_len, -1)  # (B, S, N*D)
+
+        # Gated output
+        attn_output = attn_output * torch.sigmoid(gate)
+
+        # Output projection
+        attn_output = self.o_proj(attn_output)
+        return attn_output
+
+
+# =============================================================================
+# MLP and MoE
+# =============================================================================
+
+
+class Qwen3_5MoeMLP(nn.Module):
+    """SwiGLU MLP used for the shared expert."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig, intermediate_size: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Qwen3_5MoeExperts(nn.Module):
+    """Expert weights stored as fused 3D tensors for checkpoint compatibility.
+
+    Parameters:
+        gate_up_proj: shape [num_experts, 2 * intermediate_dim, hidden_dim]
+        down_proj:    shape [num_experts, hidden_dim, intermediate_dim]
+    """
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.hidden_dim = config.hidden_size
+        self.intermediate_dim = config.moe_intermediate_size
+        self.gate_up_proj = nn.Parameter(
+            torch.empty(self.num_experts, 2 * self.intermediate_dim, self.hidden_dim)
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(self.num_experts, self.hidden_dim, self.intermediate_dim)
+        )
+
+
+class Qwen3_5MoeTopKRouter(nn.Module):
+    """Top-K router with softmax normalization."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.num_experts = config.num_experts
+        self.hidden_dim = config.hidden_size
+        self.weight = nn.Parameter(torch.zeros(self.num_experts, self.hidden_dim))
+
+    def forward(self, hidden_states: torch.Tensor):
+        hidden_states = hidden_states.reshape(-1, self.hidden_dim)
+        router_logits = F.linear(hidden_states, self.weight)  # (T, E)
+        routing_weights = F.softmax(router_logits, dtype=torch.float, dim=-1)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )  # (T, top_k)
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+        return routing_weights, selected_experts
+
+
+class Qwen3_5MoeSparseMoeBlock(nn.Module):
+    """MoE block using torch_moe custom op for routed experts.
+
+    Adapted from the Qwen3Next MoE patch. Splits the fused gate_up_proj into
+    per-expert gate and up weight lists for the torch_moe op.
+    """
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__()
+        self.gate = Qwen3_5MoeTopKRouter(config)
+        self.experts = Qwen3_5MoeExperts(config)
+        self.shared_expert = Qwen3_5MoeMLP(
+            config, intermediate_size=config.shared_expert_intermediate_size
+        )
+        self.shared_expert_gate = nn.Linear(config.hidden_size, 1, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states_flat = hidden_states.view(-1, hidden_dim)
+
+        # Router
+        routing_weights, selected_experts = self.gate(hidden_states_flat)
+
+        # Split fused expert weights into per-expert gate / up / down lists
+        I = self.experts.intermediate_dim  # noqa: E741
+        E = self.experts.num_experts
+        gate_up = self.experts.gate_up_proj  # [E, 2*I, H]
+        gate_proj_weights = [gate_up[i, :I, :] for i in range(E)]
+        up_proj_weights = [gate_up[i, I:, :] for i in range(E)]
+        down_proj_weights = [self.experts.down_proj[i] for i in range(E)]
+
+        # Routed experts via torch_moe (w1=gate, w2=down, w3=up per Qwen3Next convention)
+        expert_output = torch.ops.auto_deploy.torch_moe(
+            hidden_states_flat,
+            selected_experts,
+            routing_weights,
+            w1_weight=gate_proj_weights,
+            w2_weight=down_proj_weights,
+            w3_weight=up_proj_weights,
+        )
+
+        # Shared expert with sigmoid gating
+        shared_expert_output = self.shared_expert(hidden_states_flat)
+        shared_expert_output = (
+            F.sigmoid(self.shared_expert_gate(hidden_states_flat)) * shared_expert_output
+        )
+        expert_output = expert_output + shared_expert_output
+
+        expert_output = expert_output.reshape(batch_size, sequence_length, hidden_dim)
+        return expert_output
+
+
+# =============================================================================
+# Decoder Layer
+# =============================================================================
+
+
+class Qwen3_5MoeDecoderLayer(nn.Module):
+    """Single decoder layer: token mixer (linear_attention or full_attention) + MoE."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_type = config.layer_types[layer_idx]
+
+        if self.layer_type == "linear_attention":
+            self.linear_attn = Qwen3_5MoeGatedDeltaNet(config, layer_idx)
+        elif self.layer_type == "full_attention":
+            self.self_attn = Qwen3_5MoeAttention(config, layer_idx)
+        else:
+            raise ValueError(f"Unknown layer type: {self.layer_type}")
+
+        self.mlp = Qwen3_5MoeSparseMoeBlock(config)
+        self.input_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3_5MoeRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        # Token mixer
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            hidden_states = self.linear_attn(hidden_states)
+        elif self.layer_type == "full_attention":
+            hidden_states = self.self_attn(hidden_states, position_embeddings=position_embeddings)
+
+        hidden_states = residual + hidden_states
+
+        # Channel mixer (MoE)
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+# =============================================================================
+# Model
+# =============================================================================
+
+
+class Qwen3_5MoePreTrainedModel(PreTrainedModel):
+    """Base class for Qwen3.5 MoE pretrained models."""
+
+    config_class = Qwen3_5MoeTextConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Qwen3_5MoeDecoderLayer"]
+    supports_gradient_checkpointing = True
+    _is_stateful = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+        elif isinstance(module, Qwen3_5MoeRMSNorm):
+            module.weight.data.zero_()
+        elif isinstance(module, Qwen3_5MoeRMSNormGated):
+            module.weight.data.fill_(1.0)
+        elif isinstance(module, Qwen3_5MoeGatedDeltaNet):
+            module.dt_bias.data.fill_(1.0)
+            module.A_log.data.copy_(torch.empty_like(module.A_log).uniform_(0, 16).log_())
+        elif isinstance(module, Qwen3_5MoeExperts):
+            module.gate_up_proj.data.normal_(mean=0.0, std=std)
+            module.down_proj.data.normal_(mean=0.0, std=std)
+        elif isinstance(module, Qwen3_5MoeTopKRouter):
+            module.weight.data.normal_(mean=0.0, std=std)
+
+
+@dataclass
+class Qwen3_5MoeOutput(ModelOutput):
+    """Output of the Qwen3.5 MoE text model."""
+
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Qwen3_5MoeCausalLMOutput(ModelOutput):
+    """Output of the Qwen3.5 MoE causal language model."""
+
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
+    """Qwen3.5 MoE text model (embed + decoder layers + final norm)."""
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__(config)
+        pad_token_id = getattr(config, "pad_token_id", None)
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, padding_idx=pad_token_id
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen3_5MoeDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen3_5MoeTextRotaryEmbedding(config=config)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, new_embeddings):
+        self.embed_tokens = new_embeddings
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Union[Tuple, Qwen3_5MoeOutput]:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        # Compute position_ids for mRoPE (3, B, S)
+        if position_ids is None:
+            seq_len = inputs_embeds.shape[1]
+            position_ids = torch.arange(seq_len, device=inputs_embeds.device)
+            position_ids = position_ids.view(1, 1, -1).expand(3, inputs_embeds.shape[0], -1)
+        elif position_ids.ndim == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
+
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(hidden_states, position_embeddings=position_embeddings)
+
+        hidden_states = self.norm(hidden_states)
+        return Qwen3_5MoeOutput(last_hidden_state=hidden_states)
+
+
+class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
+    """Qwen3.5 MoE causal language model (text model + lm_head)."""
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Qwen3_5MoeTextConfig):
+        super().__init__(config)
+        self.model = Qwen3_5MoeTextModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, new_embeddings):
+        return self.model.set_input_embeddings(new_embeddings)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Union[Tuple, Qwen3_5MoeCausalLMOutput]:
+        outputs = self.model(input_ids, inputs_embeds=inputs_embeds, position_ids=position_ids)
+        hidden_states = outputs[0]
+        logits = self.lm_head(hidden_states.to(self.lm_head.weight.dtype)).float()
+        return Qwen3_5MoeCausalLMOutput(logits=logits)
+
+
+# =============================================================================
+# Registration
+# =============================================================================
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Qwen3_5MoeTextConfig", Qwen3_5MoeForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -830,7 +830,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
-    def __init__(self, config: Qwen3_5MoeTextConfig):
+    def __init__(self, config: Qwen3_5MoeTextConfig, **kwargs):
         super().__init__(config)
         self.model = Qwen3_5MoeTextModel(config)
         self.vocab_size = config.vocab_size

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -28,6 +28,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 from torch import nn
+from transformers import AutoConfig
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
@@ -1579,6 +1580,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel):
 # =============================================================================
 # Registration
 # =============================================================================
+
+AutoConfig.register("qwen3_5_moe", Qwen3_5MoeConfig)
+AutoConfig.register("qwen3_5_moe_text", Qwen3_5MoeTextConfig)
 
 AutoModelForCausalLMFactory.register_custom_model_cls("Qwen3_5MoeTextConfig", Qwen3_5MoeForCausalLM)
 AutoModelForCausalLMFactory.register_custom_model_cls(

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py
@@ -1,10 +1,33 @@
-"""A patch for Qwen3Next MoE to make it compatible with torch.export and reduce export time."""
+"""Patches for Qwen3Next to make it compatible with torch.export and reduce export time.
+
+Includes:
+  - MoE patch: replaces Qwen3NextSparseMoeBlock.forward with torch_moe op
+  - GDN patch: replaces Qwen3NextGatedDeltaNet.forward with autodeploy custom ops
+    (torch_causal_conv1d, torch_l2norm, torch_gated_delta_rule)
+  - Mask/cache patches: simplify _update_linear_attn_mask and DynamicCache.__bool__
+    for torch.export compatibility
+
+Reference HF modeling file (v4.57.1):
+  https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+"""
+
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextSparseMoeBlock
+from transformers.models.qwen3_next.modeling_qwen3_next import (
+    Qwen3NextDynamicCache,
+    Qwen3NextGatedDeltaNet,
+    Qwen3NextModel,
+    Qwen3NextSparseMoeBlock,
+    apply_mask_to_padding_states,
+)
 
 from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+# =============================================================================
+# MoE patch
+# =============================================================================
 
 
 def _forward_moe(self: Qwen3NextSparseMoeBlock, hidden_states: torch.Tensor):
@@ -54,3 +77,157 @@ class Qwen3NextMoePatch(BaseExportPatch):
         Qwen3NextSparseMoeBlock.forward = self.original_values[  # type: ignore
             "Qwen3NextSparseMoeBlock.forward"
         ]
+
+
+# =============================================================================
+# GDN (Gated Delta Net) patch
+# =============================================================================
+
+# Original implementation:
+# https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L475-L614
+# NOTE: we remove cache-related code paths and use autodeploy custom ops.
+
+
+def _patched_gdn_forward(
+    self: Qwen3NextGatedDeltaNet,
+    hidden_states: torch.Tensor,
+    cache_params: Optional[Qwen3NextDynamicCache] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+):
+    """Patched forward for Qwen3NextGatedDeltaNet.
+
+    Removes cache-dependent control flow and uses autodeploy custom ops:
+      - torch_causal_conv1d for the depthwise causal convolution
+      - torch_l2norm for L2 normalization of Q and K
+      - torch_gated_delta_rule for the core gated delta rule computation
+    """
+    hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+    batch_size, seq_len, _ = hidden_states.shape
+
+    # 1. Projections
+    projected_states_qkvz = self.in_proj_qkvz(hidden_states)
+    projected_states_ba = self.in_proj_ba(hidden_states)
+    query, key, value, z, b, a = self.fix_query_key_value_ordering(
+        projected_states_qkvz, projected_states_ba
+    )
+    # Flatten multi-head dims for conv: [B, S, key_dim] etc.
+    query, key, value = (x.reshape(x.shape[0], x.shape[1], -1) for x in (query, key, value))
+
+    # Concatenate QKV for joint convolution: [B, S, conv_dim]
+    mixed_qkv = torch.cat((query, key, value), dim=-1)
+
+    # 2. Causal Conv1d via autodeploy op
+    # torch_causal_conv1d expects [B, S, C] input, handles transpose internally
+    mixed_qkv = torch.ops.auto_deploy.torch_causal_conv1d(
+        mixed_qkv,
+        self.conv1d.weight,
+        self.conv1d.bias,
+        self.conv1d.stride[0],
+        self.conv1d.padding[0],
+        self.conv1d.dilation[0],
+        self.conv1d.groups,
+        self.conv1d.padding_mode,
+    )
+    mixed_qkv = F.silu(mixed_qkv)
+
+    # Split back into Q, K, V
+    query, key, value = torch.split(
+        mixed_qkv,
+        [self.key_dim, self.key_dim, self.value_dim],
+        dim=-1,
+    )
+
+    # Reshape to per-head: [B, S, num_heads, head_dim]
+    query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+    # 3. L2 normalize Q and K via autodeploy op
+    query = torch.ops.auto_deploy.torch_l2norm(query)
+    key = torch.ops.auto_deploy.torch_l2norm(key)
+
+    # 4. Compute beta and gating
+    beta = b.sigmoid()  # [B, S, num_v_heads]
+    # If the model is loaded in fp16, without the .float() here, A might be -inf
+    g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)  # [B, S, num_v_heads]
+
+    # Repeat-interleave Q, K if num_v_heads > num_k_heads (GQA for linear attention)
+    if self.num_v_heads // self.num_k_heads > 1:
+        query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+        key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+    # 5. Gated Delta Rule via autodeploy custom op
+    # Op expects [B, S, H, D] layout (bsnd convention)
+    core_attn_out = torch.ops.auto_deploy.torch_gated_delta_rule(query, key, value, g, beta)
+
+    # 6. Gated RMSNorm
+    z_shape_og = z.shape
+    core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+    z = z.reshape(-1, z.shape[-1])
+    core_attn_out = self.norm(core_attn_out, z)
+    core_attn_out = core_attn_out.reshape(z_shape_og)
+    core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+    # 7. Output projection
+    output = self.out_proj(core_attn_out)
+    return output
+
+
+# =============================================================================
+# Mask and cache patches for torch.export compatibility
+# =============================================================================
+
+
+def _patched_update_linear_attn_mask(self, attention_mask, cache_position):
+    """Patched _update_linear_attn_mask that returns None unconditionally.
+
+    The original checks `cache_position[0] > 0` which is data-dependent and
+    incompatible with torch.export.
+
+    Original:
+      https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L1082-L1092
+    """
+    return None
+
+
+def _cache_bool(self) -> bool:
+    """Patched __bool__ for Qwen3NextDynamicCache that returns True unconditionally.
+
+    The base Cache class's __len__ returns 0 when no cache is stored, which makes
+    `if past_key_values:` evaluate to False at initialization. The model code should
+    really check `if past_key_values is not None`, but patching __bool__ is less
+    intrusive than patching the full model forward.
+
+    Same pattern as the Bamba cache bool fix:
+      tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
+    """
+    return True
+
+
+@ExportPatchRegistry.register("hf_qwen3_next_gdn")
+class Qwen3NextGDNPatch(BaseExportPatch):
+    """Patch for Qwen3Next GatedDeltaNet for torch.export compatibility."""
+
+    def _apply_patch(self):
+        """Apply the GDN, mask, and cache patches."""
+        self.original_values["Qwen3NextGatedDeltaNet.forward"] = Qwen3NextGatedDeltaNet.forward
+        self.original_values["Qwen3NextModel._update_linear_attn_mask"] = (
+            Qwen3NextModel._update_linear_attn_mask
+        )
+        # NOTE: Qwen3NextDynamicCache does not have __bool__ by default
+        # (it inherits from object), so we just set it and delete on revert.
+
+        Qwen3NextGatedDeltaNet.forward = _patched_gdn_forward  # type: ignore
+        Qwen3NextModel._update_linear_attn_mask = _patched_update_linear_attn_mask  # type: ignore
+        Qwen3NextDynamicCache.__bool__ = _cache_bool  # type: ignore
+
+    def _revert_patch(self):
+        """Revert the GDN, mask, and cache patches."""
+        Qwen3NextGatedDeltaNet.forward = self.original_values[  # type: ignore
+            "Qwen3NextGatedDeltaNet.forward"
+        ]
+        Qwen3NextModel._update_linear_attn_mask = self.original_values[  # type: ignore
+            "Qwen3NextModel._update_linear_attn_mask"
+        ]
+        del Qwen3NextDynamicCache.__bool__

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py
@@ -1,0 +1,56 @@
+"""A patch for Qwen3Next MoE to make it compatible with torch.export and reduce export time."""
+
+import torch
+import torch.nn.functional as F
+from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextSparseMoeBlock
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+def _forward_moe(self: Qwen3NextSparseMoeBlock, hidden_states: torch.Tensor):
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+    hidden_states = hidden_states.view(-1, hidden_dim)
+
+    # router_logits: (batch * sequence_length, n_experts)
+    router_logits = self.gate(hidden_states)
+
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+    if self.norm_topk_prob:
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    # we cast back to the input dtype
+    routing_weights = routing_weights.to(hidden_states.dtype)
+
+    # Routed experts via torch_moe
+    final_hidden_states = torch.ops.auto_deploy.torch_moe(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        w1_weight=[expert.gate_proj.weight for expert in self.experts],
+        w2_weight=[expert.down_proj.weight for expert in self.experts],
+        w3_weight=[expert.up_proj.weight for expert in self.experts],
+    )
+
+    # Shared expert path (unique to Qwen3Next vs Qwen3MoE)
+    shared_expert_output = self.shared_expert(hidden_states)
+    shared_expert_output = F.sigmoid(self.shared_expert_gate(hidden_states)) * shared_expert_output
+    final_hidden_states = final_hidden_states + shared_expert_output
+
+    final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+    return final_hidden_states, router_logits
+
+
+@ExportPatchRegistry.register("hf_qwen3_next_moe")
+class Qwen3NextMoePatch(BaseExportPatch):
+    """Patch for Qwen3Next MoE for torch.export compatibility."""
+
+    def _apply_patch(self):
+        """Apply the Qwen3Next MoE patch."""
+        self.original_values["Qwen3NextSparseMoeBlock.forward"] = Qwen3NextSparseMoeBlock.forward
+        Qwen3NextSparseMoeBlock.forward = _forward_moe  # type: ignore
+
+    def _revert_patch(self):
+        """Revert the Qwen3Next MoE patch."""
+        Qwen3NextSparseMoeBlock.forward = self.original_values[  # type: ignore
+            "Qwen3NextSparseMoeBlock.forward"
+        ]

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -15,7 +15,12 @@ from ...custom_ops.quantization.quant import (
 )
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
-from ...utils._graph import delete_all_unused_submodules, eliminate_dead_code, get_attr_by_name
+from ...utils._graph import (
+    del_attr_by_name,
+    delete_all_unused_submodules,
+    eliminate_dead_code,
+    get_attr_by_name,
+)
 from ...utils.cuda_mem_tracker import cuda_memory_tracker
 from ...utils.logger import ad_logger
 from ...utils.module import get_submodule_of_param
@@ -81,6 +86,62 @@ def _bmm_moe_down_split_hook(
         w2_experts = stacked_tensor.transpose(1, 2).contiguous().unbind(0)
         for w2_key, w2 in zip(w2_keys, w2_experts):
             state_dict[prefix + w2_key] = w2
+
+
+def _fused_moe_gate_up_split_hook(
+    state_dict,
+    prefix,
+    *args,
+    source_key: str,
+    intermediate_size: int,
+    w1_keys: List[str],
+    w3_keys: List[str],
+):
+    """Fallback hook to split fused gate_up tensor into per-expert w1/w3 tensors.
+
+    This hook is intentionally ordering-agnostic w.r.t. checkpoint families:
+    it assumes `source_key` has already been normalized to runtime/operator layout
+    by model-specific hooks (if needed), then performs structural splitting only.
+    """
+    source_full_key = prefix + source_key
+    if source_full_key not in state_dict:
+        return
+
+    stacked_tensor = state_dict[source_full_key]
+    # Runtime/operator layout: [w3, w1] along dim=1 for shape (E, 2I, H)
+    w3_stacked, w1_stacked = stacked_tensor.split(intermediate_size, dim=1)
+    w3_experts = w3_stacked.contiguous().unbind(0)
+    w1_experts = w1_stacked.contiguous().unbind(0)
+
+    # Don't overwrite keys already populated by model-owned hooks.
+    for w1_key, w1 in zip(w1_keys, w1_experts):
+        dst = prefix + w1_key
+        if dst not in state_dict:
+            state_dict[dst] = w1
+    for w3_key, w3 in zip(w3_keys, w3_experts):
+        dst = prefix + w3_key
+        if dst not in state_dict:
+            state_dict[dst] = w3
+
+
+def _fused_moe_down_split_hook(
+    state_dict,
+    prefix,
+    *args,
+    source_key: str,
+    w2_keys: List[str],
+):
+    """Fallback hook to split fused down tensor into per-expert w2 tensors."""
+    source_full_key = prefix + source_key
+    if source_full_key not in state_dict:
+        return
+
+    stacked_tensor = state_dict[source_full_key]
+    w2_experts = stacked_tensor.contiguous().unbind(0)
+    for w2_key, w2 in zip(w2_keys, w2_experts):
+        dst = prefix + w2_key
+        if dst not in state_dict:
+            state_dict[dst] = w2
 
 
 def _insert_fused_moe_ops(gm: GraphModule, backend: Literal["auto", "trtllm", "triton"]) -> int:
@@ -156,6 +217,146 @@ def _replace_torch_moe_fused_ops(
             count += 1
 
     return count
+
+
+def _split_torch_moe_fused_to_expert_lists(gm: GraphModule) -> int:
+    """Rewrite torch_moe_fused nodes into torch_moe with per-expert weight lists.
+
+    This runs before sharding so EP can operate on existing torch_moe list-based path.
+    The transform keeps checkpoint-order policy out of transform logic by:
+      - materializing expert-list parameters structurally, and
+      - registering fallback structural split hooks on the owner module.
+    Model-specific hooks can normalize checkpoint layout before these fallback hooks run.
+    """
+    graph = gm.graph
+    converted = 0
+
+    for node in list(graph.nodes):
+        if not is_op(node, torch.ops.auto_deploy.torch_moe_fused):
+            continue
+
+        hidden_states, selected_experts, routing_weights, w3_w1_node, w2_node = node.args
+        if not (
+            isinstance(w3_w1_node, Node)
+            and isinstance(w2_node, Node)
+            and w3_w1_node.op == "get_attr"
+            and w2_node.op == "get_attr"
+        ):
+            continue
+
+        w3_w1_target = str(w3_w1_node.target)
+        w2_target = str(w2_node.target)
+        w3_w1_tensor = gm.get_parameter(w3_w1_target)
+        w2_tensor = gm.get_parameter(w2_target)
+
+        if len(w3_w1_tensor.shape) != 3 or len(w2_tensor.shape) != 3:
+            continue
+
+        num_experts = w3_w1_tensor.shape[0]
+        intermediate_size = w3_w1_tensor.shape[1] // 2
+        if w3_w1_tensor.shape[1] != 2 * intermediate_size:
+            continue
+        if w2_tensor.shape[0] != num_experts:
+            continue
+
+        owner_module, owner_path, source_name = get_submodule_of_param(gm, w3_w1_target)
+        owner_module_w2, owner_path_w2, source_name_w2 = get_submodule_of_param(gm, w2_target)
+        if owner_module is not owner_module_w2 or owner_path != owner_path_w2:
+            continue
+
+        # Materialize per-expert params under the owner module.
+        w1_full_keys: list[str] = []
+        w2_full_keys: list[str] = []
+        w3_full_keys: list[str] = []
+        w1_local_names: list[str] = []
+        w2_local_names: list[str] = []
+        w3_local_names: list[str] = []
+
+        for expert_idx in range(num_experts):
+            # Keep stable names so model-side hooks can target them.
+            w1_name = f"w1_expert_{expert_idx}"
+            w2_name = f"w2_expert_{expert_idx}"
+            w3_name = f"w3_expert_{expert_idx}"
+
+            if not hasattr(owner_module, w1_name):
+                owner_module.register_parameter(
+                    w1_name,
+                    torch.nn.Parameter(w3_w1_tensor[expert_idx, intermediate_size:, :]),
+                )
+            if not hasattr(owner_module, w2_name):
+                owner_module.register_parameter(
+                    w2_name,
+                    torch.nn.Parameter(w2_tensor[expert_idx, :, :]),
+                )
+            if not hasattr(owner_module, w3_name):
+                owner_module.register_parameter(
+                    w3_name,
+                    torch.nn.Parameter(w3_w1_tensor[expert_idx, :intermediate_size, :]),
+                )
+
+            w1_local_names.append(w1_name)
+            w2_local_names.append(w2_name)
+            w3_local_names.append(w3_name)
+
+            prefix = f"{owner_path}." if owner_path else ""
+            w1_full_keys.append(prefix + w1_name)
+            w2_full_keys.append(prefix + w2_name)
+            w3_full_keys.append(prefix + w3_name)
+
+        # Fallback structural split hooks (model hooks can pre-normalize layout).
+        owner_module._register_load_state_dict_pre_hook(
+            partial(
+                _fused_moe_gate_up_split_hook,
+                source_key=source_name,
+                intermediate_size=intermediate_size,
+                w1_keys=w1_local_names,
+                w3_keys=w3_local_names,
+            )
+        )
+        owner_module._register_load_state_dict_pre_hook(
+            partial(
+                _fused_moe_down_split_hook,
+                source_key=source_name_w2,
+                w2_keys=w2_local_names,
+            )
+        )
+
+        with graph.inserting_before(node):
+            w1_nodes = [graph.get_attr(k) for k in w1_full_keys]
+            w2_nodes = [graph.get_attr(k) for k in w2_full_keys]
+            w3_nodes = [graph.get_attr(k) for k in w3_full_keys]
+            new_node = graph.call_function(
+                torch.ops.auto_deploy.torch_moe,
+                args=(
+                    hidden_states,
+                    selected_experts,
+                    routing_weights,
+                    w1_nodes,
+                    w2_nodes,
+                    w3_nodes,
+                ),
+                kwargs={"is_gated_mlp": True, "act_fn": int(ActivationType.Silu)},
+            )
+
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        converted += 1
+
+        # Clean dead graph/state then explicitly remove unused fused params.
+        eliminate_dead_code(gm)
+        delete_all_unused_submodules(gm)
+
+        for old_target in (w3_w1_target, w2_target):
+            still_used = any(
+                n.op == "get_attr" and str(n.target) == old_target for n in gm.graph.nodes
+            )
+            if not still_used:
+                try:
+                    del_attr_by_name(gm, old_target)
+                except AttributeError:
+                    pass
+
+    return converted
 
 
 def _process_moe_node(
@@ -1679,6 +1880,37 @@ class FuseMoe(BaseTransform):
             num_matches=fused_key_counter,
             is_clean=fused_key_counter == 0,
             has_valid_shapes=fused_key_counter == 0,
+        )
+        return gm, info
+
+
+class SplitMoeFusedForShardingConfig(TransformConfig):
+    """Configuration for converting torch_moe_fused to torch_moe pre-sharding."""
+
+    pass
+
+
+@TransformRegistry.register("split_moe_fused_for_sharding")
+class SplitMoeFusedForSharding(BaseTransform):
+    """Convert torch_moe_fused nodes to list-based torch_moe nodes before sharding."""
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return SplitMoeFusedForShardingConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        num_matches = _split_torch_moe_fused_to_expert_lists(gm)
+        info = TransformInfo(
+            skipped=(num_matches == 0),
+            num_matches=num_matches,
+            is_clean=num_matches == 0,
+            has_valid_shapes=num_matches == 0,
         )
         return gm, info
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -2876,7 +2876,6 @@ def detect_column_row_shard(
         opening = layer.opening_nodes
         closing = layer.terminating_node
         layer_subgraph = layer.subgraph_nodes
-        min_local_shape = layer.min_local_shape
         nodes_linear = opening + [closing] + list(filtered_nodes(layer_subgraph, is_any_lin_op))
 
         if config.simple_shard_only or layer.layer_type == LayerType.UNKNOWN:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/ssm_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/ssm_cache.py
@@ -18,3 +18,8 @@ class InitializeCausalConvCache(_InsertCachedOperator):
 @TransformRegistry.register("insert_cached_delta_rule")
 class InsertCachedDeltaRule(_InsertCachedOperator):
     """A transform to handle delta rule cache operations."""
+
+
+@TransformRegistry.register("insert_cached_gated_delta_rule")
+class InsertCachedGatedDeltaRule(_InsertCachedOperator):
+    """A transform to handle gated delta rule cache operations."""

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -1379,8 +1379,10 @@ def get_layer_after_linear_node(
 
         if len(delta_nodes) == 1:
             head_size = shape(delta_nodes[0])[-1]
-            # Gated DeltaNet layers should have 2 opening linear nodes and one terminating.
-            if len(intermediate_lin_nodes) > 0 or len(opening_linear_nodes) != 2:
+            # Gated DeltaNet layers should have 2 opening linear nodes (fused qkvz + ba,
+            # e.g. Qwen3Next) or 4 opening linear nodes (unfused qkv + z + b + a,
+            # e.g. Qwen3.5 MoE) and one terminating node.
+            if len(intermediate_lin_nodes) > 0 or len(opening_linear_nodes) not in (2, 4):
                 return LayerType.UNKNOWN, 1
             # Gated DeltaNet layer should have 4 to 6 intermediate weight nodes:
             # - conv1d weight

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -320,6 +320,12 @@ def throughput_command(
                 f"Failed to import custom module from {custom_module_dir}: {e}")
             raise e
 
+    # Eagerly import auto_deploy to ensure custom model configs
+    # are registered with transformers.AutoConfig before
+    # options.model_type triggers AutoConfig.from_pretrained().
+    if options.backend == "_autodeploy":
+        import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
     # Runtime kwargs and option tracking.
     kwargs = {}
 

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -518,8 +518,7 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
     Configuration derived from examples/auto_deploy/model_registry/configs/qwen3Next.yaml.
     """
 
-    MODEL_NAME = "Qwen3/Qwen3-Next-80B-A3B-Instruct"
-    MODEL_PATH = f"{llm_models_root()}/Qwen3-Next/Qwen3-Next-80B-A3B-Instruct"
+    MODEL_NAME = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 
     def get_default_kwargs(self):
         return {
@@ -538,6 +537,9 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             "transforms": {
                 "compile_model": {
                     "backend": "torch-simple",
+                },
+                "export_to_gm": {
+                    "num_moe_experts_for_export": 2,
                 },
                 "detect_sharding": {
                     "sharding_source": ['factory', 'heuristic'],

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -585,14 +585,22 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
             "enable_chunked_prefill": True,
-            "max_batch_size": 512,
+            "compile_backend": "torch-cudagraph",
+            "max_batch_size": 64,
             "max_seq_len": self.MAX_SEQ_LEN,
             "max_num_tokens": self.MAX_SEQ_LEN,
+            "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64],
             "kv_cache_config": {
                 "enable_block_reuse": False,
-                "free_gpu_memory_fraction": 0.7,
+                "free_gpu_memory_fraction": 0.5,
                 "tokens_per_block": 64,
-            }
+            },
+            "transforms": {
+                "detect_sharding": {
+                    "sharding_source": ['factory', 'heuristic'],
+                    "sharding_dims": ['ep', 'bmm'],
+                },
+            },
         }
 
     def get_default_sampling_params(self):

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -595,6 +595,9 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
                 "free_gpu_memory_fraction": 0.5,
                 "tokens_per_block": 64,
             },
+            "model_kwargs": {
+                "torch_dtype": "bfloat16",
+            },
             "transforms": {
                 "detect_sharding": {
                     "sharding_source": ['factory', 'heuristic'],
@@ -613,13 +616,14 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device_memory(80000)
     @pytest.mark.parametrize("world_size", [8])
-    def test_auto_dtype(self, world_size):
+    def test_bf16(self, world_size):
         if get_device_count() < world_size:
             pytest.skip("Not enough devices for world size, skipping test")
         kwargs = self.get_default_kwargs()
         sampling_params = self.get_default_sampling_params()
         with AutoDeployLLM(model=self.MODEL_NAME,
                            tokenizer=self.MODEL_NAME,
+                           dtype="bfloat16",
                            world_size=world_size,
                            **kwargs) as llm:
             task = MMLU(self.MODEL_NAME)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -511,6 +511,7 @@ class TestGLM4Flash(LlmapiAccuracyTestHarness):
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
 
+
 class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
     """Accuracy regression tests for Qwen3-Next Instruct via AutoDeploy.
 
@@ -586,10 +587,10 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
             "trust_remote_code": True,
             "enable_chunked_prefill": True,
             "compile_backend": "torch-cudagraph",
-            "max_batch_size": 64,
+            "max_batch_size": 128,
             "max_seq_len": self.MAX_SEQ_LEN,
             "max_num_tokens": self.MAX_SEQ_LEN,
-            "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64],
+            "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128],
             "kv_cache_config": {
                 "enable_block_reuse": False,
                 "free_gpu_memory_fraction": 0.5,
@@ -597,12 +598,6 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
             },
             "model_kwargs": {
                 "torch_dtype": "bfloat16",
-            },
-            "transforms": {
-                "detect_sharding": {
-                    "sharding_source": ['factory', 'heuristic'],
-                    "sharding_dims": ['ep', 'bmm'],
-                },
             },
         }
 

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -525,7 +525,6 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
             "skip_loading_weights": False,
-            "attn_backend": "torch",
             "enable_chunked_prefill": True,
             "max_batch_size": 64,
             "max_seq_len": 4096,
@@ -535,9 +534,6 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
                 "free_gpu_memory_fraction": 0.7,
             },
             "transforms": {
-                "compile_model": {
-                    "backend": "torch-simple",
-                },
                 "export_to_gm": {
                     "num_moe_experts_for_export": 2,
                 },
@@ -558,6 +554,57 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device_memory(80000)
     @pytest.mark.parametrize("world_size", [1, 4])
+    def test_auto_dtype(self, world_size):
+        if get_device_count() < world_size:
+            pytest.skip("Not enough devices for world size, skipping test")
+        kwargs = self.get_default_kwargs()
+        sampling_params = self.get_default_sampling_params()
+        with AutoDeployLLM(model=self.MODEL_NAME,
+                           tokenizer=self.MODEL_NAME,
+                           world_size=world_size,
+                           **kwargs) as llm:
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm, sampling_params=sampling_params)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+
+class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
+    """Accuracy regression tests for Qwen3.5-397B-A17B via AutoDeploy.
+
+    Runs the model via AutoDeploy and verifies benchmark performance on MMLU and GSM8K.
+    Configuration derived from examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml.
+    """
+
+    MODEL_NAME = "Qwen/Qwen3.5-397B-A17B"
+    MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
+                      GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
+
+    def get_default_kwargs(self):
+        return {
+            "skip_tokenizer_init": False,
+            "trust_remote_code": True,
+            "enable_chunked_prefill": True,
+            "max_batch_size": 512,
+            "max_seq_len": self.MAX_SEQ_LEN,
+            "max_num_tokens": self.MAX_SEQ_LEN,
+            "kv_cache_config": {
+                "enable_block_reuse": False,
+                "free_gpu_memory_fraction": 0.7,
+                "tokens_per_block": 64,
+            }
+        }
+
+    def get_default_sampling_params(self):
+        eos_id = -1
+        beam_width = 1
+        return SamplingParams(end_id=eos_id,
+                              pad_id=eos_id,
+                              n=beam_width,
+                              use_beam_search=beam_width > 1)
+
+    @pytest.mark.skip_less_device_memory(80000)
+    @pytest.mark.parametrize("world_size", [8])
     def test_auto_dtype(self, world_size):
         if get_device_count() < world_size:
             pytest.skip("Not enough devices for world size, skipping test")

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -599,6 +599,11 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
             "model_kwargs": {
                 "torch_dtype": "bfloat16",
             },
+            "transforms": {
+                "export_to_gm": {
+                    "num_moe_experts_for_export": 2,
+                },
+            },
         }
 
     def get_default_sampling_params(self):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_dist_backend.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_dist_backend.py
@@ -58,6 +58,7 @@ def _create_and_transform_model(
     config = {
         "detect_sharding": {
             "stage": "sharding",
+            "shard_all_unprocessed": True,
         },
         "sharding_transform_executor": {
             "stage": "sharding",

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
@@ -224,3 +224,77 @@ def test_llama4_stacked_moe_pattern_detection():
     detected = optimizer.shared_config.sharding_transform_container.ep_transforms
     assert len(detected) == 1, f"Expected 1 EP transform, got {len(detected)}"
     assert detected[0].target_node == moe_node.name
+
+
+class PreStackedMoEModel(torch.nn.Module):
+    """Minimal model using torch_moe_fused with stacked expert tensors."""
+
+    def __init__(self, hidden_size=32, intermediate_size=16, num_experts=4, top_k=2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.top_k = top_k
+        self.gate = torch.nn.Linear(hidden_size, num_experts, bias=False)
+        self.gate_up_proj = torch.nn.Parameter(
+            torch.randn(num_experts, 2 * intermediate_size, hidden_size)
+        )
+        self.down_proj = torch.nn.Parameter(
+            torch.randn(num_experts, hidden_size, intermediate_size)
+        )
+
+    def forward(self, x):
+        router_logits = self.gate(x)
+        routing_weights = torch.nn.functional.softmax(router_logits, dim=-1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights = (routing_weights / routing_weights.sum(dim=-1, keepdim=True)).to(x.dtype)
+        return torch.ops.auto_deploy.torch_moe_fused(
+            x,
+            selected_experts,
+            routing_weights,
+            self.gate_up_proj,
+            self.down_proj,
+        )
+
+    def get_input(self, device, dtype=torch.bfloat16):
+        return torch.randn(2, self.hidden_size, device=device, dtype=dtype)
+
+
+def test_split_moe_fused_then_ep_sharding_executor():
+    """Verify pre-sharding split enables EP path for torch_moe_fused models."""
+    device = "cuda"
+    model = PreStackedMoEModel().to(device=device, dtype=torch.bfloat16)
+    x = model.get_input(device=device, dtype=torch.bfloat16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    optimizer = InferenceOptimizer(
+        None,
+        {
+            "split_moe_fused_for_sharding": {
+                "stage": "pattern_matcher",
+            },
+            "detect_sharding": {
+                "stage": "sharding",
+                "use_sharding_from_factory": False,
+                "sharding_dims": ["ep"],
+            },
+            "sharding_transform_executor": {
+                "stage": "sharding",
+            },
+        },
+    )
+    optimizer.shared_config.local_rank = 0
+    optimizer.shared_config.world_size = 2
+    gm_transformed = optimizer(None, gm)
+
+    has_torch_moe = any(
+        is_op(n, torch.ops.auto_deploy.torch_moe) for n in gm_transformed.graph.nodes
+    )
+    has_torch_moe_fused = any(
+        is_op(n, torch.ops.auto_deploy.torch_moe_fused) for n in gm_transformed.graph.nodes
+    )
+    has_allreduce = any(
+        is_op(n, torch.ops.auto_deploy.torch_dist_all_reduce) for n in gm_transformed.graph.nodes
+    )
+
+    assert has_torch_moe, "Expected converted torch_moe node for EP sharding"
+    assert not has_torch_moe_fused, "torch_moe_fused should be converted before EP sharding"
+    assert has_allreduce, "Expected EP sharding to insert torch_dist_all_reduce"

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/fla/test_fla_cached_gated_delta_rule.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/fla/test_fla_cached_gated_delta_rule.py
@@ -1,0 +1,335 @@
+"""Unit tests for the fla_cached_gated_delta_rule custom op.
+
+Covers:
+- Decode-only path: batch of single tokens, verify output and final state
+  match ``fused_recurrent_gated_delta_rule_fwd`` called directly with gathered
+  initial states.
+- Prefill-only path: batch of multi-token sequences (variable length), verify
+  output and final state match per-sequence ``chunk_gated_delta_rule``.
+- Prefill with initial state: same as prefill but with ``use_initial_states=True``
+  and non-zero initial cache, verifying the cache history is correctly loaded and
+  passed to the kernel.
+"""
+
+import pytest
+import torch
+
+# Register all auto_deploy custom ops
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.modules.fla.chunk import chunk_gated_delta_rule
+from tensorrt_llm._torch.modules.fla.fused_recurrent import fused_recurrent_gated_delta_rule_fwd
+
+
+@pytest.fixture
+def gdr_env():
+    device = "cuda"
+    dtype = torch.bfloat16
+    # FLA Triton kernels do not support float32
+    torch.manual_seed(42)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype}
+
+
+def _random_inputs(device, dtype, batch, seq, num_heads, key_dim, value_dim):
+    """Generate random gated delta rule inputs."""
+    q = torch.randn(batch, seq, num_heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(batch, seq, num_heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(batch, seq, num_heads, value_dim, device=device, dtype=dtype)
+    g = -torch.rand(batch, seq, num_heads, device=device, dtype=dtype)  # negative (decay)
+    beta = torch.sigmoid(torch.randn(batch, seq, num_heads, device=device, dtype=dtype))
+
+    # L2 normalize Q and K as the patched forward does
+    q = torch.nn.functional.normalize(q, dim=-1)
+    k = torch.nn.functional.normalize(k, dim=-1)
+    return q, k, v, g, beta
+
+
+def test_decode_only(gdr_env):
+    """Decode-only: batch of single tokens through the cached op.
+
+    Verifies output and cache state match fused_recurrent_gated_delta_rule_fwd
+    called directly with gathered initial states.
+    """
+    device = gdr_env["device"]
+    dtype = gdr_env["dtype"]
+    atol = 5e-3
+    rtol = 5e-3
+
+    batch = 3
+    seq = 1
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 6
+    scale = key_dim**-0.5
+
+    q, k, v, g, beta = _random_inputs(device, dtype, batch, seq, num_heads, key_dim, value_dim)
+
+    # Slot mapping with arbitrary order
+    slot_idx = torch.tensor([4, 1, 3], device=device, dtype=torch.int32)
+
+    # Initialize cache with random state (simulating existing history)
+    delta_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Metadata for decode-only: no prefill
+    batch_info_host = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
+    cu_seqlen = torch.zeros(1, device=device, dtype=torch.int32)
+    use_initial_states = torch.ones(batch, device=device, dtype=torch.bool)
+
+    # Snapshot cache before mutation for reference
+    gathered_before = delta_cache.clone().index_select(0, slot_idx.long())
+
+    # Run cached op
+    y = torch.ops.auto_deploy.fla_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    assert y.shape == (batch, seq, num_heads, value_dim)
+    assert torch.isfinite(y).all()
+
+    # Reference: call fused_recurrent_gated_delta_rule_fwd directly
+    # The cached op internally does:
+    #   q_flat[num_prefill_tokens:, None] -> [num_decode, 1, H, K]
+    # So we reshape our inputs similarly
+    q_flat = q.view(batch, num_heads, -1)  # [B, H, K]
+    k_flat = k.view(batch, num_heads, -1)  # [B, H, K]
+    v_flat = v.view(batch, num_heads, -1)  # [B, H, V]
+    g_flat = g.view(batch, num_heads)  # [B, H]
+    beta_flat = beta.view(batch, num_heads)  # [B, H]
+
+    y_ref, final_state_ref = fused_recurrent_gated_delta_rule_fwd(
+        q=q_flat[:, None],  # [B, 1, H, K]
+        k=k_flat[:, None],  # [B, 1, H, K]
+        v=v_flat[:, None],  # [B, 1, H, V]
+        g=g_flat[:, None],  # [B, 1, H]
+        beta=beta_flat[:, None],  # [B, 1, H]
+        scale=scale,
+        initial_state=gathered_before.clone(),
+        output_final_state=True,
+    )
+
+    # y_ref shape: [B, 1, H, V] -> compare against y: [B, 1, H, V]
+    y_ref_reshaped = y_ref.to(dtype)
+    torch.testing.assert_close(y, y_ref_reshaped, atol=atol, rtol=rtol)
+
+    # Compare updated cache states
+    after = delta_cache.index_select(0, slot_idx.long())
+    torch.testing.assert_close(
+        after,
+        final_state_ref.to(after.dtype),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def test_prefill_only(gdr_env):
+    """Prefill-only: two sequences of different lengths, flattened.
+
+    Verifies output and final state match per-sequence chunk_gated_delta_rule.
+    """
+    device = gdr_env["device"]
+    dtype = gdr_env["dtype"]
+    atol = 5e-3
+    rtol = 5e-3
+
+    seq_lens = [5, 3]
+    total_tokens = sum(seq_lens)
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 4
+    scale = key_dim**-0.5
+
+    # Create flattened inputs: [1, total_tokens, H, D]
+    q, k, v, g, beta = _random_inputs(
+        device,
+        dtype,
+        1,
+        total_tokens,
+        num_heads,
+        key_dim,
+        value_dim,
+    )
+
+    slot_idx = torch.tensor([2, 0], device=device, dtype=torch.int32)
+    delta_cache = torch.zeros(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Metadata for prefill-only
+    num_prefill = len(seq_lens)
+    batch_info_host = torch.tensor(
+        [num_prefill, total_tokens, 0],
+        device=device,
+        dtype=torch.int32,
+    )
+    cu_seqlen = torch.tensor([0, seq_lens[0], total_tokens], device=device, dtype=torch.int32)
+    use_initial_states = torch.zeros(num_prefill, device=device, dtype=torch.bool)
+
+    # Run cached op
+    y = torch.ops.auto_deploy.fla_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    assert y.shape == (1, total_tokens, num_heads, value_dim)
+    assert torch.isfinite(y).all()
+
+    # Reference: call chunk_gated_delta_rule per sequence
+    y_ref = torch.empty_like(y)
+    for i, sl in enumerate(seq_lens):
+        start = sum(seq_lens[:i])
+        end = start + sl
+
+        # chunk_gated_delta_rule expects [B, T, H, D] layout
+        y_seq, final_state = chunk_gated_delta_rule(
+            q=q[:, start:end],
+            k=k[:, start:end],
+            v=v[:, start:end],
+            g=g[:, start:end],
+            beta=beta[:, start:end],
+            scale=scale,
+            initial_state=None,
+            output_final_state=True,
+        )
+
+        y_ref[:, start:end] = y_seq.to(dtype)
+
+        # Verify cache was updated for this slot
+        torch.testing.assert_close(
+            delta_cache[slot_idx[i].long()],
+            final_state.squeeze(0).to(delta_cache.dtype),
+            atol=atol,
+            rtol=rtol,
+        )
+
+    torch.testing.assert_close(y, y_ref, atol=atol, rtol=rtol)
+
+
+def test_prefill_with_initial_state(gdr_env):
+    """Prefill with initial state: verifies cache history is correctly loaded.
+
+    Sets use_initial_states=True and a non-zero initial cache, then checks that
+    the result matches chunk_gated_delta_rule called with the same initial state
+    and differs from running without initial state.
+    """
+    device = gdr_env["device"]
+    dtype = gdr_env["dtype"]
+    atol = 5e-3
+    rtol = 5e-3
+
+    seq_len = 4
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 2
+    scale = key_dim**-0.5
+
+    q, k, v, g, beta = _random_inputs(device, dtype, 1, seq_len, num_heads, key_dim, value_dim)
+
+    slot_idx = torch.tensor([1], device=device, dtype=torch.int32)
+
+    # Non-zero initial state in cache
+    delta_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=dtype,
+    )
+    initial_state = delta_cache[1].clone()  # snapshot
+
+    # Metadata: one prefill sequence with initial state
+    batch_info_host = torch.tensor([1, seq_len, 0], device=device, dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+    use_initial_states = torch.tensor([True], device=device, dtype=torch.bool)
+
+    # Run cached op WITH initial state
+    y_with_init = torch.ops.auto_deploy.fla_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    # Reference: chunk_gated_delta_rule with the same initial state
+    y_ref, final_ref = chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state.unsqueeze(0),
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(y_with_init, y_ref.to(dtype), atol=atol, rtol=rtol)
+    torch.testing.assert_close(
+        delta_cache[1],
+        final_ref.squeeze(0).to(delta_cache.dtype),
+        atol=atol,
+        rtol=rtol,
+    )
+
+    # Also verify it's different from running WITHOUT initial state (zero state)
+    delta_cache_zero = torch.zeros_like(delta_cache)
+    use_initial_states_false = torch.tensor([False], device=device, dtype=torch.bool)
+
+    y_without_init = torch.ops.auto_deploy.fla_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states_false,
+        delta_cache_zero,
+        scale,
+    )
+
+    # The results should differ when there's a non-zero initial state
+    assert not torch.allclose(y_with_init, y_without_init, atol=1e-3, rtol=1e-3), (
+        "Output with initial state should differ from output without initial state"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/fla/test_torch_cached_gated_delta_rule.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/fla/test_torch_cached_gated_delta_rule.py
@@ -1,0 +1,335 @@
+"""Unit tests for the torch_cached_gated_delta_rule custom op.
+
+Covers:
+- Decode-only path: batch of single tokens, verify output and final state
+  match ``_torch_gated_delta_step`` called directly.
+- Prefill-only path: batch of multi-token sequences, verify output and final
+  state match ``_torch_gated_delta_prefill``.
+- Prefill with initial state: same as prefill but with ``use_initial_states=True``
+  and non-zero initial cache, verifying the cache history is correctly loaded.
+"""
+
+import pytest
+import torch
+
+# Register all auto_deploy custom ops
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.fla.torch_backend_gated_delta import (
+    _torch_gated_delta_prefill,
+    _torch_gated_delta_step,
+)
+
+
+@pytest.fixture
+def gated_delta_env():
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype}
+
+
+def _random_inputs(device, dtype, batch, seq, num_heads, key_dim, value_dim):
+    """Generate random gated delta rule inputs."""
+    q = torch.randn(batch, seq, num_heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(batch, seq, num_heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(batch, seq, num_heads, value_dim, device=device, dtype=dtype)
+    g = -torch.rand(batch, seq, num_heads, device=device, dtype=dtype)  # negative (decay)
+    beta = torch.sigmoid(torch.randn(batch, seq, num_heads, device=device, dtype=dtype))
+
+    # L2 normalize Q and K as the patched forward does
+    q = torch.nn.functional.normalize(q, dim=-1)
+    k = torch.nn.functional.normalize(k, dim=-1)
+    return q, k, v, g, beta
+
+
+def test_decode_only(gated_delta_env):
+    """Decode-only: batch of single tokens through the cached op.
+
+    Verifies output and cache state match _torch_gated_delta_step.
+    """
+    device = gated_delta_env["device"]
+    dtype = gated_delta_env["dtype"]
+
+    batch = 4
+    seq = 1
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 6
+    scale = key_dim**-0.5
+
+    q, k, v, g, beta = _random_inputs(device, dtype, batch, seq, num_heads, key_dim, value_dim)
+
+    # Slot mapping with arbitrary order
+    slot_idx = torch.tensor([5, 1, 3, 0], device=device, dtype=torch.int32)
+
+    # Initialize cache with random state (simulating existing history)
+    delta_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    # Metadata for decode-only: no prefill
+    batch_info_host = torch.tensor([0, 0, batch], device=device, dtype=torch.int32)
+    cu_seqlen = torch.zeros(1, device=device, dtype=torch.int32)
+    use_initial_states = torch.ones(batch, device=device, dtype=torch.bool)
+
+    # Snapshot cache before mutation for reference
+    gathered_before = delta_cache.clone().index_select(0, slot_idx.long())
+
+    # Run cached op
+    y = torch.ops.auto_deploy.torch_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    assert y.shape == (batch, seq, num_heads, value_dim)
+    assert torch.isfinite(y).all()
+
+    # Reference: call _torch_gated_delta_step directly per sequence
+    y_ref_list = []
+    final_state_ref_list = []
+    for i in range(batch):
+        o_ref, s_ref = _torch_gated_delta_step(
+            q[i, 0].unsqueeze(0),  # [1, H, K]
+            k[i, 0].unsqueeze(0),  # [1, H, K]
+            v[i, 0].unsqueeze(0),  # [1, H, V]
+            g[i, 0].unsqueeze(0),  # [1, H]
+            beta[i, 0].unsqueeze(0),  # [1, H]
+            gathered_before[i].unsqueeze(0),  # [1, H, K, V]
+            scale,
+        )
+        y_ref_list.append(o_ref.squeeze(0))  # [H, V]
+        final_state_ref_list.append(s_ref.squeeze(0))  # [H, K, V]
+
+    y_ref = torch.stack(y_ref_list, dim=0).unsqueeze(1).to(dtype)  # [B, 1, H, V]
+    final_state_ref = torch.stack(final_state_ref_list, dim=0)  # [B, H, K, V]
+
+    # Compare outputs
+    torch.testing.assert_close(y, y_ref, atol=1e-3, rtol=1e-3)
+
+    # Compare updated cache states
+    after = delta_cache.index_select(0, slot_idx.long())
+    torch.testing.assert_close(
+        after,
+        final_state_ref.to(after.dtype),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+def test_prefill_only(gated_delta_env):
+    """Prefill-only: two sequences of different lengths, flattened.
+
+    Verifies output and final state match _torch_gated_delta_prefill.
+    """
+    device = gated_delta_env["device"]
+    dtype = gated_delta_env["dtype"]
+
+    seq_lens = [3, 5]
+    total_tokens = sum(seq_lens)
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 4
+    scale = key_dim**-0.5
+
+    # Create flattened inputs: [1, total_tokens, H, D]
+    q, k, v, g, beta = _random_inputs(
+        device,
+        dtype,
+        1,
+        total_tokens,
+        num_heads,
+        key_dim,
+        value_dim,
+    )
+
+    slot_idx = torch.tensor([2, 0], device=device, dtype=torch.int32)
+    delta_cache = torch.zeros(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    # Metadata for prefill-only
+    num_prefill = len(seq_lens)
+    batch_info_host = torch.tensor(
+        [num_prefill, total_tokens, 0],
+        device=device,
+        dtype=torch.int32,
+    )
+    cu_seqlen = torch.tensor([0, seq_lens[0], total_tokens], device=device, dtype=torch.int32)
+    use_initial_states = torch.zeros(num_prefill, device=device, dtype=torch.bool)
+
+    # Run cached op
+    y = torch.ops.auto_deploy.torch_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    assert y.shape == (1, total_tokens, num_heads, value_dim)
+    assert torch.isfinite(y).all()
+
+    # Reference: run _torch_gated_delta_prefill per sequence
+    y_ref = torch.empty_like(y)
+    for i, sl in enumerate(seq_lens):
+        start = sum(seq_lens[:i])
+        end = start + sl
+
+        q_seq = q[:, start:end]
+        k_seq = k[:, start:end]
+        v_seq = v[:, start:end]
+        g_seq = g[:, start:end]
+        beta_seq = beta[:, start:end]
+
+        init_state = torch.zeros(
+            1,
+            num_heads,
+            key_dim,
+            value_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        y_seq, final_state = _torch_gated_delta_prefill(
+            q_seq,
+            k_seq,
+            v_seq,
+            g_seq,
+            beta_seq,
+            scale,
+            init_state,
+        )
+
+        y_ref[:, start:end] = y_seq.to(dtype)
+
+        # Verify cache was updated for this slot
+        torch.testing.assert_close(
+            delta_cache[slot_idx[i].long()],
+            final_state.squeeze(0).to(delta_cache.dtype),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+    torch.testing.assert_close(y, y_ref, atol=1e-3, rtol=1e-3)
+
+
+def test_prefill_with_initial_state(gated_delta_env):
+    """Prefill with initial state: verifies cache history is correctly loaded.
+
+    Sets use_initial_states=True and a non-zero initial cache, then checks that
+    the result differs from prefill without initial state.
+    """
+    device = gated_delta_env["device"]
+    dtype = gated_delta_env["dtype"]
+
+    seq_len = 4
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_batch_size = 2
+    scale = key_dim**-0.5
+
+    q, k, v, g, beta = _random_inputs(device, dtype, 1, seq_len, num_heads, key_dim, value_dim)
+
+    slot_idx = torch.tensor([1], device=device, dtype=torch.int32)
+
+    # Non-zero initial state in cache
+    delta_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+    initial_state = delta_cache[1].clone()  # snapshot
+
+    # Metadata: one prefill sequence with initial state
+    batch_info_host = torch.tensor([1, seq_len, 0], device=device, dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+    use_initial_states = torch.tensor([True], device=device, dtype=torch.bool)
+
+    # Run cached op WITH initial state
+    y_with_init = torch.ops.auto_deploy.torch_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states,
+        delta_cache,
+        scale,
+    )
+
+    # Reference: _torch_gated_delta_prefill with the same initial state
+    y_ref, final_ref = _torch_gated_delta_prefill(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state.unsqueeze(0),
+    )
+
+    torch.testing.assert_close(y_with_init, y_ref.to(dtype), atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(
+        delta_cache[1],
+        final_ref.squeeze(0).to(delta_cache.dtype),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+    # Also verify it's different from running WITHOUT initial state (zero state)
+    delta_cache_zero = torch.zeros_like(delta_cache)
+    use_initial_states_false = torch.tensor([False], device=device, dtype=torch.bool)
+
+    y_without_init = torch.ops.auto_deploy.torch_cached_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        batch_info_host,
+        cu_seqlen,
+        slot_idx,
+        use_initial_states_false,
+        delta_cache_zero,
+        scale,
+    )
+
+    # The results should differ when there's a non-zero initial state
+    assert not torch.allclose(y_with_init, y_without_init, atol=1e-3, rtol=1e-3), (
+        "Output with initial state should differ from output without initial state"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_5_moe.py
@@ -7,6 +7,16 @@ implementation (pure-PyTorch fallback paths) for each major block:
   2. Attention (full attention with gating)
   3. SparseMoeBlock (routed + shared experts)
   4. DecoderLayer (composed token mixer + channel mixer)
+
+Additionally validates vision tower and multimodal wrapper via functional
+comparison tests (reference re-implementations on the same weights):
+  5. VisionAttention reference comparison
+  6. VisionBlock reference comparison
+  7. VisionModel reference comparison (single-image and multi-image)
+  8. Multimodal forward reference comparison
+  9. position_embeddings passthrough equivalence
+ 10. get_rope_index correctness
+ 11. torch.export with cos/sin extra inputs
 """
 
 import pytest
@@ -17,14 +27,24 @@ import torch.nn.functional as F
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeAttention,
+    Qwen3_5MoeConfig,
     Qwen3_5MoeDecoderLayer,
     Qwen3_5MoeExperts,
+    Qwen3_5MoeForCausalLM,
+    Qwen3_5MoeForConditionalGeneration,
     Qwen3_5MoeGatedDeltaNet,
+    Qwen3_5MoeModel,
     Qwen3_5MoeSparseMoeBlock,
     Qwen3_5MoeTextConfig,
+    Qwen3_5MoeTextModel,
     Qwen3_5MoeTextRotaryEmbedding,
     Qwen3_5MoeTopKRouter,
+    Qwen3_5MoeVisionAttention,
+    Qwen3_5MoeVisionBlock,
+    Qwen3_5MoeVisionConfig,
+    Qwen3_5MoeVisionModel,
     apply_rotary_pos_emb,
+    apply_rotary_pos_emb_vision,
 )
 
 
@@ -423,6 +443,167 @@ def ref_decoder_layer_forward(module, hidden_states, position_embeddings):
 
 
 # =============================================================================
+# Vision Reference Forward Functions
+# =============================================================================
+# These re-implement the HF vision forward logic using our module's weights
+# in pure PyTorch. They validate that our simplified vision port produces
+# numerically equivalent results.
+
+
+def ref_vision_attention_forward(module, hidden_states, cu_seqlens, position_embeddings):
+    """HF-style VisionAttention forward (eager path, non-causal).
+
+    Re-implements the attention using explicit matmul SDPA, operating on the
+    same weights as the module. This validates the QKV projection, RoPE
+    application, per-chunk variable-length attention, and output projection.
+    """
+    seq_length = hidden_states.shape[0]
+
+    # QKV projection and reshape (same as HF: reshape to (S, 3, H, D), permute, unbind)
+    query_states, key_states, value_states = (
+        F.linear(hidden_states, module.qkv.weight, module.qkv.bias)
+        .reshape(seq_length, 3, module.num_heads, -1)
+        .permute(1, 0, 2, 3)
+        .unbind(0)
+    )
+
+    # Apply vision RoPE
+    cos, sin = position_embeddings
+    query_states, key_states = apply_rotary_pos_emb_vision(query_states, key_states, cos, sin)
+
+    # Transpose to (1, H, S, D) for batched attention
+    query_states = query_states.transpose(0, 1).unsqueeze(0)
+    key_states = key_states.transpose(0, 1).unsqueeze(0)
+    value_states = value_states.transpose(0, 1).unsqueeze(0)
+
+    # Split by variable-length sequences via cu_seqlens
+    lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+    q_splits = torch.split(query_states, lengths, dim=2)
+    k_splits = torch.split(key_states, lengths, dim=2)
+    v_splits = torch.split(value_states, lengths, dim=2)
+
+    # Per-chunk non-causal attention (HF eager path)
+    scaling = module.scaling
+    attn_outputs = []
+    for q, k, v in zip(q_splits, k_splits, v_splits):
+        attn_weights = torch.matmul(q, k.transpose(2, 3)) * scaling
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        attn_outputs.append(torch.matmul(attn_weights, v))
+
+    attn_output = torch.cat(attn_outputs, dim=2)  # (1, H, total_S, D)
+    attn_output = attn_output.squeeze(0).transpose(0, 1)  # (S, H, D)
+    attn_output = attn_output.reshape(seq_length, -1).contiguous()
+
+    # Output projection
+    attn_output = F.linear(attn_output, module.proj.weight, module.proj.bias)
+    return attn_output
+
+
+def ref_vision_block_forward(module, hidden_states, cu_seqlens, position_embeddings):
+    """HF-style VisionBlock forward using reference attention.
+
+    Composes: hidden_states + ref_attn(norm1(hidden_states)) + mlp(norm2(...))
+    LayerNorm and MLP are identical to our implementation (pure PyTorch, no
+    custom ops), so we use them directly from the module.
+    """
+    hidden_states = hidden_states + ref_vision_attention_forward(
+        module.attn, module.norm1(hidden_states), cu_seqlens, position_embeddings
+    )
+    hidden_states = hidden_states + module.mlp(module.norm2(hidden_states))
+    return hidden_states
+
+
+def ref_vision_model_forward(module, hidden_states, grid_thw):
+    """HF-style VisionModel forward using reference block implementations.
+
+    Re-implements the full pipeline:
+      1. PatchEmbed (same, no simplification)
+      2. fast_pos_embed_interpolate (same, no simplification)
+      3. rot_pos_emb -> (cos, sin)
+      4. cu_seqlens from grid_thw
+      5. Loop blocks using ref_vision_block_forward
+      6. Merger (same, no simplification)
+
+    This validates that the pipeline composition is correct and that the
+    intermediate tensor shapes flow correctly through all stages.
+    """
+    # 1. Patch embedding
+    hidden_states = module.patch_embed(hidden_states)
+
+    # 2. Learned positional embeddings (bilinear interpolation)
+    pos_embeds = module.fast_pos_embed_interpolate(grid_thw)
+    hidden_states = hidden_states + pos_embeds
+
+    # 3. Rotary position embeddings for vision
+    rotary_pos_emb = module.rot_pos_emb(grid_thw)
+    seq_len, _ = hidden_states.size()
+    hidden_states = hidden_states.reshape(seq_len, -1)
+    rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+    emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+    position_embeddings = (emb.cos(), emb.sin())
+
+    # 4. Compute cu_seqlens from grid_thw
+    cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+
+    # 5. Loop through vision blocks using reference implementation
+    for blk in module.blocks:
+        hidden_states = ref_vision_block_forward(
+            blk, hidden_states, cu_seqlens, position_embeddings
+        )
+
+    # 6. Patch merger
+    merged_hidden_states = module.merger(hidden_states)
+    return hidden_states, merged_hidden_states
+
+
+def ref_multimodal_forward(model, input_ids, pixel_values=None, image_grid_thw=None):
+    """HF-style multimodal forward using reference sub-pipelines.
+
+    Re-implements the Qwen3_5MoeModel.forward step by step:
+      1. embed_tokens(input_ids) -> inputs_embeds
+      2. vision model on pixel_values -> image_embeds
+      3. masked_scatter image_embeds into inputs_embeds
+      4. get_rope_index -> position_ids (3, B, S)
+      5. rotary_emb -> (cos, sin)
+      6. language_model(inputs_embeds, position_embeddings)
+
+    This validates the multimodal wrapper orchestration: embedding merge,
+    mRoPE position ID computation, and correct forwarding to the LM.
+    """
+    # 1. Embed text tokens
+    inputs_embeds = model.get_input_embeddings()(input_ids)
+
+    # 2-3. Vision encoding + embedding merge
+    if pixel_values is not None and image_grid_thw is not None:
+        vision_output = model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds = vision_output.pooler_output
+        split_sizes = (image_grid_thw.prod(-1) // model.visual.spatial_merge_size**2).tolist()
+        image_embeds_list = list(torch.split(image_embeds, split_sizes))
+        image_embeds = torch.cat(image_embeds_list, dim=0).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        image_mask = (
+            (input_ids == model.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        )
+        inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+    # 4. Compute mRoPE position IDs
+    position_ids, _ = model.get_rope_index(input_ids, image_grid_thw)
+
+    # 5. Compute cos/sin from rotary embedding
+    position_embeddings = model.rotary_emb(inputs_embeds, position_ids)
+
+    # 6. Call language model with pre-computed position embeddings
+    return model.language_model(
+        inputs_embeds=inputs_embeds,
+        position_embeddings=position_embeddings,
+    )
+
+
+# =============================================================================
 # HF Reference Comparison Tests
 # =============================================================================
 
@@ -536,3 +717,566 @@ def test_decoder_layer_matches_hf_reference():
                 f"custom-ops forward should match HF reference"
             ),
         )
+
+
+# =============================================================================
+# Vision & Multimodal Config Helpers
+# =============================================================================
+
+
+def _make_small_vision_config(**overrides) -> Qwen3_5MoeVisionConfig:
+    """Small vision config for fast tests."""
+    defaults = dict(
+        depth=2,
+        hidden_size=32,
+        hidden_act="gelu_pytorch_tanh",
+        intermediate_size=64,
+        num_heads=2,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=32,
+        num_position_embeddings=16,  # 4x4 grid
+        initializer_range=0.02,
+    )
+    defaults.update(overrides)
+    return Qwen3_5MoeVisionConfig(**defaults)
+
+
+def _make_small_composite_config(**overrides) -> Qwen3_5MoeConfig:
+    """Small composite config (text + vision) for fast tests."""
+    text_config = _make_small_config()
+    vision_config = _make_small_vision_config(out_hidden_size=text_config.hidden_size)
+    defaults = dict(
+        text_config=text_config,
+        vision_config=vision_config,
+        image_token_id=100,
+        video_token_id=101,
+        vision_start_token_id=102,
+        vision_end_token_id=103,
+    )
+    defaults.update(overrides)
+    return Qwen3_5MoeConfig(**defaults)
+
+
+# =============================================================================
+# Vision Reference Comparison Tests
+# =============================================================================
+
+
+def _make_vision_test_inputs(vision_config, grid_thw):
+    """Create test inputs for vision modules: pixel_values, cu_seqlens, position_embeddings."""
+    total_patches = int(torch.prod(grid_thw, dim=1).sum().item())
+    t_ps, ps = vision_config.temporal_patch_size, vision_config.patch_size
+    pixel_values = torch.randn(total_patches, vision_config.in_channels * t_ps * ps * ps)
+    return pixel_values
+
+
+@torch.no_grad()
+def test_vision_attention_matches_reference():
+    """Compare VisionAttention forward against HF reference eager attention."""
+    vision_config = _make_small_vision_config()
+    torch.manual_seed(42)
+    attn = Qwen3_5MoeVisionAttention(vision_config)
+    attn.eval()
+
+    # 2 variable-length sequences: 6 tokens and 4 tokens
+    S = 10
+    hidden_states = torch.randn(S, vision_config.hidden_size)
+    cu_seqlens = torch.tensor([0, 6, 10], dtype=torch.int32)
+
+    # Compute vision RoPE position embeddings
+    head_dim = vision_config.hidden_size // vision_config.num_heads
+    rotary_dim = head_dim // 2
+    freqs = torch.randn(S, rotary_dim)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    position_embeddings = (emb.cos(), emb.sin())
+
+    our_output = attn(hidden_states, cu_seqlens, position_embeddings)
+    ref_output = ref_vision_attention_forward(attn, hidden_states, cu_seqlens, position_embeddings)
+
+    torch.testing.assert_close(
+        our_output,
+        ref_output,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionAttention forward should match HF reference eager attention",
+    )
+
+
+@torch.no_grad()
+def test_vision_block_matches_reference():
+    """Compare VisionBlock forward against HF reference (ref attention + MLP)."""
+    vision_config = _make_small_vision_config()
+    torch.manual_seed(42)
+    block = Qwen3_5MoeVisionBlock(vision_config)
+    block.eval()
+
+    S = 10
+    hidden_states = torch.randn(S, vision_config.hidden_size)
+    cu_seqlens = torch.tensor([0, 6, 10], dtype=torch.int32)
+
+    head_dim = vision_config.hidden_size // vision_config.num_heads
+    rotary_dim = head_dim // 2
+    freqs = torch.randn(S, rotary_dim)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    position_embeddings = (emb.cos(), emb.sin())
+
+    our_output = block(hidden_states, cu_seqlens, position_embeddings)
+    ref_output = ref_vision_block_forward(block, hidden_states, cu_seqlens, position_embeddings)
+
+    torch.testing.assert_close(
+        our_output,
+        ref_output,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionBlock forward should match HF reference",
+    )
+
+
+@torch.no_grad()
+def test_vision_model_matches_reference():
+    """Compare VisionModel forward against HF reference for a single image."""
+    vision_config = _make_small_vision_config()
+    torch.manual_seed(42)
+    vision_model = Qwen3_5MoeVisionModel(vision_config)
+    vision_model.eval()
+
+    # Single image: T=1, H=4, W=4 -> 16 patches
+    grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    pixel_values = _make_vision_test_inputs(vision_config, grid_thw)
+
+    our_output = vision_model(pixel_values, grid_thw)
+    ref_last_hidden, ref_pooler = ref_vision_model_forward(vision_model, pixel_values, grid_thw)
+
+    torch.testing.assert_close(
+        our_output.last_hidden_state,
+        ref_last_hidden,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionModel last_hidden_state should match HF reference",
+    )
+    torch.testing.assert_close(
+        our_output.pooler_output,
+        ref_pooler,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionModel pooler_output should match HF reference",
+    )
+
+
+@torch.no_grad()
+def test_vision_model_multi_image_matches_reference():
+    """Compare VisionModel forward against HF reference for multiple images."""
+    vision_config = _make_small_vision_config()
+    torch.manual_seed(42)
+    vision_model = Qwen3_5MoeVisionModel(vision_config)
+    vision_model.eval()
+
+    # 2 images of different sizes: T=1,H=4,W=4 (16 patches) + T=1,H=2,W=4 (8 patches)
+    grid_thw = torch.tensor([[1, 4, 4], [1, 2, 4]], dtype=torch.long)
+    pixel_values = _make_vision_test_inputs(vision_config, grid_thw)
+
+    our_output = vision_model(pixel_values, grid_thw)
+    ref_last_hidden, ref_pooler = ref_vision_model_forward(vision_model, pixel_values, grid_thw)
+
+    torch.testing.assert_close(
+        our_output.last_hidden_state,
+        ref_last_hidden,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionModel multi-image last_hidden_state should match HF reference",
+    )
+    torch.testing.assert_close(
+        our_output.pooler_output,
+        ref_pooler,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VisionModel multi-image pooler_output should match HF reference",
+    )
+
+
+# =============================================================================
+# Position Embeddings Passthrough Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_position_embeddings_passthrough():
+    """Test that passing pre-computed position_embeddings produces the same output
+    as computing them internally from position_ids."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeTextModel(config)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+
+    # Path 1: Let the model compute position_embeddings internally
+    output_internal = model(input_ids=input_ids, position_ids=position_ids)
+
+    # Path 2: Compute position_embeddings externally and pass them in
+    inputs_embeds = model.embed_tokens(input_ids)
+    position_ids_3d = position_ids[None, ...].expand(3, B, -1)
+    cos, sin = model.rotary_emb(inputs_embeds, position_ids_3d)
+    output_external = model(input_ids=input_ids, position_embeddings=(cos, sin))
+
+    torch.testing.assert_close(
+        output_internal.last_hidden_state,
+        output_external.last_hidden_state,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="External position_embeddings should produce identical output to internal computation",
+    )
+
+
+@torch.no_grad()
+def test_rope_cos_sin_kwargs():
+    """Test that passing rope_cos/rope_sin as separate kwargs produces the same
+    output as using position_embeddings tuple or internal computation."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeTextModel(config)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+
+    # Reference: internal computation
+    output_ref = model(input_ids=input_ids, position_ids=position_ids)
+
+    # Compute cos/sin externally
+    inputs_embeds = model.embed_tokens(input_ids)
+    position_ids_3d = position_ids[None, ...].expand(3, B, -1)
+    cos, sin = model.rotary_emb(inputs_embeds, position_ids_3d)
+
+    # Test: pass as separate kwargs (export-friendly path)
+    output_kwargs = model(input_ids=input_ids, rope_cos=cos, rope_sin=sin)
+
+    torch.testing.assert_close(
+        output_ref.last_hidden_state,
+        output_kwargs.last_hidden_state,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="rope_cos/rope_sin kwargs should produce identical output to internal computation",
+    )
+
+
+@torch.no_grad()
+def test_causal_lm_position_embeddings():
+    """Test that Qwen3_5MoeForCausalLM correctly passes position_embeddings through."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForCausalLM(config)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+
+    # Reference output using position_ids
+    output_ref = model(input_ids=input_ids, position_ids=position_ids)
+
+    # Compute cos/sin externally
+    inputs_embeds = model.model.embed_tokens(input_ids)
+    position_ids_3d = position_ids[None, ...].expand(3, B, -1)
+    cos, sin = model.model.rotary_emb(inputs_embeds, position_ids_3d)
+
+    # Test: pass as position_embeddings tuple
+    output_tuple = model(input_ids=input_ids, position_embeddings=(cos, sin))
+
+    # Test: pass as separate rope_cos/rope_sin
+    output_kwargs = model(input_ids=input_ids, rope_cos=cos, rope_sin=sin)
+
+    torch.testing.assert_close(
+        output_ref.logits,
+        output_tuple.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="CausalLM position_embeddings tuple path should match",
+    )
+    torch.testing.assert_close(
+        output_ref.logits,
+        output_kwargs.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="CausalLM rope_cos/rope_sin path should match",
+    )
+
+
+# =============================================================================
+# get_rope_index Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_get_rope_index_text_only():
+    """Test get_rope_index for a text-only sequence (no vision tokens)."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeModel(config)
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, 50, (B, S))  # no special tokens
+
+    position_ids, deltas = model.get_rope_index(input_ids)
+
+    # For text-only: all 3 mRoPE dimensions should be identical
+    assert position_ids.shape == (3, B, S), f"Expected (3, {B}, {S}), got {position_ids.shape}"
+    torch.testing.assert_close(
+        position_ids[0],
+        position_ids[1],
+        msg="Text-only: T and H position IDs should be identical",
+    )
+    torch.testing.assert_close(
+        position_ids[0],
+        position_ids[2],
+        msg="Text-only: T and W position IDs should be identical",
+    )
+    # Should be 0, 1, 2, ..., S-1
+    expected = torch.arange(S).unsqueeze(0).expand(B, -1)
+    torch.testing.assert_close(
+        position_ids[0],
+        expected,
+        msg="Text-only position IDs should be sequential",
+    )
+    # Deltas should be 0 for text-only
+    assert (deltas == 0).all(), f"Expected zero deltas, got {deltas}"
+
+
+@torch.no_grad()
+def test_get_rope_index_with_image():
+    """Test get_rope_index for a sequence containing image placeholders."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeModel(config)
+
+    image_token_id = config.image_token_id
+    vision_start_token_id = config.vision_start_token_id
+
+    # Build a sequence: [text, vision_start, image_token*4, text]
+    # Grid: T=1, H=2, W=2 -> after spatial merge (2x2): 1 merged token
+    # But position IDs are for pre-merge (1*1*1 = 1 spatial position)
+    # Actually for the LLM: grid_h // merge = 2//2=1, grid_w // merge = 2//2=1
+    # so 1*1*1 = 1 vision position in position_ids
+    # Image tokens in input_ids: 1 token (1 merged vision token placeholder)
+    input_ids = torch.tensor(
+        [
+            [
+                1,
+                2,
+                3,  # 3 text tokens
+                vision_start_token_id,
+                image_token_id,  # 1 vision placeholder
+                4,
+                5,  # 2 text tokens
+            ]
+        ]
+    )
+    image_grid_thw = torch.tensor([[1, 2, 2]], dtype=torch.long)
+
+    position_ids, deltas = model.get_rope_index(input_ids, image_grid_thw=image_grid_thw)
+
+    assert position_ids.shape == (3, 1, 7), f"Expected (3, 1, 7), got {position_ids.shape}"
+    # Text before image: positions 0,1,2
+    assert position_ids[0, 0, 0] == 0
+    assert position_ids[0, 0, 1] == 1
+    assert position_ids[0, 0, 2] == 2
+    # vision_start_token: position 3
+    assert position_ids[0, 0, 3] == 3
+    # Image token: T dimension should use temporal index
+    # The vision token position: st_idx = 4 (text_len=4 since ed=4), T=4, H=0, W=0
+    # After image: trailing text should continue sequentially
+
+
+@torch.no_grad()
+def test_get_rope_index_with_attention_mask():
+    """Test get_rope_index respects attention_mask for text-only."""
+    config = _make_small_composite_config()
+    model = Qwen3_5MoeModel(config)
+
+    B, S = 1, 6
+    input_ids = torch.randint(0, 50, (B, S))
+    attention_mask = torch.tensor([[1, 1, 1, 1, 0, 0]])  # last 2 tokens are padding
+
+    position_ids, deltas = model.get_rope_index(input_ids, attention_mask=attention_mask)
+
+    assert position_ids.shape == (3, B, S)
+    # Non-padded positions: 0, 1, 2, 3
+    assert position_ids[0, 0, 0] == 0
+    assert position_ids[0, 0, 3] == 3
+    # Padded positions should be 1 (masked fill value)
+    assert position_ids[0, 0, 4] == 1
+    assert position_ids[0, 0, 5] == 1
+
+
+# =============================================================================
+# Multimodal Reference Comparison Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_multimodal_forward_matches_reference():
+    """Compare multimodal wrapper forward against step-by-step HF reference.
+
+    Tests the full pipeline: vision encoding + embedding merge + mRoPE + LM.
+    Runs the same input through both the wrapper's forward() and the
+    ref_multimodal_forward() that re-implements each step explicitly.
+    """
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    image_token_id = config.image_token_id
+    vision_start_token_id = config.vision_start_token_id
+    vc = config.vision_config
+
+    # Vision: 1 image, T=1, H=4, W=4 -> 16 patches -> 4 merged tokens
+    image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    num_patches = 1 * 4 * 4
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    merge_factor = vc.spatial_merge_size**2
+    num_merged_tokens = num_patches // merge_factor  # 4
+
+    # Build input_ids: [text, vision_start, image_token * num_merged_tokens, text]
+    text_before = [1, 2, 3]
+    vision_part = [vision_start_token_id] + [image_token_id] * num_merged_tokens
+    text_after = [4, 5]
+    input_ids = torch.tensor([text_before + vision_part + text_after])
+
+    # Our wrapper forward
+    our_output = model(
+        input_ids=input_ids,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+    )
+
+    # Reference: step-by-step re-implementation
+    ref_output = ref_multimodal_forward(
+        model.model, input_ids, pixel_values=pixel_values, image_grid_thw=image_grid_thw
+    )
+
+    torch.testing.assert_close(
+        our_output.logits,
+        ref_output.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Multimodal forward should match step-by-step HF reference",
+    )
+
+
+# =============================================================================
+# torch.export Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_export_text_model_with_position_ids():
+    """Test that the text model can be exported with standard position_ids."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForCausalLM(config)
+    model.eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, config.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+
+    # Run normally first
+    ref_output = model(input_ids=input_ids, position_ids=position_ids)
+
+    # Export with Dim.AUTO to let torch.export infer dynamic vs static
+    from torch.export import Dim
+
+    dynamic_shapes = {
+        "input_ids": {0: Dim.AUTO, 1: Dim.AUTO},
+        "position_ids": {0: Dim.AUTO, 1: Dim.AUTO},
+    }
+
+    exported = torch.export.export(
+        model,
+        (),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+
+    # Run exported model
+    export_output = exported.module()(input_ids=input_ids, position_ids=position_ids)
+    torch.testing.assert_close(
+        ref_output.logits,
+        export_output.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Exported model should produce same output as eager model",
+    )
+
+
+@torch.no_grad()
+def test_export_text_model_with_rope_cos_sin():
+    """Test that the text model can be exported with rope_cos/rope_sin as extra inputs.
+
+    This validates the Option 3 mRoPE export path: cos/sin are computed
+    externally and passed as separate tensor kwargs.
+    """
+    config = _make_small_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForCausalLM(config)
+    model.eval()
+
+    B, S = 2, 4
+    inputs_embeds = torch.randn(B, S, config.hidden_size)
+    position_ids_3d = torch.arange(S).view(1, 1, -1).expand(3, B, -1)
+    cos, sin = model.model.rotary_emb(inputs_embeds, position_ids_3d)
+
+    # Reference: pass cos/sin via rope_cos/rope_sin
+    ref_output = model(inputs_embeds=inputs_embeds, rope_cos=cos, rope_sin=sin)
+
+    # Export with cos/sin as inputs, using Dim.AUTO
+    from torch.export import Dim
+
+    dynamic_shapes = {
+        "inputs_embeds": {0: Dim.AUTO, 1: Dim.AUTO},
+        "rope_cos": {0: Dim.AUTO, 1: Dim.AUTO},
+        "rope_sin": {0: Dim.AUTO, 1: Dim.AUTO},
+    }
+
+    exported = torch.export.export(
+        model,
+        (),
+        kwargs={"inputs_embeds": inputs_embeds, "rope_cos": cos, "rope_sin": sin},
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+
+    export_output = exported.module()(inputs_embeds=inputs_embeds, rope_cos=cos, rope_sin=sin)
+    torch.testing.assert_close(
+        ref_output.logits,
+        export_output.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Exported model with rope_cos/rope_sin should match eager output",
+    )
+
+    # Also test with different batch/seq dims to verify dynamic shapes work
+    B2, S2 = 3, 8
+    inputs_embeds2 = torch.randn(B2, S2, config.hidden_size)
+    position_ids_3d2 = torch.arange(S2).view(1, 1, -1).expand(3, B2, -1)
+    cos2, sin2 = model.model.rotary_emb(inputs_embeds2, position_ids_3d2)
+
+    ref_output2 = model(inputs_embeds=inputs_embeds2, rope_cos=cos2, rope_sin=sin2)
+    export_output2 = exported.module()(inputs_embeds=inputs_embeds2, rope_cos=cos2, rope_sin=sin2)
+    torch.testing.assert_close(
+        ref_output2.logits,
+        export_output2.logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Dynamic shape export should work with different batch/seq dims",
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_5_moe.py
@@ -1,0 +1,538 @@
+"""Tests for the custom Qwen3.5 MoE model implementation.
+
+Validates that the prefill-only custom model (with autodeploy custom ops)
+produces numerically equivalent results to the HuggingFace reference
+implementation (pure-PyTorch fallback paths) for each major block:
+  1. GatedDeltaNet (linear attention)
+  2. Attention (full attention with gating)
+  3. SparseMoeBlock (routed + shared experts)
+  4. DecoderLayer (composed token mixer + channel mixer)
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+# Register autodeploy custom ops (torch_moe, torch_causal_conv1d, etc.)
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
+    Qwen3_5MoeAttention,
+    Qwen3_5MoeDecoderLayer,
+    Qwen3_5MoeExperts,
+    Qwen3_5MoeGatedDeltaNet,
+    Qwen3_5MoeSparseMoeBlock,
+    Qwen3_5MoeTextConfig,
+    Qwen3_5MoeTextRotaryEmbedding,
+    Qwen3_5MoeTopKRouter,
+    apply_rotary_pos_emb,
+)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _make_small_config(**overrides) -> Qwen3_5MoeTextConfig:
+    """Create a small Qwen3.5 MoE config for fast unit testing.
+
+    Uses 4 layers (3 linear_attention + 1 full_attention) with minimal dimensions.
+    """
+    defaults = dict(
+        vocab_size=128,
+        hidden_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=64,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        attention_dropout=0.0,
+        head_dim=16,
+        rope_parameters={
+            "rope_type": "default",
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 1.0,
+            "mrope_section": [2, 2, 2],
+        },
+        # GDN params
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        # MoE params
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        # layer_types: default pattern gives 3 linear + 1 full attention for 4 layers
+    )
+    defaults.update(overrides)
+    return Qwen3_5MoeTextConfig(**defaults)
+
+
+def _init_block_weights(module, std=0.02):
+    """Initialize weights for standalone block-level testing.
+
+    When modules are created directly (not via PreTrainedModel._from_config),
+    the _init_weights callback never fires, leaving torch.empty() params
+    uninitialized (containing NaN/garbage). This function initializes them.
+    """
+    for m in module.modules():
+        if isinstance(m, Qwen3_5MoeExperts):
+            m.gate_up_proj.data.normal_(mean=0.0, std=std)
+            m.down_proj.data.normal_(mean=0.0, std=std)
+        elif isinstance(m, Qwen3_5MoeTopKRouter):
+            # Use randn for non-trivial routing
+            m.weight.data.normal_(mean=0.0, std=1.0)
+
+
+# =============================================================================
+# HF Reference Implementations
+# =============================================================================
+# Pure-PyTorch "torch fallback" functions copied from the HF reference
+# modeling_qwen3_5_moe.py. These have zero external dependencies and are used
+# to validate that our autodeploy custom-ops based forward passes produce
+# equivalent results.
+
+
+def ref_l2norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
+    """L2 norm. Copied from HF modeling_qwen3_5_moe.py l2norm."""
+    inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+    return x * inv_norm
+
+
+def ref_chunk_gated_delta_rule(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    chunk_size=64,
+    initial_state=None,
+    output_final_state=False,
+    use_qk_l2norm_in_kernel=False,
+):
+    """Chunked gated delta rule. Copied from HF torch_chunk_gated_delta_rule."""
+    initial_dtype = query.dtype
+    if use_qk_l2norm_in_kernel:
+        query = ref_l2norm(query, dim=-1, eps=1e-6)
+        key = ref_l2norm(key, dim=-1, eps=1e-6)
+    query, key, value, beta, g = [
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    ]
+
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+    total_sequence_length = sequence_length + pad_size
+    scale = 1 / (query.shape[-1] ** 0.5)
+    query = query * scale
+
+    v_beta = value * beta.unsqueeze(-1)
+    k_beta = key * beta.unsqueeze(-1)
+    query, key, value, k_beta, v_beta = [
+        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
+        for x in (query, key, value, k_beta, v_beta)
+    ]
+    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
+    )
+
+    g = g.cumsum(dim=-1)
+    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+    for i in range(1, chunk_size):
+        row = attn[..., i, :i].clone()
+        sub = attn[..., :i, :i].clone()
+        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+    value = attn @ v_beta
+    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
+    last_recurrent_state = (
+        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
+        if initial_state is None
+        else initial_state.to(value)
+    )
+    core_attn_out = torch.zeros_like(value)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+    )
+
+    for i in range(0, total_sequence_length // chunk_size):
+        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
+        attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
+        v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
+        v_new = v_i - v_prime
+        attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
+        core_attn_out[:, :, i] = attn_inter + attn @ v_new
+        last_recurrent_state = (
+            last_recurrent_state * g[:, :, i, -1, None, None].exp()
+            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+        )
+
+    if not output_final_state:
+        last_recurrent_state = None
+    core_attn_out = core_attn_out.reshape(
+        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
+    )
+    core_attn_out = core_attn_out[:, :, :sequence_length]
+    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
+    return core_attn_out, last_recurrent_state
+
+
+def ref_repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """KV head repetition for GQA. Copied from HF repeat_kv."""
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def ref_eager_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    num_key_value_groups: int,
+    scaling: float,
+    attention_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Eager matmul-based attention. Adapted from HF eager_attention_forward.
+
+    All tensors in bnsd layout: [B, N, S, D].
+    Returns: [B, S, N, D] (transposed, ready for reshape).
+    """
+    key_states = ref_repeat_kv(key, num_key_value_groups)
+    value_states = ref_repeat_kv(value, num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output
+
+
+# =============================================================================
+# Reference Forward Functions
+# =============================================================================
+# These functions take our custom modules (with their weights) and re-run the
+# forward pass using the HF reference logic (no custom ops). This lets us
+# compare the two code paths on identical weights + inputs.
+
+
+def ref_gdn_forward(module, hidden_states):
+    """HF-style GatedDeltaNet forward (torch fallback path, prefill-only, no cache).
+
+    Uses module.conv1d directly (nn.Conv1d forward) instead of torch_causal_conv1d,
+    and ref_chunk_gated_delta_rule (with internal l2norm) instead of
+    torch_l2norm + torch_gated_delta_rule.
+    """
+    batch_size, seq_len, _ = hidden_states.shape
+
+    # Projections
+    mixed_qkv = module.in_proj_qkv(hidden_states)  # [B, S, conv_dim]
+    z = module.in_proj_z(hidden_states)  # [B, S, value_dim]
+    z = z.reshape(batch_size, seq_len, -1, module.head_v_dim)
+    b = module.in_proj_b(hidden_states)  # [B, S, num_v_heads]
+    a = module.in_proj_a(hidden_states)  # [B, S, num_v_heads]
+
+    # Conv1d (HF torch fallback: transpose -> nn.Conv1d -> truncate -> silu -> transpose)
+    mixed_qkv = mixed_qkv.transpose(1, 2)  # [B, conv_dim, S]
+    mixed_qkv = F.silu(module.conv1d(mixed_qkv)[:, :, :seq_len])  # [B, conv_dim, S]
+    mixed_qkv = mixed_qkv.transpose(1, 2)  # [B, S, conv_dim]
+
+    # Split Q/K/V
+    query, key, value = torch.split(
+        mixed_qkv,
+        [module.key_dim, module.key_dim, module.value_dim],
+        dim=-1,
+    )
+    query = query.reshape(batch_size, seq_len, -1, module.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, module.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, module.head_v_dim)
+
+    # Gating
+    beta = b.sigmoid()
+    g = -module.A_log.float().exp() * F.softplus(a.float() + module.dt_bias)
+
+    # GQA repeat
+    if module.num_v_heads // module.num_k_heads > 1:
+        query = query.repeat_interleave(module.num_v_heads // module.num_k_heads, dim=2)
+        key = key.repeat_interleave(module.num_v_heads // module.num_k_heads, dim=2)
+
+    # Gated delta rule (HF torch fallback -- l2norm applied internally)
+    core_attn_out, _ = ref_chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g=g,
+        beta=beta,
+        initial_state=None,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    # Gated RMSNorm
+    core_attn_out = core_attn_out.reshape(-1, module.head_v_dim)
+    z = z.reshape(-1, module.head_v_dim)
+    core_attn_out = module.norm(core_attn_out, z)
+    core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+    return module.out_proj(core_attn_out)
+
+
+def ref_attention_forward(module, hidden_states, position_embeddings):
+    """HF-style Attention forward (eager path, bnsd layout, prefill-only, no cache).
+
+    Uses ref_eager_attention_forward (matmul SDPA) instead of torch_attention,
+    and operates in bnsd layout with unsqueeze_dim=1 for RoPE.
+    """
+    input_shape = hidden_states.shape[:-1]  # (B, S)
+    head_dim = module.head_dim
+    num_heads = module.num_heads
+    num_kv_heads = module.num_key_value_heads
+    num_kv_groups = num_heads // num_kv_heads
+    scaling = head_dim**-0.5
+    hidden_shape = (*input_shape, -1, head_dim)
+
+    # Q projection with gating (HF style: view then transpose to bnsd)
+    query_states, gate = torch.chunk(
+        module.q_proj(hidden_states).view(*input_shape, -1, head_dim * 2), 2, dim=-1
+    )
+    gate = gate.reshape(*input_shape, -1)  # (B, S, N*D)
+
+    # Q/K norms then transpose to bnsd: [B, S, N, D] -> [B, N, S, D]
+    query_states = module.q_norm(query_states.view(hidden_shape)).transpose(1, 2)
+    key_states = module.k_norm(module.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+    value_states = module.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+    # RoPE (unsqueeze_dim=1 for bnsd layout)
+    cos, sin = position_embeddings
+    query_states, key_states = apply_rotary_pos_emb(
+        query_states, key_states, cos, sin, unsqueeze_dim=1
+    )
+
+    # Additive causal mask: 0 for attended, -inf for masked
+    q_len = input_shape[-1]
+    causal_mask = torch.full((q_len, q_len), float("-inf"), device=hidden_states.device)
+    causal_mask = causal_mask.triu(diagonal=1).unsqueeze(0).unsqueeze(0)  # [1, 1, S, S]
+
+    # Eager attention (HF matmul-based SDPA in bnsd layout)
+    attn_output = ref_eager_attention_forward(
+        query_states,
+        key_states,
+        value_states,
+        num_key_value_groups=num_kv_groups,
+        scaling=scaling,
+        attention_mask=causal_mask,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = attn_output * torch.sigmoid(gate)
+    return module.o_proj(attn_output)
+
+
+def ref_moe_forward(module, hidden_states):
+    """HF-style SparseMoeBlock forward (manual expert dispatch loop).
+
+    Uses the HF Qwen3_5MoeExperts.forward dispatch logic instead of torch_moe.
+    """
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+    hidden_states_flat = hidden_states.view(-1, hidden_dim)
+
+    # Router (HF-style: softmax -> topk -> renormalize)
+    router_logits = F.linear(hidden_states_flat, module.gate.weight)
+    routing_probs = F.softmax(router_logits, dtype=torch.float, dim=-1)
+    router_top_value, router_indices = torch.topk(routing_probs, module.gate.top_k, dim=-1)
+    router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
+    router_top_value = router_top_value.to(hidden_states_flat.dtype)
+
+    # Expert dispatch (HF loop from Qwen3_5MoeExperts.forward)
+    gate_up_proj = module.experts.gate_up_proj  # [E, 2*I, H]
+    down_proj = module.experts.down_proj  # [E, H, I]
+    num_experts = module.experts.num_experts
+
+    final_hidden_states = torch.zeros_like(hidden_states_flat)
+    with torch.no_grad():
+        expert_mask = F.one_hot(router_indices, num_classes=num_experts)
+        expert_mask = expert_mask.permute(2, 1, 0)
+        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for expert_idx in expert_hit:
+        expert_idx = expert_idx[0]
+        if expert_idx == num_experts:
+            continue
+        top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        current_state = hidden_states_flat[token_idx]
+        gate, up = F.linear(current_state, gate_up_proj[expert_idx]).chunk(2, dim=-1)
+        current_hidden_states = F.silu(gate) * up
+        current_hidden_states = F.linear(current_hidden_states, down_proj[expert_idx])
+        current_hidden_states = current_hidden_states * router_top_value[token_idx, top_k_pos, None]
+        final_hidden_states.index_add_(
+            0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
+        )
+
+    # Shared expert with sigmoid gating
+    shared_expert_output = module.shared_expert(hidden_states_flat)
+    shared_expert_output = (
+        F.sigmoid(module.shared_expert_gate(hidden_states_flat)) * shared_expert_output
+    )
+    final_hidden_states = final_hidden_states + shared_expert_output
+
+    return final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+
+
+def ref_decoder_layer_forward(module, hidden_states, position_embeddings):
+    """HF-style DecoderLayer forward using reference implementations.
+
+    Layernorms are identical (pure PyTorch), so we use the module's norms directly.
+    Only the attention/GDN and MoE blocks use the reference code paths.
+    """
+    residual = hidden_states
+    hidden_states = module.input_layernorm(hidden_states)
+
+    if module.layer_type == "linear_attention":
+        hidden_states = ref_gdn_forward(module.linear_attn, hidden_states)
+    elif module.layer_type == "full_attention":
+        hidden_states = ref_attention_forward(module.self_attn, hidden_states, position_embeddings)
+
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = module.post_attention_layernorm(hidden_states)
+    hidden_states = ref_moe_forward(module.mlp, hidden_states)
+    hidden_states = residual + hidden_states
+
+    return hidden_states
+
+
+# =============================================================================
+# HF Reference Comparison Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_gdn_matches_hf_reference():
+    """Compare GatedDeltaNet custom-ops forward against HF reference torch fallback."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    gdn = Qwen3_5MoeGatedDeltaNet(config, layer_idx=0)
+    gdn.eval()
+
+    B, S = 2, 8
+    hidden_states = torch.randn(B, S, config.hidden_size)
+
+    our_output = gdn(hidden_states)
+    ref_output = ref_gdn_forward(gdn, hidden_states)
+
+    torch.testing.assert_close(
+        our_output,
+        ref_output,
+        rtol=1e-4,
+        atol=1e-4,
+        msg="GatedDeltaNet custom-ops forward should match HF reference",
+    )
+
+
+@torch.no_grad()
+def test_attention_matches_hf_reference():
+    """Compare Attention custom-ops forward against HF reference eager attention."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    # Layer 3 is full_attention in the default 4-layer config
+    attn = Qwen3_5MoeAttention(config, layer_idx=3)
+    attn.eval()
+
+    rotary_emb = Qwen3_5MoeTextRotaryEmbedding(config)
+
+    B, S = 2, 8
+    hidden_states = torch.randn(B, S, config.hidden_size)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    position_ids = position_ids[None, ...].expand(3, B, -1)
+    position_embeddings = rotary_emb(hidden_states, position_ids)
+
+    our_output = attn(hidden_states, position_embeddings)
+    ref_output = ref_attention_forward(attn, hidden_states, position_embeddings)
+
+    torch.testing.assert_close(
+        our_output,
+        ref_output,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Attention custom-ops forward should match HF reference",
+    )
+
+
+@torch.no_grad()
+def test_moe_matches_hf_reference():
+    """Compare SparseMoeBlock torch_moe forward against HF reference expert dispatch."""
+    config = _make_small_config()
+    torch.manual_seed(42)
+    moe = Qwen3_5MoeSparseMoeBlock(config)
+    moe.eval()
+    _init_block_weights(moe)
+
+    B, S = 2, 8
+    hidden_states = torch.randn(B, S, config.hidden_size)
+
+    our_output = moe(hidden_states)
+    ref_output = ref_moe_forward(moe, hidden_states)
+
+    torch.testing.assert_close(
+        our_output,
+        ref_output,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="SparseMoeBlock torch_moe forward should match HF reference",
+    )
+
+
+@torch.no_grad()
+def test_decoder_layer_matches_hf_reference():
+    """Compare DecoderLayer forward against HF reference for both layer types."""
+    config = _make_small_config()
+    rotary_emb = Qwen3_5MoeTextRotaryEmbedding(config)
+
+    B, S = 2, 8
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    position_ids = position_ids[None, ...].expand(3, B, -1)
+
+    # Test one linear_attention layer (idx 0) and one full_attention layer (idx 3)
+    for layer_idx in [0, 3]:
+        torch.manual_seed(42)
+        layer = Qwen3_5MoeDecoderLayer(config, layer_idx)
+        layer.eval()
+        _init_block_weights(layer)
+
+        hidden_states = torch.randn(B, S, config.hidden_size)
+        position_embeddings = rotary_emb(hidden_states, position_ids)
+
+        our_output = layer(hidden_states, position_embeddings)
+        ref_output = ref_decoder_layer_forward(layer, hidden_states, position_embeddings)
+
+        torch.testing.assert_close(
+            our_output,
+            ref_output,
+            rtol=1e-4,
+            atol=1e-4,
+            msg=(
+                f"DecoderLayer {layer_idx} ({config.layer_types[layer_idx]}) "
+                f"custom-ops forward should match HF reference"
+            ),
+        )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_next_gdn_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_next_gdn_patches.py
@@ -1,0 +1,237 @@
+"""Testing GDN (Gated Delta Net) patches for Qwen3Next.
+
+This test verifies that:
+1. The `torch_gated_delta_rule` custom op produces the same output as the HF
+   `torch_chunk_gated_delta_rule` reference implementation.
+2. The patched `Qwen3NextGatedDeltaNet.forward` produces the same output as the
+   original HuggingFace implementation.
+
+Reference HF modeling file (v4.57.1):
+  https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+"""
+
+import types
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextGatedDeltaNet
+from transformers.models.qwen3_next.modeling_qwen3_next import (
+    torch_chunk_gated_delta_rule as hf_torch_chunk_gated_delta_rule,
+)
+
+# Register all auto_deploy custom ops (torch_gated_delta_rule, torch_causal_conv1d, torch_l2norm)
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.models.patches.qwen3_next import _patched_gdn_forward
+
+
+def test_torch_gated_delta_rule_op():
+    """Verify the `torch_gated_delta_rule` custom op produces the same output
+    as the HF `torch_chunk_gated_delta_rule` function.
+
+    Both operate on pure-torch math (no FLA kernels). We compare with
+    `use_qk_l2norm_in_kernel=False` so L2 norm is excluded from both paths.
+    """
+    torch.manual_seed(42)
+
+    batch_size = 2
+    seq_len = 128
+    num_heads = 4
+    k_head_dim = 16
+    v_head_dim = 16
+
+    # Inputs in [B, S, H, D] layout (bsnd convention)
+    q = torch.randn(batch_size, seq_len, num_heads, k_head_dim, dtype=torch.float32)
+    k = torch.randn(batch_size, seq_len, num_heads, k_head_dim, dtype=torch.float32)
+    v = torch.randn(batch_size, seq_len, num_heads, v_head_dim, dtype=torch.float32)
+    g = -torch.rand(batch_size, seq_len, num_heads, dtype=torch.float32)  # negative (decay)
+    beta = torch.sigmoid(torch.randn(batch_size, seq_len, num_heads, dtype=torch.float32))
+
+    # L2 normalize Q and K (as our patched forward does externally)
+    q = torch.nn.functional.normalize(q, dim=-1)
+    k = torch.nn.functional.normalize(k, dim=-1)
+
+    # Reference: HF torch implementation (no l2norm inside, since we did it externally)
+    with torch.no_grad():
+        ref_output, _ = hf_torch_chunk_gated_delta_rule(
+            q, k, v, g=g, beta=beta, use_qk_l2norm_in_kernel=False
+        )
+
+    # Test: our custom op
+    with torch.no_grad():
+        test_output = torch.ops.auto_deploy.torch_gated_delta_rule(q, k, v, g, beta)
+
+    torch.testing.assert_close(
+        ref_output,
+        test_output,
+        atol=1e-4,
+        rtol=1e-4,
+        msg="Output mismatch between HF torch_chunk_gated_delta_rule and auto_deploy::torch_gated_delta_rule",
+    )
+
+
+def test_torch_gated_delta_rule_op_bfloat16():
+    """Verify the custom op works correctly with bfloat16 inputs."""
+    torch.manual_seed(123)
+
+    batch_size = 1
+    seq_len = 64
+    num_heads = 2
+    k_head_dim = 8
+    v_head_dim = 8
+
+    q = torch.randn(batch_size, seq_len, num_heads, k_head_dim, dtype=torch.bfloat16)
+    k = torch.randn(batch_size, seq_len, num_heads, k_head_dim, dtype=torch.bfloat16)
+    v = torch.randn(batch_size, seq_len, num_heads, v_head_dim, dtype=torch.bfloat16)
+    g = -torch.rand(batch_size, seq_len, num_heads, dtype=torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(batch_size, seq_len, num_heads, dtype=torch.bfloat16))
+
+    q = torch.nn.functional.normalize(q, dim=-1)
+    k = torch.nn.functional.normalize(k, dim=-1)
+
+    with torch.no_grad():
+        ref_output, _ = hf_torch_chunk_gated_delta_rule(
+            q, k, v, g=g, beta=beta, use_qk_l2norm_in_kernel=False
+        )
+
+    with torch.no_grad():
+        test_output = torch.ops.auto_deploy.torch_gated_delta_rule(q, k, v, g, beta)
+
+    torch.testing.assert_close(
+        ref_output,
+        test_output,
+        atol=1e-2,
+        rtol=1e-2,
+        msg="Output mismatch for bfloat16 between HF and auto_deploy gated delta rule",
+    )
+
+
+def _load_qwen3_next_gdn_layer():
+    """Build a tiny Qwen3Next model with a linear_attention layer and extract the GDN block.
+
+    Returns:
+        module: The Qwen3NextGatedDeltaNet layer.
+    """
+    config = AutoConfig.for_model("qwen3_next")
+
+    # Minimal dimensions for fast testing
+    config.num_hidden_layers = 1
+    config.use_cache = False
+    config.hidden_size = 32
+    config.intermediate_size = 16
+    config.moe_intermediate_size = 16
+    config.shared_expert_intermediate_size = 16
+    config.num_experts = 4
+    config.num_experts_per_tok = 2
+    config.num_attention_heads = 4
+    config.num_key_value_heads = 4
+    config.head_dim = 8
+    config.decoder_sparse_step = 1
+    config.norm_topk_prob = True
+
+    # Use a single linear_attention layer to get the GDN block
+    config.layer_types = ["linear_attention"]
+
+    # Linear attention params
+    config.linear_num_key_heads = 2
+    config.linear_num_value_heads = 4
+    config.linear_key_head_dim = 8
+    config.linear_value_head_dim = 8
+    config.linear_conv_kernel_dim = 4
+
+    model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+    model.eval()
+
+    # The GDN block is at model.layers.0.linear_attn
+    layer_name = "model.layers.0.linear_attn"
+    module = dict(model.named_modules()).get(layer_name)
+    assert module is not None, f"Layer '{layer_name}' not found in the model"
+    assert isinstance(module, Qwen3NextGatedDeltaNet), (
+        f"Expected Qwen3NextGatedDeltaNet, got {type(module)}"
+    )
+    return module
+
+
+def _force_torch_fallbacks(module):
+    """Force the GDN module to use pure-torch fallbacks instead of FLA/causal_conv1d kernels.
+
+    This ensures the reference forward uses the same algorithmic path as our
+    patched forward, so we can compare with tight tolerances.
+    """
+    from transformers.models.qwen3_next.modeling_qwen3_next import (
+        torch_chunk_gated_delta_rule as hf_chunk,
+    )
+    from transformers.models.qwen3_next.modeling_qwen3_next import (
+        torch_recurrent_gated_delta_rule as hf_recurrent,
+    )
+
+    module.causal_conv1d_fn = None
+    module.chunk_gated_delta_rule = hf_chunk
+    module.recurrent_gated_delta_rule = hf_recurrent
+
+
+def test_qwen3_next_gdn_patch():
+    """Verify the patched Qwen3NextGatedDeltaNet.forward produces the same
+    output as the original HuggingFace implementation.
+
+    The patch replaces the forward with autodeploy custom ops
+    (torch_causal_conv1d, torch_l2norm, torch_gated_delta_rule) while
+    maintaining numerical equivalence.
+    """
+    torch.manual_seed(42)
+
+    module = _load_qwen3_next_gdn_layer()
+
+    # Force torch fallbacks for the reference path so both sides use pure torch
+    _force_torch_fallbacks(module)
+
+    # Convert to bfloat16 to match typical inference dtype
+    module = module.to(torch.bfloat16)
+
+    hidden_size = 32
+    inputs = torch.randn(2, 16, hidden_size, dtype=torch.bfloat16)
+
+    # Reference: original HF forward (with torch fallbacks, no cache)
+    with torch.no_grad():
+        ref_output = type(module).forward(module, inputs)
+
+    # Patched: our _patched_gdn_forward
+    module.forward = types.MethodType(_patched_gdn_forward, module)
+    with torch.no_grad():
+        test_output = module(inputs)
+
+    torch.testing.assert_close(
+        ref_output,
+        test_output,
+        atol=1e-2,
+        rtol=1e-2,
+        msg="Output mismatch between original and patched Qwen3Next GDN forward",
+    )
+
+
+def test_qwen3_next_gdn_patch_float32():
+    """Same as above but in float32 for tighter tolerance checks."""
+    torch.manual_seed(42)
+
+    module = _load_qwen3_next_gdn_layer()
+    _force_torch_fallbacks(module)
+
+    # Stay in float32 for tighter tolerances
+    module = module.to(torch.float32)
+
+    hidden_size = 32
+    inputs = torch.randn(2, 16, hidden_size, dtype=torch.float32)
+
+    with torch.no_grad():
+        ref_output = type(module).forward(module, inputs)
+
+    module.forward = types.MethodType(_patched_gdn_forward, module)
+    with torch.no_grad():
+        test_output = module(inputs)
+
+    torch.testing.assert_close(
+        ref_output,
+        test_output,
+        atol=1e-4,
+        rtol=1e-4,
+        msg="Output mismatch (float32) between original and patched Qwen3Next GDN forward",
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_next_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_next_patches.py
@@ -1,0 +1,114 @@
+"""Testing module patches that enable export of Qwen3Next MoE.
+
+This test verifies that the patched Qwen3NextSparseMoeBlock forward function
+produces identical outputs to the original HuggingFace implementation.
+"""
+
+import types
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+# Register torch.ops.auto_deploy.torch_moe
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.models.patches.qwen3_next import _forward_moe
+
+
+def _load_qwen3_next_moe_layer():
+    """Build a tiny Qwen3Next model and extract the MoE block.
+
+    We create a small model to keep tests fast while still exercising the
+    MoE routing, expert computation, shared expert, and sigmoid gating logic.
+
+    Returns:
+        module: The Qwen3NextSparseMoeBlock layer.
+    """
+    try:
+        config = AutoConfig.for_model("qwen3_next")
+
+        # Minimal dimensions for fast testing
+        config.num_hidden_layers = 1
+        config.use_cache = False
+        config.hidden_size = 16
+        config.intermediate_size = 8  # dense MLP intermediate
+        config.moe_intermediate_size = 8  # routed expert intermediate
+        config.shared_expert_intermediate_size = 8
+        config.num_experts = 4
+        config.num_experts_per_tok = 2
+        config.num_attention_heads = 2
+        config.num_key_value_heads = 2
+        config.head_dim = 8  # 2 heads * 8 = 16 = hidden_size
+        config.decoder_sparse_step = 1  # every layer is MoE
+        config.layer_types = ["full_attention"]  # 1 layer, full attention type
+        config.norm_topk_prob = True
+
+        # Linear attention params (unused for full_attention layers but required by config)
+        config.linear_num_key_heads = 2
+        config.linear_num_value_heads = 4
+        config.linear_key_head_dim = 8
+        config.linear_value_head_dim = 8
+        config.linear_conv_kernel_dim = 4
+
+        # Build the model architecture (no weights loaded -- random init)
+        model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+        model.eval()
+
+        # The MoE block is at model.layers.0.mlp
+        layer_name = "model.layers.0.mlp"
+        module = dict(model.named_modules()).get(layer_name)
+        if module is None:
+            print(f"Layer '{layer_name}' not found in the model.")
+        else:
+            print(f"Successfully extracted layer '{layer_name}'.")
+        return module
+    except Exception as e:
+        print(f"Error extracting layer: {e}")
+        return None
+
+
+def test_qwen3_next_moe_patch():
+    """Verify the patched Qwen3NextSparseMoeBlock produces the same output
+    as the original HuggingFace implementation.
+
+    The patch rewrites the forward to use torch.ops.auto_deploy.torch_moe
+    for torch.export compatibility while maintaining numerical equivalence.
+    """
+    torch.manual_seed(42)
+
+    module = _load_qwen3_next_moe_layer()
+    assert module is not None, "Failed to load Qwen3Next MoE layer"
+
+    # Convert module to bfloat16 to match inference dtype
+    module = module.to(torch.bfloat16)
+
+    # Create test input: (batch_size=2, seq_len=6, hidden_size=16)
+    hidden_size = 16
+    inputs = torch.randn(2, 6, hidden_size, dtype=torch.bfloat16)
+
+    # Reference: original HF forward returns (hidden_states, router_logits)
+    with torch.no_grad():
+        ref_output, ref_router_logits = type(module).forward(module, inputs)
+
+    # Patched: our _forward_moe also returns (hidden_states, router_logits)
+    module.forward = types.MethodType(_forward_moe, module)
+    with torch.no_grad():
+        test_output, test_router_logits = module(inputs)
+
+    # Router logits should be identical (same computation path)
+    torch.testing.assert_close(
+        ref_router_logits,
+        test_router_logits,
+        atol=1e-5,
+        rtol=1e-5,
+        msg="Router logits mismatch between original and patched Qwen3Next MoE",
+    )
+
+    # Final hidden states should be very close
+    # (small tolerance for different computation order in torch_moe)
+    torch.testing.assert_close(
+        ref_output,
+        test_output,
+        atol=1e-3,
+        rtol=1e-3,
+        msg="Output mismatch between original and patched Qwen3Next MoE",
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gated_delta_rule_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gated_delta_rule_cache.py
@@ -1,0 +1,249 @@
+"""Transform unit test for insert_cached_gated_delta_rule with the fla_gated_delta backend.
+
+Verifies the full pipeline:
+  1. Build a mock model that calls ``torch_gated_delta_rule`` internally.
+  2. Export to GraphModule.
+  3. Apply the ``insert_cached_gated_delta_rule`` transform.
+  4. Test full-sequence prefill matches uncached model output.
+  5. Test token-by-token autoregressive decode output matches the cached model's
+     own full-sequence prefill output.
+
+Note: the autoregressive test compares against the cached model's prefill output
+(y_prefill) rather than the uncached reference (y_model) because the FLA Triton
+kernels and the pure-torch ``torch_gated_delta_rule`` produce slightly different
+floating-point results.  Comparing cached prefill vs cached autoregressive
+verifies that "autoregressive caching reproduces the same result as full-sequence
+processing through the same kernel path."
+
+The stale-cache fix zeroes delta_cache tensors between phases because
+``cm.info.reset()`` only clears sequence metadata, not physical cache data.
+"""
+
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from _torch_test_utils import all_close
+
+# Register all auto_deploy custom ops
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.models.factory import (
+    FullModelExportInfo,
+    ModelFactory,
+    SubModuleExportInfo,
+)
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+# ---------------------------------------------------------------------------
+# Dummy factory (same pattern as test_kv_cache.py)
+# ---------------------------------------------------------------------------
+
+
+class DummyFactory(ModelFactory):
+    """Dummy factory to pass cache_config_updates for testing."""
+
+    def __init__(self, model, cache_config_updates):
+        self._model = model
+        self.cache_config_updates = cache_config_updates
+
+    def build_model(self, device: str):
+        return self._model.to(device=device)
+
+    def _build_model(self, device: str):
+        return
+
+    def _load_checkpoint(self, model, device):
+        return
+
+    def get_cache_config_updates(self):
+        return self.cache_config_updates
+
+    def get_export_infos(self, model: nn.Module) -> List[SubModuleExportInfo]:
+        return [FullModelExportInfo()]
+
+
+# ---------------------------------------------------------------------------
+# Mock model that uses torch_gated_delta_rule
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaRuleModel(nn.Module):
+    """Minimal model that projects embeddings through torch_gated_delta_rule.
+
+    Architecture:
+      input_ids -> embedding -> linear projections -> torch_gated_delta_rule -> output proj
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_heads: int,
+        key_dim: int,
+        value_dim: int,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.key_dim = key_dim
+        self.value_dim = value_dim
+
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.q_proj = nn.Linear(hidden_size, num_heads * key_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, num_heads * key_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, num_heads * value_dim, bias=False)
+        self.g_proj = nn.Linear(hidden_size, num_heads, bias=False)
+        self.beta_proj = nn.Linear(hidden_size, num_heads, bias=False)
+        self.o_proj = nn.Linear(num_heads * value_dim, hidden_size, bias=False)
+
+    @torch.no_grad()
+    def forward(
+        self, input_ids: torch.Tensor, position_ids: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = self.embed_tokens(input_ids)  # [B, S, hidden]
+        b, s, _ = x.shape
+
+        q = self.q_proj(x).view(b, s, self.num_heads, self.key_dim)
+        k = self.k_proj(x).view(b, s, self.num_heads, self.key_dim)
+        v = self.v_proj(x).view(b, s, self.num_heads, self.value_dim)
+
+        # L2 normalize Q and K
+        q = torch.nn.functional.normalize(q, dim=-1)
+        k = torch.nn.functional.normalize(k, dim=-1)
+
+        # g should be negative (decay), beta should be in (0, 1)
+        g = -torch.nn.functional.softplus(self.g_proj(x))  # [B, S, H]
+        beta = torch.sigmoid(self.beta_proj(x))  # [B, S, H]
+
+        attn_out = torch.ops.auto_deploy.torch_gated_delta_rule(q, k, v, g, beta)
+        # attn_out: [B, S, H, V]
+
+        attn_out = attn_out.reshape(b, s, -1)
+        return self.o_proj(attn_out)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@torch.inference_mode()
+def test_gated_delta_rule_with_cache():
+    """Test the insert_cached_gated_delta_rule transform with fla_gated_delta backend."""
+    # Configuration
+    dtype = torch.bfloat16
+    # Wider tolerances for FLA Triton vs pure-torch comparison (prefill)
+    atol_prefill = 5e-2
+    rtol_prefill = 5e-2
+    # Tighter tolerances for same-kernel-path comparison (autoregressive vs prefill)
+    atol_ar = 1e-2
+    rtol_ar = 1e-2
+    batch_size = 4
+    seq_len = 16
+    vocab_size = 100
+    hidden_size = 32
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_position_embeddings = 64
+
+    # Create CachedSequenceInterface
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=max_position_embeddings,
+        max_tokens=batch_size * max_position_embeddings,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_position_embeddings,
+        max_batch_size=batch_size,
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    # Create model
+    model = GatedDeltaRuleModel(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        key_dim=key_dim,
+        value_dim=value_dim,
+    ).to(dtype=dtype, device="cuda")
+
+    # Create input data
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    # Get uncached reference output (pure-torch torch_gated_delta_rule)
+    y_model = model(input_ids)  # [B, S, hidden]
+
+    # Apply the transformation pipeline
+    optimizer = InferenceOptimizer(
+        DummyFactory(model, cache_config_updates={}),
+        {
+            "build_model": {
+                "stage": "factory",
+                "run_per_gm": False,
+                "device": "cuda",
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "export_to_gm": {
+                "stage": "export",
+                "strict": False,
+                "run_per_gm": False,
+                "clone_state_dict": True,
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "cleanup_input_constraints": {
+                "stage": "post_export",
+            },
+            "insert_cached_gated_delta_rule": {
+                "stage": "cache_init",
+                "backend": "fla_gated_delta",
+            },
+        },
+    )  # type: ignore
+
+    gm = optimizer(cm)
+    gm.to("cuda")
+    num_caches = cm.initialize_resources()
+    print(f"num_caches: {num_caches}")
+
+    # Helper function to call the model with proper sequence nesting
+    def _call_and_unnest(x, input_pos):
+        cm.info.nest_sequences(x, input_pos=input_pos)
+        y = gm(**cm.named_args)
+        return torch.stack(cm.info.unnest_sequences(y))
+
+    # ---- Test 1: Full-sequence prefill ----
+    cm.info.reset()
+    # Zero caches for a clean start
+    for cache in cm._caches.values():
+        if cache is not None:
+            cache.zero_()
+    y_prefill = _call_and_unnest(input_ids, 0)
+    assert all_close(y_model, y_prefill, atol=atol_prefill, rtol=rtol_prefill), (
+        "Prefill output does not match uncached model output"
+    )
+
+    # ---- Test 2: Token-by-token autoregressive ----
+    # Compare against the cached model's full-sequence prefill output (y_prefill)
+    # rather than the uncached reference (y_model) because the FLA Triton kernels
+    # and the pure-torch torch_gated_delta_rule produce slightly different results.
+    cm.info.reset()
+    # CRITICAL: Zero the delta_cache tensors between test phases.
+    # cm.info.reset() only clears sequence metadata, NOT the physical cache.
+    for cache in cm._caches.values():
+        if cache is not None:
+            cache.zero_()
+
+    y_autoregressive = torch.empty_like(y_model)
+    for i_p in range(seq_len):
+        y_autoregressive[:, i_p : i_p + 1] = _call_and_unnest(
+            input_ids[:, i_p : i_p + 1],
+            i_p,
+        )
+    assert all_close(y_prefill, y_autoregressive, atol=atol_ar, rtol=rtol_ar), (
+        "Autoregressive output does not match cached prefill output"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
@@ -1,0 +1,237 @@
+"""Transform unit test for insert_cached_gated_delta_rule with the torch_gated_delta backend.
+
+Verifies the full pipeline:
+  1. Build a mock model that calls ``torch_gated_delta_rule`` internally.
+  2. Export to GraphModule.
+  3. Apply the ``insert_cached_gated_delta_rule`` transform.
+  4. Test full-sequence prefill matches uncached model output.
+  5. Test token-by-token autoregressive matches uncached model output.
+
+The stale-cache fix zeroes delta_cache tensors between phases because
+``cm.info.reset()`` only clears sequence metadata, not physical cache data.
+"""
+
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from _torch_test_utils import all_close
+
+# Register all auto_deploy custom ops
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.models.factory import (
+    FullModelExportInfo,
+    ModelFactory,
+    SubModuleExportInfo,
+)
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+# ---------------------------------------------------------------------------
+# Dummy factory (same pattern as test_kv_cache.py)
+# ---------------------------------------------------------------------------
+
+
+class DummyFactory(ModelFactory):
+    """Dummy factory to pass cache_config_updates for testing."""
+
+    def __init__(self, model, cache_config_updates):
+        self._model = model
+        self.cache_config_updates = cache_config_updates
+
+    def build_model(self, device: str):
+        return self._model.to(device=device)
+
+    def _build_model(self, device: str):
+        return
+
+    def _load_checkpoint(self, model, device):
+        return
+
+    def get_cache_config_updates(self):
+        return self.cache_config_updates
+
+    def get_export_infos(self, model: nn.Module) -> List[SubModuleExportInfo]:
+        return [FullModelExportInfo()]
+
+
+# ---------------------------------------------------------------------------
+# Mock model that uses torch_gated_delta_rule
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaRuleModel(nn.Module):
+    """Minimal model that projects embeddings through torch_gated_delta_rule.
+
+    Architecture:
+      input_ids -> embedding -> linear projections -> torch_gated_delta_rule -> output proj
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_heads: int,
+        key_dim: int,
+        value_dim: int,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.key_dim = key_dim
+        self.value_dim = value_dim
+
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.q_proj = nn.Linear(hidden_size, num_heads * key_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, num_heads * key_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, num_heads * value_dim, bias=False)
+        self.g_proj = nn.Linear(hidden_size, num_heads, bias=False)
+        self.beta_proj = nn.Linear(hidden_size, num_heads, bias=False)
+        self.o_proj = nn.Linear(num_heads * value_dim, hidden_size, bias=False)
+
+    @torch.no_grad()
+    def forward(
+        self, input_ids: torch.Tensor, position_ids: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = self.embed_tokens(input_ids)  # [B, S, hidden]
+        b, s, _ = x.shape
+
+        q = self.q_proj(x).view(b, s, self.num_heads, self.key_dim)
+        k = self.k_proj(x).view(b, s, self.num_heads, self.key_dim)
+        v = self.v_proj(x).view(b, s, self.num_heads, self.value_dim)
+
+        # L2 normalize Q and K
+        q = torch.nn.functional.normalize(q, dim=-1)
+        k = torch.nn.functional.normalize(k, dim=-1)
+
+        # g should be negative (decay), beta should be in (0, 1)
+        g = -torch.nn.functional.softplus(self.g_proj(x))  # [B, S, H]
+        beta = torch.sigmoid(self.beta_proj(x))  # [B, S, H]
+
+        attn_out = torch.ops.auto_deploy.torch_gated_delta_rule(q, k, v, g, beta)
+        # attn_out: [B, S, H, V]
+
+        attn_out = attn_out.reshape(b, s, -1)
+        return self.o_proj(attn_out)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@torch.inference_mode()
+def test_torch_gated_delta_rule_cache():
+    """Test the insert_cached_gated_delta_rule transform with torch_gated_delta backend."""
+    # Configuration
+    dtype = torch.float32
+    atol = 1e-3
+    rtol = 1e-3
+    batch_size = 4
+    seq_len = 16
+    vocab_size = 100
+    hidden_size = 32
+    num_heads = 2
+    key_dim = 8
+    value_dim = 8
+    max_position_embeddings = 64
+
+    # Create CachedSequenceInterface
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=max_position_embeddings,
+        max_tokens=batch_size * max_position_embeddings,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_position_embeddings,
+        max_batch_size=batch_size,
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    # Create model
+    model = GatedDeltaRuleModel(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        key_dim=key_dim,
+        value_dim=value_dim,
+    ).to(dtype=dtype, device="cuda")
+
+    # Create input data
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    # Get uncached reference output
+    y_model = model(input_ids)  # [B, S, hidden]
+
+    # Apply the transformation pipeline
+    optimizer = InferenceOptimizer(
+        DummyFactory(model, cache_config_updates={}),
+        {
+            "build_model": {
+                "stage": "factory",
+                "run_per_gm": False,
+                "device": "cuda",
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "export_to_gm": {
+                "stage": "export",
+                "strict": False,
+                "run_per_gm": False,
+                "clone_state_dict": True,
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "cleanup_input_constraints": {
+                "stage": "post_export",
+            },
+            "insert_cached_gated_delta_rule": {
+                "stage": "cache_init",
+                "backend": "torch_gated_delta",
+            },
+        },
+    )  # type: ignore
+
+    gm = optimizer(cm)
+    gm.to("cuda")
+    num_caches = cm.initialize_resources()
+    print(f"num_caches: {num_caches}")
+
+    # Helper function to call the model with proper sequence nesting
+    def _call_and_unnest(x, input_pos):
+        cm.info.nest_sequences(x, input_pos=input_pos)
+        y = gm(**cm.named_args)
+        return torch.stack(cm.info.unnest_sequences(y))
+
+    # ---- Test 1: Full-sequence prefill ----
+    cm.info.reset()
+    # Zero caches for a clean start
+    for cache in cm._caches.values():
+        if cache is not None:
+            cache.zero_()
+    y_no_cache = _call_and_unnest(input_ids, 0)
+    assert all_close(y_model, y_no_cache, atol=atol, rtol=rtol), (
+        "Prefill output does not match uncached model output"
+    )
+
+    # ---- Test 2: Token-by-token autoregressive ----
+    cm.info.reset()
+    # CRITICAL: Zero the delta_cache tensors between test phases.
+    # cm.info.reset() only clears sequence metadata, NOT the physical cache.
+    # For recurrent state caches, the decode path unconditionally loads state
+    # from delta_cache when num_decode > 0, so stale data from the prior
+    # prefill test would corrupt the first autoregressive token.
+    for cache in cm._caches.values():
+        if cache is not None:
+            cache.zero_()
+
+    y_with_cache = torch.empty_like(y_model)
+    for i_p in range(seq_len):
+        y_with_cache[:, i_p : i_p + 1] = _call_and_unnest(
+            input_ids[:, i_p : i_p + 1],
+            i_p,
+        )
+    assert all_close(y_model, y_with_cache, atol=atol, rtol=rtol), (
+        "Autoregressive output does not match uncached model output"
+    )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gated-Delta linear-attention with cached prefill/decode backends, Qwen3Next export patches, full Qwen3.5 MoE model and example deployment configs, MOE export-time tracing optimizations, and MoE fusion/splitting to enable per-expert sharding workflows.
* **Bug Fixes**
  * Improved L2-normalization input handling for stable numeric/kernel behavior.
* **Tests**
  * Extensive unit and integration tests covering gated-delta ops, cached attention paths, MOE export/fusion, sharding, and Qwen3.* patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
