### PR TITLE
[TRTLLM-9392][feat] Support MoE output to alltoall's workspace for all the quantization recipe of trtllm-gen.

### DIFF
--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -530,7 +530,8 @@ public:
         std::optional<int64_t> const valid_hidden_size, std::optional<int64_t> const valid_intermediate_size,
         int64_t local_expert_offset, int64_t local_num_experts, std::optional<double> routed_scaling_factor,
         int64_t routing_method_type, std::vector<int64_t> moeConfigIndex,
-        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
+        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids,
+        torch::optional<torch::Tensor> const& output = torch::nullopt)
 
     {
         // moeConfigIndex corresponds to pair (tileN, config)
@@ -555,8 +556,7 @@ public:
             gemm2_weights_scale, gemm2_bias, std::nullopt, std::nullopt, std::nullopt, num_experts, top_k, n_group,
             topk_group, intermediate_size, valid_hidden_size, valid_intermediate_size, local_expert_offset,
             local_num_experts, routed_scaling_factor, tileN, routing_method_type, mDtypeAct, *mRunners[tileN], config,
-            topk_weights, topk_ids,
-            /*out_tensor=*/torch::nullopt); // TODO: Support user-provided output
+            topk_weights, topk_ids, output);
     }
 
 private:

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -368,7 +368,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp4_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -727,7 +727,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp8_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def fp8_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: torch.Tensor,
@@ -1046,7 +1046,7 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::mxe4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def mxe4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1332,7 +1332,7 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::e4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def e4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1620,7 +1620,7 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::bf16_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def bf16_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1894,7 +1894,7 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp8_fp4_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def fp8_fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -367,7 +367,8 @@ class FP4BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
+@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner",
+                         mutates_args=("output", ))
 def fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -725,7 +726,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
+@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner",
+                         mutates_args=("output", ))
 def fp8_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: torch.Tensor,
@@ -1044,7 +1046,7 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::mxe4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=())
+                         mutates_args=("output", ))
 def mxe4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1330,7 +1332,7 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::e4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=())
+                         mutates_args=("output", ))
 def e4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1618,7 +1620,7 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::bf16_mxe2m1_block_scale_moe_runner",
-                         mutates_args=())
+                         mutates_args=("output", ))
 def bf16_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1892,7 +1894,7 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp8_fp4_block_scale_moe_runner",
-                         mutates_args=())
+                         mutates_args=("output", ))
 def fp8_fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -367,8 +367,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner",
-                         mutates_args=("output", ))
+@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
 def fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -726,8 +725,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner",
-                         mutates_args=("output", ))
+@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
 def fp8_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: torch.Tensor,
@@ -1046,7 +1044,7 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::mxe4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def mxe4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1332,7 +1330,7 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::e4m3_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def e4m3_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1620,7 +1618,7 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::bf16_mxe2m1_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def bf16_mxe2m1_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -1894,7 +1892,7 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp8_fp4_block_scale_moe_runner",
-                         mutates_args=("output", ))
+                         mutates_args=())
 def fp8_fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -367,8 +367,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner",
-                         mutates_args=())
+@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
 def fp4_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
@@ -726,8 +725,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
         return tuning_config
 
 
-@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner",
-                         mutates_args=())
+@torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
 def fp8_block_scale_moe_runner(
         routing_logits: Optional[torch.Tensor],
         routing_bias: torch.Tensor,

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -235,6 +235,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
         self,
         inputs: List[torch.Tensor],
         tactic: List[int] = [-1, -1],
+        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert isinstance(tactic, list)
 
@@ -252,7 +253,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
             self.n_group, self.topk_group, self.intermediate_size,
             self.local_expert_offset, self.local_num_experts,
             self.routed_scaling_factor, self.routing_method_type,
-            self.do_finalize, tactic, args.topk_weights, args.topk_ids)
+            self.do_finalize, tactic, args.topk_weights, args.topk_ids, output)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,
@@ -396,7 +397,8 @@ def fp4_block_scale_moe_runner(
         do_finalize: bool,
         act_type: int = ActType_TrtllmGen.SwiGlu.value,
         topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+        topk_ids: Optional[torch.Tensor] = None,
+        output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
 
     tuner = AutoTuner.get()
     kernel_runner = FP4BlockScaleMoERunner(
@@ -464,8 +466,17 @@ def fp4_block_scale_moe_runner(
         0] = routing_logits  # replace dummy routing logits with actual routing logits
     input_tensors[-2] = topk_weights  # replace dummy topk_weights with actual
     input_tensors[-1] = topk_ids  # replace dummy topk_ids with actual
-    return kernel_runner(input_tensors,
-                         tactic=[-1, -1] if best_tactic == -1 else best_tactic)
+    result = kernel_runner(
+        input_tensors,
+        tactic=[-1, -1] if best_tactic == -1 else best_tactic,
+        output=output)
+    # When output is provided and do_finalize=True, the result is written in-place to output.
+    # Return empty tensor to avoid aliasing constraint violation in PyTorch 2.9.1+
+    # (custom op output cannot be the same tensor as input).
+    # Callers should use output directly when they provide it.
+    if output is not None and do_finalize:
+        return [torch.empty(0, device=output.device, dtype=output.dtype)]
+    return result
 
 
 def fp4_block_scale_fake_output_without_finalize(
@@ -523,7 +534,8 @@ def _(routing_logits,
       do_finalize,
       act_type,
       topk_weights: Optional[torch.Tensor] = None,
-      topk_ids: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+      topk_ids: Optional[torch.Tensor] = None,
+      output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
     if do_finalize:
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[1] * 2
@@ -605,6 +617,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
         self,
         inputs: List[torch.Tensor],
         tactic: List[int] = [-1, -1],
+        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
         args = FP8BlockScaleMoEInputs(*inputs)
@@ -619,7 +632,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
             self.n_group, self.topk_group, self.intermediate_size,
             self.local_expert_offset, self.local_num_experts,
             self.routed_scaling_factor, self.routing_method_type, tactic,
-            args.topk_weights, args.topk_ids)
+            args.topk_weights, args.topk_ids, output)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,
@@ -713,26 +726,28 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
 
 @torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
-def fp8_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
-                               routing_bias: torch.Tensor,
-                               hidden_states: torch.Tensor,
-                               hidden_states_scale: torch.Tensor,
-                               gemm1_weights: torch.Tensor,
-                               gemm1_weights_scale: torch.Tensor,
-                               gemm2_weights: torch.Tensor,
-                               gemm2_weights_scale: torch.Tensor,
-                               num_experts: int,
-                               top_k: int,
-                               n_group: Optional[int],
-                               topk_group: Optional[int],
-                               intermediate_size: int,
-                               local_expert_offset: int,
-                               local_num_experts: int,
-                               routed_scaling_factor: Optional[float],
-                               routing_method_type: int,
-                               topk_weights: Optional[torch.Tensor] = None,
-                               topk_ids: Optional[torch.Tensor] = None,
-                               act_type: int = 0) -> torch.Tensor:
+def fp8_block_scale_moe_runner(
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: torch.Tensor,
+        hidden_states: torch.Tensor,
+        hidden_states_scale: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        n_group: Optional[int],
+        topk_group: Optional[int],
+        intermediate_size: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: Optional[float],
+        routing_method_type: int,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None,
+        act_type: int = 0,
+        output: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
     kernel_runner = FP8BlockScaleMoERunner(
@@ -790,8 +805,17 @@ def fp8_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
         0] = routing_logits  # replace dummy routing logits with actual routing logits
     input_tensors[-2] = topk_weights  # replace dummy topk_weights with actual
     input_tensors[-1] = topk_ids  # replace dummy topk_ids with actual
-    return kernel_runner(input_tensors,
-                         tactic=[-1, -1] if best_tactic == -1 else best_tactic)
+    result = kernel_runner(
+        input_tensors,
+        tactic=[-1, -1] if best_tactic == -1 else best_tactic,
+        output=output)
+    # When output is provided, the result is written in-place to output.
+    # Return empty tensor to avoid aliasing constraint violation in PyTorch 2.9.1+
+    # (custom op output cannot be the same tensor as input).
+    # Callers should use output directly when they provide it.
+    if output is not None:
+        return torch.empty(0, device=result.device, dtype=result.dtype)
+    return result
 
 
 @fp8_block_scale_moe_runner.register_fake
@@ -813,7 +837,9 @@ def _(routing_logits: torch.Tensor,
       routed_scaling_factor: Optional[float],
       routing_method_type: int,
       topk_weights: Optional[torch.Tensor] = None,
-      topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
+      topk_ids: Optional[torch.Tensor] = None,
+      act_type: int = 0,
+      output: Optional[torch.Tensor] = None) -> torch.Tensor:
     num_tokens = hidden_states.shape[0]
     hidden_size = hidden_states.shape[1] * 2
 
@@ -1217,8 +1243,7 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
             self.valid_hidden_size, self.valid_intermediate_size,
             self.local_expert_offset, self.local_num_experts,
             self.routed_scaling_factor, self.routing_method_type, tactic,
-            args.topk_weights, args.topk_ids, output
-        )
+            args.topk_weights, args.topk_ids, output)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,
@@ -1505,8 +1530,8 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
             self.intermediate_size, self.valid_hidden_size,
             self.valid_intermediate_size, self.local_expert_offset,
             self.local_num_experts, self.routed_scaling_factor,
-            self.routing_method_type, tactic, args.topk_weights,
-            args.topk_ids, output)
+            self.routing_method_type, tactic, args.topk_weights, args.topk_ids,
+            output)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -187,7 +187,8 @@ class MLPBlock(torch.nn.Module):
             'bias': True,
             'swiglu_alpha': self.swiglu_alpha,
             'swiglu_beta': self.swiglu_beta,
-            'swiglu_limit': self.swiglu_limit
+            'swiglu_limit': self.swiglu_limit,
+            'layer_idx': self.layer_idx,
         }
 
         self.experts = create_moe(**moe_params)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -566,10 +566,9 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                token_final_scales,
-                token_selected_experts,
-                0,  # act_type
-                moe_output,
+                topk_weights=token_final_scales,
+                topk_ids=token_selected_experts,
+                output=moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -604,11 +603,11 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                do_finalize,
-                act_type,
-                token_final_scales,
-                token_selected_experts,
-                moe_output,
+                do_finalize=do_finalize,
+                act_type=act_type,
+                topk_weights=token_final_scales,
+                topk_ids=token_selected_experts,
+                output=moe_output,
             )
 
             if not do_finalize:
@@ -656,7 +655,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                moe_output,
+                output=moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -686,11 +685,11 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                do_finalize,
-                0,  # act_type
-                token_final_scales,
-                token_selected_experts,
-                moe_output,
+                do_finalize=do_finalize,
+                act_type=0,
+                topk_weights=token_final_scales,
+                topk_ids=token_selected_experts,
+                output=moe_output,
             )
 
             if not do_finalize:
@@ -735,7 +734,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                moe_output,
+                output=moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -778,7 +777,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                moe_output,
+                output=moe_output,
             )
 
             # When output is provided, use it directly as the result

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -984,7 +984,7 @@ class TRTLLMGenFusedMoE(MoE):
 
         moe_output: Optional[torch.Tensor] = None
         use_workspace_output = False
-        if self.alltoall_method_type == AlltoallMethodType.NVLinkOneSided and self.supports_moe_output_in_alltoall_workspace(
+        if do_finalize and self.alltoall_method_type == AlltoallMethodType.NVLinkOneSided and self.supports_moe_output_in_alltoall_workspace(
         ):
             moe_output = self.moe_a2a.get_combine_payload_tensor_in_workspace(
                 runtime_max_tokens_per_rank, self.hidden_size, torch.bfloat16)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -566,9 +566,10 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                topk_weights=token_final_scales,
-                topk_ids=token_selected_experts,
-                output=moe_output,
+                token_final_scales,
+                token_selected_experts,
+                0,  # act_type
+                moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -603,11 +604,11 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                do_finalize=do_finalize,
-                act_type=act_type,
-                topk_weights=token_final_scales,
-                topk_ids=token_selected_experts,
-                output=moe_output,
+                do_finalize,
+                act_type,
+                token_final_scales,
+                token_selected_experts,
+                moe_output,
             )
 
             if not do_finalize:
@@ -655,7 +656,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                output=moe_output,
+                moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -685,11 +686,11 @@ class TRTLLMGenFusedMoE(MoE):
                 self.expert_size_per_partition,
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
-                do_finalize=do_finalize,
-                act_type=0,
-                topk_ids=token_selected_experts,
-                topk_weights=token_final_scales,
-                output=moe_output,
+                do_finalize,
+                0,  # act_type
+                token_final_scales,
+                token_selected_experts,
+                moe_output,
             )
 
             if not do_finalize:
@@ -734,7 +735,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                output=moe_output,
+                moe_output,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -777,7 +778,7 @@ class TRTLLMGenFusedMoE(MoE):
                 0,  # act_type
                 token_final_scales,
                 token_selected_experts,
-                output=moe_output,
+                moe_output,
             )
 
             # When output is provided, use it directly as the result


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added optional output tensor support to MOE (Mixture of Experts) kernels, enabling users to provide pre-allocated tensors for reduced memory movement and improved performance.

**Refactor**
- Unified and propagated output tensor handling across all MOE quantization schemes (FP4, FP8, and mixed-format variants) for consistent and flexible API design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
