### PR TITLE
[None][perf] Enable fused MoE routing kernel and reduce Python overhead in decode hot path

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -247,9 +247,8 @@ class ModelConfig(Generic[TConfig]):
         if moe_backend.upper() != "AUTO":
             return moe_backend
 
-        sm_version = get_sm_version()
-
         if architecture == "GptOssForCausalLM":
+            sm_version = get_sm_version()
             # Select the best performing backend based on SM version
             if 100 <= sm_version < 120:  # Blackwell
                 return "TRTLLM"
@@ -257,12 +256,6 @@ class ModelConfig(Generic[TConfig]):
                 return "TRITON"
             else:
                 return "CUTLASS"  # Fallback to CUTLASS for other SM versions (e.g., SM120)
-
-        if architecture in ("DeepseekV3ForCausalLM", "DeepseekV32ForCausalLM"):
-            if 100 <= sm_version < 120:  # Blackwell
-                return "TRTLLM"
-            elif 90 <= sm_version < 100:  # Hopper
-                return "DEEPGEMM"
 
         return "CUTLASS"
 

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -247,8 +247,9 @@ class ModelConfig(Generic[TConfig]):
         if moe_backend.upper() != "AUTO":
             return moe_backend
 
+        sm_version = get_sm_version()
+
         if architecture == "GptOssForCausalLM":
-            sm_version = get_sm_version()
             # Select the best performing backend based on SM version
             if 100 <= sm_version < 120:  # Blackwell
                 return "TRTLLM"
@@ -256,6 +257,12 @@ class ModelConfig(Generic[TConfig]):
                 return "TRITON"
             else:
                 return "CUTLASS"  # Fallback to CUTLASS for other SM versions (e.g., SM120)
+
+        if architecture in ("DeepseekV3ForCausalLM", "DeepseekV32ForCausalLM"):
+            if 100 <= sm_version < 120:  # Blackwell
+                return "TRTLLM"
+            elif 90 <= sm_version < 100:  # Hopper
+                return "DEEPGEMM"
 
         return "CUTLASS"
 

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -264,9 +264,10 @@ class Deepseekv3RoutingImpl:
                         "The configuration is not supported by the fused routing kernel. We have to use the original pytorch implementation."
                     )
                 self.is_fused = False
-        elif (num_experts > 512 or (self.top_k > 8 and self.top_k != 22)
-              or (self.topk_group == 1 and self.top_k != 22)):
-            # We have special implementation for n_group == 1, top_k == 22 and num_experts == 512 for Nemotron Super v3.
+        elif (num_experts > 512 or (self.top_k > 8 and self.top_k != 22)):
+            # The fused CUDA kernel supports:
+            #   - n_group == 1 with top_k <= 8 and num_experts <= 512
+            #   - n_group == 1 with top_k == 22 and num_experts == 512 (Nemotron Super v3)
             if self.is_fused:
                 warnings.warn(
                     "The configuration is not supported by the fused routing kernel. We have to use the original pytorch implementation."

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -50,6 +50,11 @@ class ScheduledRequests:
         return len(self.context_requests) + len(self.generation_requests)
 
     def all_requests(self) -> list[LlmRequest]:
+        # Fast path: returns generation_requests directly when context_requests
+        # is empty (decode-only) to avoid list concatenation. Callers must not
+        # structurally modify (append/remove) the returned list.
+        if not self.context_requests:
+            return self.generation_requests
         return self.context_requests + self.generation_requests
 
 


### PR DESCRIPTION
## Description

Optimize DeepSeek V3/V3 Lite serving performance through two areas:

### 1. Enable fused routing kernel for single-group MoE configs
The Python guard in `Deepseekv3RoutingImpl.noaux_tc()` was overly restrictive, blocking the fused CUDA kernel for `n_group=1, topk_group=1` configurations unless `top_k==22`. The underlying C++ kernel (`noAuxTcKernels.cu`) already supports `n_group<=1` with `top_k<=8` and `num_experts<=512` via the `is_single_group` path.

Remove the unnecessary condition to allow models like DeepSeek V3 Lite (72 experts, top_k=6) and Kimi K2 (384 experts, top_k=8) to use the fused kernel instead of falling back to separate PyTorch ops (sigmoid, topk, gather, sum, div).

### 2. Reduce Python overhead in decode hot path
- Pre-allocate pinned host buffers for `input_ids`, `position_ids`, `previous_batch_indices`, and `seq_lens` to avoid per-iteration `mlock()` syscalls from `torch.tensor(..., pin_memory=True)`
- Cache D2H copy destination buffers in `TRTLLMSampler` by source tensor `data_ptr` to eliminate repeated pinned memory allocation
- Replace `.tolist()` with `.numpy()` in sampler hot path for zero-copy tensor-to-host conversion
- Add early-exit guard for `log_probs` when no requests need them
- Return `generation_requests` directly from `all_requests()` in decode-only case to avoid list concatenation called 3-5x/iteration
- Cache `HandleLogits`/`HandleAdditionalOutputs` instances on executor
- Replace per-iteration inner function creation in `_forward_step` with `nvtx_range` context manager
- Replace `active_requests` `clear()`+`extend()` with direct assignment
- Avoid list concatenation when building reqs in sampler update paths

### Performance (DeepSeek V3 Lite NVFP4 / B200, ISL=1024, OSL=512)
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Output throughput | 1776 tok/s | 2109 tok/s | **+18.8%** |
| TPOT | 6.72 ms | 5.91 ms | **-12.2%** |
| TTFT | 504 ms | 283 ms | **-44.0%** |

## Test Coverage

- Existing MoE routing unit tests cover kernel dispatch logic
- `trtllm-bench` end-to-end benchmarks used for performance validation

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.