### PR TITLE
[None][feat] Fuse shared to sparse experts MoE

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
@@ -742,9 +742,7 @@ void run(Data& data, void* stream)
     {
         data.mNumExperts += data.mNumFusedSharedExperts;
         data.mTopK += data.mNumFusedSharedExperts;
-        // Note: mNumLocalExperts should NOT be modified as fused shared experts are
-        // globally indexed at [mNumExperts, mNumExperts + mNumFusedSharedExperts),
-        // not local to each rank. Modifying it breaks locality semantics in multi-rank scenarios.
+        data.mNumLocalExperts += data.mNumFusedSharedExperts;
     }
 
     if (data.mPtrPermutedIdxSize != nullptr)

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
@@ -712,7 +712,8 @@ void run(Data& data, void* stream)
                 data.mNumExperts);
 
             TLLM_CHECK_WITH_INFO(data.mNumFusedSharedExperts <= WarpSize,
-                "Number of fused shared experts (%d must be less than warp size.", WarpSize);
+                "Number of fused shared experts (%d) must be less than or equal to warp size (%d).",
+                data.mNumFusedSharedExperts, WarpSize);
 
             if (data.mNumFusedSharedExperts > 0)
             {
@@ -741,8 +742,9 @@ void run(Data& data, void* stream)
     {
         data.mNumExperts += data.mNumFusedSharedExperts;
         data.mTopK += data.mNumFusedSharedExperts;
-        data.mNumLocalExperts += data.mNumFusedSharedExperts;
-        // data.mLocalExpertsStartIdx += data.mNumFusedSharedExperts;
+        // Note: mNumLocalExperts should NOT be modified as fused shared experts are
+        // globally indexed at [mNumExperts, mNumExperts + mNumFusedSharedExperts),
+        // not local to each rank. Modifying it breaks locality semantics in multi-rank scenarios.
     }
 
     if (data.mPtrPermutedIdxSize != nullptr)

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
@@ -107,6 +107,12 @@ struct DataBase
     int32_t mLocalExpertsStartIdx;
     int32_t mLocalExpertsStrideLog2;
     int32_t mNumLocalExperts;
+
+    /// For fused shared expert
+    int32_t mNumFusedSharedExperts;
+    int32_t mSharedExpertTokenOffset;
+    int32_t mSharedExpertNumTokens;
+    int32_t mTotalExpertsPerToken;
 };
 
 template <typename InputT_, typename OutputT_, int MaxNumExperts_, bool isPow2_, bool UsePdl_>
@@ -141,6 +147,11 @@ struct KernelParamsBase
     int32_t mLocalExpertsStrideLog2 = 0;
     int32_t mNumLocalExperts = 0;
 
+    int32_t mNumFusedSharedExperts;
+    int32_t mSharedExpertTokenOffset;
+    int32_t mSharedExpertNumTokens;
+    int32_t mTotalExpertsPerToken;
+
     // Public initialization function - make it a template to accept different Data types
     template <typename DataType>
     void setBaseParams(DataType const& data)
@@ -165,6 +176,11 @@ struct KernelParamsBase
         mLocalExpertsStartIdx = data.mLocalExpertsStartIdx;
         mLocalExpertsStrideLog2 = data.mLocalExpertsStrideLog2;
         mNumLocalExperts = data.mNumLocalExperts;
+
+        mNumFusedSharedExperts = data.mNumFusedSharedExperts;
+        mSharedExpertTokenOffset = data.mSharedExpertTokenOffset;
+        mSharedExpertNumTokens = data.mSharedExpertNumTokens;
+        mTotalExpertsPerToken = data.mTotalExpertsPerToken;
     }
 };
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
@@ -109,10 +109,10 @@ struct DataBase
     int32_t mNumLocalExperts;
 
     /// For fused shared expert
-    int32_t mNumFusedSharedExperts;
-    int32_t mSharedExpertTokenOffset;
-    int32_t mSharedExpertNumTokens;
-    int32_t mTotalExpertsPerToken;
+    int32_t mNumFusedSharedExperts = 0;
+    int32_t mSharedExpertTokenOffset = 0;
+    int32_t mSharedExpertNumTokens = 0;
+    int32_t mTotalExpertsPerToken = 0;
 };
 
 template <typename InputT_, typename OutputT_, int MaxNumExperts_, bool isPow2_, bool UsePdl_>
@@ -147,10 +147,10 @@ struct KernelParamsBase
     int32_t mLocalExpertsStrideLog2 = 0;
     int32_t mNumLocalExperts = 0;
 
-    int32_t mNumFusedSharedExperts;
-    int32_t mSharedExpertTokenOffset;
-    int32_t mSharedExpertNumTokens;
-    int32_t mTotalExpertsPerToken;
+    int32_t mNumFusedSharedExperts = 0;
+    int32_t mSharedExpertTokenOffset = 0;
+    int32_t mSharedExpertNumTokens = 0;
+    int32_t mTotalExpertsPerToken = 0;
 
     // Public initialization function - make it a template to accept different Data types
     template <typename DataType>

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -61,8 +61,8 @@ Runner::Runner(int32_t tileTokensDim)
 }
 
 void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts, int32_t topK,
-    int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset, int32_t localNumExperts, float routedScalingFactor,
-    int32_t* routingExpertIndexes, int32_t* expertCountHistogram, int32_t* permutedIdxSize,
+    int32_t numFusedSharedExpert, int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset, int32_t localNumExperts,
+    float routedScalingFactor, int32_t* routingExpertIndexes, int32_t* expertCountHistogram, int32_t* permutedIdxSize,
     int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx, int32_t* permutedIdxToTokenIdx,
     void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx,
     int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas, btg::Dtype dtypeElt, bool useRoutingScalesOnInput,
@@ -75,6 +75,8 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         moe::dev::routing::routingDeepSeek::Data routingData;
         routingData.mDtypeExpW = btg::Dtype::Bfloat16;
         routingData.mUsePdl = true;
+
+        int32_t const totalExpertsPerToken = topK + numFusedSharedExpert;
 
         // output:
         routingData.mPtrTopKPacked = routingExpertIndexes;
@@ -96,9 +98,11 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mPtrTopKIds = expertIds;
         routingData.mNumTokens = numTokens;
         routingData.mNumExperts = numExperts;
+        routingData.mNumFusedSharedExperts = numFusedSharedExpert;
         routingData.mNumExpertGroups = nGroup;
         routingData.mNumLimitedGroups = topkGroup;
         routingData.mTopK = topK;
+        routingData.mTotalExpertsPerToken = totalExpertsPerToken;
         routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
         routingData.mTileTokensDim = mTileTokensDim;
         routingData.mLocalExpertsStartIdx = localExpertOffset;
@@ -106,6 +110,23 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mNumLocalExperts = localNumExperts;
         routingData.mRouteScale = routedScalingFactor;
         routingData.mUseRoutingSoftmax = false;
+
+        // TODO Should these be passed directly instead? This does assume a constant number of experts per device
+        int32_t const numDevices = numExperts / localNumExperts;
+        int32_t const deviceIndex = localExpertOffset / localNumExperts;
+        int32_t const baseTokensPerDevice = numTokens / numDevices;
+        int32_t const remainingTokens = numTokens % numDevices;
+
+        if (deviceIndex < remainingTokens)
+        {
+            routingData.mSharedExpertTokenOffset = (baseTokensPerDevice + 1) * deviceIndex;
+            routingData.mSharedExpertNumTokens = baseTokensPerDevice + 1;
+        }
+        else
+        {
+            routingData.mSharedExpertTokenOffset = remainingTokens + deviceIndex * baseTokensPerDevice;
+            routingData.mSharedExpertNumTokens = baseTokensPerDevice;
+        }
         moe::dev::routing::routingDeepSeek::run(routingData, stream);
     }
     else if (routingMethodType == RoutingMethodType::Llama4)
@@ -115,6 +136,8 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         {
             TLLM_LOG_WARNING("For Llama routing method, nGroup/topkGroup is ignored, got %d/%d.", nGroup, topkGroup);
         }
+        TLLM_CHECK_WITH_INFO(numFusedSharedExpert == 0, "Llama routing method does not support fusing shared expert");
+
         moe::dev::routing::routingLlama4::Data routingData;
         routingData.mDtypeExpW = btg::Dtype::Bfloat16;
         routingData.mUsePdl = true;
@@ -159,6 +182,9 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     else if (routingMethodType == RoutingMethodType::Renormalize /* default */
         || routingMethodType == RoutingMethodType::RenormalizeNaive /* Softmax -> TopK */)
     {
+        TLLM_CHECK_WITH_INFO(
+            numFusedSharedExpert == 0, "Renormalize routing method does not support fusing shared expert");
+
         moe::dev::routing::routingRenormalize::Data routingData;
 
         //
@@ -467,6 +493,9 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
     moe::dev::convertsf::Data& convertSfData, moe::dev::activation::Data& activationData,
     moe::dev::finalize::Data& finalizeData)
 {
+    int32_t const totalNumExperts = args.num_experts + args.num_fused_shared_experts;
+    int32_t const totalExpertsPerToken = args.top_k + args.num_fused_shared_experts;
+
     // Setup sf conversion data if needed
     convertSfData.inSfPtr = args.hidden_states_scale;
     convertSfData.outSfPtr = workspace.hidden_states_scale_linear;
@@ -485,7 +514,7 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
     activationData.inDqSfsPtr = workspace.gemm1_output_scale;
     activationData.outDqSfsPtr = workspace.activation_output_scale;
     activationData.innerDim = args.intermediate_size * (mActType == ActType::SwiGlu ? 2 : 1);
-    activationData.topK = args.top_k;
+    activationData.topK = totalExpertsPerToken; // TODO Rename topK in activation data struct
     activationData.numTokens = args.num_tokens;
     activationData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
 
@@ -512,8 +541,8 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
         }
         finalizeData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
         finalizeData.numTokens = args.num_tokens;
-        finalizeData.numExperts = args.num_experts;
-        finalizeData.topK = args.top_k;
+        finalizeData.numExperts = totalNumExperts; // TODO Is this used?
+        finalizeData.topK = totalExpertsPerToken;  // TODO Rename topK in finalize data struct
         // We want to fuse unpadding into the finalize kernel, so we need to use the output hidden size.
         finalizeData.hiddenDim = args.valid_hidden_size.value_or(args.hidden_size);
         finalizeData.hiddenDimPadded = args.output_hidden_size.value_or(args.hidden_size);
@@ -523,12 +552,15 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
 
 std::tuple<int32_t, int32_t> Runner::getWorkspaceSizeInBytes(MoERunnerArgs const& args, int64_t configIndex) const
 {
+    int32_t const totalLocalExperts = args.local_num_experts + args.num_fused_shared_experts;
+    int32_t const totalExpertsPerToken = args.top_k + args.num_fused_shared_experts;
+
     auto const& config = mPassingConfigs[configIndex];
 
-    auto workspace_size_fc1 = static_cast<int32_t>(mPermuteGemm1.getWorkspaceSizeInBytes(args.top_k, args.hidden_size,
-        args.intermediate_size, args.local_num_experts, args.num_tokens, config.gemm1Config));
-    auto workspace_size_fc2 = static_cast<int32_t>(mGemm2.getWorkspaceSizeInBytes(args.top_k, args.hidden_size,
-        args.intermediate_size, args.local_num_experts, args.num_tokens, config.gemm2Config));
+    auto workspace_size_fc1 = static_cast<int32_t>(mPermuteGemm1.getWorkspaceSizeInBytes(totalExpertsPerToken,
+        args.hidden_size, args.intermediate_size, totalLocalExperts, args.num_tokens, config.gemm1Config));
+    auto workspace_size_fc2 = static_cast<int32_t>(mGemm2.getWorkspaceSizeInBytes(totalExpertsPerToken,
+        args.hidden_size, args.intermediate_size, totalLocalExperts, args.num_tokens, config.gemm2Config));
     return std::make_tuple(workspace_size_fc1, workspace_size_fc2);
 }
 
@@ -563,7 +595,6 @@ std::vector<int64_t> Runner::getValidConfigIndices(int32_t topK, int32_t hiddenS
 int64_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
     int32_t numLocalExperts, int32_t numTokens, int32_t validHiddenSize, int32_t validIntermediateSize) const
 {
-
     int32_t indexGemm1 = mPermuteGemm1.getDefaultValidConfigIndex(
         topK, hiddenSize, intermediateSize, numLocalExperts, numTokens, validHiddenSize, validIntermediateSize);
     int32_t indexGemm2 = mGemm2.getDefaultValidConfigIndex(
@@ -586,6 +617,9 @@ void Runner::run(
     sync_check_cuda_error(stream);
     setOpsData(args, workspace, convertSfData, activationData, finalizeData);
 
+    int32_t const totalLocalExperts = args.local_num_experts + args.num_fused_shared_experts;
+    int32_t const totalExpertsPerToken = args.top_k + args.num_fused_shared_experts;
+
     void* hidden_states_scale_linear{args.hidden_states_scale};
 
     auto const& config = mPassingConfigs[configIndex];
@@ -593,7 +627,7 @@ void Runner::run(
     mPermuteGemm1.run(args.hidden_states, hidden_states_scale_linear, args.gemm1_weights, args.gemm1_weights_scale,
         workspace.expert_weights, args.output1_scales_scalar, args.output1_scales_gate_scalar, args.gemm1_bias,
         args.gemm1_alpha, args.gemm1_beta, args.gemm1_clamp_limit, workspace.gemm1_output, workspace.gemm1_output_scale,
-        args.top_k, args.hidden_size, args.intermediate_size, args.local_num_experts, args.num_tokens,
+        totalExpertsPerToken, args.hidden_size, args.intermediate_size, totalLocalExperts, args.num_tokens,
         workspace.permuted_idx_to_token_idx, workspace.num_non_exiting_ctas, workspace.total_num_padded_tokens,
         workspace.cta_idx_xy_to_batch_idx, workspace.cta_idx_xy_to_mn_limit, workspace.bmm1_workspace,
         args.mUseRoutingScalesOnInput, device, stream, config.gemm1Config,
@@ -614,11 +648,11 @@ void Runner::run(
 
     // Run gemm2
     mGemm2.run(gemm2_input, gemm2_input_scale, args.gemm2_weights, args.gemm2_weights_scale, args.output2_scales_scalar,
-        args.gemm2_bias, workspace.gemm2_output, workspace.gemm2_output_scale, args.top_k,
-        args.output_hidden_size.value_or(args.hidden_size), args.intermediate_size, args.local_num_experts,
-        args.num_tokens, workspace.num_non_exiting_ctas, workspace.total_num_padded_tokens,
-        workspace.cta_idx_xy_to_batch_idx, workspace.cta_idx_xy_to_mn_limit, workspace.bmm2_workspace, device, stream,
-        config.gemm2Config, args.valid_hidden_size.value_or(args.hidden_size),
+        args.gemm2_bias, workspace.gemm2_output, workspace.gemm2_output_scale, totalExpertsPerToken,
+        args.output_hidden_size.value_or(args.hidden_size), args.intermediate_size, totalLocalExperts, args.num_tokens,
+        workspace.num_non_exiting_ctas, workspace.total_num_padded_tokens, workspace.cta_idx_xy_to_batch_idx,
+        workspace.cta_idx_xy_to_mn_limit, workspace.bmm2_workspace, device, stream, config.gemm2Config,
+        args.valid_hidden_size.value_or(args.hidden_size),
         args.valid_intermediate_size.value_or(args.intermediate_size));
 
     // Run finalize

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
@@ -150,13 +150,13 @@ public:
     explicit Runner(int32_t tileTokensDim);
 
     void run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts, int32_t topK,
-        int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset, int32_t localNumExperts,
-        float routedScalingFactor, int32_t* routingExpertIndexes, int32_t* expertCountHistogram,
-        int32_t* permutedIdxSize, int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx,
-        int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert,
-        int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas,
-        batchedGemm::trtllm::gen::Dtype dtypeElt, bool useRoutingScalesOnInput, bool useDeepSeekFp8,
-        RoutingMethodType routingMethodType, cudaStream_t stream);
+        int32_t numFusedSharedExpert, int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset,
+        int32_t localNumExperts, float routedScalingFactor, int32_t* routingExpertIndexes,
+        int32_t* expertCountHistogram, int32_t* permutedIdxSize, int32_t* expandedIdxToPermutedIdx,
+        int32_t* permutedIdxToExpandedIdx, int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds,
+        int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit,
+        int32_t* numNonExitingCtas, batchedGemm::trtllm::gen::Dtype dtypeElt, bool useRoutingScalesOnInput,
+        bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream);
 
 private:
     int32_t mTileTokensDim;
@@ -272,6 +272,7 @@ struct MoERunnerArgs
 
     int32_t num_tokens{0};
     int32_t num_experts{0};
+    int32_t num_fused_shared_experts{0};
     // Hidden dimension input of MoE block. It might be padded.
     int32_t hidden_size{0};
     // Hidden dimension output of MoE block. It might be padded.

--- a/cpp/tensorrt_llm/thop/cuteDslMoeUtilsOp.cpp
+++ b/cpp/tensorrt_llm/thop/cuteDslMoeUtilsOp.cpp
@@ -74,9 +74,10 @@ std::vector<torch::Tensor> moe_topk_sort_impl(torch::optional<torch::Tensor> con
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::Runner routing_runner(tile_tokens_dim);
     auto const& stream = at::cuda::getCurrentCUDAStream(
         routing_logits.has_value() ? routing_logits->get_device() : token_selected_experts->get_device());
-    routing_runner.run(routing_logits_ptr, routing_bias_ptr, num_tokens, num_experts, top_k, n_group.value_or(0),
-        topk_group.value_or(0), local_expert_offset, local_num_experts, routed_scaling_factor.value_or(1.0),
-        expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
+    routing_runner.run(routing_logits_ptr, routing_bias_ptr, num_tokens, num_experts, top_k,
+        /* num_fused_shared_expert */ 0, n_group.value_or(0), topk_group.value_or(0), local_expert_offset,
+        local_num_experts, routed_scaling_factor.value_or(1.0), expert_indexes.data_ptr<int>(),
+        expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), permuted_idx_to_expanded_idx.data_ptr<int>(),
         nullptr /*permuted_idx_to_token_idx.data_ptr<int>()*/, token_final_scales_ptr, token_selected_experts_ptr,
         num_tokens_per_expert.data_ptr<int>(), tile_idx_to_expert_idx.data_ptr<int>(),

--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -40,11 +40,12 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     torch::Tensor const& gemm2_weights_scale, std::optional<torch::Tensor> const& gemm2_bias,
     torch::Tensor const& output1_scales_scalar, torch::Tensor const& output1_scales_gate_scalar,
     torch::Tensor const& output2_scales_scalar, int64_t const num_experts, int64_t const top_k,
-    std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
-    int64_t const local_expert_offset, int64_t const local_num_experts,
-    std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim, int64_t const routing_method_type,
-    bool const do_finalize, btg::Dtype const dtype, MoeRunnerType& moe_runner, int64_t const moeConfigIndex,
-    torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
+    std::optional<int64_t> const num_fused_shared_experts, std::optional<int64_t> const n_group,
+    std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
+    int64_t const local_num_experts, std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim,
+    int64_t const routing_method_type, bool const do_finalize, btg::Dtype const dtype, MoeRunnerType& moe_runner,
+    int64_t const moeConfigIndex, torch::optional<torch::Tensor> const& topk_weights,
+    torch::optional<torch::Tensor> const& topk_ids)
 {
     TORCH_CHECK(dtype == btg::Dtype::E4m3 || dtype == btg::Dtype::E2m1, "dtype can only be e4m3 or e2m1.");
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by FP4 block scale MOE");
@@ -147,6 +148,13 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoERunnerArgs args;
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoEWorkspace workspace;
 
+    int64_t const num_total_experts
+        = num_experts + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+    int64_t const total_experts_per_token
+        = top_k + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+    int64_t const num_total_local_experts
+        = local_num_experts + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+
     // setup args
     // note: the assumption is that output data type is always Bfloat16 (the default)
     auto const routing_bias_dtype
@@ -182,6 +190,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         args.hidden_size = hidden_states.sizes()[1] * 2;
     }
     args.top_k = top_k;
+    args.num_fused_shared_experts = num_fused_shared_experts.value_or(0);
     args.n_group = n_group.value_or(0);
     args.topk_group = topk_group.value_or(0);
     args.local_expert_offset = local_expert_offset;
@@ -200,7 +209,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_device, std::nullopt);
     int32_t max_num_padded_tokens
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxPermutedPaddedCount(
-            args.num_tokens, top_k, num_experts, tile_tokens_dim);
+            args.num_tokens, total_experts_per_token, num_total_experts, tile_tokens_dim);
     int32_t max_num_padded_tokens_gemm1
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::maybeGetMinTokenCount(
             max_num_padded_tokens, args.intermediate_size, btg::dtypeGetNumBits(args.mDtypeElt));
@@ -209,15 +218,15 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
             max_num_padded_tokens, args.hidden_size, btg::dtypeGetNumBits(args.mDtypeOut));
     at::Tensor total_num_padded_tokens
         = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
-    at::Tensor expanded_idx_to_permuted_idx
-        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expanded_idx_to_permuted_idx = at::detail::empty_cuda(
+        {args.num_tokens, total_experts_per_token}, at::ScalarType::Int, routing_device, std::nullopt);
 
     at::Tensor permuted_idx_to_token_idx
         = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_device, std::nullopt);
-    at::Tensor expert_weights
-        = at::detail::empty_cuda({args.num_tokens, args.top_k}, routing_bias_dtype, routing_device, std::nullopt);
-    at::Tensor expert_indexes
-        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expert_weights = at::detail::empty_cuda(
+        {args.num_tokens, total_experts_per_token}, routing_bias_dtype, routing_device, std::nullopt);
+    at::Tensor expert_indexes = at::detail::empty_cuda(
+        {args.num_tokens, total_experts_per_token}, at::ScalarType::Int, routing_device, std::nullopt);
     int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
     at::Tensor expert_count_histogram
         = at::detail::empty_cuda({size_of_expert_count_histogram}, at::ScalarType::Int, routing_device, std::nullopt);
@@ -245,7 +254,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         {max_num_padded_tokens_gemm2, args.hidden_size}, at::ScalarType::BFloat16, routing_device, std::nullopt);
 
     int32_t max_num_ctas = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxNumCtasInBatchDim(
-        args.num_tokens, args.top_k, args.num_experts, tile_tokens_dim);
+        args.num_tokens, total_experts_per_token, num_total_experts, tile_tokens_dim);
     at::Tensor cta_idx_xy_to_batch_idx
         = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor cta_idx_xy_to_mn_limit
@@ -264,9 +273,10 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     auto const& stream = at::cuda::getCurrentCUDAStream(
         routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
-        args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
-        expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
+        args.num_fused_shared_experts, args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts,
+        args.routed_scaling_factor, expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(),
+        total_num_padded_tokens.data_ptr<int>(), expanded_idx_to_permuted_idx.data_ptr<int>(),
+        nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
         permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
@@ -322,7 +332,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     TORCH_CHECK(gemm1_weights_scale.scalar_type() == at::ScalarType::Float8_e4m3fn, "gemm1_weights_scale must be fp8.");
 
     TORCH_CHECK(gemm1_weights_scale.dim() == 3, "gemm1_weights_scale must be 3D.");
-    TORCH_CHECK(gemm1_weights_scale.sizes()[0] == local_num_experts, "gemm1_weights_scale has incorrect dim 0.");
+    TORCH_CHECK(gemm1_weights_scale.sizes()[0] == num_total_local_experts, "gemm1_weights_scale has incorrect dim 0.");
     TORCH_CHECK(intermediate_size % 16 == 0, "the second dimension of weights must be a multiple of 16.");
     TORCH_CHECK(gemm1_weights_scale.sizes()[1] == (is_gated_activation ? 2 * intermediate_size : intermediate_size),
         "gemm1_weights_scale has incorrect dim 1.");
@@ -332,7 +342,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         TORCH_CHECK(gemm1_bias.value().scalar_type() == at::ScalarType::Float, "gemm1_bias must be float, got %s.",
             c10::toString(gemm1_bias.value().scalar_type()));
         TORCH_CHECK(gemm1_bias.value().dim() == 2, "gemm1_bias must be 2D.");
-        TORCH_CHECK(gemm1_bias.value().sizes()[0] == local_num_experts, "gemm1_bias has incorrect dim 0.");
+        TORCH_CHECK(gemm1_bias.value().sizes()[0] == num_total_local_experts, "gemm1_bias has incorrect dim 0.");
         TORCH_CHECK(gemm1_bias.value().sizes()[1] == (is_gated_activation ? 2 * intermediate_size : intermediate_size),
             "gemm1_bias has incorrect dim 1.");
     }
@@ -342,14 +352,14 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         TORCH_CHECK(gemm1_alpha.value().scalar_type() == at::ScalarType::Float, "gemm1_alpha must be float, got %s.",
             c10::toString(gemm1_alpha.value().scalar_type()));
         TORCH_CHECK(gemm1_alpha.value().dim() == 1, "gemm1_alpha must be 1D.");
-        TORCH_CHECK(gemm1_alpha.value().sizes()[0] == local_num_experts, "gemm1_alpha has incorrect dim 0.");
+        TORCH_CHECK(gemm1_alpha.value().sizes()[0] == num_total_local_experts, "gemm1_alpha has incorrect dim 0.");
     }
     if (gemm1_beta.has_value())
     {
         TORCH_CHECK(gemm1_beta.value().scalar_type() == at::ScalarType::Float, "gemm1_beta must be float, got %s.",
             c10::toString(gemm1_beta.value().scalar_type()));
         TORCH_CHECK(gemm1_beta.value().dim() == 1, "gemm1_beta must be 1D.");
-        TORCH_CHECK(gemm1_beta.value().sizes()[0] == local_num_experts, "gemm1_beta has incorrect dim 0.");
+        TORCH_CHECK(gemm1_beta.value().sizes()[0] == num_total_local_experts, "gemm1_beta has incorrect dim 0.");
     }
     if (gemm1_clamp_limit.has_value())
     {
@@ -357,7 +367,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
             "gemm1_clamp_limit must be float, got %s.", c10::toString(gemm1_clamp_limit.value().scalar_type()));
         TORCH_CHECK(gemm1_clamp_limit.value().dim() == 1, "gemm1_clamp_limit must be 1D.");
         TORCH_CHECK(
-            gemm1_clamp_limit.value().sizes()[0] == local_num_experts, "gemm1_clamp_limit has incorrect dim 0.");
+            gemm1_clamp_limit.value().sizes()[0] == num_total_local_experts, "gemm1_clamp_limit has incorrect dim 0.");
     }
 
     TORCH_CHECK(gemm2_weights.scalar_type() == FLOAT4_E2M1X2, "gemm2_weights must be byte.");
@@ -374,27 +384,29 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
         TORCH_CHECK(gemm2_bias.value().scalar_type() == at::ScalarType::Float, "gemm2_bias must be float, got %s.",
             c10::toString(gemm2_bias.value().scalar_type()));
         TORCH_CHECK(gemm2_bias.value().dim() == 2, "gemm2_bias must be 2D.");
-        TORCH_CHECK(gemm2_bias.value().sizes()[0] == local_num_experts, "gemm2_bias has incorrect dim 0.");
+        TORCH_CHECK(gemm2_bias.value().sizes()[0] == num_total_local_experts, "gemm2_bias has incorrect dim 0.");
         TORCH_CHECK(gemm2_bias.value().sizes()[1] == args.hidden_size, "gemm2_bias has incorrect dim 1.");
     }
 
     TORCH_CHECK(gemm2_weights_scale.dim() == 3, "gemm2_weights_scale must be 3D.");
-    TORCH_CHECK(gemm2_weights_scale.sizes()[0] == local_num_experts, "gemm2_weights_scale has incorrect dim 0.");
+    TORCH_CHECK(gemm2_weights_scale.sizes()[0] == num_total_local_experts, "gemm2_weights_scale has incorrect dim 0.");
     TORCH_CHECK(gemm2_weights_scale.sizes()[1] == args.hidden_size, "gemm2_weights_scale has incorrect dim 1.");
 
     TORCH_CHECK(output1_scales_scalar.scalar_type() == at::ScalarType::Float, "output1_scales_scalar must be float.");
     TORCH_CHECK(output1_scales_scalar.dim() == 1, "output1_scales_scalar must be 1D.");
-    TORCH_CHECK(output1_scales_scalar.sizes()[0] == local_num_experts, "output1_scales_scalar has incorrect dim 0.");
+    TORCH_CHECK(
+        output1_scales_scalar.sizes()[0] == num_total_local_experts, "output1_scales_scalar has incorrect dim 0.");
 
     TORCH_CHECK(
         output1_scales_gate_scalar.scalar_type() == at::ScalarType::Float, "output1_scales_gate_scalar must be float.");
     TORCH_CHECK(output1_scales_gate_scalar.dim() == 1, "output1_scales_gate_scalar must be 1D.");
-    TORCH_CHECK(
-        output1_scales_gate_scalar.sizes()[0] == local_num_experts, "output1_scales_gate_scalar has incorrect dim 0.");
+    TORCH_CHECK(output1_scales_gate_scalar.sizes()[0] == num_total_local_experts,
+        "output1_scales_gate_scalar has incorrect dim 0.");
 
     TORCH_CHECK(output2_scales_scalar.scalar_type() == at::ScalarType::Float, "output2_scales_scalar must be float.");
     TORCH_CHECK(output2_scales_scalar.dim() == 1, "output2_scales_scalar must be 1D.");
-    TORCH_CHECK(output2_scales_scalar.sizes()[0] == local_num_experts, "output2_scales_scalar has incorrect dim 0.");
+    TORCH_CHECK(
+        output2_scales_scalar.sizes()[0] == num_total_local_experts, "output2_scales_scalar has incorrect dim 0.");
 
     // allocate output
     at::Tensor output = at::detail::empty_cuda(
@@ -473,20 +485,25 @@ public:
         }
     }
 
-    [[nodiscard]] std::vector<std::vector<int64_t>> getValidConfigs(
-        int64_t topK, int64_t hiddenSize, int64_t intermediateSize, int64_t numLocalExperts, int64_t numTokens) const
+    [[nodiscard]] std::vector<std::vector<int64_t>> getValidConfigs(int64_t topK,
+        std::optional<int64_t> const numFusedSharedExpert, int64_t hiddenSize, int64_t intermediateSize,
+        int64_t numLocalExperts, int64_t numTokens) const
     {
+        int64_t const totalExpertsPerToken
+            = topK + (numFusedSharedExpert.value_or(0) > 0 ? numFusedSharedExpert.value() : 0);
+        int64_t const numTotalLocalExperts
+            = numLocalExperts + (numFusedSharedExpert.value_or(0) > 0 ? numFusedSharedExpert.value() : 0);
         // returns (tileN, config)
         std::vector<std::vector<int64_t>> tactics;
         for (auto& [tileN, runner] : mRunners)
         {
-            auto chosen = computeSelectedTileN(mSupportedTileN, numTokens, topK, numLocalExperts);
+            auto chosen = computeSelectedTileN(mSupportedTileN, numTokens, totalExpertsPerToken, numTotalLocalExperts);
             if (chosen.find(tileN) == chosen.end())
             {
                 continue;
             }
-            auto config_indices_per_runner
-                = runner->getValidConfigIndices(topK, hiddenSize, intermediateSize, numLocalExperts, numTokens);
+            auto config_indices_per_runner = runner->getValidConfigIndices(
+                totalExpertsPerToken, hiddenSize, intermediateSize, numTotalLocalExperts, numTokens);
             for (auto cfg : config_indices_per_runner)
             {
                 tactics.push_back({tileN, cfg});
@@ -504,11 +521,11 @@ public:
         torch::Tensor const& gemm2_weights_scale, std::optional<torch::Tensor> const& gemm2_bias,
         torch::Tensor const& output1_scales_scalar, torch::Tensor const& output1_scales_gate_scalar,
         torch::Tensor const& output2_scales_scalar, int64_t const num_experts, int64_t const top_k,
-        std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
-        int64_t const local_expert_offset, int64_t const local_num_experts,
-        std::optional<double> const routed_scaling_factor, int64_t const routing_method_type, bool const do_finalize,
-        std::vector<int64_t> moeConfigIndex, torch::optional<torch::Tensor> const& topk_weights,
-        torch::optional<torch::Tensor> const& topk_ids)
+        std::optional<int64_t> const num_fused_shared_experts, std::optional<int64_t> const n_group,
+        std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
+        int64_t const local_num_experts, std::optional<double> const routed_scaling_factor,
+        int64_t const routing_method_type, bool const do_finalize, std::vector<int64_t> moeConfigIndex,
+        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
     {
         // moeConfigIndex corresponds to pair (tileN, config)
         auto [tileN, config] = std::tie(moeConfigIndex[0], moeConfigIndex[1]);
@@ -516,24 +533,30 @@ public:
         // Autotuner has requested a default or 'fallback' config index
         if (tileN == -1 || config == -1)
         {
+            int64_t const total_experts_per_token
+                = top_k + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+            int64_t const num_total_local_experts
+                = local_num_experts + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+
             auto const num_tokens = hidden_states.sizes()[0];
 
             // 2x FP4 per byte element
             auto const hidden_size = 2 * hidden_states.sizes()[1];
 
-            float const avg_tokens_per_expert = static_cast<float>(num_tokens * top_k) / local_num_experts;
+            float const avg_tokens_per_expert
+                = static_cast<float>(num_tokens * total_experts_per_token) / num_total_local_experts;
             tileN = std::clamp(nextPowerOfTwo(avg_tokens_per_expert), mSupportedTileN.front(), mSupportedTileN.back());
 
             config = mRunners[tileN]->getDefaultValidConfigIndex(
-                top_k, hidden_size, intermediate_size, local_num_experts, num_tokens);
+                total_experts_per_token, hidden_size, intermediate_size, num_total_local_experts, num_tokens);
         }
 
         return run_fp4_block_scale_moe_runner(routing_logits, routing_bias, hidden_states, hidden_states_scale,
             gemm1_weights, gemm1_weights_scale, gemm1_bias, gemm1_alpha, gemm1_beta, gemm1_clamp_limit, gemm2_weights,
             gemm2_weights_scale, gemm2_bias, output1_scales_scalar, output1_scales_gate_scalar, output2_scales_scalar,
-            num_experts, top_k, n_group, topk_group, intermediate_size, local_expert_offset, local_num_experts,
-            routed_scaling_factor, tileN, routing_method_type, do_finalize, mDtypeElt, *mRunners[tileN], config,
-            topk_weights, topk_ids);
+            num_experts, top_k, num_fused_shared_experts, n_group, topk_group, intermediate_size, local_expert_offset,
+            local_num_experts, routed_scaling_factor, tileN, routing_method_type, do_finalize, mDtypeElt,
+            *mRunners[tileN], config, topk_weights, topk_ids);
     }
 
 private:
@@ -565,20 +588,25 @@ public:
         }
     }
 
-    [[nodiscard]] std::vector<std::vector<int64_t>> getValidConfigs(
-        int64_t topK, int64_t hiddenSize, int64_t intermediateSize, int64_t numLocalExperts, int64_t numTokens) const
+    [[nodiscard]] std::vector<std::vector<int64_t>> getValidConfigs(int64_t topK,
+        std::optional<int64_t> const numFusedSharedExpert, int64_t hiddenSize, int64_t intermediateSize,
+        int64_t numLocalExperts, int64_t numTokens) const
     {
+        int64_t const totalExpertsPerToken
+            = topK + (numFusedSharedExpert.value_or(0) > 0 ? numFusedSharedExpert.value() : 0);
+        int64_t const numTotalLocalExperts
+            = numLocalExperts + (numFusedSharedExpert.value_or(0) > 0 ? numFusedSharedExpert.value() : 0);
         // returns (tileN, config)
         std::vector<std::vector<int64_t>> tactics;
         for (auto& [tileN, runner] : mRunners)
         {
-            auto chosen = computeSelectedTileN(mSupportedTileN, numTokens, topK, numLocalExperts);
+            auto chosen = computeSelectedTileN(mSupportedTileN, numTokens, totalExpertsPerToken, numTotalLocalExperts);
             if (chosen.find(tileN) == chosen.end())
             {
                 continue;
             }
-            auto config_indices_per_runner
-                = runner->getValidConfigIndices(topK, hiddenSize, intermediateSize, numLocalExperts, numTokens);
+            auto config_indices_per_runner = runner->getValidConfigIndices(
+                totalExpertsPerToken, hiddenSize, intermediateSize, numTotalLocalExperts, numTokens);
             for (auto cfg : config_indices_per_runner)
             {
                 tactics.push_back({tileN, cfg});
@@ -593,11 +621,11 @@ public:
         torch::Tensor const& gemm2_weights, torch::Tensor const& gemm2_weights_scale,
         torch::Tensor const& output1_scales_scalar, torch::Tensor const& output1_scales_gate_scalar,
         torch::Tensor const& output2_scales_scalar, int64_t const num_experts, int64_t const top_k,
-        std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
-        int64_t const local_expert_offset, int64_t const local_num_experts,
-        std::optional<double> const routed_scaling_factor, int64_t const routing_method_type, bool const do_finalize,
-        std::vector<int64_t> moeConfigIndex, torch::optional<torch::Tensor> const& topk_weights,
-        torch::optional<torch::Tensor> const& topk_ids)
+        std::optional<int64_t> const num_fused_shared_experts, std::optional<int64_t> const n_group,
+        std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
+        int64_t const local_num_experts, std::optional<double> const routed_scaling_factor,
+        int64_t const routing_method_type, bool const do_finalize, std::vector<int64_t> moeConfigIndex,
+        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
     {
         // moeConfigIndex corresponds to pair (tileN, config)
         auto [tileN, config] = std::tie(moeConfigIndex[0], moeConfigIndex[1]);
@@ -605,22 +633,28 @@ public:
         // Autotuner has requested a default or 'fallback' config index
         if (tileN == -1 || config == -1)
         {
+            int64_t const total_experts_per_token
+                = top_k + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+            int64_t const num_total_local_experts
+                = local_num_experts + (num_fused_shared_experts.value_or(0) > 0 ? num_fused_shared_experts.value() : 0);
+
             auto const num_tokens = hidden_states.sizes()[0];
 
             auto const hidden_size = hidden_states.sizes()[1];
 
-            float const avg_tokens_per_expert = static_cast<float>(num_tokens * top_k) / local_num_experts;
+            float const avg_tokens_per_expert
+                = static_cast<float>(num_tokens * total_experts_per_token) / num_total_local_experts;
             tileN = std::clamp(nextPowerOfTwo(avg_tokens_per_expert), mSupportedTileN.front(), mSupportedTileN.back());
 
             config = mRunners[tileN]->getDefaultValidConfigIndex(
-                top_k, hidden_size, intermediate_size, local_num_experts, num_tokens);
+                total_experts_per_token, hidden_size, intermediate_size, num_total_local_experts, num_tokens);
         }
 
         return run_fp4_block_scale_moe_runner(routing_logits, routing_bias, hidden_states,
             std::nullopt /*hidden_states_scale*/, gemm1_weights, gemm1_weights_scale, std::nullopt, std::nullopt,
             std::nullopt, std::nullopt, gemm2_weights, gemm2_weights_scale, std::nullopt, output1_scales_scalar,
-            output1_scales_gate_scalar, output2_scales_scalar, num_experts, top_k, n_group, topk_group,
-            intermediate_size, local_expert_offset, local_num_experts, routed_scaling_factor, tileN,
+            output1_scales_gate_scalar, output2_scales_scalar, num_experts, top_k, num_fused_shared_experts, n_group,
+            topk_group, intermediate_size, local_expert_offset, local_num_experts, routed_scaling_factor, tileN,
             routing_method_type, do_finalize, mDtypeAct, *mRunners[tileN], config, topk_weights, topk_ids);
     }
 

--- a/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
@@ -225,8 +225,9 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::optional<torch::Tensor> con
     auto const& stream = at::cuda::getCurrentCUDAStream(
         routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
-        args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
-        expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
+        /* num_fused_shared_expert */ 0, args.n_group, args.topk_group, args.local_expert_offset,
+        args.local_num_experts, args.routed_scaling_factor, expert_indexes.data_ptr<int>(),
+        expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/,
         permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -275,8 +275,9 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
     auto const& stream = at::cuda::getCurrentCUDAStream(
         routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
-        args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
-        expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
+        /* num_fused_shared_expert */ 0, args.n_group, args.topk_group, args.local_expert_offset,
+        args.local_num_experts, args.routed_scaling_factor, expert_indexes.data_ptr<int>(),
+        expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
         permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -200,8 +200,7 @@ class FP4BlockScaleMoERunner(TunableRunner):
                  num_fused_shared_experts: Optional[int],
                  n_group: Optional[int], topk_group: Optional[int],
                  intermediate_size: int, local_expert_offset: int,
-                 local_num_experts: int,
-                 routed_scaling_factor: Optional[float],
+                 local_num_experts: int, routed_scaling_factor: Optional[float],
                  routing_method_type: int, do_finalize: bool, act_type: int):
 
         self.num_experts = num_experts
@@ -223,8 +222,8 @@ class FP4BlockScaleMoERunner(TunableRunner):
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing type does not matter
     def unique_id(self):
-        return (self.top_k, self.intermediate_size, self.local_num_experts,
-                self.act_type)
+        return (self.top_k, self.num_fused_shared_experts,
+                self.intermediate_size, self.local_num_experts, self.act_type)
 
     def get_runner(self):
         instance_key = (self.act_type, )
@@ -600,8 +599,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing
     # type does not matter
     def unique_id(self):
-        return (self.top_k, self.intermediate_size, self.local_num_experts,
-                self.act_type)
+        return (self.top_k, self.num_fused_shared_experts,
+                self.intermediate_size, self.local_num_experts, self.act_type)
 
     def get_runner(self):
         instance_key = ()
@@ -749,7 +748,7 @@ def fp8_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
     kernel_runner = FP8BlockScaleMoERunner(
         num_experts,
         top_k,
-        num_fused_shared_experts
+        num_fused_shared_experts,
         n_group,
         topk_group,
         intermediate_size,
@@ -1764,11 +1763,11 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
             args.gemm1_weights, args.gemm1_weights_scale, args.gemm2_weights,
             args.gemm2_weights_scale, args.output1_scale_scalar,
             args.output1_scale_gate_scalar, args.output2_scale_scalar,
-            self.num_experts, self.top_k, None, self.n_group,
-            self.topk_group, self.intermediate_size,
-            self.local_expert_offset, self.local_num_experts,
-            self.routed_scaling_factor, self.routing_method_type,
-            self.do_finalize, tactic, args.topk_weights, args.topk_ids)
+            self.num_experts, self.top_k, None, self.n_group, self.topk_group,
+            self.intermediate_size, self.local_expert_offset,
+            self.local_num_experts, self.routed_scaling_factor,
+            self.routing_method_type, self.do_finalize, tactic,
+            args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -974,7 +974,7 @@ class Deepseekv3MoE(nn.Module):
         if model_config.quant_config and model_config.quant_config.group_size is not None:
             block_size = model_config.quant_config.group_size
 
-        shared_tp_size, self.shared_output_scale = self._compute_shared_expert_tp_size(
+        self.shared_tp_size, self.shared_output_scale = self._compute_shared_expert_tp_size(
             shared_expert_intermediate_size, block_size)
 
         self.shared_experts = GatedMLP(
@@ -983,10 +983,9 @@ class Deepseekv3MoE(nn.Module):
             bias=False,
             dtype=dtype,
             config=model_config,
-            overridden_tp_size=shared_tp_size,
+            overridden_tp_size=self.shared_tp_size,
             reduce_output=False,
-            use_cute_dsl_blockscaling_mm=self.use_cute_dsl_blockscaling_mm,
-        )
+            use_cute_dsl_blockscaling_mm=self.use_cute_dsl_blockscaling_mm)
 
         self.allreduce = None
         if not self.use_dp and self.mapping.tp_size > 1:
@@ -1036,6 +1035,9 @@ class Deepseekv3MoE(nn.Module):
         if self.use_dp:
             # If using attention DP, the shared experts also use DP instead of TP.
             shared_tp_size = 1
+        elif hasattr(self.experts, 'num_fused_shared_expert'
+                     ) and self.experts.num_fused_shared_expert > 0:
+            shared_tp_size = self.mapping.moe_tp_size
         else:
             # Due to the restriction of block scale size (i.e., 128), the supported TP sizes only include 1, 2, 4, 8, and 16.
             # The math.gcd operation ensures that shared_tp_size falls in the supported TP sizes.
@@ -1140,14 +1142,18 @@ class Deepseekv3MoE(nn.Module):
 
         # NOTE: define compiled helpers at module scope to avoid defining decorators inside compiled frames
 
-        routed_output, shared_output = maybe_execute_in_parallel(
-            _compute_routed_output, _compute_shared_output,
-            self.event_dict[EventType.Main],
-            self.event_dict[EventType.MoeShared], self.aux_stream)
+        if self.shared_experts is not None:
+            routed_output, shared_output = maybe_execute_in_parallel(
+                _compute_routed_output, _compute_shared_output,
+                self.event_dict[EventType.Main],
+                self.event_dict[EventType.MoeShared], self.aux_stream)
+        else:
+            shared_output = None
+            routed_output = _compute_routed_output()
 
         if not do_finalize:
             return [shared_output, *routed_output]
-        else:
+        elif shared_output is not None:
             if routed_output.dim() == 3:
                 assert shared_output.numel(
                 ) * self.top_k == routed_output.numel(
@@ -1158,13 +1164,13 @@ class Deepseekv3MoE(nn.Module):
                 assert shared_output.size() == routed_output.size(
                 ), 'unmatched tensor shape'
                 final_hidden_states = shared_output + routed_output
+        else:
+            final_hidden_states = routed_output
 
-            if not self.use_dp and self.mapping.tp_size > 1:
-                final_hidden_states = self.allreduce(
-                    final_hidden_states,
-                    all_reduce_params=final_all_reduce_params)
-
-            return final_hidden_states
+        if not self.use_dp and self.mapping.tp_size > 1:
+            final_hidden_states = self.allreduce(
+                final_hidden_states, all_reduce_params=final_all_reduce_params)
+        return final_hidden_states
 
 
 class DeepseekV3DecoderLayer(DecoderLayer):
@@ -1881,3 +1887,24 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
             else:
                 layer.next_layer_layernorm = self.model.layers[
                     idx + 1].input_layernorm
+
+            # Note: merge shared expert into FusedMoe module
+            if idx >= self.config.first_k_dense_replace and idx % self.config.moe_layer_freq == 0:
+                if hasattr(layer.mlp.experts, 'num_fused_shared_expert'
+                           ) and layer.mlp.experts.num_fused_shared_expert > 0:
+                    layer.mlp.experts.fuse_shared_expert(
+                        layer.mlp.shared_experts)
+                    layer.mlp.shared_experts = None
+
+        # Also process MTP layers if present
+        if self.draft_model is not None and hasattr(self.draft_model,
+                                                    'mtp_layers'):
+            for layer in self.model.layers[self.config.num_hidden_layers:]:
+                # MTP layers also have MoE, need to fuse shared experts
+                if hasattr(layer, 'mlp') and hasattr(layer.mlp, 'experts'):
+                    if hasattr(
+                            layer.mlp.experts, 'num_fused_shared_expert'
+                    ) and layer.mlp.experts.num_fused_shared_expert > 0:
+                        layer.mlp.experts.fuse_shared_expert(
+                            layer.mlp.shared_experts)
+                        layer.mlp.shared_experts = None

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -32,16 +32,16 @@ from ...custom_ops.trtllm_gen_custom_ops import \
 from ...distributed import allgather
 from ...expert_statistic import ExpertStatistic
 from ...model_config import ModelConfig
-from ...utils import (ActivationType, AuxStreamType, Fp4QuantizedTensor)
+from ...utils import ActivationType, AuxStreamType, Fp4QuantizedTensor
 from ..gated_mlp import GatedMLP
 from .interface import AlltoallMethodType, MoE, MoEWeightLoadingMode
 
 # isort: off
 from .quantization import (
-    DeepSeekFP8BlockScalesFusedMoEMethod, NVFP4TRTLLMGenFusedMoEBaseMethod,
-    NVFP4TRTLLMGenFusedMoEMethod, W4A8MXFP4FP8TRTLLMGenFusedMoEMethod,
-    W4A8MXFP4MXFP8TRTLLMGenFusedMoEMethod, W4A8NVFP4FP8TRTLLMGenFusedMoEMethod,
-    W4A16MXFP4TRTLLMGenFusedMoEMethod)
+    DeepSeekFP8TRTLLMGenBlockScalesFusedMoEMethod,
+    NVFP4TRTLLMGenFusedMoEBaseMethod, NVFP4TRTLLMGenFusedMoEMethod,
+    W4A8MXFP4FP8TRTLLMGenFusedMoEMethod, W4A8MXFP4MXFP8TRTLLMGenFusedMoEMethod,
+    W4A8NVFP4FP8TRTLLMGenFusedMoEMethod, W4A16MXFP4TRTLLMGenFusedMoEMethod)
 # isort: on
 from .routing import BaseMoeRoutingMethod, DeepSeekV3MoeRoutingMethod
 
@@ -276,14 +276,16 @@ class TRTLLMGenFusedMoE(MoE):
 
         self._weights_created = False
         self.num_fused_shared_expert = 0
-        if not model_config.skip_create_weights_in_init:
-            self.create_weights()
-        self.layer_idx = layer_idx
 
+        # Set num_fused_shared_expert BEFORE create_weights() to ensure correct buffer sizes
         if model_config.mapping.dp_size == 1 and (
                 self.quant_config.layer_quant_mode.has_fp8_block_scales()
                 or self.quant_config.layer_quant_mode.has_nvfp4()):
             self.num_fused_shared_expert = model_config.pretrained_config.n_shared_experts
+
+        if not model_config.skip_create_weights_in_init:
+            self.create_weights()
+        self.layer_idx = layer_idx
 
     def _to_trtllm_gen_activation_type(self,
                                        activation_type: ActivationType) -> int:
@@ -345,7 +347,7 @@ class TRTLLMGenFusedMoE(MoE):
         if self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
                 exclude_kv_cache=True):
             if self.quant_config.layer_quant_mode.has_fp8_block_scales():
-                return DeepSeekFP8BlockScalesFusedMoEMethod()
+                return DeepSeekFP8TRTLLMGenBlockScalesFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_nvfp4():
                 return NVFP4TRTLLMGenFusedMoEMethod(
                 ) if self.swiglu_alpha is not None or self.activation_type == ActivationType.Relu2 else NVFP4TRTLLMGenFusedMoEBaseMethod(

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -36,6 +36,7 @@ from tensorrt_llm.quantization.utils.fp8_utils import (
 
 from ...utils import (replace_parameter_and_save_metadata, swizzle_sf,
                       unswizzle_sf)
+from ..gated_mlp import GatedMLP
 from ..linear import TensorParallelMode, load_weight_shard
 from .interface import MoEWeightLoadingMode
 from .moe_load_balancer import advise_tensor_pageout
@@ -909,14 +910,15 @@ class FP8QDQFusedMoEMethod(FusedMoEMethodBase):
 class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
     eplb_support_status = EplbSupportStatus.NOT_VERIFIED
 
-    def create_weights(self, module: torch.nn.Module):
+    def create_weights(self, module: torch.nn.Module, n_shared_experts=0):
         weight_dtype = torch.float8_e4m3fn
 
-        w3_w1_weight_shape = (module.expert_size_per_partition,
+        w3_w1_weight_shape = (module.expert_size_per_partition +
+                              n_shared_experts,
                               module.intermediate_size_per_partition * 2,
                               module.hidden_size)
         w2_weight_shape = (
-            module.expert_size_per_partition,
+            module.expert_size_per_partition + n_shared_experts,
             module.hidden_size,
             module.intermediate_size_per_partition,
         )
@@ -925,7 +927,7 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
 
         cell_div = lambda x, y: (x + y - 1) // y
         w3_w1_weight_scaling_factor = nn.Parameter(torch.empty(
-            (module.expert_size_per_partition,
+            (module.expert_size_per_partition + n_shared_experts,
              cell_div(module.intermediate_size_per_partition, 128) * 2,
              cell_div(w3_w1_weight_shape[2], 128)),
             dtype=torch.float32),
@@ -934,8 +936,9 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
                                   w3_w1_weight_scaling_factor)
 
         w2_weight_scaling_factor = nn.Parameter(torch.empty(
-            (module.expert_size_per_partition, cell_div(
-                w2_weight_shape[1], 128), cell_div(w2_weight_shape[2], 128)),
+            (module.expert_size_per_partition + n_shared_experts,
+             cell_div(w2_weight_shape[1], 128), cell_div(
+                 w2_weight_shape[2], 128)),
             dtype=torch.float32),
                                                 requires_grad=False)
         module.register_parameter("w2_weight_scaling_factor",
@@ -1164,6 +1167,170 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                                                 transformed_w2_scale,
                                                 module.rebuild_tensor_metadata)
             self.setup_quant_scales(module)
+
+
+class DeepSeekFP8TRTLLMGenBlockScalesFusedMoEMethod(
+        DeepSeekFP8BlockScalesFusedMoEMethod):
+
+    # Cache the permute indices during weight loading to avoid recompute
+    # This assumes the same input shape always results in the same permute indices
+    _cache_permute_indices: Dict[torch.Size, torch.Tensor] = {}
+
+    @staticmethod
+    def convert_to_block_layout(input_tensor: torch.Tensor,
+                                blockK: int) -> torch.Tensor:
+        M, K = input_tensor.shape
+        assert K % blockK == 0, "K must be divisible by blockK"
+        return input_tensor.view(M, K // blockK,
+                                 blockK).permute(1, 0,
+                                                 2).contiguous().view(M, K)
+
+    def load_expert_w3_w1_weight(self,
+                                 module: torch.nn.Module,
+                                 w1_weight: torch.Tensor,
+                                 w3_weight: torch.Tensor,
+                                 dst_w3_w1_weight: torch.Tensor,
+                                 allow_partial_loading: bool = False):
+        # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        dst_on_gpu = dst_w3_w1_weight.device.type == "cuda"
+        dst_w3_w1_weight_gpu = dst_w3_w1_weight if dst_on_gpu else dst_w3_w1_weight.cuda(
+        )
+        if not allow_partial_loading:
+            assert w1_weight is not None and w3_weight is not None
+        w1_weight_shard = load_weight_shard(
+            w1_weight,
+            module.tp_size,
+            module.tp_rank,
+            TensorParallelMode.COLUMN,
+            device=device) if w1_weight is not None else None
+        w3_weight_shard = load_weight_shard(
+            w3_weight,
+            module.tp_size,
+            module.tp_rank,
+            TensorParallelMode.COLUMN,
+            device=device) if w3_weight is not None else None
+
+        # FIXME: this depends on the kernel internals
+
+        # Keep weights in device buffer
+        dst_w3_weight, dst_w1_weight = dst_w3_w1_weight_gpu.split(
+            module.intermediate_size_per_partition, dim=0)
+
+        dst_w3_weight.copy_(w3_weight_shard.view(dst_w3_weight.dtype))
+        dst_w1_weight.copy_(w1_weight_shard.view(dst_w1_weight.dtype))
+
+        # Copy the result into device buffer
+        dst_w3_w1_weight_gpu.copy_(processed_w31_weight_shard.view(
+            dst_w3_w1_weight_gpu.dtype),
+                                   non_blocking=dst_on_gpu)
+        if not dst_on_gpu:
+            dst_w3_w1_weight.copy_(dst_w3_w1_weight_gpu)
+
+    # Helper function
+    def load_expert_w2_weight(self,
+                              module: torch.nn.Module,
+                              w2_weight: torch.Tensor,
+                              dst_w2_weight: torch.Tensor,
+                              allow_partial_loading: bool = False):
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        dst_on_gpu = dst_w2_weight.device.type == "cuda"
+        dst_w2_weight_gpu = dst_w2_weight if dst_on_gpu else dst_w2_weight.cuda(
+        )
+        if not allow_partial_loading:
+            assert w2_weight is not None
+        w2_weight_shard = load_weight_shard(w2_weight,
+                                            module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.ROW,
+                                            device=device)
+
+        # Keep weights in device buffer
+        dst_w2_weight_gpu.copy_(w2_weight_shard.view(dst_w2_weight_gpu.dtype),
+                                non_blocking=dst_on_gpu)
+
+        # Copy the result into device buffer
+        dst_w2_weight_gpu.copy_(processed_w2_weight.view(
+            dst_w2_weight_gpu.dtype),
+                                non_blocking=dst_on_gpu)
+
+        if not dst_on_gpu:
+            dst_w2_weight.copy_(dst_w2_weight_gpu)
+
+    def fuse_shared_expert(self, module: torch.nn.Module,
+                           shared_experts: GatedMLP, n_shared_experts: int):
+
+        def fuse_shared_expert_weight(dst_w3_w1_weight, dst_w2_weight,
+                                      w1_weight, w2_weight, w3_weight):
+            # Keep weights in device buffer
+            dst_w3_weight, dst_w1_weight = dst_w3_w1_weight.split(
+                module.intermediate_size_per_partition, dim=0)
+
+            dst_w3_weight.copy_(w3_weight.view(dst_w3_weight.dtype),
+                                non_blocking=True)
+            dst_w1_weight.copy_(w1_weight.view(dst_w1_weight.dtype),
+                                non_blocking=True)
+
+            # Keep weights in device buffer
+            dst_w2_weight.copy_(w2_weight.view(dst_w2_weight.dtype),
+                                non_blocking=True)
+
+        def fuse_shared_expert_weight_scale(dst_w3_w1_weight_scale,
+                                            dst_w2_weight_scale,
+                                            w1_weight_scale, w2_weight_scale,
+                                            w3_weight_scale):
+            # Keep weights in device buffer
+            # w3
+            dst_w3_weight_scale, dst_w1_weight_scale = dst_w3_w1_weight_scale.chunk(
+                2, dim=0)
+            dst_w3_weight_scale.copy_(
+                w3_weight_scale.view(dst_w3_weight_scale.dtype))
+
+            # w1
+            dst_w1_weight_scale.copy_(
+                w1_weight_scale.view(dst_w1_weight_scale.dtype))
+
+            # Keep weights in device buffer
+            dst_w2_weight_scale.copy_(
+                w2_weight_scale.view(dst_w2_weight_scale.dtype))
+
+        w1_weight, w3_weight = shared_experts.gate_up_proj.weight.data.chunk(
+            2, dim=0)
+        w1_weight = w1_weight.view(n_shared_experts,
+                                   module.w3_w1_weight.shape[1] // 2,
+                                   module.w3_w1_weight.shape[2])
+        w3_weight = w3_weight.view(n_shared_experts,
+                                   module.w3_w1_weight.shape[1] // 2,
+                                   module.w3_w1_weight.shape[2])
+        w2_weight = shared_experts.down_proj.weight.view(
+            module.w2_weight.shape[1], n_shared_experts,
+            module.w2_weight.shape[2]).permute(1, 0, 2).contiguous()
+
+        w1_w3_weight_scale = shared_experts.gate_up_proj.weight_scale.data
+        w1_weight_scale, w3_weight_scale = w1_w3_weight_scale.chunk(2, dim=0)
+        w1_weight_scale = w1_weight_scale.view(
+            n_shared_experts, module.w3_w1_weight_scaling_factor.shape[1] // 2,
+            module.w3_w1_weight_scaling_factor.shape[2])
+        w3_weight_scale = w3_weight_scale.view(
+            n_shared_experts, module.w3_w1_weight_scaling_factor.shape[1] // 2,
+            module.w3_w1_weight_scaling_factor.shape[2])
+
+        w2_weight_scale = shared_experts.down_proj.weight_scale.data
+        w2_weight_scale = w2_weight_scale.view(
+            n_shared_experts, module.w2_weight_scaling_factor.shape[1],
+            module.w2_weight_scaling_factor.shape[2])
+
+        for i in range(n_shared_experts):
+            fuse_shared_expert_weight(
+                module.w3_w1_weight[module.expert_size_per_partition + i],
+                module.w2_weight[module.expert_size_per_partition + i],
+                w1_weight[i], w2_weight[i], w3_weight[i])
+            fuse_shared_expert_weight_scale(
+                module.w3_w1_weight_scaling_factor[
+                    module.expert_size_per_partition + i],
+                module.w2_weight_scaling_factor[module.expert_size_per_partition
+                                                + i], w1_weight_scale[i],
+                w2_weight_scale[i], w3_weight_scale[i])
 
 
 class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
@@ -1947,31 +2114,33 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
     """
     eplb_support_status = EplbSupportStatus.SUPPORTED
 
-    def get_weights_shapes(self, module: torch.nn.Module, weight_vec_size: int,
-                           block_scales_vec_size: int):
+    def get_weights_shapes(self,
+                           module: torch.nn.Module,
+                           weight_vec_size: int,
+                           block_scales_vec_size: int,
+                           n_shared_experts: int = 0):
         # Divide by 16 because we use int64 to pack 16 fp4 values
-        w3_w1_weight_shape = (module.expert_size_per_partition,
+        num_total_experts = module.expert_size_per_partition + n_shared_experts
+        w3_w1_weight_shape = (num_total_experts,
                               module.expand_intermediate_size_per_partition,
                               module.hidden_size // weight_vec_size)
-        w2_weight_shape = (module.expert_size_per_partition, module.hidden_size,
+        w2_weight_shape = (num_total_experts, module.hidden_size,
                            module.intermediate_size_per_partition //
                            weight_vec_size)
 
         w3_w1_weight_scale_shape = (
-            module.expert_size_per_partition,
-            module.expand_intermediate_size_per_partition, module.hidden_size //
-            module.scaling_vector_size // block_scales_vec_size)
-        w2_weight_scale_shape = (module.expert_size_per_partition,
-                                 module.hidden_size,
+            num_total_experts, module.expand_intermediate_size_per_partition,
+            module.hidden_size // module.scaling_vector_size //
+            block_scales_vec_size)
+        w2_weight_scale_shape = (num_total_experts, module.hidden_size,
                                  module.intermediate_size_per_partition //
                                  module.scaling_vector_size //
                                  block_scales_vec_size)
 
         if module.bias:
-            w3_w1_bias_shape = (module.expert_size_per_partition,
+            w3_w1_bias_shape = (num_total_experts,
                                 module.expand_intermediate_size_per_partition)
-            w2_bias_shape = (module.expert_size_per_partition,
-                             module.hidden_size)
+            w2_bias_shape = (num_total_experts, module.hidden_size)
         else:
             w3_w1_bias_shape = None
             w2_bias_shape = None
@@ -1986,14 +2155,15 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                        block_scales_dtype,
                        block_scales_vec_size,
                        scaling_vector_size=16,
-                       bias_dtype: Optional[torch.dtype] = None):
+                       bias_dtype: Optional[torch.dtype] = None,
+                       n_shared_experts: int = 0):
 
         module.scaling_vector_size = scaling_vector_size
 
         (w3_w1_weight_shape, w2_weight_shape, w3_w1_bias_shape, w2_bias_shape,
          w3_w1_weight_scale_shape,
          w2_weight_scale_shape) = self.get_weights_shapes(
-             module, weight_vec_size, block_scales_vec_size)
+             module, weight_vec_size, block_scales_vec_size, n_shared_experts)
 
         # Divide by 4 because we use int32 to pack 4 fp8 values
         # column parallel
@@ -2016,12 +2186,13 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                                        requires_grad=False)
         module.register_parameter("fc2_input_scale", fc2_input_scale)
 
-        fc31_alpha = nn.Parameter(torch.ones(module.expert_size_per_partition,
+        num_total_experts = module.expert_size_per_partition + n_shared_experts
+        fc31_alpha = nn.Parameter(torch.ones(num_total_experts,
                                              dtype=torch.float32),
                                   requires_grad=False)
         module.register_parameter("fc31_alpha", fc31_alpha)
 
-        fc2_alpha = nn.Parameter(torch.ones(module.expert_size_per_partition,
+        fc2_alpha = nn.Parameter(torch.ones(num_total_experts,
                                             dtype=torch.float32),
                                  requires_grad=False)
         module.register_parameter("fc2_alpha", fc2_alpha)
@@ -2566,6 +2737,7 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
 
     def create_weights(self,
                        module: torch.nn.Module,
+                       n_shared_experts: int = 0,
                        bias_dtype: Optional[torch.dtype] = None):
         weight_vec_size = torch.iinfo(self.weight_dtype).bits // 4
         block_scales_vec_size = 1
@@ -2575,9 +2747,11 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
                                weight_vec_size,
                                self.block_scales_dtype,
                                block_scales_vec_size,
-                               bias_dtype=bias_dtype)
+                               bias_dtype=bias_dtype,
+                               n_shared_experts=n_shared_experts)
 
-        fc31_scale_c = nn.Parameter(torch.ones(module.expert_size_per_partition,
+        num_total_experts = module.expert_size_per_partition + n_shared_experts
+        fc31_scale_c = nn.Parameter(torch.ones(num_total_experts,
                                                dtype=torch.float32),
                                     requires_grad=False)
         module.register_parameter("fc31_scale_c", fc31_scale_c)
@@ -2874,13 +3048,228 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
                 local_shared_fc31_scale_c,
             })
 
+    def fuse_shared_expert(self, module: torch.nn.Module,
+                           shared_experts: GatedMLP, n_shared_experts: int):
+
+        def _pad_up(x, align):
+            return (x + align - 1) // align * align
+
+        # FIXME: this depends on the kernel internals
+        epilogue_tile_m = 128
+        scaling_vector_size = module.scaling_vector_size
+
+        def fuse_shared_expert_weight_w31(dst_w3_w1_weight, w1_weight,
+                                          w3_weight):
+            """Copy shared expert w1/w3 weights into MoE buffer and shuffle."""
+            dst_w3_w1_weight_gpu = dst_w3_w1_weight.cuda()
+
+            if module.is_gated_activation:
+                if dst_w3_w1_weight_gpu.shape[
+                        0] != module.intermediate_size_per_partition * 2:
+                    dst_w3_weight = dst_w3_w1_weight_gpu.narrow(
+                        0, 0, module.intermediate_size_per_partition)
+                    dst_w1_weight = dst_w3_w1_weight_gpu.narrow(
+                        0, module.intermediate_size_per_partition,
+                        module.intermediate_size_per_partition)
+                else:
+                    dst_w3_weight, dst_w1_weight = dst_w3_w1_weight_gpu.split(
+                        module.intermediate_size_per_partition, dim=0)
+
+                dst_w3_weight.copy_(w3_weight.view(dst_w3_weight.dtype))
+                dst_w1_weight.copy_(w1_weight.view(dst_w1_weight.dtype))
+            else:
+                dst_w3_w1_weight_gpu.copy_(
+                    w1_weight.view(dst_w3_w1_weight_gpu.dtype))
+
+            # Get permute indices and shuffle
+            permute_indices = trtllmgen_maybe_get_cached_w3_w1_permute_indices(
+                dst_w3_w1_weight_gpu, self._cache_permute_indices,
+                epilogue_tile_m)
+            processed = torch.ops.trtllm.shuffle_matrix(
+                dst_w3_w1_weight_gpu,
+                permute_indices.to(dst_w3_w1_weight_gpu.device))
+            dst_w3_w1_weight_gpu.copy_(processed.view(
+                dst_w3_w1_weight_gpu.dtype),
+                                       non_blocking=True)
+
+        def fuse_shared_expert_weight_w2(dst_w2_weight, w2_weight):
+            """Copy shared expert w2 weight into MoE buffer and shuffle."""
+            dst_w2_weight_gpu = dst_w2_weight.cuda()
+            dst_w2_weight_gpu.copy_(w2_weight.view(dst_w2_weight_gpu.dtype))
+
+            # Get permute indices and shuffle
+            permute_indices = trtllmgen_maybe_get_cached_w2_permute_indices(
+                dst_w2_weight_gpu, self._cache_permute_indices, epilogue_tile_m)
+            processed = torch.ops.trtllm.shuffle_matrix(
+                dst_w2_weight_gpu, permute_indices.to(dst_w2_weight_gpu.device))
+            dst_w2_weight_gpu.copy_(processed.view(dst_w2_weight_gpu.dtype),
+                                    non_blocking=True)
+
+        def fuse_shared_expert_weight_scale_w31(dst_w3_w1_weight_scale,
+                                                w1_weight_scale,
+                                                w3_weight_scale):
+            """Copy shared expert w1/w3 weight scales into MoE buffer, shuffle, and interleave."""
+            dst_w3_w1_weight_scale_gpu = dst_w3_w1_weight_scale.cuda()
+
+            if module.is_gated_activation:
+                dst_w3_scale = dst_w3_w1_weight_scale_gpu.narrow(
+                    0, 0, module.intermediate_size_per_partition)
+                dst_w1_scale = dst_w3_w1_weight_scale_gpu.narrow(
+                    0, module.intermediate_size_per_partition,
+                    module.intermediate_size_per_partition)
+                dst_w3_scale.copy_(w3_weight_scale.view(dst_w3_scale.dtype))
+                dst_w1_scale.copy_(w1_weight_scale.view(dst_w1_scale.dtype))
+            else:
+                dst_w3_w1_weight_scale_gpu.copy_(
+                    w1_weight_scale.view(dst_w3_w1_weight_scale_gpu.dtype))
+
+            orig_shape = dst_w3_w1_weight_scale_gpu.shape
+
+            # Get permute indices
+            permute_indices = trtllmgen_maybe_get_cached_w3_w1_permute_indices(
+                dst_w3_w1_weight_scale_gpu.view(float4_sf_dtype),
+                self._cache_permute_indices,
+                epilogue_tile_m,
+                num_elts_per_sf=scaling_vector_size)
+            # Shuffle
+            w3_w1_weight_scale = torch.ops.trtllm.shuffle_matrix(
+                dst_w3_w1_weight_scale_gpu.view(float4_sf_dtype),
+                permute_indices)
+            # Interleave
+            processed = torch.ops.trtllm.block_scale_interleave(
+                w3_w1_weight_scale.view(float4_sf_dtype).reshape(orig_shape))
+            dst_w3_w1_weight_scale_gpu.copy_(
+                processed.view(self.block_scales_dtype).reshape(orig_shape))
+
+        def fuse_shared_expert_weight_scale_w2(dst_w2_weight_scale,
+                                               w2_weight_scale):
+            """Copy shared expert w2 weight scale into MoE buffer, shuffle, and interleave."""
+            dst_w2_weight_scale_gpu = dst_w2_weight_scale.cuda()
+            dst_w2_weight_scale_gpu.copy_(
+                w2_weight_scale.view(dst_w2_weight_scale_gpu.dtype))
+
+            orig_shape = dst_w2_weight_scale_gpu.shape
+
+            # Get permute indices
+            permute_indices = trtllmgen_maybe_get_cached_w2_permute_indices(
+                dst_w2_weight_scale_gpu.view(float4_sf_dtype),
+                self._cache_permute_indices,
+                epilogue_tile_m,
+                num_elts_per_sf=scaling_vector_size)
+            # Shuffle
+            w_shuffled = torch.ops.trtllm.shuffle_matrix(
+                dst_w2_weight_scale_gpu.view(float4_sf_dtype), permute_indices)
+            # Interleave
+            processed = torch.ops.trtllm.block_scale_interleave(w_shuffled)
+            dst_w2_weight_scale_gpu.copy_(
+                processed.view(self.block_scales_dtype).reshape(orig_shape))
+
+        # === Extract weights from shared expert ===
+        # Weight is in raw format (not shuffled by NVFP4 linear loader)
+        w1_weight, w3_weight = shared_experts.gate_up_proj.weight.data.chunk(
+            2, dim=0)
+        w1_weight = w1_weight.view(n_shared_experts,
+                                   module.w3_w1_weight.shape[1] // 2,
+                                   module.w3_w1_weight.shape[2])
+        w3_weight = w3_weight.view(n_shared_experts,
+                                   module.w3_w1_weight.shape[1] // 2,
+                                   module.w3_w1_weight.shape[2])
+        w2_weight = shared_experts.down_proj.weight.view(
+            module.w2_weight.shape[1], n_shared_experts,
+            module.w2_weight.shape[2]).permute(1, 0, 2).contiguous()
+
+        # === Extract weight scales from shared expert ===
+        # The linear loader interleaved the scale (block_scale_interleave) but
+        # did NOT shuffle it. We need to un-interleave, split, then process
+        # with MoE-specific shuffling + interleaving.
+        gate_up_scale = shared_experts.gate_up_proj.weight_scale.data
+        gate_up_out_dim = shared_experts.gate_up_proj.weight.shape[0]
+        gate_up_in_dim = shared_experts.gate_up_proj.weight.shape[1] * 2
+        scale_nrows = _pad_up(gate_up_out_dim, 128)
+        scale_ncols = _pad_up(gate_up_in_dim // scaling_vector_size, 4)
+
+        # Un-interleave to get raw 2D scale
+        gate_up_scale_raw = unswizzle_sf(gate_up_scale, scale_nrows,
+                                         scale_ncols * scaling_vector_size,
+                                         scaling_vector_size)
+        # Strip padding to get real data
+        real_out = 2 * module.intermediate_size_per_partition
+        real_in_sf = module.hidden_size // scaling_vector_size
+        gate_up_scale_raw = gate_up_scale_raw[:real_out, :real_in_sf]
+        # Split into w3 and w1 scales
+        w3_weight_scale, w1_weight_scale = gate_up_scale_raw.chunk(2, dim=0)
+        w1_weight_scale = w1_weight_scale.view(
+            n_shared_experts, module.w3_w1_weight_scale.shape[1] // 2,
+            module.w3_w1_weight_scale.shape[2])
+        w3_weight_scale = w3_weight_scale.view(
+            n_shared_experts, module.w3_w1_weight_scale.shape[1] // 2,
+            module.w3_w1_weight_scale.shape[2])
+
+        # Down proj scale
+        down_scale = shared_experts.down_proj.weight_scale.data
+        down_out_dim = shared_experts.down_proj.weight.shape[0]
+        down_in_dim = shared_experts.down_proj.weight.shape[1] * 2
+        down_scale_nrows = _pad_up(down_out_dim, 128)
+        down_scale_ncols = _pad_up(down_in_dim // scaling_vector_size, 4)
+
+        down_scale_raw = unswizzle_sf(down_scale, down_scale_nrows,
+                                      down_scale_ncols * scaling_vector_size,
+                                      scaling_vector_size)
+        real_down_out = module.hidden_size
+        real_down_in_sf = module.intermediate_size_per_partition // scaling_vector_size
+        down_scale_raw = down_scale_raw[:real_down_out, :real_down_in_sf]
+        w2_weight_scale = down_scale_raw.view(
+            module.w2_weight_scale.shape[1], n_shared_experts,
+            module.w2_weight_scale.shape[2]).permute(1, 0, 2).contiguous()
+
+        # === Compute alphas for shared experts ===
+        # For NVFP4 linear: alpha = 1 / (raw_input_scale * weight_scale_2)
+        #                   input_scale = 1 / raw_input_scale
+        # So: weight_scale_2 = input_scale / alpha
+        gate_up_ws2 = (shared_experts.gate_up_proj.input_scale.data /
+                       shared_experts.gate_up_proj.alpha.data)
+        down_ws2 = (shared_experts.down_proj.input_scale.data /
+                    shared_experts.down_proj.alpha.data)
+
+        # === Fuse into MoE buffer ===
+        for i in range(n_shared_experts):
+            slot = module.expert_size_per_partition + i
+
+            # Fuse weights (copy + shuffle)
+            fuse_shared_expert_weight_w31(module.w3_w1_weight[slot],
+                                          w1_weight[i], w3_weight[i])
+            fuse_shared_expert_weight_w2(module.w2_weight[slot], w2_weight[i])
+
+            # Fuse weight scales (copy + shuffle + interleave)
+            fuse_shared_expert_weight_scale_w31(module.w3_w1_weight_scale[slot],
+                                                w1_weight_scale[i],
+                                                w3_weight_scale[i])
+            fuse_shared_expert_weight_scale_w2(module.w2_weight_scale[slot],
+                                               w2_weight_scale[i])
+
+            # Fuse alphas
+            # fc31_alpha = 1 / (fc31_input_scale * weight_scale_2)
+            module.fc31_alpha.data[slot] = 1.0 / (module.fc31_input_scale.data *
+                                                  gate_up_ws2)
+            # fc2_alpha = 1 / (fc2_input_scale * weight_scale_2)
+            module.fc2_alpha.data[slot] = 1.0 / (module.fc2_input_scale.data *
+                                                 down_ws2)
+
+            # Recompute fc31_scale_c for the shared expert slot
+            module.fc31_scale_c.data[
+                slot] = module.fc2_input_scale.data * module.fc31_alpha.data[
+                    slot]
+
 
 class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
     weight_alignment = 32
     input_hidden_alignment = 32
 
-    def get_weights_shapes(self, module: torch.nn.Module, weight_vec_size: int,
-                           block_scales_vec_size: int):
+    def get_weights_shapes(self,
+                           module: torch.nn.Module,
+                           weight_vec_size: int,
+                           block_scales_vec_size: int,
+                           n_shared_experts: int = 0):
 
         def round_up(x, alignment):
             return (x + alignment - 1) // alignment * alignment
@@ -2893,34 +3282,33 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
         w2_hidden_size_padded = round_up(module.hidden_size,
                                          self.weight_alignment)
 
+        num_total_experts = module.expert_size_per_partition + n_shared_experts
+
         # Divide by 16 because we use int64 to pack 16 fp4 values
-        w3_w1_weight_shape = (module.expert_size_per_partition,
+        w3_w1_weight_shape = (num_total_experts,
                               intermediate_size_per_partition_padded *
                               module.intermediate_size_expand_ratio,
                               w3_w1_hidden_size_padded // weight_vec_size)
-        w2_weight_shape = (module.expert_size_per_partition,
-                           w2_hidden_size_padded,
+        w2_weight_shape = (num_total_experts, w2_hidden_size_padded,
                            intermediate_size_per_partition_padded //
                            weight_vec_size)
 
-        w3_w1_weight_scale_shape = (module.expert_size_per_partition,
+        w3_w1_weight_scale_shape = (num_total_experts,
                                     intermediate_size_per_partition_padded *
                                     module.intermediate_size_expand_ratio,
                                     w3_w1_hidden_size_padded //
                                     module.scaling_vector_size //
                                     block_scales_vec_size)
-        w2_weight_scale_shape = (module.expert_size_per_partition,
-                                 w2_hidden_size_padded,
+        w2_weight_scale_shape = (num_total_experts, w2_hidden_size_padded,
                                  intermediate_size_per_partition_padded //
                                  module.scaling_vector_size //
                                  block_scales_vec_size)
 
         if module.bias:
-            w3_w1_bias_shape = (module.expert_size_per_partition,
+            w3_w1_bias_shape = (num_total_experts,
                                 intermediate_size_per_partition_padded *
                                 module.intermediate_size_expand_ratio)
-            w2_bias_shape = (module.expert_size_per_partition,
-                             w2_hidden_size_padded)
+            w2_bias_shape = (num_total_experts, w2_hidden_size_padded)
         else:
             w3_w1_bias_shape = None
             w2_bias_shape = None
@@ -2931,7 +3319,8 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
     def _round_up(self, x, alignment):
         return (x + alignment - 1) // alignment * alignment
 
-    def create_weights(self, module: torch.nn.Module):
+    def create_weights(self, module: torch.nn.Module,
+                       n_shared_experts: int = 0):
         # Here we only enable padding for hidden_size > 1024 since there are small unit tests that expect no padding.
         if module.hidden_size > 1024 and module.hidden_size % 256 != 0:
             self.weight_alignment = 256
@@ -2948,7 +3337,7 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
             if intermediate_size_padded % 128 != 0:
                 self.weight_alignment = 128
 
-        super().create_weights(module, bias_dtype=torch.float32)
+        super().create_weights(module, n_shared_experts=n_shared_experts, bias_dtype=torch.float32)
 
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = tuple()

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -3319,7 +3319,8 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
     def _round_up(self, x, alignment):
         return (x + alignment - 1) // alignment * alignment
 
-    def create_weights(self, module: torch.nn.Module,
+    def create_weights(self,
+                       module: torch.nn.Module,
                        n_shared_experts: int = 0):
         # Here we only enable padding for hidden_size > 1024 since there are small unit tests that expect no padding.
         if module.hidden_size > 1024 and module.hidden_size % 256 != 0:
@@ -3337,7 +3338,9 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
             if intermediate_size_padded % 128 != 0:
                 self.weight_alignment = 128
 
-        super().create_weights(module, n_shared_experts=n_shared_experts, bias_dtype=torch.float32)
+        super().create_weights(module,
+                               n_shared_experts=n_shared_experts,
+                               bias_dtype=torch.float32)
 
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = tuple()

--- a/tests/unittest/_torch/thop/serial/test_moe.py
+++ b/tests/unittest/_torch/thop/serial/test_moe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unittest/_torch/thop/serial/test_moe.py
+++ b/tests/unittest/_torch/thop/serial/test_moe.py
@@ -159,9 +159,9 @@ def routing_reference(expertLogits, topK, padding, num_fused_shared_experts=0):
         assert totalExpertsPerToken == topKLogits.shape[1]
 
         # Shared experts will have index starting at number of local experts
-        sharedIndices = torch.range(numExperts,
-                                    numExperts + num_fused_shared_experts - 1,
-                                    dtype=topKIndices.dtype)
+        sharedIndices = torch.arange(numExperts,
+                                     numExperts + num_fused_shared_experts,
+                                     dtype=topKIndices.dtype)
         sharedIndices = torch.unsqueeze(sharedIndices, 0)
         sharedIndices = sharedIndices.repeat(numTokens, 1)
         topKIndices = torch.cat((topKIndices, sharedIndices), dim=1)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fused shared experts support for Mixture of Experts routing, allowing shared expert weights to be integrated directly into the expert selection process alongside routed experts.
  * Extended MOE kernel configurations to handle combined expert counts and updated per-token expert selection logic for models utilizing fused shared experts.
  * Improved MOE execution efficiency by enabling seamless coordination between dynamically routed and fused shared experts during inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
