### PR TITLE
[None][fix] enable async-worker D2H copies for MTP/Eagle3 sampler and…

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ..speculative.interface import SpecMetadata
     from ..speculative.spec_tree_manager import SpecTreeManager
 
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.functional import (PositionEmbeddingType, RopeEmbeddingUtils,
                                      RotaryScalingType)
 from tensorrt_llm.mapping import Mapping
@@ -199,7 +200,8 @@ class AttentionMetadata:
 
         # The model executor sets seq_lens to None initially.
         if self._seq_lens is not None:
-            self._seq_lens = self._seq_lens.pin_memory()
+            if use_pinned_memory():
+                self._seq_lens = self._seq_lens.pin_memory()
 
             if self.is_cuda_graph and self._seq_lens_cuda is not None:
                 # Very important: do not reallocate if we are using CUDA graphs.
@@ -249,7 +251,8 @@ class AttentionMetadata:
         self.on_update()
         # The model executor sets seqlens to None initially.
         if self._seq_lens_kv is not None:
-            self._seq_lens_kv = self._seq_lens_kv.pin_memory()
+            if use_pinned_memory():
+                self._seq_lens_kv = self._seq_lens_kv.pin_memory()
             self._seq_lens_kv_cuda = self._seq_lens_kv.cuda(non_blocking=True)
 
     @property

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -18,7 +18,7 @@ from tensorrt_llm._torch.modules.multi_stream_utils import \
 from tensorrt_llm._torch.modules.rotary_embedding import RotaryEmbedding
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._torch.utils import maybe_compile, maybe_compiled_cat
-from tensorrt_llm._utils import get_size_in_bytes, get_sm_version
+from tensorrt_llm._utils import get_size_in_bytes, get_sm_version, use_pinned_memory
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.bindings.internal.batch_manager import \
@@ -339,7 +339,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_indexer_k_cache_block_offsets = torch.zeros_like(
             self.indexer_k_cache_block_offsets,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
 
         if not self.enable_context_mla_with_cached_kv:
@@ -353,7 +353,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             self.host_ctx_cached_token_indptr = torch.zeros_like(
                 self.ctx_cached_token_indptr,
                 device='cpu',
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
             self.ctx_kv_indptr = self.get_empty(
                 self.cuda_graph_buffers,
@@ -365,7 +365,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             self.host_ctx_kv_indptr = torch.zeros_like(
                 self.ctx_kv_indptr,
                 device='cpu',
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
 
         # Only when MLA chunked prefill is enabled, we need to gather the full KV for indexer's logit computation.
@@ -385,7 +385,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_gen_cached_token_indptr = torch.zeros_like(
             self.gen_cached_token_indptr,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         self.gen_kv_indptr = self.get_empty(
             self.cuda_graph_buffers,
@@ -397,7 +397,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_gen_kv_indptr = torch.zeros_like(
             self.gen_kv_indptr,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         # Indexer metadata
         # Separate slot mappings for non-interleaved layout (flat byte indices)
@@ -411,7 +411,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_slot_mapping_fp8 = torch.zeros_like(
             self.slot_mapping_fp8,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         self.slot_mapping_scale = self.get_empty(
             self.cuda_graph_buffers,
@@ -423,7 +423,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_slot_mapping_scale = torch.zeros_like(
             self.slot_mapping_scale,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         # Per-token request index buffer for topk_indices conversion
         self.req_idx_per_token = self.get_empty(
@@ -474,7 +474,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             self.host_topk_indices_buffer = torch.zeros_like(
                 self.topk_indices_buffer,
                 device='cpu',
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
         # Create expanded buffers for MTP support
         self.create_expanded_buffers(capture_graph=capture_graph)
@@ -491,7 +491,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.kv_lens_expanded_host = torch.zeros_like(
             self.kv_lens_expanded_cuda,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         self.block_table_expanded = self.get_empty(
             self.cuda_graph_buffers,
@@ -506,7 +506,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_block_table_expanded = torch.zeros_like(
             self.block_table_expanded,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
         self.scheduler_metadata_buffer_expanded = self.get_empty(
             self.cuda_graph_buffers,
@@ -1173,10 +1173,10 @@ class Indexer(nn.Module):
                                                                             num_contexts]
             host_slot_mapping_fp8_fullkv = torch.empty(total_kv_len,
                                                        dtype=torch.int64,
-                                                       pin_memory=True)
+                                                       pin_memory=use_pinned_memory())
             host_slot_mapping_scale_fullkv = torch.empty(total_kv_len,
                                                          dtype=torch.int64,
-                                                         pin_memory=True)
+                                                         pin_memory=use_pinned_memory())
 
             req_indices = torch.repeat_interleave(
                 torch.arange(num_contexts, dtype=torch.int64, device='cpu'),

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -15,7 +15,7 @@ from tensorrt_llm._torch.attention_backend.vanilla import (
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
 from tensorrt_llm._torch.pyexecutor.resource_manager import (BlockManager,
                                                              KVCacheManager)
-from tensorrt_llm._utils import get_size_in_bytes
+from tensorrt_llm._utils import get_size_in_bytes, use_pinned_memory
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.bindings.internal.batch_manager import \
@@ -143,7 +143,7 @@ class RocketTrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.host_kt_cache_block_offsets = torch.zeros_like(
             self.kt_cache_block_offsets,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
 
         # Number of KT tokens for each sequence
@@ -594,7 +594,7 @@ class RocketVanillaAttentionMetadata(VanillaAttentionMetadata):
         self.host_kt_cache_block_offsets = torch.zeros_like(
             self.kt_cache_block_offsets,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         )
 
     def prepare(self) -> None:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -35,7 +35,7 @@ from torch.types import Number
 
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
-from ...._utils import nvtx_range, str_dtype_to_torch
+from ...._utils import nvtx_range, str_dtype_to_torch, use_pinned_memory
 from ..utils.logger import ad_logger
 
 Constant = Union[int, float, str, None]
@@ -92,7 +92,7 @@ class InputBuffer:
         # Allocate contiguous buffers (device buffer starts on default device, use to() to move)
         self._device_buffer = torch.empty(self._total_bytes, dtype=torch.uint8)
         self._host_buffer = torch.empty(
-            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=True
+            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=use_pinned_memory()
         )
 
         # Create persistent views into device and host buffers
@@ -276,7 +276,7 @@ class InputBuffer:
         # Host buffer must be re-allocated to ensure we have pinned memory
         old_host_buffer = self._host_buffer
         self._host_buffer = torch.empty(
-            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=True
+            self._total_bytes, dtype=torch.uint8, device="cpu", pin_memory=use_pinned_memory()
         )
         self._host_buffer[: old_host_buffer.numel()].copy_(old_host_buffer)
         del old_host_buffer

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rope.py
@@ -53,6 +53,8 @@ import torch
 from pydantic import Field
 from torch.fx import GraphModule, Node
 
+from tensorrt_llm._utils import use_pinned_memory
+
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils.node_utils import extract_op_args, extract_output_tuple, is_op

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -9,6 +9,8 @@ from transformers.modeling_utils import (get_parameter_device,
 from transformers.models.clip.configuration_clip import CLIPVisionConfig
 from transformers.models.clip.modeling_clip import CLIPVisionEmbeddings
 
+from tensorrt_llm._utils import use_pinned_memory
+
 from ..attention_backend.interface import (AttentionMetadata,
                                            PredefinedAttentionMask)
 from ..attention_backend.utils import get_attention_backend
@@ -206,7 +208,7 @@ class CLIPVisionModel(nn.Module):
         prompt_lens = [seq_len] * batch_size
         seq_lens = torch.tensor([seq_len] * batch_size,
                                 dtype=torch.int,
-                                pin_memory=True)
+                                pin_memory=use_pinned_memory())
 
         self.attn_metadata.num_contexts = batch_size
         self.attn_metadata.request_ids = request_ids

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -27,7 +27,7 @@ from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
-from ..._utils import nvtx_range
+from ..._utils import nvtx_range, use_pinned_memory
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
                        BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        MultimodalPlaceholderMetadata,
@@ -775,7 +775,7 @@ class Qwen2_5_VisionModel(torch.nn.Module):
     def prepare_attn_metadata(self, seq_lens, attn_metadata: AttentionMetadata):
         batch_size = 1  # NOTE: Qwen2/2.5-VL concats all the pixel_values into a single tensor, so batch_size is 1
         prompt_lens = seq_lens
-        seq_lens = torch.tensor(seq_lens, dtype=torch.int, pin_memory=True)
+        seq_lens = torch.tensor(seq_lens, dtype=torch.int, pin_memory=use_pinned_memory())
         request_ids = list(range(1, batch_size + 1))
 
         attn_metadata.num_contexts = len(seq_lens)

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -17,7 +17,7 @@ from tensorrt_llm._torch.models.modeling_multimodal_utils import _is_disagg
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.mapping import Mapping
 
-from ..._utils import nvtx_range, nvtx_range_debug
+from ..._utils import nvtx_range, nvtx_range_debug, use_pinned_memory
 from ...inputs import (
     BaseMultimodalDummyInputsBuilder,
     BaseMultimodalInputProcessor,
@@ -716,7 +716,7 @@ class Qwen3VisionModel(torch.nn.Module):
         # NOTE: The single prompt is divided into multiple seq_lens, so pretending have many batch_sizes.
         batch_size = len(seq_lens)
         prompt_lens = seq_lens
-        seq_lens = torch.tensor(seq_lens, dtype=torch.int, pin_memory=True)
+        seq_lens = torch.tensor(seq_lens, dtype=torch.int, pin_memory=use_pinned_memory())
         request_ids = list(range(1, batch_size + 1))
 
         attn_metadata.num_contexts = batch_size

--- a/tensorrt_llm/_torch/models/modeling_radio.py
+++ b/tensorrt_llm/_torch/models/modeling_radio.py
@@ -22,6 +22,7 @@ from tensorrt_llm._torch.attention_backend import utils as attention_utils
 from tensorrt_llm._torch.models import modeling_utils
 from tensorrt_llm._torch.modules import attention as trtllm_attention
 from tensorrt_llm._torch.modules import mlp as trtllm_mlp
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
 InputDimT = Union[int, Tuple[int, int]]
@@ -594,7 +595,7 @@ class VisionTransformer(nn.Module):
         Call this function before forward pass
         """
         prompt_lens = seq_lengths
-        seq_lens = torch.tensor(seq_lengths, dtype=torch.int, pin_memory=True)
+        seq_lens = torch.tensor(seq_lengths, dtype=torch.int, pin_memory=use_pinned_memory())
         request_ids = list(range(1, batch_size + 1))
 
         attn_metadata.seq_lens = seq_lens

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -8,6 +8,8 @@ from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
 from transformers.models.siglip.modeling_siglip import (SiglipVisionConfig,
                                                         SiglipVisionEmbeddings)
 
+from tensorrt_llm._utils import use_pinned_memory
+
 from ..attention_backend.interface import AttentionMetadata
 from ..attention_backend.utils import get_attention_backend
 from ..model_config import ModelConfig
@@ -99,7 +101,7 @@ class SiglipVisionModel(nn.Module):
         prompt_lens = [seq_len] * batch_size
         seq_lens = torch.tensor([seq_len] * batch_size,
                                 dtype=torch.int,
-                                pin_memory=True)
+                                pin_memory=use_pinned_memory())
 
         self.attn_metadata.num_contexts = batch_size
         self.attn_metadata.request_ids = request_ids

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -25,6 +25,7 @@ from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import \
     CUDA_GRAPH_DUMMY_REQUEST_ID
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
     use_cpp_mamba_cache_manager
+from tensorrt_llm._utils import use_pinned_memory
 
 
 @triton.jit
@@ -195,7 +196,7 @@ class Mamba2Metadata:
 
         self.state_indices_cpu = torch.zeros(max_batch_size,
                                              dtype=torch.int32,
-                                             pin_memory=True)
+                                             pin_memory=use_pinned_memory())
         self.state_indices = torch.zeros(max_batch_size,
                                          dtype=torch.int32,
                                          device="cuda")

--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -7,7 +7,7 @@ import torch
 
 from tensorrt_llm.llmapi.llm_args import GuidedDecodingConfig
 
-from ..._utils import nvtx_range
+from ..._utils import nvtx_range, use_pinned_memory
 from ...bindings.executor import GuidedDecodingParams
 from ...bindings.internal.batch_manager import LlmRequestType
 from ...logger import logger
@@ -178,14 +178,14 @@ class GuidedDecoder:
                                    device='cuda')
         self.bitmask_host = torch.empty_like(self.bitmask,
                                              device='cpu',
-                                             pin_memory=True)
+                                             pin_memory=use_pinned_memory())
         self.token_mask = torch.empty(self.max_num_sequences *
                                       (self.max_num_draft_tokens + 1),
                                       dtype=self.token_mask_dtype,
                                       device='cuda')
         self.token_mask_host = torch.empty_like(self.token_mask,
                                                 device='cpu',
-                                                pin_memory=True)
+                                                pin_memory=use_pinned_memory())
 
         # The number of tokens accepted by the grammar matcher in a build step.
         self.num_advanced_tokens: List[int] = [0] * self.max_num_sequences
@@ -457,10 +457,10 @@ class CapturableGuidedDecoder(GuidedDecoder):
         self.new_tokens = torch.empty(self.max_num_draft_tokens + 1,
                                       self.max_num_sequences,
                                       dtype=torch.int32,
-                                      pin_memory=True)
+                                      pin_memory=use_pinned_memory())
         self.num_accepted_tokens = torch.empty(self.max_num_sequences,
                                                dtype=torch.int32,
-                                               pin_memory=True)
+                                               pin_memory=use_pinned_memory())
 
         # torch.compile kernels are called with GIL being held;
         # this could cause deadlock with CUDA callback to Python code.

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -6,6 +6,7 @@ import torch
 
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.shared_tensor import SharedTensorContainer
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.bindings import executor as tllm_executor
 from tensorrt_llm.executor.result import TokenLogprobs
 from tensorrt_llm.sampling_params import LogprobMode
@@ -85,7 +86,7 @@ class LogitsStorage:
                 (self.seq_length, self.beam_width, self.vocab_size),
                 dtype=logits.dtype,
                 device='cpu',
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
                 requires_grad=False)
 
     def _init_chunked_storage(self, logits: torch.Tensor):
@@ -96,7 +97,7 @@ class LogitsStorage:
             (self.seq_length, self.beam_width, self.vocab_size),
             dtype=logits.dtype,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
             requires_grad=False)
 
     def append(self, logits: torch.Tensor):

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -28,7 +28,7 @@ from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
     BaseResourceManager, CacheTypeCpp, DataType, KVCacheManager, get_pp_layers)
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
-from tensorrt_llm._utils import torch_dtype_to_binding
+from tensorrt_llm._utils import torch_dtype_to_binding, use_pinned_memory
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
@@ -337,7 +337,7 @@ class PythonMambaCacheManager(BaseResourceManager):
         self.state_indices[:len(self.state_indices_list)].copy_(
             torch.tensor(self.state_indices_list,
                          dtype=torch.int32,
-                         pin_memory=True),
+                         pin_memory=use_pinned_memory()),
             non_blocking=True)
 
     # When there exists padded requests, the state indices should not be repeated.
@@ -354,7 +354,7 @@ class PythonMambaCacheManager(BaseResourceManager):
                                padding_size] = torch.tensor(
                                    self.mamba_cache_free_blocks[:padding_size],
                                    dtype=self.state_indices.dtype,
-                                   pin_memory=True).to(
+                                   pin_memory=use_pinned_memory()).to(
                                        self.state_indices.device,
                                        non_blocking=True)
         # But just finished requests won't free their used resources immediately
@@ -368,7 +368,7 @@ class PythonMambaCacheManager(BaseResourceManager):
                                padding_size] = torch.tensor(
                                    free_indices[:padding_size],
                                    dtype=self.state_indices.dtype,
-                                   pin_memory=True).to(
+                                   pin_memory=use_pinned_memory()).to(
                                        self.state_indices.device,
                                        non_blocking=True)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -15,7 +15,8 @@ import torch._dynamo.config
 
 import tensorrt_llm.bindings.internal.userbuffers as ub
 from tensorrt_llm._utils import (is_trace_enabled, nvtx_range, release_gc,
-                                 torch_dtype_to_str, trace_func)
+                                 torch_dtype_to_str, trace_func,
+                                 use_pinned_memory)
 from tensorrt_llm.bindings.internal.runtime import TaskLayerModuleConfig
 from tensorrt_llm.inputs.multimodal import (MultimodalParams,
                                             MultimodalRuntimeData)
@@ -1894,15 +1895,15 @@ class PyTorchModelEngine(ModelEngine):
         prompt_lengths = torch.empty(num_extend_requests,
                                      dtype=torch.int,
                                      device='cpu',
-                                     pin_memory=True)
+                                     pin_memory=use_pinned_memory())
         num_cached_tokens_per_seq = torch.empty(num_extend_requests,
                                                 dtype=torch.int,
                                                 device='cpu',
-                                                pin_memory=True)
+                                                pin_memory=use_pinned_memory())
         previous_batch_indices = torch.empty(num_extend_requests,
                                              dtype=torch.int,
                                              device='cpu',
-                                             pin_memory=True)
+                                             pin_memory=use_pinned_memory())
 
         request_accepted_path = {}
         num_extend_dummy_requests = 0
@@ -2154,7 +2155,7 @@ class PyTorchModelEngine(ModelEngine):
                 # TODO: Visit later to decide the appropriate position of sending multimodal data & selectively sending multimodal data
                 multimodal_params.to_device("multimodal_data",
                                             "cuda",
-                                            pin_memory=True,
+                                            pin_memory=use_pinned_memory(),
                                             target_keywords=getattr(
                                                 self.model,
                                                 "multimodal_data_device_paths",
@@ -2453,7 +2454,7 @@ class PyTorchModelEngine(ModelEngine):
                             multimodal_params.to_device(
                                 "multimodal_data",
                                 "cuda",
-                                pin_memory=True,
+                                pin_memory=use_pinned_memory(),
                                 target_keywords=[
                                     "mrope_config.mrope_position_deltas"
                                 ])
@@ -2470,7 +2471,7 @@ class PyTorchModelEngine(ModelEngine):
         def previous_seq_slots_device():
             previous_batch_indices_host = torch.tensor(previous_batch_indices,
                                                        dtype=torch.int,
-                                                       pin_memory=True)
+                                                       pin_memory=use_pinned_memory())
             previous_slots = self.previous_batch_indices_cuda[:
                                                               previous_batch_len]
             previous_slots.copy_(previous_batch_indices_host, non_blocking=True)
@@ -2486,7 +2487,7 @@ class PyTorchModelEngine(ModelEngine):
         if num_tokens > 0:
             input_ids = torch.tensor(input_ids,
                                      dtype=torch.int,
-                                     pin_memory=True)
+                                     pin_memory=use_pinned_memory())
             self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
 
             # Update input_ids_cuda with new tokens from new_tensors_device (draft model only)
@@ -2500,13 +2501,13 @@ class PyTorchModelEngine(ModelEngine):
                         for _, last_token_idx, _ in context_input_ids_positions
                     ],
                                                          dtype=torch.long,
-                                                         pin_memory=True)
+                                                         pin_memory=use_pinned_memory())
                     ctx_seq_slots_cpu = torch.tensor([
                         seq_slot
                         for _, _, seq_slot in context_input_ids_positions
                     ],
                                                      dtype=torch.long,
-                                                     pin_memory=True)
+                                                     pin_memory=use_pinned_memory())
                     # Copy to pre-allocated GPU buffers
                     self.draft_ctx_token_indices_cuda[:num_ctx_positions].copy_(
                         ctx_token_indices_cpu, non_blocking=True)
@@ -2539,10 +2540,10 @@ class PyTorchModelEngine(ModelEngine):
                     total_tokens = len(all_indices)
                     idx_tensor_cpu = torch.tensor(all_indices,
                                                   dtype=torch.long,
-                                                  pin_memory=True)
+                                                  pin_memory=use_pinned_memory())
                     seq_slots_tensor_cpu = torch.tensor(all_seq_slots,
                                                         dtype=torch.long,
-                                                        pin_memory=True)
+                                                        pin_memory=use_pinned_memory())
 
                     # Copy to pre-allocated GPU buffers
                     self.draft_first_draft_indices_cuda[:total_tokens].copy_(
@@ -2564,13 +2565,13 @@ class PyTorchModelEngine(ModelEngine):
         if num_draft_tokens > 0:
             draft_tokens = torch.tensor(draft_tokens,
                                         dtype=torch.int,
-                                        pin_memory=True)
+                                        pin_memory=use_pinned_memory())
             self.draft_tokens_cuda[:len(draft_tokens)].copy_(draft_tokens,
                                                              non_blocking=True)
         if self.is_spec_decode and len(num_accepted_draft_tokens) > 0:
             num_accepted_draft_tokens = torch.tensor(num_accepted_draft_tokens,
                                                      dtype=torch.int,
-                                                     pin_memory=True)
+                                                     pin_memory=use_pinned_memory())
             self.num_accepted_draft_tokens_cuda[:len(
                 num_accepted_draft_tokens)].copy_(num_accepted_draft_tokens,
                                                   non_blocking=True)
@@ -2581,11 +2582,11 @@ class PyTorchModelEngine(ModelEngine):
                 num_first_draft = len(first_draft_seq_slots)
                 first_draft_seq_slots_cpu = torch.tensor(first_draft_seq_slots,
                                                          dtype=torch.int,
-                                                         pin_memory=True)
+                                                         pin_memory=use_pinned_memory())
                 first_draft_indices_cpu = torch.tensor(
                     first_draft_request_indices,
                     dtype=torch.int,
-                    pin_memory=True)
+                    pin_memory=use_pinned_memory())
 
                 # Copy to pre-allocated GPU buffers
                 self.draft_seq_slots_buffer_cuda[:num_first_draft].copy_(
@@ -2627,7 +2628,7 @@ class PyTorchModelEngine(ModelEngine):
                 kv_len_offsets_device = new_tokens_lens_device - self.runtime_draft_len - 1
                 previous_pos_indices_host = torch.tensor(previous_pos_indices,
                                                          dtype=torch.int,
-                                                         pin_memory=True)
+                                                         pin_memory=use_pinned_memory())
                 self.previous_pos_indices_cuda[0:previous_batch_tokens].copy_(
                     previous_pos_indices_host, non_blocking=True)
 
@@ -2686,7 +2687,7 @@ class PyTorchModelEngine(ModelEngine):
             # `_create_dummy_context_requests` from `kv_cache_creater` makes an exception that I can not add multimodal_data to the dummy_request
             # so that we only replace position_ids with mrope_position_ids when it is not a dummy request and for models who is using mrope.
             mrope_position_ids = torch.cat(mrope_position_ids, dim=-1)
-            if mrope_position_ids.device.type == "cpu":
+            if mrope_position_ids.device.type == "cpu" and use_pinned_memory():
                 mrope_position_ids = mrope_position_ids.pin_memory()
             self.mrope_position_ids_cuda[:, :, :total_num_tokens].copy_(
                 mrope_position_ids[:, :, :total_num_tokens], non_blocking=True)
@@ -2695,7 +2696,7 @@ class PyTorchModelEngine(ModelEngine):
         else:
             position_ids = torch.tensor(position_ids,
                                         dtype=torch.int,
-                                        pin_memory=True)
+                                        pin_memory=use_pinned_memory())
             self.position_ids_cuda[:total_num_tokens].copy_(position_ids,
                                                             non_blocking=True)
             final_position_ids = self.position_ids_cuda[:
@@ -2704,7 +2705,7 @@ class PyTorchModelEngine(ModelEngine):
 
         if self.enable_spec_decode:
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
-                gather_ids, dtype=torch.int, pin_memory=True),
+                gather_ids, dtype=torch.int, pin_memory=use_pinned_memory()),
                                                          non_blocking=True)
 
             # Update gather_ids for first_draft_requests on GPU (draft model only)
@@ -2713,11 +2714,11 @@ class PyTorchModelEngine(ModelEngine):
                 num_first_draft = len(first_draft_seq_slots)
                 first_draft_seq_slots_cpu = torch.tensor(first_draft_seq_slots,
                                                          dtype=torch.int,
-                                                         pin_memory=True)
+                                                         pin_memory=use_pinned_memory())
                 first_draft_indices_cpu = torch.tensor(
                     first_draft_request_indices,
                     dtype=torch.int,
-                    pin_memory=True)
+                    pin_memory=use_pinned_memory())
 
                 # Copy to pre-allocated GPU buffers
                 self.draft_seq_slots_buffer_cuda[:num_first_draft].copy_(
@@ -2747,7 +2748,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
 
         num_generation_requests = len(gen_request_seq_slots)
@@ -2760,7 +2761,7 @@ class PyTorchModelEngine(ModelEngine):
                 # Convert to GPU tensor to avoid implicit sync
                 gen_request_seq_slots_tensor = torch.tensor(
                     gen_request_seq_slots, dtype=torch.long,
-                    pin_memory=True).to(device='cuda', non_blocking=True)
+                    pin_memory=use_pinned_memory()).to(device='cuda', non_blocking=True)
                 self.cache_indirection_attention[:num_generation_requests].copy_(
                     cache_indirection_buffer[gen_request_seq_slots_tensor])
             if cache_indirection_buffer is not None or is_cuda_graph_during_warmup:
@@ -2869,9 +2870,15 @@ class PyTorchModelEngine(ModelEngine):
         if mm_token_indices is not None:
             mask = torch.ones(total_num_tokens, dtype=torch.bool)
             mask[mm_token_indices] = False
-            inputs['mm_token_indices'] = mm_token_indices.pin_memory().to(
+            mm_idx = mm_token_indices
+            if use_pinned_memory():
+                mm_idx = mm_idx.pin_memory()
+            inputs['mm_token_indices'] = mm_idx.to(
                 "cuda", non_blocking=True)
-            inputs['text_token_indices'] = torch.where(mask)[0].pin_memory().to(
+            text_idx = torch.where(mask)[0]
+            if use_pinned_memory():
+                text_idx = text_idx.pin_memory()
+            inputs['text_token_indices'] = text_idx.to(
                 "cuda", non_blocking=True)
 
         num_generation_tokens = len(generation_requests) + len(
@@ -2929,7 +2936,7 @@ class PyTorchModelEngine(ModelEngine):
                     multimodal_data=request.py_multimodal_data, )
                 multimodal_params.to_device("multimodal_data",
                                             "cuda",
-                                            pin_memory=True)
+                                            pin_memory=use_pinned_memory())
                 multimodal_params_list.append(multimodal_params)
 
             request.py_batch_idx = request.py_seq_slot
@@ -2937,17 +2944,17 @@ class PyTorchModelEngine(ModelEngine):
         num_tokens = len(input_ids)
         assert num_tokens <= self.max_num_tokens, (
             "num_tokens should be less than or equal to max_num_tokens")
-        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=True)
+        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=use_pinned_memory())
         self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
 
         position_ids = torch.tensor(position_ids,
                                     dtype=torch.int,
-                                    pin_memory=True)
+                                    pin_memory=use_pinned_memory())
         self.position_ids_cuda[:num_tokens].copy_(position_ids,
                                                   non_blocking=True)
         if self.enable_spec_decode:
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
-                gather_ids, dtype=torch.int, pin_memory=True),
+                gather_ids, dtype=torch.int, pin_memory=use_pinned_memory()),
                                                          non_blocking=True)
 
         if not attn_metadata.is_cuda_graph:
@@ -2960,7 +2967,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
 
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
@@ -3220,12 +3227,12 @@ class PyTorchModelEngine(ModelEngine):
         num_tokens = len(input_ids)
         assert num_tokens <= self.max_num_tokens, (
             "num_tokens should be less than or equal to max_num_tokens")
-        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=True)
+        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=use_pinned_memory())
         self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
 
         position_ids = torch.tensor(position_ids,
                                     dtype=torch.int,
-                                    pin_memory=True)
+                                    pin_memory=use_pinned_memory())
         self.position_ids_cuda[:num_tokens].copy_(position_ids,
                                                   non_blocking=True)
 
@@ -3239,7 +3246,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
 
         attn_metadata.request_ids = request_ids

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -613,6 +613,7 @@ class PyExecutor:
             # Start the sampler's async worker, if it is enabled
             if (isinstance(self.sampler, AsyncWorkerMixin)
                     and self.sampler.async_worker_enabled()):
+                logger.info(f"Starting the async worker for sampler D2H copies")
                 self.sampler.async_worker_start()
 
     def _set_global_steady_clock_offset(self):

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -15,7 +15,7 @@ import tensorrt_llm.bindings
 from tensorrt_llm._torch.distributed.communicator import Distributed, ReduceOp
 from tensorrt_llm._utils import (TensorWrapper, convert_to_torch_tensor,
                                  get_size_in_bytes, mpi_comm, mpi_disabled,
-                                 torch_comm)
+                                 torch_comm, use_pinned_memory)
 from tensorrt_llm.bindings.internal.batch_manager.kv_cache_manager_v2_utils import (
     IndexMapper, copy_batch_block_offsets_to_device)
 from tensorrt_llm.bindings.internal.runtime import TaskLayerModuleConfig
@@ -480,7 +480,7 @@ class KVCacheManager(BaseResourceManager):
                                                        2,
                                                        self.max_blocks_per_seq,
                                                        dtype=torch.int32,
-                                                       pin_memory=True,
+                                                       pin_memory=use_pinned_memory(),
                                                        device='cpu')
 
     def shutdown(self):
@@ -1709,7 +1709,7 @@ class KVCacheManagerV2(BaseResourceManager):
         ] for pool_id in range(self.num_pools)],
                                                    dtype=torch.int64,
                                                    device="cpu",
-                                                   pin_memory=True)
+                                                   pin_memory=use_pinned_memory())
 
         if kv_cache_config.dtype == "nvfp4":
             self.kv_cache_pool_pointers = torch.stack([
@@ -1757,7 +1757,7 @@ class KVCacheManagerV2(BaseResourceManager):
         self.kv_cache_pool_mapping = torch.tensor(kv_cache_pool_mapping_list,
                                                   dtype=torch.int32,
                                                   device="cpu",
-                                                  pin_memory=True)
+                                                  pin_memory=use_pinned_memory())
 
         # Pad max_blocks_per_seq to next multiple of 4 for copy_block_offsets kernel
         self.max_blocks_per_seq = (max_seq_len + tokens_per_block -
@@ -1807,7 +1807,7 @@ class KVCacheManagerV2(BaseResourceManager):
             2,  # key and value
             self.max_blocks_per_seq,
             dtype=torch.int32,
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
             device='cpu')
 
     @property

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -26,6 +26,7 @@ from typing import Generic, Literal, Optional, Type, TypeAlias, TypeVar, cast
 
 import torch
 
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.bindings.executor import FinishReason
 from tensorrt_llm.sampling_params import SamplingParams
 
@@ -439,7 +440,7 @@ def get_rejected_indices(
     # NB: torch.arange is needed to enable "advanced indexing",
     #   cf. https://numpy.org/devdocs/user/basics.indexing.html#integer-array-indexing
     token_idx = torch.arange(num_draft_tokens, dtype=torch.int32, device=generator.device)
-    draft_tokens_cuda = torch.tensor(draft_tokens, dtype=torch.int32, pin_memory=True).to(
+    draft_tokens_cuda = torch.tensor(draft_tokens, dtype=torch.int32, pin_memory=use_pinned_memory()).to(
         device=generator.device, non_blocking=True
     )
     p = draft_probs[token_idx, draft_tokens_cuda]

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py
@@ -30,6 +30,7 @@ if sys.version_info[:2] >= (3, 12):
 else:
     from typing_extensions import override
 
+from ..._utils import use_pinned_memory
 from ..flashinfer_utils import get_env_enable_pdl
 from .sampling_utils import (
     GREEDY,
@@ -91,7 +92,7 @@ class _StrategyImpls:
 
         @staticmethod
         def _make_tensor(data: list, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
-            return torch.tensor(data, dtype=dtype, pin_memory=True).to(
+            return torch.tensor(data, dtype=dtype, pin_memory=use_pinned_memory()).to(
                 device=device, non_blocking=True
             )
 

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set
 import torch
 from torch import nn
 
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
@@ -235,9 +236,9 @@ class Eagle3SpecMetadata(SpecMetadata):
             self.eagle3_resource_manager.seq_lens[slot_id] = seq_len
         # Prepare hidden states gather ids
         self.hidden_states_read_indices_host = torch.tensor(
-            hidden_states_read_indices, dtype=torch.long, pin_memory=True)
+            hidden_states_read_indices, dtype=torch.long, pin_memory=use_pinned_memory())
         self.hidden_states_write_indices_host = torch.tensor(
-            hidden_states_write_indices, dtype=torch.long, pin_memory=True)
+            hidden_states_write_indices, dtype=torch.long, pin_memory=use_pinned_memory())
         self.is_first_draft = is_first_draft and self.is_draft_model
         if self.is_draft_model:
             self.eagle3_resource_manager.is_first_draft = False
@@ -330,7 +331,7 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
         batch_indices = torch.arange(num_seqs,
                                      dtype=torch.int,
                                      device='cpu',
-                                     pin_memory=True)
+                                     pin_memory=use_pinned_memory())
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices,
                                                  non_blocking=True)
         self.num_tokens -= (self.num_generations) * self.max_draft_len

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from tensorrt_llm.logger import logger
 
-from ..._utils import get_sm_version
+from ..._utils import get_sm_version, use_pinned_memory
 from ..attention_backend.trtllm import (AttentionBackend, TrtllmAttention,
                                         TrtllmAttentionMetadata)
 from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE
@@ -366,15 +366,15 @@ class SpecMetadata:
                 device='cuda')
 
         self.temperatures[:len(temperatures)].copy_(torch.tensor(
-            temperatures, dtype=torch.float32, pin_memory=True),
+            temperatures, dtype=torch.float32, pin_memory=use_pinned_memory()),
                                                     non_blocking=True)
         self.top_ks[:len(top_ks)].copy_(torch.tensor(top_ks,
                                                      dtype=torch.int32,
-                                                     pin_memory=True),
+                                                     pin_memory=use_pinned_memory()),
                                         non_blocking=True)
         self.top_ps[:len(top_ps)].copy_(torch.tensor(top_ps,
                                                      dtype=torch.float32,
-                                                     pin_memory=True),
+                                                     pin_memory=use_pinned_memory()),
                                         non_blocking=True)
 
 

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import torch
 
-from tensorrt_llm._utils import nvtx_range
+from tensorrt_llm._utils import nvtx_range, use_pinned_memory
 from tensorrt_llm.logger import logger
 
 from ..attention_backend.trtllm import TrtllmAttention
@@ -597,11 +597,11 @@ class ModelDrafter(Drafter):
         # Create index tensors
         draft_indices_tensor = torch.tensor(draft_indices,
                                             dtype=torch.long,
-                                            pin_memory=True).to(
+                                            pin_memory=use_pinned_memory()).to(
                                                 device, non_blocking=True)
         target_indices_tensor = torch.tensor(target_indices,
                                              dtype=torch.long,
-                                             pin_memory=True).to(
+                                             pin_memory=use_pinned_memory()).to(
                                                  device, non_blocking=True)
 
         # Pre-slice draft tensors: [draft_length, batch_size]

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
     MambaHybridCacheManager
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
@@ -171,7 +172,7 @@ class MTPSpecMetadata(SpecMetadata):
         batch_indices = torch.arange(num_seqs,
                                      dtype=torch.int,
                                      device='cpu',
-                                     pin_memory=True)
+                                     pin_memory=use_pinned_memory())
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices,
                                                  non_blocking=True)
         # MTP vanilla worker uses total max_draft_len input tokens in generation phase,
@@ -201,17 +202,17 @@ class MTPSpecMetadata(SpecMetadata):
                         mtp_past_tokens_pool[slot_id].data_ptr())
                 mtp_hidden_states_ptrs = torch.tensor(mtp_hidden_states_ptrs,
                                                       dtype=torch.int64,
-                                                      pin_memory=True)
+                                                      pin_memory=use_pinned_memory())
                 mtp_past_tokens_ptrs = torch.tensor(mtp_past_tokens_ptrs,
                                                     dtype=torch.int64,
-                                                    pin_memory=True)
+                                                    pin_memory=use_pinned_memory())
                 self.mtp_hidden_states_ptrs[:num_seqs].copy_(
                     mtp_hidden_states_ptrs, non_blocking=True)
                 self.mtp_past_tokens_ptrs[:num_seqs].copy_(mtp_past_tokens_ptrs,
                                                            non_blocking=True)
             mtp_slot_ids = torch.tensor(mtp_slot_ids,
                                         dtype=torch.int,
-                                        pin_memory=True)
+                                        pin_memory=use_pinned_memory())
             self.slot_ids[:num_seqs].copy_(mtp_slot_ids, non_blocking=True)
 
 

--- a/tensorrt_llm/_torch/speculative/spec_tree_manager.py
+++ b/tensorrt_llm/_torch/speculative/spec_tree_manager.py
@@ -3,6 +3,8 @@ from typing import List
 
 import torch
 
+from tensorrt_llm._utils import use_pinned_memory
+
 
 class SpecTreeManager:
     use_dynamic_tree: bool  # Whether using dynamic tree
@@ -87,7 +89,7 @@ class SpecTreeManager:
              self.max_draft_len + 1),
             dtype=torch.int32,
             device='cpu',
-            pin_memory=True,
+            pin_memory=use_pinned_memory(),
         ) * -1
 
         self.spec_dec_mask_matrix = torch.eye(
@@ -122,7 +124,7 @@ class SpecTreeManager:
             torch.ones(self.dynamic_tree_max_topK,
                        dtype=torch.int32,
                        device='cpu',
-                       pin_memory=True) * self.dynamic_tree_max_topK
+                       pin_memory=use_pinned_memory()) * self.dynamic_tree_max_topK
         ]
 
     # For the static tree
@@ -171,7 +173,7 @@ class SpecTreeManager:
                 torch.tensor(tmp_top_k_list,
                              dtype=torch.int32,
                              device='cpu',
-                             pin_memory=True))
+                             pin_memory=use_pinned_memory()))
 
         # 6) Compute the spec decoding according to the eagle_paths for the target model
         for i, path in enumerate(self.eagle_paths[0]):

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -1302,6 +1302,14 @@ def confidential_compute_enabled() -> bool:
     return cc_enabled
 
 
+@lru_cache(maxsize=None)
+def use_pinned_memory() -> bool:
+    """Return False when confidential compute is enabled to avoid DMA
+    contention between pinned-memory H2D copies and the sampler's async
+    D2H copies that share the CC bounce-buffer path."""
+    return not confidential_compute_enabled()
+
+
 P = ParamSpec("P")
 
 

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -10,6 +10,7 @@ from blake3 import blake3
 from torchvision.transforms import ToPILImage
 
 import tensorrt_llm
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.logger import logger
 
 # Default hasher
@@ -381,7 +382,8 @@ class MultimodalParams:
 
                 pin_memory = kwargs.get('pin_memory', False)
                 try:
-                    if pin_memory and input_data.device.type == 'cpu':
+                    if pin_memory and use_pinned_memory(
+                    ) and input_data.device.type == 'cpu':
                         return input_data.pin_memory().to(device,
                                                           non_blocking=True)
                     else:

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -22,7 +22,7 @@ from typing import Dict, List, Optional, Union
 import torch
 
 from .. import profiler
-from .._utils import mpi_broadcast
+from .._utils import mpi_broadcast, use_pinned_memory
 from ..bindings import DataType, GptJsonConfig, ModelConfig, WorldConfig
 from ..bindings import executor as trtllm
 from ..bindings.executor import (DecodingMode, ExternalDraftTokensConfig,
@@ -855,7 +855,9 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 # 1. Both memory copy stream and kernel execution stream must be non-default streams
                 # 2. For host<->device transfers (H2D/D2H), host memory MUST be page-locked (pinned)
                 prompt_table_data = self._prepare_embedding_table(
-                    prompt_table).pin_memory()
+                    prompt_table)
+                if use_pinned_memory():
+                    prompt_table_data = prompt_table_data.pin_memory()
             else:
                 prompt_table_data = self._prepare_embedding_table(
                     prompt_table).cuda()

--- a/tensorrt_llm/tools/layer_wise_benchmarks/calibrator.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/calibrator.py
@@ -8,6 +8,7 @@ from typing import Optional
 import nvtx
 import torch
 
+from tensorrt_llm._utils import use_pinned_memory
 from tensorrt_llm.logger import logger
 
 
@@ -487,7 +488,7 @@ class Calibrator:
                 self.MAX_SLOTS_BUFFER_SIZE,
                 dtype=torch.int32,
                 device="cpu",
-                pin_memory=True,
+                pin_memory=use_pinned_memory(),
             )
             self._collected_records = []
 


### PR DESCRIPTION
… fix issues in confidential_compute_enabled()

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
