### PR TITLE
[None][chore] TAVA architecture diagram updates for visual gen flow and auto deploy flow

### DIFF
--- a/.github/tava_architecture_diagram.md
+++ b/.github/tava_architecture_diagram.md
@@ -49,6 +49,32 @@ graph TB
         CustomOps --> CUDAKernel
     end
 
+    subgraph "AutoDeploy_Flow"
+        ADExecutor[ADExecutor]
+        ADEngine[ADEngine]
+        GraphTransforms[Graph Transforms]
+        TorchExport[torch.export]
+        LLMAPI --> ADExecutor
+        ADExecutor --> ADEngine
+        ADEngine --> GraphTransforms
+        GraphTransforms --> TorchExport
+    end
+
+    subgraph "Visual_Gen_Flow"
+        VisualGenAPI[VisualGen API]
+        DiffusionClient[DiffusionRemoteClient]
+        DiffusionExecutor[DiffusionExecutor]
+        PipelineLoader[PipelineLoader]
+        DiffusionPipeline[BasePipeline WAN]
+        MediaOutput[MediaOutput]
+        LLMAPI --> VisualGenAPI
+        VisualGenAPI --> DiffusionClient
+        DiffusionClient --> DiffusionExecutor
+        DiffusionExecutor --> PipelineLoader
+        PipelineLoader --> DiffusionPipeline
+        DiffusionPipeline --> MediaOutput
+    end
+
     subgraph "Shared_Component"
         Shared_Decoder[Decoder]
         Shared_Scheduler[Scheduler]
@@ -57,7 +83,8 @@ graph TB
         KVCache[KV Cache Manager]
         PyScheduler --> |Nanobind|Shared_Scheduler
         PyDecoder --> |Nanobind|Shared_Decoder
-        Executor --> Shared_Decoder
+        ADExecutor --> Shared_Scheduler
+        ADExecutor --> Shared_Decoder
         Shared_Decoder --> Sampling
         Executor --> Shared_Scheduler[Scheduler]
         Shared_Scheduler --> |In-flight Batching| BatchManager
@@ -68,12 +95,16 @@ graph TB
         Tokens[Generated Tokens]
         Stats[Performance Stats]
         Metrics[Accuracy Metrics]
+        GenImages[Generated Images]
+        GenVideos[Generated Videos]
     end
 
-    %% PyTorch_Flow ~~~ TensorRT_Flow 
+    PyTorch_Flow ~~~ TensorRT_Flow
 
     TensorRT_Flow --> Output_Results
     PyTorch_Flow --> Output_Results
+    AutoDeploy_Flow --> Output_Results
+    Visual_Gen_Flow --> Output_Results
 
     %% Force Output_Results to be between PyTorch_flow and TensorRT_flow
     PyTorch_Flow ~~~ Output_Results
@@ -85,7 +116,7 @@ graph TB
     %% CLI tools format
     classDef cli fill:#f9f,stroke:#333,stroke-width:2px;
     class CLI cli;
-    
+
     %% TRT flow format
     classDef trt fill:#bbf,stroke:#333,stroke-width:2px;
     class trtllmExecutor,TRTGraph,Plugins,Engine,Executor,cudaKernel trt;
@@ -94,15 +125,23 @@ graph TB
     classDef pytorch fill:#8bf,stroke:#333,stroke-width:2px;
     class PyExecutor,PyEngine,CustomOps,PyTorchOps,KernelLibs,PyScheduler,PyDecoder,CUDAKernel pytorch;
 
+    %% AutoDeploy flow format
+    classDef autodeploy fill:#9f8,stroke:#333,stroke-width:2px;
+    class ADExecutor,ADEngine,GraphTransforms,TorchExport autodeploy;
+
+    %% Visual Gen flow format
+    classDef visualgen fill:#d9c,stroke:#333,stroke-width:2px;
+    class VisualGenAPI,DiffusionClient,DiffusionExecutor,PipelineLoader,DiffusionPipeline,MediaOutput visualgen;
+
     %% Shared Componnet format
     classDef component fill:#fc8,stroke:#333,stroke-width:2px;
     class Shared_Decoder,Sampling,Shared_Scheduler,BatchManager,KVCache component;
-    
+
     %% APIs format
     classDef api fill:#bfb,stroke:#333,stroke-width:2px;
     class PythonAPI,CppAPI,LLMAPI api;
 
     %% Results format
     classDef result fill:#fbb,stroke:#333,stroke-width:2px;
-    class Tokens,Stats,Metrics result;
+    class Tokens,Stats,Metrics,GenImages,GenVideos result;
 ```


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
New diagram
<img width="2065" height="1304" alt="mermaid-diagram-2026-02-14-135537" src="https://github.com/user-attachments/assets/d99f2d99-7908-476e-8aea-ce58e2ff2610" />

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
