### PR TITLE
[#11398][feat] AutoDeploy: flashinfer rope for GLM4.7-Flash

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/flashinfer_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/flashinfer_rope.py
@@ -51,26 +51,35 @@ def apply_rope_with_input_pos_flashinfer(
     """
     q_shape = q.shape
     k_shape = k.shape
+    head_dim = cos_sin_cache.shape[-1]
 
     position_ids = position_ids.view(-1).to(device=q.device, dtype=torch.int32)
+    num_nnz = position_ids.shape[0]
 
-    # Flatten batch and seq dims only (contiguous), keep (num_heads, head_dim) as-is.
-    # This avoids forcing .contiguous() on non-contiguous split_with_sizes outputs.
-    q_3d = q.flatten(0, -3)  # [B, S, H, D] -> [nnz, H, D]
-    k_3d = k.flatten(0, -3)
-
-    q_rope = torch.empty_like(q_3d)
-    k_rope = torch.empty_like(k_3d)
-
-    flashinfer.rope._apply_rope_pos_ids_cos_sin_cache(
-        q=q_3d,
-        k=k_3d,
-        q_rope=q_rope,
-        k_rope=k_rope,
-        cos_sin_cache=cos_sin_cache,
-        pos_ids=position_ids,
-        interleave=(not is_neox),
-    )
+    if q.is_contiguous() and k.is_contiguous():
+        # Standard path: flatten to 2D and use the public FlashInfer API.
+        q_flat = q.view(num_nnz, -1)
+        k_flat = k.view(num_nnz, -1)
+        q_rope, k_rope = flashinfer.rope.apply_rope_with_cos_sin_cache(
+            position_ids, q_flat, k_flat, head_dim, cos_sin_cache, is_neox=is_neox
+        )
+    else:
+        # Strided path (e.g. MLA split_with_sizes outputs where the head dim
+        # is non-contiguous): flatten batch+seq dims only, keep (H, D) as-is
+        # so we never need to materialise a contiguous copy.
+        q_3d = q.flatten(0, -3)  # [B, S, H, D] -> [nnz, H, D]
+        k_3d = k.flatten(0, -3)
+        q_rope = torch.empty_like(q_3d)
+        k_rope = torch.empty_like(k_3d)
+        flashinfer.rope._apply_rope_pos_ids_cos_sin_cache(
+            q=q_3d,
+            k=k_3d,
+            q_rope=q_rope,
+            k_rope=k_rope,
+            cos_sin_cache=cos_sin_cache,
+            pos_ids=position_ids,
+            interleave=(not is_neox),
+        )
 
     return q_rope.view(q_shape), k_rope.view(k_shape)
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/mla_rope_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/mla_rope_utils.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Shared MLA RoPE utilities for auto_deploy custom models.
+
+Contains helper functions for RoPE weight de-interleaving,
+used by DeepSeek V3 and GLM4 MoE Lite model implementations.
+"""
+
+from typing import Dict
+
+import torch
+
+
+def _rope_deinterleave_load_hook(
+    state_dict: Dict[str, torch.Tensor],
+    prefix: str,
+    *args,
+    qk_rope_head_dim: int,
+    qk_nope_head_dim: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    num_layers: int,
+):
+    """Pre-load hook that permutes RoPE weight columns from interleaved to non-interleaved.
+
+    For q_b_proj: output shape is [num_heads * (qk_nope_head_dim + qk_rope_head_dim), q_lora_rank]
+      -> permute the last qk_rope_head_dim columns within each head's block
+
+    For kv_a_proj_with_mqa: output shape is [kv_lora_rank + qk_rope_head_dim, hidden_size]
+      -> permute the last qk_rope_head_dim rows (the k_pe portion)
+    """
+    d = qk_rope_head_dim
+    perm = torch.cat([torch.arange(0, d, 2), torch.arange(1, d, 2)])
+    qk_head_dim = qk_nope_head_dim + d
+
+    for layer_idx in range(num_layers):
+        layer_prefix = f"{prefix}model.layers.{layer_idx}.self_attn."
+
+        # --- q_b_proj.weight ---
+        q_key = layer_prefix + "q_b_proj.weight"
+        if q_key in state_dict:
+            w = state_dict[q_key]
+            w = w.view(num_heads, qk_head_dim, -1)
+            w_nope = w[:, :qk_nope_head_dim, :]
+            w_rope = w[:, qk_nope_head_dim:, :]
+            w_rope = w_rope[:, perm, :]
+            w = torch.cat([w_nope, w_rope], dim=1)
+            state_dict[q_key] = w.view(-1, w.shape[-1])
+
+        # --- kv_a_proj_with_mqa.weight ---
+        kv_key = layer_prefix + "kv_a_proj_with_mqa.weight"
+        if kv_key in state_dict:
+            w = state_dict[kv_key]
+            w_kv = w[:kv_lora_rank, :]
+            w_pe = w[kv_lora_rank:, :]
+            w_pe = w_pe[perm, :]
+            state_dict[kv_key] = torch.cat([w_kv, w_pe], dim=0)
+
+        # --- kv_a_proj_with_mqa.bias (if present) ---
+        kv_bias_key = layer_prefix + "kv_a_proj_with_mqa.bias"
+        if kv_bias_key in state_dict:
+            b = state_dict[kv_bias_key]
+            b_kv = b[:kv_lora_rank]
+            b_pe = b[kv_lora_rank:]
+            b_pe = b_pe[perm]
+            state_dict[kv_bias_key] = torch.cat([b_kv, b_pe])

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek.py
@@ -28,9 +28,7 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
-    _rope_deinterleave_load_hook,
-)
+from tensorrt_llm._torch.auto_deploy.models.custom import mla_rope_utils
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -621,7 +619,7 @@ class DeepSeekV3ForCausalLM(DeepSeekV3PreTrainedModel, GenerationMixin):
         # so the forward can use torch_rope_with_explicit_cos_sin (→ flashinfer_rope).
         self._register_load_state_dict_pre_hook(
             partial(
-                _rope_deinterleave_load_hook,
+                mla_rope_utils._rope_deinterleave_load_hook,
                 qk_rope_head_dim=config.qk_rope_head_dim,
                 qk_nope_head_dim=config.qk_nope_head_dim,
                 num_heads=config.num_attention_heads,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek.py
@@ -30,7 +30,6 @@ from transformers.utils import ModelOutput
 
 from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
     _rope_deinterleave_load_hook,
-    build_cos_sin_caches,
 )
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
@@ -53,8 +52,10 @@ class DeepSeekV3RMSNorm(nn.Module):
 class DeepSeekV3RotaryEmbedding(nn.Module):
     """Rotary Position Embedding for DeepSeekV3.
 
-    Simplified version that precomputes and caches cos/sin values.
-    Returns full cached values (not sliced by seq_len) to enable export.
+    Stores only inv_freq and computes the full cos/sin table dynamically in
+    forward.  The rope.py optimization pass detects the computation pattern,
+    pre-computes a static fused cos_sin_cache, and replaces the dynamic ops
+    with flashinfer_rope.
     """
 
     def __init__(self, dim: int, max_position_embeddings: int = 2048, base: float = 10000.0):
@@ -62,35 +63,25 @@ class DeepSeekV3RotaryEmbedding(nn.Module):
         self.dim = dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base
+        self._rope_scale = 1.0
 
         inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float() / self.dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-        # Build cos/sin cache
-        self._set_cos_sin_cache(max_position_embeddings)
-
-    def _set_cos_sin_cache(self, seq_len: int):
-        self.max_seq_len_cached = seq_len
-        t = torch.arange(seq_len, dtype=self.inv_freq.dtype)
-        freqs = torch.outer(t, self.inv_freq)  # [max_seq_len, D/2]
-
-        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(freqs)
-
-        # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
-        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
-        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
+        self.max_seq_len_cached = max_position_embeddings
 
     def forward(
         self, x: torch.Tensor, seq_len: Optional[int] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        # Return full cached cos/sin (not sliced) for export compatibility,
-        # plus pre-fused cache for FlashInfer RoPE optimization
-        return (
-            self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
-            self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
-            self._ad_rope_cos_sin_cache,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Compute full [max_seq_len, D] cos/sin table dynamically from inv_freq.
+        # The optimization pass will detect this and replace with a static cache.
+        t = torch.arange(
+            self.max_seq_len_cached, device=self.inv_freq.device, dtype=self.inv_freq.dtype
         )
+        freqs = torch.outer(t, self.inv_freq)  # [max_seq_len, D/2]
+        emb = torch.cat([freqs, freqs], dim=-1)  # [max_seq_len, D]
+        cos = emb.cos() * self._rope_scale
+        sin = emb.sin() * self._rope_scale
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
 class DeepSeekV3YarnRotaryEmbedding(DeepSeekV3RotaryEmbedding):
@@ -115,11 +106,12 @@ class DeepSeekV3YarnRotaryEmbedding(DeepSeekV3RotaryEmbedding):
         self.mscale = mscale
         self.mscale_all_dim = mscale_all_dim
         super().__init__(dim, max_position_embeddings, base)
+        # Override inv_freq with YaRN-modified version and set mscale
+        self._setup_buffers()
 
-    def _set_cos_sin_cache(self, seq_len: int):
-        self.max_seq_len_cached = seq_len
+    def _compute_yarn_inv_freq(self) -> torch.Tensor:
+        """Compute YaRN-modified inv_freq with frequency interpolation."""
         dim = self.dim
-
         freq_extra = 1.0 / (self.base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
         freq_inter = 1.0 / (
             self.scaling_factor * self.base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
@@ -133,23 +125,17 @@ class DeepSeekV3YarnRotaryEmbedding(DeepSeekV3RotaryEmbedding):
             self.original_max_position_embeddings,
         )
         inv_freq_mask = 1.0 - self._yarn_linear_ramp_mask(low, high, dim // 2)
-        inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
+        return freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
+
+    def _setup_buffers(self):
+        """Override inv_freq with YaRN-modified version and set scale."""
+        inv_freq = self._compute_yarn_inv_freq()
         self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-        t = torch.arange(seq_len, dtype=torch.float32)
-        freqs = torch.outer(t, inv_freq)
-
-        _mscale = float(
+        self.max_seq_len_cached = self.max_position_embeddings
+        self._rope_scale = float(
             self._yarn_get_mscale(self.scaling_factor, self.mscale)
             / self._yarn_get_mscale(self.scaling_factor, self.mscale_all_dim)
         )
-
-        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(freqs, scale=_mscale)
-
-        # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
-        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
-        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
 
     @staticmethod
     def _yarn_find_correction_dim(
@@ -444,8 +430,8 @@ class DeepSeekV3Attention(nn.Module):
 
         kv_seq_len = q_len
 
-        # Get cos/sin for RoPE (third element is pre-fused cache, unused here)
-        cos, sin, _ = self.rotary_emb(hidden_states, seq_len=kv_seq_len)
+        # Get cos/sin for RoPE
+        cos, sin = self.rotary_emb(hidden_states, seq_len=kv_seq_len)
         cos = cos[position_ids]  # [B, S, head_dim]
         sin = sin[position_ids]  # [B, S, head_dim]
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
@@ -30,9 +30,7 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
-    _rope_deinterleave_load_hook,
-)
+from tensorrt_llm._torch.auto_deploy.models.custom import mla_rope_utils
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -798,7 +796,7 @@ class Glm4MoeLiteForCausalLM(Glm4MoeLitePreTrainedModel, GenerationMixin):
         # so the forward can use torch_rope_with_explicit_cos_sin (→ flashinfer_rope).
         self._register_load_state_dict_pre_hook(
             partial(
-                _rope_deinterleave_load_hook,
+                mla_rope_utils._rope_deinterleave_load_hook,
                 qk_rope_head_dim=config.qk_rope_head_dim,
                 qk_nope_head_dim=config.qk_nope_head_dim,
                 num_heads=config.num_attention_heads,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
@@ -32,7 +32,6 @@ from transformers.utils import ModelOutput
 
 from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
     _rope_deinterleave_load_hook,
-    build_cos_sin_caches,
 )
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
@@ -166,10 +165,10 @@ class Glm4MoeLiteRMSNorm(nn.Module):
 class Glm4MoeLiteRotaryEmbedding(nn.Module):
     """Rotary Position Embedding for GLM4 MoE Lite.
 
-    Simplified version that precomputes and caches cos/sin values.
-    Returns full cached values (not sliced by seq_len) to enable export.
-
-    Uses _ad_ prefix for buffer names to work with AutoDeploy's lift_to_meta.
+    Stores only inv_freq and computes the full cos/sin table dynamically in
+    forward.  The rope.py optimization pass detects the computation pattern,
+    pre-computes a static fused cos_sin_cache, and replaces the dynamic ops
+    with flashinfer_rope.
     """
 
     def __init__(
@@ -183,38 +182,25 @@ class Glm4MoeLiteRotaryEmbedding(nn.Module):
         self.dim = dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base
-        self.attention_scaling = attention_scaling
+        self._rope_scale = attention_scaling
 
         inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float() / self.dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-        # Build cos/sin cache with AD-specific naming
-        self._set_cos_sin_cache(max_position_embeddings)
-
-    def _set_cos_sin_cache(self, seq_len: int):
-        self.max_seq_len_cached = seq_len
-        t = torch.arange(seq_len, dtype=self.inv_freq.dtype)
-        freqs = torch.outer(t, self.inv_freq)  # [max_seq_len, D/2]
-
-        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(
-            freqs, scale=self.attention_scaling
-        )
-
-        # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
-        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
-        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
+        self.max_seq_len_cached = max_position_embeddings
 
     def forward(
         self, x: torch.Tensor, seq_len: Optional[int] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        # Return full cached cos/sin (not sliced) for export compatibility,
-        # plus pre-fused cache for FlashInfer RoPE optimization
-        return (
-            self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
-            self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
-            self._ad_rope_cos_sin_cache,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Compute full [max_seq_len, D] cos/sin table dynamically from inv_freq.
+        # The optimization pass will detect this and replace with a static cache.
+        t = torch.arange(
+            self.max_seq_len_cached, device=self.inv_freq.device, dtype=self.inv_freq.dtype
         )
+        freqs = torch.outer(t, self.inv_freq)  # [max_seq_len, D/2]
+        emb = torch.cat([freqs, freqs], dim=-1)  # [max_seq_len, D]
+        cos = emb.cos() * self._rope_scale
+        sin = emb.sin() * self._rope_scale
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
 class Glm4MoeLiteYarnRotaryEmbedding(Glm4MoeLiteRotaryEmbedding):
@@ -240,11 +226,12 @@ class Glm4MoeLiteYarnRotaryEmbedding(Glm4MoeLiteRotaryEmbedding):
         self.mscale = mscale
         self.mscale_all_dim = mscale_all_dim
         super().__init__(dim, max_position_embeddings, base, attention_scaling)
+        # Override inv_freq with YaRN-modified version and set mscale
+        self._setup_buffers()
 
-    def _set_cos_sin_cache(self, seq_len: int):
-        self.max_seq_len_cached = seq_len
+    def _compute_yarn_inv_freq(self) -> torch.Tensor:
+        """Compute YaRN-modified inv_freq with frequency interpolation."""
         dim = self.dim
-
         freq_extra = 1.0 / (self.base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
         freq_inter = 1.0 / (
             self.scaling_factor * self.base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
@@ -258,23 +245,17 @@ class Glm4MoeLiteYarnRotaryEmbedding(Glm4MoeLiteRotaryEmbedding):
             self.original_max_position_embeddings,
         )
         inv_freq_mask = 1.0 - self._yarn_linear_ramp_mask(low, high, dim // 2)
-        inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
+        return freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
+
+    def _setup_buffers(self):
+        """Override inv_freq with YaRN-modified version and set scale."""
+        inv_freq = self._compute_yarn_inv_freq()
         self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-        t = torch.arange(seq_len, dtype=torch.float32)
-        freqs = torch.outer(t, inv_freq)
-
-        _mscale = float(
+        self.max_seq_len_cached = self.max_position_embeddings
+        self._rope_scale = float(
             self._yarn_get_mscale(self.scaling_factor, self.mscale)
             / self._yarn_get_mscale(self.scaling_factor, self.mscale_all_dim)
         )
-
-        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(freqs, scale=_mscale)
-
-        # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
-        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
-        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
 
     @staticmethod
     def _yarn_find_correction_dim(

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_glm4_moe_lite.py
@@ -18,6 +18,7 @@ The GLM4 MoE Lite model uses Multi-head Latent Attention (MLA), similar to DeepS
 
 import math
 from dataclasses import dataclass
+from functools import partial
 from typing import Optional, Tuple
 
 import torch
@@ -29,6 +30,10 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
+from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
+    _rope_deinterleave_load_hook,
+    build_cos_sin_caches,
+)
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -189,19 +194,26 @@ class Glm4MoeLiteRotaryEmbedding(nn.Module):
     def _set_cos_sin_cache(self, seq_len: int):
         self.max_seq_len_cached = seq_len
         t = torch.arange(seq_len, dtype=self.inv_freq.dtype)
-        freqs = torch.outer(t, self.inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1)
+        freqs = torch.outer(t, self.inv_freq)  # [max_seq_len, D/2]
+
+        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(
+            freqs, scale=self.attention_scaling
+        )
+
         # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        self.register_buffer("_ad_cos_cached", emb.cos() * self.attention_scaling, persistent=False)
-        self.register_buffer("_ad_sin_cached", emb.sin() * self.attention_scaling, persistent=False)
+        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
+        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
+        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
 
     def forward(
         self, x: torch.Tensor, seq_len: Optional[int] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Return full cached cos/sin (not sliced) for export compatibility
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Return full cached cos/sin (not sliced) for export compatibility,
+        # plus pre-fused cache for FlashInfer RoPE optimization
         return (
             self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
             self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_rope_cos_sin_cache,
         )
 
 
@@ -257,11 +269,12 @@ class Glm4MoeLiteYarnRotaryEmbedding(Glm4MoeLiteRotaryEmbedding):
             / self._yarn_get_mscale(self.scaling_factor, self.mscale_all_dim)
         )
 
-        emb = torch.cat((freqs, freqs), dim=-1)
+        cos_full, sin_full, cos_sin_cache = build_cos_sin_caches(freqs, scale=_mscale)
+
         # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
-        # Note: attention_scaling is already incorporated in _mscale for YaRN
-        self.register_buffer("_ad_cos_cached", (emb.cos() * _mscale), persistent=False)
-        self.register_buffer("_ad_sin_cached", (emb.sin() * _mscale), persistent=False)
+        self.register_buffer("_ad_cos_cached", cos_full, persistent=False)
+        self.register_buffer("_ad_sin_cached", sin_full, persistent=False)
+        self.register_buffer("_ad_rope_cos_sin_cache", cos_sin_cache, persistent=False)
 
     @staticmethod
     def _yarn_find_correction_dim(
@@ -545,12 +558,13 @@ class Glm4MoeLiteAttention(nn.Module):
         k_pe = k_pe.view(bsz, q_len, 1, self.qk_rope_head_dim)
 
         # Get cos/sin from position_embeddings (full cached from shared rotary embedding)
-        cos, sin = position_embeddings  # Full table: [max_seq_len, head_dim]
+        cos = position_embeddings[0]  # Full table: [max_seq_len, head_dim]
+        sin = position_embeddings[1]  # Full table: [max_seq_len, head_dim]
         cos = cos[position_ids]  # [B, S, head_dim]
         sin = sin[position_ids]  # [B, S, head_dim]
 
-        # Apply RoPE using custom op
-        q_pe_rotated, kpe = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
+        # Apply RoPE using custom op (weights pre-permuted to NeoX format at load time)
+        q_pe_rotated, kpe = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
             q_pe,
             k_pe,
             cos,
@@ -788,6 +802,19 @@ class Glm4MoeLiteForCausalLM(Glm4MoeLitePreTrainedModel, GenerationMixin):
         self.model = Glm4MoeLiteModel(config)
         self.vocab_size = config.vocab_size
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Pre-permute RoPE weight rows from interleaved to NeoX format at load time
+        # so the forward can use torch_rope_with_explicit_cos_sin (→ flashinfer_rope).
+        self._register_load_state_dict_pre_hook(
+            partial(
+                _rope_deinterleave_load_hook,
+                qk_rope_head_dim=config.qk_rope_head_dim,
+                qk_nope_head_dim=config.qk_nope_head_dim,
+                num_heads=config.num_attention_heads,
+                kv_lora_rank=config.kv_lora_rank,
+                num_layers=config.num_hidden_layers,
+            )
+        )
 
         self.post_init()
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pytest
 import torch
 from _graph_test_helpers import run_test_transformed_gm
@@ -9,6 +11,9 @@ from _model_test_utils import (
 from torch.export import Dim
 
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.mla_rope_utils import (
+    _rope_deinterleave_load_hook,
+)
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_output_tuple, is_op
 
@@ -258,6 +263,7 @@ def test_rope_variants(
         gm_transformed.to("cuda")
 
         def checker(gm):
+            matched = False
             for n in gm.graph.nodes:
                 if is_op(
                     n,
@@ -456,6 +462,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
         gm_transformed.to("cuda")
 
         def checker(gm):
+            matched = False
             for n in gm.graph.nodes:
                 if is_op(n, torch.ops.auto_deploy.torch_rope_with_qk_interleaving):
                     q_arg, k_arg, *rest = n.args
@@ -551,3 +558,252 @@ def test_optimize_interleaved_rope(num_heads, num_kv_heads):
         None,  # check_num_matches
         False,  # skip_output_assert
     )
+
+
+class DSExplicitRotaryEmbedding(torch.nn.Module):
+    """Rotary embedding that stores cos/sin as buffers (full tables).
+
+    When indexed with position_ids in the model forward, this creates the
+    ``aten.index.Tensor(table, [position_ids])`` graph pattern that triggers
+    the full-table optimization path in ``optimize_rope``.
+    """
+
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device).float() / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        t = torch.arange(max_position_embeddings, device=device, dtype=inv_freq.dtype)
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos(), persistent=False)
+        self.register_buffer("sin_cached", emb.sin(), persistent=False)
+
+    def forward(self, x, seq_len=None):
+        return self.cos_cached, self.sin_cached
+
+
+class MLASelfAttn(torch.nn.Module):
+    """Simplified MLA self-attention for testing interleaved weights + RoPE.
+
+    Mirrors the GLM4/DeepSeek MLA attention:
+    - q_b_proj output is split into nope + rope parts via torch.split
+    - kv_a_proj_with_mqa output is split into compressed_kv + k_pe
+    - torch.split produces non-contiguous q_pe/k_pe (strided tensors)
+    - RoPE is applied on the rope parts only
+
+    rope_mode:
+    - "explicit": uses torch_rope_with_explicit_cos_sin (NeoX layout)
+    - "triton": uses torch_rope_with_qk_interleaving (interleaved layout)
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        q_lora_rank,
+        rope_mode="explicit",
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.kv_lora_rank = kv_lora_rank
+        self.rope_mode = rope_mode
+
+        self.q_a_proj = torch.nn.Linear(hidden_size, q_lora_rank, bias=False)
+        self.q_b_proj = torch.nn.Linear(q_lora_rank, num_heads * self.qk_head_dim, bias=False)
+        self.kv_a_proj_with_mqa = torch.nn.Linear(
+            hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False
+        )
+
+    def forward(self, x, cos, sin):
+        b, s, _ = x.shape
+        q = self.q_b_proj(self.q_a_proj(x))
+        q = q.view(b, s, self.num_heads, self.qk_head_dim)
+        # split produces non-contiguous q_pe (strided tensor)
+        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = torch.split(kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        k_pe = k_pe.view(b, s, 1, self.qk_rope_head_dim)
+
+        if self.rope_mode == "explicit":
+            q_pe_rot, k_pe_rot = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
+                q_pe,
+                k_pe,
+                cos,
+                sin,
+                2,
+            )
+        else:  # triton
+            q_pe_rot, k_pe_rot = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
+                q_pe,
+                k_pe,
+                cos,
+                sin,
+                2,
+            )
+
+        q_out = torch.cat([q_nope, q_pe_rot], dim=-1).reshape(b, s, -1)
+        k_out = k_pe_rot.reshape(b, s, -1)
+        return torch.cat([q_out, k_out, compressed_kv], dim=-1)
+
+
+class DSMLAModelWithExplicitCosSinRopE(torch.nn.Module):
+    """MLA-style model with RoPE on split (non-contiguous) tensors.
+
+    End-to-end test model mirroring the DeepSeek/GLM4 MLA pipeline:
+    - model.layers[0].self_attn.{q_b_proj, kv_a_proj_with_mqa}: MLA weight layout
+    - torch.split creates non-contiguous q_pe/k_pe (tests flashinfer strided path)
+    - cos/sin table indexing with position_ids (tests full-table optimization)
+
+    rope_mode:
+    - "explicit": NeoX layout, optimized to flashinfer_rope. Needs de-interleave
+      load hook when loading interleaved checkpoints.
+    - "triton": interleaved layout, optimized to triton_rope. No load hook needed.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        max_seq,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        q_lora_rank,
+        rope_mode="explicit",
+    ):
+        super().__init__()
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.kv_lora_rank = kv_lora_rank
+        self.num_heads = num_heads
+        self.rope_mode = rope_mode
+        self.model = torch.nn.Module()
+        layer = torch.nn.Module()
+        layer.self_attn = MLASelfAttn(
+            hidden_size,
+            num_heads,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            kv_lora_rank,
+            q_lora_rank,
+            rope_mode=rope_mode,
+        )
+        self.model.layers = torch.nn.ModuleList([layer])
+        self.rotary = DSExplicitRotaryEmbedding(
+            qk_rope_head_dim, max_seq, base=10000, device="cuda"
+        )
+
+    def forward(self, x):
+        b, s, _ = x.shape
+        cos_table, sin_table = self.rotary(x)
+        pos_ids = torch.arange(s, device=x.device).unsqueeze(0).expand(b, s)
+        cos = cos_table[pos_ids]
+        sin = sin_table[pos_ids]
+        return self.model.layers[0].self_attn(x, cos, sin)
+
+    def get_dynamic_shapes(self):
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
+
+
+@pytest.mark.parametrize(
+    "num_heads",
+    [4, 8],
+)
+@torch.inference_mode()
+def test_optimize_mla_rope(num_heads):
+    """Test both explicit and triton RoPE paths on the MLA pipeline.
+
+    Creates a triton model (interleaved weights, no load hook) and an explicit
+    model (de-interleaved weights via load hook). After optimize_rope:
+    - explicit path should use flashinfer_rope
+    - triton path should use triton_rope_on_interleaved_qk_inputs
+    - both paths should produce the same output
+    """
+    hidden_size = 256
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64  # must be multiple of 64 for flashinfer
+    kv_lora_rank = 64
+    q_lora_rank = 128
+    batch, seq, max_seq = 4, 12, 16
+    model_args = (
+        hidden_size,
+        max_seq,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        q_lora_rank,
+    )
+
+    x = torch.randn(batch, seq, hidden_size, device="cuda", dtype=torch.float16)
+
+    # --- Triton path: interleaved weights, no load hook ---
+    model_triton = DSMLAModelWithExplicitCosSinRopE(
+        *model_args,
+        rope_mode="triton",
+    ).to("cuda", torch.float16)
+
+    dynamic_shapes = model_triton.get_dynamic_shapes()
+    gm_triton = torch_export_to_gm(
+        model_triton,
+        args=(x,),
+        dynamic_shapes=(dynamic_shapes,),
+        clone=True,
+    )
+    gm_triton_opt = InferenceOptimizer(
+        None,
+        {"optimize_rope": {"stage": "pattern_matcher"}},
+    )(None, gm_triton)
+    gm_triton_opt.to("cuda")
+
+    assert any(
+        is_op(n, torch.ops.auto_deploy.triton_rope_on_interleaved_qk_inputs)
+        for n in gm_triton_opt.graph.nodes
+    ), "Expected triton_rope_on_interleaved_qk_inputs in triton-optimized graph"
+
+    # --- Explicit path: de-interleaved weights via load hook ---
+    model_explicit = DSMLAModelWithExplicitCosSinRopE(
+        *model_args,
+        rope_mode="explicit",
+    ).to("cuda", torch.float16)
+
+    # Load triton model's (interleaved) weights through the de-interleave hook
+    model_explicit._register_load_state_dict_pre_hook(
+        partial(
+            _rope_deinterleave_load_hook,
+            qk_rope_head_dim=qk_rope_head_dim,
+            qk_nope_head_dim=qk_nope_head_dim,
+            num_heads=num_heads,
+            kv_lora_rank=kv_lora_rank,
+            num_layers=1,
+        )
+    )
+    model_explicit.load_state_dict(model_triton.state_dict())
+
+    gm_explicit = torch_export_to_gm(
+        model_explicit,
+        args=(x,),
+        dynamic_shapes=(dynamic_shapes,),
+        clone=True,
+    )
+    gm_explicit_opt = InferenceOptimizer(
+        None,
+        {"optimize_rope": {"stage": "pattern_matcher"}},
+    )(None, gm_explicit)
+    gm_explicit_opt.to("cuda")
+
+    assert any(
+        is_op(n, torch.ops.auto_deploy.flashinfer_rope) for n in gm_explicit_opt.graph.nodes
+    ), "Expected flashinfer_rope in explicit-optimized graph"
+
+    # --- Compare outputs: both paths should produce the same result ---
+    y_triton = model_triton(x)
+    y_explicit = model_explicit(x)
+    torch.testing.assert_close(y_triton, y_explicit, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced rotary position embedding computation with improved caching strategies and dynamic table optimization.
  * Optimized tensor memory layout handling for better performance across different input formats.

* **Bug Fixes**
  * Improved compatibility with non-contiguous tensor layouts in position embedding operations.
  * Fixed position ID dtype consistency across different model architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
GLM4 MoE Lite and DeepSeek-V3 use Multi-head Latent Attention (MLA) which applies RoPE to a subset of Q/K dimensions. The model weights produce Q/K in interleaved format ([q0_r, q0_i, q1_r, q1_i, ...]), so the model currently
uses torch_rope_with_qk_interleaving which de-interleaves and rotates in one op. 

Though flashinfer_rope presents good performance, it could not be used for this RoPE op because of the interleaved inputs. 

In this PR, a trick was applied for q/k weights order so that the projection results are de-interleaved. As  a result, flashinfer rope kernel can be used for GLM4 MoE Lite and DeepSeek-V3 too. 

See issue https://github.com/NVIDIA/TensorRT-LLM/issues/11398 for the detailed benchmark. 

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
