### PR TITLE
[None][feat] Visual Gen: add cuda graphs; torch compile; nvtx; warmup

### DIFF
--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -126,6 +126,41 @@ def parse_args():
         help="Ulysses (sequence) parallel size within each CFG group.",
     )
 
+    # torch compile
+    parser.add_argument(
+        "--disable_torch_compile", action="store_true", help="Disable TorchCompile acceleration"
+    )
+    parser.add_argument(
+        "--torch_compile_models",
+        type=str,
+        nargs="+",
+        default=["transformer"],
+        help="Torch compile models",
+    )
+    parser.add_argument(
+        "--torch_compile_mode",
+        type=str,
+        default="default",
+        help="Torch compile mode",
+        choices=["default", "max-autotune", "reduce-overhead"],
+    )
+    parser.add_argument(
+        "--enable_fullgraph", action="store_true", help="Enable fullgraph for TorchCompile"
+    )
+
+    # Warmup
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=1,
+        help="Warmup steps. Useful for performance benchmarking.",
+    )
+
+    # Layerwise nvtx marker
+    parser.add_argument(
+        "--enable_layerwise_nvtx_marker", action="store_true", help="Enable layerwise nvtx marker"
+    )
+
     return parser.parse_args()
 
 
@@ -160,6 +195,15 @@ def main():
         "parallel": {
             "dit_cfg_size": args.cfg_size,
             "dit_ulysses_size": args.ulysses_size,
+        },
+        "pipeline": {
+            "enable_cuda_graph": args.enable_cudagraph,
+            "enable_torch_compile": not args.disable_torch_compile,
+            "torch_compile_models": args.torch_compile_models,
+            "torch_compile_mode": args.torch_compile_mode,
+            "enable_fullgraph": args.enable_fullgraph,
+            "warmup_steps": args.warmup_steps,
+            "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },
     }
 

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -134,7 +134,7 @@ def parse_args():
         "--torch_compile_models",
         type=str,
         nargs="+",
-        default=["transformer"],
+        default=[],  # empty = auto detect transformer components
         help="Torch compile models",
     )
     parser.add_argument(

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -126,6 +126,11 @@ def parse_args():
         help="Ulysses (sequence) parallel size within each CFG group.",
     )
 
+    # Cuda graph
+    parser.add_argument(
+        "--enable_cudagraph", action="store_true", help="Enable CudaGraph acceleration"
+    )
+
     # torch compile
     parser.add_argument(
         "--disable_torch_compile", action="store_true", help="Disable TorchCompile acceleration"

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -139,7 +139,7 @@ def parse_args():
         "--torch_compile_models",
         type=str,
         nargs="+",
-        default=["transformer"],
+        default=[],  # empty = auto detect transformer components
         help="Torch compile models",
     )
     parser.add_argument(

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -126,6 +126,46 @@ def parse_args():
         "2 CFG groups × 2 Ulysses ranks = 4 GPUs total.",
     )
 
+    # Cuda graph
+    parser.add_argument(
+        "--enable_cudagraph", action="store_true", help="Enable CudaGraph acceleration"
+    )
+
+    # torch compile
+    parser.add_argument(
+        "--disable_torch_compile", action="store_true", help="Disable TorchCompile acceleration"
+    )
+    parser.add_argument(
+        "--torch_compile_models",
+        type=str,
+        nargs="+",
+        default=["transformer"],
+        help="Torch compile models",
+    )
+    parser.add_argument(
+        "--torch_compile_mode",
+        type=str,
+        default="default",
+        help="Torch compile mode",
+        choices=["default", "max-autotune", "reduce-overhead"],
+    )
+    parser.add_argument(
+        "--enable_fullgraph", action="store_true", help="Enable fullgraph for TorchCompile"
+    )
+
+    # Warmup
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=1,
+        help="Warmup steps. Useful for performance benchmarking.",
+    )
+
+    # Layerwise nvtx marker
+    parser.add_argument(
+        "--enable_layerwise_nvtx_marker", action="store_true", help="Enable layerwise nvtx marker"
+    )
+
     return parser.parse_args()
 
 
@@ -168,6 +208,15 @@ def main():
         "parallel": {
             "dit_cfg_size": args.cfg_size,
             "dit_ulysses_size": args.ulysses_size,
+        },
+        "pipeline": {
+            "enable_cuda_graph": args.enable_cudagraph,
+            "enable_torch_compile": not args.disable_torch_compile,
+            "torch_compile_models": args.torch_compile_models,
+            "torch_compile_mode": args.torch_compile_mode,
+            "enable_fullgraph": args.enable_fullgraph,
+            "warmup_steps": args.warmup_steps,
+            "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },
     }
 

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -196,7 +196,7 @@ class PipelineConfig(BaseModel):
     """General pipeline configuration."""
 
     enable_torch_compile: bool = True
-    torch_compile_models: List[str] = [PipelineComponent.TRANSFORMER]
+    torch_compile_models: List[str] = []  # empty = auto detect transformer components
     torch_compile_mode: Literal["default", "max-autotune", "reduce-overhead"] = "default"
     enable_fullgraph: bool = False
     fuse_qkv: bool = True

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -196,14 +196,19 @@ class PipelineConfig(BaseModel):
     """General pipeline configuration."""
 
     enable_torch_compile: bool = True
-    torch_compile_models: str = PipelineComponent.TRANSFORMER
-    torch_compile_mode: str = "default"
+    torch_compile_models: List[str] = [PipelineComponent.TRANSFORMER]
+    torch_compile_mode: Literal["default", "max-autotune", "reduce-overhead"] = "default"
+    enable_fullgraph: bool = False
     fuse_qkv: bool = True
+    enable_cuda_graph: bool = False
+    enable_layerwise_nvtx_marker: bool = False
 
     # Offloading Config
     enable_offloading: bool = False
     offload_device: Literal["cpu", "cuda"] = "cpu"
     offload_param_pin_memory: bool = True
+
+    warmup_steps: int = 1  # Number of denoising steps to run during warmup (0 to disable)
 
 
 # =============================================================================

--- a/tensorrt_llm/_torch/visual_gen/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/visual_gen/cuda_graph_runner.py
@@ -1,0 +1,151 @@
+import functools
+import gc
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Tuple, TypeAlias
+
+import torch
+
+from tensorrt_llm.logger import logger
+
+from ..utils import make_weak_ref
+
+KeyType: TypeAlias = Tuple[Tuple[int, ...] | Tuple[str, Tuple[int, ...]], ...]
+
+
+@dataclass
+class CUDAGraphRunnerConfig:
+    """Configuration for the CUDAGraphRunner."""
+
+    use_cuda_graph: bool
+    """
+    Master switch. Same three-path semantics as the LLM runner:
+
+    1. False  → runner is dormant, maybe_get_cuda_graph always returns None
+    2. True, ineligible → fallback to eager (e.g., first call with new shapes)
+    3. True, eligible   → capture (if new) or replay
+    """
+    cuda_graph_mem_pool: Any = None
+
+
+class CUDAGraphRunner:
+    """
+    Manages CUDA graph lifecycle for visual generation.
+
+    Mirrors the LLM CUDAGraphRunner API:
+      get_graph_key → maybe_get_cuda_graph → needs_capture → capture / replay
+
+    Key differences from the LLM runner:
+    - Keys are derived from tensor shapes (automatic), not batch metadata
+    - Static buffers are per-key (allocated at capture time), not shared/pre-allocated
+    - No batch padding, speculative decoding, or cross-rank coordination
+    - Outputs returned via make_weak_ref (zero-copy, same as LLM runner)
+    """
+
+    WARMUP_STEPS = 2
+
+    def __init__(self, config: CUDAGraphRunnerConfig):
+        self.config = config
+        self.enabled = config.use_cuda_graph
+
+        self.graphs: Dict[KeyType, torch.cuda.CUDAGraph] = {}
+        self.graph_outputs: Dict[KeyType, Any] = {}  # weak refs
+        self.static_inputs: Dict[KeyType, Tuple[List[Any], Dict[str, Any]]] = {}
+        self.memory_pool = config.cuda_graph_mem_pool
+
+    def get_graph_key(self, *args, **kwargs) -> KeyType:
+        input_shapes = tuple(
+            list(tuple(arg.shape) for arg in args if isinstance(arg, torch.Tensor))
+            + list(
+                (k, tuple(kwargs[k].shape))
+                for k in sorted(kwargs.keys())
+                if isinstance(kwargs[k], torch.Tensor)
+            )
+        )
+        return input_shapes
+
+    def capture(
+        self, key: KeyType, fn: Callable, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+    ) -> None:
+        logger.info(f"Capturing graph for shapes: {key}")
+
+        # One time clone of inputs
+        static_args = [arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args]
+        static_kwargs = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()
+        }
+
+        graph = torch.cuda.CUDAGraph()
+        for _ in range(self.WARMUP_STEPS):
+            fn(*static_args, **static_kwargs)
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        with torch.cuda.graph(graph, pool=self.memory_pool):
+            output = fn(*static_args, **static_kwargs)
+
+        self.graphs[key] = graph
+        self.static_inputs[key] = (static_args, static_kwargs)
+        self.graph_outputs[key] = make_weak_ref(output)
+        self.memory_pool = graph.pool()
+
+    def replay(
+        self,
+        key: KeyType,
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+    ) -> Any:
+        static_args, static_kwargs = self.static_inputs[key]
+
+        for i, arg in enumerate(args):
+            if isinstance(arg, torch.Tensor):
+                static_args[i].copy_(arg)
+            else:
+                static_args[i] = arg
+
+        for k, v in kwargs.items():
+            if isinstance(v, torch.Tensor):
+                static_kwargs[k].copy_(v)
+            else:
+                static_kwargs[k] = v
+
+        self.graphs[key].replay()
+        return self.graph_outputs[key]
+
+    def wrap(self, fn):
+        """Wrap a callable with CUDA graph capture/replay.
+
+        Returns a drop-in replacement that:
+        - On first call with new tensor shapes: captures a graph
+        - On subsequent calls with same shapes: replays the graph
+        - Falls back to eager if called with positional args or if disabled
+        """
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            if not self.enabled:
+                return fn(*args, **kwargs)
+
+            key = self.get_graph_key(*args, **kwargs)
+
+            if key not in self.graphs:
+                self.capture(key, fn, args, kwargs)
+                return self.replay(key, args, kwargs)
+            else:
+                return self.replay(key, args, kwargs)
+
+        return wrapper
+
+    def __del__(self):
+        self.clear()
+
+    def clear(self):
+        """Releases all captured graphs and the associated memory pool."""
+        for graph in self.graphs.values():
+            graph.reset()
+        self.graphs.clear()
+        self.graph_outputs.clear()
+        self.static_inputs.clear()
+        del self.memory_pool
+        self.memory_pool = None
+        torch.cuda.empty_cache()

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -80,6 +80,7 @@ class DiffusionExecutor:
         self.device_id = device_id
         self.diffusion_config = diffusion_config
 
+        self.pipeline = None  # initialized in _load_pipeline
         self.requests_ipc = None
         self.rank = dist.get_rank()
         self.response_queue = queue.Queue()
@@ -239,6 +240,8 @@ def run_diffusion_worker(
             diffusion_config=diffusion_config,
         )
         executor.serve_forever()
+        if executor.pipeline is not None:
+            executor.pipeline.cleanup()
         dist.destroy_process_group()
 
     except Exception as e:

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -187,6 +187,16 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
+        if (
+            self.pipeline.common_warmup_shapes
+            and (req.height, req.width, req.num_frames) not in self.pipeline.common_warmup_shapes
+        ):
+            logger.warning(
+                f"Requested shape (height={req.height}, width={req.width}, num_frames={req.num_frames}) "
+                f"was not warmed up. First request with this shape will be slower due to "
+                "torch.compile recompilation or CUDA graph capture."
+                f"Warmed-up shapes: {self.pipeline.common_warmup_shapes}"
+            )
         try:
             output = self.pipeline.infer(req)
             if self.rank == 0:

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -254,6 +254,9 @@ class WanPipeline(BasePipeline):
             "1.3B": (480, 832, 33),
         }
         fallback = (720, 1280, 81)  # TODO: make this better
+        if self.is_wan22:
+            # Double warmup steps to also warmup the 2nd transformer
+            warmup_steps = warmup_steps * 2
 
         checkpoint_path = getattr(self.model_config.pretrained_config, "_name_or_path", "") or ""
         height, width, num_frames = fallback
@@ -275,6 +278,7 @@ class WanPipeline(BasePipeline):
                 num_inference_steps=warmup_steps,
                 guidance_scale=5.0,
                 seed=0,
+                max_sequence_length=512,  # should match DiffusionRequest.max_sequence_length
             )
 
     def infer(self, req):

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -106,6 +106,11 @@ class WanPipeline(BasePipeline):
             return ["transformer", "transformer_2"]
         return ["transformer"]
 
+    @property
+    def common_warmup_shapes(self) -> list:
+        """Return list of common warmup shapes for the pipeline."""
+        return [(480, 832, 33), (480, 832, 81), (720, 1280, 81)]
+
     def _init_transformer(self) -> None:
         logger.info("Creating WAN transformer with quantization support...")
         self.transformer = WanTransformer3DModel(model_config=self.model_config)
@@ -247,13 +252,12 @@ class WanPipeline(BasePipeline):
 
         Runs warmup inference with common shapes for Wan models.
         """
-        common_shapes = [(480, 832, 33), (720, 1280, 81)]
-        
+
         if self.is_wan22:
             # Double warmup steps to also warmup the 2nd transformer
             warmup_steps = warmup_steps * 2
 
-        for height, width, num_frames in common_shapes:
+        for height, width, num_frames in self.common_warmup_shapes:
             logger.info(f"Warmup: Wan {height}x{width}, {num_frames} frames {warmup_steps} steps")
 
             with torch.no_grad():

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -95,6 +95,11 @@ class WanImageToVideoPipeline(BasePipeline):
             return ["transformer", "transformer_2"]
         return ["transformer"]
 
+    @property
+    def common_warmup_shapes(self) -> list:
+        """Return list of common warmup shapes for the pipeline."""
+        return [(480, 832, 33), (480, 832, 81), (720, 1280, 81)]
+
     def _init_transformer(self) -> None:
         logger.info("Creating WAN I2V transformer with quantization support...")
         self.transformer = WanTransformer3DModel(model_config=self.model_config)
@@ -277,12 +282,11 @@ class WanImageToVideoPipeline(BasePipeline):
         Runs warmup inference with common shapes for Wan I2V models.
         Creates a dummy black image for the image conditioning input.
         """
-        common_shapes = [(480, 832, 33), (720, 1280, 81)]
 
         if self.is_wan22:
             warmup_steps = warmup_steps * 2
 
-        for height, width, num_frames in common_shapes:
+        for height, width, num_frames in self.common_warmup_shapes:
             logger.info(
                 f"Warmup: Wan I2V {height}x{width}, {num_frames} frames {warmup_steps} steps"
             )

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -5,9 +5,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
+from .cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig
 from .teacache import TeaCacheBackend
 
 if TYPE_CHECKING:
@@ -34,6 +36,25 @@ class BasePipeline(nn.Module):
 
         # Initialize transformer
         self._init_transformer()
+
+        # CUDA graph runner — wrap transformer.forward
+        # Order matters: TeaCache will wrap on top of it and still call the
+        # graphed transformer.forward if should_compute == True.
+        if self.model_config.pipeline.enable_cuda_graph and self.transformer is not None:
+            if self.model_config.pipeline.enable_torch_compile:
+                logger.warning(
+                    "Cuda graphs with torch compile is not supported yet. "
+                    "Only using torch compile for better performance. "
+                )
+                return
+
+            self.cuda_graph_runner = CUDAGraphRunner(
+                CUDAGraphRunnerConfig(
+                    use_cuda_graph=model_config.pipeline.enable_cuda_graph,
+                )
+            )
+            logger.info("Cuda graph runner enabled, wrapping transformer.forward")
+            self.transformer.forward = self.cuda_graph_runner.wrap(self.transformer.forward)
 
     @property
     def rank(self):
@@ -121,6 +142,97 @@ class BasePipeline(nn.Module):
         logger.info("TeaCache: Initializing...")
         self.cache_backend = TeaCacheBackend(teacache_cfg)
         self.cache_backend.enable(model)
+
+    def torch_compile(self) -> None:
+        """Apply torch.compile to pipeline components based on PipelineConfig.
+
+        For transformer models, compiles each block in the ModuleList individually.
+        This enables future block-wise offloading and keeps compilation efficient
+        (all blocks share the same structure, so compile cost is paid once).
+
+        For non-transformer components, compiles the entire module.
+        """
+        pipeline_config = self.model_config.pipeline
+        compile_mode = pipeline_config.torch_compile_mode
+
+        for name in pipeline_config.torch_compile_models:
+            model = getattr(self, name, None)
+            if model is None:
+                logger.warning(f"torch.compile: component '{name}' not found, skipping")
+                continue
+
+            # For transformer models with ModuleList blocks, compile per-block
+            blocks_attr = self._find_transformer_blocks(model)
+            if blocks_attr:
+                for block_name in blocks_attr:
+                    blocks = getattr(model, block_name)
+                    logger.info(
+                        f"torch.compile: {name}.{block_name} "
+                        f"({len(blocks)} blocks, mode={compile_mode})"
+                    )
+                    compiled_blocks = []
+                    for block in blocks:
+                        # NOTE: dynamic=False is helpful for speed
+                        compiled_blocks.append(
+                            torch.compile(block, mode=compile_mode, dynamic=False)
+                        )
+                    setattr(model, block_name, nn.ModuleList(compiled_blocks))
+            else:
+                logger.info(f"torch.compile: {name} (whole module, mode={compile_mode})")
+                compiled = torch.compile(model, mode=compile_mode, dynamic=False)
+                setattr(self, name, compiled)
+
+    @staticmethod
+    def _find_transformer_blocks(model: nn.Module) -> list:
+        """Find ModuleList children that look like transformer blocks.
+
+        Returns list of attribute names containing nn.ModuleList with >1 elements.
+        """
+        block_names = []
+        for name, child in model.named_children():
+            if isinstance(child, nn.ModuleList) and len(child) > 1:
+                block_names.append(name)
+        return block_names
+
+    def warmup(self) -> None:
+        """Run warmup inference to trigger torch.compile and CUDA initialization.
+
+        Runs a short denoising loop with dummy inputs. This:
+        1. Triggers torch.compile's lazy compilation (first forward trace + codegen)
+        2. Warms up CUDA kernels and allocators
+        3. Populates any lazy caches (e.g., RoPE frequencies)
+
+        Called automatically by PipelineLoader after model loading and torch.compile.
+        """
+        warmup_steps = self.model_config.pipeline.warmup_steps
+        if warmup_steps <= 0:
+            logger.info("Warmup disabled (warmup_steps=0)")
+            return
+
+        logger.info(f"Running warmup ({warmup_steps} steps)...")
+        warmup_start = time.time()
+
+        self._run_warmup(warmup_steps)
+
+        torch.cuda.synchronize()
+        elapsed = time.time() - warmup_start
+        logger.info(f"Warmup completed in {elapsed:.2f}s")
+
+    def _run_warmup(self, warmup_steps: int) -> None:
+        """Execute warmup forward passes. Subclasses should override for model-specific warmup.
+
+        Default implementation runs the transformer forward with dummy tensors matching
+        typical input shapes. Subclasses can override to run the full pipeline with
+        reduced steps for more thorough warmup.
+
+        Args:
+            warmup_steps: Number of denoising steps to run
+        """
+        # Subclasses should override this with model-specific warmup
+        logger.warning(
+            f"{self.__class__.__name__} does not implement _run_warmup(); "
+            "skipping warmup. Override _run_warmup() for model-specific warmup."
+        )
 
     def decode_latents(
         self,
@@ -355,6 +467,7 @@ class BasePipeline(nn.Module):
 
         return noise_pred, extra_noise_preds, t_transformer, t_cfg
 
+    @nvtx_range("_scheduler_step", color="blue")
     def _scheduler_step(
         self,
         latents,
@@ -379,6 +492,7 @@ class BasePipeline(nn.Module):
         t_sched = time.time() - t_start
         return latents, extra_stream_latents, t_sched
 
+    @nvtx_range("denoise_loop", color="blue")
     def denoise(
         self,
         latents: torch.Tensor,
@@ -476,30 +590,31 @@ class BasePipeline(nn.Module):
                     current_guidance_scale = guidance_scale_2
 
             # Denoise
-            if do_cfg_parallel:
-                timestep = t.expand(latents.shape[0])
-                noise_pred, extra_noise_preds, t_trans, t_cfg = self._denoise_step_cfg_parallel(
-                    latents,
-                    extra_stream_latents,
-                    timestep,
-                    cfg_config["local_embeds"],
-                    forward_fn,
-                    current_guidance_scale,
-                    guidance_rescale,
-                    cfg_config["ulysses_size"],
-                    local_extras,
-                )
-            else:
-                noise_pred, extra_noise_preds, t_trans, t_cfg = self._denoise_step_standard(
-                    latents,
-                    extra_stream_latents,
-                    t,
-                    prompt_embeds,
-                    forward_fn,
-                    current_guidance_scale,
-                    guidance_rescale,
-                    local_extras,
-                )
+            with nvtx_range(f"denoise_step {i}"):
+                if do_cfg_parallel:
+                    timestep = t.expand(latents.shape[0])
+                    noise_pred, extra_noise_preds, t_trans, t_cfg = self._denoise_step_cfg_parallel(
+                        latents,
+                        extra_stream_latents,
+                        timestep,
+                        cfg_config["local_embeds"],
+                        forward_fn,
+                        current_guidance_scale,
+                        guidance_rescale,
+                        cfg_config["ulysses_size"],
+                        local_extras,
+                    )
+                else:
+                    noise_pred, extra_noise_preds, t_trans, t_cfg = self._denoise_step_standard(
+                        latents,
+                        extra_stream_latents,
+                        t,
+                        prompt_embeds,
+                        forward_fn,
+                        current_guidance_scale,
+                        guidance_rescale,
+                        local_extras,
+                    )
 
             # Scheduler step for all streams
             latents, extra_stream_latents, t_sched = self._scheduler_step(

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -198,13 +198,13 @@ class BasePipeline(nn.Module):
                         f"({len(blocks)} blocks, mode={compile_mode})"
                     )
                     compiled_blocks = []
+                    # dynamic=None works better with multiple warmup shapes
                     for block in blocks:
-                        # NOTE: dynamic=False is helpful for speed
                         compiled_blocks.append(
                             torch.compile(
                                 block,
                                 mode=compile_mode,
-                                dynamic=False,
+                                dynamic=None,
                                 fullgraph=pipeline_config.enable_fullgraph,
                             )
                         )
@@ -214,7 +214,7 @@ class BasePipeline(nn.Module):
                 compiled = torch.compile(
                     model,
                     mode=compile_mode,
-                    dynamic=False,
+                    dynamic=None,
                     fullgraph=pipeline_config.enable_fullgraph,
                 )
                 setattr(self, name, compiled)

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -207,8 +207,7 @@ class PipelineLoader:
             pipeline.post_load_weights()
 
         if config.pipeline.enable_torch_compile:
-            torch._dynamo.config.capture_scalar_outputs = True
-            torch._dynamo.config.cache_size_limit = 128  # TODO: what's the best way to set this?
+            torch._dynamo.config.cache_size_limit = 128
             pipeline.torch_compile()
         else:
             logger.info("torch.compile disabled by config")

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -177,7 +177,7 @@ class PipelineLoader:
         if pipeline.transformer is None:
             raise ValueError("Pipeline has no transformer component")
 
-        transformer_components = getattr(pipeline, "transformer_components", ["transformer"])
+        transformer_components = pipeline.transformer_components
         logger.info(f"Transformer components: {transformer_components}")
 
         transformer_path = os.path.join(checkpoint_dir, PipelineComponent.TRANSFORMER)
@@ -220,7 +220,9 @@ class PipelineLoader:
 
             marker = LayerwiseNvtxMarker()
             module_prefix = pipeline.__class__.__name__
-            marker.register_hooks(pipeline.transformer, module_prefix)
+            for transformer_component in transformer_components:
+                logger.info(f"Registering layerwise NVTX markers for {transformer_component}")
+                marker.register_hooks(getattr(pipeline, transformer_component), module_prefix)
 
         logger.info(f"Pipeline loaded: {pipeline.__class__.__name__}")
         return pipeline

--- a/tests/unittest/_torch/visual_gen/test_model_loader.py
+++ b/tests/unittest/_torch/visual_gen/test_model_loader.py
@@ -82,6 +82,7 @@ def test_load_wan_pipeline_basic(checkpoint_exists):
     args = DiffusionArgs(
         checkpoint_path=CHECKPOINT_PATH,
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
 
@@ -120,6 +121,7 @@ def test_load_wan_pipeline_with_fp8_dynamic_quant(checkpoint_exists):
         checkpoint_path=CHECKPOINT_PATH,
         quant_config={"quant_algo": "FP8", "dynamic": True},
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
 
@@ -158,6 +160,7 @@ def test_load_wan_pipeline_with_fp8_blockwise(checkpoint_exists):
         checkpoint_path=CHECKPOINT_PATH,
         quant_config={"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True},
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
 
@@ -264,6 +267,7 @@ def test_load_without_quant_config_no_fp8(checkpoint_exists):
     args = DiffusionArgs(
         checkpoint_path=CHECKPOINT_PATH,
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
 
@@ -354,6 +358,7 @@ def test_fp8_vs_bf16_memory_comparison(checkpoint_exists):
     args_bf16 = DiffusionArgs(
         checkpoint_path=CHECKPOINT_PATH,
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -378,6 +383,7 @@ def test_fp8_vs_bf16_memory_comparison(checkpoint_exists):
         checkpoint_path=CHECKPOINT_PATH,
         quant_config={"quant_algo": "FP8", "dynamic": True},
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline_fp8 = PipelineLoader(args_fp8).load()
 
@@ -434,6 +440,7 @@ def test_fp8_vs_bf16_memory_comparison(checkpoint_exists):
         checkpoint_path=CHECKPOINT_PATH,
         quant_config={"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True},
         skip_components=SKIP_HEAVY_COMPONENTS,
+        pipeline={"warmup_steps": 0},
     )
     pipeline_fp8_block = PipelineLoader(args_fp8_block).load()
 

--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -155,6 +155,7 @@ def _run_cfg_worker(rank, world_size, checkpoint_path, inputs_list, return_dict)
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             parallel=ParallelConfig(dit_cfg_size=world_size),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -262,6 +263,7 @@ def _run_all_optimizations_worker(rank, world_size, checkpoint_path, inputs_list
             ),
             attention=AttentionConfig(backend="TRTLLM"),
             parallel=ParallelConfig(dit_cfg_size=world_size),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args_full).load()
         transformer = pipeline.transformer.eval()
@@ -769,6 +771,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -823,6 +826,7 @@ class TestWanPipeline:
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             quant_config={"quant_algo": quant_algo, "dynamic": True},
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -868,6 +872,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -881,6 +886,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             quant_config={"quant_algo": quant_algo, "dynamic": True},
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8 = PipelineLoader(args_fp8).load()
 
@@ -986,6 +992,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -1006,6 +1013,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             quant_config={"quant_algo": "FP8", "dynamic": True},
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8 = PipelineLoader(args_fp8).load()
 
@@ -1056,6 +1064,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
         transformer_bf16 = pipeline_bf16.transformer
@@ -1070,6 +1079,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             quant_config={"quant_algo": quant_algo, "dynamic": True},
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8 = PipelineLoader(args_fp8).load()
         transformer_fp8 = pipeline_fp8.transformer
@@ -1226,6 +1236,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         # Default attention backend is VANILLA
         pipeline_baseline = PipelineLoader(args_baseline).load()
@@ -1240,6 +1251,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         args_vanilla.attention = AttentionConfig(backend="VANILLA")
         pipeline_vanilla = PipelineLoader(args_vanilla).load()
@@ -1353,6 +1365,7 @@ class TestWanPipeline:
             checkpoint_path=CHECKPOINT_PATH,
             device="cuda",
             dtype="bfloat16",
+            pipeline={"warmup_steps": 0},
         )
         args_trtllm.attention = AttentionConfig(backend="TRTLLM")
         pipeline_trtllm = PipelineLoader(args_trtllm).load()
@@ -1464,6 +1477,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -1478,6 +1492,7 @@ class TestWanPipeline:
                 "dynamic": True,
                 "ignore": mixed_ignore_patterns,
             },
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8_mixed = PipelineLoader(args_fp8_mixed).load()
 
@@ -1589,6 +1604,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -1599,6 +1615,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8_static = PipelineLoader(args_fp8_static).load()
 
@@ -1613,6 +1630,7 @@ class TestWanPipeline:
                 "quant_algo": "FP8",
                 "dynamic": True,
             },
+            pipeline={"warmup_steps": 0},
         )
         pipeline_fp8_dynamic = PipelineLoader(args_fp8_dynamic).load()
 
@@ -1797,6 +1815,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_bf16 = PipelineLoader(args_bf16).load()
 
@@ -1807,6 +1826,7 @@ class TestWanPipeline:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_nvfp4_static = PipelineLoader(args_nvfp4_static).load()
 
@@ -2020,6 +2040,7 @@ class TestWanOptimizations(unittest.TestCase):
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline_trtllm = PipelineLoader(args_trtllm).load()
         config = pipeline_trtllm.transformer.model_config.pretrained_config
@@ -2069,6 +2090,7 @@ class TestWanOptimizations(unittest.TestCase):
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline_teacache = PipelineLoader(args_teacache).load()
         transformer_teacache = pipeline_teacache.transformer.eval()
@@ -2211,6 +2233,7 @@ class TestWanParallelism(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             parallel=ParallelConfig(dit_cfg_size=1),  # Standard CFG (no parallel)
+            pipeline={"warmup_steps": 0},
         )
         pipeline_baseline = PipelineLoader(args_baseline).load()
         config = pipeline_baseline.transformer.model_config.pretrained_config
@@ -2405,6 +2428,7 @@ class TestWanCombinedOptimizations(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             parallel=ParallelConfig(dit_cfg_size=1),  # Standard CFG
+            pipeline={"warmup_steps": 0},
         )
         pipeline_baseline = PipelineLoader(args_baseline).load()
         config = pipeline_baseline.transformer.model_config.pretrained_config
@@ -2573,6 +2597,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2621,6 +2646,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2717,6 +2743,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2768,6 +2795,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2809,6 +2837,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2863,6 +2892,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             quant_config={"quant_algo": "FP8", "dynamic": True},
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2915,6 +2945,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_COMPONENTS,
             attention=AttentionConfig(backend="TRTLLM"),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -2988,6 +3019,7 @@ class TestWanTwoStageTransformer(unittest.TestCase):
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -3084,6 +3116,7 @@ class TestWanRobustness(unittest.TestCase):
                 dtype="bfloat16",
                 skip_components=SKIP_COMPONENTS,
                 quant_config={"quant_algo": "INVALID_ALGO"},
+                pipeline={"warmup_steps": 0},
             )
             pipeline = PipelineLoader(args).load()  # noqa: F841
 

--- a/tests/unittest/_torch/visual_gen/test_wan_i2v.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_i2v.py
@@ -108,6 +108,7 @@ def wan21_i2v_pipeline_bf16():
         device="cuda",
         dtype="bfloat16",
         skip_components=SKIP_MINIMAL,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -129,6 +130,7 @@ def wan21_i2v_pipeline_fp8():
         dtype="bfloat16",
         skip_components=SKIP_MINIMAL,
         quant_config={"quant_algo": "FP8", "dynamic": True},
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -150,6 +152,7 @@ def wan21_i2v_pipeline_fp8_blockwise():
         dtype="bfloat16",
         skip_components=SKIP_MINIMAL,
         quant_config={"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True},
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -170,6 +173,7 @@ def wan21_i2v_pipeline_with_image_encoder():
         device="cuda",
         dtype="bfloat16",
         skip_components=SKIP_WITH_IMAGE,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -190,6 +194,7 @@ def wan22_i2v_pipeline_bf16():
         device="cuda",
         dtype="bfloat16",
         skip_components=SKIP_MINIMAL,
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -211,6 +216,7 @@ def wan22_i2v_pipeline_fp8():
         dtype="bfloat16",
         skip_components=SKIP_MINIMAL,
         quant_config={"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True},
+        pipeline={"warmup_steps": 0},
     )
     pipeline = PipelineLoader(args).load()
     yield pipeline
@@ -279,6 +285,7 @@ def _run_cfg_worker_i2v(rank, world_size, checkpoint_path, inputs_list, return_d
             dtype="bfloat16",
             skip_components=SKIP_MINIMAL,
             parallel=ParallelConfig(dit_cfg_size=world_size),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -389,6 +396,7 @@ def _run_all_optimizations_worker_i2v(rank, world_size, checkpoint_path, inputs_
             ),
             attention=AttentionConfig(backend="TRTLLM"),
             parallel=ParallelConfig(dit_cfg_size=world_size),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args_full).load()
         transformer = pipeline.transformer.eval()
@@ -647,6 +655,7 @@ class TestWanI2VIntegration:
             dtype="bfloat16",
             skip_components=SKIP_MINIMAL,
             attention=AttentionConfig(backend=backend),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -703,6 +712,7 @@ class TestWanI2VIntegration:
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -750,6 +760,7 @@ class TestWanI2VIntegration:
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -986,6 +997,7 @@ class TestWanI2VTwoStage:
                 teacache_thresh=0.2,
                 use_ret_steps=True,
             ),
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -1044,6 +1056,7 @@ class TestWanI2VRobustness:
                 dtype="bfloat16",
                 skip_components=SKIP_MINIMAL,
                 quant_config={"quant_algo": "INVALID_ALGO", "dynamic": True},
+                pipeline={"warmup_steps": 0},
             )
             pipeline = PipelineLoader(args).load()
             del pipeline
@@ -1058,6 +1071,7 @@ class TestWanI2VRobustness:
             device="cuda",
             dtype="bfloat16",
             skip_components=SKIP_WITH_IMAGE,
+            pipeline={"warmup_steps": 0},
         )
         pipeline = PipelineLoader(args).load()
 
@@ -1138,6 +1152,7 @@ class TestWanI2VParallelism(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_MINIMAL,
             parallel=ParallelConfig(dit_cfg_size=1),  # Standard CFG (no parallel)
+            pipeline={"warmup_steps": 0},
         )
         pipeline_baseline = PipelineLoader(args_baseline).load()
         config = pipeline_baseline.transformer.model_config.pretrained_config
@@ -1349,6 +1364,7 @@ class TestWanI2VCombinedOptimizations(unittest.TestCase):
             dtype="bfloat16",
             skip_components=SKIP_MINIMAL,
             parallel=ParallelConfig(dit_cfg_size=1),  # Standard CFG
+            pipeline={"warmup_steps": 0},
         )
         pipeline_baseline = PipelineLoader(args_baseline).load()
         config = pipeline_baseline.transformer.model_config.pretrained_config


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TorchCompile support with multiple compilation modes (default, max-autotune, reduce-overhead) and fullgraph option for flexible optimization
  * Introduced CUDA graph optimization to improve inference performance
  * Added configurable warmup steps for model initialization and compilation
  * Integrated layer-wise NVTX markers for detailed performance profiling and analysis
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Performance:

WAN 2.1 w/ torch compile + warmup: 30-90% lower latency
WAN 2.2 w/torch compile + warmup: 15-60% lower latency

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
