### PR TITLE
Draft: DON'T REVIEW: improved perf of host time attention metadata list to tensor handling

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -28,6 +28,7 @@ import math
 from abc import ABC, abstractmethod
 from typing import Dict, List, Literal, Optional, Protocol, Sequence, Set, Tuple, Type, Union
 
+import numpy as np
 import torch
 from torch._ops import OpOverloadPacket
 from torch.fx import Node
@@ -189,17 +190,36 @@ class InputBuffer:
         """
         return self._current_lengths[name]
 
+    # Mapping from torch dtype to numpy dtype for fast list-to-pinned-memory writes
+    _TORCH_TO_NUMPY_DTYPE = {
+        torch.int: np.int32,
+        torch.int32: np.int32,
+        torch.int64: np.int64,
+        torch.long: np.int64,
+        torch.float: np.float32,
+        torch.float32: np.float32,
+        torch.float64: np.float64,
+        torch.double: np.float64,
+        torch.float16: np.float16,
+        torch.bool: np.bool_,
+    }
+
     def store(
         self,
         name: str,
-        data: List[Number],
+        data: "Union[List[Number], torch.Tensor]",
         fill_value: Optional[Number] = None,
     ) -> int:
         """Store data into the host buffer.
 
+        Accepts either a Python list or a torch.Tensor. When a Tensor is provided, it is
+        copied directly into pinned memory (fast path, avoids torch.tensor() from list).
+        When a list is provided, numpy is used to write directly into pinned memory,
+        which is faster than torch.tensor(list) for large lists.
+
         Args:
             name: Name of the tensor to store to.
-            data: List of values to store.
+            data: List of values or a 1-D torch.Tensor to store.
             fill_value: Optional value to fill the entire tensor with before storing.
                        If None, only the provided data is written.
 
@@ -213,12 +233,18 @@ class InputBuffer:
         if fill_value is not None:
             host_view.fill_(fill_value)
 
-        # Convert list to tensor and copy to host buffer
-        length = len(data)
-        assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
-
-        temp_tensor = torch.tensor(data, dtype=dtype)
-        host_view[:length].copy_(temp_tensor)
+        if isinstance(data, torch.Tensor):
+            length = data.numel()
+            assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
+            host_view[:length].copy_(data if data.dtype == dtype else data.to(dtype))
+        else:
+            length = len(data)
+            assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
+            np_dtype = self._TORCH_TO_NUMPY_DTYPE.get(dtype)
+            if np_dtype is not None:
+                host_view[:length].numpy()[:] = np.array(data, dtype=np_dtype)
+            else:
+                host_view[:length].copy_(torch.tensor(data, dtype=dtype))
 
         self._current_lengths[name] = length
         return length
@@ -624,10 +650,22 @@ class SequenceInfo:
         estimated_capacity = estimated_capacity + 1
 
         if estimated_capacity > cache_loc_capacity:
+            # Resize cache_loc (the only truncatable tensor in InputBuffer)
             self._input_buffer.resize("cache_loc", estimated_capacity)
-            # Also resize the args_list to match
-            old_size = len(self._args_list["cache_loc"])
-            self._args_list["cache_loc"].extend([0] * (estimated_capacity - old_size))
+
+            # Also resize any host-side page metadata lists/tensors to match.
+            # These fields may be created lazily by nest_sequences() when cache_loc/pages_per_seq
+            # are provided.
+            for tensor_name in ("cache_loc", "page_seq_indices", "page_in_seq"):
+                current = self._args_list.get(tensor_name)
+                if current is None:
+                    self._args_list[tensor_name] = [0] * estimated_capacity
+                    continue
+                if isinstance(current, list):
+                    old_size = len(current)
+                    current.extend([0] * (estimated_capacity - old_size))
+                else:
+                    self._args_list[tensor_name] = [0] * estimated_capacity
 
     @staticmethod
     def _get_page_assignments(
@@ -766,7 +804,7 @@ class SequenceInfo:
     def _store_arg(
         self,
         name: str,
-        tnsr_like: List[Number],
+        tnsr_like: "Union[List[Number], torch.Tensor]",
         reset_val: Optional[Number] = None,
         force_copy: bool = False,
     ) -> None:
@@ -775,15 +813,23 @@ class SequenceInfo:
         The data is stored in the host-side pinned memory buffer managed by InputBuffer.
         The actual H2D transfer happens in a single batch at the end of nest_sequences().
 
+        Accepts either a Python list or a 1-D torch.Tensor. Tensor inputs use a fast path
+        that avoids the expensive torch.tensor(list) conversion in InputBuffer.store().
+
         Args:
             name: Name of the argument to store.
-            tnsr_like: List of values to store.
+            tnsr_like: List of values or a 1-D torch.Tensor to store.
             reset_val: Value to reset/fill the tensor with before writing data.
             force_copy: Whether to force immediate copy to device (for use outside nest_sequences).
         """
         with nvtx_range(f"ad_store_on_host_seq_info_arg_{name}"):
-            # Always store list object for Python access
-            self._args_list[name] = tnsr_like.copy()
+            # Store for Python access. Tensor data is stored as-is to avoid expensive
+            # .tolist() conversion on the hot path. Properties that need lists (seq_len,
+            # input_pos, cache_loc, pages_per_seq) always receive list inputs.
+            if isinstance(tnsr_like, torch.Tensor):
+                self._args_list[name] = tnsr_like
+            else:
+                self._args_list[name] = tnsr_like.copy()
 
             # Only store to buffer when the argument is active or force_copy is True
             if not (name in self._active_args or f"{name}_host" in self._active_args or force_copy):
@@ -919,6 +965,23 @@ class SequenceInfo:
         if cache_loc is not None and pages_per_seq is not None:
             self._store_arg("cache_loc", cache_loc)
             self._store_arg("pages_per_seq", pages_per_seq)
+
+            # Auto-compute page_seq_indices and page_in_seq from pages_per_seq using
+            # vectorized torch ops. This avoids the slow Python-list-to-tensor conversion
+            # that dominates host time for large page counts (e.g., 50k ISL models).
+            # page_seq_indices[j] = which sequence page j belongs to
+            # page_in_seq[j] = which page within that sequence (0-indexed)
+            pages_per_seq_t = torch.tensor(pages_per_seq, dtype=torch.int)
+            seq_indices = torch.arange(len(pages_per_seq), dtype=torch.int)
+            page_seq_indices_t = torch.repeat_interleave(seq_indices, pages_per_seq_t)
+            cu_pages = torch.zeros(len(pages_per_seq) + 1, dtype=torch.int)
+            cu_pages[1:] = pages_per_seq_t.cumsum(0)
+            total_pages = cu_pages[-1].item()
+            page_in_seq_t = torch.arange(total_pages, dtype=torch.int) - torch.repeat_interleave(
+                cu_pages[:-1], pages_per_seq_t
+            )
+            self._store_arg("page_seq_indices", page_seq_indices_t)
+            self._store_arg("page_in_seq", page_in_seq_t)
 
         # update cumulative number of pages
         if cu_num_pages is None:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -656,16 +656,14 @@ class SequenceInfo:
             # Also resize any host-side page metadata lists/tensors to match.
             # These fields may be created lazily by nest_sequences() when cache_loc/pages_per_seq
             # are provided.
-            for tensor_name in ("cache_loc", "page_seq_indices", "page_in_seq"):
-                current = self._args_list.get(tensor_name)
-                if current is None:
-                    self._args_list[tensor_name] = [0] * estimated_capacity
-                    continue
-                if isinstance(current, list):
-                    old_size = len(current)
-                    current.extend([0] * (estimated_capacity - old_size))
-                else:
-                    self._args_list[tensor_name] = [0] * estimated_capacity
+            old_size = self._args_list.get("cache_loc")
+            if old_size is None:
+                self._args_list["cache_loc"] = [0] * estimated_capacity
+            if isinstance(old_size, list):
+                old_size = len(old_size)
+                old_size.extend([0] * (estimated_capacity - old_size))
+            else:
+                self._args_list["cache_loc"] = [0] * estimated_capacity
 
     @staticmethod
     def _get_page_assignments(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for accepting torch.Tensor inputs in addition to Python lists for improved data storage flexibility.
  * Enhanced dtype handling with automatic conversion between Torch and NumPy types when needed.

* **Refactor**
  * Optimized internal data storage paths to minimize unnecessary tensor-to-list conversions for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
