### PR TITLE
[None][fix] Fix int4 awq for sm120/121

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -587,7 +587,8 @@ std::vector<CutlassGemmConfig> get_candidate_configs(
     {
         return get_candidate_configs_sm100(config_type_param, sm);
     }
-    if (sm >= 120 && (config_type_param & CutlassGemmConfig::BLACKWELL))
+    if (sm >= 120 && (config_type_param & CutlassGemmConfig::BLACKWELL)
+        && !(config_type_param & CutlassGemmConfig::WEIGHT_ONLY))
     {
         return get_candidate_configs_sm120(config_type_param);
     }

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -587,13 +587,12 @@ std::vector<CutlassGemmConfig> get_candidate_configs(
     {
         return get_candidate_configs_sm100(config_type_param, sm);
     }
-    // Take the SM120/121 path for FP4-mixed GEMMs (FP4xFP4, FP8xFP4 /
-    // W4A8_MXFP4_*). Pure integer weight-only (W4A16 / W8A16) falls through
-    // to the Ampere candidate list. The WEIGHT_ONLY flag is set whenever
-    // T != WeightType (true for FP8xFP4 too), so guard with the FP4 flags.
+    // Use the Blackwell (SM120+) specialized candidate list only for these cases:
+    //   - FP4 dense GEMM (FP4_ONLY)
+    //   - Mixed FP8/FP4 (FP8FP4_MIXED, e.g., W4A8_MXFP4_*)
+    // If neither applies, fall through (e.g. pure int W4A16/W8A16 handled elsewhere).
     if (sm >= 120 && (config_type_param & CutlassGemmConfig::BLACKWELL)
-        && (!(config_type_param & CutlassGemmConfig::WEIGHT_ONLY)
-            || (config_type_param & (CutlassGemmConfig::FP4_ONLY | CutlassGemmConfig::FP8FP4_MIXED))))
+        && ((config_type_param & CutlassGemmConfig::FP4_ONLY) || (config_type_param & CutlassGemmConfig::FP8FP4_MIXED)))
     {
         return get_candidate_configs_sm120(config_type_param);
     }

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -587,13 +587,10 @@ std::vector<CutlassGemmConfig> get_candidate_configs(
     {
         return get_candidate_configs_sm100(config_type_param, sm);
     }
-    // SM120/121 path: take it for any BLACKWELL request unless this is a
-    // pure integer weight-only GEMM (W4A16 / W8A16). Those need the
-    // Ampere-style fallback because the SM120 candidate list only covers
-    // the FP4-mixed shapes (FP4xFP4, FP8xFP4 / W4A8_MXFP4_*) added by the
-    // GPT-OSS SM120/121 enablement. WEIGHT_ONLY here means T != WeightType,
-    // which is also true for FP8xFP4, so we must additionally check the
-    // FP4 flags before falling through.
+    // Take the SM120/121 path for FP4-mixed GEMMs (FP4xFP4, FP8xFP4 /
+    // W4A8_MXFP4_*). Pure integer weight-only (W4A16 / W8A16) falls through
+    // to the Ampere candidate list. The WEIGHT_ONLY flag is set whenever
+    // T != WeightType (true for FP8xFP4 too), so guard with the FP4 flags.
     if (sm >= 120 && (config_type_param & CutlassGemmConfig::BLACKWELL)
         && (!(config_type_param & CutlassGemmConfig::WEIGHT_ONLY)
             || (config_type_param & (CutlassGemmConfig::FP4_ONLY | CutlassGemmConfig::FP8FP4_MIXED))))

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -587,8 +587,16 @@ std::vector<CutlassGemmConfig> get_candidate_configs(
     {
         return get_candidate_configs_sm100(config_type_param, sm);
     }
+    // SM120/121 path: take it for any BLACKWELL request unless this is a
+    // pure integer weight-only GEMM (W4A16 / W8A16). Those need the
+    // Ampere-style fallback because the SM120 candidate list only covers
+    // the FP4-mixed shapes (FP4xFP4, FP8xFP4 / W4A8_MXFP4_*) added by the
+    // GPT-OSS SM120/121 enablement. WEIGHT_ONLY here means T != WeightType,
+    // which is also true for FP8xFP4, so we must additionally check the
+    // FP4 flags before falling through.
     if (sm >= 120 && (config_type_param & CutlassGemmConfig::BLACKWELL)
-        && !(config_type_param & CutlassGemmConfig::WEIGHT_ONLY))
+        && (!(config_type_param & CutlassGemmConfig::WEIGHT_ONLY)
+            || (config_type_param & (CutlassGemmConfig::FP4_ONLY | CutlassGemmConfig::FP8FP4_MIXED))))
     {
         return get_candidate_configs_sm120(config_type_param);
     }

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1412,7 +1412,13 @@ def _(
 
 class FinegrainedMixedDtypeGemm(TunableRunner):
     _runner_dict = dict()
+    # Max SM for W4A8 (FP8 activation). The Sm80 fallback used on SM120/121
+    # has no FP8 mma, so W4A8 remains capped here.
     MAX_SUPPORTED_SM_VERSION = 103
+    # Max SM for W4A16 (FP16/BF16 activation). SM120/121 dispatch through
+    # cutlass::arch::Sm80 MMA kernels which are MMA-compatible with Blackwell
+    # consumer GPUs (RTX 5090/5080).
+    MAX_SUPPORTED_SM_VERSION_W4A16 = 121
 
     def __init__(self, activation_dtype: torch.dtype, output_dtype: torch.dtype,
                  quant_mode: int):
@@ -1445,7 +1451,10 @@ class FinegrainedMixedDtypeGemm(TunableRunner):
                 do_preparation: bool = False,
                 **kwargs) -> torch.Tensor:
 
-        if get_sm_version() > self.MAX_SUPPORTED_SM_VERSION:
+        max_sm = (self.MAX_SUPPORTED_SM_VERSION
+                  if self.activation_dtype == torch.float8_e4m3fn else
+                  self.MAX_SUPPORTED_SM_VERSION_W4A16)
+        if get_sm_version() > max_sm:
             raise ValueError(
                 f"SM version {get_sm_version()} is not supported for W4A16/W4A8 finegrained mixed dtype GEMM"
             )

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1447,12 +1447,16 @@ class FinegrainedMixedDtypeGemm(TunableRunner):
                 do_preparation: bool = False,
                 **kwargs) -> torch.Tensor:
 
-        max_sm = (self.MAX_SUPPORTED_SM_VERSION_W4A8
-                  if self.activation_dtype == torch.float8_e4m3fn else
-                  self.MAX_SUPPORTED_SM_VERSION_W4A16)
-        if get_sm_version() > max_sm:
+        sm = get_sm_version()
+        if (self.activation_dtype == torch.float8_e4m3fn
+                and sm > self.MAX_SUPPORTED_SM_VERSION_W4A8):
             raise ValueError(
-                f"SM version {get_sm_version()} is not supported for W4A16/W4A8 finegrained mixed dtype GEMM"
+                f"SM version {sm} is not supported for W4A8 finegrained mixed dtype GEMM"
+            )
+        if (self.activation_dtype in (torch.float16, torch.bfloat16)
+                and sm > self.MAX_SUPPORTED_SM_VERSION_W4A16):
+            raise ValueError(
+                f"SM version {sm} is not supported for W4A16 finegrained mixed dtype GEMM"
             )
 
         activation, weights_packed, scales = inputs

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1412,12 +1412,8 @@ def _(
 
 class FinegrainedMixedDtypeGemm(TunableRunner):
     _runner_dict = dict()
-    # Max SM for W4A8 (FP8 activation). The Sm80 fallback used on SM120/121
-    # has no FP8 mma, so W4A8 remains capped here.
-    MAX_SUPPORTED_SM_VERSION = 103
-    # Max SM for W4A16 (FP16/BF16 activation). SM120/121 dispatch through
-    # cutlass::arch::Sm80 MMA kernels which are MMA-compatible with Blackwell
-    # consumer GPUs (RTX 5090/5080).
+    MAX_SUPPORTED_SM_VERSION_W4A8 = 103
+    # W4A16 (FP16/BF16 activation): SM120/121 dispatch via cutlass::arch::Sm80.
     MAX_SUPPORTED_SM_VERSION_W4A16 = 121
 
     def __init__(self, activation_dtype: torch.dtype, output_dtype: torch.dtype,
@@ -1451,7 +1447,7 @@ class FinegrainedMixedDtypeGemm(TunableRunner):
                 do_preparation: bool = False,
                 **kwargs) -> torch.Tensor:
 
-        max_sm = (self.MAX_SUPPORTED_SM_VERSION
+        max_sm = (self.MAX_SUPPORTED_SM_VERSION_W4A8
                   if self.activation_dtype == torch.float8_e4m3fn else
                   self.MAX_SUPPORTED_SM_VERSION_W4A16)
         if get_sm_version() > max_sm:

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -111,9 +111,14 @@ class CutlassFusedMoE(MoE):
             "sm_constraint": ("in", {100, 103}),
             "dtypes": {torch.float16, torch.bfloat16, torch.float32},
         },
-        # W4A8_MXFP4_MXFP8: SM in {100, 103}
+        # W4A8_MXFP4_MXFP8: SM in {100, 103, 120, 121}
+        # SM120/121 added by commit 27a5091f ([None][feat] GPT-OSS Sm120/Sm121
+        # Support); the C++ isValidSM120MOESpecialisation<T=FP8, WeightType=FP4>
+        # path covers MXFP4_MXFP8 since use_wfp4afp8 is type-defined as
+        # (T==FP8 && WeightType==FP4), and the runtime block-scaling type for
+        # use_wfp4afp8 is hard-wired to MXFPX in moe_gemm_template_dispatch.h.
         QuantAlgo.W4A8_MXFP4_MXFP8: {
-            "sm_constraint": ("in", {100, 103}),
+            "sm_constraint": ("in", {100, 103, 120, 121}),
             "dtypes": {torch.float16, torch.bfloat16},
         },
     }
@@ -140,7 +145,7 @@ class CutlassFusedMoE(MoE):
         - W8A16: SM >= 80
         - W4A16_MXFP4: SM == 90 only
         - W4A8_MXFP4_FP8: SM in {100, 103}
-        - W4A8_MXFP4_MXFP8: SM in {100, 103}
+        - W4A8_MXFP4_MXFP8: SM in {100, 103, 120, 121}
 
         Args:
             quant_algo: The quantization algorithm to check (None for unquantized)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -84,9 +84,6 @@ class CutlassFusedMoE(MoE):
             "dtypes": {torch.bfloat16},
         },
         # NVFP4: SM in {100, 103, 120, 121}
-        # SM 120 = desktop Blackwell (e.g. RTX 5090 / GB202)
-        # SM 121 = GB10 / DGX Spark
-        # C++ kernel: isValidSM120MOESpecialisation() supports FP4xFP4 and FP8xFP4
         QuantAlgo.NVFP4: {
             "sm_constraint": ("in", {100, 103, 120, 121}),
             "dtypes": {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
@@ -112,11 +109,6 @@ class CutlassFusedMoE(MoE):
             "dtypes": {torch.float16, torch.bfloat16, torch.float32},
         },
         # W4A8_MXFP4_MXFP8: SM in {100, 103, 120, 121}
-        # SM120/121 added by commit 27a5091f ([None][feat] GPT-OSS Sm120/Sm121
-        # Support); the C++ isValidSM120MOESpecialisation<T=FP8, WeightType=FP4>
-        # path covers MXFP4_MXFP8 since use_wfp4afp8 is type-defined as
-        # (T==FP8 && WeightType==FP4), and the runtime block-scaling type for
-        # use_wfp4afp8 is hard-wired to MXFPX in moe_gemm_template_dispatch.h.
         QuantAlgo.W4A8_MXFP4_MXFP8: {
             "sm_constraint": ("in", {100, 103, 120, 121}),
             "dtypes": {torch.float16, torch.bfloat16},

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -957,16 +957,12 @@ def preprocess_weights_for_mixed_gemm(
         sm_: int = -1,
         do_weight_interleave: bool = True) -> torch.Tensor:
     sm_ = sm_ if sm_ > 0 else get_sm_version()
+    # 3-D inputs (MoE) on Hopper+ and any input on SM120/SM121 reuse the SM80
+    # interleaved layout. Check the original rank before unsqueeze.
+    if (len(tensor.shape) == 3 and sm_ >= 90) or sm_ >= 120:
+        sm_ = 80
     if len(tensor.shape) == 2:
         tensor = tensor.unsqueeze(0)
-    elif sm_ >= 90:
-        # 3-D inputs (MoE) fall back to SM80 interleaved layout, mirroring the
-        # `force_interleave && arch >= 90` clause in the C++ preprocessor.
-        sm_ = 80
-    if sm_ >= 120:
-        # SM120/SM121 dispatch through cutlass::arch::Sm80; reuse SM80 layout
-        # for both 2-D and 3-D inputs.
-        sm_ = 80
     if sm_ == 100 or sm_ == 103:
         do_weight_interleave = False
 

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -959,7 +959,13 @@ def preprocess_weights_for_mixed_gemm(
     sm_ = sm_ if sm_ > 0 else get_sm_version()
     if len(tensor.shape) == 2:
         tensor = tensor.unsqueeze(0)
-    elif sm_ >= 90:
+    # Hopper / Blackwell weight-only paths reuse the SM80 layout (TMA-WS or
+    # SM80-fallback kernels read the same interleaved/row-permuted format).
+    # This adjustment must apply for both 2-D and 3-D inputs; previously it
+    # was guarded by an elif tied to the 2-D shape check, which silently
+    # skipped row permutation + column interleave for vanilla 2-D linears on
+    # SM>=90 and produced wrong-layout weights on SM120/121.
+    if sm_ >= 90:
         sm_ = 80
     if sm_ == 100 or sm_ == 103:
         do_weight_interleave = False

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -959,13 +959,17 @@ def preprocess_weights_for_mixed_gemm(
     sm_ = sm_ if sm_ > 0 else get_sm_version()
     if len(tensor.shape) == 2:
         tensor = tensor.unsqueeze(0)
-    # Hopper / Blackwell weight-only paths reuse the SM80 layout (TMA-WS or
-    # SM80-fallback kernels read the same interleaved/row-permuted format).
-    # This adjustment must apply for both 2-D and 3-D inputs; previously it
-    # was guarded by an elif tied to the 2-D shape check, which silently
-    # skipped row permutation + column interleave for vanilla 2-D linears on
-    # SM>=90 and produced wrong-layout weights on SM120/121.
-    if sm_ >= 90:
+    elif sm_ >= 90:
+        # 3-D inputs (MoE expert weights) have no specialised Hopper/Blackwell
+        # kernels and fall back to the SM80 interleaved layout, mirroring the
+        # `force_interleave && arch >= 90` clause in the C++ preprocessor.
+        sm_ = 80
+    if sm_ >= 120:
+        # SM120/SM121 (RTX 5090 / 5080) reuse the SM80 layout for both 2-D and
+        # 3-D inputs because the SM120 dispatch routes through cutlass::arch::Sm80.
+        # Without this, vanilla 2-D Linear weights on SM120 skipped both row
+        # permutation (gated sm_ < 100) and column interleave (gated sm_ < 90)
+        # and produced wrong-layout weights for the Sm80 finegrained kernel.
         sm_ = 80
     if sm_ == 100 or sm_ == 103:
         do_weight_interleave = False

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -960,16 +960,12 @@ def preprocess_weights_for_mixed_gemm(
     if len(tensor.shape) == 2:
         tensor = tensor.unsqueeze(0)
     elif sm_ >= 90:
-        # 3-D inputs (MoE expert weights) have no specialised Hopper/Blackwell
-        # kernels and fall back to the SM80 interleaved layout, mirroring the
+        # 3-D inputs (MoE) fall back to SM80 interleaved layout, mirroring the
         # `force_interleave && arch >= 90` clause in the C++ preprocessor.
         sm_ = 80
     if sm_ >= 120:
-        # SM120/SM121 (RTX 5090 / 5080) reuse the SM80 layout for both 2-D and
-        # 3-D inputs because the SM120 dispatch routes through cutlass::arch::Sm80.
-        # Without this, vanilla 2-D Linear weights on SM120 skipped both row
-        # permutation (gated sm_ < 100) and column interleave (gated sm_ < 90)
-        # and produced wrong-layout weights for the Sm80 finegrained kernel.
+        # SM120/SM121 dispatch through cutlass::arch::Sm80; reuse SM80 layout
+        # for both 2-D and 3-D inputs.
         sm_ = 80
     if sm_ == 100 or sm_ == 103:
         do_weight_interleave = False

--- a/tests/integration/test_lists/test-db/l0_rtx_pro_6000.yml
+++ b/tests/integration/test_lists/test-db/l0_rtx_pro_6000.yml
@@ -17,6 +17,13 @@ l0_rtx_pro_6000:
   - unittest/_torch/modeling -k "modeling_out_of_tree"
   # - unittest/_torch/modeling -k "modeling_qwen" # https://nvbugs/5234573
   - unittest/_torch/attention/test_attention_mla.py
+  # SM120 W4A16 / W4A8 mixed-dtype GEMM coverage (paired with FinegrainedMixedDtypeGemm
+  # MAX_SUPPORTED_SM_VERSION_W4A* gates and cutlass_heuristic.cpp SM120 routing).
+  - unittest/_torch/thop/parallel/test_w4a16_linear.py
+  - unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
+  - unittest/_torch/thop/parallel/test_weight_only_quant_linear.py
+  - unittest/_torch/thop/parallel/test_weight_only_quant_gemm.py
+  - unittest/_torch/thop/parallel/test_w4a8_linear.py
   - test_e2e.py::test_ptp_quickstart_bert[VANILLA-BertForSequenceClassification-bert/bert-base-uncased-yelp-polarity]
   - test_e2e.py::test_ptp_quickstart_bert[TRTLLM-BertForSequenceClassification-bert/bert-base-uncased-yelp-polarity]
   - test_e2e.py::test_ptp_quickstart_advanced[Llama3.1-8B-BF16-llama-3.1-model/Meta-Llama-3.1-8B]

--- a/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
@@ -51,12 +51,13 @@ def test_matmul_activation_int4_input(m, n, k, group_size, activation_dtype,
     torch.manual_seed(0)
     device = "cuda"
 
-    max_sm = (FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A8
-              if use_w4a8_awq else
-              FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16)
-    if get_sm_version() > max_sm:
-        pytest.skip(
-            f"W4A16/W4A8 not supported for SM version {get_sm_version()}")
+    sm = get_sm_version()
+    if (use_w4a8_awq
+            and sm > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A8):
+        pytest.skip(f"W4A8 not supported for SM version {sm}")
+    if (not use_w4a8_awq
+            and sm > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16):
+        pytest.skip(f"W4A16 not supported for SM version {sm}")
 
     total_groups = (k + group_size - 1) // group_size
     scale_zero_dtype = torch.float16 if use_w4a8_awq else activation_dtype

--- a/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
@@ -51,8 +51,9 @@ def test_matmul_activation_int4_input(m, n, k, group_size, activation_dtype,
     torch.manual_seed(0)
     device = "cuda"
 
-    max_sm = (FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION if use_w4a8_awq
-              else FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16)
+    max_sm = (FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A8
+              if use_w4a8_awq else
+              FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16)
     if get_sm_version() > max_sm:
         pytest.skip(
             f"W4A16/W4A8 not supported for SM version {get_sm_version()}")

--- a/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_finegrained_mixed_dtype_gemm.py
@@ -51,7 +51,9 @@ def test_matmul_activation_int4_input(m, n, k, group_size, activation_dtype,
     torch.manual_seed(0)
     device = "cuda"
 
-    if get_sm_version() > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION:
+    max_sm = (FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION if use_w4a8_awq
+              else FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16)
+    if get_sm_version() > max_sm:
         pytest.skip(
             f"W4A16/W4A8 not supported for SM version {get_sm_version()}")
 

--- a/tests/unittest/_torch/thop/parallel/test_w4a16_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_w4a16_linear.py
@@ -17,10 +17,10 @@ from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 )
 def test_w4a16_linear(dtype, weights_dtype, has_zero=False):
 
-    if get_sm_version() > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION:
+    if get_sm_version(
+    ) > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A16:
         pytest.skip(
-            f"W4A16/W4A8 is not supported in this SM version {get_sm_version()}"
-        )
+            f"W4A16 is not supported in this SM version {get_sm_version()}")
 
     SEQ_LEN = 10
     HIDDEN_SIZE = 128

--- a/tests/unittest/_torch/thop/parallel/test_w4a8_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_w4a8_linear.py
@@ -18,10 +18,11 @@ from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 )
 def test_w4a8_linear(dtype, weights_dtype, has_zero=False):
 
+    # W4A8 requires an FP8-capable mixed-dtype dispatch; SM120/121 fall back
+    # to the Sm80 MMA path which has no FP8, so W4A8 stays gated on SM>103.
     if get_sm_version() > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION:
         pytest.skip(
-            f"W4A16/W4A8 is not supported in this SM version {get_sm_version()}"
-        )
+            f"W4A8 is not supported in this SM version {get_sm_version()}")
 
     SEQ_LEN = 10
     HIDDEN_SIZE = 128

--- a/tests/unittest/_torch/thop/parallel/test_w4a8_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_w4a8_linear.py
@@ -20,7 +20,8 @@ def test_w4a8_linear(dtype, weights_dtype, has_zero=False):
 
     # W4A8 requires an FP8-capable mixed-dtype dispatch; SM120/121 fall back
     # to the Sm80 MMA path which has no FP8, so W4A8 stays gated on SM>103.
-    if get_sm_version() > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION:
+    if get_sm_version(
+    ) > FinegrainedMixedDtypeGemm.MAX_SUPPORTED_SM_VERSION_W4A8:
         pytest.skip(
             f"W4A8 is not supported in this SM version {get_sm_version()}")
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight preprocessing logic for SM120/Blackwell architectures to ensure correct weight layout handling
  * Improved SM120 candidate selection for Blackwell to properly distinguish between weight-only and non-weight-only configurations
  * Enhanced W4A16 quantization support with expanded GPU architecture compatibility beyond previous limits, while maintaining FP8 activation constraints

* **Tests**
  * Updated architecture capability checks to reflect expanded GPU support for W4A16 quantization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
