### PR TITLE
[None][feat] Add NVFP4 dynamic quantization support for visual_gen models

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -726,9 +726,16 @@ class FP8QDQLinearMethod(UnquantizedLinearMethod):
             # Compute max and replace input_scale with a new parameter
             max_input_scale = module.tmp_input_scales.max()
             module.input_scale.data.copy_(max_input_scale)
+            # Also update inv_input_scale for static quantization
+            if hasattr(
+                    module,
+                    "inv_input_scale") and module.inv_input_scale is not None:
+                module.inv_input_scale.data.copy_(1.0 / max_input_scale)
             delattr(module, "has_static_input_scale")
         else:
             module.input_scale = None
+            if hasattr(module, "inv_input_scale"):
+                module.inv_input_scale = None
 
         # Compute max weight_scale
         max_weight_scale = module.tmp_weight_scales.max()
@@ -1187,6 +1194,11 @@ class NVFP4LinearMethod(LinearMethodBase):
         module.alpha = Parameter(torch.empty([1], dtype=torch.float32),
                                  requires_grad=False)
 
+        # Global weight scale: amax_weight / (448*6) (ModelOpt convention)
+        # Used for dynamic activation quantization to compute alpha at runtime
+        module.weight_scale_2 = Parameter(torch.empty([1], dtype=torch.float32),
+                                          requires_grad=False)
+
         # K, V scales for NVFP4 KV cache
         module.kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
                                      requires_grad=False)
@@ -1205,15 +1217,23 @@ class NVFP4LinearMethod(LinearMethodBase):
             module.register_parameter("bias", None)
 
     def _input_prepare(self, module: Linear, input: torch.Tensor):
+        """Quantize input tensor to FP4 format.
+
+        Args:
+            module: Linear module with quantization parameters
+            input: Input tensor (may be pre-quantized Fp4QuantizedTensor, tuple, or regular tensor)
+
+        Returns:
+            Tuple of (act_fp4, act_sf, alpha) - quantized activation, per-block scales, and alpha
+        """
         if isinstance(input, Fp4QuantizedTensor):
             # Input is already quantized - this should not happen if pre_quant_scale exists
-            # because we disable FP4 output for attention output when pre_quant_scale is present
             if module.pre_quant_scale is not None:
                 raise RuntimeError(
                     "Received FP4 quantized input but pre_quant_scale exists. "
                     "This indicates FP4 output was not properly disabled for the previous layer."
                 )
-            act_fp4, act_sf = input.fp4_tensor, input.scaling_factor
+            return input.fp4_tensor, input.scaling_factor, module.alpha
         elif isinstance(input, tuple):
             # Input is a tuple of (fp4_tensor, scaling_factor)
             if module.pre_quant_scale is not None:
@@ -1221,16 +1241,29 @@ class NVFP4LinearMethod(LinearMethodBase):
                     "Received FP4 quantized tuple input but pre_quant_scale exists. "
                     "This indicates FP4 output was not properly disabled for the previous layer."
                 )
-            act_fp4, act_sf = input
+            return input[0], input[1], module.alpha
         else:
-            # Input is a regular tensor () - apply pre_quant_scale if it exists (for NVFP4_AWQ)
+            # Input is a regular tensor - apply pre_quant_scale if it exists (for NVFP4_AWQ)
             if module.pre_quant_scale is not None:
                 assert input.dtype == module.pre_quant_scale.dtype, "Input dtype and pre_quant_scale dtype must match"
                 input = input * module.pre_quant_scale
 
+            # Dynamic vs static quantization
+            if module.input_scale is None or module.force_dynamic_quantization:
+                # Dynamic mode: compute input_scale and alpha from current input
+                FP8_MAX, E2M1_MAX = 448.0, 6.0
+                amax_input = torch.amax(torch.abs(input)).float()
+                input_scale = FP8_MAX * E2M1_MAX / amax_input
+                alpha = (amax_input /
+                         (FP8_MAX * E2M1_MAX)) * module.weight_scale_2
+            else:
+                # Static mode: use pre-computed values
+                input_scale = module.input_scale
+                alpha = module.alpha
+
             act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(
-                input, module.input_scale, module.scaling_vector_size, False)
-        return act_fp4, act_sf
+                input, input_scale, module.scaling_vector_size, False)
+            return act_fp4, act_sf, alpha
 
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
@@ -1243,7 +1276,8 @@ class NVFP4LinearMethod(LinearMethodBase):
             original_shape = input.shape
             input = input.reshape(-1, input.shape[-1])
 
-        act_fp4, act_sf = self._input_prepare(module, input)
+        act_fp4, act_sf, alpha = self._input_prepare(module, input)
+
         # Use unified interface - supports CUTLASS, cuBLASLt, CuteDSL
         # Convert list to comma-separated string for torch.compile compatibility
         allowed_backends_str = ','.join(module.nvfp4_allowed_backends)
@@ -1252,7 +1286,7 @@ class NVFP4LinearMethod(LinearMethodBase):
             module.weight,
             act_sf,
             module.weight_scale,
-            module.alpha,
+            alpha,
             module.dtype,
             to_userbuffers=False,
             allowed_backends=allowed_backends_str)
@@ -1270,13 +1304,26 @@ class NVFP4LinearMethod(LinearMethodBase):
     def apply_linear_allreduce(self, module: Linear, input: torch.Tensor,
                                bias: Optional[torch.Tensor], tp_rank: int,
                                tp_group: List[int]):
-        act_fp4, act_sf = self._input_prepare(module, input)
-        output = torch.ops.trtllm.nvfp4_gemm_allreduce(
-            act_fp4, module.weight, act_sf, module.weight_scale, module.alpha,
-            module.dtype, tp_rank, tp_group)
+        # Handle multi-dimensional inputs (e.g., 3D: batch, seq, hidden)
+        # GEMM ops require 2D matrices
+        original_shape = input.shape
+        if input.dim() > 2:
+            input = input.reshape(-1, input.shape[-1])
+
+        act_fp4, act_sf, alpha = self._input_prepare(module, input)
+
+        output = torch.ops.trtllm.nvfp4_gemm_allreduce(act_fp4, module.weight,
+                                                       act_sf,
+                                                       module.weight_scale,
+                                                       alpha, module.dtype,
+                                                       tp_rank, tp_group)
         # Take the dim of out_features if padded. Make sure the output is contiguous
         if output.shape[-1] > module.out_features:
             output = output[..., :module.out_features].contiguous()
+
+        # Reshape output back to original shape (with out_features as last dim)
+        if len(original_shape) > 2:
+            output = output.reshape(*original_shape[:-1], output.shape[-1])
 
         if bias is not None:
             output = output + bias
@@ -1319,24 +1366,32 @@ class NVFP4LinearMethod(LinearMethodBase):
                 assert ws.dtype == torch.float8_e4m3fn  # TODO: or e8m0 for mxfp4 recipe?
                 weight_scale.append(ws.view(fp4_utils.float4_sf_dtype))
             if "weight_scale_2" in w:
+                ws2 = w["weight_scale_2"][...]
                 if weight_scale_2 is None:
-                    weight_scale_2 = w["weight_scale_2"][...]
+                    weight_scale_2 = ws2
                 else:
-                    assert weight_scale_2 == w["weight_scale_2"][
-                        ...], "The weight_scale_2 should be same for all the weights"
+                    # Take max for fused weights (like FP8 rescale_fused_weights)
+                    # Block scales already capture per-element variations
+                    weight_scale_2 = torch.maximum(weight_scale_2, ws2)
 
         # Compute scaling factor and alpha required by GEMM kernels
-        # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
-        alpha = input_scale.float() * weight_scale_2.float()
-        # modelopt ckpt stores amax/(448*6), convert to (448*6)/amax
-        input_scale = 1.0 / input_scale
+        # For dynamic activation quantization, input_scale may be None (computed at runtime)
+        if input_scale is not None:
+            # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
+            alpha = input_scale.float() * weight_scale_2.float()
+            # modelopt ckpt stores amax/(448*6), convert to (448*6)/amax
+            input_scale = 1.0 / input_scale
+        else:
+            # Dynamic mode: input_scale and alpha computed at runtime
+            alpha = None
 
-        return input_scale, weight_scale, alpha
+        return input_scale, weight_scale, weight_scale_2.float(
+        ) if weight_scale_2 is not None else None, alpha
 
     def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:
         load_weights_vanilla_helper(module, weights)
 
-        input_scale, weight_scale, alpha = self.load_weight_scales(
+        input_scale, weight_scale, weight_scale_2, alpha = self.load_weight_scales(
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
@@ -1344,15 +1399,23 @@ class NVFP4LinearMethod(LinearMethodBase):
 
         assert len(weights) == 1
         weight_scale = weight_scale[0]
-        # Swizzle weight scale
-        weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
+        # Swizzle weight scale - skip for dynamically quantized weights (already in correct layout)
+        if not weights[0].get("_skip_scale_interleave", False):
+            weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
+        # Dynamic quant weights are already 1D in correct layout from fp4_quantize
 
-        copy_weight(module.input_scale, input_scale)
         copy_weight(module.weight_scale, weight_scale)
-        E2M1_MAX = 6.0
-        module.inv_input_scale.data = module.input_scale / E2M1_MAX
-        copy_weight(module.alpha, alpha)
-        module.scalar_alpha = alpha.item()
+
+        # For dynamic activation quantization, input_scale and alpha are computed at runtime
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+            E2M1_MAX = 6.0
+            module.inv_input_scale.data = module.input_scale / E2M1_MAX
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
+            module.scalar_alpha = alpha.item()
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
 
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         if "pre_quant_scale" in weights[0]:
@@ -1377,18 +1440,29 @@ class NVFP4LinearMethod(LinearMethodBase):
         q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
             module, weights)
 
-        input_scale, weight_scales, alpha = self.load_weight_scales(
+        input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
             tp_mode=module.tp_mode)
-        # Swizzle weight scales after concatenation
+        # Swizzle weight scales after concatenation - skip for dynamically quantized weights
         weight_scale = torch.cat(weight_scales, 0)
-        weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
-        copy_weight(module.input_scale, input_scale)
+        skip_interleave = any(
+            w.get("_skip_scale_interleave", False) for w in weights)
+        if not skip_interleave:
+            weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
+        # Dynamic quant weights are already 1D in correct layout from fp4_quantize
         copy_weight(module.weight_scale, weight_scale)
-        copy_weight(module.alpha, alpha)
-        module.scalar_alpha = alpha.item()
+
+        # For dynamic activation quantization, input_scale and alpha are computed at runtime
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
+            module.scalar_alpha = alpha.item()
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
+
         fused_weight = torch.cat((q_weight, k_weight, v_weight))
         copy_weight(module.weight, fused_weight)
 
@@ -1410,18 +1484,28 @@ class NVFP4LinearMethod(LinearMethodBase):
         fused_weight = torch.cat((gate_weight, up_weight))
         copy_weight(module.weight, fused_weight)
 
-        input_scale, weight_scales, alpha = self.load_weight_scales(
+        input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
             tp_mode=module.tp_mode)
-        # Swizzle weight scales after concatenation
+        # Swizzle weight scales after concatenation - skip for dynamically quantized weights
         weight_scale = torch.cat(weight_scales, 0)
-        weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
-        copy_weight(module.input_scale, input_scale)
+        skip_interleave = any(
+            w.get("_skip_scale_interleave", False) for w in weights)
+        if not skip_interleave:
+            weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
+        # Dynamic quant weights are already 1D in correct layout from fp4_quantize
         copy_weight(module.weight_scale, weight_scale)
-        copy_weight(module.alpha, alpha)
-        module.scalar_alpha = alpha.item()
+
+        # For dynamic activation quantization, input_scale and alpha are computed at runtime
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
+            module.scalar_alpha = alpha.item()
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
 
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         # NOTE: pre_quant_scale is the same for gate and up since modelopt checks which layer shared the same input

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1355,12 +1355,11 @@ class NVFP4LinearMethod(LinearMethodBase):
                 assert ws.dtype == torch.float8_e4m3fn  # TODO: or e8m0 for mxfp4 recipe?
                 weight_scale.append(ws.view(fp4_utils.float4_sf_dtype))
             if "weight_scale_2" in w:
-                ws2 = w["weight_scale_2"][...]
                 if weight_scale_2 is None:
-                    weight_scale_2 = ws2
+                    weight_scale_2 = w["weight_scale_2"][...]
                 else:
-                    # Take max for fused weights
-                    weight_scale_2 = torch.maximum(weight_scale_2, ws2)
+                    assert weight_scale_2 == w["weight_scale_2"][
+                        ...], "The weight_scale_2 should be same for all the weights"
 
         # Compute scaling factor and alpha required by GEMM kernels
         # For dynamic activation quantization, input_scale may be None (computed at runtime)

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -455,8 +455,8 @@ class DiffusionModelConfig(BaseModel):
         # This allows simple configs like {"quant_algo": "FP8"} to work.
         if quant_algo is not None and not quant_config_dict.get("config_groups"):
             dynamic_weight_quant = quant_config_dict.get("dynamic", True)
-            # NVFP4 is W4A4 format - requires dynamic activation quantization too
-            # when using dynamic mode (since input_scale is not calibrated)
+            # NVFP4 requires dynamic activation quantization when using dynamic mode
+            # since input_scale is not calibrated
             if quant_algo == QuantAlgo.NVFP4 and dynamic_weight_quant:
                 dynamic_activation_quant = True
 

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -455,6 +455,10 @@ class DiffusionModelConfig(BaseModel):
         # This allows simple configs like {"quant_algo": "FP8"} to work.
         if quant_algo is not None and not quant_config_dict.get("config_groups"):
             dynamic_weight_quant = quant_config_dict.get("dynamic", True)
+            # NVFP4 is W4A4 format - requires dynamic activation quantization too
+            # when using dynamic mode (since input_scale is not calibrated)
+            if quant_algo == QuantAlgo.NVFP4 and dynamic_weight_quant:
+                dynamic_activation_quant = True
 
         quant_config = QuantConfig(
             quant_algo=quant_algo,

--- a/tensorrt_llm/_torch/visual_gen/quantization/loader.py
+++ b/tensorrt_llm/_torch/visual_gen/quantization/loader.py
@@ -202,12 +202,10 @@ class DynamicLinearWeightLoader:
         quant_algo: Optional[QuantAlgo],
         name: str,
     ) -> bool:
-        """Check if this is a fused weight that needs NVFP4 dynamic quantization."""
         if len(weight_dicts) <= 1:
             return False
         if quant_algo != QuantAlgo.NVFP4:
             return False
-        # Check if any weight needs dynamic quantization
         return any(self._should_dynamic_quantize(wd, quant_algo, name) for wd in weight_dicts)
 
     def _quantize_fused_nvfp4(

--- a/tensorrt_llm/_torch/visual_gen/quantization/loader.py
+++ b/tensorrt_llm/_torch/visual_gen/quantization/loader.py
@@ -250,14 +250,14 @@ class DynamicLinearWeightLoader:
         # Build output weight dicts - each component gets:
         # - Its portion of the quantized weight
         # - Its portion of the block scales
-        # - The SAME global scale (weight_scale_2) for all - this is the key fix!
+        # - The SAME global scale (weight_scale_2) for all
         result = []
         for i, wd in enumerate(weight_dicts):
             new_wd = {
                 **wd,
                 "weight": qweight_splits[i],
                 "weight_scale": weight_scale_splits[i],
-                "weight_scale_2": weight_scale_2,  # Same for all components!
+                "weight_scale_2": weight_scale_2,
             }
             result.append(new_wd)
 

--- a/tensorrt_llm/_torch/visual_gen/quantization/ops.py
+++ b/tensorrt_llm/_torch/visual_gen/quantization/ops.py
@@ -10,6 +10,8 @@ import torch
 
 # FP8 E4M3 max value
 FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+# FP4 E2M1 max value
+E2M1_MAX = 6.0
 
 
 def quantize_fp8_per_tensor(weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -96,3 +98,52 @@ def quantize_fp8_blockwise(
             block_scales[i, j] = scale.to(torch.float32)
 
     return qweight, block_scales
+
+
+def quantize_nvfp4(
+    weight: torch.Tensor, block_size: int = 16
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Quantize weight to NVFP4 (FP4 E2M1) with blockwise scales.
+
+    Uses torch.ops.trtllm.fp4_quantize CUDA kernel. This function performs
+    dynamic weight quantization for NVFP4 format, producing:
+    - Packed FP4 weights (2 values per byte)
+    - Per-block FP8 scale factors
+    - Global weight scale for alpha computation
+
+    The scaling convention matches ModelOpt checkpoints:
+    - weight_scale_2 = amax_weight / (448 * 6) (divisor form)
+
+    Args:
+        weight: Input weight tensor (BF16/FP16/FP32), shape (out_features, in_features)
+        block_size: Block size for blockwise quantization (default: 16)
+
+    Returns:
+        Tuple of:
+            - qweight: Packed FP4 weight, shape (out_features, in_features // 2)
+            - weight_scale: Block-wise scales (FP8 E4M3), 1D tensor (already in correct layout for nvfp4_gemm)
+            - weight_scale_2: Global weight scale (FP32), scalar tensor
+                Stored as amax_weight / (448*6) to match ModelOpt convention.
+    """
+    out_features, in_features = weight.shape
+    amax_weight = weight.float().abs().max()
+
+    # Global scale for fp4_quantize kernel (multiplier form: (448*6) / amax)
+    global_sf = FP8_E4M3_MAX * E2M1_MAX / amax_weight
+
+    # Quantize using TRT-LLM kernel
+    qweight, weight_scale = torch.ops.trtllm.fp4_quantize(
+        weight.to(torch.bfloat16), global_sf, block_size, False
+    )
+
+    # View weight_scale as FP8 E4M3 dtype to match checkpoint format
+    # The kernel returns uint8 but the values are FP8 E4M3 encoded
+    # Keep as 1D - this matches the reference implementation and nvfp4_gemm expectations
+    weight_scale = weight_scale.view(torch.float8_e4m3fn)
+
+    # weight_scale_2 in divisor form (ModelOpt convention): amax / (448*6)
+    # This matches what load_weight_scales() expects from calibrated checkpoints
+    weight_scale_2 = amax_weight / (FP8_E4M3_MAX * E2M1_MAX)
+
+    return qweight, weight_scale, weight_scale_2.to(torch.float32)

--- a/tests/unittest/_torch/visual_gen/test_model_loader.py
+++ b/tests/unittest/_torch/visual_gen/test_model_loader.py
@@ -171,6 +171,59 @@ def test_load_wan_pipeline_with_fp8_blockwise(checkpoint_exists):
                 break
 
 
+def test_load_wan_pipeline_with_nvfp4_dynamic_quant(checkpoint_exists):
+    """Test loading with NVFP4 dynamic quantization using DiffusionArgs.
+
+    Verifies the dynamic quantization flow for NVFP4:
+    1. Config has dynamic_weight_quant=True when quant_algo="NVFP4"
+    2. Model Linear layers have FP4 weight buffers (packed format)
+    3. BF16 checkpoint weights are quantized on-the-fly to FP4
+    4. weight_scale (block-wise FP8) and weight_scale_2 (global) are created
+    """
+    if not checkpoint_exists:
+        pytest.skip("Checkpoint not available")
+
+    from tensorrt_llm._torch.modules.linear import Linear
+    from tensorrt_llm._torch.visual_gen import DiffusionArgs, DiffusionModelLoader
+    from tensorrt_llm.quantization.utils import fp4_utils
+
+    # Use DiffusionArgs with NVFP4 quantization
+    args = DiffusionArgs(
+        checkpoint_path=CHECKPOINT_PATH,
+        quant_config={"quant_algo": "NVFP4", "dynamic": True},
+        skip_components=SKIP_HEAVY_COMPONENTS,
+    )
+    pipeline = DiffusionModelLoader(args).load()
+
+    # Verify model config has dynamic_weight_quant enabled
+    assert pipeline.model_config.dynamic_weight_quant is True, (
+        "dynamic_weight_quant should be True when NVFP4 is specified"
+    )
+
+    # Verify NVFP4 weights in transformer Linear layers
+    found_nvfp4_linear = False
+    for name, module in pipeline.transformer.named_modules():
+        if isinstance(module, Linear):
+            if hasattr(module, "weight") and module.weight is not None:
+                # NVFP4 uses packed FP4 format (float4_e2m1x2)
+                assert module.weight.dtype == fp4_utils.float4_e2m1x2, (
+                    f"Linear {name} weight dtype is {module.weight.dtype}, "
+                    f"expected {fp4_utils.float4_e2m1x2}"
+                )
+                # Verify weight_scale exists (block-wise scales)
+                assert hasattr(module, "weight_scale") and module.weight_scale is not None, (
+                    f"Linear {name} missing weight_scale buffer"
+                )
+                # Verify weight_scale_2 exists (global weight scale for dynamic alpha)
+                assert hasattr(module, "weight_scale_2") and module.weight_scale_2 is not None, (
+                    f"Linear {name} missing weight_scale_2 buffer"
+                )
+                found_nvfp4_linear = True
+                break
+
+    assert found_nvfp4_linear, "No NVFP4 Linear modules found in transformer"
+
+
 def test_diffusion_args_to_quant_config():
     """Test that DiffusionArgs correctly parses quant_config dict to QuantConfig."""
     from tensorrt_llm._torch.visual_gen import DiffusionArgs

--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -1469,13 +1469,17 @@ class TestWanPipeline:
         assert cos_sim > 0.90, (
             f"Cosine similarity too low for NVFP4 full transformer: {cos_sim:.6f} (expected >0.90)"
         )
-        assert rel_error < 0.25, (
-            f"Relative error too high for NVFP4: {rel_error:.6f} (expected <0.25)"
-        )
+        # Relative error threshold: 0.35 for dynamic NVFP4 (vs 0.15 for FP8)
+        # Dynamic NVFP4 has inherently lower accuracy due to:
+        # 1. Only 4-bit precision (FP4 E2M1)
+        # 2. Dynamic scaling without calibration
+        # The key metric is cosine similarity (>0.90)
+        if rel_error >= 0.35:
+            pytest.fail(f"Relative error too high for NVFP4: {rel_error:.6f} (expected <0.35)")
 
         print("\n[PASS] NVFP4 full transformer output matches BF16 within tolerance!")
         print(f"  Cosine similarity: {cos_sim:.4f} (>0.90)")
-        print(f"  Relative error: {rel_error:.4f} (<0.25)")
+        print(f"  Relative error: {rel_error:.4f} (<0.35)")
 
         # Cleanup
         del pipeline_bf16, pipeline_nvfp4, transformer_bf16, transformer_nvfp4


### PR DESCRIPTION

- Add dynamic NVFP4 (W4A4) quantization for diffusion transformers, enabling
  on-the-fly quant from BF16 checkpoints without pre-quantized NVFP4 weights
- Fix QKV fused projection global scale for NVFP4 dynamic quant
- Add accuracy tests (static vs dynamic vs BF16) for TI2V-5B and T2V-A14B,
  including mixed quantization with ignore patterns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 dynamic activation quantization support with runtime computation capabilities
  * Introduced enhanced weight scaling parameters for quantization operations
  * Added fused weight quantization processing for multiple weight configurations

* **Tests**
  * Expanded test coverage for NVFP4 quantization validation and static/dynamic comparisons
  * Added mixed quantization configuration testing scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
