### PR TITLE
[None][chore] split up TorchSampler.Store

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -398,196 +398,255 @@ def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
     return resolve_sampling_strategy(params, vocab_size=vocab_size)
 
 
-def _group_requests_by_strategy_key(
-    requests: Iterable[LlmRequest],
-    *,
-    strategy_to_key: Callable[[Strategy], GenericStrategyKeyType],
-    pin_memory: bool = False,
-    store: "TorchSampler.Store",
-    seq_slots: torch.Tensor,
-    vocab_size: int,
-) -> dict[RequestGroupKey[GenericStrategyKeyType], RequestGroupValue]:
-    """
-    Optimized implementation with vectorized boolean operations and efficient grouping.
+class _CachingRequestGrouper(Generic[GenericStrategyKeyType]):
+    """Efficiently groups requests for batched sampling."""
 
-    NB: Client code relies on request indices in returned torch.Tensor being sorted.
-    """
-    # Convert to list for efficient indexing
-    requests_list = list(requests) if not isinstance(requests, list) else requests
-    n = len(requests_list)
+    @dataclass(kw_only=True)
+    class _Store:
+        """Auxiliary data structures used for efficiently grouping requests for batched sampling."""
 
-    if n == 0:
-        return {}
+        slots_needing_recompute: set
+        """Slots where strategy needs (re)computation. Populated in setup_sampler_step."""
+        need_processed: list
+        """Length: max_num_sequences. True if logprob mode is PROCESSED and return_log_probs is set."""
+        need_raw: list
+        """Length: max_num_sequences. True if logprob mode is RAW and return_log_probs is set."""
+        strategies: list
+        """Length: max_num_sequences. Stores cached Strategy tuple for each seq_slot."""
+        uses_beam_search: list
+        """Length: max_num_sequences. True if max_beam_width > 1 for this slot."""
+        non_greedy_slots: set
+        """Slots with non-greedy strategies. Used to limit draft-token checks."""
+        speculation_needs_probs: list
+        """Length: max_num_sequences. True if request has draft tokens and non-greedy sampling."""
+        needs_probs: list
+        """Length: max_num_sequences. True if speculation_needs_probs or need_processed."""
 
-    assert not seq_slots.is_cuda, "seq_slots is expected to be a host tensor"
-    seq_slots_list = seq_slots.tolist()
+    def __init__(self, max_num_sequences: int):
+        # Use Python lists instead of tensors to avoid .item() overhead in hot loops
+        speculation_needs_probs: list = [False] * max_num_sequences
+        need_processed: list = [False] * max_num_sequences
+        need_raw: list = [False] * max_num_sequences
+        needs_probs: list = [False] * max_num_sequences
+        strategies: list = [None] * max_num_sequences
+        uses_beam_search: list = [False] * max_num_sequences
+        slots_needing_recompute: set = set()
+        non_greedy_slots: set = set()
 
-    # Get strategies from cache, only recomputing for slots that need it.
-    # Recompute is needed for:
-    #   - Uncached slots (strategy is None) — recorded in store.slots_needing_recompute
-    #   - Beam search (beam_width_in changes) — kept in slots_needing_recompute permanently
-    #   - Speculative decoding (draft_tokens can change) — checked for non-greedy slots only
-
-    # Build strategies from cache in one shot (C-level list comprehension, ~50ns/elem)
-    s_strategies = store.strategies
-    strategies = [s_strategies[slot] for slot in seq_slots_list]
-
-    # Build slot→request_index mapping for targeted access
-    slot_to_idx = {slot: i for i, slot in enumerate(seq_slots_list)}
-    active_slots = set(slot_to_idx)
-
-    # 1) Slots pre-recorded for recompute (context-phase or beam search)
-    recompute_batch_slots = store.slots_needing_recompute & active_slots
-
-    # 2) Non-greedy slots where draft-token status may have changed
-    #    (For greedy: current_has_draft is always False, matching cached, so never stale)
-    draft_check_slots = (store.non_greedy_slots & active_slots) - recompute_batch_slots
-    for slot in draft_check_slots:
-        i = slot_to_idx[slot]
-        has_draft = bool(requests_list[i].py_draft_tokens)
-        if store.speculation_needs_probs[slot] != has_draft:
-            # Draft-token status changed — only update the affected flags.
-            # The strategy itself doesn't depend on draft tokens (only on sampling params).
-            store.speculation_needs_probs[slot] = has_draft
-            store.needs_probs[slot] = has_draft or store.need_processed[slot]
-
-    # 3) Full recompute for the pre-recorded slots.
-    #    Every slot with a None strategy must already be in slots_needing_recompute
-    #    (populated by setup_sampler_step when a new request arrives).
-    assert None not in strategies or all(
-        seq_slots_list[i] in recompute_batch_slots for i in range(n) if strategies[i] is None
-    ), (
-        "Found slots with uncached strategies not registered in slots_needing_recompute. "
-        "Ensure setup_sampler_step is called before sample_async for new requests."
-    )
-
-    for slot in recompute_batch_slots:
-        i = slot_to_idx[slot]
-        request = requests_list[i]
-        has_draft_tokens = bool(request.py_draft_tokens)
-
-        strategy = _request_strategy(request, vocab_size=vocab_size)
-        store.strategies[slot] = strategy
-        strategies[i] = strategy
-
-        is_greedy = strategy == GREEDY
-        store.speculation_needs_probs[slot] = has_draft_tokens and not is_greedy
-        store.need_processed[slot] = (
-            request.py_logprobs_mode == LogprobMode.PROCESSED and request.return_log_probs
+        self._store = self._Store(
+            speculation_needs_probs=speculation_needs_probs,
+            need_processed=need_processed,
+            need_raw=need_raw,
+            needs_probs=needs_probs,
+            strategies=strategies,
+            uses_beam_search=uses_beam_search,
+            slots_needing_recompute=slots_needing_recompute,
+            non_greedy_slots=non_greedy_slots,
         )
-        store.need_raw[slot] = (
-            request.py_logprobs_mode == LogprobMode.RAW and request.return_log_probs
+
+    def prepare_for_new_request(self, request: LlmRequest, slot: int):
+        store = self._store
+        # Initialize cached data for this slot (prevents stale data from previous request)
+        store.strategies[slot] = None
+        store.uses_beam_search[slot] = _get_max_beam_width(request) > 1
+        # Mark slot for strategy recomputation in _group_requests_by_strategy_key
+        store.slots_needing_recompute.add(slot)
+        store.non_greedy_slots.discard(slot)  # reset until strategy is computed
+
+    def group_requests_by_strategy_key(
+        self,
+        requests: Iterable[LlmRequest],
+        *,
+        strategy_to_key: Callable[[Strategy], GenericStrategyKeyType],
+        pin_memory: bool = False,
+        seq_slots: torch.Tensor,
+        vocab_size: int,
+    ) -> dict[RequestGroupKey[GenericStrategyKeyType], RequestGroupValue]:
+        """
+        Optimized implementation with vectorized boolean operations and efficient grouping.
+
+        NB: Client code relies on request indices in returned torch.Tensor being sorted.
+        """
+        store = self._store
+
+        # Convert to list for efficient indexing
+        requests_list = list(requests) if not isinstance(requests, list) else requests
+        n = len(requests_list)
+
+        if n == 0:
+            return {}
+
+        assert not seq_slots.is_cuda, "seq_slots is expected to be a host tensor"
+        seq_slots_list = seq_slots.tolist()
+
+        # Get strategies from cache, only recomputing for slots that need it.
+        # Recompute is needed for:
+        #   - Uncached slots (strategy is None) — recorded in store.slots_needing_recompute
+        #   - Beam search (beam_width_in changes) — kept in slots_needing_recompute permanently
+        #   - Speculative decoding (draft_tokens can change) — checked for non-greedy slots only
+
+        # Build strategies from cache in one shot (C-level list comprehension, ~50ns/elem)
+        s_strategies = store.strategies
+        strategies = [s_strategies[slot] for slot in seq_slots_list]
+
+        # Build slot→request_index mapping for targeted access
+        slot_to_idx = {slot: i for i, slot in enumerate(seq_slots_list)}
+        active_slots = set(slot_to_idx)
+
+        # 1) Slots pre-recorded for recompute (context-phase or beam search)
+        recompute_batch_slots = store.slots_needing_recompute & active_slots
+
+        # 2) Non-greedy slots where draft-token status may have changed
+        #    (For greedy: current_has_draft is always False, matching cached, so never stale)
+        draft_check_slots = (store.non_greedy_slots & active_slots) - recompute_batch_slots
+        for slot in draft_check_slots:
+            i = slot_to_idx[slot]
+            has_draft = bool(requests_list[i].py_draft_tokens)
+            if store.speculation_needs_probs[slot] != has_draft:
+                # Draft-token status changed — only update the affected flags.
+                # The strategy itself doesn't depend on draft tokens (only on sampling params).
+                store.speculation_needs_probs[slot] = has_draft
+                store.needs_probs[slot] = has_draft or store.need_processed[slot]
+
+        # 3) Full recompute for the pre-recorded slots.
+        #    Every slot with a None strategy must already be in slots_needing_recompute
+        #    (populated by setup_sampler_step when a new request arrives).
+        assert None not in strategies or all(
+            seq_slots_list[i] in recompute_batch_slots for i in range(n) if strategies[i] is None
+        ), (
+            "Found slots with uncached strategies not registered in slots_needing_recompute. "
+            "Ensure setup_sampler_step is called before sample_async for new requests."
         )
-        store.needs_probs[slot] = store.speculation_needs_probs[slot] or store.need_processed[slot]
 
-        # Track non-greedy slots for future draft-token checks
-        if is_greedy:
-            store.non_greedy_slots.discard(slot)
-        else:
-            store.non_greedy_slots.add(slot)
+        for slot in recompute_batch_slots:
+            i = slot_to_idx[slot]
+            request = requests_list[i]
+            has_draft_tokens = bool(request.py_draft_tokens)
 
-        # Keep beam-search slots in the recompute set (they always need it);
-        # remove everything else (strategy is now cached).
-        if not store.uses_beam_search[slot]:
-            store.slots_needing_recompute.discard(slot)
+            strategy = _request_strategy(request, vocab_size=vocab_size)
+            store.strategies[slot] = strategy
+            strategies[i] = strategy
 
-    # Gather flags using list comprehension (faster than append in loop)
-    needs_probs = torch.tensor(
-        [store.needs_probs[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
-    )
-    speculation_needs_probs = torch.tensor(
-        [store.speculation_needs_probs[slot] for slot in seq_slots_list],
-        dtype=torch.bool,
-        device="cpu",
-    )
-    need_processed = torch.tensor(
-        [store.need_processed[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
-    )
-    need_raw = torch.tensor(
-        [store.need_raw[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
-    )
-    # Build strategy ID mapping for vectorized comparison (all on CPU).
-    # NB: set() does not preserve insertion order, so we use dict.fromkeys() to deduplicate while preserving order.
-    unique_strategies = list(dict.fromkeys(strategies))
-    strategy_to_id = {s: idx for idx, s in enumerate(unique_strategies)}
-    strategy_ids = torch.tensor(
-        [strategy_to_id[s] for s in strategies], dtype=torch.int32, device="cpu"
-    )
-
-    # Pre-allocate group_ids array
-    group_ids = torch.empty(n, dtype=torch.int32, device="cpu")
-
-    _next_gid = 0
-
-    def _provision_gid() -> int:
-        nonlocal _next_gid
-        gid = _next_gid
-        _next_gid += 1
-        return gid
-
-    unique_keys: defaultdict[tuple, int] = defaultdict(_provision_gid)
-
-    # Vectorized assignment: loop over unique combinations instead of all requests
-    for sid, strategy in enumerate(unique_strategies):
-        strat_mask = strategy_ids == sid
-
-        for needs_probs_val in (False, True):
-            # Vectorized mask for this (strategy, needs_probs) group
-            mask = strat_mask & (needs_probs if needs_probs_val else ~needs_probs)
-
-            if torch.any(mask):
-                strategy_key = strategy_to_key(strategy)  # Called once per group!
-                key = (strategy_key, needs_probs_val)
-                group_ids[mask] = unique_keys[key]  # Vectorized assignment
-
-    # Efficient grouping using sort
-    sorted_group_ids, sorted_order = torch.sort(group_ids, stable=True)
-    # Use prepend to detect a "change" at position 0, giving us group_starts directly
-    group_starts = torch.nonzero(
-        torch.diff(sorted_group_ids, prepend=torch.tensor([-1], device="cpu")) != 0
-    ).squeeze(1)
-    group_ends = torch.cat([group_starts[1:], torch.tensor([n], device="cpu")])
-    # Since groups are assigned in request order, gid → key is just list indexing
-    id_to_key = list(unique_keys)
-
-    # Build result dictionary efficiently
-    result: dict[RequestGroupKey, RequestGroupValue] = {}
-
-    for gid, (start, end) in enumerate(zip(group_starts.tolist(), group_ends.tolist())):
-        group_sorted_indices = sorted_order[start:end]
-        strategy_key, needs_probs_bool = id_to_key[gid]
-
-        indices_arr = group_sorted_indices.to(torch.int32)
-        # Convert to list for Python list indexing
-        group_sorted_indices_list = group_sorted_indices.tolist()
-        group_strategies = [strategies[i] for i in group_sorted_indices_list]
-        spec_mask = speculation_needs_probs[group_sorted_indices]
-        spec_indices = indices_arr[spec_mask]
-        processed_flags = need_processed[group_sorted_indices]
-        raw_flags = need_raw[group_sorted_indices]
-
-        if pin_memory:
-            indices_tensor = indices_arr.pin_memory()
-            spec_tensor = spec_indices.pin_memory()
-            processed_tensor = processed_flags.pin_memory()
-            raw_tensor = raw_flags.pin_memory()
-        else:
-            indices_tensor = indices_arr
-            spec_tensor = spec_indices
-            processed_tensor = processed_flags
-            raw_tensor = raw_flags
-
-        result[RequestGroupKey(strategy_key=strategy_key, needs_probs=needs_probs_bool)] = (
-            RequestGroupValue(
-                indices=indices_tensor,
-                strategies=group_strategies,
-                speculation_needs_probs_indices=spec_tensor,
-                need_processed_logprobs=processed_tensor,
-                need_raw_logprobs=raw_tensor,
+            is_greedy = strategy == GREEDY
+            store.speculation_needs_probs[slot] = has_draft_tokens and not is_greedy
+            store.need_processed[slot] = (
+                request.py_logprobs_mode == LogprobMode.PROCESSED and request.return_log_probs
             )
+            store.need_raw[slot] = (
+                request.py_logprobs_mode == LogprobMode.RAW and request.return_log_probs
+            )
+            store.needs_probs[slot] = (
+                store.speculation_needs_probs[slot] or store.need_processed[slot]
+            )
+
+            # Track non-greedy slots for future draft-token checks
+            if is_greedy:
+                store.non_greedy_slots.discard(slot)
+            else:
+                store.non_greedy_slots.add(slot)
+
+            # Keep beam-search slots in the recompute set (they always need it);
+            # remove everything else (strategy is now cached).
+            if not store.uses_beam_search[slot]:
+                store.slots_needing_recompute.discard(slot)
+
+        # Gather flags using list comprehension (faster than append in loop)
+        needs_probs = torch.tensor(
+            [store.needs_probs[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
+        )
+        speculation_needs_probs = torch.tensor(
+            [store.speculation_needs_probs[slot] for slot in seq_slots_list],
+            dtype=torch.bool,
+            device="cpu",
+        )
+        need_processed = torch.tensor(
+            [store.need_processed[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
+        )
+        need_raw = torch.tensor(
+            [store.need_raw[slot] for slot in seq_slots_list], dtype=torch.bool, device="cpu"
+        )
+        # Build strategy ID mapping for vectorized comparison (all on CPU).
+        # NB: set() does not preserve insertion order, so we use dict.fromkeys() to deduplicate while preserving order.
+        unique_strategies = list(dict.fromkeys(strategies))
+        strategy_to_id = {s: idx for idx, s in enumerate(unique_strategies)}
+        strategy_ids = torch.tensor(
+            [strategy_to_id[s] for s in strategies], dtype=torch.int32, device="cpu"
         )
 
-    return result
+        # Pre-allocate group_ids array
+        group_ids = torch.empty(n, dtype=torch.int32, device="cpu")
+
+        _next_gid = 0
+
+        def _provision_gid() -> int:
+            nonlocal _next_gid
+            gid = _next_gid
+            _next_gid += 1
+            return gid
+
+        unique_keys: defaultdict[tuple, int] = defaultdict(_provision_gid)
+
+        # Vectorized assignment: loop over unique combinations instead of all requests
+        for sid, strategy in enumerate(unique_strategies):
+            strat_mask = strategy_ids == sid
+
+            for needs_probs_val in (False, True):
+                # Vectorized mask for this (strategy, needs_probs) group
+                mask = strat_mask & (needs_probs if needs_probs_val else ~needs_probs)
+
+                if torch.any(mask):
+                    strategy_key = strategy_to_key(strategy)  # Called once per group!
+                    key = (strategy_key, needs_probs_val)
+                    group_ids[mask] = unique_keys[key]  # Vectorized assignment
+
+        # Efficient grouping using sort
+        sorted_group_ids, sorted_order = torch.sort(group_ids, stable=True)
+        # Use prepend to detect a "change" at position 0, giving us group_starts directly
+        group_starts = torch.nonzero(
+            torch.diff(sorted_group_ids, prepend=torch.tensor([-1], device="cpu")) != 0
+        ).squeeze(1)
+        group_ends = torch.cat([group_starts[1:], torch.tensor([n], device="cpu")])
+        # Since groups are assigned in request order, gid → key is just list indexing
+        id_to_key = list(unique_keys)
+
+        # Build result dictionary efficiently
+        result: dict[RequestGroupKey, RequestGroupValue] = {}
+
+        for gid, (start, end) in enumerate(zip(group_starts.tolist(), group_ends.tolist())):
+            group_sorted_indices = sorted_order[start:end]
+            strategy_key, needs_probs_bool = id_to_key[gid]
+
+            indices_arr = group_sorted_indices.to(torch.int32)
+            # Convert to list for Python list indexing
+            group_sorted_indices_list = group_sorted_indices.tolist()
+            group_strategies = [strategies[i] for i in group_sorted_indices_list]
+            spec_mask = speculation_needs_probs[group_sorted_indices]
+            spec_indices = indices_arr[spec_mask]
+            processed_flags = need_processed[group_sorted_indices]
+            raw_flags = need_raw[group_sorted_indices]
+
+            if pin_memory:
+                indices_tensor = indices_arr.pin_memory()
+                spec_tensor = spec_indices.pin_memory()
+                processed_tensor = processed_flags.pin_memory()
+                raw_tensor = raw_flags.pin_memory()
+            else:
+                indices_tensor = indices_arr
+                spec_tensor = spec_indices
+                processed_tensor = processed_flags
+                raw_tensor = raw_flags
+
+            result[RequestGroupKey(strategy_key=strategy_key, needs_probs=needs_probs_bool)] = (
+                RequestGroupValue(
+                    indices=indices_tensor,
+                    strategies=group_strategies,
+                    speculation_needs_probs_indices=spec_tensor,
+                    need_processed_logprobs=processed_tensor,
+                    need_raw_logprobs=raw_tensor,
+                )
+            )
+
+        return result
 
 
 def add_token(
@@ -1030,75 +1089,81 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
     @override
     def get_cache_indirection(self) -> torch.Tensor | None:
-        return self.store.cache_indirection
+        if (beam_search_store := self.store.beam_search_store) is not None:
+            return beam_search_store.cache_indirection
+        return None
 
     @override
     def is_generation_model(self) -> bool:
         return True
 
     @dataclass(kw_only=True)
+    class BeamSearchStore:
+        """Auxiliary data structures required for beam search."""
+
+        cache_indirection: torch.Tensor
+        """Shape: batch_size, beam_width, attention_size
+           Usage: Stores the cache indirection necessary for beam search sampling"""
+        cache_indirection_buffer: torch.Tensor
+        """Shape: batch_size, beam_width, attention_size
+           Usage: A second buffer used to update the cache indirection during sampling"""
+        cum_log_probs: torch.Tensor
+        """Shape: batch_size, beam_width
+           Usage: Stores the current cumulative logprob of each active beam for faster sampling"""
+        first_finish_reasons: torch.Tensor
+        """Shape: batch_size, beam_width
+           Usage: Stores the first finish reason for each beam"""
+        predecessor_beams: torch.Tensor
+        """Shape: batch_size, beam_width
+           Usage: Stores the predecessor beams for each beam used for stop word detection"""
+        original_tokens: torch.Tensor
+        """Shape: batch_size, beam_width, sequence_length
+           Usage: Stores the original tokens for each beam.
+           This is used to recover the original tokens for each beam when streaming is enabled"""
+
+    @dataclass(kw_only=True)
+    class LogProbsStore:
+        """Auxiliary data structures used for log-probs handling."""
+
+        sampled_log_prob_indices: torch.Tensor
+        """Shape: batch_size, beam_width, max_tokens
+           Usage: Stores the token indices of the sampled logprobs"""
+        sampled_log_probs: torch.Tensor
+        """Shape: batch_size, beam_width, max_tokens
+           Usage: Stores the values of the sampled logprobs"""
+        sampled_log_prob_ranks: torch.Tensor
+        """Shape: batch_size, beam_width, max_tokens
+           Usage: Stores the ranks of the sampled logprobs"""
+        topk_indices: torch.Tensor
+        """Shape: batch_size, max_tokens, max_topk_logprobs
+           Usage: Stores the token indices of the topk logprobs"""
+        topk_vals: torch.Tensor
+        """Shape: batch_size, max_tokens, max_topk_logprobs
+           Usage: Stores the values of the topk logprobs"""
+
+    @dataclass(kw_only=True)
     class Store:
         new_tokens: torch.Tensor
-        """Shape: See cpp DecoderState.getAllNewTokens()"""
+        """Device tensor containing latest sampled tokens.
+
+        Shape: See cpp DecoderState.getAllNewTokens().
+        """
+        finish_reasons: torch.Tensor
+        """Shape: max_tokens, batch_size, beam_width
+           Usage: Stores the currently estimated finish_reasons for each request"""
+
+        # Per-request static metadata
         max_lengths_tensor: torch.Tensor
         """Shape: batch_size
            Usage: Stores the maximum lengths for each request"""
         end_ids: torch.Tensor
         """Shape: batch_size
            Usage: Stores the end ids for each request"""
-        finish_reasons: torch.Tensor
-        """Shape: max_tokens, batch_size, beam_width
-           Usage: Stores the currently estimated finish_reasons for each request"""
-        cache_indirection: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, attention_size
-           Usage: Stores the cache indirection necessary for beam search sampling"""
-        cache_indirection_buffer: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, attention_size
-           Usage: A second buffer used to update the cache indirection during sampling"""
-        cum_log_probs: torch.Tensor | None = None
-        """Shape: batch_size, beam_width
-           Usage: Stores the current cumulative logprob of each active beam for faster sampling"""
-        sampled_log_prob_indices: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, max_tokens
-           Usage: Stores the token indices of the sampled logprobs"""
-        sampled_log_probs: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, max_tokens
-           Usage: Stores the values of the sampled logprobs"""
-        sampled_log_prob_ranks: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, max_tokens
-           Usage: Stores the ranks of the sampled logprobs"""
-        topk_indices: torch.Tensor | None = None
-        """Shape: batch_size, max_tokens, max_topk_logprobs
-           Usage: Stores the token indices of the topk logprobs"""
-        topk_vals: torch.Tensor | None = None
-        """Shape: batch_size, max_tokens, max_topk_logprobs
-           Usage: Stores the values of the topk logprobs"""
-        first_finish_reasons: torch.Tensor | None = None
-        """Shape: batch_size, beam_width
-           Usage: Stores the first finish reason for each beam"""
-        predecessor_beams: torch.Tensor | None = None
-        """Shape: batch_size, beam_width
-           Usage: Stores the predecessor beams for each beam used for stop word detection"""
-        original_tokens: torch.Tensor | None = None
-        """Shape: batch_size, beam_width, sequence_length
-           Usage: Stores the original tokens for each beam.
-           This is used to recover the original tokens for each beam when streaming is enabled"""
-        speculation_needs_probs: list | None = None
-        """Length: max_num_sequences. True if request has draft tokens and non-greedy sampling."""
-        need_processed: list | None = None
-        """Length: max_num_sequences. True if logprob mode is PROCESSED and return_log_probs is set."""
-        need_raw: list | None = None
-        """Length: max_num_sequences. True if logprob mode is RAW and return_log_probs is set."""
-        needs_probs: list | None = None
-        """Length: max_num_sequences. True if speculation_needs_probs or need_processed."""
-        strategies: list | None = None
-        """Length: max_num_sequences. Stores cached Strategy tuple for each seq_slot."""
-        uses_beam_search: list | None = None
-        """Length: max_num_sequences. True if max_beam_width > 1 for this slot."""
-        slots_needing_recompute: set | None = None
-        """Slots where strategy needs (re)computation. Populated in setup_sampler_step."""
-        non_greedy_slots: set | None = None
-        """Slots with non-greedy strategies. Used to limit draft-token checks."""
+
+        beam_search_store: "TorchSampler.BeamSearchStore | None" = None
+        """Holds data related to beam search."""
+        log_probs_store: "TorchSampler.LogProbsStore"
+        """Holds data related to log-probs handling."""
 
         def __post_init__(self):
             assert self.new_tokens.shape == self.finish_reasons.shape
@@ -1120,25 +1185,15 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         # These are 0 sized tensors, if topk-logprobs are not used
         topk_indices = torch.empty(self.TOPK_LOGPROBS_SHAPE, device="cuda", dtype=torch.int32)
         topk_vals = torch.empty(self.TOPK_LOGPROBS_SHAPE, device="cuda", dtype=torch.float32)
+        log_probs_store = self.LogProbsStore(
+            sampled_log_prob_indices=sampled_log_prob_indices,
+            sampled_log_probs=sampled_log_probs,
+            sampled_log_prob_ranks=sampled_log_prob_ranks,
+            topk_indices=topk_indices,
+            topk_vals=topk_vals,
+        )
 
-        # Only used for beam search
-        cache_indirection: torch.Tensor | None = None
-        cache_indirection_buffer: torch.Tensor | None = None
-        cum_log_probs: torch.Tensor | None = None
-        predecessor_beams: torch.Tensor | None = None
-        original_tokens: torch.Tensor | None = None
-        first_finish_reasons: torch.Tensor | None = None
-
-        # Use Python lists instead of tensors to avoid .item() overhead in hot loops
-        speculation_needs_probs: list = [False] * self.max_num_sequences
-        need_processed: list = [False] * self.max_num_sequences
-        need_raw: list = [False] * self.max_num_sequences
-        needs_probs: list = [False] * self.max_num_sequences
-        strategies: list = [None] * self.max_num_sequences
-        uses_beam_search: list = [False] * self.max_num_sequences
-        slots_needing_recompute: set = set()
-        non_greedy_slots: set = set()
-
+        beam_search_store = None
         if self._use_beam_search:
             cache_indirection = torch.empty(
                 self.CACHE_INDIRECTION_SHAPE, device="cuda", dtype=torch.int
@@ -1150,30 +1205,21 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             predecessor_beams = int_tensor(self.CACHE_INDIRECTION_SHAPE[:-1])
             original_tokens = int_tensor(self.CACHE_INDIRECTION_SHAPE)
             first_finish_reasons = int_tensor(self.CACHE_INDIRECTION_SHAPE[:-1])
+            beam_search_store = self.BeamSearchStore(
+                cache_indirection=cache_indirection,
+                cache_indirection_buffer=cache_indirection_buffer,
+                cum_log_probs=cum_log_probs,
+                predecessor_beams=predecessor_beams,
+                original_tokens=original_tokens,
+                first_finish_reasons=first_finish_reasons,
+            )
         return self.Store(
             new_tokens=new_tokens,
             finish_reasons=finish_reasons,
             max_lengths_tensor=max_lengths_tensor,
             end_ids=end_ids,
-            cache_indirection=cache_indirection,
-            cache_indirection_buffer=cache_indirection_buffer,
-            cum_log_probs=cum_log_probs,
-            sampled_log_prob_indices=sampled_log_prob_indices,
-            sampled_log_probs=sampled_log_probs,
-            sampled_log_prob_ranks=sampled_log_prob_ranks,
-            topk_indices=topk_indices,
-            topk_vals=topk_vals,
-            predecessor_beams=predecessor_beams,
-            original_tokens=original_tokens,
-            first_finish_reasons=first_finish_reasons,
-            speculation_needs_probs=speculation_needs_probs,
-            need_processed=need_processed,
-            need_raw=need_raw,
-            needs_probs=needs_probs,
-            strategies=strategies,
-            uses_beam_search=uses_beam_search,
-            slots_needing_recompute=slots_needing_recompute,
-            non_greedy_slots=non_greedy_slots,
+            log_probs_store=log_probs_store,
+            beam_search_store=beam_search_store,
         )
 
     @dataclass(frozen=True, kw_only=True)
@@ -1212,6 +1258,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         # So, we temporarily exit inference mode.
         with torch.inference_mode(False):
             self.store = self._create_store()
+            self._request_grouper = _CachingRequestGrouper(self.max_num_sequences)
             # Helper tensors for finish_reasons:
             """Preallocate buffer needed for torch.nonzero_static(..., out=finish_reasons_nonzero_static_buffer).
             See `def _write_reason`."""
@@ -1394,19 +1441,22 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         return False
 
     @nvtx_range("update_original_tokens")
+    @staticmethod
     def _update_original_tokens(
-        self, seq_slots: torch.Tensor, seq_lens: torch.Tensor, new_tokens: torch.Tensor
+        original_tokens: torch.Tensor,
+        seq_slots: torch.Tensor,
+        seq_lens: torch.Tensor,
+        new_tokens: torch.Tensor,
     ):
         """Update the original tokens storage for the request with the newly sampled tokens
 
         When using streaming a requests tokens may be altered, leading to wrong results when called multiple times.
         Store the original tokens in a separate buffer to use them as a consistent basis
         when updating the tokens in a request."""
-        assert self.store.original_tokens is not None
-        assert new_tokens.device == self.store.original_tokens.device, (
+        assert new_tokens.device == original_tokens.device, (
             "new_tokens and original_tokens must be on the same device"
         )
-        self.store.original_tokens[seq_slots, :, seq_lens] = new_tokens[0, seq_slots, :]
+        original_tokens[seq_slots, :, seq_lens] = new_tokens[0, seq_slots, :]
 
     def _convert_logprobs_tensor_to_list(
         self,
@@ -1660,7 +1710,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
         return num_accepted_draft_tokens - 1
 
-    def _is_new_request(self, request: LlmRequest) -> bool:
+    @staticmethod
+    def _is_new_request(request: LlmRequest) -> bool:
         return (
             not request.is_finished
             and not request.py_is_draft
@@ -1669,6 +1720,10 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 or request.is_disagg_generation_transmission_complete
             )
         )
+
+    @classmethod
+    def _filter_new_requests(cls, requests: ScheduledRequests) -> list[LlmRequest]:
+        return [request for request in requests.context_requests if cls._is_new_request(request)]
 
     @override
     def setup_sampler_step(self, scheduled_requests: ScheduledRequests):
@@ -1681,27 +1736,21 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         max_lens: list[int] = []
         end_ids: list[int] = []
         prompt_lens: list[int] = []
-        for request in scheduled_requests.context_requests:
-            if self._is_new_request(request):
-                assert request.py_seq_slot is not None
-                slot = request.py_seq_slot
-                seq_slots.append(slot)
-                max_lens.append(
-                    min(self.max_seq_len, request.orig_prompt_len + request.py_max_new_tokens)
-                )
-                end_ids.append(request.py_end_id if request.py_end_id is not None else -1)
+        for request in self._filter_new_requests(scheduled_requests):
+            slot = request.py_seq_slot
+            assert slot is not None
+            seq_slots.append(slot)
+            max_lens.append(
+                min(self.max_seq_len, request.orig_prompt_len + request.py_max_new_tokens)
+            )
+            end_ids.append(request.py_end_id if request.py_end_id is not None else -1)
 
-                if self._use_beam_search:
-                    if request.py_return_log_probs and request.py_num_logprobs > 1:
-                        raise ValueError("Beam search does not support multiple logprobs")
-                    prompt_lens.append(request.py_prompt_len)
+            if self._use_beam_search:
+                if request.py_return_log_probs and request.py_num_logprobs > 1:
+                    raise ValueError("Beam search does not support multiple logprobs")
+                prompt_lens.append(request.py_prompt_len)
 
-                # Initialize cached data for this slot (prevents stale data from previous request)
-                self.store.strategies[slot] = None
-                self.store.uses_beam_search[slot] = _get_max_beam_width(request) > 1
-                # Mark slot for strategy recomputation in _group_requests_by_strategy_key
-                self.store.slots_needing_recompute.add(slot)
-                self.store.non_greedy_slots.discard(slot)  # reset until strategy is computed
+            self._request_grouper.prepare_for_new_request(request, slot)
 
         if len(seq_slots) > 0:
             full_list = [seq_slots, max_lens, end_ids]
@@ -1719,13 +1768,19 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             if self._use_beam_search:
                 prompt_lens_tensor = full_list_tensor[3]
+                beam_search_store = self.store.beam_search_store
+                assert beam_search_store is not None
                 self._prepare_beam_search(
+                    beam_search_store,
+                    self.store.log_probs_store,
                     seq_slots=seq_slots_tensor,
                     prompt_lens=prompt_lens_tensor,
                 )
 
+    @staticmethod
     def _prepare_beam_search(
-        self,
+        beam_search_store: BeamSearchStore,
+        log_probs_store: LogProbsStore,
         seq_slots: torch.Tensor,
         prompt_lens: torch.Tensor,
     ):
@@ -1734,51 +1789,51 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         If the last context chunk is being processed,
         initialize/reset the buffers for the request
         """
-        assert self.store.cache_indirection is not None
-        assert self.store.cum_log_probs is not None
-        assert self.store.sampled_log_probs is not None
-        assert self.store.sampled_log_prob_ranks is not None
-        assert self.store.predecessor_beams is not None
-        assert self.store.first_finish_reasons is not None
-        assert self.store.original_tokens is not None
-        self.store.cache_indirection[seq_slots, :, prompt_lens] = torch.zeros(
+        cache_indirection = beam_search_store.cache_indirection
+        cache_indirection[seq_slots, :, prompt_lens] = torch.zeros(
             (1, 1),
-            dtype=self.store.cache_indirection.dtype,
-            device=self.store.cache_indirection.device,
+            dtype=cache_indirection.dtype,
+            device=cache_indirection.device,
         )
-        self.store.cum_log_probs[seq_slots] = torch.zeros(
+        cum_log_probs = beam_search_store.cum_log_probs
+        cum_log_probs[seq_slots] = torch.zeros(
             (1,),
-            dtype=self.store.cum_log_probs.dtype,
-            device=self.store.cum_log_probs.device,
+            dtype=cum_log_probs.dtype,
+            device=cum_log_probs.device,
         )
-        self.store.sampled_log_probs[seq_slots] = torch.zeros(
+        sampled_log_probs = log_probs_store.sampled_log_probs
+        sampled_log_probs[seq_slots] = torch.zeros(
             (1,),
-            dtype=self.store.sampled_log_probs.dtype,
-            device=self.store.sampled_log_probs.device,
+            dtype=sampled_log_probs.dtype,
+            device=sampled_log_probs.device,
         )
-        self.store.sampled_log_prob_ranks[seq_slots] = torch.zeros(
+        sampled_log_prob_ranks = log_probs_store.sampled_log_prob_ranks
+        sampled_log_prob_ranks[seq_slots] = torch.zeros(
             (1,),
-            dtype=self.store.sampled_log_prob_ranks.dtype,
-            device=self.store.sampled_log_prob_ranks.device,
+            dtype=sampled_log_prob_ranks.dtype,
+            device=sampled_log_prob_ranks.device,
         )
-        self.store.predecessor_beams[seq_slots] = torch.zeros(
+        predecessor_beams = beam_search_store.predecessor_beams
+        predecessor_beams[seq_slots] = torch.zeros(
             (1,),
-            dtype=self.store.predecessor_beams.dtype,
-            device=self.store.predecessor_beams.device,
+            dtype=predecessor_beams.dtype,
+            device=predecessor_beams.device,
         )
-        self.store.first_finish_reasons[seq_slots] = (
+        first_finish_reasons = beam_search_store.first_finish_reasons
+        first_finish_reasons[seq_slots] = (
             torch.tensor(
                 FinishReason.NOT_FINISHED.value,
                 pin_memory=True,
-                dtype=self.store.first_finish_reasons.dtype,
+                dtype=first_finish_reasons.dtype,
             )
-            .to(self.store.first_finish_reasons.device, non_blocking=True)
+            .to(first_finish_reasons.device, non_blocking=True)
             .unsqueeze(0)
         )
-        self.store.original_tokens[seq_slots] = torch.zeros(
+        original_tokens = beam_search_store.original_tokens
+        original_tokens[seq_slots] = torch.zeros(
             (1,),
-            dtype=self.store.original_tokens.dtype,
-            device=self.store.original_tokens.device,
+            dtype=original_tokens.dtype,
+            device=original_tokens.device,
         )
 
     @torch.inference_mode()
@@ -2006,12 +2061,13 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             # early return if no tokens have been generated yet or the request is already finished
             return None
 
-        assert self.store.cache_indirection is not None
-        assert self.store.original_tokens is not None
-        cache_indirection = self.store.cache_indirection[
+        beam_search_store = self.store.beam_search_store
+        assert beam_search_store is not None
+
+        cache_indirection = beam_search_store.cache_indirection[
             request.py_seq_slot, :num_beams, prompt_length:num_tokens
         ]
-        current_path = self.store.original_tokens[
+        current_path = beam_search_store.original_tokens[
             request.py_seq_slot, :num_beams, prompt_length:num_tokens
         ]
 
@@ -2026,15 +2082,14 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             return new_path
 
         if request.py_return_log_probs:
-            assert self.store.sampled_log_probs is not None
-            assert self.store.cum_log_probs is not None
-            sampled_log_probs = self.store.sampled_log_probs[request.py_seq_slot, :num_beams].view(
-                -1, 1
-            )
+            log_probs_store = self.store.log_probs_store
+            sampled_log_probs = log_probs_store.sampled_log_probs[
+                request.py_seq_slot, :num_beams
+            ].view(-1, 1)
             sampled_logprobs_indices = self.store.new_tokens[
                 0, request.py_seq_slot, :num_beams
             ].view(-1, 1)
-            cum_logprobs = self.store.cum_log_probs[request.py_seq_slot, :num_beams]
+            cum_logprobs = beam_search_store.cum_log_probs[request.py_seq_slot, :num_beams]
 
             # enqueue async D2H copies
             sampled_log_probs = self._copy_to_host(sampled_log_probs)
@@ -2169,39 +2224,26 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         grouped_requests_with_metadata: dict[
             RequestGroupKey[GenericStrategyKeyType], RequestGroupValueWithMetadata
         ] = {}
+        beam_search_store = self.store.beam_search_store
+        log_probs_store = self.store.log_probs_store
         for key, value in grouped_requests.items():
             metadata_type = get_metadata_type_for_group_fn(key.strategy_key)
             if metadata_type is BeamSearchMetadata:
+                assert beam_search_store is not None
                 assert seq_lens is not None, "seq_lens is required for beam search"
-                assert self.store.cache_indirection is not None
-                assert self.store.cache_indirection_buffer is not None
-                assert self.store.cum_log_probs is not None
-                assert self.store.sampled_log_probs is not None
-                assert self.store.first_finish_reasons is not None
-                assert self.store.predecessor_beams is not None
                 metadata = BeamSearchMetadata(
-                    cache_indirection=self.store.cache_indirection,
-                    cache_indirection_buffer=self.store.cache_indirection_buffer,
-                    cum_log_probs=self.store.cum_log_probs,
-                    new_log_probs=self.store.sampled_log_probs[..., DEFAULT_STEP_IDX],
+                    cache_indirection=beam_search_store.cache_indirection,
+                    cache_indirection_buffer=beam_search_store.cache_indirection_buffer,
+                    cum_log_probs=beam_search_store.cum_log_probs,
+                    new_log_probs=log_probs_store.sampled_log_probs[..., DEFAULT_STEP_IDX],
                     seq_slots=seq_slots[grouped_requests[key].indices].to(
                         device="cuda", dtype=torch.int64, non_blocking=True
                     ),  # Should be on device for beam search, need long for index_copy_
                     seq_lens=seq_lens[grouped_requests[key].indices].to(
                         device="cuda", non_blocking=True
                     ),  # Should be on device for beam search
-                    finished_beams=self.store.first_finish_reasons,
-                    predecessor_beams=self.store.predecessor_beams,
-                    end_ids=torch.tensor(
-                        [
-                            requests[request_idx].py_end_id
-                            for request_idx in grouped_requests[key].indices
-                        ],
-                        dtype=torch.int32,
-                        pin_memory=True,
-                    ).to(
-                        device="cuda", non_blocking=True
-                    ),  # end_ids should be on device for beam search
+                    finished_beams=beam_search_store.first_finish_reasons,
+                    predecessor_beams=beam_search_store.predecessor_beams,
                 )
             elif metadata_type is None:
                 metadata = None
@@ -2217,8 +2259,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             )
         return grouped_requests_with_metadata
 
+    @staticmethod
     def _check_beam_search_stop_criteria(
-        self,
         request: LlmRequest,
         finish_reasons: torch.Tensor,
     ) -> torch.Tensor:
@@ -2230,7 +2272,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             finish_reasons[: request.sampling_config.beam_width] > 0
         ).sum() == request.sampling_config.beam_width
 
-    def _check_stop_words_length(self, request: LlmRequest) -> bool:
+    @staticmethod
+    def _check_stop_words_length(request: LlmRequest) -> bool:
         """Check if the stop words length is greater than 1"""
         if request.py_stop_words_list is not None:
             _, cumsum = request.py_stop_words_list
@@ -2347,7 +2390,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
     def _prepare_log_probs(self, requests: list[LlmRequest]) -> None:
         self.batch_max_topk_logprobs = max(
-            (req.py_num_logprobs or 0 for req in requests), default=0
+            (req.py_num_logprobs or 0 for req in requests),
+            default=0,
         )
         if self.max_topk_logprobs < self.batch_max_topk_logprobs:
             self.max_topk_logprobs = self.batch_max_topk_logprobs
@@ -2356,10 +2400,9 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 self.max_tokens,
                 self.max_topk_logprobs,
             )
-            assert self.store.topk_vals is not None
-            assert self.store.topk_indices is not None
-            self.store.topk_vals.resize_(self.TOPK_LOGPROBS_SHAPE)
-            self.store.topk_indices.resize_(self.TOPK_LOGPROBS_SHAPE)
+            log_probs_store = self.store.log_probs_store
+            log_probs_store.topk_vals.resize_(self.TOPK_LOGPROBS_SHAPE)
+            log_probs_store.topk_indices.resize_(self.TOPK_LOGPROBS_SHAPE)
 
     @override
     @torch.inference_mode()
@@ -2400,29 +2443,34 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         finish_reasons = self.store.finish_reasons
         seq_slots = seq_slots_host.to(device="cuda", non_blocking=True)
         seq_lens = seq_lens_host.to(device="cuda", non_blocking=True)
-        first_finish_reasons = self.store.first_finish_reasons if self._use_beam_search else None
 
+        beam_search_store = self.store.beam_search_store
+        assert self._use_beam_search == (beam_search_store is not None)
         self._write_finish_reasons(
             requests,
             finish_reasons=finish_reasons,
             seq_slots=seq_slots,
             seq_lens=seq_lens,
             new_tokens=new_tokens,
-            first_finish_reasons=first_finish_reasons,
-            predecessor_beams=self.store.predecessor_beams,
+            first_finish_reasons=(
+                beam_search_store.first_finish_reasons if beam_search_store is not None else None
+            ),
+            predecessor_beams=(
+                beam_search_store.predecessor_beams if beam_search_store is not None else None
+            ),
         )
         finish_reasons_host = self._copy_to_host(finish_reasons)
 
         beam_history_builders = None
         if self._use_beam_search:
-            assert first_finish_reasons is not None
+            assert beam_search_store is not None
+            first_finish_reasons = beam_search_store.first_finish_reasons
             assert seq_lens_host is not None, "seq_lens is required for beam search"
-            assert self.store.first_finish_reasons is not None, (
-                "first_finish_reasons must be provided"
-            )
             seq_lens = seq_lens_host.to(device="cuda", non_blocking=True)
-            first_finish_reasons_host = self._copy_to_host(self.store.first_finish_reasons)
-            self._update_original_tokens(seq_slots, seq_lens, new_tokens)
+            first_finish_reasons_host = self._copy_to_host(first_finish_reasons)
+            self._update_original_tokens(
+                beam_search_store.original_tokens, seq_slots, seq_lens, new_tokens
+            )
             beam_history_builders = self._prepare_beam_histories(
                 requests, finish_reasons=first_finish_reasons
             )
@@ -2432,24 +2480,16 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         # copy logprobs to host
         logprobs_state: LogProbsState | None = None
         if self._return_log_probs(requests):
-            assert self.store.topk_vals is not None, "topk_vals must be provided"
-            assert self.store.topk_indices is not None, "topk_indices must be provided"
-            assert self.store.sampled_log_probs is not None, "sampled_log_probs must be provided"
-            assert self.store.sampled_log_prob_indices is not None, (
-                "sampled_log_prob_indices must be provided"
-            )
-            assert self.store.sampled_log_prob_ranks is not None, (
-                "sampled_log_prob_ranks must be provided"
-            )
+            log_probs_store = self.store.log_probs_store
             host_topk_vals = self._copy_to_host(
-                self.store.topk_vals[..., : self.batch_max_topk_logprobs]
+                log_probs_store.topk_vals[..., : self.batch_max_topk_logprobs]
             )
             host_topk_indices = self._copy_to_host(
-                self.store.topk_indices[..., : self.batch_max_topk_logprobs]
+                log_probs_store.topk_indices[..., : self.batch_max_topk_logprobs]
             )
-            host_sampled_vals = self._copy_to_host(self.store.sampled_log_probs)
-            host_sampled_indices = self._copy_to_host(self.store.sampled_log_prob_indices)
-            host_sampled_rank = self._copy_to_host(self.store.sampled_log_prob_ranks)
+            host_sampled_vals = self._copy_to_host(log_probs_store.sampled_log_probs)
+            host_sampled_indices = self._copy_to_host(log_probs_store.sampled_log_prob_indices)
+            host_sampled_rank = self._copy_to_host(log_probs_store.sampled_log_prob_ranks)
             logprobs_state = LogProbsState(
                 topk_vals=host_topk_vals,
                 topk_indices=host_topk_indices,
@@ -2611,11 +2651,10 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         token_dtype: torch.dtype,
         return_log_probs: bool,
     ) -> _BatchedSamplingResult:
-        grouped_requests = _group_requests_by_strategy_key(
+        grouped_requests = self._request_grouper.group_requests_by_strategy_key(
             requests,
             pin_memory=True,
             strategy_to_key=self._grouped_sampler_cls.strategy_grouping_key,
-            store=self.store,
             seq_slots=seq_slots,
             vocab_size=logits_cuda.size(1),  # Dummy value; strategy should already be cached
         )
@@ -3303,17 +3342,14 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
         any_request_without_beam_search = local_group_req_indices.shape[0] > 0
 
+        log_probs_store = self.store.log_probs_store
+        sampled_log_prob_indices = log_probs_store.sampled_log_prob_indices
+        sampled_log_prob_ranks = log_probs_store.sampled_log_prob_ranks
         if any_request_without_beam_search:
-            assert self.store.sampled_log_probs is not None, "sampled_log_probs must be provided"
-            assert self.store.sampled_log_prob_indices is not None, (
-                "sampled_log_prob_indices must be provided"
-            )
-            assert self.store.sampled_log_prob_ranks is not None, (
-                "sampled_log_prob_ranks must be provided"
-            )
+            sampled_log_probs = log_probs_store.sampled_log_probs
             # NB: Already begin copy here, to overlap with the remaining host code
             padded_indices_cuda = padded_indexer[local_group_req_indices].to(
-                device=self.store.sampled_log_probs.device, non_blocking=True
+                device=sampled_log_probs.device, non_blocking=True
             )
 
             # get indices of the logits after grouping
@@ -3330,8 +3366,6 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             # Process the topk logprobs
             if self.batch_max_topk_logprobs > 0:
-                assert self.store.topk_vals is not None, "topk_vals must be provided"
-                assert self.store.topk_indices is not None, "topk_indices must be provided"
                 # Get the topk logprobs
                 # The request indices in the batch before grouping
                 group_req_indices = batched_sampling_result.batch_req_indices[
@@ -3345,10 +3379,10 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 expanded_indices_cuda = padded_indices_cuda.view(-1, 1).expand(
                     -1, topk_vals_cuda.shape[-1]
                 )
-                self.store.topk_vals[..., : self.batch_max_topk_logprobs].view(
+                log_probs_store.topk_vals[..., : self.batch_max_topk_logprobs].view(
                     self.max_num_sequences * self.max_tokens, self.batch_max_topk_logprobs
                 ).scatter_(dim=0, index=expanded_indices_cuda, src=topk_vals_cuda)
-                self.store.topk_indices[..., : self.batch_max_topk_logprobs].view(
+                log_probs_store.topk_indices[..., : self.batch_max_topk_logprobs].view(
                     self.max_num_sequences * self.max_tokens, self.batch_max_topk_logprobs
                 ).scatter_(
                     dim=0, index=expanded_indices_cuda, src=topk_indices_cuda.to(torch.int32)
@@ -3373,18 +3407,17 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             sampled_vals_cuda = sampled_vals_cuda.squeeze(1)
 
-            self.store.sampled_log_prob_indices.view(
+            sampled_log_prob_indices.view(
                 self.max_num_sequences * self.max_tokens * self.max_beam_width
             ).scatter_(dim=0, index=padded_indices_cuda, src=sampled_indices_cuda)
-            self.store.sampled_log_probs.view(
+            sampled_log_probs.view(
                 self.max_num_sequences * self.max_tokens * self.max_beam_width
             ).scatter_(dim=0, index=padded_indices_cuda, src=sampled_vals_cuda)
-            self.store.sampled_log_prob_ranks.view(
+            sampled_log_prob_ranks.view(
                 self.max_num_sequences * self.max_tokens * self.max_beam_width
             ).scatter_(dim=0, index=padded_indices_cuda, src=sampled_rank_cuda)
 
         if self._use_beam_search:
-            assert self.store.sampled_log_prob_indices is not None
             local_group_req_indices_with_beam_search = torch.tensor(
                 [
                     req_id
@@ -3412,8 +3445,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 )
                 padded_indices_with_beam_search_cuda = padded_indexer[
                     local_group_req_indices_with_beam_search
-                ].to(device=self.store.sampled_log_prob_indices.device, non_blocking=True)
-                self.store.sampled_log_prob_indices.view(-1).scatter_(
+                ].to(device=sampled_log_prob_indices.device, non_blocking=True)
+                sampled_log_prob_indices.view(-1).scatter_(
                     dim=0,
                     index=padded_indices_with_beam_search_cuda,
                     src=group_next_tokens_with_beam_search_cuda,

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -63,7 +63,6 @@ class BeamSearchMetadata(StrategyMetadata):
     seq_lens: torch.Tensor
     finished_beams: torch.Tensor
     predecessor_beams: torch.Tensor
-    end_ids: torch.Tensor
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -227,19 +227,12 @@ class MTPSampler(Sampler[SampleStateMTP]):
         return True
 
     @dataclass(kw_only=True)
-    class Store(TorchSampler.Store):
+    class Store:
         new_tokens: torch.Tensor
         next_new_tokens: torch.Tensor
         next_draft_tokens: torch.Tensor
         new_tokens_lens: torch.Tensor
         max_total_draft_tokens: torch.Tensor
-        # Necessary to satisfy the interface of TorchSampler.Store
-        finish_reasons: None = None
-        end_ids: None = None
-        max_lengths_tensor: None = None
-
-        def __post_init__(self):
-            pass  # finish_reasons has no size to compare against new_tokens in MTPSampler
 
     def setup_sampler_step(self, scheduled_requests: ScheduledRequests):
         # MTPSampler does not need to setup additional buffers before the sampler step

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -525,7 +525,8 @@ def test_beam_search_sampling_batch_basic():
     logprobs = torch.log_softmax(logits, dim=-1)
     # adjust our expected log probs accordingly
     logprobs[beam_width - 1] = float('-inf')
-    logprobs[beam_width - 1, vocab_size - 1] = 0
+    end_id = vocab_size - 1
+    logprobs[beam_width - 1, end_id] = 0
     logprobs = logprobs.view(batch_size, beam_width * vocab_size)
 
     _, top_indices = torch.topk(logprobs, k=beam_width, dim=-1, sorted=True)

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -468,9 +468,6 @@ def test_beam_search_sampling_batch_basic():
     finished_beams[seq_slots[0], beam_width - 1] = FinishReason.STOP_WORDS.value
     finished_beams_result = finished_beams.clone()
 
-    # define our end ids for each request
-    end_ids = torch.tensor([vocab_size - 1] * batch_size, dtype=torch.int32)
-
     new_log_probs = torch.zeros((max_batch_size, beam_width),
                                 dtype=torch.float32)
     predecessor_beams = torch.zeros((max_batch_size, beam_width),
@@ -489,7 +486,6 @@ def test_beam_search_sampling_batch_basic():
         finished_beams=finished_beams_result,
         new_log_probs=new_log_probs_result,
         predecessor_beams=predecessor_beams_result,
-        end_ids=end_ids,
     )
 
     # Run beam search sampling
@@ -529,7 +525,7 @@ def test_beam_search_sampling_batch_basic():
     logprobs = torch.log_softmax(logits, dim=-1)
     # adjust our expected log probs accordingly
     logprobs[beam_width - 1] = float('-inf')
-    logprobs[beam_width - 1, end_ids[0]] = 0
+    logprobs[beam_width - 1, vocab_size - 1] = 0
     logprobs = logprobs.view(batch_size, beam_width * vocab_size)
 
     _, top_indices = torch.topk(logprobs, k=beam_width, dim=-1, sorted=True)
@@ -629,12 +625,14 @@ def create_default_sampler(test_params: GeneralTestParams) -> TorchSampler:
     assert max_seq_len > test_params.seq_len, "Max sequence length must be greater than sequence length"
     assert max_batch_size > test_params.batch_size, "Max batch size must be greater than batch size"
     assert max_batch_size > test_params.seq_slot, "Max batch size must be greater than sequence slot"
-    assert sampler.store.cache_indirection is not None
-    assert sampler.store.cache_indirection.shape == (
+    beam_search_store = sampler.store.beam_search_store
+    assert beam_search_store is not None
+    assert beam_search_store.cache_indirection is not None
+    assert beam_search_store.cache_indirection.shape == (
         max_batch_size, max_beam_width,
         max_seq_len), "Cache indirection shape mismatch"
-    assert sampler.store.original_tokens is not None
-    assert sampler.store.original_tokens.shape == (
+    assert beam_search_store.original_tokens is not None
+    assert beam_search_store.original_tokens.shape == (
         max_batch_size, max_beam_width,
         max_seq_len), "Original tokens shape mismatch"
     return sampler
@@ -661,9 +659,11 @@ def test_create_beam_history():
         seq_slot = test_params.seq_slot
         vocab_size = test_params.vocab_size
         num_logprobs = test_params.num_logprobs + 1
-        cache_indirection = sampler.store.cache_indirection
+        beam_search_store = sampler.store.beam_search_store
+        assert beam_search_store is not None
+        cache_indirection = beam_search_store.cache_indirection
         assert cache_indirection is not None
-        original_tokens = sampler.store.original_tokens
+        original_tokens = beam_search_store.original_tokens
         assert original_tokens is not None
         original_logprobs = torch.zeros(
             (beam_width, num_generated_tokens, num_logprobs),
@@ -673,7 +673,7 @@ def test_create_beam_history():
             (beam_width, num_generated_tokens, num_logprobs),
             dtype=torch.int32,
             device=original_tokens.device)
-        original_cum_logprobs = sampler.store.cum_log_probs
+        original_cum_logprobs = beam_search_store.cum_log_probs
         assert original_cum_logprobs is not None
 
         # Fill the request with some random tokens that will be overwritten by the beam search sampling
@@ -731,8 +731,8 @@ def test_create_beam_history():
             ) > 0, "Deterministic offsets must not only contain zeros. Otherwise change the seed."
 
         # set the new log probs and tokens for the beam search sampling
-        assert sampler.store.sampled_log_probs is not None
-        sampler.store.sampled_log_probs[
+        log_probs_store = sampler.store.log_probs_store
+        log_probs_store.sampled_log_probs[
             seq_slot, :beam_width] = original_logprobs[:beam_width,
                                                        num_generated_tokens - 1,
                                                        0:1]
@@ -814,7 +814,9 @@ def test_finish_beams():
         num_logprobs = 1
         request = create_default_request(test_params)
         sampler = create_default_sampler(test_params)
-        assert sampler.store.cache_indirection is not None
+        beam_search_store = sampler.store.beam_search_store
+        assert beam_search_store is not None
+        assert beam_search_store.cache_indirection is not None
 
         request.set_generated_tokens(
             torch.randint(0,


### PR DESCRIPTION
## Description

Detailed changes:

* Restore type correctness of sampler code
* Prune obsolete `BeamSearchMetadata.end_ids`
* Make type annotations stricter, by grouping fields with correlated values of `is not None`, reducing the amount of `assert ... is not None` required for type correctness.
* Encapsulate request grouping and related cache data structures
* Change an implementation detail in `TorchSampler.setup_sampler_step` to make tests more robust (cf. discussions in #11141)
* Further decouple `MTPSampler` from `TorchSampler`

## Test Coverage

n/a

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal sampler state management and data structure handling to improve code maintainability.

* **Breaking Changes**
  * Removed `end_ids` field from `BeamSearchMetadata`. Update code referencing this field accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->