### PR TITLE
[TRTLLM-11069][fix] validate requests outside sampling loop

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -41,6 +41,7 @@ from tensorrt_llm.tools.profiler.host_profile_tools.host_profiler import \
 
 from ..distributed import Distributed
 from ..expert_statistic import ExpertStatistic
+from ..models.modeling_llama import Llama4ForConditionalGeneration
 from ..models.modeling_utils import DecoderModelForCausalLM
 from ..modules.decoder_layer import DecoderLayer
 from ..speculative.drafter import Drafter
@@ -2209,20 +2210,9 @@ class PyExecutor:
             sampler_event=SamplerEvent(cuda_event=sampler_event),
         )
 
-    def _validate_request(self, request: LlmRequest):
-        # Validate beam width
-        sampling_config = request.sampling_config
-        if sampling_config is not None:
-            if sampling_config.beam_width != self.max_beam_width:
-                raise ValueError(
-                    f"Request beam width {sampling_config.beam_width} "
-                    f"is not equal to max_beam_width {self.max_beam_width}. This is not supported!"
-                )
-
-        # Check token ID ranges
+    def _validate_token_id_range(self, request: LlmRequest) -> None:
         if isinstance(self.model_engine.model, DecoderModelForCausalLM):
             # Only skip token‐range checks for Llama4 when the request has multimodal data
-            from ..models.modeling_llama import Llama4ForConditionalGeneration
             if isinstance(self.model_engine.model,
                           Llama4ForConditionalGeneration):
                 has_mm = bool(request.py_multimodal_data)
@@ -2242,6 +2232,22 @@ class PyExecutor:
             if not request.check_token_id_range(
                     self.model_engine.model.lm_head.num_embeddings):
                 raise ValueError("Token ID out of range")
+
+    def _validate_request(self, request: LlmRequest):
+        # Validate beam width
+        sampling_config = request.sampling_config
+        if sampling_config is not None:
+            if sampling_config.beam_width != self.max_beam_width:
+                raise ValueError(
+                    f"Request beam width {sampling_config.beam_width} "
+                    f"is not equal to max_beam_width {self.max_beam_width}. This is not supported!"
+                )
+
+        # Check token ID ranges
+        self._validate_token_id_range(request)
+
+        # Perform sampler-specific validation
+        self.sampler.validate_request(request)
 
     def _fetch_and_enqueue_requests(self, waiting_queue: WaitingQueue,
                                     total_num_active_requests: int) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -199,6 +199,15 @@ class Sampler(ABC, Generic[GenericSampleState]):
 
         If the request is not supported by the sampler, this should raise an
         appropriate exception.
+
+        Args:
+            request: The request to validate
+
+        Returns:
+            None if request is valid
+
+        Raises:
+            Appropriate exception if request is not supported by sampler.
         """
 
     def should_provide_draft_probs(self, request: LlmRequest) -> bool:

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -1022,7 +1022,7 @@ class TestParameterValidation:
         assert fixed_params["max_beam_width"] > 2
         with pytest.raises(
                 RequestError,
-                match=".*Request beam width 2 is not equal to max_beam_width 4*"
+                match=".*Request beam width 2 is not equal to max_beam_width 4.*"
         ):
             _ = llm.generate(input_prompts,
                              sampling_params=SamplingParams(
@@ -1049,7 +1049,8 @@ class TestParameterValidation:
 
         with pytest.raises(
                 RequestError,
-                match=".*Beam search only supports logprobs when batch size is 1*"
+                match=
+                ".*Beam search only supports logprobs when batch size is 1.*"
         ) if batch_size > 1 else nullcontext():
             _ = llm.generate(input_prompts,
                              sampling_params=SamplingParams(
@@ -1090,7 +1091,7 @@ class TestParameterValidation:
         with pytest.raises(
                 RequestError,
                 match=
-                ".*Beam search only supports returning the sampled logprob per token*"
+                ".*Beam search only supports returning the sampled logprob per token.*"
         ):
             _ = llm.generate(input_prompts,
                              sampling_params=SamplingParams(
@@ -1105,7 +1106,7 @@ class TestParameterValidation:
         with pytest.raises(
                 RequestError,
                 match=
-                ".*Beam search does not support returning multiple logprobs per request*"
+                ".*Beam search does not support returning multiple logprobs per request.*"
         ):
             _ = llm.generate(input_prompts,
                              sampling_params=SamplingParams(

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -81,14 +81,17 @@ def with_cuda_graph_and_overlap(request):
 
 
 def _build_llm(fixed_params, input_prompts, llm_kwargs):
+    if "max_batch_size" not in llm_kwargs:
+        llm_kwargs = llm_kwargs | dict(
+            max_batch_size=fixed_params["max_beam_width"] * len(
+                input_prompts
+            ),  # use small batch size to prevent large buffers from possibly hiding wrong data accesses.
+        )
     return LLM(
         **llm_kwargs,
         kv_cache_config=KvCacheConfig(
             max_tokens=10000,  # type: ignore
         ),
-        max_batch_size=fixed_params["max_beam_width"] * len(
-            input_prompts
-        ),  # use small batch size to prevent large buffers from possibly hiding wrong data accesses.
         max_seq_len=32,
         max_beam_width=fixed_params["max_beam_width"],
     )
@@ -904,6 +907,16 @@ class TestParameterValidation:
     def fixed_params():
         return {"max_tokens": 8, "max_beam_width": 4}
 
+    @pytest.fixture(scope="module", params=[1, 4])
+    @staticmethod
+    def batch_size(request) -> int:
+        return request.param
+
+    @pytest.fixture(scope="module", params=["TRTLLMSampler", "TorchSampler"])
+    @staticmethod
+    def sampler_type(request) -> str:
+        return request.param
+
     @pytest.fixture(scope="module")
     @staticmethod
     def model_kwargs() -> dict[str, Any]:
@@ -915,8 +928,17 @@ class TestParameterValidation:
     # NB: Class-level fixture overrides do not work without this
     @pytest.fixture(scope="module")
     @staticmethod
-    def llm(fixed_params, input_prompts, model_kwargs):
-        return _build_llm(fixed_params, input_prompts, model_kwargs)
+    def llm(fixed_params, input_prompts, model_kwargs, batch_size: int,
+            sampler_type: str):
+        return _build_llm(
+            fixed_params,
+            input_prompts,
+            (model_kwargs
+             | dict(
+                 max_batch_size=batch_size,
+                 sampler_type=sampler_type,
+             )),
+        )
 
     def _check_engine_responds(self, llm: LLM, input_prompts: list[str],
                                fixed_params: dict):
@@ -936,7 +958,13 @@ class TestParameterValidation:
         llm: LLM,
         input_prompts: list[str],
         fixed_params: dict,
+        batch_size: int,
+        sampler_type: str,
     ):
+        if batch_size == 1:
+            pytest.skip("Test does not depend on batch size")
+        if sampler_type == "TorchSampler":
+            pytest.skip("Test does not depend on sampler_type")
         assert fixed_params["max_beam_width"] > 2
         with pytest.raises(
                 ValueError,
@@ -955,12 +983,13 @@ class TestParameterValidation:
 
     @pytest.mark.timeout(120)
     @pytest.mark.threadleak(enabled=False)
-    def test_use_beam_search_ommitted(
-        self,
-        llm: LLM,
-        input_prompts: list[str],
-        fixed_params: dict,
-    ):
+    def test_use_beam_search_ommitted(self, llm: LLM, input_prompts: list[str],
+                                      fixed_params: dict, batch_size: int,
+                                      sampler_type: str):
+        if batch_size == 1:
+            pytest.skip("Test does not depend on batch size")
+        if sampler_type == "TorchSampler":
+            pytest.skip("Test does not depend on sampler_type")
         assert fixed_params["max_beam_width"] > 2
         with pytest.raises(
                 ValueError,
@@ -983,7 +1012,13 @@ class TestParameterValidation:
         llm: LLM,
         input_prompts: list[str],
         fixed_params: dict,
+        batch_size: int,
+        sampler_type: str,
     ):
+        if batch_size == 1:
+            pytest.skip("Test does not depend on batch size")
+        if sampler_type == "TorchSampler":
+            pytest.skip("Test does not depend on sampler_type")
         assert fixed_params["max_beam_width"] > 2
         with pytest.raises(
                 RequestError,
@@ -997,6 +1032,91 @@ class TestParameterValidation:
                                  use_beam_search=True,
                                  end_id=-1,
                              ))
+        self._check_engine_responds(llm, input_prompts, fixed_params)
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.threadleak(enabled=False)
+    def test_logprobs_trtllm_sampler(
+        self,
+        llm: LLM,
+        input_prompts: list[str],
+        fixed_params: dict,
+        batch_size: int,
+        sampler_type: str,
+    ):
+        if sampler_type != "TRTLLMSampler":
+            pytest.skip("Test is specific to TRTLLMSampler")
+
+        with pytest.raises(
+                RequestError,
+                match=".*Beam search only supports logprobs when batch size is 1*"
+        ) if batch_size > 1 else nullcontext():
+            _ = llm.generate(input_prompts,
+                             sampling_params=SamplingParams(
+                                 max_tokens=fixed_params["max_tokens"],
+                                 n=1,
+                                 best_of=fixed_params["max_beam_width"],
+                                 use_beam_search=True,
+                                 end_id=-1,
+                                 logprobs=1,
+                             ))
+        self._check_engine_responds(llm, input_prompts, fixed_params)
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.threadleak(enabled=False)
+    def test_logprobs_torch_sampler(
+        self,
+        llm: LLM,
+        input_prompts: list[str],
+        fixed_params: dict,
+        batch_size: int,
+        sampler_type: str,
+    ):
+        if sampler_type != "TorchSampler":
+            pytest.skip("Test is specific to TorchSampler")
+        if batch_size == 1:
+            pytest.skip("Test does not depend on batch size")
+
+        _ = llm.generate(input_prompts,
+                         sampling_params=SamplingParams(
+                             max_tokens=fixed_params["max_tokens"],
+                             n=1,
+                             best_of=fixed_params["max_beam_width"],
+                             use_beam_search=True,
+                             end_id=-1,
+                             logprobs=0,
+                         ))
+
+        with pytest.raises(
+                RequestError,
+                match=
+                ".*Beam search only supports returning the sampled logprob per token*"
+        ):
+            _ = llm.generate(input_prompts,
+                             sampling_params=SamplingParams(
+                                 max_tokens=fixed_params["max_tokens"],
+                                 n=1,
+                                 best_of=fixed_params["max_beam_width"],
+                                 use_beam_search=True,
+                                 end_id=-1,
+                                 logprobs=1,
+                             ))
+
+        with pytest.raises(
+                RequestError,
+                match=
+                ".*Beam search does not support returning multiple logprobs per request*"
+        ):
+            _ = llm.generate(input_prompts,
+                             sampling_params=SamplingParams(
+                                 max_tokens=fixed_params["max_tokens"],
+                                 n=1,
+                                 best_of=fixed_params["max_beam_width"],
+                                 use_beam_search=True,
+                                 end_id=-1,
+                                 logprobs=2,
+                             ))
+
         self._check_engine_responds(llm, input_prompts, fixed_params)
 
 


### PR DESCRIPTION
## Description

This avoids engine hangs caused by unsupported user requests.

## Test Coverage

Added relevant tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for beam search requests with logprobs output, now enforces proper batch size constraints.
  * Enhanced request validation with centralized token ID range and beam width checks.

* **Tests**
  * Expanded test coverage for beam search functionality across different sampler types and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->