### PR TITLE
[None][fix] unify yaml validation harness for curated and database c…

### DIFF
--- a/examples/configs/curated/deepseek-r1-deepgemm.yaml
+++ b/examples/configs/curated/deepseek-r1-deepgemm.yaml
@@ -1,15 +1,14 @@
 max_batch_size: 1024
 max_num_tokens: 3200
-kv_cache_free_gpu_memory_fraction: 0.8
 tensor_parallel_size: 8
 moe_expert_parallel_size: 8
 trust_remote_code: true
 enable_attention_dp: true
 cuda_graph_config:
   enable_padding: true
-  max_batch_size: 128
 kv_cache_config:
   dtype: fp8
+  free_gpu_memory_fraction: 0.8
 stream_interval: 10
 speculative_config:
   decoding_type: MTP

--- a/examples/configs/curated/deepseek-r1-latency.yaml
+++ b/examples/configs/curated/deepseek-r1-latency.yaml
@@ -3,9 +3,10 @@ tensor_parallel_size: 8
 moe_expert_parallel_size: 2
 max_num_tokens: 32768
 trust_remote_code: true
-kv_cache_free_gpu_memory_fraction: 0.75
-moe_backend: TRTLLM
-use_cuda_graph: true
+kv_cache_config:
+  free_gpu_memory_fraction: 0.75
+moe_config:
+  backend: TRTLLM
 speculative_config:
   decoding_type: MTP
   num_nextn_predict_layers: 3

--- a/examples/configs/curated/deepseek-r1-throughput.yaml
+++ b/examples/configs/curated/deepseek-r1-throughput.yaml
@@ -1,15 +1,14 @@
 max_batch_size: 1024
 max_num_tokens: 3200
-kv_cache_free_gpu_memory_fraction: 0.8
 tensor_parallel_size: 8
 moe_expert_parallel_size: 8
 trust_remote_code: true
 enable_attention_dp: true
 cuda_graph_config:
   enable_padding: true
-  max_batch_size: 128
 kv_cache_config:
   dtype: fp8
+  free_gpu_memory_fraction: 0.8
 stream_interval: 10
 speculative_config:
   decoding_type: MTP

--- a/examples/configs/curated/gpt-oss-120b-latency.yaml
+++ b/examples/configs/curated/gpt-oss-120b-latency.yaml
@@ -1,10 +1,8 @@
 max_batch_size: 64
 max_num_tokens: 16384
-kv_cache_free_gpu_memory_fraction: 0.9
 tensor_parallel_size: 8
 moe_expert_parallel_size: 1
 trust_remote_code: true
-enable_attention_dp: false
 cuda_graph_config:
   enable_padding: true
   max_batch_size: 64

--- a/examples/configs/curated/gpt-oss-120b-throughput.yaml
+++ b/examples/configs/curated/gpt-oss-120b-throughput.yaml
@@ -1,6 +1,5 @@
 max_batch_size: 720 # Depends on max_sequence_length
 max_num_tokens: 16384
-kv_cache_free_gpu_memory_fraction: 0.9
 tensor_parallel_size: 2
 moe_expert_parallel_size: 2
 trust_remote_code: true

--- a/examples/configs/curated/llama-3.3-70b.yaml
+++ b/examples/configs/curated/llama-3.3-70b.yaml
@@ -1,10 +1,7 @@
 max_batch_size: 1024
 max_num_tokens: 2048
-kv_cache_free_gpu_memory_fraction: 0.9
-tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 trust_remote_code: true
-enable_attention_dp: false
 cuda_graph_config:
   enable_padding: true
   max_batch_size: 1024

--- a/examples/configs/curated/llama-4-scout.yaml
+++ b/examples/configs/curated/llama-4-scout.yaml
@@ -1,10 +1,7 @@
 max_batch_size: 1024
 max_num_tokens: 2048
-kv_cache_free_gpu_memory_fraction: 0.9
-tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 trust_remote_code: true
-enable_attention_dp: false
 cuda_graph_config:
   enable_padding: true
   max_batch_size: 1024

--- a/examples/configs/curated/qwen3-disagg-prefill.yaml
+++ b/examples/configs/curated/qwen3-disagg-prefill.yaml
@@ -1,8 +1,8 @@
 max_batch_size: 161
 max_num_tokens: 1160
-kv_cache_free_gpu_memory_fraction: 0.8
-tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 trust_remote_code: true
 print_iter_log: true
 enable_attention_dp: true
+kv_cache_config:
+  free_gpu_memory_fraction: 0.8

--- a/examples/configs/curated/qwen3-next.yaml
+++ b/examples/configs/curated/qwen3-next.yaml
@@ -3,14 +3,12 @@ max_num_tokens: 4096
 tensor_parallel_size: 4
 moe_expert_parallel_size: 4
 trust_remote_code: true
-enable_attention_dp: false
 cuda_graph_config:
   enable_padding: true
   max_batch_size: 720
 moe_config:
-    backend: TRTLLM
+  backend: TRTLLM
 stream_interval: 20
 num_postprocess_workers: 4
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.9

--- a/examples/configs/curated/qwen3.yaml
+++ b/examples/configs/curated/qwen3.yaml
@@ -1,7 +1,5 @@
 max_batch_size: 161
 max_num_tokens: 1160
-kv_cache_free_gpu_memory_fraction: 0.8
-tensor_parallel_size: 1
 moe_expert_parallel_size: 1
 cuda_graph_config:
   enable_padding: true
@@ -18,3 +16,5 @@ cuda_graph_config:
   - 384
 print_iter_log: true
 enable_attention_dp: true
+kv_cache_config:
+  free_gpu_memory_fraction: 0.8

--- a/tests/unittest/llmapi/test_curated_yaml_configs.py
+++ b/tests/unittest/llmapi/test_curated_yaml_configs.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""L0 tests for validating curated YAML files against TorchLlmArgs."""
+
+from pathlib import Path
+
+import pytest
+
+from tensorrt_llm.llmapi import llm_args as llm_args_module
+
+from . import yaml_validation_harness as yaml_harness
+
+CONFIG_ROOT = Path(__file__).parents[3] / "examples" / "configs"
+CURATED_DIR = CONFIG_ROOT / "curated"
+
+CURATED_CONFIGS = yaml_harness.collect_yaml_files(CURATED_DIR, "**/*.yaml")
+
+DEPRECATED_KEY_MAP = {
+    "kv_cache_free_gpu_memory_fraction": "kv_cache_config.free_gpu_memory_fraction",
+    "moe_backend": "moe_config.backend",
+    "use_cuda_graph": "cuda_graph_config",
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_gpu_environment():
+    """Mock GPU functions for CPU-only schema test execution."""
+    with yaml_harness.mock_cuda_for_schema_validation():
+        yield
+
+
+def get_config_id(config_path: Path) -> str:
+    return str(config_path.relative_to(CURATED_DIR))
+
+
+@pytest.mark.part0
+@pytest.mark.parametrize("config_path", CURATED_CONFIGS, ids=get_config_id)
+def test_curated_config_validates_against_llm_args(config_path: Path):
+    config_dict = yaml_harness.load_yaml_dict(config_path)
+    yaml_harness.validate_torch_llm_args_config(config_dict)
+
+
+@pytest.mark.part0
+@pytest.mark.parametrize("config_path", CURATED_CONFIGS, ids=get_config_id)
+def test_curated_config_does_not_use_deprecated_keys(config_path: Path):
+    config_dict = yaml_harness.load_yaml_dict(config_path)
+    yaml_harness.assert_no_deprecated_keys(config_dict, DEPRECATED_KEY_MAP)
+
+
+@pytest.mark.part0
+@pytest.mark.parametrize("config_path", CURATED_CONFIGS, ids=get_config_id)
+def test_curated_config_does_not_set_default_leaves(config_path: Path):
+    config_dict = yaml_harness.load_yaml_dict(config_path)
+    default_cfg = llm_args_module.TorchLlmArgs(
+        model="dummy/model", skip_tokenizer_init=True
+    ).model_dump(mode="json")
+    yaml_harness.assert_no_default_valued_leaves(config_dict, default_cfg)
+
+
+@pytest.mark.part0
+def test_curated_config_count():
+    assert len(CURATED_CONFIGS) > 0, "No curated config files found"

--- a/tests/unittest/llmapi/yaml_validation_harness.py
+++ b/tests/unittest/llmapi/yaml_validation_harness.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared YAML validation helpers for llmapi config tests."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import yaml
+
+from tensorrt_llm.llmapi import llm_args as llm_args_module
+
+
+def collect_yaml_files(
+    parent_dir: Path, include_glob: str, exclude_names: Iterable[str] = ()
+) -> list[Path]:
+    excluded = set(exclude_names)
+    if not parent_dir.exists():
+        return []
+
+    return sorted(
+        path
+        for path in parent_dir.glob(include_glob)
+        if path.is_file() and path.name not in excluded
+    )
+
+
+def load_yaml_dict(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise TypeError(f"YAML at {path} must parse to a dict, got {type(loaded).__name__}")
+    return loaded
+
+
+def validate_torch_llm_args_config(cfg: dict[str, Any]) -> llm_args_module.TorchLlmArgs:
+    base_args = llm_args_module.TorchLlmArgs(model="dummy/model", skip_tokenizer_init=True)
+    merged = llm_args_module.update_llm_args_with_extra_dict(
+        copy.deepcopy(base_args.model_dump(mode="json")), copy.deepcopy(cfg)
+    )
+    return llm_args_module.TorchLlmArgs(**merged)
+
+
+def assert_no_deprecated_keys(cfg: dict[str, Any], deprecated_map: dict[str, str]) -> None:
+    violations: list[str] = []
+
+    def walk_dict(node: dict[str, Any], path: tuple[str, ...]) -> None:
+        for key, value in node.items():
+            full_path = path + (str(key),)
+            if key in deprecated_map:
+                replacement = deprecated_map[key]
+                violations.append(f"{'.'.join(full_path)} -> {replacement}")
+
+            if isinstance(value, dict):
+                walk_dict(value, full_path)
+
+    walk_dict(cfg, ())
+    if violations:
+        raise AssertionError("Found deprecated config keys:\n" + "\n".join(sorted(violations)))
+
+
+def assert_no_default_valued_leaves(
+    cfg: dict[str, Any],
+    default_cfg: dict[str, Any],
+    allowlist: Iterable[str | tuple[str, ...]] = (),
+) -> None:
+    normalized_allowlist: set[tuple[str, ...]] = set()
+    for item in allowlist:
+        if isinstance(item, str):
+            normalized_allowlist.add(tuple(item.split(".")))
+        else:
+            normalized_allowlist.add(tuple(item))
+
+    violations: list[str] = []
+
+    def walk(candidate: dict[str, Any], defaults: dict[str, Any], path: tuple[str, ...]) -> None:
+        for key, value in candidate.items():
+            full_path = path + (str(key),)
+            if full_path in normalized_allowlist:
+                continue
+
+            if key not in defaults:
+                continue
+            default_value = defaults[key]
+
+            if isinstance(value, dict) and isinstance(default_value, dict):
+                walk(value, default_value, full_path)
+                continue
+
+            if value == default_value:
+                violations.append(".".join(full_path))
+
+    walk(cfg, default_cfg, ())
+    if violations:
+        raise AssertionError(
+            "Found default-valued config leaves:\n" + "\n".join(sorted(violations))
+        )
+
+
+def assert_custom_policy(cfg: dict[str, Any], policy_fn: Callable[[dict[str, Any]], None]) -> None:
+    policy_fn(cfg)
+
+
+@contextmanager
+def mock_cuda_for_schema_validation(
+    device_count: int = 8, compute_capability_major: int = 8, is_available: bool = True
+) -> Iterator[None]:
+    mock_props = mock.Mock()
+    mock_props.major = compute_capability_major
+
+    with mock.patch("torch.cuda.device_count", return_value=device_count):
+        with mock.patch("torch.cuda.get_device_properties", return_value=mock_props):
+            with mock.patch("torch.cuda.is_available", return_value=is_available):
+                yield


### PR DESCRIPTION
…onfigs

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
