### PR TITLE
[TRTLLM-11567][feat] Added GatedDeltaNet sharding from config

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -16,3 +16,23 @@ model_kwargs:
   #   num_hidden_layers: 6
   # vision_config:
   #   depth: 2
+transforms:
+  detect_sharding:
+    sharding_dims: ['tp','ep', 'bmm']
+    # use only manual config for TP sharding
+    sharding_source: ['manual']
+    manual_config:
+      tp_plan:
+        # GDN layer
+        "in_proj_qkv": "delta"
+        # attention layer
+        "q_proj": "colwise"
+        "k_proj": "colwise"
+        "v_proj": "colwise"
+        "o_proj": "rowwise"
+        # replicating shared experts (keep them commented out)
+        # "shared_expert_gate_proj": "colwise"
+        # "shared_expert_up_proj": "colwise"
+        # "shared_expert_down_proj": "rowwise"
+        # gating layer should be replicated as well
+        # "gate": "gather"

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -16,3 +16,22 @@ model_kwargs:
 transforms:
   export_to_gm:
     num_moe_experts_for_export: 2
+  detect_sharding:
+    sharding_dims: ['tp','ep', 'bmm']
+    # use only manual config for TP sharding
+    sharding_source: ['manual']
+    manual_config:
+      tp_plan:
+        # GDN layer
+        "in_proj_qkv": "delta"
+        # attention layer
+        "q_proj": "colwise"
+        "k_proj": "colwise"
+        "v_proj": "colwise"
+        "o_proj": "rowwise"
+        # replicating shared experts (keep them commented out)
+        # "shared_expert_gate_proj": "colwise"
+        # "shared_expert_up_proj": "colwise"
+        # "shared_expert_down_proj": "rowwise"
+        # gating layer should be replicated as well
+        # "gate": "gather"

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -2728,7 +2728,7 @@ def detect_sharding_from_config(
                     if _process_ssm_sharding(layer_subgraph, transform_container) > 0:
                         num_ssm_shards += 1
                         num_row_col_shards += 1
-                elif config == "gdn":
+                elif config == "delta":
                     if _process_delta_sharding(layer_subgraph, transform_container) > 0:
                         num_delta_shards += 1
                         num_row_col_shards += 1

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -239,7 +239,9 @@ class ShardingTransformConfig(TransformConfig):
             supported_modes = {
                 "colwise",  # row split and no collective
                 "rowwise",  # column split and all-reduce
+                "mla",  # mla layer
                 "mamba",  # mamba SSM layer
+                "delta",  # gated delta net layer
                 "gather",  # simple shard (row + all_gather)
                 # TODO: remaining values are not supported yet.
                 # They require hybrid EP+TP and/or SP support.
@@ -2663,6 +2665,8 @@ def detect_sharding_from_config(
     num_row_col_shards = 0
     num_attention_shards = 0
     num_ssm_shards = 0
+    num_mla_shards = 0
+    num_delta_shards = 0
     linear_nodes = list(filtered_nodes(gm.graph.nodes, is_any_lin_op))
 
     # use layer_subgraphs to determine the layer_type
@@ -2724,7 +2728,14 @@ def detect_sharding_from_config(
                     if _process_ssm_sharding(layer_subgraph, transform_container) > 0:
                         num_ssm_shards += 1
                         num_row_col_shards += 1
-
+                elif config == "gdn":
+                    if _process_delta_sharding(layer_subgraph, transform_container) > 0:
+                        num_delta_shards += 1
+                        num_row_col_shards += 1
+                elif config == "mla":
+                    if _process_mla_sharding(layer_subgraph, transform_container) > 0:
+                        num_mla_shards += 1
+                        num_row_col_shards += 1
                 elif "sequence" in config:
                     # TODO: Sequence parallelism is not supported yet.
                     ad_logger.warning("Sequence parallelism is not supported yet. Skipping.")
@@ -2783,7 +2794,8 @@ def detect_sharding_from_config(
     num_shards = num_simple_shards + num_row_col_shards
     ad_logger.info(
         f"Applied {num_shards} TP shards from config. Simple: {num_simple_shards}, "
-        f"row-col: {num_row_col_shards} (including: ssm: {num_ssm_shards}, attention: {num_attention_shards})"
+        f"row-col: {num_row_col_shards} (attention: {num_attention_shards}, "
+        f"mla: {num_mla_shards}, delta: {num_delta_shards}, ssm: {num_ssm_shards})"
     )
 
     num_matches = len(transform_container.weight_sharding_transforms)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -1727,7 +1727,7 @@ def _insert_sharded_mxfp4_mlp_ep(
 def _process_simple_shard(
     nodes_linear: Dict[Node, List[Node]],
     transform_container: ShardingTransformContainer,
-    layer_type: LayerType = LayerType.MLP,
+    layer_type: LayerType = LayerType.UNKNOWN,
 ) -> int:
     # for every linear node:
     # --> row_split (dim 0 of weight) + all_gather (dim -1 of output)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -45,11 +45,11 @@ class LayerType(Enum):
 
 class LayerSubgraph(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    opening_nodes: List[Node]
-    subgraph_nodes: List[Node]
-    terminating_node: Union[Node, None]
     layer_type: LayerType
+    opening_nodes: List[Node]
+    terminating_node: Union[Node, None]
     min_local_shape: int = 1
+    subgraph_nodes: List[Node]
 
 
 class WeightNode(BaseModel):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -28,25 +28,25 @@ from tensorrt_llm.functional import AllReduceStrategy
 
 base_model_tp_plan = {
     # ATTENTION
-    # "q_proj": "colwise",
-    # "k_proj": "colwise",
-    # "v_proj": "colwise",
-    # "o_proj": "rowwise",
-    # # gated MLP
-    # "gate_proj": "colwise",
-    # "up_proj": "colwise",
-    # "down_proj": "rowwise",
-    # # GPT-style MLP
-    # "linear1": "colwise",
-    # "linear2": "rowwise",
-    # "linear": "gather",
-    # # Mamba2 specific projections
-    # "in_proj": "mamba",
-    # # MLA specific projections
-    # "q_a_proj": "mla",
-    # # delta net
-    # # qkv regex matches both fused (qkvz) and unfused (qkv) opening nodes
-    # "in_proj_qkv": "delta",
+    "q_proj": "colwise",
+    "k_proj": "colwise",
+    "v_proj": "colwise",
+    "o_proj": "rowwise",
+    # gated MLP
+    "gate_proj": "colwise",
+    "up_proj": "colwise",
+    "down_proj": "rowwise",
+    # GPT-style MLP
+    "linear1": "colwise",
+    "linear2": "rowwise",
+    "linear": "gather",
+    # Mamba2 specific projections
+    "in_proj": "mamba",
+    # MLA specific projections
+    "q_a_proj": "mla",
+    # delta net
+    # qkv regex matches both fused (qkvz) and unfused (qkv) opening nodes
+    "in_proj_qkv": "delta",
 }
 
 predefined_config = {

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_tp_sharding.py
@@ -26,33 +26,6 @@ from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimiz
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_linear_op, is_op, is_weight_node
 from tensorrt_llm.functional import AllReduceStrategy
 
-base_model_tp_plan = {
-    # ATTENTION
-    "q_proj": "colwise",
-    "k_proj": "colwise",
-    "v_proj": "colwise",
-    "o_proj": "rowwise",
-    # gated MLP
-    "gate_proj": "colwise",
-    "up_proj": "colwise",
-    "down_proj": "rowwise",
-    # GPT-style MLP
-    "linear1": "colwise",
-    "linear2": "rowwise",
-    "linear": "gather",
-    # Mamba2 specific projections
-    "in_proj": "mamba",
-    # MLA specific projections
-    "q_a_proj": "mla",
-    # delta net
-    # qkv regex matches both fused (qkvz) and unfused (qkv) opening nodes
-    "in_proj_qkv": "delta",
-}
-
-predefined_config = {
-    "tp_plan": base_model_tp_plan,
-}
-
 
 class GQA_Block(nn.Module):
     def __init__(
@@ -423,8 +396,27 @@ def _run_sharding_execution_job(
             hidden_size=num_features,
             num_key_value_heads=num_key_value_heads,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {
+            "tp_plan": {
+                "q_proj": "colwise",
+                "k_proj": "colwise",
+                "v_proj": "colwise",
+                "o_proj": "rowwise",
+            }
+        }
     elif model_cls == FP8MLP:
         model = model_cls(num_features, num_features, bias=bias).to("cuda")
+        predefined_config = {
+            "tp_plan": {
+                # gated MLP
+                "gate_proj": "colwise",
+                "up_proj": "colwise",
+                "down_proj": "rowwise",
+                # GPT-style MLP
+                "linear1": "colwise",
+                "linear2": "rowwise",
+            }
+        }
     elif model_cls == NemotronHMamba2Mixer:
         # Create config for Mamba2 based on Nemotron models
         # Scaled down from typical values: hidden_size=5120, ssm_state_size=128
@@ -450,6 +442,7 @@ def _run_sharding_execution_job(
             num_hidden_layers=1,
         )
         model = model_cls(mamba_config, layer_idx=0).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"in_proj": "mamba"}}
     elif model_cls == MLA_Block:
         # Use actual DeepSeek-V3/R1 production values
         # From HuggingFace config (HunYuanPretrainedConfig defaults):
@@ -473,6 +466,7 @@ def _run_sharding_execution_job(
             v_head_dim=v_head_dim,
             bias=bias,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"q_a_proj": "mla"}}
     elif model_cls in (GDN_Block, GDN_Block_Unfused):
         num_k_heads_gdn = 4
         num_v_heads_gdn = 8
@@ -487,10 +481,28 @@ def _run_sharding_execution_job(
             head_v_dim=head_v_dim,
             bias=bias,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"in_proj_qkv": "delta"}}
+    elif model_cls == nn.Linear:
+        model = model_cls(num_features, num_features, bias=bias).to(
+            device="cuda", dtype=torch.float16
+        )
+        # update the tp_plan in predefined_config to force simple sharding of the single linear layer
+        predefined_config = {"tp_plan": {"*": "gather"}}
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
         )
+        predefined_config = {
+            "tp_plan": {
+                # gated MLP
+                "gate_proj": "colwise",
+                "up_proj": "colwise",
+                "down_proj": "rowwise",
+                # GPT-style MLP
+                "linear1": "colwise",
+                "linear2": "rowwise",
+            }
+        }
     x = torch.randn(batch_size, sequence_len, num_features, device="cuda", dtype=torch.float16)
 
     # Scale down GDN_Block weights if needed to avoid numerical instability
@@ -531,10 +543,15 @@ def _run_sharding_execution_job(
         else:
             num_params = num_p_og // world_size + num_update
         if model_cls == MLA_Block:
-            # since q_a_proj is simple-sharded and followed by q_a_layernorm, the layernorm params
-            # are NOT sharded - they have to be replicated. To account for this, we need to add the
-            # number of parameters of the layernorm (weight and bias)to the number of parameters of the model.
-            num_params += 2 * kv_lora_rank * (world_size - 1) // world_size
+            # Both q_a_layernorm and kv_a_layernorm are replicated because their preceding
+            # projections (q_a_proj, kv_a_proj_with_mqa) use simple-shard/all_gather.
+            # Each LayerNorm has weight + bias of size kv_lora_rank → 4 * kv_lora_rank
+            # replicated params total.  The base formula (num_p_og // world_size) treated
+            # these as sharded, so we add back the under-counted fraction.
+            replicated_ln_params = (
+                4 * kv_lora_rank
+            )  # q_a_layernorm + kv_a_layernorm, weight+bias each
+            num_params += replicated_ln_params * (world_size - 1) // world_size
         return num_params
 
     def verify_local_weight_sizes(gm) -> bool:
@@ -563,6 +580,8 @@ def _run_sharding_execution_job(
                 "sharding_scope": ["tp"],
                 "sharding_source": [sharding_source],
                 "manual_config": predefined_config,
+                # needed for a solitary Linear node that is not part of any layer subgraph
+                "shard_all_unprocessed": True,
             },
             "sharding_transform_executor": {
                 "stage": "sharding",
@@ -610,6 +629,14 @@ def _run_pattern_detection_job(
             hidden_size=num_features,
             num_key_value_heads=num_key_value_heads,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {
+            "tp_plan": {
+                "q_proj": "colwise",
+                "k_proj": "colwise",
+                "v_proj": "colwise",
+                "o_proj": "rowwise",
+            }
+        }
     elif model_cls == NemotronHMamba2Mixer:
         # Create config for Mamba2
         mamba_config = SimpleNamespace(
@@ -634,6 +661,7 @@ def _run_pattern_detection_job(
             num_hidden_layers=1,
         )
         model = model_cls(mamba_config, layer_idx=0).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"in_proj": "mamba"}}
     elif model_cls == MLA_Block:
         # Create simplified MLA based on DeepSeek-V3 architecture
         qk_nope_head_dim = 2
@@ -651,6 +679,7 @@ def _run_pattern_detection_job(
             v_head_dim=v_head_dim,
             bias=bias,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"q_a_proj": "mla"}}
     elif model_cls in (GDN_Block, GDN_Block_Unfused):
         num_k_heads_gdn = 4
         num_v_heads_gdn = 8
@@ -664,10 +693,26 @@ def _run_pattern_detection_job(
             head_v_dim=head_v_dim,
             bias=bias,
         ).to(device="cuda", dtype=torch.float16)
+        predefined_config = {"tp_plan": {"in_proj_qkv": "delta"}}
+    elif model_cls == nn.Linear:
+        model = model_cls(num_features, num_features, bias=bias).to(
+            device="cuda", dtype=torch.float16
+        )
+        # update the tp_plan in predefined_config to force simple sharding of the single linear layer
+        predefined_config = {"tp_plan": {"*": "gather"}}
     else:
         model = model_cls(num_features, num_features, bias=bias).to(
             device="cuda", dtype=torch.float16
         )
+        predefined_config = {
+            "tp_plan": {
+                "gate_proj": "colwise",
+                "up_proj": "colwise",
+                "down_proj": "rowwise",
+                "linear1": "colwise",
+                "linear2": "rowwise",
+            }
+        }
     x = torch.randn(batch_size, sequence_len, num_features, device="cuda", dtype=torch.float16)
 
     # Test pattern detection - create expected transformations for validation
@@ -739,7 +784,7 @@ def _run_pattern_detection_job(
                             config=config,
                             dist_op="all_gather",
                             min_local_shape=1,
-                            layer_type=LayerType.MLP,
+                            layer_type=LayerType.UNKNOWN,
                         )
                     )
         elif model_cls == FP8MLP:


### PR DESCRIPTION
Fixes #11567 

Supports both fused (qkvz) and unfused (qkv + z) input layer projections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new sharding modes in tensor parallelism pipeline for improved model deployment.
  * New configuration examples for model registry setups.

* **Infrastructure Improvements**
  * Enhanced sharding configuration detection and validation capabilities.
  * Updated configuration handling for advanced deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
