### PR TITLE
[TRTLLM-11087][doc] Update speculative decoding docs

### DIFF
--- a/docs/source/features/speculative-decoding.md
+++ b/docs/source/features/speculative-decoding.md
@@ -1,29 +1,6 @@
 # Speculative Decoding
 
-There are two flavors of speculative decoding currently supported in the PyTorch backend:
-- The "one model" implementation -- a variant which inserts a drafter directly into the model code as a submodule.
-- The "two model" implementation -- a variant which produces draft tokens in the `PyExecutor`. The draft tokens are attached to requests before they are passed
-into the target model's `ModelEngine`.
-
-In general, the one model implementation is faster. It's able to achieve better performance in extreme low latency
-scenarios because it can launch the entire drafting loop as a single CUDA graph. The trade off is flexibility. The one model implementation
-does not support dynamic draft lengths. Additionally, only a subset of models/speculative decoding algorithms support the one model implementation.
-The table below enumerates all of the algorithm/model combinations that are supported.
-
-| Speculative Decoding Algorithm | Model                          |
-| ------------------------------ | ------------------------------ |
-| EAGLE 3                        | Llama 4 Maverick               |
-| MTP                            | Deepseek V3/R1                 |
-| EAGLE-style MTP                | Deepseek V3/R1                 |
-
-The two model implementation supports the following speculative decoding algorithms:
-
-| Speculative Decoding Algorithm                | Model                                         |
-| --------------------------------------------- | --------------------------------------------- |
-| EAGLE 3                                       | Llama 4 Maverick, Llama 3.1 8B, Llama 3.3 70B |
-| Draft/target                                  | All models                                    |
-| NGram                                         | All models                                    |
-| User-provided                                 | All models                                    |
+Speculative decoding is a technique for accelerating LLM inference at low batch sizes. A lightweight drafting mechanism proposes candidate tokens, and the target model verifies them in a single forward pass. Tokens that match are accepted, reducing the number of sequential forward passes needed.
 
 ## Quick Start
 
@@ -61,18 +38,14 @@ The following draft model checkpoints can be used for EAGLE 3:
 ```python
 from tensorrt_llm.llmapi import Eagle3DecodingConfig
 
-# Enable to use the faster one-model implementation for Llama 4.
-eagle3_one_model = False
 model = "meta-llama/Llama-3.1-8B-Instruct"
 speculative_model = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
 
 speculative_config = Eagle3DecodingConfig(
     max_draft_len=3,
-    speculative_model=speculative_model,
-    eagle3_one_model=eagle3_one_model)
+    speculative_model=speculative_model)
 
-# Only need to disable overlap scheduler if eagle3_one_model is False.
-llm = LLM(model, speculative_config=speculative_config, disable_overlap_scheduler=True)
+llm = LLM(model, speculative_config=speculative_config)
 ```
 
 ### NGram
@@ -151,16 +124,14 @@ The rest of the argument names/valid values are the same as in their correspondi
 
 ```yaml
 # Using a HuggingFace Hub model ID (auto-downloaded)
-disable_overlap_scheduler: true
 speculative_config:
-  decoding_type: Eagle
+  decoding_type: Eagle3
   max_draft_len: 4
   speculative_model: yuhuili/EAGLE3-LLaMA3.1-Instruct-8B
 ```
 
 ```yaml
 # Or using a local path
-disable_overlap_scheduler: true
 speculative_config:
   decoding_type: Eagle3
   max_draft_len: 4
@@ -171,109 +142,7 @@ speculative_config:
 The field name `speculative_model_dir` can also be used as an alias for `speculative_config.speculative_model`. For example:
 
     speculative_config:
-      decoding_type: Eagle
+      decoding_type: Eagle3
       max_draft_len: 4
       speculative_model_dir: /path/to/draft/model
 ```
-
-
-## Developer Guide
-
-This section describes the components of a speculative decoding algorithm. All of the interfaces are defined in [`_torch/speculative/interface.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/speculative/interface.py).
-
-1. `SpeculativeDecodingMode`: this is a simple `IntEnum`, one for each supported algorithm. There are a few
-nontrivial methods, however.
-- `needs_kv_cache_rewind`. See "KV Cache Rewind" below. In general, this is true for all two model speculative
-decoding algorithms.
-- `extend_ctx`: If true, the speculative decoding dispatches requests with `py_draft_tokens` attached to them
-to the *prefill* version of the attention kernels. This usually needs to be true. The exception is when you're on
-Blackwell using the TensorRT LLM attention backend. In that case, use the generation kernels for better performance.
-This optimized kernel has one limitation; all draft lengths must be the same (or padding must be used) in this case.
-
-> *These may be refactored in the future to reduce the difficulty of adding a new speculative
-decoding algorithm. `extend_ctx` in particular is problematic. Ideally, we would move all of the kernel dispatching logic
-to a lower level of abstraction.*
-
-2. `SpecMetadata`: Defines all metadata that should be passed to the model during the forward pass to facilitate speculative decoding.
-Each speculative decoding algorithm defines a subclass of `SpecMetadata`. Similar to `AttentionMetadata`, each `CUDAGraphRunner` owns
-its own `SpecMetadata`, and CUDA-graph compatible `SpecMetadata` objects may be created by invoking `create_cuda_graph_metadata(batch_size)`.
-`SpecMetadata` has many fields. Many of them are exclusively used by the one model implementation. For the two model implementation, the
-main purpose of `SpecMetadata` is to facilitate the capture of hidden states. In EAGLE 3, we need to capture hidden states from the
-target model to use as draft model inputs. The `SpecMetadata` stores a list of layers to capture and the model calls
-`maybe_capture_hidden_states(layer_id, hidden_states, residual)` during its forward pass. If the layer ID is in the list of layers to capture,
-the hidden states are saved. For CUDA graph compatibility, these may be saved in pre-allocated buffers.
-
-`SpecMetadata` is derived from a `SpecConfig` object in `_torch/speculative/utils.py`. There are a few other optional components created in
-this file too:
-
-4. `ResourceManager`: Create a custom resource manager to prepare and free resources before and after target forward passes; see
-the section on `ResourceManager` in `arch.md`. This is used by the n-gram method to manage its pool. The one model implementation also uses
-`ResourceManager`s to manage hidden states.
-
-5. `Sampler`: Each speculative decoding algorithm can optionally create its own sampler. This is mostly used by the one model implementation.
-The default `TorchSampler` is used as a fallback if no custom sampler is provided. EAGLE 3 two model also has a simple custom decoder to handle
-differences in the draft/target model vocab sizes.
-
-6. `Worker`: This is exclusive to the one-model implementation. The `Worker` is the object that gets injected into the target model as a
-submodule.
-
-7. `Drafter`: All of the logic required to actually produce draft tokens should be implemented in a `Drafter` subclass. There is a single
-abstract method, `prepare_draft_tokens`. It takes a set of requests (a `ScheduledRequests` object) and returns nothing. The [`PyExecutor`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/py_executor.py#L162) expects
-draft tokens to be attached to the `py_draft_tokens` field of request that speculation is to be done for.
-
-## Two Model Speculative Decoding Architecture
-
-Two-model based speculation implementations do not support overlap scheduler. It will be disabled automatically.
-
-In this approach, there are two new steps to the `PyExecutor`'s `_executor_loop`.
-* `_prepare_draft_requests`
-* `_prepare_draft_tokens`
-
-### `_prepare_draft_requests`
-
-This stage occurs for all speculative decoding algorithms before scheduling. The purpose
-of this stage is to make the KV cache and scheduler aware of the fact that speculative decoding
-will occur. Draft tokens take up extra KV cache pages and count towards the executor's
-`max_num_tokens` limit. Thus, we need a way to tell the scheduler that drafting will occur
-**before we do the scheduling**.
-
-To achieve this, we simply attach the maximum number of draft tokens to each request. The
-scheduler and KV cache manager will automatically account for tokens attached to the
-`py_draft_tokens` attribute.
-
-```python
-for req in self.active_requests:
-    req.py_draft_tokens = [0] * max_draft_len
-```
-
-### `_prepare_draft_tokens`
-
-This stage occurs after scheduling and KV cache allocation. The purpose of this stage
-is to attach draft tokens to the `py_draft_tokens` attribute. This occurs by calling `self.drafter.prepare_draft_tokens`;
-each speculative decoding algorithm should have a concrete instance of the `Drafter` class associated with it that defines
-the drafting logic.
-
-In addition to producing all "real" draft tokens, `_prepare_draft_tokens` currently must also pad
-all `py_draft_tokens` to the maximum draft length. This is a CUDA graph limitation - the target
-model captures its CUDA graphs using the maximum number of draft tokens on each request.
-
-### Verification and Sampling
-
-Once the draft tokens are obtained, the target model runs a forward pass through the usual flow.
-Everything is the same, except that the logits for all the draft tokens are returned and passed
-to the sampler.
-
-Currently, only greedy sampling is supported for speculative decoding. A draft token is accepted if
-matches the previously decoded token exactly. For example, suppose there is a generation request
-`[t, d1, d2, d3]`, where `d1`, `d2`, and `d3` are drat tokens. Suppose the token after `t` is `d1`
-(determined with the `argmax` of the logits). `d1` is then accepted. If the token after `d1` is `d2`,
-then `d2` can be accepted. And so on until draft tokens cannot be accepted anymore.
-
-### KV Cache Rewind
-
-KV cache space allocated to rejected tokens is freed before the next iteration. This is achieved by setting
-the `request.py_rewind_len` attribute to `num_draft_tokens_allocated - num_accepted_tokens`. The pages are
-freed as part of the `resource_manager.free_resources` routine.
-
-The purpose of KV cache rewind is to avoid complicated page reuse logic in the KV cache manager's `prepare_resources`
-function. In practice, this is very cheap since the blocks are just marked as available; no memory is actually freed.


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->
Update the speculative decoding documentation.

* Remove the outdated list of supported models. We have a feature x model support matrix elsewhere, so there's no need to maintain this one.
* Remove mentions of 2-model as this is not recommend for customer use anymore.
* Remove the implementation details. The code should speak for itself, translating it into English is not helpful and prone to going out of date.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
N/A

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined speculative decoding documentation with clearer, unified explanation
  * Updated Quick Start and configuration examples to emphasize Eagle3
  * Removed deprecated configuration options and obsolete setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->