### PR TITLE
[None][infra] add visual_gen codeowners paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,11 @@
 # TensorRT-LLM Pytorch backend
 /tensorrt_llm/_torch @NVIDIA/trt-llm-torch-devs
 
+## TensorRT-LLM Pytorch - Visual Gen
+/tensorrt_llm/_torch/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs
+/tests/unittest/_torch/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs
+/tests/integration/defs/examples/test_visual_gen.py @NVIDIA/trt-llm-torch-visual-gen-devs
+
 ## TensorRT-LLM Pytorch - Modules
 /tensorrt_llm/_torch/modules @NVIDIA/trt-llm-torch-modules
 


### PR DESCRIPTION
## Summary
- Add CODEOWNERS entries for Visual Gen code and tests.
- Assign ownership to @NVIDIA/trt-llm-torch-visual-gen-devs.

## Files
- .github/CODEOWNERS

## Paths Added
- /tensorrt_llm/_torch/visual_gen
- /tests/unittest/_torch/visual_gen
- /tests/integration/defs/examples/test_visual_gen.py

## Testing
- Not run (CODEOWNERS-only change).