### PR TITLE
[None][feat] NIXL support for hybrid model cache transfer

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -288,7 +288,7 @@ private:
     std::unique_ptr<executor::kv_cache::ConnectionManager> mManager;
     std::optional<executor::CacheTransceiverConfig> mCacheTransceiverConfig;
     std::vector<std::unique_ptr<kv_cache_manager::CacheTransBufferManager>> mCacheTransBufferManagers;
-    std::vector<kv_cache_manager::CacheTransBufferManager*> mCacheTransBufferManagerPtrs;
+    std::vector<BaseTransBufferManager*> mCacheTransBufferManagerPtrs;
 
     rnn_state_manager::RnnStateManager* mRnnStateManager{nullptr};
     // TODO(shreyasm): update this to use same container as kv by using base trans buffers instead

--- a/cpp/include/tensorrt_llm/executor/cacheCommunicator.h
+++ b/cpp/include/tensorrt_llm/executor/cacheCommunicator.h
@@ -18,6 +18,8 @@
 
 #include "tensorrt_llm/executor/serialization.h"
 #include <atomic>
+#include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace tensorrt_llm::executor::kv_cache
@@ -62,6 +64,13 @@ public:
     [[nodiscard]] virtual bool isThreadSafe() const noexcept
     {
         return false;
+    }
+
+    virtual void activateBuffer(uint8_t /*kind*/) const {}
+
+    [[nodiscard]] virtual std::optional<size_t> getPreAssignedBufferId(uint8_t /*kind*/) const
+    {
+        return std::nullopt;
     }
 };
 

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -38,6 +39,13 @@ class FabricMemory;
 namespace tensorrt_llm::batch_manager
 {
 
+enum class BufferKind : uint8_t
+{
+    kKV = 0,
+    kKV_INDEXER = 1,
+    kRNN = 2
+};
+
 /// @brief Base class for cache transfer buffer management.
 /// Handles buffer pool allocation, index assignment, and slicing.
 /// Derived classes provide cache-specific size calculations.
@@ -45,6 +53,8 @@ class BaseTransBufferManager
 {
 public:
     virtual ~BaseTransBufferManager() = default;
+
+    [[nodiscard]] virtual BufferKind getBufferKind() const = 0;
 
     /// @brief Assign a buffer index for sending.
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -539,9 +539,10 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
             "bufferCoverTargetNum:%d pickUpConnections.size():%ld",
             bufferTargetNum, targetNum, peerDuplicateHeadFactor, targetInfo.mDupHeadFactor, bufferCoverTargetNum,
             pickUpConnections.size());
-        auto* agentConnnecion
-            = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
-        if (agentConnnecion != nullptr)
+        bool isAgentConnection = connections[pickUpConnections[0]]
+                                     ->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV))
+                                     .has_value();
+        if (isAgentConnection)
         {
             TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == bufferTargetNum, "Agent need all buffer pre-allocated");
             TLLM_CHECK(onlyUseDynamicBuffer == false);
@@ -792,12 +793,11 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
 
                 TLLM_CHECK(blockNum > 0);
 
-                auto* agentConnnecion
-                    = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
-                if (agentConnnecion != nullptr)
+                auto preAssignedKvId
+                    = connections[pickUpConnections[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV));
+                if (preAssignedKvId.has_value())
                 {
-                    cacheBufferId = agentConnnecion->getCacheBufferId();
-                    TLLM_CHECK(cacheBufferId.has_value());
+                    cacheBufferId = static_cast<int>(*preAssignedKvId);
                 }
                 else
                 {
@@ -811,7 +811,7 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                 bufferCoverTargetNum = bufferCoverTargetNumtmp;
                 remainNoCoverTargetNum = targetNum > bufferCoverTargetNum ? targetNum - bufferCoverTargetNum : 0;
 
-                if (agentConnnecion != nullptr)
+                if (preAssignedKvId.has_value())
                 {
                     TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == targetNum, "Agent need buffer pre-allocated");
                     TLLM_CHECK(onlyUseDynamicBuffer == false);

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -539,10 +539,9 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
             "bufferCoverTargetNum:%d pickUpConnections.size():%ld",
             bufferTargetNum, targetNum, peerDuplicateHeadFactor, targetInfo.mDupHeadFactor, bufferCoverTargetNum,
             pickUpConnections.size());
-        bool isAgentConnection = connections[pickUpConnections[0]]
-                                     ->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV))
-                                     .has_value();
-        if (isAgentConnection)
+        auto const* agentConnection
+            = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
+        if (agentConnection != nullptr)
         {
             TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == bufferTargetNum, "Agent need all buffer pre-allocated");
             TLLM_CHECK(onlyUseDynamicBuffer == false);

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -249,6 +249,7 @@ CacheTransBufferManager::CacheTransBufferManager(
                               : cacheManager->getPrimaryPool(0)->getDataType(),
         maxNumTokens)
     , mCacheManager{cacheManager}
+    , mTransferIndexerKCache{transferIndexerKCache}
 {
     // TODO: FP4 dataSize
     TLLM_CHECK(mCacheManager);

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.h
@@ -74,12 +74,18 @@ public:
         return mCacheManager;
     }
 
+    [[nodiscard]] BufferKind getBufferKind() const override
+    {
+        return mTransferIndexerKCache ? BufferKind::kKV_INDEXER : BufferKind::kKV;
+    }
+
 private:
     /// @brief Compute transfer buffer size from KV cache configuration.
     static size_t computeTransferBufferSize(KVCacheManager::BaseKVCacheManager* cacheManager,
         std::optional<size_t> maxNumTokens, bool transferIndexerKCache);
 
     KVCacheManager::BaseKVCacheManager* mCacheManager;
+    bool mTransferIndexerKCache;
 };
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheTransferLayer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransferLayer.cpp
@@ -96,20 +96,11 @@ void CacheTransferLayer::format(TransferSession& session) const
     mKvFormatter->format(session);
     if (mRnnFormatter)
     {
-        // For NIXL agent connections, switch the active buffer index to the RNN buffer
-        // before running the RNN formatter. The buffer descs are ordered [KV..., RNN],
-        // so the RNN buffer is always the last one.
-        auto const& sessionConnections = session.getConnections();
-        for (auto const* conn : sessionConnections)
+        for (auto const* conn : session.getConnections())
         {
             if (conn != nullptr)
             {
-                auto const* agentConn = dynamic_cast<executor::kv_cache::AgentConnection const*>(conn);
-                if (agentConn != nullptr && agentConn->getSenderBufferCount() > 1)
-                {
-                    size_t rnnBufferIdx = agentConn->getSenderBufferCount() - 1;
-                    const_cast<executor::kv_cache::AgentConnection*>(agentConn)->setActiveSenderBufferIdx(rnnBufferIdx);
-                }
+                conn->activateBuffer(static_cast<uint8_t>(BufferKind::kRNN));
             }
         }
         mRnnFormatter->format(session);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -361,7 +361,6 @@ public:
         auto const* connection = isAgent
             ? agentConnectionManager->recvConnectionAndRequestInfo(info, mTerminate)
             : mManager->recvConnect(DataContext{TransceiverTag::kID_TAG, mTerminate}, &id, sizeof(id));
-        TLLM_LOG_INFO("isAgent: %d", isAgent);
         if (connection == nullptr && !mManager->isRunning())
         {
             TLLM_LOG_WARNING(" recvRequestInfo connection is nullptr, maybe the server is terminating");
@@ -389,12 +388,7 @@ public:
         auto peerSelfIdx = info.getTransState().getCommState()->getSelfIdx();
         int peerIdx = std::distance(
             allCounterparts.begin(), std::find(allCounterparts.begin(), allCounterparts.end(), peerSelfIdx));
-        TLLM_LOG_INFO("[CTX] reqId=%lu allCounterparts.size()=%zu", requestId, allCounterparts.size());
-        for (size_t idx = 0; idx < allCounterparts.size(); idx++)
-        {
-            TLLM_LOG_INFO("[CTX] allCounterparts[%zu]=%d", idx, allCounterparts[idx]);
-        }
-        TLLM_LOG_INFO("[CTX] peerSelfIdx=%d, peerIdx=%d", peerSelfIdx, peerIdx);
+
         TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
             "Peer rank %d not found in expected counterparts", peerSelfIdx);
         {
@@ -466,7 +460,6 @@ public:
                 TLLM_CHECK(agentConnection);
                 agentConnection->sendReadySignal(
                     executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, isReady);
-                TLLM_LOG_INFO("sendReadySignal to agent: %d, isReady: %d", i, isReady);
             }
             else
             {
@@ -555,7 +548,6 @@ private:
     {
         auto reqId = mCurrentRequest.value();
         auto count = --mRemainSendCount[reqId];
-        TLLM_LOG_INFO("[CTX] sendResponse reqId=%lu count after decrement=%d", reqId, count);
         TLLM_CHECK(count >= 0);
         if (count == 0)
         {
@@ -647,7 +639,6 @@ private:
                     {
                         mRemainSendCount[reqId] = getCounterpartsCount(reqId);
                     }
-                    TLLM_LOG_INFO("[CTX] reqId=%lu mRemainSendCount=%d", reqId, mRemainSendCount[reqId]);
                 }
                 auto it = getCurrentResponse();
                 if (it != mReadyResponses.end())
@@ -866,7 +857,6 @@ public:
             {
                 cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv());
             }
-            TLLM_LOG_INFO("cacheBufferIds: %zu", cacheBufferIds.size());
             TLLM_CHECK(!cacheBufferIds.empty());
         }
 
@@ -885,9 +875,6 @@ public:
                 destCacheState, mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx())
                                   .mIRanks;
         }
-
-        TLLM_LOG_INFO("[GEN] kvCounterParts.size()=%zu, rnnCounterParts.size()=%zu, allCounterparts.size()=%zu",
-            kvCounterParts.size(), rnnCounterParts.size(), allCounterparts.size());
 
         auto connections = mManager->getConnections(commState);
         std::vector<executor::kv_cache::Connection const*> allConnections;
@@ -948,8 +935,6 @@ public:
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
                 TLLM_CHECK(agentConnection != nullptr);
 
-                TLLM_LOG_INFO("Sending request info to agent for rank %d (KV=%d, RNN=%d)", rank,
-                    static_cast<int>(isKvCounterpart), static_cast<int>(isRnnCounterpart));
                 const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
                     ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx);
             }
@@ -1029,7 +1014,6 @@ public:
         bool isReadyFinal = true;
         bool isReady = false;
         auto const& connections = session.getConnections();
-        TLLM_LOG_INFO("[GEN] receiveReadySignal: waiting for %zu connections", session.getConnections().size());
 
         for (size_t i = 0; i < connections.size(); i++)
         {
@@ -1040,7 +1024,6 @@ public:
                 TLLM_CHECK(agentConnection);
                 isReady = agentConnection->recvReadySignal(
                     executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, mTerminate});
-                TLLM_LOG_INFO("[GEN] received ready signal from connection %zu, isReady=%d", i, isReady);
             }
             else
             {

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -168,16 +168,12 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
 
     for (auto transferIndexerKCache : transferringIndexerKCache)
     {
-        auto activeBufferIdx = transferIndexerKCache ? 1UL : 0UL;
+        auto bufferKind = transferIndexerKCache ? static_cast<uint8_t>(BufferKind::kKV_INDEXER)
+                                                : static_cast<uint8_t>(BufferKind::kKV);
         for (size_t i = 0; i < pickUpConnections.size(); i++)
         {
             auto const* connection = connections.at(pickUpConnections[i]);
-            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
-            {
-                TLLM_CHECK(agentConnection->getSenderBufferCount() > activeBufferIdx);
-                const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
-                    ->setActiveSenderBufferIdx(activeBufferIdx);
-            }
+            connection->activateBuffer(bufferKind);
         }
         int blockNum = 0;
         std::vector<runtime::ITensor::SharedPtr> inputKvCacheBlocks;
@@ -263,9 +259,10 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         auto& outputSplitCaches = std::get<0>(result);
         auto& bufferCoverTargetNum = std::get<1>(result);
         auto& onlyUseDynamicBuffer = std::get<2>(result);
-        auto* agentConnnecion
-            = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
-        if (agentConnnecion != nullptr)
+        bool isAgentConnection = connections[pickUpConnections[0]]
+                                     ->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV))
+                                     .has_value();
+        if (isAgentConnection)
         {
             TLLM_CHECK_WITH_INFO(
                 bufferCoverTargetNum == pPDomainSize * cPDomainSize, "Agent need all buffer pre-allocated");
@@ -488,13 +485,12 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
         }
         else
         {
-            auto* agentConnnecion
-                = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
-            size_t activeBufferIdx = transferIndexerKCache ? 1 : 0;
-            if (agentConnnecion != nullptr)
+            auto bufferKind = transferIndexerKCache ? static_cast<uint8_t>(BufferKind::kKV_INDEXER)
+                                                    : static_cast<uint8_t>(BufferKind::kKV);
+            auto preAssignedId = connections[pickUpConnections[0]]->getPreAssignedBufferId(bufferKind);
+            if (preAssignedId.has_value())
             {
-                cacheBufferId = agentConnnecion->getCacheBufferId(activeBufferIdx);
-                TLLM_CHECK(cacheBufferId.has_value());
+                cacheBufferId = static_cast<int>(*preAssignedId);
             }
             else
             {

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -259,10 +259,9 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         auto& outputSplitCaches = std::get<0>(result);
         auto& bufferCoverTargetNum = std::get<1>(result);
         auto& onlyUseDynamicBuffer = std::get<2>(result);
-        bool isAgentConnection = connections[pickUpConnections[0]]
-                                     ->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV))
-                                     .has_value();
-        if (isAgentConnection)
+        auto const* agentConnection
+            = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
+        if (agentConnection != nullptr)
         {
             TLLM_CHECK_WITH_INFO(
                 bufferCoverTargetNum == pPDomainSize * cPDomainSize, "Agent need all buffer pre-allocated");
@@ -526,7 +525,7 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
             auto& bufferCoverTargetNum = std::get<1>(result);
             size_t remainNoCoverTargetNum = targetNum > bufferCoverTargetNum ? targetNum - bufferCoverTargetNum : 0;
             auto& onlyUseDynamicBuffer = std::get<2>(result);
-            if (agentConnnecion != nullptr)
+            if (preAssignedId.has_value())
             {
                 TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == targetNum, "Agent need buffer pre-allocated");
                 TLLM_CHECK(onlyUseDynamicBuffer == false);

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -157,9 +157,9 @@ void RnnCacheFormatter::format(TransferSession& session)
 
     TLLM_CHECK(cacheBufferId.has_value() || onlyUseDynamicBuffer);
 
-    bool isAgentConnection
-        = connections[pickUpConnections[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN)).has_value();
-    if (isAgentConnection)
+    auto const* agentConnection
+        = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[pickUpConnections[0]]);
+    if (agentConnection != nullptr)
     {
         TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == bufferTargetNum, "Agent needs all RNN send buffers pre-allocated");
         TLLM_CHECK(onlyUseDynamicBuffer == false);

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheTransBuffer.h
@@ -55,8 +55,10 @@ public:
         return mRnnStateManager;
     }
 
-    /// @brief set dtypes
-    // void setDtypes(RnnCacheState const& cacheState) noexcept;
+    [[nodiscard]] BufferKind getBufferKind() const override
+    {
+        return BufferKind::kRNN;
+    }
 
 private:
     /// @brief Compute transfer buffer size from RNN state configuration.

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -288,7 +288,7 @@ std::optional<size_t> AgentConnection::getPreAssignedBufferId(uint8_t kind) cons
 {
     for (size_t i = 0; i < mBufferKinds.size(); i++)
     {
-        if (mBufferKinds[i] == kind)
+        if (mBufferKinds[i] == kind && i < mCacheBufferIds.size())
         {
             return mCacheBufferIds[i];
         }

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -81,27 +81,6 @@ AgentConnection::AgentConnection(
     TLLM_CHECK(!mCacheTransBufferManagers.empty());
 }
 
-std::optional<size_t> AgentConnection::getCacheBufferId(size_t bufferIdx) const
-{
-    TLLM_CHECK(bufferIdx < mCacheBufferIds.size());
-    return mCacheBufferIds[bufferIdx];
-}
-
-size_t AgentConnection::getCacheBufferIdCount() const
-{
-    return mCacheBufferIds.size();
-}
-
-size_t AgentConnection::getSenderBufferCount() const
-{
-    return mSenderState.mCacheReceiverBufferDescs.size();
-}
-
-void AgentConnection::setActiveSenderBufferIdx(size_t bufferIdx)
-{
-    mSenderState.setActiveBufferIdx(bufferIdx);
-}
-
 MemoryDesc const& AgentConnection::SenderState::activeBufferDesc() const
 {
     TLLM_CHECK(!mCacheReceiverBufferDescs.empty());
@@ -527,18 +506,6 @@ std::vector<batch_manager::BaseTransBufferManager*> const& AgentConnectionManage
 std::vector<uint8_t> const& AgentConnectionManager::getBufferKinds() const
 {
     return mBufferKinds;
-}
-
-batch_manager::BaseTransBufferManager* AgentConnectionManager::findManagerForKind(batch_manager::BufferKind kind) const
-{
-    for (size_t i = 0; i < mCacheTransBufferManagers.size(); i++)
-    {
-        if (mCacheTransBufferManagers[i]->getBufferKind() == kind)
-        {
-            return mCacheTransBufferManagers[i];
-        }
-    }
-    return nullptr;
 }
 
 AgentConnection* AgentConnectionManager::connect(std::string const& remoteAgentName, std::string const& connectionInfo,

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
@@ -263,10 +263,6 @@ public:
         std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx);
     void setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int valideSegmentIdx,
         std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds);
-    void setActiveSenderBufferIdx(size_t bufferIdx);
-    [[nodiscard]] size_t getSenderBufferCount() const;
-    [[nodiscard]] std::optional<size_t> getCacheBufferId(size_t bufferIdx = 0) const;
-    [[nodiscard]] size_t getCacheBufferIdCount() const;
     void setHasLoadRemoteAgent(bool hasLoadRemoteAgent);
     [[nodiscard]] bool hasLoadRemoteAgent() const;
     void sendReadySignal(DataContext const& ctx, bool isReady) const;
@@ -316,7 +312,6 @@ public:
         batch_manager::RequestInfo& requestInfo, std::atomic<bool> const& terminateFlag);
     [[nodiscard]] std::vector<batch_manager::BaseTransBufferManager*> const& getCacheTransBufferManagers() const;
     [[nodiscard]] std::vector<uint8_t> const& getBufferKinds() const;
-    [[nodiscard]] batch_manager::BaseTransBufferManager* findManagerForKind(batch_manager::BufferKind kind) const;
     void updateUnhandledNotifications();
     [[nodiscard]] BaseTransferAgent* getAgent() const;
     AgentConnection* connect(std::string const& remoteAgentName, std::string const& address,

--- a/cpp/tests/unit_tests/executor/agentCommTest.cpp
+++ b/cpp/tests/unit_tests/executor/agentCommTest.cpp
@@ -155,7 +155,7 @@ protected:
 
 TEST_P(AgentCommTest, AgentConnectionManagerBasic)
 {
-    std::vector<CacheTransBufferManager*> bufferManagers{mTransBufferManager.get()};
+    std::vector<tensorrt_llm::batch_manager::BaseTransBufferManager*> bufferManagers{mTransBufferManager.get()};
     auto connectionManager = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState, backend);
     ASSERT_TRUE(connectionManager != nullptr);
     ASSERT_EQ(connectionManager->getCacheTransBufferManagers().size(), bufferManagers.size());
@@ -170,7 +170,7 @@ TEST_P(AgentCommTest, AgentConnectionManagerBasic)
 
 TEST_P(AgentCommTest, AgentConnectionManagerConnect)
 {
-    std::vector<CacheTransBufferManager*> bufferManagers{mTransBufferManager.get()};
+    std::vector<tensorrt_llm::batch_manager::BaseTransBufferManager*> bufferManagers{mTransBufferManager.get()};
     auto connectionManager0 = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState, backend);
     auto connectionManager1 = std::make_unique<AgentConnectionManager>(bufferManagers, *mCacheState, backend);
     auto agentName0 = connectionManager0->getAgentName();

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -767,13 +767,17 @@ protected:
 
                 setenv("TRTLLM_NIXL_PORT", std::to_string(port).c_str(), 1);
 
-                mConnectionManager
-                    = std::make_unique<texec::kv_cache::AgentConnectionManager>(bufferManagers, *mCacheState, "nixl");
+                std::vector<tensorrt_llm::batch_manager::BaseTransBufferManager*> baseBufferManagers(
+                    bufferManagers.begin(), bufferManagers.end());
+                mConnectionManager = std::make_unique<texec::kv_cache::AgentConnectionManager>(
+                    baseBufferManagers, *mCacheState, "nixl");
             }
             else if (isMooncake)
             {
+                std::vector<tensorrt_llm::batch_manager::BaseTransBufferManager*> baseBufferManagers(
+                    bufferManagers.begin(), bufferManagers.end());
                 mConnectionManager = std::make_unique<texec::kv_cache::AgentConnectionManager>(
-                    bufferManagers, *mCacheState, "mooncake");
+                    baseBufferManagers, *mCacheState, "mooncake");
             }
             else
             {

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -44,10 +44,7 @@ def create_kv_cache_transceiver(
     if cache_transceiver_config.backend == "DEFAULT":
         # When cache_transceiver_config.backend is not set, fallback to env_vars settings
         # NIXL is the default backend for non hybrid models
-        if mamba_cache_manager is None:
-            cache_transceiver_config.backend = "NIXL"
-        else:
-            cache_transceiver_config.backend = "UCX"
+        cache_transceiver_config.backend = "NIXL"
         # Ordered by priority
         env_vars = [
             ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
@@ -71,14 +68,6 @@ def create_kv_cache_transceiver(
             f"Using UCX kv-cache transceiver. If your devices are not in the same domain, please consider setting "
             f"UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
             f"hangs or lower-than-expected performance.")
-
-    if mamba_cache_manager is not None and cache_transceiver_config.backend in [
-            "NIXL", "MOONCAKE"
-    ]:
-        raise ValueError(
-            "NIXL or MOONCAKE backend does not support hybrid models with RNN (Mamba) states. "
-            "Please use UCX or MPI backend for cache transfer with hybrid models."
-        )
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -64,6 +64,7 @@ from .cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig
 from .guided_decoder import CapturableGuidedDecoder
 from .layerwise_nvtx_marker import LayerwiseNvtxMarker
 from .llm_request import LlmRequest, get_draft_token_length
+from .mamba_cache_manager import MambaHybridCacheManager
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .resource_manager import (BaseResourceManager, KVCacheManager,
                                KVCacheManagerV2, PeftCacheManager,
@@ -678,7 +679,8 @@ class PyTorchModelEngine(ModelEngine):
             self._run_autotuner_warmup(resource_manager)
         self._run_cuda_graph_warmup(resource_manager)
         if not self.is_draft_model and not self.mapping.has_cp_helix(
-        ) and self.guided_decoder is None:
+        ) and self.guided_decoder is None and not isinstance(
+                kv_cache_manager, MambaHybridCacheManager):
             # Run extra general warmup to warmup memory pool before running real requests to reduce memory fragmentation.
             self._general_warmup(resource_manager, reverse=True)
 

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1621,13 +1621,12 @@ class TestNemotron3Super120B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "nvidia/NVIDIA-Nemotron-3-Super-120B-012726"
     MODEL_PATH = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-FP8-FP8KV-012726"
 
-    @pytest.mark.skip_less_device(8)
-    def test_auto_dtype(self):
+    def _make_configs(self, backend: str):
         ctx_server_config = {
             "max_batch_size": 32,
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
-                "backend": "UCX",
+                "backend": backend,
                 "max_tokens_in_buffer": 8192,
             },
             "tensor_parallel_size": 4,
@@ -1646,7 +1645,7 @@ class TestNemotron3Super120B(LlmapiAccuracyTestHarness):
             "max_batch_size": 32,
             "disable_overlap_scheduler": False,
             "cache_transceiver_config": {
-                "backend": "UCX",
+                "backend": backend,
                 "max_tokens_in_buffer": 8192,
             },
             "tensor_parallel_size": 2,
@@ -1679,7 +1678,18 @@ class TestNemotron3Super120B(LlmapiAccuracyTestHarness):
                 "urls": ["localhost:8002"]
             }
         }
-        with launch_disaggregated_llm(disaggregated_server_config,
-                                      ctx_server_config, gen_server_config,
+        return ctx_server_config, gen_server_config, disaggregated_server_config
+
+    @pytest.mark.skip_less_device(8)
+    def test_auto_dtype(self):
+        ctx_cfg, gen_cfg, disagg_cfg = self._make_configs("UCX")
+        with launch_disaggregated_llm(disagg_cfg, ctx_cfg, gen_cfg,
+                                      self.MODEL_PATH) as llm:
+            run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])
+
+    @pytest.mark.skip_less_device(8)
+    def test_nixl_backend(self):
+        ctx_cfg, gen_cfg, disagg_cfg = self._make_configs("NIXL")
+        with launch_disaggregated_llm(disagg_cfg, ctx_cfg, gen_cfg,
                                       self.MODEL_PATH) as llm:
             run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -380,6 +380,8 @@ accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[True-True]
 accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype[False-False]
 accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_nixl_backend
 accuracy/test_disaggregated_serving.py::TestKimiK2::test_nvfp4
+accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_auto_dtype
+accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_nixl_backend
 
 # e2e test
 test_e2e.py::test_llama_e2e[use_py_session-remove_input_padding-]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -119,6 +119,8 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-cutlass] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TP4_PP2] TIMEOUT (60)
+  - accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_auto_dtype TIMEOUT (60)
+  - accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_nixl_backend TIMEOUT (60)
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -334,7 +334,7 @@ def hybrid_dtypes(request):
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.parametrize("backend", ["UCX"], ids=["UCX"])
+@pytest.mark.parametrize("backend", ["NIXL", "UCX"], ids=["NIXL", "UCX"])
 @pytest.mark.parametrize(
     "hybrid_dtypes",
     [
@@ -450,7 +450,7 @@ def test_hybrid_cache_transceiver_single_process(backend, hybrid_dtypes,
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.parametrize("backend", ["UCX"], ids=["UCX"])
+@pytest.mark.parametrize("backend", ["NIXL", "UCX"], ids=["NIXL", "UCX"])
 def test_hybrid_cache_transceiver_cancel_request(backend, monkeypatch):
     monkeypatch.setenv("TRTLLM_USE_CPP_MAMBA", "1")
 
@@ -460,7 +460,7 @@ def test_hybrid_cache_transceiver_cancel_request(backend, monkeypatch):
     hybrid_cache_manager_ctx = create_hybrid_cache_manager(mapping, dtype)
     hybrid_cache_manager_gen = create_hybrid_cache_manager(mapping, dtype)
 
-    cache_transceiver_config = CacheTransceiverConfig(backend="DEFAULT",
+    cache_transceiver_config = CacheTransceiverConfig(backend=backend,
                                                       max_tokens_in_buffer=512)
     dist = Distributed.get(mapping)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RNN cache transfer now supported on NIXL and MOONCAKE backends
  * Hybrid Mamba models no longer blocked on NIXL and MOONCAKE backends
  * Enhanced logging for cache transfer operations to improve debugging visibility

* **Refactor**
  * Improved buffer manager abstraction for greater flexibility
  * Optimized per-buffer offset ratio handling for cache transfers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
