### PR TITLE
[https://nvbugs/5856659][infra] add leaner runtime container image

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -4,6 +4,8 @@ ARG TRITON_IMAGE=nvcr.io/nvidia/tritonserver
 ARG BASE_TAG=25.12-py3
 ARG TRITON_BASE_TAG=25.12-py3
 ARG DEVEL_IMAGE=devel
+ARG RUNTIME_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base
+ARG RUNTIME_BASE_TAG=25.12-cuda13.1-runtime-ubuntu24.04
 
 FROM ${BASE_IMAGE}:${BASE_TAG} AS base
 
@@ -200,6 +202,143 @@ ENV TRT_LLM_GIT_COMMIT=${GIT_COMMIT} \
 # Generate OSS attribution file for release image
 COPY scripts/generate_container_oss_attribution.sh /tmp/generate_container_oss_attribution.sh
 RUN bash /tmp/generate_container_oss_attribution.sh "release" "${TRT_LLM_VER}" "${TARGETARCH}" && rm /tmp/generate_container_oss_attribution.sh
+
+FROM ${RUNTIME_BASE_IMAGE}:${RUNTIME_BASE_TAG} AS runtime
+
+LABEL com.nvidia.eula="https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/"
+LABEL com.nvidia.ai-terms="https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/"
+
+ARG ARCH_ALT=x86_64
+SHELL ["/bin/bash", "-c"]
+
+# Copy CUDA development tools needed for Triton JIT kernel compilation
+COPY --from=base /usr/local/cuda/bin/nvcc /usr/local/cuda/bin/nvcc
+COPY --from=base /usr/local/cuda/bin/cudafe++ /usr/local/cuda/bin/cudafe++
+COPY --from=base /usr/local/cuda/bin/ptxas /usr/local/cuda/bin/ptxas
+COPY --from=base /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary
+COPY --from=base /usr/local/cuda/include/ /usr/local/cuda/include/
+COPY --from=base /usr/local/cuda/nvvm /usr/local/cuda/nvvm
+COPY --from=base /usr/local/cuda/bin/cuobjdump /usr/local/cuda/bin/cuobjdump
+COPY --from=base /usr/local/cuda/bin/nvdisasm /usr/local/cuda/bin/nvdisasm
+COPY --from=base /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
+COPY --from=base /usr/local/cuda/lib64/libcupti* /usr/local/cuda/lib64/
+COPY --from=base /usr/local/cuda/lib64/libcusparseLt* /usr/local/cuda/lib64/
+
+# Copy HPC-X stack (OpenMPI, UCX, UCC) from the PyTorch base image
+COPY --from=base /opt/hpcx /opt/hpcx
+
+# Copy additional system libraries from the PyTorch base image
+COPY --from=base /usr/local/lib/lib* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH_ALT}-linux-gnu/libnuma.so* /usr/lib/${ARCH_ALT}-linux-gnu/
+
+# Copy TensorRT from the release stage (installed in devel via install_tensorrt.sh)
+COPY --from=release /usr/local/tensorrt /usr/local/tensorrt
+
+# Copy standalone UCX build (installed in devel via install_ucx.sh)
+COPY --from=release /usr/local/ucx /usr/local/ucx
+
+# Copy NIXL (installed in devel via install_nixl.sh)
+COPY --from=release /opt/nvidia/nvda_nixl /opt/nvidia/nvda_nixl
+
+# Copy etcd binaries (installed in devel via install_etcd.sh)
+COPY --from=release /usr/local/bin/etcd /usr/local/bin/etcd
+COPY --from=release /usr/local/bin/etcdctl /usr/local/bin/etcdctl
+COPY --from=release /usr/local/bin/etcdutl /usr/local/bin/etcdutl
+
+# Install runtime system packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        gnupg2 curl ca-certificates && \
+    if [ "${ARCH_ALT}" = "x86_64" ]; then ARCH_GPG="x86_64"; else ARCH_GPG="sbsa"; fi && \
+    curl -fsSL \
+        "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${ARCH_GPG}/cuda-archive-keyring.gpg" \
+        -o /usr/share/keyrings/cuda-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${ARCH_GPG} /" \
+        > /etc/apt/sources.list.d/cuda.repo.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        g++ \
+        ninja-build \
+        git \
+        git-lfs \
+        python3-dev \
+        python3-pip \
+        jq \
+        libcudnn9-cuda-13 \
+        libnvshmem3-cuda-13 \
+        libzmq3-dev \
+        ibverbs-providers \
+        ibverbs-utils \
+        libibumad3 \
+        libibverbs1 \
+        libnuma1 \
+        numactl \
+        librdmacm1 \
+        rdma-core \
+        openssh-client \
+        openssh-server && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf /usr/lib/${ARCH_ALT}-linux-gnu/libnccl.so.2 /usr/lib/${ARCH_ALT}-linux-gnu/libnccl.so || true
+
+# Copy Python packages with TRT-LLM and all dependencies from the release stage
+COPY --from=release /usr/local/lib/python3.12/dist-packages/ /usr/local/lib/python3.12/dist-packages/
+
+# Set up TRT-LLM application directory
+WORKDIR /app/tensorrt_llm
+COPY --from=release /app/tensorrt_llm/ /app/tensorrt_llm/
+
+# Register library paths with the dynamic linker
+RUN echo "/app/tensorrt_llm/lib" > /etc/ld.so.conf.d/tensorrt_llm.conf && \
+    echo "/usr/local/tensorrt/lib" > /etc/ld.so.conf.d/tensorrt.conf && \
+    echo "/usr/local/ucx/lib" > /etc/ld.so.conf.d/ucx.conf && \
+    echo "/usr/local/ucx/lib/ucx" >> /etc/ld.so.conf.d/ucx.conf && \
+    echo "/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
+    echo "/opt/nvidia/nvda_nixl/lib64" >> /etc/ld.so.conf.d/nixl.conf && \
+    ldconfig
+
+ENV CUDA_HOME=/usr/local/cuda \
+    NVIDIA_DRIVER_CAPABILITIES=video,compute,utility \
+    OMPI_MCA_coll_ucc_enable=0 \
+    OPAL_PREFIX=/opt/hpcx/ompi
+
+ENV PATH="/usr/local/ucx/bin:/opt/hpcx/ompi/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin:${PATH}"
+
+ENV LD_LIBRARY_PATH="\
+/app/tensorrt_llm/lib:\
+/usr/local/tensorrt/lib:\
+/usr/local/ucx/lib:\
+/usr/local/ucx/lib/ucx:\
+/opt/hpcx/ompi/lib:\
+/opt/hpcx/ucc/lib:\
+/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu:\
+/opt/nvidia/nvda_nixl/lib64:\
+/usr/lib/${ARCH_ALT}-linux-gnu/nvshmem/13/:\
+/usr/local/cuda/lib64"
+
+ENV TRITON_CUPTI_PATH=/usr/local/cuda/include \
+    TRITON_CUDACRT_PATH=/usr/local/cuda/include \
+    TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump \
+    TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm \
+    TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
+    TRITON_CUDART_PATH=/usr/local/cuda/include
+
+# Validate critical binaries and library linkage
+RUN test -f /app/tensorrt_llm/bin/executorWorker && \
+    ! ( ldd -v /app/tensorrt_llm/bin/executorWorker | grep tensorrt_llm | grep -q "not found" )
+
+ARG GIT_COMMIT
+ARG TRT_LLM_VER
+ARG TARGETARCH
+ENV TRT_LLM_GIT_COMMIT=${GIT_COMMIT} \
+    TRT_LLM_VERSION=${TRT_LLM_VER}
+
+COPY scripts/generate_container_oss_attribution.sh /tmp/generate_container_oss_attribution.sh
+RUN bash /tmp/generate_container_oss_attribution.sh "runtime" "${TRT_LLM_VER}" "${TARGETARCH}" && \
+    rm /tmp/generate_container_oss_attribution.sh
+
 
 FROM wheel AS tritonbuild
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,6 +3,9 @@ BASE_IMAGE         ?= $(shell grep '^ARG BASE_IMAGE=' Dockerfile.multi | grep -o
 BASE_TAG           ?= $(shell grep '^ARG BASE_TAG=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
 TRITON_IMAGE       ?= $(shell grep '^ARG TRITON_IMAGE=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
 TRITON_BASE_TAG    ?= $(shell grep '^ARG TRITON_BASE_TAG=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
+RUNTIME_BASE_IMAGE ?= $(shell grep '^ARG RUNTIME_BASE_IMAGE=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
+RUNTIME_BASE_TAG   ?= $(shell grep '^ARG RUNTIME_BASE_TAG=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
+ARCH_ALT           ?= $(if $(filter arm64,$(PLATFORM)),aarch64,x86_64)
 # Name of the new image
 IMAGE_NAME         ?= tensorrt_llm
 IMAGE_TAG          ?= latest
@@ -105,6 +108,9 @@ base_pull:
 		$(if $(GIT_COMMIT), --build-arg GIT_COMMIT="$(GIT_COMMIT)") \
 		$(if $(GITHUB_MIRROR), --build-arg GITHUB_MIRROR="$(GITHUB_MIRROR)") \
 		$(if $(PYTHON_VERSION), --build-arg PYTHON_VERSION="$(PYTHON_VERSION)") \
+		$(if $(RUNTIME_BASE_IMAGE), --build-arg RUNTIME_BASE_IMAGE="$(RUNTIME_BASE_IMAGE)") \
+		$(if $(RUNTIME_BASE_TAG), --build-arg RUNTIME_BASE_TAG="$(RUNTIME_BASE_TAG)") \
+		$(if $(ARCH_ALT), --build-arg ARCH_ALT="$(ARCH_ALT)") \
 		$(if $(SH_ENV), --build-arg SH_ENV="$(SH_ENV)") \
 		$(if $(BASH_ENV), --build-arg BASH_ENV="$(BASH_ENV)") \
 		$(if $(STAGE), --target $(STAGE)) \
@@ -189,6 +195,9 @@ wheel_run: WORK_DIR = /src/tensorrt_llm
 release_%: STAGE = release
 release_run: WORK_DIR = /app/tensorrt_llm
 
+runtime_%: STAGE = runtime
+runtime_run: WORK_DIR = /app/tensorrt_llm
+
 # For x86_64
 jenkins_%: IMAGE_WITH_TAG = $(shell . ../jenkins/current_image_tags.properties && echo $$LLM_DOCKER_IMAGE)
 jenkins_%: STAGE = tritondevel
@@ -248,6 +257,18 @@ ngc-release_run:  IMAGE_NAME = $(NGC_AUTO_REPO)
 ngc-release_run:  IMAGE_TAG = $(TRT_LLM_VERSION)
 ngc-release_pull: IMAGE_NAME = $(NGC_AUTO_REPO)
 ngc-release_pull: IMAGE_TAG = $(TRT_LLM_VERSION)
+
+ngc-runtime_%: STAGE = runtime
+ngc-runtime_%: DOCKER_BUILD_OPTS = --pull --load --platform linux/$(PLATFORM)
+ngc-runtime_%: DEVEL_IMAGE = $(NGC_STAGING_REPO)/devel:$(TRT_LLM_VERSION)
+ngc-runtime_%: IMAGE_NAME = $(NGC_STAGING_REPO)
+ngc-runtime_%: IMAGE_TAG = $(TRT_LLM_VERSION)-$(PLATFORM)
+
+ngc-runtime_run:  WORK_DIR = /app/tensorrt_llm
+ngc-runtime_run:  IMAGE_NAME = $(NGC_AUTO_REPO)
+ngc-runtime_run:  IMAGE_TAG = $(TRT_LLM_VERSION)
+ngc-runtime_pull: IMAGE_NAME = $(NGC_AUTO_REPO)
+ngc-runtime_pull: IMAGE_TAG = $(TRT_LLM_VERSION)
 
 ngc-manifest_%: STAGE = release
 ngc-manifest_%: IMAGE_NAME = $(NGC_STAGING_REPO)


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

The "release" image is large. This PR introduces a smaller "runtime" image that only contains enough to run TRT-LLM and not build it. The runtime image in this PR is inspired by the runtime image used by Dynamo: https://github.com/ai-dynamo/dynamo/blob/main/container/templates/trtllm_runtime.Dockerfile

This PR also significantly refactors the image generation pipeline to support various container images in a more unified way.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
