### PR TITLE
[None][chore] Refactor fused qk norm rope kernel

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -56,11 +56,56 @@ namespace kernels
 {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Apply the RoPE rotation to a single element.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+template <bool full_rotary>
+__device__ __forceinline__ float applyRoPERotation(float element, float paired_element, float sin_val, float cos_val,
+    float attention_factor, int dim_idx, int rotary_dim)
+{
+    if constexpr (full_rotary)
+    {
+        return (element * cos_val + paired_element * sin_val) * attention_factor;
+    }
+
+    float rotated_element{element};
+    if (dim_idx < rotary_dim)
+    {
+        rotated_element = (element * cos_val + paired_element * sin_val) * attention_factor;
+    }
+
+    return rotated_element;
+}
+
+// Apply YaRN frequency scaling to adjust the RoPE frequency
+__device__ __forceinline__ float applyYaRNScaling(float freq, int half_dim, float factor, float low, float high)
+{
+    float const inv_freq_extrapolation = freq;
+    float const inv_freq_interpolation = freq / factor;
+
+    // Inverse lerp
+    float const linear_func = (static_cast<float>(half_dim) - low) / (high - low);
+    // clamp linear_func to [0.0f, 1.0f]
+    float const ramp_func = fminf(fmaxf(linear_func, 0.0f), 1.0f);
+    return inv_freq_interpolation * ramp_func + inv_freq_extrapolation * (1.0f - ramp_func);
+}
+
+// Determine the RoPE frequency for a given dimension index, applying YaRN scaling if needed
+__device__ __forceinline__ float computeRoPEFrequency(
+    float base, int half_dim, int rotary_dim, float factor, float low, float high)
+{
+    float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
+    if (factor != 1.0f)
+    {
+        freq = applyYaRNScaling(freq, half_dim, factor, low, high);
+    }
+    return freq;
+}
 
 // Perform per-head QK Norm and RoPE in a single kernel.
 // head_dim: the dimension of each head
 // interleave: interleave=!is_neox.
-template <int head_dim, bool interleave>
+// full_rotary: true when rotary_dim == head_dim (no partial-RoPE predicate needed in the kernel)
+template <int head_dim, bool interleave, bool full_rotary>
 __global__ void fusedQKNormRopeKernel(
     __nv_bfloat16* qkv,            // Combined QKV tensor [num_tokens, (num_heads_q+num_heads_k+num_heads_v)*head_dim]
     int const num_heads_q,         // Number of query heads
@@ -98,7 +143,9 @@ __global__ void fusedQKNormRopeKernel(
 
     // Skip if this warp is assigned beyond the number of tokens
     if (tokenIdx >= num_tokens)
+    {
         return;
+    }
 
     bool const isQ = localHeadIdx < num_heads_q;
     int const headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
@@ -147,6 +194,7 @@ __global__ void fusedQKNormRopeKernel(
 
     if (is_qk_norm)
     {
+        __syncwarp();
         // Reduce sum across warp using the utility function
         sumOfSquares = tensorrt_llm::common::warpReduceSum(sumOfSquares);
 
@@ -161,117 +209,62 @@ __global__ void fusedQKNormRopeKernel(
             elements[i] *= rms_rcp * weight;
         }
     }
-    // Apply RoPE to normalized elements
-    float elements2[numElemsPerThread]; // Additional buffer required for RoPE.
-    float cos_vals[numElemsPerThread];
-    float sin_vals[numElemsPerThread];
 
-    float pos_id = static_cast<float>(position_ids[tokenIdx]);
+    float const pos_id = static_cast<float>(position_ids[tokenIdx]);
 
-    // TODO: cos sin calculation could be halved.
     if constexpr (interleave)
     {
-        // Perform interleaving. Fill cos_vals and sin_vals.
-        for (int i = 0; i < numElemsPerThread; i++)
+        // Compute RoPE with interleaving. Even/odd pairs share the same half_dim
+        // so sin/cos are computed once per pair and reused
+        for (int i = 0; i < numElemsPerThread; i += 2)
         {
-            if (i % 2 == 0)
-            {
-                elements2[i] = -elements[i + 1];
-            }
-            else
-            {
-                elements2[i] = elements[i - 1];
-            }
+            int const dim_idx = laneId * numElemsPerThread + i;
+            int const half_dim = dim_idx / 2;
+            float const freq{computeRoPEFrequency(base, half_dim, rotary_dim, factor, low, high)};
+            float const theta = pos_id * freq;
+            float sin_val, cos_val;
+            __sincosf(theta, &sin_val, &cos_val);
 
-            int dim_idx = laneId * numElemsPerThread + i;
-            int half_dim = dim_idx / 2;
-            float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
+            // Save originals before mutation
+            float const orig_even = elements[i];
+            float const orig_odd = elements[i + 1];
 
-            if (factor != 1.0f)
-            {
-                float inv_freq_extrapolation = freq;
-                float inv_freq_interpolation = freq / factor;
-
-                // linear_ramp_factor
-                if (fabsf(low - high) <= 1e-6f)
-                {
-                    high += 0.001; // Prevent singularity
-                }
-                float linear_func = (static_cast<float>(half_dim) - low) / (high - low);
-                // clamp linear_func to [0.0f, 1.0f]
-                float ramp_func = fmin(fmax(linear_func, 0.0f), 1.0f);
-                float inv_freq_extrapolation_factor = 1.0f - ramp_func;
-                freq = inv_freq_interpolation * (1.0f - inv_freq_extrapolation_factor)
-                    + inv_freq_extrapolation * inv_freq_extrapolation_factor;
-            }
-
-            float theta = pos_id * freq;
-            __sincosf(theta, &sin_vals[i], &cos_vals[i]);
+            // Even element: paired with next
+            elements[i] = applyRoPERotation<full_rotary>(
+                orig_even, -orig_odd, sin_val, cos_val, attention_factor, dim_idx, rotary_dim);
+            // Odd element: paired with previous (reuse same sin/cos)
+            elements[i + 1] = applyRoPERotation<full_rotary>(
+                orig_odd, orig_even, sin_val, cos_val, attention_factor, dim_idx + 1, rotary_dim);
         }
     }
     else
     {
         // Before data exchange with in warp, we need to sync.
         __syncwarp();
-        int pairOffset = (rotary_dim / 2) / numElemsPerThread;
-        // Get the data from the other half of the warp. Fill cos_vals and sin_vals.
+        int const pairOffset = (rotary_dim / 2) / numElemsPerThread;
         for (int i = 0; i < numElemsPerThread; i++)
         {
-            elements2[i] = __shfl_xor_sync(0xffffffff, elements[i], pairOffset);
+            float elem2 = __shfl_xor_sync(0xffffffff, elements[i], pairOffset);
             if (laneId < pairOffset)
             {
-                elements2[i] = -elements2[i];
+                elem2 = -elem2;
             }
 
-            int dim_idx = laneId * numElemsPerThread + i;
-            dim_idx = (dim_idx * 2) % rotary_dim;
-            int half_dim = dim_idx / 2;
-            float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
+            int const orig_dim_idx = laneId * numElemsPerThread + i;
+            int const dim_idx = (orig_dim_idx * 2) % rotary_dim;
+            int const half_dim = dim_idx / 2;
 
-            if (factor != 1.0f)
-            {
-                float inv_freq_extrapolation = freq;
-                float inv_freq_interpolation = freq / factor;
+            float const freq{computeRoPEFrequency(base, half_dim, rotary_dim, factor, low, high)};
 
-                // linear_ramp_factor
-                if (fabsf(low - high) <= 1e-6f)
-                {
-                    high += 0.001; // Prevent singularity
-                }
-                float linear_func = (static_cast<float>(half_dim) - low) / (high - low);
-                // clamp linear_func to [0.0f, 1.0f]
-                float ramp_func = fmin(fmax(linear_func, 0.0f), 1.0f);
-                float inv_freq_extrapolation_factor = 1.0f - ramp_func;
-                freq = inv_freq_interpolation * (1.0f - inv_freq_extrapolation_factor)
-                    + inv_freq_extrapolation * inv_freq_extrapolation_factor;
-            }
+            float const theta = pos_id * freq;
+            float sin_val, cos_val;
+            __sincosf(theta, &sin_val, &cos_val);
 
-            float theta = pos_id * freq;
-            __sincosf(theta, &sin_vals[i], &cos_vals[i]);
+            elements[i] = applyRoPERotation<full_rotary>(
+                elements[i], elem2, sin_val, cos_val, attention_factor, orig_dim_idx, rotary_dim);
         }
         // __shfl_xor_sync does not provide memfence. Need to sync again.
         __syncwarp();
-    }
-
-    bool const is_full_rope = (rotary_dim == head_dim);
-    if (is_full_rope)
-    {
-        for (int i = 0; i < numElemsPerThread; i++)
-        {
-            elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
-        }
-    }
-    else
-    {
-        for (int i = 0; i < numElemsPerThread; i++)
-        {
-            int dim_idx = laneId * numElemsPerThread + i;
-
-            if (dim_idx < rotary_dim)
-            {
-                elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
-            }
-        }
     }
 
     // Store.
@@ -292,13 +285,51 @@ __global__ void fusedQKNormRopeKernel(
 #define DISPATCH_INTERLEAVE(interleave, INTERLEAVE, ...)                                                               \
     if (interleave)                                                                                                    \
     {                                                                                                                  \
-        const bool INTERLEAVE = true;                                                                                  \
+        bool const INTERLEAVE = true;                                                                                  \
         __VA_ARGS__                                                                                                    \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
-        const bool INTERLEAVE = false;                                                                                 \
+        bool const INTERLEAVE = false;                                                                                 \
         __VA_ARGS__                                                                                                    \
+    }
+
+#define DISPATCH_FULL_ROTARY(full_rotary, FULL_ROTARY, ...)                                                            \
+    if (full_rotary)                                                                                                   \
+    {                                                                                                                  \
+        bool const FULL_ROTARY = true;                                                                                 \
+        __VA_ARGS__                                                                                                    \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        bool const FULL_ROTARY = false;                                                                                \
+        __VA_ARGS__                                                                                                    \
+    }
+
+// Head dimensions should be a multiple of 64
+// Add more cases as needed
+#define DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, ...)                                                                     \
+    switch (head_dim)                                                                                                  \
+    {                                                                                                                  \
+    case 64:                                                                                                           \
+    {                                                                                                                  \
+        constexpr int HEAD_DIM = 64;                                                                                   \
+        __VA_ARGS__                                                                                                    \
+    }                                                                                                                  \
+    break;                                                                                                             \
+    case 128:                                                                                                          \
+    {                                                                                                                  \
+        constexpr int HEAD_DIM = 128;                                                                                  \
+        __VA_ARGS__                                                                                                    \
+    }                                                                                                                  \
+    break;                                                                                                             \
+    case 256:                                                                                                          \
+    {                                                                                                                  \
+        constexpr int HEAD_DIM = 256;                                                                                  \
+        __VA_ARGS__                                                                                                    \
+    }                                                                                                                  \
+    break;                                                                                                             \
+    default: TLLM_THROW("Unsupported head dimension for fusedQKNormRope: %d", head_dim);                               \
     }
 
 void launchFusedQKNormRope(void* qkv, int const num_tokens, int const num_heads_q, int const num_heads_k,
@@ -319,46 +350,30 @@ void launchFusedQKNormRope(void* qkv, int const num_tokens, int const num_heads_
             (rotary_dim * 16) % head_dim == 0, "Unsupported rotary dimension for fusedQKNormRope: %d", rotary_dim);
     }
 
-    constexpr int blockSize = 256;
+    constexpr dim3 blockSize(256, 1, 1);
+    constexpr int warpsPerBlock = blockSize.x / 32;
 
-    int const warpsPerBlock = blockSize / 32;
     int const totalQKHeads = num_heads_q + num_heads_k;
     int const totalWarps = num_tokens * totalQKHeads;
 
     int const gridSize = common::divUp(totalWarps, warpsPerBlock);
-    dim3 gridDim(gridSize);
-    dim3 blockDim(blockSize);
 
-    // Head dimensions should be a multiple of 64
-    // Add more cases as needed
-    switch (head_dim)
+    // linear_ramp_factor
+    if (factor != 1.0f)
     {
-    case 64:
-        DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<64, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
-        });
-        break;
-    case 128:
-        DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<128, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
-        });
-        break;
-    case 256:
-        DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<256, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
-        });
-        break;
-    default: TLLM_THROW("Unsupported head dimension for fusedQKNormRope: %d", head_dim);
+        high += 0.001f; // Prevent singularity
     }
+
+    DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
+        DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
+            DISPATCH_FULL_ROTARY(rotary_dim == head_dim, FULL_ROTARY, {
+                fusedQKNormRopeKernel<HEAD_DIM, INTERLEAVE, FULL_ROTARY><<<gridSize, blockSize, 0, stream>>>(
+                    reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
+                    reinterpret_cast<__nv_bfloat16 const*>(q_weight), static_cast<__nv_bfloat16 const*>(k_weight), base,
+                    position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
+            });
+        });
+    });
 }
 } // namespace kernels
 


### PR DESCRIPTION
For memory-bounded kernels, this refactor might not yield observable performance improvements. Key changes include:
- Refactoring: Addressed existing TODOs to improve readability and reduce code duplication.
- Optimization: Reduced potential register pressure for `head_dim` = 128.
- Styling: Applied clang-format to the specific file.

I haven't done much NCU profiling regarding the change. I am more than happy to provide the isolated profiling proof that this refactor wouldn't negatively impact the existing functionalities. 

Thank you! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized rotary position embedding (RoPE) kernel with flexible support for partial and full rotation modes
  * Added advanced frequency scaling for enhanced positional encoding flexibility
  * Extended compatibility across various head dimensions in kernel operations
  * Improved handling of different model configurations and rotation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
