### PR TITLE
Draft - DO NOT REVIEW -[#11529][perf] reduce per-Mamba-layer dtype-copy overhead in AD decode

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/cuda_backend_causal_conv.py
@@ -77,6 +77,10 @@ def _cuda_cached_causal_conv1d(
     bs = b * s
     inp_flat = input.reshape(bs, *input.shape[2:])  # [total_s, C_in]
 
+    # Pre-convert slot_idx to int32 once (CUDA kernels require int32 indices).
+    # Doing this here rather than at each use site avoids duplicate CUDA copy kernels.
+    slot_idx_i32 = slot_idx.to(torch.int32)
+
     # Prepare weight as [dim, width] (depthwise)
     if weight.ndim == 3:
         assert weight.shape[-2] == 1
@@ -95,7 +99,7 @@ def _cuda_cached_causal_conv1d(
             w2d,
             bias,
             query_start_loc=cu_seqlen[: num_prefill + 1],
-            cache_indices=slot_idx[:num_prefill].to(torch.int32),
+            cache_indices=slot_idx_i32[:num_prefill],
             has_initial_state=use_initial_states[:num_prefill],
             conv_states=conv_state_cache,
             activation=activation,
@@ -115,7 +119,7 @@ def _cuda_cached_causal_conv1d(
             bias,
             activation=activation,
             cache_seqlens=None,
-            conv_state_indices=slot_idx[num_prefill:num_seq].to(torch.int32),
+            conv_state_indices=slot_idx_i32[num_prefill:num_seq],
             pad_slot_id=PAD_SLOT_ID,
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/triton_backend_causal_conv.py
@@ -80,6 +80,10 @@ def _triton_cached_causal_conv1d(
     bs = b * s
     inp_flat = input.reshape(bs, *input.shape[2:])  # [total_s, C_in]
 
+    # Pre-convert slot_idx to int32 once (CUDA kernels require int32 indices).
+    # Doing this here rather than at each use site avoids duplicate CUDA copy kernels.
+    slot_idx_i32 = slot_idx.to(torch.int32)
+
     # Prepare weight as [dim, width] (depthwise)
     if weight.ndim == 3:
         assert weight.shape[-2] == 1
@@ -104,7 +108,7 @@ def _triton_cached_causal_conv1d(
             conv_state_cache,
             prefill_cu_seqlen,
             seq_lens_cpu,
-            cache_indices=slot_idx[:num_prefill].to(torch.int32),
+            cache_indices=slot_idx_i32[:num_prefill],
             has_initial_state=use_initial_states[:num_prefill],
             activation=activation,
             pad_slot_id=PAD_SLOT_ID,
@@ -125,7 +129,7 @@ def _triton_cached_causal_conv1d(
             bias,
             activation=activation,
             cache_seqlens=None,
-            conv_state_indices=slot_idx[num_prefill:num_seq].to(torch.int32),
+            conv_state_indices=slot_idx_i32[num_prefill:num_seq],
             pad_slot_id=PAD_SLOT_ID,
         )
         inp_flat[num_prefill_tokens:num_total_tokens] = y_decode


### PR DESCRIPTION
Two sources of unnecessary BF16/int64→float32/int32 conversion kernels were firing once per Mamba layer (~40×/step) inside every CUDA graph replay for NemotronH decode:

1. `A = -torch.exp(self.A_log.float())` in NemotronHMamba2Mixer.torch_forward computed and type-cast A_log (BF16→float32) on every step. Since A_log is a fixed inference-time parameter, cache A as a float32 buffer on the first forward call (before CUDA graph capture). The CUDA graph then sees only a tensor reference — zero per-step conversion overhead.

2. `slot_idx[:N].to(torch.int32)` and `slot_idx[N:M].to(torch.int32)` were called at separate use sites in cuda_backend_causal_conv and triton_backend_causal_conv. Consolidate to a single `.to(torch.int32)` call at function entry so the result is reused for both prefill and decode branches, avoiding a duplicate CUDA copy kernel in mixed batches.

Expected gain: ~64 µs/step from eliminating the A_log dtype copies (40 layers × 1.6 µs); the slot_idx consolidation eliminates a redundant copy for mixed prefill+decode batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized tensor type conversions in causal convolution operations to reduce redundant processing.
  * Added caching for matrix computations in Nemotron H model to improve efficiency and enable better system-level optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
