### PR TITLE
[TRTLLM-9605][feat] Support streaming tool calls for Responses API

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -94,6 +94,7 @@ l0_a10:
   - unittest/llmapi/apps/test_chat_utils.py
   - unittest/llmapi/apps/test_tool_parsers.py
   - unittest/llmapi/apps/test_harmony_channel_validation.py
+  - unittest/llmapi/apps/test_responses_streaming_tool_calls.py
   - llmapi/test_llm_api_connector.py::test_connector_simple[True]
   - llmapi/test_llm_api_connector.py::test_connector_simple[False]
   - llmapi/test_llm_api_connector.py::test_connector_async_onboard[True]

--- a/tests/unittest/llmapi/apps/test_responses_streaming_tool_calls.py
+++ b/tests/unittest/llmapi/apps/test_responses_streaming_tool_calls.py
@@ -42,9 +42,11 @@ def _make_mock_request(tools: list | None = None):
     """Create a minimal ResponsesRequest-like object with .tools."""
 
     class MockRequest:
-        tools = tools or []
+        pass
 
-    return MockRequest()
+    req = MockRequest()
+    req.tools = tools if tools is not None else []
+    return req
 
 
 class TestShouldSendDoneEventsToolCalls:

--- a/tests/unittest/llmapi/apps/test_responses_streaming_tool_calls.py
+++ b/tests/unittest/llmapi/apps/test_responses_streaming_tool_calls.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Responses API streaming tool call emission (TRTLLM-9605)."""
+
+from unittest.mock import patch
+
+from tensorrt_llm.serve.responses_utils import (
+    ResponsesStreamingEventsHelper,
+    _generate_streaming_event,
+    _should_send_done_events,
+)
+from tensorrt_llm.serve.tool_parser.core_types import ToolCallItem
+
+
+def _make_mock_output(index: int = 0, text: str = "", text_diff: str = ""):
+    """Create a minimal mock output with .index, .text, .text_diff."""
+
+    class MockOutput:
+        pass
+
+    out = MockOutput()
+    out.index = index
+    out.text = text
+    out.text_diff = text_diff
+    return out
+
+
+def _make_mock_request(tools: list | None = None):
+    """Create a minimal ResponsesRequest-like object with .tools."""
+
+    class MockRequest:
+        tools = tools or []
+
+    return MockRequest()
+
+
+class TestShouldSendDoneEventsToolCalls:
+    """Test that _should_send_done_events returns tool_calls when text is done due to tool calls."""
+
+    def test_returns_tool_calls_when_text_done_due_to_tool_calls(self):
+        """When full text and tool_calls exist and is_text_sent, 5th return is tool_calls."""
+        output = _make_mock_output(
+            index=0,
+            text='Some text before <tool_call>{"name":"get_weather"}</tool_call>',
+            text_diff="",
+        )
+        tool_calls = [
+            ToolCallItem(tool_index=0, name="get_weather", parameters='{"location":"SF"}'),
+        ]
+        helper = ResponsesStreamingEventsHelper()
+        helper.is_text_sent = True
+
+        with (
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_reasoning_parser",
+                return_value=('Some text before <tool_call>{"name":"get_weather"}</tool_call>', ""),
+            ),
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_tool_parser",
+                return_value=("Some text before ", tool_calls),
+            ),
+        ):
+            result = _should_send_done_events(
+                output=output,
+                output_index=0,
+                tool_parser_id="test_parser",
+                tools=[],
+                tool_parser_dict={0: None},
+                streaming_events_helper=helper,
+                finished_generation=False,
+            )
+
+        should_reasoning, should_text, reasoning_content, text_content, done_tool_calls = result
+        assert should_text is True
+        assert text_content == "Some text before "
+        assert len(done_tool_calls) == 1
+        assert done_tool_calls[0].name == "get_weather"
+        assert done_tool_calls[0].parameters == '{"location":"SF"}'
+
+    def test_returns_empty_tool_calls_when_no_tool_calls(self):
+        """When full text but no tool_calls, 5th return is empty list."""
+        output = _make_mock_output(index=0, text="Just plain text", text_diff="")
+        helper = ResponsesStreamingEventsHelper()
+        helper.is_text_sent = True
+
+        with (
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_reasoning_parser",
+                return_value=("Just plain text", ""),
+            ),
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_tool_parser",
+                return_value=("Just plain text", []),
+            ),
+        ):
+            result = _should_send_done_events(
+                output=output,
+                output_index=0,
+                tools=[],
+                streaming_events_helper=helper,
+                finished_generation=True,
+            )
+
+        _, _, _, _, done_tool_calls = result
+        assert done_tool_calls == []
+
+
+class TestGenerateStreamingEventToolCalls:
+    """Test that _generate_streaming_event yields output_item events for tool calls."""
+
+    def test_emits_output_item_added_and_done_for_each_tool_call(self):
+        """When done_tool_calls is non-empty, we get output_item.added and .done per tool call."""
+        output = _make_mock_output(
+            index=0,
+            text='Hello <tool_call>{"name":"get_weather","arguments":{"location":"NYC"}}</tool_call>',
+            text_diff="",
+        )
+        request = _make_mock_request(
+            tools=[{"type": "function", "function": {"name": "get_weather"}}]
+        )
+        helper = ResponsesStreamingEventsHelper()
+        helper.is_text_sent = True
+        helper.item_id = "msg_initial"
+
+        tool_calls = [
+            ToolCallItem(tool_index=0, name="get_weather", parameters='{"location":"NYC"}'),
+        ]
+
+        # _apply_reasoning_parser: once for delta (""), once for full output in _should_send_done_events
+        # _apply_tool_parser: once in _should_send_done_events with full text -> return text before tools + tool_calls
+        with (
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_reasoning_parser",
+                side_effect=[("", ""), (output.text, "")],
+            ),
+            patch(
+                "tensorrt_llm.serve.responses_utils._apply_tool_parser",
+                return_value=("Hello ", tool_calls),
+            ),
+            patch(
+                "tensorrt_llm.serve.responses_utils._get_chat_completion_function_tools",
+                return_value=[],
+            ),
+        ):
+            events = list(
+                _generate_streaming_event(
+                    output=output,
+                    request=request,
+                    finished_generation=True,
+                    streaming_events_helper=helper,
+                    tool_parser_id="test",
+                    tool_parser_dict={0: None},
+                )
+            )
+
+        # We should have at least: text_done, content_part_done, output_item_done (text),
+        # then output_item_added (tool), output_item_done (tool)
+        types = [getattr(e, "type", None) for e in events]
+        assert "response.output_item.added" in types
+        assert "response.output_item.done" in types
+        # Find the done event that has a function_call item
+        from openai.types.responses import ResponseOutputItemDoneEvent
+
+        done_events = [e for e in events if isinstance(e, ResponseOutputItemDoneEvent)]
+        function_call_dones = [
+            e
+            for e in done_events
+            if getattr(getattr(e, "item", None), "type", None) == "function_call"
+        ]
+        assert len(function_call_dones) >= 1
+        assert function_call_dones[0].item.name == "get_weather"
+        assert function_call_dones[0].item.arguments == '{"location":"NYC"}'


### PR DESCRIPTION
- Return tool_calls from _should_send_done_events when text is done due to tool calls
- Emit response.output_item.added and response.output_item.done for each tool call in _generate_streaming_event so streaming Responses API includes function_call output items (gpt_oss compatibility)
- Remove TODO for handling tool calls in streaming mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for tool calls in streaming responses. Tool call outputs generated during text processing are now properly emitted with correct event sequencing and index management. Tool calls are tracked and surfaced throughout the entire streaming pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
