### PR TITLE
[None][perf] Remove unnecessary ToPIL() from find_mm_token_lengths

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -303,8 +303,8 @@ class MistralCommonImageProcessor:
             [self.get_num_tokens_per_image(size) for size in image_sizes]
         }
 
-    def get_num_tokens_per_image(self, image: torch.Tensor):
-        h, w = image.shape[-2:]
+    def get_num_tokens_per_image(self, image_size):
+        h, w = image_size
         ncols, nrows = self.image_processor._image_to_num_tokens(
             Image.new("RGB", (w, h)))
         return ncols * nrows + nrows

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -303,8 +303,8 @@ class MistralCommonImageProcessor:
             [self.get_num_tokens_per_image(size) for size in image_sizes]
         }
 
-    def get_num_tokens_per_image(self, image_sizes):
-        h, w = image_sizes
+    def get_num_tokens_per_image(self, image: torch.Tensor):
+        h, w = image.shape[-2:]
         ncols, nrows = self.image_processor._image_to_num_tokens(
             Image.new("RGB", (w, h)))
         return ncols * nrows + nrows

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -21,7 +21,6 @@ import torch
 import torchvision
 import transformers
 from einops import rearrange
-from PIL import Image
 from torchvision.transforms.functional import get_image_size, pad, resize
 from transformers.image_processing_utils import BatchFeature
 from transformers.image_utils import (ImageInput, is_pil_image,
@@ -823,7 +822,7 @@ class Phi4MMInputProcessor(BaseMultimodalInputProcessor,
     def get_num_tokens_per_image(
         self,
         *,
-        image: Image.Image,
+        image: torch.Tensor,
         **kwargs,
     ):
         images = [image]

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -7,7 +7,6 @@ import numpy as np
 import PIL
 import torch
 from blake3 import blake3
-from torchvision.transforms import ToPILImage
 
 import tensorrt_llm
 from tensorrt_llm._utils import maybe_pin_memory
@@ -770,8 +769,6 @@ def find_mm_token_lengths(mm_data: Dict[str, Any],
         modality_token_lengths = []
         for item in items:
             if modality == "image":
-                if isinstance(item, torch.Tensor):
-                    item = ToPILImage()(item)
                 num_tokens = input_processor.get_num_tokens_per_image(
                     image=item, )
                 modality_token_lengths.append(num_tokens)
@@ -779,8 +776,6 @@ def find_mm_token_lengths(mm_data: Dict[str, Any],
                 if isinstance(item, tensorrt_llm.inputs.utils.VideoData):
                     item = item.frames
                 assert isinstance(item, list), "Video must be a list of frames"
-                if isinstance(item[0], torch.Tensor):
-                    item = [ToPILImage()(frame) for frame in item]
                 num_tokens = input_processor.get_num_tokens_per_video(
                     video=item, )
                 modality_token_lengths.append(num_tokens)

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -277,7 +277,7 @@ class BaseMultimodalInputProcessor(ABC):
     def get_num_tokens_per_image(
         self,
         *,
-        image: Image.Image,
+        image: torch.Tensor,
         **kwargs,
     ):
         """
@@ -288,9 +288,7 @@ class BaseMultimodalInputProcessor(ABC):
 
         Subclasses can override this method to provide custom logic to calculate the number of tokens.
         """
-        image_height = image.height
-        image_width = image.width
-        image_size = (image_height, image_width)
+        image_size = image.shape[-2:]
         return self.get_num_multimodal_tokens([image_size],
                                               **kwargs)["num_image_tokens"][0]
 
@@ -308,10 +306,8 @@ class BaseMultimodalInputProcessor(ABC):
 
         Subclasses can override this method to provide custom logic to calculate the number of tokens.
         """
-        video_width = video[0].width
-        video_height = video[0].height
         num_frames = len(video)
-        video_size = (num_frames, video_height, video_width)
+        video_size = (num_frames, video[0].shape[-2], video[0].shape[-1])
         try:
             num_video_tokens = self.get_num_multimodal_tokens(
                 video_sizes=[video_size], **kwargs)["num_video_tokens"][0]

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -277,37 +277,48 @@ class BaseMultimodalInputProcessor(ABC):
     def get_num_tokens_per_image(
         self,
         *,
-        image: torch.Tensor,
+        image: Union[Image.Image, torch.Tensor],
         **kwargs,
     ):
         """
         Calculate the number of tokens generated for an image.
 
         This (default) method delegates to the Hugging Face processor's '_get_num_multimodal_tokens' method.
-        Returns the token count for the given image.
+        Accepts either a PIL Image or a CHW ``torch.Tensor`` — the hashing path
+        in ``find_mm_token_lengths`` feeds tensors directly to avoid a costly
+        ToPIL round-trip, while existing direct callers may still pass PIL.
 
         Subclasses can override this method to provide custom logic to calculate the number of tokens.
         """
-        image_size = image.shape[-2:]
+        if isinstance(image, torch.Tensor):
+            image_size = tuple(image.shape[-2:])
+        else:
+            image_size = (image.height, image.width)
         return self.get_num_multimodal_tokens([image_size],
                                               **kwargs)["num_image_tokens"][0]
 
     def get_num_tokens_per_video(
         self,
         *,
-        video: List[Image.Image],
+        video: List[Union[Image.Image, torch.Tensor]],
         **kwargs,
     ):
         """
         Calculate the number of tokens generated for a video.
 
         This (default) method delegates to the Hugging Face processor's '_get_num_multimodal_tokens' method.
-        Returns the token count for the given video.
+        Accepts a list of PIL Images or CHW ``torch.Tensor`` frames.
 
         Subclasses can override this method to provide custom logic to calculate the number of tokens.
         """
         num_frames = len(video)
-        video_size = (num_frames, video[0].shape[-2], video[0].shape[-1])
+        first_frame = video[0]
+        if isinstance(first_frame, torch.Tensor):
+            frame_h = int(first_frame.shape[-2])
+            frame_w = int(first_frame.shape[-1])
+        else:
+            frame_h, frame_w = first_frame.height, first_frame.width
+        video_size = (num_frames, frame_h, frame_w)
         try:
             num_video_tokens = self.get_num_multimodal_tokens(
                 video_sizes=[video_size], **kwargs)["num_video_tokens"][0]

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -118,8 +118,8 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
         for image_idx, test_image in enumerate(example_images):
 
             # Get test image dimensions
-            test_image = load_image(test_image, format="pil")
-            image_width, image_height = test_image.size
+            test_image = load_image(test_image)
+            image_width, image_height = test_image.shape[-2:]
 
             # Get actual embedding tensor for this image
             disagg_params = encoder_outputs[image_idx].disaggregated_params

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -119,7 +119,7 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
 
             # Get test image dimensions
             test_image = load_image(test_image)
-            image_width, image_height = test_image.shape[-2:]
+            image_height, image_width = test_image.shape[-2:]
 
             # Get actual embedding tensor for this image
             disagg_params = encoder_outputs[image_idx].disaggregated_params


### PR DESCRIPTION
This PR removes ToPIL() from find_mm_token_lengths.
It takes around 5ms per request to convert Tensor to Image.Image object. By removing this, we could obtain around ~3-5% improved TTFT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated image and video input processing to use torch.Tensor instead of PIL Image objects.
  * Modified method signatures in multimodal input processors to accept tensor-based inputs.
  * Removed automatic PIL image conversion in multimodal length computation.

* **Tests**
  * Updated image token count tests to align with tensor-based input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->