### PR TITLE
[None][feat] add globaltimer-based timing backend for autotuner profi…

### DIFF
--- a/cpp/tensorrt_llm/kernels/globalTimerKernel.cu
+++ b/cpp/tensorrt_llm/kernels/globalTimerKernel.cu
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/globalTimerKernel.h"
+
+using namespace tensorrt_llm::common;
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+__global__ void readGlobalTimerKernel(uint64_t* timestamp)
+{
+    asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(*timestamp));
+}
+
+void invokeReadGlobalTimer(uint64_t* d_timestamp, cudaStream_t stream)
+{
+    readGlobalTimerKernel<<<1, 1, 0, stream>>>(d_timestamp);
+    check_cuda_error(cudaGetLastError());
+}
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/globalTimerKernel.h
+++ b/cpp/tensorrt_llm/kernels/globalTimerKernel.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+void invokeReadGlobalTimer(uint64_t* d_timestamp, cudaStream_t stream);
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -713,7 +713,6 @@ class AutoTuner:
         stream_delay_micro_secs (int): Delay on CUDA stream before the profiled kernel runs in microseconds (default: 1000)
     """
     _CUDA_GRAPH_DELAY_MICRO_SECS = 100
-    _NS_PER_MS = 1e6
     _instance = None
 
     def __init__(self, warmup=2, repeat=10, stream_delay_micro_secs=1000):
@@ -1182,7 +1181,7 @@ class AutoTuner:
                 def elapsed_time():
                     # GPU %globaltimer counts in nanoseconds,
                     # Torch.cuda.Event.elapsed_time() returns ms
-                    return (end_ts.item() - start_ts.item()) / self._NS_PER_MS
+                    return (end_ts.item() - start_ts.item()) / 1e6
             else:
                 start_evt = torch.cuda.Event(enable_timing=True)
                 end_evt = torch.cuda.Event(enable_timing=True)

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -1180,6 +1180,8 @@ class AutoTuner:
                     record_global_timer(end_ts.data_ptr(), stream)
 
                 def elapsed_time():
+                    # GPU %globaltimer counts in nanoseconds,
+                    # Torch.cuda.Event.elapsed_time() returns ms
                     return (end_ts.item() - start_ts.item()) / self._NS_PER_MS
             else:
                 start_evt = torch.cuda.Event(enable_timing=True)

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -1179,8 +1179,8 @@ class AutoTuner:
                     record_global_timer(end_ts.data_ptr(), stream)
 
                 def elapsed_time():
-                    # GPU %globaltimer counts in nanoseconds,
-                    # Torch.cuda.Event.elapsed_time() returns ms
+                    # GPU %globaltimer counts in ns; convert to ms to match the
+                    # units of Torch.cuda.Event.elapsed_time()
                     return (end_ts.item() - start_ts.item()) / 1e6
             else:
                 start_evt = torch.cuda.Event(enable_timing=True)

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -19,8 +19,9 @@ from cuda.bindings import driver
 
 import tensorrt_llm
 from tensorrt_llm._torch.distributed import Distributed
-from tensorrt_llm._utils import nvtx_range
-from tensorrt_llm.bindings.internal.runtime import delay_kernel
+from tensorrt_llm._utils import confidential_compute_enabled, nvtx_range
+from tensorrt_llm.bindings.internal.runtime import (delay_kernel,
+                                                    record_global_timer)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -712,6 +713,7 @@ class AutoTuner:
         stream_delay_micro_secs (int): Delay on CUDA stream before the profiled kernel runs in microseconds (default: 1000)
     """
     _CUDA_GRAPH_DELAY_MICRO_SECS = 100
+    _NS_PER_MS = 1e6
     _instance = None
 
     def __init__(self, warmup=2, repeat=10, stream_delay_micro_secs=1000):
@@ -725,6 +727,21 @@ class AutoTuner:
         self.stream_delay_micro_secs = stream_delay_micro_secs
         self.profiling_cache = AutoTunerProfilingCache()
         self.is_tuning_mode = False
+
+        # Timing backend: globaltimer kernel vs cuda events.
+        # TLLM_PROFILING_TIMER env var overrides auto-detection:
+        #   "globaltimer" -> force globaltimer
+        #   "cuda_event"  -> force cuda events
+        #   unset/default -> auto-detect via confidential_compute_enabled()
+        timer_env = os.getenv("TLLM_PROFILING_TIMER", "").lower()
+        if timer_env == "globaltimer":
+            self._use_global_timer = True
+        elif timer_env == "cuda_event":
+            self._use_global_timer = False
+        else:
+            self._use_global_timer = confidential_compute_enabled()
+
+        logger.debug(f"[Autotuner] use_global_timer: {self._use_global_timer}")
 
         # Add statistics tracking
         self.stats = AutoTunerStatistics()
@@ -1150,9 +1167,32 @@ class AutoTuner:
         avg_time = float('inf')
 
         def pure_profile(stream: torch.cuda.Stream, repeat: int):
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
             graph = torch.cuda.CUDAGraph()
+
+            if self._use_global_timer:
+                start_ts = torch.empty(1, dtype=torch.int64, device='cuda')
+                end_ts = torch.empty(1, dtype=torch.int64, device='cuda')
+
+                def record_start():
+                    record_global_timer(start_ts.data_ptr(), stream)
+
+                def record_end():
+                    record_global_timer(end_ts.data_ptr(), stream)
+
+                def elapsed_time():
+                    return (end_ts.item() - start_ts.item()) / self._NS_PER_MS
+            else:
+                start_evt = torch.cuda.Event(enable_timing=True)
+                end_evt = torch.cuda.Event(enable_timing=True)
+
+                def record_start():
+                    start_evt.record()
+
+                def record_end():
+                    end_evt.record()
+
+                def elapsed_time():
+                    return start_evt.elapsed_time(end_evt)
 
             with torch.cuda.stream(stream):
                 if use_cuda_graph:
@@ -1176,7 +1216,7 @@ class AutoTuner:
                 else:
                     delay_kernel(self.stream_delay_micro_secs, stream)
 
-                start.record()
+                record_start()
 
                 if use_cuda_graph:
                     graph.replay()
@@ -1188,10 +1228,10 @@ class AutoTuner:
                             **kwargs,
                         )
 
-                end.record()
+                record_end()
                 stream.synchronize()
 
-                return start.elapsed_time(end) / repeat
+                return elapsed_time() / repeat
 
         # warm up, no timing
         for _ in range(self.warmup):

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -1,7 +1,9 @@
 import itertools
 import json
+import math
 import os
 import pickle
+import statistics
 import sys
 import tempfile
 from typing import Any, List
@@ -871,41 +873,116 @@ def test_autotuner_distributed_strategy(strategy, mpi_pool_executor):
 
 
 @pytest.mark.parametrize("use_cuda_graph", [False, True])
-def test_global_timer_vs_cuda_event(use_cuda_graph):
-    """Verify globaltimer and cuda-event backends report times within 5%."""
-    runner = GemmRunner()
-    x = torch.randn(M // 2, 64, device='cuda')
-    w = torch.randn(64, 128, device='cuda')
+def test_global_timer_vs_cuda_event(use_cuda_graph, monkeypatch):
+    """Verify globaltimer and cuda-event backends are statistically indistinguishable."""
+
+    class PureGemmRunner(TunableRunner):
+
+        def get_valid_tactics(self, inputs: List[FakeTensor],
+                              profile: OptimizationProfile,
+                              **kwargs) -> List[int]:
+            return [0]
+
+        def forward(self,
+                    /,
+                    inputs: List[torch.Tensor],
+                    *,
+                    tactic: int = 0,
+                    **kwargs) -> torch.Tensor:
+            assert tactic == 0
+            return inputs[0] @ inputs[1]
+
+    # Keep full profiling repeats enabled to reduce measurement noise.
+    monkeypatch.setenv("TLLM_AUTOTUNER_DISABLE_SHORT_PROFILE", "1")
+
+    gemm_shapes = [
+        (256, 4096, 11008),
+        (512, 8192, 8192),
+    ]
+    num_trials = 6
+    rel_tol = 0.05
+    stat_zscore = 3.0
+    abs_tol_ms = 0.01
+
+    runner = PureGemmRunner()
     tuning_config = TuningConfig(use_cuda_graph=use_cuda_graph)
-
     tuner = AutoTuner()
+    trial_rows = []
 
-    for tactic in runner.get_valid_tactics([x, w], OptimizationProfile()):
-        # Profile with cuda events
-        tuner._use_global_timer = False
-        event_time = tuner._profile_single_kernel(
-            runner=runner,
-            inputs=[x, w],
-            tactic=tactic,
-            tuning_config=tuning_config,
-            use_cuda_graph=use_cuda_graph,
+    for m, k, n in gemm_shapes:
+        x = torch.randn(m, k, device='cuda', dtype=torch.float16)
+        w = torch.randn(k, n, device='cuda', dtype=torch.float16)
+
+        event_times = []
+        gt_times = []
+
+        # Interleave both backends to avoid drift effects from neighboring load.
+        for _ in range(num_trials):
+            tuner._use_global_timer = False
+            event_times.append(
+                tuner._profile_single_kernel(
+                    runner=runner,
+                    inputs=[x, w],
+                    tactic=0,
+                    tuning_config=tuning_config,
+                    use_cuda_graph=use_cuda_graph,
+                ))
+
+            tuner._use_global_timer = True
+            gt_times.append(
+                tuner._profile_single_kernel(
+                    runner=runner,
+                    inputs=[x, w],
+                    tactic=0,
+                    tuning_config=tuning_config,
+                    use_cuda_graph=use_cuda_graph,
+                ))
+
+            event_ms = event_times[-1]
+            gt_ms = gt_times[-1]
+            abs_diff = abs(gt_ms - event_ms)
+            rel_diff = abs_diff / event_ms if event_ms > 0 else float('inf')
+            trial_rows.append((m, k, n, len(event_times), event_ms, gt_ms,
+                               abs_diff, rel_diff))
+
+        event_mean = statistics.fmean(event_times)
+        gt_mean = statistics.fmean(gt_times)
+        event_var = statistics.variance(event_times)
+        gt_var = statistics.variance(gt_times)
+        mean_diff = abs(gt_mean - event_mean)
+        rel_diff = mean_diff / event_mean
+
+        # Two-sample mean delta should be small vs a fixed tolerance and
+        # indistinguishable within sampling noise.
+        combined_sem = math.sqrt(event_var / num_trials + gt_var / num_trials)
+        allowed_diff = max(abs_tol_ms, rel_tol * event_mean,
+                           stat_zscore * combined_sem)
+
+        assert event_mean > 0, (
+            f"({m},{k},{n}): cuda event mean should be positive, got {event_mean}"
         )
-
-        # Profile with globaltimer
-        tuner._use_global_timer = True
-        gt_time = tuner._profile_single_kernel(
-            runner=runner,
-            inputs=[x, w],
-            tactic=tactic,
-            tuning_config=tuning_config,
-            use_cuda_graph=use_cuda_graph,
+        assert gt_mean > 0, (
+            f"({m},{k},{n}): globaltimer mean should be positive, got {gt_mean}"
         )
+        assert mean_diff <= allowed_diff, (
+            f"({m},{k},{n}): timing backends are distinguishable "
+            f"(cuda_event_mean={event_mean:.4f}ms, "
+            f"globaltimer_mean={gt_mean:.4f}ms, "
+            f"relative_diff={rel_diff * 100:.2f}%, "
+            f"allowed_diff={allowed_diff:.4f}ms, "
+            f"combined_sem={combined_sem:.4f}ms, "
+            f"event_samples={event_times}, gt_samples={gt_times})")
 
-        assert event_time > 0, f"cuda event time should be positive, got {event_time}"
-        assert gt_time > 0, f"globaltimer time should be positive, got {gt_time}"
-
-        rel_diff = abs(gt_time - event_time) / event_time
-        assert rel_diff < 0.05, (
-            f"tactic={tactic}: globaltimer ({gt_time:.4f}ms) and cuda event "
-            f"({event_time:.4f}ms) differ by {rel_diff * 100:.1f}%, expected < 5%"
-        )
+    # Visible with `pytest -s`; otherwise captured by pytest.
+    print("\nGlobaltimer vs cuda-event trial comparison")
+    print(f"cuda_graph={use_cuda_graph}, trials_per_shape={num_trials}")
+    print("-" * 102)
+    print(
+        f"{'shape (M,K,N)':>21} {'trial':>5} {'cuda_event (ms)':>16} "
+        f"{'globaltimer (ms)':>17} {'abs diff (ms)':>14} {'rel diff (%)':>13}")
+    print("-" * 102)
+    for m, k, n, trial, event_ms, gt_ms, abs_diff, rel_diff in trial_rows:
+        print(f"{f'({m},{k},{n})':>21} {trial:>5d} "
+              f"{event_ms:>16.4f} {gt_ms:>17.4f} "
+              f"{abs_diff:>14.4f} {rel_diff * 100:>13.2f}")
+    print("-" * 102)


### PR DESCRIPTION
…ling

CUDA event timing (cudaEventElapsedTime) is unreliable when confidential compute (CC) is enabled (see https://nvbugs/4159316 for details). This adds an alternative timing backend that uses a small CUDA kernel reading %globaltimer before and after the profiled work, then computes elapsed time on the host.

The timing backend is auto-selected based on CC state, with an env var override (TLLM_PROFILING_TIMER=globaltimer|cuda_event) for manual control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced GPU global timer support for autotuner profiling as an alternative to CUDA event-based timing
  * Added configurable timing backend selection via environment variable for explicit control
  * Autotuner now automatically detects and uses the optimal timing backend based on system capabilities

* **Chores**
  * Refactored profiling timing logic to support dual timing backends
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
