### PR TITLE
[TRTLLM-11090][perf] Improve fp8 (per-tensor) quant kernel by vectorized load/store

### DIFF
--- a/cpp/tensorrt_llm/common/cudaFp8Utils.cu
+++ b/cpp/tensorrt_llm/common/cudaFp8Utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,74 @@ namespace common
 #ifdef ENABLE_FP8
 
 constexpr int CTA_SIZE = 256;
+constexpr int VEC_SIZE = 8; // elements per vectorized iteration (128-bit load = 8 × bf16)
+constexpr int64_t MAX_GRID_DIM = 65536;
+
+inline int64_t scaleMatrixGridSize(int64_t numel)
+{
+    return std::min((numel + CTA_SIZE - 1) / CTA_SIZE, MAX_GRID_DIM);
+}
+
+inline int64_t scaleMatrixVecGridSize(int64_t numel)
+{
+    int64_t vecElements = numel / VEC_SIZE;
+    return std::min((vecElements + CTA_SIZE - 1) / CTA_SIZE, MAX_GRID_DIM);
+}
 
 template <bool QUANTIZE>
 __inline__ __device__ float scale(float a, float b)
 {
     return QUANTIZE ? a / b : a * b;
+}
+
+// Vectorized PER_TENSOR kernel for bf16 input → fp8 output.
+// Each thread processes 8 bf16 values per iteration via 128-bit loads / 64-bit stores.
+template <bool QUANTIZE>
+__global__ void scaleMatrixPerTensorVec(
+    __nv_fp8_e4m3* output, float const* input_scale, __nv_bfloat16 const* input, int64_t numel)
+{
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaGridDependencySynchronize();
+#endif
+
+    float const s = input_scale[0];
+    float const factor = QUANTIZE ? (1.0f / s) : s;
+    int64_t const vecElements = numel / VEC_SIZE;
+    int64_t const stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+
+    for (int64_t vi = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x; vi < vecElements; vi += stride)
+    {
+        int64_t const base = vi * VEC_SIZE;
+
+        // 128-bit load: 8 × bf16
+        float4 raw = *reinterpret_cast<float4 const*>(input + base);
+        __nv_bfloat162 const* pairs = reinterpret_cast<__nv_bfloat162 const*>(&raw);
+
+        // Convert 4 × bf16-pair → 4 × float2 → 4 × fp8-pair → pack into 2 × uint32
+        __nv_fp8x2_storage_t fp8_pairs[4];
+#pragma unroll
+        for (int p = 0; p < 4; ++p)
+        {
+            float2 f2 = __bfloat1622float2(pairs[p]);
+            f2.x *= factor;
+            f2.y *= factor;
+            fp8_pairs[p] = __nv_cvt_float2_to_fp8x2(f2, __NV_SATFINITE, __NV_E4M3);
+        }
+
+        // 64-bit store: 8 × fp8
+        *reinterpret_cast<uint2*>(output + base) = *reinterpret_cast<uint2 const*>(fp8_pairs);
+    }
+
+    // Scalar tail for remaining elements (numel not divisible by 8)
+    int64_t const tailStart = vecElements * VEC_SIZE;
+    for (int64_t i = tailStart + threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x; i < numel; i += stride)
+    {
+        output[i] = __nv_fp8_e4m3(static_cast<float>(input[i]) * factor);
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 template <QuantizeMode QUANTIZE_MODE, bool QUANTIZE, typename T_OUT, typename T_S, typename T_IN>
@@ -46,20 +109,29 @@ __global__ void scaleMatrix(T_OUT* output, T_S const* input_scale, T_IN const* i
     cudaGridDependencySynchronize();
 #endif
 
-    for (int64_t i = threadIdx.x + blockIdx.x * blockDim.x; i < numel; i += blockDim.x * gridDim.x)
+    if constexpr (QUANTIZE_MODE == QuantizeMode::PER_TENSOR)
     {
-
-        if (QUANTIZE_MODE == QuantizeMode::PER_CHANNEL)
+        float const s = static_cast<float>(input_scale[0]);
+        float const factor = QUANTIZE ? (1.0f / s) : s;
+        for (int64_t i = threadIdx.x + blockIdx.x * blockDim.x; i < numel; i += blockDim.x * gridDim.x)
         {
-            output[i] = T_OUT(scale<QUANTIZE>(static_cast<float>(input[i]), static_cast<float>(input_scale[i % lda])));
+            output[i] = T_OUT(static_cast<float>(input[i]) * factor);
         }
-        else if (QUANTIZE_MODE == QuantizeMode::PER_TOKEN)
+    }
+    else
+    {
+        for (int64_t i = threadIdx.x + blockIdx.x * blockDim.x; i < numel; i += blockDim.x * gridDim.x)
         {
-            output[i] = T_OUT(scale<QUANTIZE>(static_cast<float>(input[i]), static_cast<float>(input_scale[i / lda])));
-        }
-        else if (QUANTIZE_MODE == QuantizeMode::PER_TENSOR)
-        {
-            output[i] = T_OUT(scale<QUANTIZE>(static_cast<float>(input[i]), static_cast<float>(input_scale[0])));
+            if constexpr (QUANTIZE_MODE == QuantizeMode::PER_CHANNEL)
+            {
+                output[i]
+                    = T_OUT(scale<QUANTIZE>(static_cast<float>(input[i]), static_cast<float>(input_scale[i % lda])));
+            }
+            else if constexpr (QUANTIZE_MODE == QuantizeMode::PER_TOKEN)
+            {
+                output[i]
+                    = T_OUT(scale<QUANTIZE>(static_cast<float>(input[i]), static_cast<float>(input_scale[i / lda])));
+            }
         }
     }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -67,11 +139,46 @@ __global__ void scaleMatrix(T_OUT* output, T_S const* input_scale, T_IN const* i
 #endif
 }
 
+// Helper: can we use the vectorized PER_TENSOR kernel for this type combination?
+template <typename T_OUT, typename T_S, typename T_IN>
+struct CanUseVecPerTensor : std::false_type
+{
+};
+
+template <>
+struct CanUseVecPerTensor<__nv_fp8_e4m3, float, __nv_bfloat16> : std::true_type
+{
+};
+
 template <typename T_OUT, typename T_S, typename T_IN>
 void invokeQuantizeMatrix(T_OUT* output, T_S const* input_scale, T_IN const* input, int64_t numel, int64_t lda,
     QuantizeMode quantize_mode, cudaStream_t stream)
 {
-    dim3 grid(1024);
+    // PER_TENSOR + bf16→fp8 with float scale: use vectorized kernel (128-bit loads)
+    if constexpr (CanUseVecPerTensor<T_OUT, T_S, T_IN>::value)
+    {
+        if (quantize_mode == QuantizeMode::PER_TENSOR)
+        {
+            dim3 grid(static_cast<unsigned int>(scaleMatrixVecGridSize(numel)));
+            dim3 block(CTA_SIZE);
+            cudaLaunchConfig_t config;
+            config.gridDim = grid;
+            config.blockDim = block;
+            config.dynamicSmemBytes = 0;
+            config.stream = stream;
+            cudaLaunchAttribute attrs[1];
+            attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+            config.numAttrs = 1;
+            config.attrs = attrs;
+            cudaLaunchKernelEx(&config, scaleMatrixPerTensorVec<true>, output, input_scale, input, numel);
+            sync_check_cuda_error(stream);
+            return;
+        }
+    }
+
+    // General path: scalar kernel
+    dim3 grid(static_cast<unsigned int>(scaleMatrixGridSize(numel)));
     dim3 block(CTA_SIZE);
     cudaLaunchConfig_t config;
     config.gridDim = grid;
@@ -105,7 +212,7 @@ template <typename T_OUT, typename T_S, typename T_IN>
 void invokeDequantizeMatrix(T_OUT* output, T_S const* input_scale, T_IN const* input, int64_t numel, int64_t lda,
     QuantizeMode quantize_mode, cudaStream_t stream)
 {
-    dim3 grid(1024);
+    dim3 grid(static_cast<unsigned int>(scaleMatrixGridSize(numel)));
     dim3 block(CTA_SIZE);
     cudaLaunchConfig_t config;
     config.gridDim = grid;


### PR DESCRIPTION
Measured Perf Speedup:

- Microbenchmark of `static_quantize_e4m3_per_tensor`/`quantize_e4m3_per_tensor`:

```
static_quantize_e4m3_per_tensor(static fp8 path):

| Shape          | Kernel      | before (µs) | this PR (µs) | Speedup   |
|----------------|------------|---------------|----------------|-----------|
| [75600, 5120]  | `attn_main` | 761.5         | 184.9          | **4.12×** |
| [512, 5120]    | `cross_kv`  | 5.1           | 5.1            | 1.0×      |
| [75600, 13824] | `ffn_down`  | 2044.5        | 467.0          | **4.38×** |

quantize_e4m3_per_tensor(dynamic fp8 path):

| Shape          | Kernel      | before (µs) | this PR (µs) | Speedup   |
|----------------|------------|---------------|----------------|-----------|
| [75600, 5120]  | `attn_main` | 1005.9         | 426.1          | **2.35×** |
| [512, 5120]    | `cross_kv`  | 16.4           | 15.4            | 1.06×      |
| [75600, 13824] | `ffn_down`  | 2683.2        | 1095.7          | **2.45×** |

```



- E2E: Wan2.2 T2V A14B FP8 (720x1280, 81f, 50 steps, 1 GPU) – static FP8

| Metric               | before     | this PR   | Delta                  |
|----------------------|--------------|-------------|------------------------|
| **Denoising total**  | 507.73 s     | 493.71 s    | **-14.0 s (-2.8%)**    |
| Avg per step         | 10.15 s/step | 9.87 s/step | -0.28 s/step           |
| Transformer per step | 10.04 s      | 9.83 s      | -0.21 s                |
| **Generation total** | 518.97 s     | 504.74 s    | **-14.2 s**            |

- E2E: Wan2.2 T2V A14B FP8 (720x1280, 81f, 50 steps, 1 GPU) – dynamic FP8

| Metric               | before     | this PR   | Delta                  |
|----------------------|--------------|-------------|------------------------|
| **Denoising total**  | 510.8 s     | 493.3 s    | **-17.0 s (-3.5%)**    |
| Avg per step         | 10.22 s/step | 9.87 s/step | -0.35 s/step           |
| **Generation total** | 520.8 s     | 503.2 s    | **-17.55 s**            |

Test already covered by: 
```
tests/unittest/trt/quantization/test_fp8_quantization.py::test_quantization_per_tensor_scales
```

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
