### PR TITLE
[None][fix] rename svd-nvfp4 to trtllm-nvfp4 in visual gen examples

### DIFF
--- a/docs/source/features/visual-generation.md
+++ b/docs/source/features/visual-generation.md
@@ -132,7 +132,7 @@ python visual_gen_wan_t2v.py \
     --output_path output_fp8.mp4
 ```
 
-Supported `--linear_type` values: `default` (BF16/FP16), `trtllm-fp8-per-tensor`, `trtllm-fp8-blockwise`, `svd-nvfp4`.
+Supported `--linear_type` values: `default` (BF16/FP16), `trtllm-fp8-per-tensor`, `trtllm-fp8-blockwise`, `trtllm-nvfp4`.
 
 **ModelOpt `quantization_config` format:**
 

--- a/docs/source/features/visual-generation.md
+++ b/docs/source/features/visual-generation.md
@@ -132,7 +132,9 @@ python visual_gen_wan_t2v.py \
     --output_path output_fp8.mp4
 ```
 
-Supported `--linear_type` values: `default` (BF16/FP16), `trtllm-fp8-per-tensor`, `trtllm-fp8-blockwise`, `trtllm-nvfp4`.
+The `--linear_type` flag enables **dynamic quantization**, which quantizes linear layer weights on-the-fly during loading from an unquantized (BF16/FP16) checkpoint. No pre-quantized checkpoint is needed — the weights are converted to the target precision at load time.
+
+Supported `--linear_type` values: `default` (BF16/FP16, no quantization), `trtllm-fp8-per-tensor`, `trtllm-fp8-blockwise`, `trtllm-nvfp4`.
 
 **ModelOpt `quantization_config` format:**
 

--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -126,7 +126,7 @@ def parse_args():
         "--linear_type",
         type=str,
         default="default",
-        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "svd-nvfp4"],
+        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
         help="Linear layer quantization type",
     )
 
@@ -205,7 +205,7 @@ def build_diffusion_config(args):
         quant_config = {"quant_algo": "FP8", "dynamic": True}
     elif args.linear_type == "trtllm-fp8-blockwise":
         quant_config = {"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True}
-    elif args.linear_type == "svd-nvfp4":
+    elif args.linear_type == "trtllm-nvfp4":
         quant_config = {"quant_algo": "NVFP4", "dynamic": True}
 
     # Note: pipeline type (FLUX.1 vs FLUX.2) is auto-detected from model_index.json

--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -127,7 +127,10 @@ def parse_args():
         type=str,
         default="default",
         choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
-        help="Linear layer quantization type",
+        help=(
+            "Dynamic quantization mode for linear layers. "
+            "Quantizes weights on-the-fly during loading from an unquantized checkpoint."
+        ),
     )
 
     # Attention Backend

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -98,7 +98,10 @@ def parse_args():
         type=str,
         default="default",
         choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
-        help="Linear layer quantization type",
+        help=(
+            "Dynamic quantization mode for linear layers. "
+            "Quantizes weights on-the-fly during loading from an unquantized checkpoint."
+        ),
     )
 
     # Attention Backend

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -97,7 +97,7 @@ def parse_args():
         "--linear_type",
         type=str,
         default="default",
-        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "svd-nvfp4"],
+        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
         help="Linear layer quantization type",
     )
 
@@ -184,7 +184,7 @@ def main():
         quant_config = {"quant_algo": "FP8", "dynamic": True}
     elif args.linear_type == "trtllm-fp8-blockwise":
         quant_config = {"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True}
-    elif args.linear_type == "svd-nvfp4":
+    elif args.linear_type == "trtllm-nvfp4":
         quant_config = {"quant_algo": "NVFP4", "dynamic": True}
 
     # 1. Setup Configuration

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -92,7 +92,10 @@ def parse_args():
         type=str,
         default="default",
         choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
-        help="Linear layer quantization type",
+        help=(
+            "Dynamic quantization mode for linear layers. "
+            "Quantizes weights on-the-fly during loading from an unquantized checkpoint."
+        ),
     )
 
     # Attention Backend

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -91,7 +91,7 @@ def parse_args():
         "--linear_type",
         type=str,
         default="default",
-        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "svd-nvfp4"],
+        choices=["default", "trtllm-fp8-per-tensor", "trtllm-fp8-blockwise", "trtllm-nvfp4"],
         help="Linear layer quantization type",
     )
 
@@ -191,7 +191,7 @@ def main():
         quant_config = {"quant_algo": "FP8", "dynamic": True}
     elif args.linear_type == "trtllm-fp8-blockwise":
         quant_config = {"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True}
-    elif args.linear_type == "svd-nvfp4":
+    elif args.linear_type == "trtllm-nvfp4":
         quant_config = {"quant_algo": "NVFP4", "dynamic": True}
 
     # 1. Setup Configuration


### PR DESCRIPTION
## Summary
- Rename `--linear_type` choice from `svd-nvfp4` to `trtllm-nvfp4` for consistency with other `trtllm-` prefixed quantization types (`trtllm-fp8-per-tensor`, `trtllm-fp8-blockwise`)
- Updated in all 3 example scripts (flux, wan_t2v, wan_i2v) and docs

## Test plan
- [x] `python examples/visual_gen/visual_gen_flux.py --help` shows `trtllm-nvfp4`
- [x] `python examples/visual_gen/visual_gen_wan_t2v.py --help` shows `trtllm-nvfp4`
- [x] `python examples/visual_gen/visual_gen_wan_i2v.py --help` shows `trtllm-nvfp4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and examples to reflect the renamed linear type flag option from "svd-nvfp4" to "trtllm-nvfp4" for NVFP4 quantization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->