### PR TITLE
[TRTLLM-10962][feat] Refactor video encoding to use ffmpeg CLI or pur…

### DIFF
--- a/examples/visual_gen/serve/README.md
+++ b/examples/visual_gen/serve/README.md
@@ -24,12 +24,12 @@ Before running these examples, ensure you have:
    pip install git+https://github.com/huggingface/diffusers.git
    ```
 
-   **Optional**: For better video compression (H.264/MP4), install ffmpeg:
+   **Optional**: For better video compression (H.264/MP4), install [ffmpeg](https://ffmpeg.org/):
    ```bash
    # Ubuntu/Debian
    apt-get install ffmpeg
    ```
-   If ffmpeg is not available, the server will use a pure Python encoder that outputs MJPEG/AVI format.
+   If ffmpeg is not available, the server will use a pure Python encoder that outputs MJPEG/AVI format. See [FFmpeg download page](https://ffmpeg.org/download.html) for installation instructions on other platforms.
 
 2. **Server Running**: The TensorRT-LLM visual generation server must be running
    ```bash

--- a/examples/visual_gen/serve/README.md
+++ b/examples/visual_gen/serve/README.md
@@ -22,8 +22,14 @@ Before running these examples, ensure you have:
 
    ```bash
    pip install git+https://github.com/huggingface/diffusers.git
-   pip install av
    ```
+
+   **Optional**: For better video compression (H.264/MP4), install ffmpeg:
+   ```bash
+   # Ubuntu/Debian
+   apt-get install ffmpeg
+   ```
+   If ffmpeg is not available, the server will use a pure Python encoder that outputs MJPEG/AVI format.
 
 2. **Server Running**: The TensorRT-LLM visual generation server must be running
    ```bash
@@ -275,7 +281,12 @@ curl -X GET "http://localhost:8000/v1/videos/{video_id}"
 
 ### Download Video
 ```bash
+# The server returns either MP4 (with ffmpeg) or AVI (without ffmpeg)
+# Check the Content-Type header to determine the format
 curl -X GET "http://localhost:8000/v1/videos/{video_id}/content" -o output.mp4
+
+# Or use -J -O to let curl use the server-provided filename
+curl -X GET "http://localhost:8000/v1/videos/{video_id}/content" -J -O
 ```
 
 ### Delete Video
@@ -315,8 +326,18 @@ Errors are displayed with full stack traces for debugging.
 Generated files are saved to the current working directory:
 
 - `output_generation.png` - Synchronous image generation (`sync_image_gen.py`)
-- `output_sync.mp4` - Synchronous video generation (`sync_video_gen.py`)
-- `output_async.mp4` - Asynchronous video generation (`async_video_gen.py`)
-- `output_multipart.mp4` - Multipart example output (`multipart_example.py`)
+- `output_sync.mp4` or `output_sync.avi` - Synchronous video generation (`sync_video_gen.py`)
+- `output_async.mp4` or `output_async.avi` - Asynchronous video generation (`async_video_gen.py`)
 
 **Note:** You can customize output filenames using the `--output` parameter in all scripts.
+
+## Video Encoding
+
+The server supports two video encoding modes:
+
+| Encoder | Format | Requirements | Features |
+|---------|--------|--------------|----------|
+| **FFmpeg (H.264)** | MP4 | ffmpeg installed | Better compression, audio support |
+| **Pure Python (MJPEG)** | AVI | None (built-in) | No external dependencies |
+
+The server automatically selects the best available encoder. The example scripts detect the actual format from the server response and adjust the output filename extension accordingly.

--- a/tensorrt_llm/serve/media_storage.py
+++ b/tensorrt_llm/serve/media_storage.py
@@ -471,7 +471,10 @@ def get_video_encoder() -> Optional["VideoEncoder"]:
             logger.info("Using ffmpeg CLI for video encoding")
             _VIDEO_ENCODER = FfmpegCliEncoder()
         else:
-            logger.info("Using pure Python MJPEG/AVI encoder (no audio support)")
+            logger.warning(
+                "FFmpeg is unavailable so no MP4 generation support."
+                "Using pure Python MJPEG/AVI encoder (no audio support)"
+            )
             _VIDEO_ENCODER = PurePythonEncoder()
     return _VIDEO_ENCODER
 

--- a/tensorrt_llm/serve/media_storage.py
+++ b/tensorrt_llm/serve/media_storage.py
@@ -6,14 +6,454 @@ This module provides storage handlers for persisting generated media assets
 """
 
 import os
+import struct
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import torch
 from PIL import Image
 
 from tensorrt_llm.logger import logger
+
+# Video encoder availability flags (cached after first check)
+_FFMPEG_AVAILABLE: Optional[bool] = None
+
+
+def _check_ffmpeg_available() -> bool:
+    """Check if ffmpeg CLI is available."""
+    global _FFMPEG_AVAILABLE
+    if _FFMPEG_AVAILABLE is None:
+        try:
+            result = subprocess.run(
+                ["ffmpeg", "-version"],
+                capture_output=True,
+                text=True,
+            )
+            _FFMPEG_AVAILABLE = result.returncode == 0
+        except FileNotFoundError:
+            _FFMPEG_AVAILABLE = False
+    return _FFMPEG_AVAILABLE
+
+
+class VideoEncoder(ABC):
+    """Abstract base class for video encoders."""
+
+    @abstractmethod
+    def encode_video(
+        self,
+        video: torch.Tensor,
+        output_path: str,
+        frame_rate: float,
+        audio: Optional[torch.Tensor] = None,
+    ) -> str:
+        """Encode video frames to file.
+
+        Args:
+            video: Video frames as torch.Tensor (T, H, W, C) uint8
+            output_path: Path to save the video
+            frame_rate: Frames per second
+            audio: Optional audio as torch.Tensor
+
+        Returns:
+            Path where the video was saved
+        """
+        pass
+
+    @staticmethod
+    def _validate_video_tensor(video: torch.Tensor) -> None:
+        """Validate video tensor format."""
+        if not isinstance(video, torch.Tensor):
+            raise ValueError(f"Expected torch.Tensor for video, got {type(video)}")
+
+    @staticmethod
+    def _validate_audio_tensor(audio: torch.Tensor) -> torch.Tensor:
+        """Validate and normalize audio tensor format.
+
+        Args:
+            audio: Audio tensor in various formats
+
+        Returns:
+            Normalized audio tensor in (samples, channels) format as int16
+        """
+        if not isinstance(audio, torch.Tensor):
+            raise ValueError(f"Expected torch.Tensor for audio, got {type(audio)}")
+
+        audio_tensor = audio
+
+        # Handle different audio tensor dimensions
+        if audio_tensor.ndim == 1:
+            # Mono audio: (samples,) -> (samples, 1)
+            audio_tensor = audio_tensor[:, None]
+        elif audio_tensor.ndim == 2:
+            # If shape[1] != 2 and shape[0] == 2, transpose to (samples, channels)
+            if audio_tensor.shape[1] != 2 and audio_tensor.shape[0] == 2:
+                audio_tensor = audio_tensor.T
+            if audio_tensor.shape[1] > 2:
+                audio_tensor = audio_tensor[:, :2]
+        elif audio_tensor.ndim == 3:
+            if audio_tensor.shape[0] == 1:
+                audio_tensor = audio_tensor.squeeze(0)
+            else:
+                audio_tensor = audio_tensor[0]
+            if audio_tensor.shape[1] != 2 and audio_tensor.shape[0] == 2:
+                audio_tensor = audio_tensor.T
+            if audio_tensor.shape[1] > 2:
+                audio_tensor = audio_tensor[:, :2]
+        else:
+            raise ValueError(
+                f"Unsupported audio tensor shape: {audio_tensor.shape}. "
+                f"Expected 1D, 2D, or 3D tensor."
+            )
+
+        if audio_tensor.shape[1] > 2:
+            audio_tensor = audio_tensor[:, :2]
+
+        # Convert to int16 if needed
+        if audio_tensor.dtype != torch.int16:
+            audio_tensor = torch.clip(audio_tensor, -1.0, 1.0)
+            audio_tensor = (audio_tensor * 32767.0).to(torch.int16)
+
+        return audio_tensor
+
+
+class FfmpegCliEncoder(VideoEncoder):
+    """Video encoder using ffmpeg CLI for both encoding and muxing.
+
+    This encoder pipes raw RGB frames to ffmpeg for H.264 encoding
+    and MP4 container muxing. Does not require any Python video libraries,
+    only the ffmpeg CLI tool.
+    """
+
+    def encode_video(
+        self,
+        video: torch.Tensor,
+        output_path: str,
+        frame_rate: float,
+        audio: Optional[torch.Tensor] = None,
+    ) -> str:
+        """Encode video using ffmpeg CLI.
+
+        Args:
+            video: Video frames as torch.Tensor (T, H, W, C) uint8 RGB
+            output_path: Path to save the video
+            frame_rate: Frames per second
+            audio: Optional audio as torch.Tensor
+
+        Returns:
+            Path where the video was saved
+        """
+        self._validate_video_tensor(video)
+
+        # Convert video tensor to numpy: (T, H, W, C) uint8
+        video_np = video.cpu().numpy()
+        num_frames, height, width, channels = video_np.shape
+
+        if channels != 3:
+            raise ValueError(f"Expected 3-channel RGB video, got {channels} channels")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Handle audio if provided
+            audio_input_args = []
+            audio_output_args = []
+            if audio is not None:
+                audio_tensor = self._validate_audio_tensor(audio)
+                audio_np = audio_tensor.cpu().numpy()
+                tmp_audio_path = os.path.join(tmp_dir, "audio.wav")
+                self._write_wav(tmp_audio_path, audio_np, sample_rate=24000)
+                audio_input_args = ["-i", tmp_audio_path]
+                audio_output_args = ["-c:a", "aac", "-shortest"]
+
+            # Build ffmpeg command
+            # Input: raw RGB frames piped via stdin
+            # Output: H.264 encoded MP4
+            cmd = [
+                "ffmpeg",
+                "-y",  # Overwrite output
+                "-f",
+                "rawvideo",  # Input format
+                "-pix_fmt",
+                "rgb24",  # Pixel format
+                "-s",
+                f"{width}x{height}",  # Frame size
+                "-r",
+                str(frame_rate),  # Frame rate
+                "-i",
+                "-",  # Read from stdin
+                *audio_input_args,  # Audio input (if any)
+                "-c:v",
+                "libx264",  # Video codec
+                "-pix_fmt",
+                "yuv420p",  # Output pixel format
+                "-preset",
+                "medium",  # Encoding preset
+                "-crf",
+                "23",  # Quality (lower = better)
+                *audio_output_args,  # Audio output args (if any)
+                output_path,
+            ]
+
+            try:
+                # Run ffmpeg with raw frames piped to stdin
+                process = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+
+                # Write all frames to ffmpeg stdin
+                raw_frames = video_np.tobytes()
+                stdout, stderr = process.communicate(input=raw_frames)
+
+                if process.returncode != 0:
+                    raise RuntimeError(f"ffmpeg encoding failed: {stderr.decode()}")
+
+            except FileNotFoundError:
+                raise RuntimeError("ffmpeg not found. Install ffmpeg for video encoding.")
+
+        logger.info(f"Saved video{' with audio' if audio is not None else ''} to {output_path}")
+        return output_path
+
+    def _write_wav(self, path: str, audio: Any, sample_rate: int = 24000) -> None:
+        """Write audio to WAV file.
+
+        Args:
+            path: Output path
+            audio: Audio data as numpy array (samples, channels) int16
+            sample_rate: Audio sample rate
+        """
+        import wave
+
+        import numpy as np
+
+        # Ensure stereo
+        if audio.ndim == 1:
+            audio = np.column_stack([audio, audio])
+        elif audio.shape[1] == 1:
+            audio = np.column_stack([audio, audio])
+
+        # Interleave channels for WAV format
+        audio_interleaved = audio.flatten().astype(np.int16)
+
+        with wave.open(path, "wb") as wav_file:
+            wav_file.setnchannels(2)
+            wav_file.setsampwidth(2)  # 16-bit
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(audio_interleaved.tobytes())
+
+
+class PurePythonEncoder(VideoEncoder):
+    """Pure Python video encoder using MJPEG in AVI container.
+
+    This encoder creates Motion JPEG (MJPEG) videos in AVI format using only
+    Python standard library and PIL (for JPEG encoding). No ffmpeg or other
+    external video libraries required.
+
+    Note: Audio is not supported with this encoder.
+    """
+
+    def encode_video(
+        self,
+        video: torch.Tensor,
+        output_path: str,
+        frame_rate: float,
+        audio: Optional[torch.Tensor] = None,
+    ) -> str:
+        """Encode video as MJPEG in AVI container.
+
+        Args:
+            video: Video frames as torch.Tensor (T, H, W, C) uint8 RGB
+            output_path: Path to save the video
+            frame_rate: Frames per second
+            audio: Optional audio (NOT SUPPORTED - will be ignored with warning)
+
+        Returns:
+            Path where the video was saved
+        """
+        if audio is not None:
+            logger.warning(
+                "PurePythonEncoder does not support audio. "
+                "Audio will be ignored. Use FfmpegCliEncoder for audio support."
+            )
+
+        self._validate_video_tensor(video)
+
+        # Convert video tensor to numpy: (T, H, W, C) uint8
+        video_np = video.cpu().numpy()
+        num_frames, height, width, channels = video_np.shape
+
+        if channels != 3:
+            raise ValueError(f"Expected 3-channel RGB video, got {channels} channels")
+
+        # Convert frames to JPEG
+        jpeg_frames: List[bytes] = []
+        for frame in video_np:
+            pil_image = Image.fromarray(frame)
+            buffer = BytesIO()
+            pil_image.save(buffer, format="JPEG", quality=85)
+            jpeg_frames.append(buffer.getvalue())
+
+        # Write AVI file
+        self._write_mjpeg_avi(output_path, jpeg_frames, width, height, frame_rate)
+
+        logger.info(f"Saved video to {output_path}")
+        return output_path
+
+    def _write_mjpeg_avi(
+        self,
+        output_path: str,
+        jpeg_frames: List[bytes],
+        width: int,
+        height: int,
+        frame_rate: float,
+    ) -> None:
+        """Write MJPEG frames to AVI container.
+
+        Args:
+            output_path: Output file path
+            jpeg_frames: List of JPEG-encoded frames
+            width: Frame width
+            height: Frame height
+            frame_rate: Frames per second
+        """
+        num_frames = len(jpeg_frames)
+        usec_per_frame = int(1000000 / frame_rate)
+
+        # Build movi chunk with all frames
+        movi_data = b""
+        frame_index: List[tuple] = []  # (offset, size) for each frame
+
+        for jpeg_data in jpeg_frames:
+            original_size = len(jpeg_data)
+            # Record offset within movi (after 'movi' fourcc)
+            frame_index.append((len(movi_data) + 4, original_size))
+
+            # 00dc = compressed video chunk
+            chunk = b"00dc" + struct.pack("<I", original_size) + jpeg_data
+            # Pad to word boundary
+            if original_size % 2:
+                chunk += b"\x00"
+            movi_data += chunk
+
+        # Build index (idx1)
+        idx1_data = b""
+        for offset, size in frame_index:
+            idx1_data += b"00dc"  # chunk id
+            idx1_data += struct.pack("<I", 0x10)  # flags: AVIIF_KEYFRAME
+            idx1_data += struct.pack("<I", offset)  # offset from movi
+            idx1_data += struct.pack("<I", size)  # chunk size
+
+        # Calculate sizes
+        movi_list_size = 4 + len(movi_data)  # 'movi' + data
+        idx1_size = len(idx1_data)
+
+        # Build AVI headers
+        # Main AVI header (avih)
+        avih = struct.pack(
+            "<IIIIIIIIIIIIII",
+            usec_per_frame,  # dwMicroSecPerFrame
+            0,  # dwMaxBytesPerSec
+            0,  # dwPaddingGranularity
+            0x10,  # dwFlags (AVIF_HASINDEX)
+            num_frames,  # dwTotalFrames
+            0,  # dwInitialFrames
+            1,  # dwStreams
+            max(len(f) for f in jpeg_frames),  # dwSuggestedBufferSize
+            width,  # dwWidth
+            height,  # dwHeight
+            0,
+            0,
+            0,
+            0,  # dwReserved[4]
+        )
+
+        # Stream header (strh) for video
+        strh = struct.pack(
+            "<4s4sIHHIIIIIIIIHHHH",
+            b"vids",  # fccType
+            b"MJPG",  # fccHandler
+            0,  # dwFlags
+            0,  # wPriority
+            0,  # wLanguage
+            0,  # dwInitialFrames
+            1,  # dwScale
+            int(frame_rate),  # dwRate
+            0,  # dwStart
+            num_frames,  # dwLength
+            max(len(f) for f in jpeg_frames),  # dwSuggestedBufferSize
+            0,  # dwQuality
+            0,  # dwSampleSize
+            0,
+            0,  # rcFrame left, top
+            width,
+            height,  # rcFrame right, bottom
+        )
+
+        # Stream format (strf) for video - BITMAPINFOHEADER
+        strf = struct.pack(
+            "<IiiHHIIiiII",
+            40,  # biSize
+            width,  # biWidth
+            height,  # biHeight (positive = bottom-up, but MJPEG handles it)
+            1,  # biPlanes
+            24,  # biBitCount
+            0x47504A4D,  # biCompression = 'MJPG' (little-endian)
+            width * height * 3,  # biSizeImage
+            0,  # biXPelsPerMeter
+            0,  # biYPelsPerMeter
+            0,  # biClrUsed
+            0,  # biClrImportant
+        )
+
+        # Build strl LIST (stream list)
+        strh_chunk = b"strh" + struct.pack("<I", len(strh)) + strh
+        strf_chunk = b"strf" + struct.pack("<I", len(strf)) + strf
+        strl_data = strh_chunk + strf_chunk
+        strl_list = b"LIST" + struct.pack("<I", 4 + len(strl_data)) + b"strl" + strl_data
+
+        # Build hdrl LIST (header list)
+        avih_chunk = b"avih" + struct.pack("<I", len(avih)) + avih
+        hdrl_data = avih_chunk + strl_list
+        hdrl_list = b"LIST" + struct.pack("<I", 4 + len(hdrl_data)) + b"hdrl" + hdrl_data
+
+        # Build movi LIST
+        movi_list = b"LIST" + struct.pack("<I", movi_list_size) + b"movi" + movi_data
+
+        # Build idx1 chunk
+        idx1_chunk = b"idx1" + struct.pack("<I", idx1_size) + idx1_data
+
+        # Calculate total RIFF size
+        riff_data = hdrl_list + movi_list + idx1_chunk
+        riff_size = 4 + len(riff_data)  # 'AVI ' + data
+
+        # Write the file
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF")
+            f.write(struct.pack("<I", riff_size))
+            f.write(b"AVI ")
+            f.write(riff_data)
+
+
+def get_video_encoder() -> Optional[VideoEncoder]:
+    """Get the best available video encoder.
+
+    Checks availability in order:
+    1. ffmpeg CLI - Full-featured solution (supports audio)
+    2. Pure Python MJPEG/AVI - No external dependencies (video only, no audio)
+
+    Returns:
+        VideoEncoder instance, or None if no encoder is available
+    """
+    if _check_ffmpeg_available():
+        logger.info("Using ffmpeg CLI for video encoding")
+        return FfmpegCliEncoder()
+    else:
+        logger.info("Using pure Python MJPEG/AVI encoder (no audio support)")
+        return PurePythonEncoder()
 
 
 class MediaStorage:
@@ -169,15 +609,16 @@ class MediaStorage:
 
         # Save based on format
         if format == "mp4":
-            MediaStorage._save_mp4(video, audio, output_path, frame_rate)
+            # _save_mp4 may return a different path (e.g., .avi when using PurePythonEncoder)
+            output_path = MediaStorage._save_mp4(video, audio, output_path, frame_rate)
         elif format == "gif":
-            MediaStorage._save_gif(video, output_path, frame_rate)
+            output_path = MediaStorage._save_gif(video, output_path, frame_rate)
         elif format == "png":
-            MediaStorage._save_middle_frame(video, output_path)
+            output_path = MediaStorage._save_middle_frame(video, output_path)
         else:
             logger.warning(f"Unsupported video format: {format}, defaulting to mp4")
             output_path = output_path.rsplit(".", 1)[0] + ".mp4"
-            MediaStorage._save_mp4(video, audio, output_path, frame_rate)
+            output_path = MediaStorage._save_mp4(video, audio, output_path, frame_rate)
 
         return output_path
 
@@ -222,6 +663,9 @@ class MediaStorage:
     ) -> str:
         """Save video with optional audio as MP4.
 
+        Uses ffmpeg CLI if available (supports audio), otherwise falls back to
+        pure Python MJPEG/AVI encoder (video only).
+
         Args:
             video: Video frames as torch.Tensor (T, H, W, C) uint8
             audio: Optional audio as torch.Tensor
@@ -232,137 +676,20 @@ class MediaStorage:
             Path where the video was saved
         """
         try:
-            from fractions import Fraction
-
-            import av
-
-            if not isinstance(video, torch.Tensor):
-                raise ValueError(f"Expected torch.Tensor for video, got {type(video)}")
-
-            # Convert video tensor to numpy: (T, H, W, C) uint8
-            video_np = video.cpu().numpy()
-            num_frames, height, width, channels = video_np.shape
-
-            # Ensure RGB format (3 channels)
-            if channels != 3:
-                raise ValueError(f"Expected 3-channel RGB video, got {channels} channels")
-
-            # Open output container
-            container = av.open(output_path, mode="w")
-
-            # Add video stream (H.264 codec)
-            video_stream = container.add_stream("libx264", rate=int(frame_rate))
-            video_stream.width = width
-            video_stream.height = height
-            video_stream.pix_fmt = "yuv420p"
-            video_stream.options = {"preset": "medium", "crf": "23"}
-
-            # Pre-process audio and add audio stream BEFORE any muxing.
-            # All streams must be registered before the first mux() call
-            # (which triggers container header writing).
-            audio_stream = None
-            audio_tensor = None
-            audio_sample_rate = 24000  # Default sample rate
-            if audio is not None:
-                if not isinstance(audio, torch.Tensor):
-                    raise ValueError(f"Expected torch.Tensor for audio, got {type(audio)}")
-
-                # Prepare audio tensor: convert to (samples, channels) format
-                audio_tensor = audio
-
-                # Handle different audio tensor dimensions
-                if audio_tensor.ndim == 1:
-                    # Mono audio: (samples,) -> (samples, 1)
-                    audio_tensor = audio_tensor[:, None]
-                elif audio_tensor.ndim == 2:
-                    # If shape[1] != 2 and shape[0] == 2, transpose to (samples, channels)
-                    if audio_tensor.shape[1] != 2 and audio_tensor.shape[0] == 2:
-                        audio_tensor = audio_tensor.T
-                    if audio_tensor.shape[1] > 2:
-                        audio_tensor = audio_tensor[:, :2]
-                elif audio_tensor.ndim == 3:
-                    if audio_tensor.shape[0] == 1:
-                        audio_tensor = audio_tensor.squeeze(0)
-                    else:
-                        audio_tensor = audio_tensor[0]
-                    if audio_tensor.shape[1] != 2 and audio_tensor.shape[0] == 2:
-                        audio_tensor = audio_tensor.T
-                    if audio_tensor.shape[1] > 2:
-                        audio_tensor = audio_tensor[:, :2]
-                else:
-                    raise ValueError(
-                        f"Unsupported audio tensor shape: {audio_tensor.shape}. "
-                        f"Expected 1D, 2D, or 3D tensor."
-                    )
-
-                if audio_tensor.shape[1] > 2:
-                    audio_tensor = audio_tensor[:, :2]
-
-                # Convert to int16 if needed
-                if audio_tensor.dtype != torch.int16:
-                    audio_tensor = torch.clip(audio_tensor, -1.0, 1.0)
-                    audio_tensor = (audio_tensor * 32767.0).to(torch.int16)
-
-                # Add audio stream now (before any muxing)
-                audio_stream = container.add_stream("aac", rate=audio_sample_rate)
-                audio_stream.codec_context.sample_rate = audio_sample_rate
-                audio_stream.codec_context.layout = "stereo"
-                audio_stream.codec_context.time_base = Fraction(1, audio_sample_rate)
-
-            # --- Encode video frames ---
-            for frame_array in video_np:
-                frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
-                for packet in video_stream.encode(frame):
-                    container.mux(packet)
-
-            # Flush video encoder
-            for packet in video_stream.encode():
-                container.mux(packet)
-
-            # --- Encode audio (after video is done) ---
-            if audio_stream is not None and audio_tensor is not None:
-                # Build packed int16 frame: (1, samples*channels)
-                audio_np = audio_tensor.contiguous().reshape(1, -1).cpu().numpy()
-
-                frame_in = av.AudioFrame.from_ndarray(audio_np, format="s16", layout="stereo")
-                frame_in.sample_rate = audio_sample_rate
-
-                # Use AudioResampler to convert s16→fltp (AAC's native format)
-                cc = audio_stream.codec_context
-                audio_resampler = av.audio.resampler.AudioResampler(
-                    format=cc.format or "fltp",
-                    layout=cc.layout or "stereo",
-                    rate=cc.sample_rate or audio_sample_rate,
+            encoder = get_video_encoder()
+            if encoder is not None:
+                # If using pure Python encoder and output is .mp4, change to .avi
+                if isinstance(encoder, PurePythonEncoder) and output_path.lower().endswith(".mp4"):
+                    output_path = output_path[:-4] + ".avi"
+                return encoder.encode_video(video, output_path, frame_rate, audio)
+            else:
+                logger.warning(
+                    "No video encoder available. Falling back to saving middle frame as PNG."
                 )
-
-                audio_next_pts = 0
-                for rframe in audio_resampler.resample(frame_in):
-                    if rframe.pts is None:
-                        rframe.pts = audio_next_pts
-                    audio_next_pts += rframe.samples
-                    rframe.sample_rate = audio_sample_rate
-                    container.mux(audio_stream.encode(rframe))
-
-                # Flush audio encoder
-                for packet in audio_stream.encode():
-                    container.mux(packet)
-
-            # Close container
-            container.close()
-
-            logger.info(f"Saved video{' with audio' if audio is not None else ''} to {output_path}")
-            return output_path
-
-        except ImportError:
-            logger.warning(
-                "PyAV (av) library not available. "
-                "Falling back to saving middle frame as PNG. "
-                "Install with: pip install av"
-            )
-            png_path = output_path.replace(".mp4", ".png")
-            return MediaStorage._save_middle_frame(video, png_path)
+                png_path = output_path.replace(".mp4", ".png")
+                return MediaStorage._save_middle_frame(video, png_path)
         except Exception as e:
-            logger.error(f"Error encoding video with PyAV: {e}")
+            logger.error(f"Error encoding video: {e}")
             import traceback
 
             logger.error(traceback.format_exc())

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1327,6 +1327,8 @@ class VideoJob(OpenAIBaseModel):
     fps: Optional[int] = Field(default=None, description="Frames per second")
     size: Optional[str] = Field(default=None,
                                 description="Video dimensions in 'WxH' format")
+    output_path: Optional[str] = Field(
+        default=None, description="Actual path where the video file was saved")
 
 
 class VideoJobList(OpenAIBaseModel):

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1471,17 +1471,21 @@ class OpenAIServer:
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
 
-            MediaStorage.save_video(
+            actual_output_path = MediaStorage.save_video(
                 video=output.video,
                 output_path=self.media_storage_path / f"{video_id}.mp4",
                 audio=output.audio,
                 frame_rate=request.fps or params.frame_rate,
             )
 
+            # Determine media type based on actual output file extension
+            actual_path = Path(actual_output_path)
+            media_type = "video/mp4" if actual_path.suffix == ".mp4" else "video/x-msvideo"
+
             return FileResponse(
-                self.media_storage_path / f"{video_id}.mp4",
-                media_type="video/mp4",
-                filename=f"{video_id}.mp4",
+                actual_output_path,
+                media_type=media_type,
+                filename=actual_path.name,
             )
 
         except ValueError as e:
@@ -1628,7 +1632,7 @@ class OpenAIServer:
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
 
-            MediaStorage.save_video(
+            actual_output_path = MediaStorage.save_video(
                 video=output.video,
                 output_path=self.media_storage_path / f"{video_id}.mp4",
                 audio=output.audio,
@@ -1638,6 +1642,8 @@ class OpenAIServer:
             if job:
                 job.status = "completed"
                 job.completed_at = int(time.time())
+                # Store actual file extension in case it differs from requested (.mp4 vs .avi)
+                job.output_path = str(actual_output_path)
                 await VIDEO_STORE.upsert(video_id, job)
 
         except Exception as e:
@@ -1742,12 +1748,24 @@ class OpenAIServer:
                     status_code=HTTPStatus.BAD_REQUEST
                 )
 
-            video_file_name = f"{video_id}.mp4"
-            if os.path.exists(self.media_storage_path / video_file_name):
+            # Try to use stored output path, otherwise check for both .mp4 and .avi
+            video_path = None
+            if hasattr(job, 'output_path') and job.output_path and os.path.exists(job.output_path):
+                video_path = Path(job.output_path)
+            else:
+                # Fall back to checking common extensions
+                for ext in [".mp4", ".avi"]:
+                    candidate = self.media_storage_path / f"{video_id}{ext}"
+                    if os.path.exists(candidate):
+                        video_path = candidate
+                        break
+
+            if video_path and os.path.exists(video_path):
+                media_type = "video/mp4" if video_path.suffix == ".mp4" else "video/x-msvideo"
                 return FileResponse(
-                    self.media_storage_path / video_file_name,
-                    media_type="video/mp4",
-                    filename=video_file_name,
+                    video_path,
+                    media_type=media_type,
+                    filename=video_path.name,
                 )
             else:
                 return self.create_error_response(
@@ -1788,12 +1806,23 @@ class OpenAIServer:
                     status_code=HTTPStatus.BAD_REQUEST
                 )
 
-            # Delete the video
-            success = await VIDEO_STORE.pop(video_id)
-            video_file_name = f"{video_id}.mp4"
+            # Delete the video file(s) - check for both .mp4 and .avi
+            video_path = None
+            if hasattr(job, 'output_path') and job.output_path and os.path.exists(job.output_path):
+                video_path = job.output_path
+            else:
+                # Fall back to checking common extensions
+                for ext in [".mp4", ".avi"]:
+                    candidate = self.media_storage_path / f"{video_id}{ext}"
+                    if os.path.exists(candidate):
+                        video_path = candidate
+                        break
 
-            if os.path.exists(self.media_storage_path / video_file_name):
-                os.remove(self.media_storage_path / video_file_name)
+            if video_path and os.path.exists(video_path):
+                os.remove(video_path)
+
+            # Delete from store
+            success = await VIDEO_STORE.pop(video_id)
 
             return JSONResponse(content={"deleted": success is not None})
 

--- a/tests/unittest/_torch/visual_gen/test_media_storage.py
+++ b/tests/unittest/_torch/visual_gen/test_media_storage.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# Copyright 2026 NVIDIA Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for media_storage module."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tensorrt_llm.serve.media_storage import MediaStorage, PurePythonEncoder, get_video_encoder
+
+
+def _make_dummy_video_tensor(
+    num_frames: int = 4, height: int = 64, width: int = 64
+) -> torch.Tensor:
+    """Create a small dummy uint8 video tensor (T, H, W, C)."""
+    return torch.randint(0, 256, (num_frames, height, width, 3), dtype=torch.uint8)
+
+
+class TestMediaStoragePNGFallback:
+    """Test PNG fallback path handling when video encoding fails."""
+
+    def test_png_fallback_with_avi_extension(self, tmp_path):
+        """Test that PNG fallback uses correct path after .avi extension change."""
+        video = _make_dummy_video_tensor()
+        output_path = str(tmp_path / "test.avi")
+
+        # Mock encoder to return None (no encoder available)
+        with patch("tensorrt_llm.serve.media_storage.get_video_encoder", return_value=None):
+            result = MediaStorage._save_mp4(video, None, output_path, 24.0)
+
+        # Should create PNG file with correct name
+        assert result.endswith(".png")
+        assert os.path.exists(result)
+        expected_path = str(tmp_path / "test.png")
+        assert result == expected_path
+
+    def test_png_fallback_with_mp4_extension(self, tmp_path):
+        """Test that PNG fallback uses correct path after .mp4 extension."""
+        video = _make_dummy_video_tensor()
+        output_path = str(tmp_path / "test.mp4")
+
+        # Mock encoder to return None (no encoder available)
+        with patch("tensorrt_llm.serve.media_storage.get_video_encoder", return_value=None):
+            result = MediaStorage._save_mp4(video, None, output_path, 24.0)
+
+        # Should create PNG file with correct name
+        assert result.endswith(".png")
+        assert os.path.exists(result)
+        expected_path = str(tmp_path / "test.png")
+        assert result == expected_path
+
+
+class TestMediaStorageMP4Encoding:
+    """Test MP4 encoding with and without ffmpeg."""
+
+    def test_mp4_requires_ffmpeg_error(self, tmp_path):
+        """Test that requesting MP4 without ffmpeg raises an error."""
+        video = _make_dummy_video_tensor()
+        output_path = str(tmp_path / "test.mp4")
+
+        # Mock to simulate pure Python encoder (no ffmpeg)
+        with patch(
+            "tensorrt_llm.serve.media_storage.get_video_encoder",
+            return_value=PurePythonEncoder(),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                MediaStorage._save_mp4(video, None, output_path, 24.0)
+
+            assert "MP4 format requires ffmpeg" in str(exc_info.value)
+            assert "apt-get install ffmpeg" in str(exc_info.value)
+
+
+class TestConvertVideoToBytes:
+    """Test convert_video_to_bytes handles actual output path correctly."""
+
+    def test_convert_video_to_bytes_uses_actual_path(self):
+        """Test that convert_video_to_bytes reads from the actual returned path."""
+        video = _make_dummy_video_tensor()
+
+        # Mock save_video to return a different path than requested
+        def mock_save_video(video, output_path, audio, frame_rate, format):
+            # Simulate changing extension (e.g., .mp4 -> .avi)
+            if output_path.endswith(".mp4"):
+                actual_path = output_path[:-4] + ".avi"
+            else:
+                actual_path = output_path
+
+            # Write dummy content
+            with open(actual_path, "wb") as f:
+                f.write(b"test video content")
+            return actual_path
+
+        with patch.object(MediaStorage, "save_video", side_effect=mock_save_video):
+            result = MediaStorage.convert_video_to_bytes(video, None, 24.0, "mp4")
+
+        assert result == b"test video content"
+
+
+class TestVideoEncoderCaching:
+    """Test that video encoder is cached as singleton."""
+
+    def test_encoder_is_cached(self):
+        """Test that get_video_encoder returns the same instance on multiple calls."""
+        # Clear cache
+        import tensorrt_llm.serve.media_storage as ms
+
+        ms._VIDEO_ENCODER = None
+
+        encoder1 = get_video_encoder()
+        encoder2 = get_video_encoder()
+
+        # Should be the exact same instance
+        assert encoder1 is encoder2
+
+        # Clean up
+        ms._VIDEO_ENCODER = None


### PR DESCRIPTION
…e Python MJPEG/AVI encoder

- Simplify media_storage.py to keep only FfmpegCliEncoder and add PurePythonEncoder
- PurePythonEncoder outputs MJPEG codec in AVI container (no external dependencies)
- Fix save_video() to return actual output path from format-specific save methods
- Update openai_server.py to handle both .mp4 and .avi output formats
- Add output_path field to VideoJob model for tracking actual file path
- Update sync/async video gen examples to detect Content-Type and adjust filename
- Update README to remove PyAV dependency and document video encoding options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Video encoding now supports automatic fallback to AVI format when FFmpeg is unavailable, eliminating external dependencies while maintaining functionality.
- Output filenames dynamically adjust to match actual server-selected video format (MP4 or AVI).
- Enhanced video format detection during download and retrieval operations.

## Documentation
- Updated setup instructions with optional FFmpeg installation details and fallback encoding notes.
- Added examples for downloading and handling server-provided video formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
