### PR TITLE
[None][fix] Add comparison operators for perf regression triage

### DIFF
--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -286,29 +286,39 @@ class OpenSearchDB:
     @staticmethod
     def queryPerfDataFromOpenSearchDB(project_name,
                                       must_clauses,
-                                      size=DEFAULT_QUERY_SIZE):
+                                      size=DEFAULT_QUERY_SIZE,
+                                      must_not_clauses=None):
         """
-        Query perf data from OpenSearchDB using must clauses.
+        Query perf data from OpenSearchDB using must and must_not clauses.
 
         :param project_name: Name of the project.
         :param must_clauses: List of must clauses for query.
         :param size: Query size.
+        :param must_not_clauses: List of must_not clauses for query.
         :return: list of data dicts, empty list if no data, None on error.
         """
         if DISABLE_OPEN_SEARCH_DB_FOR_LOCAL_TEST:
             return []
         if must_clauses is None:
             must_clauses = []
+        if must_not_clauses is None:
+            must_not_clauses = []
         if not isinstance(must_clauses, list):
             OpenSearchDB.logger.info(
                 f"Invalid must_clauses type: {type(must_clauses).__name__}")
             return None
+        if not isinstance(must_not_clauses, list):
+            OpenSearchDB.logger.info(
+                f"Invalid must_not_clauses type: {type(must_not_clauses).__name__}")
+            return None
+
+        bool_query = {"must": must_clauses}
+        if must_not_clauses:
+            bool_query["must_not"] = must_not_clauses
 
         json_data = {
             "query": {
-                "bool": {
-                    "must": must_clauses
-                }
+                "bool": bool_query
             },
             "size": size,
         }

--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -309,7 +309,8 @@ class OpenSearchDB:
             return None
         if not isinstance(must_not_clauses, list):
             OpenSearchDB.logger.info(
-                f"Invalid must_not_clauses type: {type(must_not_clauses).__name__}")
+                f"Invalid must_not_clauses type: {type(must_not_clauses).__name__}"
+            )
             return None
 
         bool_query = {"must": must_clauses}

--- a/jenkins/scripts/perf/README.md
+++ b/jenkins/scripts/perf/README.md
@@ -38,8 +38,27 @@ SLACK BOT SENDS MESSAGE
 Updates fields on existing perf records that match a query scope and posts the
 updated documents back to OpenSearch.
 
-**Format**
+**Operators**
+
+- SET clause: Only `=` is supported.
+- WHERE clause: Supports `=`, `!=`, `>`, `<`, `>=`, `<=` operators.
+- `=` and `!=` operators are allowed for all fields.
+- `>`, `<`, `>=`, `<=` operators are only allowed for `ts_created` field (timestamp) or fields starting with `d_` (double type) or `l_` (integer type).
+
+**ts_created Date Formats**
+
+The `ts_created` field accepts date strings in the following formats:
+- `'Feb 18, 2026 @ 22:32:02.960'` (with milliseconds)
+- `'Feb 18, 2026 @ 22:32:02'` (without milliseconds)
+- `'2026/02/18'` (date only)
+
+**Note:** All date strings are interpreted as UTC for consistent timestamp conversion across different environments.
+
+**Examples**
 
 ```
-UPDATE SET <field>=<value> [AND <field>=<value> ...] [WHERE <field>=<value> [AND <field>=<value> ...]]
+UPDATE SET b_is_valid=false WHERE s_test_case_name='test1'
+UPDATE SET b_is_valid=false WHERE s_gpu_type!='H100'
+UPDATE SET b_is_valid=false WHERE d_latency > 100.5 AND l_count >= 10
+UPDATE SET b_is_valid=false WHERE ts_created <= 'Feb 18, 2026 @ 22:32:02.960' AND s_test_case_name='test1'
 ```

--- a/jenkins/scripts/perf/perf_sanity_triage.py
+++ b/jenkins/scripts/perf/perf_sanity_triage.py
@@ -511,8 +511,7 @@ def main():
                 must_not_clauses.append(clause)
 
         data_list = OpenSearchDB.queryPerfDataFromOpenSearchDB(
-            args.project_name, must_clauses, size=MAX_QUERY_SIZE,
-            must_not_clauses=must_not_clauses
+            args.project_name, must_clauses, size=MAX_QUERY_SIZE, must_not_clauses=must_not_clauses
         )
         if data_list is None:
             print("Failed to query data for update")

--- a/jenkins/scripts/perf/perf_sanity_triage.py
+++ b/jenkins/scripts/perf/perf_sanity_triage.py
@@ -5,7 +5,7 @@ import json
 import re
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -19,6 +19,11 @@ MAX_QUERY_SIZE = 3000
 MAX_TEST_CASES_PER_MSG = 4
 POST_SLACK_MSG_RETRY_TIMES = 5
 
+# Comparison operators (order matters: >= before >, <= before <, != before =)
+COMPARISON_OPERATORS = [">=", "<=", "!=", ">", "<", "="]
+COMPARISON_ALLOWED_PREFIXES = ("d_", "l_")
+COMPARISON_ALLOWED_FIELDS = ("ts_created",)
+
 
 def _timestamp_to_date(ts):
     """Convert millisecond timestamp to YYYY/MM/DD format."""
@@ -31,6 +36,46 @@ def _timestamp_to_date(ts):
         return dt.strftime("%Y/%m/%d")
     except (ValueError, TypeError, OSError):
         return str(ts)
+
+
+def _parse_date_string(date_str):
+    """Convert date string like 'Feb 18, 2026 @ 22:32:02.960' to millisecond timestamp.
+
+    All date strings are interpreted as UTC to ensure consistent timestamps
+    across different environments/timezones.
+    """
+    date_str = date_str.strip()
+    # Try format: "Feb 18, 2026 @ 22:32:02.960"
+    try:
+        dt = datetime.strptime(date_str, "%b %d, %Y @ %H:%M:%S.%f")
+        dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        pass
+    # Try format: "Feb 18, 2026 @ 22:32:02"
+    try:
+        dt = datetime.strptime(date_str, "%b %d, %Y @ %H:%M:%S")
+        dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        pass
+    # Try format: "2026/02/18"
+    try:
+        dt = datetime.strptime(date_str, "%Y/%m/%d")
+        dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        pass
+    raise ValueError(f"Unable to parse date string: {date_str}")
+
+
+def _can_use_comparison_operator(field_name):
+    """Check if a field can use comparison operators (>, <, >=, <=)."""
+    if field_name in COMPARISON_ALLOWED_FIELDS:
+        return True
+    if field_name.startswith(COMPARISON_ALLOWED_PREFIXES):
+        return True
+    return False
 
 
 def _parse_value(value):
@@ -71,6 +116,71 @@ def _parse_assignments(text):
     return result, None
 
 
+def _parse_where_clauses(text):
+    """Parse WHERE clauses supporting =, >, <, >=, <= operators.
+
+    Returns a list of tuples: (field_name, operator, value)
+    Only d_*, l_*, and ts_created fields can use comparison operators.
+    """
+    clauses = _split_and_clauses(text)
+    if not clauses:
+        return None, "No fields provided"
+
+    result = []
+    for clause in clauses:
+        # Match: field_name <operator> value
+        # Using regex to find operator right after field name, avoiding false matches in values
+        m = re.match(r"^\s*(\w+)\s*(>=|<=|!=|>|<|=)\s*(.*)", clause)
+        if not m:
+            return None, f"Invalid clause (missing operator): {clause}"
+
+        key = m.group(1).strip()
+        found_op = m.group(2)
+        value = _parse_value(m.group(3))
+
+        if not key:
+            return None, f"Invalid clause (empty field name): {clause}"
+
+        # Check if comparison operator is allowed for this field
+        # != is allowed for all fields, but >, <, >=, <= are restricted
+        if found_op not in ("=", "!=") and not _can_use_comparison_operator(key):
+            return None, (
+                f"Comparison operator '{found_op}' not allowed for field '{key}'. "
+                f"Only fields starting with 'd_', 'l_', or field 'ts_created' can use >, <, >=, <= operators."
+            )
+
+        # Convert date string to timestamp for ts_created
+        if key == "ts_created" and isinstance(value, str):
+            try:
+                value = _parse_date_string(value)
+            except ValueError as e:
+                return None, str(e)
+
+        result.append((key, found_op, value))
+
+    return result, None
+
+
+def _build_opensearch_clause(field, operator, value):
+    """Build OpenSearch query clause from field, operator, and value.
+
+    Returns a tuple (clause_type, clause) where clause_type is "must" or "must_not".
+    """
+    if operator == "=":
+        return ("must", {"term": {field: value}})
+
+    if operator == "!=":
+        return ("must_not", {"term": {field: value}})
+
+    op_map = {
+        ">": "gt",
+        "<": "lt",
+        ">=": "gte",
+        "<=": "lte",
+    }
+    return ("must", {"range": {field: {op_map[operator]: value}}})
+
+
 def parse_update_operation(operation):
     match = re.match(
         r"^\s*UPDATE\s+SET\s+(.+?)(?:\s+WHERE\s+(.+))?\s*$", operation, flags=re.IGNORECASE
@@ -82,14 +192,14 @@ def parse_update_operation(operation):
     set_values, error = _parse_assignments(set_text)
     if error:
         return None, None, f"Invalid SET clause: {error}"
-    where_values = {}
+    where_clauses = []
     if match.group(2) is not None:
         if not where_text:
             return None, None, "Invalid WHERE clause: empty scope"
-        where_values, error = _parse_assignments(where_text)
+        where_clauses, error = _parse_where_clauses(where_text)
         if error:
             return None, None, f"Invalid WHERE clause: {error}"
-    return set_values, where_values, None
+    return set_values, where_clauses, None
 
 
 def update_perf_data_fields(data_list, set_values):
@@ -386,17 +496,23 @@ def main():
         messages = split_regression_message(regression_dict)
         send_regression_message(messages, args.channel_id, args.bot_token)
     elif args.operation.strip().upper().startswith("UPDATE"):
-        set_values, where_values, error = parse_update_operation(args.operation)
+        set_values, where_clauses, error = parse_update_operation(args.operation)
         if error:
             print(error)
             return
 
         must_clauses = []
-        for key, value in where_values.items():
-            must_clauses.append({"term": {key: value}})
+        must_not_clauses = []
+        for field, operator, value in where_clauses:
+            clause_type, clause = _build_opensearch_clause(field, operator, value)
+            if clause_type == "must":
+                must_clauses.append(clause)
+            else:
+                must_not_clauses.append(clause)
 
         data_list = OpenSearchDB.queryPerfDataFromOpenSearchDB(
-            args.project_name, must_clauses, size=MAX_QUERY_SIZE
+            args.project_name, must_clauses, size=MAX_QUERY_SIZE,
+            must_not_clauses=must_not_clauses
         )
         if data_list is None:
             print("Failed to query data for update")


### PR DESCRIPTION
Add support for comparison operators (>, <, >=, <=, !=) in WHERE clause of UPDATE operations for perf_sanity_triage.py:
- >, <, >=, <= allowed for d_* (double), l_* (integer), and ts_created fields
- != allowed for all fields
- ts_created accepts date strings like 'Feb 18, 2026 @ 22:32:02.960'
- Updated open_search_db.py to support must_not_clauses for != operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added exclusion filtering support to narrow results with negative conditions in data queries.
  * Extended filtering with comparison operators (>=, <=, !=, >, <, =) for more precise data searches.
  * Added date format parsing for timestamp fields, supporting common human-readable date formats.

* **Documentation**
  * Updated query syntax documentation with supported operators and date format specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
