### PR TITLE
[TRTLLM-9939][perf] Short-sequence MHA optimization for DSA MLA prefill

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1507,10 +1507,10 @@ class MLA(nn.Module):
 
         # Check if the short-seq MHA path will handle context, in which case
         # the indexer (topk_indices) is not needed for context tokens.
-        # Disable when cached tokens exist: forward_context_default does not
-        # attend over cached KV from previous chunks/turns.
-        has_cached_ctx = getattr(attn_metadata, 'num_ctx_cached_tokens', 0) > 0
-        use_short_mha_for_ctx = (num_contexts > 0 and not has_cached_ctx
+        # The MHA path handles cached tokens via forward_context(), which
+        # dispatches to forward_context_with_cached_kv or
+        # forward_context_with_chunked_prefill as needed.
+        use_short_mha_for_ctx = (num_contexts > 0
                                  and self._should_use_short_mha(
                                      num_ctx_tokens, position_ids))
 
@@ -1625,9 +1625,10 @@ class MLA(nn.Module):
                               position_ids: Optional[torch.Tensor]) -> bool:
         """Check if the short-seq MHA optimization should be used for context.
 
-        This checks only token count vs threshold. Callers MUST separately
-        verify that there are no cached tokens (num_ctx_cached_tokens == 0),
-        because forward_context_default does not attend over cached KV.
+        This checks only new token count vs threshold.  When cached tokens
+        exist, the caller should route through forward_context() which
+        dispatches to the appropriate cached-KV handler
+        (forward_context_with_cached_kv or forward_context_with_chunked_prefill).
         """
         return (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
                 and self.mapping.cp_size == 1 and position_ids is not None
@@ -1665,13 +1666,12 @@ class MLA(nn.Module):
         # using kv_b_proj expansion + standard attention instead.
         # See __init__ comment for rationale. topk_indices is not used
         # because dense attention is faster than sparse routing at this scale.
+        # forward_context() handles cached tokens by dispatching to
+        # forward_context_with_cached_kv or forward_context_with_chunked_prefill.
         num_ctx_tokens = q.shape[0]
-        has_cached = getattr(attn_metadata, 'num_ctx_cached_tokens', 0) > 0
-        if not has_cached and self._should_use_short_mha(
-                num_ctx_tokens, position_ids):
-            return self.forward_context_default(q, compressed_kv, k_pe,
-                                                position_ids, attn_metadata,
-                                                output, latent_cache)
+        if self._should_use_short_mha(num_ctx_tokens, position_ids):
+            return self.forward_context(q, compressed_kv, k_pe, position_ids,
+                                        attn_metadata, output, latent_cache)
 
         if get_sm_version() >= 100:
             return self.forward_absorption_context(q,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -28,7 +28,7 @@ from ..distributed import (AllReduceParams, HelixAllToAllNative, alltoall_helix,
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..utils import (Fp4QuantizedTensor, get_model_extra_attrs,
-                     is_torch_compiling, maybe_compile, maybe_compiled_cat,
+                     is_torch_compiling, maybe_compiled_cat,
                      maybe_compiled_copy_)
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 from .multi_stream_utils import maybe_execute_in_parallel
@@ -872,22 +872,6 @@ def fp8_block_scaling_bmm_out(
                       out=out)
     else:
         raise NotImplementedError(f"SM{sm_version} is not supported")
-
-
-@maybe_compile(dynamic=True)
-def _short_mha_reshape_kv(kv, k_pe_roped, num_heads_tp, qk_nope_head_dim,
-                           v_head_dim, qk_rope_head_dim, qk_head_dim):
-    """Fused split + reshape + expand + cat for short-seq MHA KV construction."""
-    k_nope, v = kv.split(
-        [num_heads_tp * qk_nope_head_dim, num_heads_tp * v_head_dim], -1)
-    k_nope_r = k_nope.view(-1, num_heads_tp, qk_nope_head_dim)
-    k_pe_expanded = k_pe_roped.view(-1, 1,
-                                    qk_rope_head_dim).expand(
-                                        -1, num_heads_tp, -1)
-    k = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
-    k = k.view(-1, num_heads_tp * qk_head_dim)
-    v = v.view(-1, num_heads_tp * v_head_dim)
-    return k, v
 
 
 class MLA(nn.Module):
@@ -1769,15 +1753,31 @@ class MLA(nn.Module):
         ctx_position_ids = position_ids[..., :num_ctx_tokens]
         [k_pe_roped] = self._rotary_emb_mha(ctx_position_ids, [k_pe])
 
-        # Step 3: Expand KV via kv_b_proj, construct full K, flatten.
-        # The reshape/cat ops are compiled via _short_mha_reshape_kv to fuse
-        # split + view + expand + cat into fewer kernels.
+        # Step 3: Expand KV via kv_b_proj.
         kv = self.kv_b_proj(compressed_kv)
-        k, v = _short_mha_reshape_kv(kv, k_pe_roped, self.num_heads_tp,
-                                      self.qk_nope_head_dim, self.v_head_dim,
-                                      self.qk_rope_head_dim, self.qk_head_dim)
+        k_nope, v = kv.split(
+            [
+                self.num_heads_tp * self.qk_nope_head_dim,
+                self.num_heads_tp * self.v_head_dim
+            ],
+            -1,
+        )
 
-        # Step 4: Compute attention via the fused MHA backend.
+        # Step 4: Construct full K = [k_nope, k_pe_roped] per head.
+        k_nope_r = k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim)
+        k_pe_expanded = k_pe_roped.view(-1, 1,
+                                        self.qk_rope_head_dim).expand(
+                                            -1, self.num_heads_tp, -1)
+        k = maybe_compiled_cat([k_nope_r, k_pe_expanded], dim=-1)
+        # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
+
+        # Step 5: Flatten Q, K, V to 2D packed layout for the fused attention
+        # backend, which natively handles variable-length sequences via
+        # attn_metadata (no padding/batching needed).
+        k = k.view(-1, self.num_heads_tp * self.qk_head_dim)
+        v = v.view(-1, self.num_heads_tp * self.v_head_dim)
+
+        # Step 6: Compute attention via the fused MHA backend.
         # latent_cache=None signals that RoPE and KV cache append were already
         # done in Step 1 (mla_rope_append_paged_kv_assign_q), matching the
         # pattern used by forward_context_with_cached_kv.

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1507,7 +1507,10 @@ class MLA(nn.Module):
 
         # Check if the short-seq MHA path will handle context, in which case
         # the indexer (topk_indices) is not needed for context tokens.
-        use_short_mha_for_ctx = (num_contexts > 0
+        # Disable when cached tokens exist: forward_context_default does not
+        # attend over cached KV from previous chunks/turns.
+        has_cached_ctx = getattr(attn_metadata, 'num_ctx_cached_tokens', 0) > 0
+        use_short_mha_for_ctx = (num_contexts > 0 and not has_cached_ctx
                                  and self._should_use_short_mha(
                                      num_ctx_tokens, position_ids))
 
@@ -1620,7 +1623,12 @@ class MLA(nn.Module):
 
     def _should_use_short_mha(self, num_ctx_tokens: int,
                               position_ids: Optional[torch.Tensor]) -> bool:
-        """Check if the short-seq MHA optimization should be used for context."""
+        """Check if the short-seq MHA optimization should be used for context.
+
+        This checks only token count vs threshold. Callers MUST separately
+        verify that there are no cached tokens (num_ctx_cached_tokens == 0),
+        because forward_context_default does not attend over cached KV.
+        """
         return (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
                 and self.mapping.cp_size == 1 and position_ids is not None
                 and num_ctx_tokens <= self.short_seq_mha_threshold)
@@ -1658,7 +1666,9 @@ class MLA(nn.Module):
         # See __init__ comment for rationale. topk_indices is not used
         # because dense attention is faster than sparse routing at this scale.
         num_ctx_tokens = q.shape[0]
-        if self._should_use_short_mha(num_ctx_tokens, position_ids):
+        has_cached = getattr(attn_metadata, 'num_ctx_cached_tokens', 0) > 0
+        if not has_cached and self._should_use_short_mha(
+                num_ctx_tokens, position_ids):
             return self.forward_context_default(q, compressed_kv, k_pe,
                                                 position_ids, attn_metadata,
                                                 output, latent_cache)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1126,29 +1126,6 @@ class MLA(nn.Module):
         mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
         q_scaling = 1.0 / (mscale * mscale)
 
-        if not self.is_dsa:
-            self.mha = create_attention(
-                config.attn_backend,
-                self.layer_idx,
-                self.num_heads_tp,
-                head_dim=self.qk_head_dim,
-                num_kv_heads=self.num_key_value_heads_tp,
-                pos_embd_params=pos_embd_params,
-                quant_config=quant_config,
-                q_scaling=q_scaling,
-                is_mla_enable=True,
-                q_lora_rank=self.q_lora_rank,
-                kv_lora_rank=self.kv_lora_rank,
-                qk_nope_head_dim=self.qk_nope_head_dim,
-                qk_rope_head_dim=self.qk_rope_head_dim,
-                v_head_dim=self.v_head_dim,
-                predicted_tokens_per_seq=self.predicted_tokens_per_seq,
-                skip_create_weights_in_init=config.skip_create_weights_in_init,
-                sparse_attention_config=config.sparse_attention_config,
-            )
-        else:
-            self.mha = None
-
         self.mqa = create_attention(
             config.attn_backend,
             self.layer_idx,
@@ -1200,12 +1177,12 @@ class MLA(nn.Module):
             raise ValueError(
                 f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
                 f"got '{_threshold_str}'") from err
-        if (self.is_dsa and self.short_seq_mha_threshold > 0
-                and not self.apply_rotary_emb):
-            # Dense MHA attention backend for the short-seq path. Uses plain
-            # TrtllmAttention (sparse_attention_config=None) because this path
-            # computes dense attention over all tokens. TrtllmAttention has no
-            # weight parameters, so memory overhead is negligible.
+
+        # MHA attention backend: used by non-DSA (standard MLA) and optionally
+        # by DSA for the short-seq path (dense attention, no sparse config).
+        _short_seq_mha = (self.is_dsa and self.short_seq_mha_threshold > 0
+                          and not self.apply_rotary_emb)
+        if not self.is_dsa or _short_seq_mha:
             self.mha = create_attention(
                 config.attn_backend,
                 self.layer_idx,
@@ -1223,8 +1200,11 @@ class MLA(nn.Module):
                 v_head_dim=self.v_head_dim,
                 predicted_tokens_per_seq=self.predicted_tokens_per_seq,
                 skip_create_weights_in_init=config.skip_create_weights_in_init,
-                sparse_attention_config=None,
+                sparse_attention_config=(None if _short_seq_mha else
+                                         config.sparse_attention_config),
             )
+        else:
+            self.mha = None
 
         self.llama_4_scaling = False
         if hasattr(config.pretrained_config, 'llama_4_scaling'):

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -5,9 +5,7 @@ import weakref
 from typing import List, Optional, Union, cast
 
 import torch
-import torch.nn.functional as F
 from torch import nn
-from torch.nn.utils.rnn import pad_sequence
 
 import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
 from tensorrt_llm._utils import (get_sm_version, is_sm_100f, nvtx_range,
@@ -1207,11 +1205,37 @@ class MLA(nn.Module):
         # False). When apply_rotary_emb is True the dispatch guard skips this
         # path, so the embedding would never be used.
         self._rotary_emb_mha = None
+        self._short_seq_mha = None
         if self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb:
             self._rotary_emb_mha = RotaryEmbedding(
                 pos_embd_params.rope,
                 head_dim=self.qk_rope_head_dim,
                 is_neox=pos_embd_params.is_neox,
+            )
+            # Dense MHA attention backend for the short-seq path. Uses plain
+            # TrtllmAttention (sparse_attention_config=None) because this path
+            # computes dense attention over all tokens. TrtllmAttention has no
+            # weight parameters, so memory overhead is negligible. Stored as a
+            # separate attribute (not self.mha) to preserve the DSA assertion
+            # that self.mha is None in forward_impl_with_dsa.
+            self._short_seq_mha = create_attention(
+                config.attn_backend,
+                self.layer_idx,
+                self.num_heads_tp,
+                head_dim=self.qk_head_dim,
+                num_kv_heads=self.num_key_value_heads_tp,
+                pos_embd_params=pos_embd_params,
+                quant_config=quant_config,
+                q_scaling=q_scaling,
+                is_mla_enable=True,
+                q_lora_rank=self.q_lora_rank,
+                kv_lora_rank=self.kv_lora_rank,
+                qk_nope_head_dim=self.qk_nope_head_dim,
+                qk_rope_head_dim=self.qk_rope_head_dim,
+                v_head_dim=self.v_head_dim,
+                predicted_tokens_per_seq=self.predicted_tokens_per_seq,
+                skip_create_weights_in_init=config.skip_create_weights_in_init,
+                sparse_attention_config=None,
             )
 
         self.llama_4_scaling = False
@@ -1230,6 +1254,8 @@ class MLA(nn.Module):
         # which could be modified after __init__
         if not self.is_dsa:
             self.mha.update_quant_config(self.quant_config)
+        if self._short_seq_mha is not None:
+            self._short_seq_mha.update_quant_config(self.quant_config)
         self.mqa.update_quant_config(self.quant_config)
 
         # Although we use FP8 MLA for context/generation phase, the output is still in BF16
@@ -1678,8 +1704,11 @@ class MLA(nn.Module):
         V-projection) and uses a larger head_dim (kv_lora_rank + rope_dim = 576)
         for the attention kernel, compared to the standard qk_head_dim = 192.
 
-        Uses SDPA instead of self.mha.forward() because DSA models set
-        self.mha = None (only self.mqa is available for MQA/generation).
+        Uses self._short_seq_mha (a dedicated TrtllmAttention backend) for
+        the attention computation. This backend natively handles variable-length
+        packed sequences via attn_metadata, avoiding the need for padding or
+        per-sequence Python loops. latent_cache=None tells the backend to skip
+        RoPE and KV cache append (already done in Step 1).
 
         This method:
         1. Stores latent_cache in paged KV cache and applies RoPE to q via the
@@ -1687,9 +1716,9 @@ class MLA(nn.Module):
         2. Applies RoPE to k_pe manually using the RotaryEmbedding.
         3. Expands compressed KV via kv_b_proj to get full k_nope and v.
         4. Constructs full K = [k_nope, RoPE(k_pe)] per head.
-        5. Computes dense attention via torch SDPA (no sparse routing — for
-           short sequences, dense attention is both faster and higher quality
-           than sparse selection via topk_indices).
+        5. Computes dense attention via fused MHA backend (no sparse routing —
+           for short sequences, dense attention is both faster and higher
+           quality than sparse selection via topk_indices).
         """
         num_ctx_tokens = q.shape[0]
 
@@ -1726,70 +1755,26 @@ class MLA(nn.Module):
         k = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
         # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
 
-        # Step 5: Reshape Q, V for attention.
-        q_r = q.view(-1, self.num_heads_tp,
-                     self.qk_head_dim)  # [tokens, H, D]
-        v_r = v.view(-1, self.num_heads_tp,
-                     self.v_head_dim)  # [tokens, H, Dv]
+        # Step 5: Flatten Q, K, V to 2D packed layout for the fused attention
+        # backend, which natively handles variable-length sequences via
+        # attn_metadata (no padding/batching needed).
+        k = k.view(-1, self.num_heads_tp * self.qk_head_dim)
+        v = v.view(-1, self.num_heads_tp * self.v_head_dim)
 
-        # Step 6: Compute attention using SDPA.
-        # Handle packed variable-length sequences by processing per-sequence.
-        num_contexts = attn_metadata.num_contexts
-        seq_lens = attn_metadata.prompt_lens_cpu_runtime[:num_contexts]
-
-        if num_contexts == 1:
-            # Single sequence: straightforward SDPA with [1, H, S, D] layout.
-            q_b = q_r.unsqueeze(0).transpose(1, 2)
-            k_b = k.unsqueeze(0).transpose(1, 2)
-            v_b = v_r.unsqueeze(0).transpose(1, 2)
-
-            attn_out = F.scaled_dot_product_attention(
-                q_b, k_b, v_b, is_causal=True, scale=self.softmax_scale)
-
-            attn_out = attn_out.transpose(1, 2).squeeze(0)  # [S, H, Dv]
-            output[:num_ctx_tokens].copy_(
-                attn_out.reshape(num_ctx_tokens,
-                                 self.num_heads_tp * self.v_head_dim))
-        else:
-            # Multiple packed sequences: pad to max length and batch SDPA.
-            # For short sequences, padding overhead is minimal and batching
-            # reduces kernel launch overhead vs. a per-sequence Python loop.
-            seq_lens_list = seq_lens.tolist()
-            max_seq_len = max(seq_lens_list)
-
-            # Split packed tensors into per-sequence views
-            q_seqs = torch.split(q_r, seq_lens_list, dim=0)
-            k_seqs = torch.split(k, seq_lens_list, dim=0)
-            v_seqs = torch.split(v_r, seq_lens_list, dim=0)
-
-            # Pad and stack into [B, max_seq_len, H, D],
-            # then transpose to [B, H, S, D] for SDPA
-            q_padded = pad_sequence(q_seqs,
-                                    batch_first=True).transpose(1, 2)
-            k_padded = pad_sequence(k_seqs,
-                                    batch_first=True).transpose(1, 2)
-            v_padded = pad_sequence(v_seqs,
-                                    batch_first=True).transpose(1, 2)
-
-            # Single batched SDPA call. is_causal=True is correct because
-            # real token at position j only attends to positions 0..j, all
-            # of which are real tokens (padding is right-aligned at end).
-            attn_out = F.scaled_dot_product_attention(
-                q_padded, k_padded, v_padded, is_causal=True,
-                scale=self.softmax_scale)
-
-            # [B, H, S, Dv] -> [B, S, H*Dv]
-            hd = self.num_heads_tp * self.v_head_dim
-            attn_out = attn_out.transpose(1, 2).reshape(
-                num_contexts, max_seq_len, hd)
-
-            # Extract valid (non-padded) tokens via boolean mask
-            seq_lens_t = torch.tensor(seq_lens_list, device=q.device)
-            positions = torch.arange(max_seq_len, device=q.device)
-            valid_mask = positions.unsqueeze(0) < seq_lens_t.unsqueeze(1)
-            output[:num_ctx_tokens].copy_(attn_out[valid_mask])
-
-        return output
+        # Step 6: Compute attention via the fused MHA backend.
+        # latent_cache=None signals that RoPE and KV cache append were already
+        # done in Step 1 (mla_rope_append_paged_kv_assign_q), matching the
+        # pattern used by forward_context_with_cached_kv.
+        return self._short_seq_mha.forward(
+            q,
+            k,
+            v,
+            attn_metadata,
+            attention_input_type=AttentionInputType.context_only,
+            latent_cache=None,
+            out_scale=self.out_scale,
+            output=output,
+        )
 
     def forward_generation_dsa(
         self,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1200,25 +1200,12 @@ class MLA(nn.Module):
             raise ValueError(
                 f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
                 f"got '{_threshold_str}'") from err
-        # Create a RotaryEmbedding for the short-seq MHA path only when the
-        # optimization is enabled AND rope_fusion is True (apply_rotary_emb is
-        # False). When apply_rotary_emb is True the dispatch guard skips this
-        # path, so the embedding would never be used.
-        self._rotary_emb_mha = None
-        self._short_seq_mha = None
         if self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb:
-            self._rotary_emb_mha = RotaryEmbedding(
-                pos_embd_params.rope,
-                head_dim=self.qk_rope_head_dim,
-                is_neox=pos_embd_params.is_neox,
-            )
             # Dense MHA attention backend for the short-seq path. Uses plain
             # TrtllmAttention (sparse_attention_config=None) because this path
             # computes dense attention over all tokens. TrtllmAttention has no
-            # weight parameters, so memory overhead is negligible. Stored as a
-            # separate attribute (not self.mha) to preserve the DSA assertion
-            # that self.mha is None in forward_impl_with_dsa.
-            self._short_seq_mha = create_attention(
+            # weight parameters, so memory overhead is negligible.
+            self.mha = create_attention(
                 config.attn_backend,
                 self.layer_idx,
                 self.num_heads_tp,
@@ -1252,10 +1239,8 @@ class MLA(nn.Module):
     def create_weights(self):
         # self.mha/mqa has no weights but has states that are related to quant_config,
         # which could be modified after __init__
-        if not self.is_dsa:
+        if self.mha is not None:
             self.mha.update_quant_config(self.quant_config)
-        if self._short_seq_mha is not None:
-            self._short_seq_mha.update_quant_config(self.quant_config)
         self.mqa.update_quant_config(self.quant_config)
 
         # Although we use FP8 MLA for context/generation phase, the output is still in BF16
@@ -1508,7 +1493,7 @@ class MLA(nn.Module):
         Returns:
             torch.Tensor: The output tensor.
         """
-        assert self.mha is None and self.mqa is not None, "DSA is only supported in MQA mode"
+        assert self.mqa is not None, "DSA is only supported in MQA mode"
         # split q, k, v into context and gen batches
         num_contexts = attn_metadata.num_contexts
         num_generations = attn_metadata.num_generations
@@ -1678,12 +1663,12 @@ class MLA(nn.Module):
         # Guard: only when rope_fusion is True (apply_rotary_emb is False) to
         # avoid double-RoPE application. When apply_rotary_emb is True, the
         # caller already applied RoPE to q and k_pe, and our path would apply
-        # it again via mla_rope_append_paged_kv_assign_q / _rotary_emb_mha.
+        # it again via the C++ invokeMLARopeContext kernel.
         num_ctx_tokens = q.shape[0]
         if self._should_use_short_mha(num_ctx_tokens, position_ids):
-            return self.forward_context_short_mha(q, compressed_kv, k_pe,
-                                                  position_ids, attn_metadata,
-                                                  output, latent_cache)
+            return self.forward_context_default(q, compressed_kv, k_pe,
+                                                position_ids, attn_metadata,
+                                                output, latent_cache)
 
         if get_sm_version() >= 100:
             return self.forward_absorption_context(q,
@@ -1700,97 +1685,6 @@ class MLA(nn.Module):
                                                         output,
                                                         topk_indices,
                                                         is_generation=False)
-
-    @nvtx_range("forward_context_short_mha")
-    def forward_context_short_mha(
-        self,
-        q: torch.Tensor,
-        compressed_kv: torch.Tensor,
-        k_pe: torch.Tensor,
-        position_ids: torch.Tensor,
-        attn_metadata: AttentionMetadata,
-        output: torch.Tensor,
-        latent_cache: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Dense MHA for short sequences during prefill.
-
-        For short sequences, using standard multi-head attention with expanded
-        KV (via kv_b_proj) is more efficient than the absorption path used by
-        DSA. The absorption path requires two extra BMMs (Q-absorption and
-        V-projection) and uses a larger head_dim (kv_lora_rank + rope_dim = 576)
-        for the attention kernel, compared to the standard qk_head_dim = 192.
-
-        Uses self._short_seq_mha (a dedicated TrtllmAttention backend) for
-        the attention computation. This backend natively handles variable-length
-        packed sequences via attn_metadata, avoiding the need for padding or
-        per-sequence Python loops. latent_cache=None tells the backend to skip
-        RoPE and KV cache append (already done in Step 1).
-
-        This method:
-        1. Stores latent_cache in paged KV cache and applies RoPE to q via the
-           MQA backend's mla_rope_append_paged_kv_assign_q.
-        2. Applies RoPE to k_pe manually using the RotaryEmbedding.
-        3. Expands compressed KV via kv_b_proj to get full k_nope and v.
-        4. Constructs full K = [k_nope, RoPE(k_pe)] per head.
-        5. Computes dense attention via fused MHA backend (no sparse routing —
-           for short sequences, dense attention is both faster and higher
-           quality than sparse selection via topk_indices).
-        """
-        num_ctx_tokens = q.shape[0]
-
-        # Step 1: Store latent_cache in paged cache + apply RoPE to q.
-        # mla_rope_append_paged_kv_assign_q modifies q in-place: applies RoPE
-        # to the rope portion of each head, and appends latent_cache (with
-        # RoPE'd k_pe) to the paged KV cache for future generation.
-        # NOTE: This path is only safe when apply_rotary_emb is False (i.e.,
-        # rope_fusion is True), so q and k_pe arrive WITHOUT RoPE applied.
-        trtllm_mqa = cast(TrtllmAttention, self.mqa)
-        trtllm_mqa.mla_rope_append_paged_kv_assign_q(q, latent_cache,
-                                                     attn_metadata)
-
-        # Step 2: Apply RoPE to k_pe via the fused compiled helper.
-        # position_ids covers all tokens; slice to context tokens only.
-        ctx_position_ids = position_ids[..., :num_ctx_tokens]
-        k_pe_roped = self._rotary_emb_mha.apply_rope_single_packed(
-            k_pe, ctx_position_ids.view(-1))
-
-        # Step 3: Expand KV via kv_b_proj.
-        kv = self.kv_b_proj(compressed_kv)
-        k_nope, v = kv.split(
-            [
-                self.num_heads_tp * self.qk_nope_head_dim,
-                self.num_heads_tp * self.v_head_dim
-            ],
-            -1,
-        )
-
-        # Step 4: Construct full K = [k_nope, k_pe_roped] per head.
-        k_nope_r = k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim)
-        k_pe_expanded = k_pe_roped.view(-1, 1, self.qk_rope_head_dim).expand(
-            -1, self.num_heads_tp, -1)
-        k = maybe_compiled_cat([k_nope_r, k_pe_expanded], dim=-1)
-        # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
-
-        # Step 5: Flatten Q, K, V to 2D packed layout for the fused attention
-        # backend, which natively handles variable-length sequences via
-        # attn_metadata (no padding/batching needed).
-        k = k.view(-1, self.num_heads_tp * self.qk_head_dim)
-        v = v.view(-1, self.num_heads_tp * self.v_head_dim)
-
-        # Step 6: Compute attention via the fused MHA backend.
-        # latent_cache=None signals that RoPE and KV cache append were already
-        # done in Step 1 (mla_rope_append_paged_kv_assign_q), matching the
-        # pattern used by forward_context_with_cached_kv.
-        return self._short_seq_mha.forward(
-            q,
-            k,
-            v,
-            attn_metadata,
-            attention_input_type=AttentionInputType.context_only,
-            latent_cache=None,
-            out_scale=self.out_scale,
-            output=output,
-        )
 
     def forward_generation_dsa(
         self,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1509,7 +1509,7 @@ class MLA(nn.Module):
         # forward_context_with_chunked_prefill as needed.
         use_short_mha_for_ctx = (num_contexts > 0
                                  and self._should_use_short_mha(
-                                     num_ctx_tokens, position_ids))
+                                     attn_metadata, position_ids))
 
         # Skip the indexer entirely when the short MHA path handles all
         # context tokens and there are no generation tokens.
@@ -1618,18 +1618,23 @@ class MLA(nn.Module):
 
         return attn_output
 
-    def _should_use_short_mha(self, num_ctx_tokens: int,
+    def _should_use_short_mha(self, attn_metadata: AttentionMetadata,
                               position_ids: Optional[torch.Tensor]) -> bool:
         """Check if the short-seq MHA optimization should be used for context.
 
-        This checks only new token count vs threshold.  When cached tokens
-        exist, the caller should route through forward_context() which
-        dispatches to the appropriate cached-KV handler
-        (forward_context_with_cached_kv or forward_context_with_chunked_prefill).
+        Uses max_ctx_kv_len (max total KV length per context sequence,
+        including cached tokens) when available, to correctly account for
+        chunked context where the full attention span exceeds the threshold
+        even if the new token count is small.  Falls back to num_ctx_tokens
+        (total new context tokens) when max_ctx_kv_len is not set.
         """
-        return (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
-                and self.mapping.cp_size == 1 and position_ids is not None
-                and num_ctx_tokens <= self.short_seq_mha_threshold)
+        if not (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
+                and self.mapping.cp_size == 1 and position_ids is not None):
+            return False
+        effective_len = getattr(attn_metadata, 'max_ctx_kv_len', 0)
+        if effective_len == 0:
+            effective_len = attn_metadata.num_ctx_tokens
+        return effective_len <= self.short_seq_mha_threshold
 
     def forward_context_dsa(
         self,
@@ -1644,9 +1649,12 @@ class MLA(nn.Module):
     ) -> torch.Tensor:
         """Run context-phase attention for DSA models.
 
-        Dispatches to the short-seq MHA path (forward_context_default) when
-        the total packed context tokens are within the threshold, or falls
-        through to the absorption/sparse MLA path otherwise.
+        Dispatches to the short-seq MHA path (forward_context) when the max
+        per-sequence KV length (including cached tokens) is within the
+        threshold, or falls through to the absorption/sparse MLA path
+        otherwise.  forward_context() further dispatches to the appropriate
+        handler (forward_context_default, forward_context_with_cached_kv, or
+        forward_context_with_chunked_prefill) based on cached-KV state.
 
         Args:
             q: Query tensor, shape [num_ctx_tokens, num_heads * qk_head_dim].
@@ -1665,8 +1673,7 @@ class MLA(nn.Module):
         # because dense attention is faster than sparse routing at this scale.
         # forward_context() handles cached tokens by dispatching to
         # forward_context_with_cached_kv or forward_context_with_chunked_prefill.
-        num_ctx_tokens = q.shape[0]
-        if self._should_use_short_mha(num_ctx_tokens, position_ids):
+        if self._should_use_short_mha(attn_metadata, position_ids):
             return self.forward_context(q, compressed_kv, k_pe, position_ids,
                                         attn_metadata, output, latent_cache)
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1200,7 +1200,8 @@ class MLA(nn.Module):
             raise ValueError(
                 f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
                 f"got '{_threshold_str}'") from err
-        if self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb:
+        if (self.is_dsa and self.short_seq_mha_threshold > 0
+                and not self.apply_rotary_emb):
             # Dense MHA attention backend for the short-seq path. Uses plain
             # TrtllmAttention (sparse_attention_config=None) because this path
             # computes dense attention over all tokens. TrtllmAttention has no
@@ -1237,8 +1238,10 @@ class MLA(nn.Module):
             self.create_weights()
 
     def create_weights(self):
-        # self.mha/mqa has no weights but has states that are related to quant_config,
-        # which could be modified after __init__
+        # self.mha/mqa has no weights but has states that are related to
+        # quant_config, which could be modified after __init__.
+        # self.mha is non-None for non-DSA models (standard MHA) and for DSA
+        # models when the short-seq MHA optimization is active.
         if self.mha is not None:
             self.mha.update_quant_config(self.quant_config)
         self.mqa.update_quant_config(self.quant_config)
@@ -1597,6 +1600,10 @@ class MLA(nn.Module):
         output: torch.Tensor,
         latent_cache: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Dense MHA context path: expand KV via kv_b_proj and run attention.
+
+        Used by non-DSA models and as the short-seq MHA fallback for DSA models.
+        """
         kv = self.kv_b_proj(compressed_kv)
         k_nope, v = kv.split(
             [
@@ -1610,6 +1617,9 @@ class MLA(nn.Module):
         maybe_compiled_copy_(
             k[..., :self.qk_nope_head_dim],
             k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim))
+        # When rope_fusion=True (apply_rotary_emb=False), the rope portion
+        # of k is left uninitialized here; the fused attention kernel
+        # handles k_pe RoPE via latent_cache instead.
         if self.apply_rotary_emb:
             k[..., self.qk_nope_head_dim:] = k_pe.view(-1, 1,
                                                        self.qk_rope_head_dim)
@@ -1646,6 +1656,23 @@ class MLA(nn.Module):
         topk_indices: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Run context-phase attention for DSA models.
+
+        Dispatches to the short-seq MHA path (forward_context_default) when
+        the total packed context tokens are within the threshold, or falls
+        through to the absorption/sparse MLA path otherwise.
+
+        Args:
+            q: Query tensor, shape [num_ctx_tokens, num_heads * qk_head_dim].
+            compressed_kv: Latent KV, shape [num_ctx_tokens, kv_lora_rank].
+            k_pe: RoPE key portion, shape [num_ctx_tokens, qk_rope_head_dim].
+            attn_metadata: Attention metadata for the current batch.
+            output: Pre-allocated output tensor, written in-place.
+            latent_cache: Concatenated [compressed_kv, k_pe] for KV cache.
+            topk_indices: Sparse routing indices from the indexer (None when
+                the short-seq MHA path is used).
+            position_ids: Token position IDs (required for short-seq MHA).
+        """
         # Short-sequence MHA: bypass absorption path for short prefills,
         # using kv_b_proj expansion + standard attention instead.
         # See __init__ comment for rationale. topk_indices is not used

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1569,11 +1569,7 @@ class MLA(nn.Module):
         # the indexer (topk_indices) is not needed for context tokens.
         use_short_mha_for_ctx = (
             num_contexts > 0
-            and self.short_seq_mha_threshold > 0
-            and not self.apply_rotary_emb
-            and self.mapping.cp_size == 1
-            and position_ids is not None
-            and num_ctx_tokens <= self.short_seq_mha_threshold)
+            and self._should_use_short_mha(num_ctx_tokens, position_ids))
 
         # Skip the indexer entirely when the short MHA path handles all
         # context tokens and there are no generation tokens.
@@ -1674,6 +1670,15 @@ class MLA(nn.Module):
 
         return attn_output
 
+    def _should_use_short_mha(self, num_ctx_tokens: int,
+                              position_ids: Optional[torch.Tensor]) -> bool:
+        """Check if the short-seq MHA optimization should be used for context."""
+        return (self.short_seq_mha_threshold > 0
+                and not self.apply_rotary_emb
+                and self.mapping.cp_size == 1
+                and position_ids is not None
+                and num_ctx_tokens <= self.short_seq_mha_threshold)
+
     def forward_context_dsa(
         self,
         q: torch.Tensor,
@@ -1702,11 +1707,7 @@ class MLA(nn.Module):
         # caller already applied RoPE to q and k_pe, and our path would apply
         # it again via mla_rope_append_paged_kv_assign_q / _rotary_emb_mha.
         num_ctx_tokens = q.shape[0]
-        if (self.short_seq_mha_threshold > 0
-                and not self.apply_rotary_emb
-                and self.mapping.cp_size == 1
-                and position_ids is not None
-                and num_ctx_tokens <= self.short_seq_mha_threshold):
+        if self._should_use_short_mha(num_ctx_tokens, position_ids):
             return self.forward_context_short_mha(q, compressed_kv, k_pe,
                                                   position_ids, attn_metadata,
                                                   output, latent_cache)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1538,14 +1538,31 @@ class MLA(nn.Module):
 
         # TODO: fuse wq_b + (indexer) wlq here
         q = self.q_b_proj(q)
-        # Indexer
-        topk_indices = self.indexer(
-            qr,
-            hidden_states,
-            attn_metadata,
-            position_ids,
-            indexer_k=indexer_k,  # indexer K proj
-        )
+
+        # Check if the short-seq MHA path will handle context, in which case
+        # the indexer (topk_indices) is not needed for context tokens.
+        use_short_mha_for_ctx = (
+            num_contexts > 0
+            and self.short_seq_mha_threshold > 0
+            and not self.apply_rotary_emb
+            and self.mapping.cp_size == 1
+            and position_ids is not None
+            and attn_metadata.max_ctx_seq_len
+            <= self.short_seq_mha_threshold)
+
+        # Skip the indexer entirely when the short MHA path handles all
+        # context tokens and there are no generation tokens.
+        if use_short_mha_for_ctx and num_generations == 0:
+            topk_indices = None
+        else:
+            # Indexer
+            topk_indices = self.indexer(
+                qr,
+                hidden_states,
+                attn_metadata,
+                position_ids,
+                indexer_k=indexer_k,  # indexer K proj
+            )
 
         assert q.shape[
             0] == num_tokens, f"Expect q.shape[0] to be {num_tokens}, but got {q.shape[0]}"
@@ -1568,7 +1585,7 @@ class MLA(nn.Module):
                 attn_metadata,
                 output[:num_ctx_tokens, :],
                 latent_cache_ctx,
-                topk_indices=topk_indices[:num_ctx_tokens, :],
+                topk_indices=topk_indices[:num_ctx_tokens, :] if topk_indices is not None else None,
                 position_ids=position_ids,
             )
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1170,7 +1170,7 @@ class MLA(nn.Module):
         # extra BMMs and larger head_dim (kv_lora_rank + qk_rope_head_dim).
         # Only active when rope_fusion is True (DSA with TrtllmAttention).
         _threshold_str = os.environ.get('TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD',
-                                        '10240')
+                                        '0')
         try:
             self.short_seq_mha_threshold = int(_threshold_str)
         except ValueError as err:
@@ -1366,11 +1366,8 @@ class MLA(nn.Module):
             position_ids (Optional[torch.IntTensor]): The position IDs.
             hidden_states (torch.Tensor): The hidden states.
             attn_metadata (AttentionMetadata): The attention metadata.
-            all_reduce_params (Optional[AllReduceParams]): The all reduce parameters.
+            output (torch.Tensor): Pre-allocated output tensor, written in-place.
             latent_cache_gen (Optional[torch.Tensor]): The latent cache used in generation.
-
-        Returns:
-            torch.Tensor: The output tensor.
         """
         # split q, k, v into context and gen batches
         num_contexts = attn_metadata.num_contexts

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1193,7 +1193,7 @@ class MLA(nn.Module):
         # extra BMMs and larger head_dim (kv_lora_rank + qk_rope_head_dim).
         # Only active when rope_fusion is True (DSA with TrtllmAttention).
         _threshold_str = os.environ.get(
-            'TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', '0')
+            'TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', '10240')
         try:
             self.short_seq_mha_threshold = int(_threshold_str)
         except ValueError as err:
@@ -1547,8 +1547,7 @@ class MLA(nn.Module):
             and not self.apply_rotary_emb
             and self.mapping.cp_size == 1
             and position_ids is not None
-            and attn_metadata.max_ctx_seq_len
-            <= self.short_seq_mha_threshold)
+            and num_ctx_tokens <= self.short_seq_mha_threshold)
 
         # Skip the indexer entirely when the short MHA path handles all
         # context tokens and there are no generation tokens.
@@ -1676,12 +1675,12 @@ class MLA(nn.Module):
         # avoid double-RoPE application. When apply_rotary_emb is True, the
         # caller already applied RoPE to q and k_pe, and our path would apply
         # it again via mla_rope_append_paged_kv_assign_q / _rotary_emb_mha.
+        num_ctx_tokens = q.shape[0]
         if (self.short_seq_mha_threshold > 0
                 and not self.apply_rotary_emb
                 and self.mapping.cp_size == 1
                 and position_ids is not None
-                and attn_metadata.max_ctx_seq_len
-                <= self.short_seq_mha_threshold):
+                and num_ctx_tokens <= self.short_seq_mha_threshold):
             return self.forward_context_short_mha(q, compressed_kv, k_pe,
                                                   position_ids, attn_metadata,
                                                   output, latent_cache)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -28,7 +28,7 @@ from ..distributed import (AllReduceParams, HelixAllToAllNative, alltoall_helix,
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..utils import (Fp4QuantizedTensor, get_model_extra_attrs,
-                     is_torch_compiling, maybe_compiled_cat,
+                     is_torch_compiling, maybe_compile, maybe_compiled_cat,
                      maybe_compiled_copy_)
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 from .multi_stream_utils import maybe_execute_in_parallel
@@ -872,6 +872,22 @@ def fp8_block_scaling_bmm_out(
                       out=out)
     else:
         raise NotImplementedError(f"SM{sm_version} is not supported")
+
+
+@maybe_compile(dynamic=True)
+def _short_mha_reshape_kv(kv, k_pe_roped, num_heads_tp, qk_nope_head_dim,
+                           v_head_dim, qk_rope_head_dim, qk_head_dim):
+    """Fused split + reshape + expand + cat for short-seq MHA KV construction."""
+    k_nope, v = kv.split(
+        [num_heads_tp * qk_nope_head_dim, num_heads_tp * v_head_dim], -1)
+    k_nope_r = k_nope.view(-1, num_heads_tp, qk_nope_head_dim)
+    k_pe_expanded = k_pe_roped.view(-1, 1,
+                                    qk_rope_head_dim).expand(
+                                        -1, num_heads_tp, -1)
+    k = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
+    k = k.view(-1, num_heads_tp * qk_head_dim)
+    v = v.view(-1, num_heads_tp * v_head_dim)
+    return k, v
 
 
 class MLA(nn.Module):
@@ -1753,31 +1769,15 @@ class MLA(nn.Module):
         ctx_position_ids = position_ids[..., :num_ctx_tokens]
         [k_pe_roped] = self._rotary_emb_mha(ctx_position_ids, [k_pe])
 
-        # Step 3: Expand KV via kv_b_proj.
+        # Step 3: Expand KV via kv_b_proj, construct full K, flatten.
+        # The reshape/cat ops are compiled via _short_mha_reshape_kv to fuse
+        # split + view + expand + cat into fewer kernels.
         kv = self.kv_b_proj(compressed_kv)
-        k_nope, v = kv.split(
-            [
-                self.num_heads_tp * self.qk_nope_head_dim,
-                self.num_heads_tp * self.v_head_dim
-            ],
-            -1,
-        )
+        k, v = _short_mha_reshape_kv(kv, k_pe_roped, self.num_heads_tp,
+                                      self.qk_nope_head_dim, self.v_head_dim,
+                                      self.qk_rope_head_dim, self.qk_head_dim)
 
-        # Step 4: Construct full K = [k_nope, k_pe_roped] per head.
-        k_nope_r = k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim)
-        k_pe_expanded = k_pe_roped.view(-1, 1,
-                                        self.qk_rope_head_dim).expand(
-                                            -1, self.num_heads_tp, -1)
-        k = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
-        # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
-
-        # Step 5: Flatten Q, K, V to 2D packed layout for the fused attention
-        # backend, which natively handles variable-length sequences via
-        # attn_metadata (no padding/batching needed).
-        k = k.view(-1, self.num_heads_tp * self.qk_head_dim)
-        v = v.view(-1, self.num_heads_tp * self.v_head_dim)
-
-        # Step 6: Compute attention via the fused MHA backend.
+        # Step 4: Compute attention via the fused MHA backend.
         # latent_cache=None signals that RoPE and KV cache append were already
         # done in Step 1 (mla_rope_append_paged_kv_assign_q), matching the
         # pattern used by forward_context_with_cached_kv.

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Union, cast
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch.nn.utils.rnn import pad_sequence
 
 import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
 from tensorrt_llm._utils import (get_sm_version, is_sm_100f, nvtx_range,
@@ -1750,26 +1751,43 @@ class MLA(nn.Module):
                 attn_out.reshape(num_ctx_tokens,
                                  self.num_heads_tp * self.v_head_dim))
         else:
-            # Multiple packed sequences: process per-sequence to apply causal
-            # masking correctly per sequence boundary.
-            # TODO: Consider using NestedTensor or padding+mask to avoid the
-            # Python loop when batch sizes are large.
-            offset = 0
-            for i in range(num_contexts):
-                slen = seq_lens[i].item()
-                q_seq = q_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)
-                k_seq = k[offset:offset + slen].unsqueeze(0).transpose(1, 2)
-                v_seq = v_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)
+            # Multiple packed sequences: pad to max length and batch SDPA.
+            # For short sequences, padding overhead is minimal and batching
+            # reduces kernel launch overhead vs. a per-sequence Python loop.
+            seq_lens_list = seq_lens.tolist()
+            max_seq_len = max(seq_lens_list)
 
-                attn_out_seq = F.scaled_dot_product_attention(
-                    q_seq, k_seq, v_seq, is_causal=True,
-                    scale=self.softmax_scale)
+            # Split packed tensors into per-sequence views
+            q_seqs = torch.split(q_r, seq_lens_list, dim=0)
+            k_seqs = torch.split(k, seq_lens_list, dim=0)
+            v_seqs = torch.split(v_r, seq_lens_list, dim=0)
 
-                attn_out_seq = attn_out_seq.transpose(1, 2).squeeze(0)
-                output[offset:offset + slen].copy_(
-                    attn_out_seq.reshape(
-                        slen, self.num_heads_tp * self.v_head_dim))
-                offset += slen
+            # Pad and stack into [B, max_seq_len, H, D],
+            # then transpose to [B, H, S, D] for SDPA
+            q_padded = pad_sequence(q_seqs,
+                                    batch_first=True).transpose(1, 2)
+            k_padded = pad_sequence(k_seqs,
+                                    batch_first=True).transpose(1, 2)
+            v_padded = pad_sequence(v_seqs,
+                                    batch_first=True).transpose(1, 2)
+
+            # Single batched SDPA call. is_causal=True is correct because
+            # real token at position j only attends to positions 0..j, all
+            # of which are real tokens (padding is right-aligned at end).
+            attn_out = F.scaled_dot_product_attention(
+                q_padded, k_padded, v_padded, is_causal=True,
+                scale=self.softmax_scale)
+
+            # [B, H, S, Dv] -> [B, S, H*Dv]
+            hd = self.num_heads_tp * self.v_head_dim
+            attn_out = attn_out.transpose(1, 2).reshape(
+                num_contexts, max_seq_len, hd)
+
+            # Extract valid (non-padded) tokens via boolean mask
+            seq_lens_t = torch.tensor(seq_lens_list, device=q.device)
+            positions = torch.arange(max_seq_len, device=q.device)
+            valid_mask = positions.unsqueeze(0) < seq_lens_t.unsqueeze(1)
+            output[:num_ctx_tokens].copy_(attn_out[valid_mask])
 
         return output
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1218,8 +1218,8 @@ class MLA(nn.Module):
         # attention) instead of the absorption path, which has overhead from
         # extra BMMs and larger head_dim (kv_lora_rank + qk_rope_head_dim).
         # Only active when rope_fusion is True (DSA with TrtllmAttention).
-        _threshold_str = os.environ.get(
-            'TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', '10240')
+        _threshold_str = os.environ.get('TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD',
+                                        '10240')
         try:
             self.short_seq_mha_threshold = int(_threshold_str)
         except ValueError as err:
@@ -1567,9 +1567,9 @@ class MLA(nn.Module):
 
         # Check if the short-seq MHA path will handle context, in which case
         # the indexer (topk_indices) is not needed for context tokens.
-        use_short_mha_for_ctx = (
-            num_contexts > 0
-            and self._should_use_short_mha(num_ctx_tokens, position_ids))
+        use_short_mha_for_ctx = (num_contexts > 0
+                                 and self._should_use_short_mha(
+                                     num_ctx_tokens, position_ids))
 
         # Skip the indexer entirely when the short MHA path handles all
         # context tokens and there are no generation tokens.
@@ -1606,7 +1606,8 @@ class MLA(nn.Module):
                 attn_metadata,
                 output[:num_ctx_tokens, :],
                 latent_cache_ctx,
-                topk_indices=topk_indices[:num_ctx_tokens, :] if topk_indices is not None else None,
+                topk_indices=topk_indices[:num_ctx_tokens, :]
+                if topk_indices is not None else None,
                 position_ids=position_ids,
             )
 
@@ -1673,10 +1674,8 @@ class MLA(nn.Module):
     def _should_use_short_mha(self, num_ctx_tokens: int,
                               position_ids: Optional[torch.Tensor]) -> bool:
         """Check if the short-seq MHA optimization should be used for context."""
-        return (self.short_seq_mha_threshold > 0
-                and not self.apply_rotary_emb
-                and self.mapping.cp_size == 1
-                and position_ids is not None
+        return (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
+                and self.mapping.cp_size == 1 and position_ids is not None
                 and num_ctx_tokens <= self.short_seq_mha_threshold)
 
     def forward_context_dsa(
@@ -1773,7 +1772,7 @@ class MLA(nn.Module):
         # rope_fusion is True), so q and k_pe arrive WITHOUT RoPE applied.
         trtllm_mqa = cast(TrtllmAttention, self.mqa)
         trtllm_mqa.mla_rope_append_paged_kv_assign_q(q, latent_cache,
-                                                      attn_metadata)
+                                                     attn_metadata)
 
         # Step 2: Apply RoPE to k_pe via the fused compiled helper.
         # position_ids covers all tokens; slice to context tokens only.
@@ -1797,9 +1796,8 @@ class MLA(nn.Module):
 
         # Step 4: Construct full K = [k_nope, k_pe_roped] per head.
         k_nope_r = k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim)
-        k_pe_expanded = k_pe_roped.view(-1, 1,
-                                        self.qk_rope_head_dim).expand(
-                                            -1, self.num_heads_tp, -1)
+        k_pe_expanded = k_pe_roped.view(-1, 1, self.qk_rope_head_dim).expand(
+            -1, self.num_heads_tp, -1)
         k = maybe_compiled_cat([k_nope_r, k_pe_expanded], dim=-1)
         # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1202,10 +1202,11 @@ class MLA(nn.Module):
                 f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
                 f"got '{_threshold_str}'") from err
         # Create a RotaryEmbedding for the short-seq MHA path only when the
-        # optimization is enabled. This is needed to apply RoPE to k_pe
-        # manually since the attention backend's fused RoPE is bypassed.
+        # optimization is enabled AND rope_fusion is True (apply_rotary_emb is
+        # False). When apply_rotary_emb is True the dispatch guard skips this
+        # path, so the embedding would never be used.
         self._rotary_emb_mha = None
-        if self.short_seq_mha_threshold > 0:
+        if self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb:
             self._rotary_emb_mha = RotaryEmbedding(
                 pos_embd_params.rope,
                 head_dim=self.qk_rope_head_dim,
@@ -1633,6 +1634,7 @@ class MLA(nn.Module):
         # it again via mla_rope_append_paged_kv_assign_q / _rotary_emb_mha.
         if (self.short_seq_mha_threshold > 0
                 and not self.apply_rotary_emb
+                and self.mapping.cp_size == 1
                 and position_ids is not None
                 and attn_metadata.max_ctx_seq_len
                 <= self.short_seq_mha_threshold):

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -2018,10 +2018,13 @@ class MLA(nn.Module):
                     self.qk_rope_head_dim, self.kv_lora_rank, self.v_head_dim,
                     q.dtype, q.device)
             if trtllm_attention.is_chunked_prefill_for_mla_context(
-                    attn_metadata):
+                    attn_metadata) and get_sm_version() >= 100:
                 return self.forward_context_with_chunked_prefill(
                     q, compressed_kv, latent_cache, attn_metadata, output)
-            elif trtllm_attention.has_cached_kv_for_mla_context(attn_metadata):
+            elif trtllm_attention.has_cached_kv_for_mla_context(
+                    attn_metadata
+            ) or trtllm_attention.is_chunked_prefill_for_mla_context(
+                    attn_metadata):
                 return self.forward_context_with_cached_kv(
                     q, latent_cache, attn_metadata, output)
         return self.forward_context_default(q, compressed_kv, k_pe,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1489,9 +1489,7 @@ class MLA(nn.Module):
             position_ids (Optional[torch.IntTensor]): The position IDs.
             hidden_states (torch.Tensor): The hidden states.
             attn_metadata (AttentionMetadata): The attention metadata.
-
-        Returns:
-            torch.Tensor: The output tensor.
+            output (torch.Tensor): Pre-allocated output tensor, written in-place.
         """
         assert self.mqa is not None, "DSA is only supported in MQA mode"
         # split q, k, v into context and gen batches
@@ -1648,22 +1646,10 @@ class MLA(nn.Module):
         topk_indices: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # Short-sequence MHA optimization: for short prefill sequences, use
-        # dense MHA (kv_b_proj expansion + SDPA) instead of the absorption
-        # path. MHA avoids the Q-absorption and V-projection BMMs and uses a
-        # smaller head_dim (qk_head_dim=192 vs kv_lora_rank+rope=576),
-        # yielding faster attention for small sequence lengths.
-        #
-        # topk_indices (sparse routing) is intentionally not used here: for
-        # short sequences, dense attention over all tokens is both faster and
-        # produces higher-quality output than sparse selection. The DSA sparse
-        # routing is an optimization for long sequences where the quadratic
-        # attention cost dominates.
-        #
-        # Guard: only when rope_fusion is True (apply_rotary_emb is False) to
-        # avoid double-RoPE application. When apply_rotary_emb is True, the
-        # caller already applied RoPE to q and k_pe, and our path would apply
-        # it again via the C++ invokeMLARopeContext kernel.
+        # Short-sequence MHA: bypass absorption path for short prefills,
+        # using kv_b_proj expansion + standard attention instead.
+        # See __init__ comment for rationale. topk_indices is not used
+        # because dense attention is faster than sparse routing at this scale.
         num_ctx_tokens = q.shape[0]
         if self._should_use_short_mha(num_ctx_tokens, position_ids):
             return self.forward_context_default(q, compressed_kv, k_pe,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1631,9 +1631,8 @@ class MLA(nn.Module):
         if not (self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
                 and self.mapping.cp_size == 1 and position_ids is not None):
             return False
-        effective_len = getattr(attn_metadata, 'max_ctx_kv_len', 0)
-        if effective_len == 0:
-            effective_len = attn_metadata.num_ctx_tokens
+        effective_len = getattr(attn_metadata, 'max_ctx_kv_len',
+                                attn_metadata.num_ctx_tokens)
         return effective_len <= self.short_seq_mha_threshold
 
     def forward_context_dsa(

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1197,10 +1197,10 @@ class MLA(nn.Module):
             'TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', '0')
         try:
             self.short_seq_mha_threshold = int(_threshold_str)
-        except ValueError:
+        except ValueError as err:
             raise ValueError(
                 f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
-                f"got '{_threshold_str}'")
+                f"got '{_threshold_str}'") from err
         # Create a RotaryEmbedding for the short-seq MHA path only when the
         # optimization is enabled. This is needed to apply RoPE to k_pe
         # manually since the attention backend's fused RoPE is bypassed.
@@ -1616,10 +1616,17 @@ class MLA(nn.Module):
         position_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Short-sequence MHA optimization: for short prefill sequences, use
-        # direct MHA (kv_b_proj expansion + SDPA) instead of the absorption
+        # dense MHA (kv_b_proj expansion + SDPA) instead of the absorption
         # path. MHA avoids the Q-absorption and V-projection BMMs and uses a
         # smaller head_dim (qk_head_dim=192 vs kv_lora_rank+rope=576),
         # yielding faster attention for small sequence lengths.
+        #
+        # topk_indices (sparse routing) is intentionally not used here: for
+        # short sequences, dense attention over all tokens is both faster and
+        # produces higher-quality output than sparse selection. The DSA sparse
+        # routing is an optimization for long sequences where the quadratic
+        # attention cost dominates.
+        #
         # Guard: only when rope_fusion is True (apply_rotary_emb is False) to
         # avoid double-RoPE application. When apply_rotary_emb is True, the
         # caller already applied RoPE to q and k_pe, and our path would apply
@@ -1660,7 +1667,7 @@ class MLA(nn.Module):
         output: torch.Tensor,
         latent_cache: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """MHA (dense or masked) for short sequences during prefill.
+        """Dense MHA for short sequences during prefill.
 
         For short sequences, using standard multi-head attention with expanded
         KV (via kv_b_proj) is more efficient than the absorption path used by
@@ -1668,13 +1675,18 @@ class MLA(nn.Module):
         V-projection) and uses a larger head_dim (kv_lora_rank + rope_dim = 576)
         for the attention kernel, compared to the standard qk_head_dim = 192.
 
+        Uses SDPA instead of self.mha.forward() because DSA models set
+        self.mha = None (only self.mqa is available for MQA/generation).
+
         This method:
         1. Stores latent_cache in paged KV cache and applies RoPE to q via the
            MQA backend's mla_rope_append_paged_kv_assign_q.
         2. Applies RoPE to k_pe manually using the RotaryEmbedding.
         3. Expands compressed KV via kv_b_proj to get full k_nope and v.
         4. Constructs full K = [k_nope, RoPE(k_pe)] per head.
-        5. Computes attention via torch scaled_dot_product_attention (SDPA).
+        5. Computes dense attention via torch SDPA (no sparse routing — for
+           short sequences, dense attention is both faster and higher quality
+           than sparse selection via topk_indices).
         """
         num_ctx_tokens = q.shape[0]
 
@@ -1723,9 +1735,7 @@ class MLA(nn.Module):
         seq_lens = attn_metadata.prompt_lens_cpu_runtime[:num_contexts]
 
         if num_contexts == 1:
-            # Single sequence: straightforward SDPA.
-            seq_len = num_ctx_tokens
-            # [1, H, S, D]
+            # Single sequence: straightforward SDPA with [1, H, S, D] layout.
             q_b = q_r.unsqueeze(0).transpose(1, 2)
             k_b = k.unsqueeze(0).transpose(1, 2)
             v_b = v_r.unsqueeze(0).transpose(1, 2)
@@ -1733,18 +1743,18 @@ class MLA(nn.Module):
             attn_out = F.scaled_dot_product_attention(
                 q_b, k_b, v_b, is_causal=True, scale=self.softmax_scale)
 
-            attn_out = attn_out.transpose(1, 2).squeeze(
-                0)  # [S, H, Dv]
-            output[:seq_len].copy_(
-                attn_out.reshape(seq_len,
+            attn_out = attn_out.transpose(1, 2).squeeze(0)  # [S, H, Dv]
+            output[:num_ctx_tokens].copy_(
+                attn_out.reshape(num_ctx_tokens,
                                  self.num_heads_tp * self.v_head_dim))
         else:
-            # Multiple sequences: process per-sequence to handle variable
-            # lengths correctly with causal masking.
+            # Multiple packed sequences: process per-sequence to apply causal
+            # masking correctly per sequence boundary.
+            # TODO: Consider using NestedTensor or padding+mask to avoid the
+            # Python loop when batch sizes are large.
             offset = 0
             for i in range(num_contexts):
                 slen = seq_lens[i].item()
-                # [1, H, slen, D]
                 q_seq = q_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)
                 k_seq = k[offset:offset + slen].unsqueeze(0).transpose(1, 2)
                 v_seq = v_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -28,7 +28,7 @@ from ..distributed import (AllReduceParams, HelixAllToAllNative, alltoall_helix,
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..utils import (Fp4QuantizedTensor, get_model_extra_attrs,
-                     is_torch_compiling, maybe_compiled_cat,
+                     is_torch_compiling, maybe_compile, maybe_compiled_cat,
                      maybe_compiled_copy_)
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 from .multi_stream_utils import maybe_execute_in_parallel
@@ -40,6 +40,32 @@ try:
     from tensorrt_llm.flash_mla import flash_mla_sparse_fwd
 except ImportError:
     flash_mla_sparse_fwd = None
+
+
+@maybe_compile
+def _apply_rope_single_packed(x, cos_sin_cache, position_ids, is_neox):
+    """Fused RoPE for a single packed 2D tensor [N, head_dim].
+
+    Optimized replacement for RotaryEmbedding.forward() when called with a
+    single target and remove_input_padding=True (2D input).  Avoids the
+    unnecessary view/transpose/contiguous reshape dance (since there is
+    effectively 1 head) and fuses gather + rotation into a single compiled
+    kernel via @maybe_compile.
+    """
+    cos_sin = cos_sin_cache[position_ids]  # [N, 2, head_dim//2]
+    cos = cos_sin[:, 0, :].to(x.dtype)  # [N, head_dim//2]
+    sin = cos_sin[:, 1, :].to(x.dtype)  # [N, head_dim//2]
+    if is_neox:
+        half = x.shape[-1] // 2
+        x1 = x[:, :half]
+        x2 = x[:, half:]
+        return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
+    else:
+        x1 = x[:, ::2]
+        x2 = x[:, 1::2]
+        o1 = x1 * cos - x2 * sin
+        o2 = x2 * cos + x1 * sin
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
 
 
 def extract_extra_attrs(layer_idx: str, attn_type: str):
@@ -1748,10 +1774,15 @@ class MLA(nn.Module):
         trtllm_mqa.mla_rope_append_paged_kv_assign_q(q, latent_cache,
                                                       attn_metadata)
 
-        # Step 2: Apply RoPE to k_pe using the RotaryEmbedding.
+        # Step 2: Apply RoPE to k_pe via the fused compiled helper.
         # position_ids covers all tokens; slice to context tokens only.
         ctx_position_ids = position_ids[..., :num_ctx_tokens]
-        [k_pe_roped] = self._rotary_emb_mha(ctx_position_ids, [k_pe])
+        k_pe_roped = _apply_rope_single_packed(
+            k_pe,
+            self._rotary_emb_mha.rotary_cos_sin,
+            ctx_position_ids.view(-1),
+            self._rotary_emb_mha.is_neox,
+        )
 
         # Step 3: Expand KV via kv_b_proj.
         kv = self.kv_b_proj(compressed_kv)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1,9 +1,11 @@
 import functools
 import math
+import os
 import weakref
 from typing import List, Optional, Union, cast
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
@@ -1186,6 +1188,30 @@ class MLA(nn.Module):
                 is_neox=pos_embd_params.is_neox,
             )
 
+        # Short-sequence MHA optimization for DSA models:
+        # For short prefill sequences, use MHA (kv_b_proj expansion + standard
+        # attention) instead of the absorption path, which has overhead from
+        # extra BMMs and larger head_dim (kv_lora_rank + qk_rope_head_dim).
+        # Only active when rope_fusion is True (DSA with TrtllmAttention).
+        _threshold_str = os.environ.get(
+            'TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', '0')
+        try:
+            self.short_seq_mha_threshold = int(_threshold_str)
+        except ValueError:
+            raise ValueError(
+                f"TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD must be an integer, "
+                f"got '{_threshold_str}'")
+        # Create a RotaryEmbedding for the short-seq MHA path only when the
+        # optimization is enabled. This is needed to apply RoPE to k_pe
+        # manually since the attention backend's fused RoPE is bypassed.
+        self._rotary_emb_mha = None
+        if self.short_seq_mha_threshold > 0:
+            self._rotary_emb_mha = RotaryEmbedding(
+                pos_embd_params.rope,
+                head_dim=self.qk_rope_head_dim,
+                is_neox=pos_embd_params.is_neox,
+            )
+
         self.llama_4_scaling = False
         if hasattr(config.pretrained_config, 'llama_4_scaling'):
             self.llama_4_scaling = True
@@ -1515,6 +1541,7 @@ class MLA(nn.Module):
                 output[:num_ctx_tokens, :],
                 latent_cache_ctx,
                 topk_indices=topk_indices[:num_ctx_tokens, :],
+                position_ids=position_ids,
             )
 
         if num_generations > 0:
@@ -1586,7 +1613,26 @@ class MLA(nn.Module):
         output: torch.Tensor,
         latent_cache: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        # Short-sequence MHA optimization: for short prefill sequences, use
+        # direct MHA (kv_b_proj expansion + SDPA) instead of the absorption
+        # path. MHA avoids the Q-absorption and V-projection BMMs and uses a
+        # smaller head_dim (qk_head_dim=192 vs kv_lora_rank+rope=576),
+        # yielding faster attention for small sequence lengths.
+        # Guard: only when rope_fusion is True (apply_rotary_emb is False) to
+        # avoid double-RoPE application. When apply_rotary_emb is True, the
+        # caller already applied RoPE to q and k_pe, and our path would apply
+        # it again via mla_rope_append_paged_kv_assign_q / _rotary_emb_mha.
+        if (self.short_seq_mha_threshold > 0
+                and not self.apply_rotary_emb
+                and position_ids is not None
+                and attn_metadata.max_ctx_seq_len
+                <= self.short_seq_mha_threshold):
+            return self.forward_context_short_mha(q, compressed_kv, k_pe,
+                                                  position_ids, attn_metadata,
+                                                  output, latent_cache)
+
         if get_sm_version() >= 100:
             return self.forward_absorption_context(q,
                                                    compressed_kv,
@@ -1602,6 +1648,118 @@ class MLA(nn.Module):
                                                         output,
                                                         topk_indices,
                                                         is_generation=False)
+
+    @nvtx_range("forward_context_short_mha")
+    def forward_context_short_mha(
+        self,
+        q: torch.Tensor,
+        compressed_kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        position_ids: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+        latent_cache: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """MHA (dense or masked) for short sequences during prefill.
+
+        For short sequences, using standard multi-head attention with expanded
+        KV (via kv_b_proj) is more efficient than the absorption path used by
+        DSA. The absorption path requires two extra BMMs (Q-absorption and
+        V-projection) and uses a larger head_dim (kv_lora_rank + rope_dim = 576)
+        for the attention kernel, compared to the standard qk_head_dim = 192.
+
+        This method:
+        1. Stores latent_cache in paged KV cache and applies RoPE to q via the
+           MQA backend's mla_rope_append_paged_kv_assign_q.
+        2. Applies RoPE to k_pe manually using the RotaryEmbedding.
+        3. Expands compressed KV via kv_b_proj to get full k_nope and v.
+        4. Constructs full K = [k_nope, RoPE(k_pe)] per head.
+        5. Computes attention via torch scaled_dot_product_attention (SDPA).
+        """
+        num_ctx_tokens = q.shape[0]
+
+        # Step 1: Store latent_cache in paged cache + apply RoPE to q.
+        # mla_rope_append_paged_kv_assign_q modifies q in-place: applies RoPE
+        # to the rope portion of each head, and appends latent_cache (with
+        # RoPE'd k_pe) to the paged KV cache for future generation.
+        # NOTE: This path is only safe when apply_rotary_emb is False (i.e.,
+        # rope_fusion is True), so q and k_pe arrive WITHOUT RoPE applied.
+        trtllm_mqa = cast(TrtllmAttention, self.mqa)
+        trtllm_mqa.mla_rope_append_paged_kv_assign_q(q, latent_cache,
+                                                      attn_metadata)
+
+        # Step 2: Apply RoPE to k_pe using the RotaryEmbedding.
+        # position_ids covers all tokens; slice to context tokens only.
+        ctx_position_ids = position_ids[..., :num_ctx_tokens]
+        [k_pe_roped] = self._rotary_emb_mha(ctx_position_ids, [k_pe])
+
+        # Step 3: Expand KV via kv_b_proj.
+        kv = self.kv_b_proj(compressed_kv)
+        k_nope, v = kv.split(
+            [
+                self.num_heads_tp * self.qk_nope_head_dim,
+                self.num_heads_tp * self.v_head_dim
+            ],
+            -1,
+        )
+
+        # Step 4: Construct full K = [k_nope, k_pe_roped] per head.
+        k_nope_r = k_nope.view(-1, self.num_heads_tp, self.qk_nope_head_dim)
+        k_pe_expanded = k_pe_roped.view(-1, 1,
+                                        self.qk_rope_head_dim).expand(
+                                            -1, self.num_heads_tp, -1)
+        k = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
+        # k: [num_ctx_tokens, num_heads_tp, qk_head_dim]
+
+        # Step 5: Reshape Q, V for attention.
+        q_r = q.view(-1, self.num_heads_tp,
+                     self.qk_head_dim)  # [tokens, H, D]
+        v_r = v.view(-1, self.num_heads_tp,
+                     self.v_head_dim)  # [tokens, H, Dv]
+
+        # Step 6: Compute attention using SDPA.
+        # Handle packed variable-length sequences by processing per-sequence.
+        num_contexts = attn_metadata.num_contexts
+        seq_lens = attn_metadata.prompt_lens_cpu_runtime[:num_contexts]
+
+        if num_contexts == 1:
+            # Single sequence: straightforward SDPA.
+            seq_len = num_ctx_tokens
+            # [1, H, S, D]
+            q_b = q_r.unsqueeze(0).transpose(1, 2)
+            k_b = k.unsqueeze(0).transpose(1, 2)
+            v_b = v_r.unsqueeze(0).transpose(1, 2)
+
+            attn_out = F.scaled_dot_product_attention(
+                q_b, k_b, v_b, is_causal=True, scale=self.softmax_scale)
+
+            attn_out = attn_out.transpose(1, 2).squeeze(
+                0)  # [S, H, Dv]
+            output[:seq_len].copy_(
+                attn_out.reshape(seq_len,
+                                 self.num_heads_tp * self.v_head_dim))
+        else:
+            # Multiple sequences: process per-sequence to handle variable
+            # lengths correctly with causal masking.
+            offset = 0
+            for i in range(num_contexts):
+                slen = seq_lens[i].item()
+                # [1, H, slen, D]
+                q_seq = q_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)
+                k_seq = k[offset:offset + slen].unsqueeze(0).transpose(1, 2)
+                v_seq = v_r[offset:offset + slen].unsqueeze(0).transpose(1, 2)
+
+                attn_out_seq = F.scaled_dot_product_attention(
+                    q_seq, k_seq, v_seq, is_causal=True,
+                    scale=self.softmax_scale)
+
+                attn_out_seq = attn_out_seq.transpose(1, 2).squeeze(0)
+                output[offset:offset + slen].copy_(
+                    attn_out_seq.reshape(
+                        slen, self.num_heads_tp * self.v_head_dim))
+                offset += slen
+
+        return output
 
     def forward_generation_dsa(
         self,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -28,7 +28,7 @@ from ..distributed import (AllReduceParams, HelixAllToAllNative, alltoall_helix,
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
 from ..utils import (Fp4QuantizedTensor, get_model_extra_attrs,
-                     is_torch_compiling, maybe_compile, maybe_compiled_cat,
+                     is_torch_compiling, maybe_compiled_cat,
                      maybe_compiled_copy_)
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 from .multi_stream_utils import maybe_execute_in_parallel
@@ -40,32 +40,6 @@ try:
     from tensorrt_llm.flash_mla import flash_mla_sparse_fwd
 except ImportError:
     flash_mla_sparse_fwd = None
-
-
-@maybe_compile
-def _apply_rope_single_packed(x, cos_sin_cache, position_ids, is_neox):
-    """Fused RoPE for a single packed 2D tensor [N, head_dim].
-
-    Optimized replacement for RotaryEmbedding.forward() when called with a
-    single target and remove_input_padding=True (2D input).  Avoids the
-    unnecessary view/transpose/contiguous reshape dance (since there is
-    effectively 1 head) and fuses gather + rotation into a single compiled
-    kernel via @maybe_compile.
-    """
-    cos_sin = cos_sin_cache[position_ids]  # [N, 2, head_dim//2]
-    cos = cos_sin[:, 0, :].to(x.dtype)  # [N, head_dim//2]
-    sin = cos_sin[:, 1, :].to(x.dtype)  # [N, head_dim//2]
-    if is_neox:
-        half = x.shape[-1] // 2
-        x1 = x[:, :half]
-        x2 = x[:, half:]
-        return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
-    else:
-        x1 = x[:, ::2]
-        x2 = x[:, 1::2]
-        o1 = x1 * cos - x2 * sin
-        o2 = x2 * cos + x1 * sin
-        return torch.stack((o1, o2), dim=-1).flatten(-2)
 
 
 def extract_extra_attrs(layer_idx: str, attn_type: str):
@@ -1777,12 +1751,8 @@ class MLA(nn.Module):
         # Step 2: Apply RoPE to k_pe via the fused compiled helper.
         # position_ids covers all tokens; slice to context tokens only.
         ctx_position_ids = position_ids[..., :num_ctx_tokens]
-        k_pe_roped = _apply_rope_single_packed(
-            k_pe,
-            self._rotary_emb_mha.rotary_cos_sin,
-            ctx_position_ids.view(-1),
-            self._rotary_emb_mha.is_neox,
-        )
+        k_pe_roped = self._rotary_emb_mha.apply_rope_single_packed(
+            k_pe, ctx_position_ids.view(-1))
 
         # Step 3: Expand KV via kv_b_proj.
         kv = self.kv_b_proj(compressed_kv)

--- a/tensorrt_llm/_torch/modules/rotary_embedding.py
+++ b/tensorrt_llm/_torch/modules/rotary_embedding.py
@@ -5,6 +5,52 @@ from torch import nn
 
 from ..attention_backend.interface import RopeParams
 from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE
+from ..utils import maybe_compile
+
+
+def _rotate(q_or_k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
+            is_neox: bool) -> torch.Tensor:
+    """Core rotation math shared by all RoPE entry points.
+
+    This is intentionally *not* compiled so that callers can wrap it in their
+    own @maybe_compile boundary — torch.compile will inline it into whatever
+    compiled region invokes it, allowing optimal fusion.
+    """
+    rot_dim = cos.shape[-1] * 2
+    # If q_or_k_pass is empty, rotary pos embedding is applied to all tensor
+    q_or_k, q_or_k_pass = q_or_k[..., :rot_dim], q_or_k[..., rot_dim:]
+
+    if is_neox:
+        x1 = q_or_k[..., :q_or_k.shape[-1] // 2]
+        x2 = q_or_k[..., q_or_k.shape[-1] // 2:]
+    else:
+        x1 = q_or_k[..., ::2]
+        x2 = q_or_k[..., 1::2]
+
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+
+    if is_neox:
+        return torch.cat((o1, o2, q_or_k_pass), dim=-1)
+    else:
+        embed = torch.stack((o1, o2), dim=-1).flatten(-2)
+        return torch.cat((embed, q_or_k_pass), dim=-1)
+
+
+@maybe_compile
+def _apply_rope_single_packed(x: torch.Tensor, cos_sin_cache: torch.Tensor,
+                              position_ids: torch.Tensor,
+                              is_neox: bool) -> torch.Tensor:
+    """Fused RoPE for a single packed 2D tensor [N, head_dim].
+
+    Compiles the gather + rotation into a single kernel via @maybe_compile,
+    avoiding the reshape overhead of RotaryEmbedding.forward() which is
+    designed for multi-head 3D/4D tensors.
+    """
+    cos_sin = cos_sin_cache[position_ids]  # [N, 2, head_dim//2]
+    cos = cos_sin[:, 0, :].to(x.dtype)  # [N, head_dim//2]
+    sin = cos_sin[:, 1, :].to(x.dtype)  # [N, head_dim//2]
+    return _rotate(x, cos, sin, is_neox)
 
 
 class RotaryEmbedding(nn.Module):
@@ -80,7 +126,19 @@ class RotaryEmbedding(nn.Module):
 
         return [rope_target(target) for target in targets]
 
+    def apply_rope_single_packed(self, x: torch.Tensor,
+                                 position_ids: torch.Tensor) -> torch.Tensor:
+        """Apply RoPE to a single packed 2D tensor [N, head_dim].
+
+        Optimized path for single-head 2D inputs (e.g., k_pe in the short-seq
+        MHA path).  Compiles gather + rotation into one fused kernel, avoiding
+        the reshape overhead of forward().
+        """
+        return _apply_rope_single_packed(x, self.rotary_cos_sin, position_ids,
+                                         self.is_neox)
+
     @staticmethod
+    @maybe_compile
     def apply_rotary_pos_emb(q_or_k: torch.Tensor,
                              cos: torch.Tensor,
                              sin: torch.Tensor,
@@ -105,26 +163,7 @@ class RotaryEmbedding(nn.Module):
         """
         cos = cos.unsqueeze(unsqueeze_dim)
         sin = sin.unsqueeze(unsqueeze_dim)
-
-        rot_dim = cos.shape[-1] * 2
-        # If q_or_k_pass is empty, rotary pos embedding is applied to all tensor
-        q_or_k, q_or_k_pass = q_or_k[..., :rot_dim], q_or_k[..., rot_dim:]
-
-        if is_neox:
-            x1 = q_or_k[..., :q_or_k.shape[-1] // 2]
-            x2 = q_or_k[..., q_or_k.shape[-1] // 2:]
-        else:
-            x1 = q_or_k[..., ::2]
-            x2 = q_or_k[..., 1::2]
-
-        o1 = x1 * cos - x2 * sin
-        o2 = x2 * cos + x1 * sin
-
-        if is_neox:
-            return torch.cat((o1, o2, q_or_k_pass), dim=-1)
-        else:
-            embed = torch.stack((o1, o2), dim=-1).flatten(-2)
-            return torch.cat((embed, q_or_k_pass), dim=-1)
+        return _rotate(q_or_k, cos, sin, is_neox)
 
 
 class MRotaryEmbedding(RotaryEmbedding):

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -12,14 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Test suite for the short-sequence MHA optimization path in MLA.
+"""Test short-sequence MHA optimization path in MLA.
 
-When TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD is set and the total number of
-packed context tokens is within the threshold, MLA.forward_context_dsa
-dispatches to forward_context which routes to the appropriate MHA path:
-forward_context_default (no cached tokens), forward_context_with_cached_kv
-(cached tokens), or forward_context_with_chunked_prefill (chunked prefill).
+Covers: pure prefill correctness (vs reference), threshold boundary condition,
+threshold=0 disables MHA, above-threshold fallback to standard path,
+A/B comparison vs absorption path, and chunked context with cached KV.
 """
 
 import math
@@ -45,110 +42,12 @@ from tensorrt_llm.functional import PositionEmbeddingType, RopeEmbeddingUtils
 from tensorrt_llm.llmapi.llm_args import DeepSeekSparseAttentionConfig
 from tensorrt_llm.mapping import Mapping
 
-# DSACacheManager creates background ThreadPoolExecutor threads that outlive
-# the test. Disable pytest-threadleak for this entire module.
+# DSACacheManager creates background ThreadPoolExecutor threads.
 pytestmark = pytest.mark.threadleak(enabled=False)
 
-
-def rotate_half(x):
-    """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-def apply_rotary_embedding(x, cos_sin):
-    """Apply rotary position embedding to x."""
-    original_dtype = x.dtype
-    cos, sin = cos_sin.chunk(2, dim=-2)
-    cos = cos.squeeze(1)
-    sin = sin.squeeze(1)
-    x_interleaved = x.unflatten(-1, [-1, 2]).transpose(-2, -1).flatten(start_dim=-2)
-    cos_expanded = cos.view(cos.shape[0], *([1] * (x.ndim - 2)), cos.shape[-1])
-    sin_expanded = sin.view(sin.shape[0], *([1] * (x.ndim - 2)), sin.shape[-1])
-    x_rotated = (x_interleaved * cos_expanded) + (rotate_half(x_interleaved) * sin_expanded)
-    return x_rotated.to(original_dtype)
-
-
-def calculate_reference_output(
-    q,
-    compressed_kv,
-    k_pe,
-    kv_b_proj_weight,
-    rope_cos_sin,
-    sequence_lengths,
-    num_heads,
-    kv_lora_rank,
-    qk_nope_head_dim,
-    qk_rope_head_dim,
-    v_head_dim,
-    softmax_scale,
-    device,
-):
-    """Reference implementation using kv_b_proj expansion + causal SDPA.
-
-    This mirrors the short-seq MHA path (forward_context_default):
-    1. Apply RoPE to q (rope portion) and k_pe.
-    2. Expand compressed_kv via kv_b_proj to get k_nope and v.
-    3. Construct K = [k_nope, RoPE(k_pe)] per head.
-    4. Run causal attention per sequence.
-    """
-    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
-    results = []
-    offset = 0
-
-    for seq_len in sequence_lengths:
-        q_seq = q[offset : offset + seq_len].view(-1, num_heads, qk_head_dim)
-        compressed_kv_seq = compressed_kv[offset : offset + seq_len]
-        k_pe_seq = k_pe[offset : offset + seq_len]
-        cos_sin = rope_cos_sin[:seq_len]
-
-        # Apply RoPE to q rope portion
-        q_nope = q_seq[..., :qk_nope_head_dim]
-        q_pe = q_seq[..., qk_nope_head_dim:]
-        q_pe_roped = apply_rotary_embedding(q_pe, cos_sin)
-        q_full = torch.cat([q_nope, q_pe_roped], dim=-1)
-
-        # Apply RoPE to k_pe
-        k_pe_roped = apply_rotary_embedding(k_pe_seq, cos_sin)
-
-        # Expand via kv_b_proj: weight is [out_features, kv_lora_rank]
-        kv = torch.nn.functional.linear(compressed_kv_seq, kv_b_proj_weight)
-        k_nope, v = kv.split([num_heads * qk_nope_head_dim, num_heads * v_head_dim], -1)
-
-        k_nope_r = k_nope.view(-1, num_heads, qk_nope_head_dim)
-        k_pe_expanded = k_pe_roped.view(-1, 1, qk_rope_head_dim).expand(-1, num_heads, -1)
-        k_full = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
-
-        v_r = v.view(-1, num_heads, v_head_dim)
-
-        # SDPA: [1, H, S, D]
-        q_b = q_full.unsqueeze(0).transpose(1, 2)
-        k_b = k_full.unsqueeze(0).transpose(1, 2)
-        v_b = v_r.unsqueeze(0).transpose(1, 2)
-
-        attn_out = torch.nn.functional.scaled_dot_product_attention(
-            q_b, k_b, v_b, is_causal=True, scale=softmax_scale
-        )
-        attn_out = attn_out.transpose(1, 2).squeeze(0)
-        results.append(attn_out.reshape(seq_len, num_heads * v_head_dim))
-        offset += seq_len
-
-    return torch.cat(results, dim=0)
-
-
-@dataclass
-class RopeConfig:
-    hidden_size: int
-    num_attention_heads: int
-    rope_scaling: dict
-    max_position_embeddings: int
-    rope_theta: float
-    qk_rope_head_dim: int
-    model_type: str
-
-
-# Model configuration matching DeepSeek V3
+# ---------------------------------------------------------------------------
+# Model constants (DeepSeek V3-like)
+# ---------------------------------------------------------------------------
 NUM_HEADS = 128
 Q_LORA_RANK = 512
 KV_LORA_RANK = 512
@@ -164,17 +63,17 @@ LAYER_IDX = 0
 TOPK_TOKENS = 2048
 NN_INIT_STD = 0.02
 
-# Test batch specifications: (name, sequence_lengths)
+# "boundary_exact" tests the dispatch guard boundary (threshold == total_tokens).
 BATCH_SPECS = [
     ("single_short", [16]),
     ("single_medium", [64]),
     ("multi_short", [8, 12, 16]),
     ("multi_varied", [4, 32, 10]),
     ("single_one_token", [1]),
+    ("boundary_exact", [24, 16]),
 ]
 
-# Chunked context specifications: (name, [(cached_tokens, new_tokens), ...])
-# Each tuple represents one sequence with its cached/new token split.
+# (name, [(cached_tokens, new_tokens), ...])
 CHUNKED_CONTEXT_SPECS = [
     ("single_small", [(16, 8)]),
     ("single_medium", [(64, 32)]),
@@ -184,6 +83,79 @@ CHUNKED_CONTEXT_SPECS = [
     ("multi_varied", [(128, 8), (16, 64)]),
     ("three_seqs", [(32, 16), (16, 8), (48, 4)]),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation
+# ---------------------------------------------------------------------------
+def _rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_embedding(x, cos_sin):
+    original_dtype = x.dtype
+    cos, sin = cos_sin.chunk(2, dim=-2)
+    cos = cos.squeeze(1)
+    sin = sin.squeeze(1)
+    x_interleaved = x.unflatten(-1, [-1, 2]).transpose(-2, -1).flatten(start_dim=-2)
+    cos_expanded = cos.view(cos.shape[0], *([1] * (x.ndim - 2)), cos.shape[-1])
+    sin_expanded = sin.view(sin.shape[0], *([1] * (x.ndim - 2)), sin.shape[-1])
+    x_rotated = (x_interleaved * cos_expanded) + (_rotate_half(x_interleaved) * sin_expanded)
+    return x_rotated.to(original_dtype)
+
+
+def _reference_attention(
+    q, compressed_kv, k_pe, kv_b_proj_weight, rope_cos_sin, seq_lens, softmax_scale
+):
+    """kv_b_proj expansion + RoPE + causal SDPA reference."""
+    results = []
+    offset = 0
+    for slen in seq_lens:
+        qs = q[offset : offset + slen].view(-1, NUM_HEADS, QK_HEAD_DIM)
+        cs = rope_cos_sin[:slen]
+
+        q_nope = qs[..., :QK_NOPE_HEAD_DIM]
+        q_pe = _apply_rotary_embedding(qs[..., QK_NOPE_HEAD_DIM:], cs)
+        q_full = torch.cat([q_nope, q_pe], dim=-1)
+
+        k_pe_roped = _apply_rotary_embedding(k_pe[offset : offset + slen], cs)
+        kv = torch.nn.functional.linear(compressed_kv[offset : offset + slen], kv_b_proj_weight)
+        k_nope, v = kv.split([NUM_HEADS * QK_NOPE_HEAD_DIM, NUM_HEADS * V_HEAD_DIM], -1)
+        k_full = torch.cat(
+            [
+                k_nope.view(-1, NUM_HEADS, QK_NOPE_HEAD_DIM),
+                k_pe_roped.view(-1, 1, QK_ROPE_HEAD_DIM).expand(-1, NUM_HEADS, -1),
+            ],
+            dim=-1,
+        )
+        v_r = v.view(-1, NUM_HEADS, V_HEAD_DIM)
+
+        attn_out = torch.nn.functional.scaled_dot_product_attention(
+            q_full.unsqueeze(0).transpose(1, 2),
+            k_full.unsqueeze(0).transpose(1, 2),
+            v_r.unsqueeze(0).transpose(1, 2),
+            is_causal=True,
+            scale=softmax_scale,
+        )
+        results.append(attn_out.transpose(1, 2).squeeze(0).reshape(slen, NUM_HEADS * V_HEAD_DIM))
+        offset += slen
+    return torch.cat(results, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+@dataclass
+class RopeConfig:
+    hidden_size: int
+    num_attention_heads: int
+    rope_scaling: dict
+    max_position_embeddings: int
+    rope_theta: float
+    qk_rope_head_dim: int
+    model_type: str
 
 
 def _make_rope_config():
@@ -261,7 +233,6 @@ def _build_mla(rope_config, device, threshold):
         is_neox=False,
     )
 
-    # Set env var BEFORE constructing MLA so __init__ picks it up.
     old_val = os.environ.get("TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD")
     os.environ["TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD"] = str(threshold)
     try:
@@ -283,15 +254,13 @@ def _build_mla(rope_config, device, threshold):
             config=model_config,
         ).to(device)
     finally:
-        # Restore env var.
         if old_val is None:
             os.environ.pop("TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD", None)
         else:
             os.environ["TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD"] = old_val
 
-    # mla.mqa (DSATrtllmAttention) does not inherit from nn.Module, so
-    # mla.to(device) does NOT recursively move its children. Explicitly
-    # move the indexer (which IS an nn.Module) so its weights are on CUDA.
+    # mla.mqa (DSATrtllmAttention) is not an nn.Module, so mla.to(device)
+    # does not move its children. Explicitly move the indexer.
     if hasattr(mla, "mqa") and hasattr(mla.mqa, "indexer"):
         mla.mqa.indexer.to(device)
 
@@ -299,41 +268,21 @@ def _build_mla(rope_config, device, threshold):
 
 
 def _init_mla_weights(mla):
-    """Initialize MLA weights deterministically.
+    """Initialize MLA weights deterministically in the loaded layout.
 
-    The kv_b_proj weight must use the LOADED layout (as produced by
-    modeling_deepseekv3.py's load_kv_b_proj_and_k_b_proj_trans), NOT the raw
-    HuggingFace layout. The loaded layout is:
-        [all_heads_k_nope, all_heads_v] along the output dimension,
-    i.e. rows 0..num_heads*qk_nope-1 are k_nope weights for all heads, and
-    rows num_heads*qk_nope..end are v weights for all heads.
-
-    This layout is what forward_context_default expects when it does:
-        kv.split([num_heads * qk_nope, num_heads * v], dim=-1)
+    The loaded layout (as produced by modeling_deepseekv3.py) is:
+    [all_heads_k_nope, all_heads_v] along the output dimension.
     """
     with torch.no_grad():
-        # Generate k_nope and v weights separately, then concatenate in the
-        # loaded layout: [all_k_nope || all_v].
-        k_nope_weight = torch.empty(
-            NUM_HEADS,
-            QK_NOPE_HEAD_DIM,
-            KV_LORA_RANK,
-            dtype=mla.kv_b_proj.weight.dtype,
-            device=mla.kv_b_proj.weight.device,
-        )
+        dev = mla.kv_b_proj.weight.device
+        dt = mla.kv_b_proj.weight.dtype
+
+        k_nope_weight = torch.empty(NUM_HEADS, QK_NOPE_HEAD_DIM, KV_LORA_RANK, dtype=dt, device=dev)
         k_nope_weight.normal_(mean=0.0, std=NN_INIT_STD)
 
-        v_weight = torch.empty(
-            NUM_HEADS,
-            V_HEAD_DIM,
-            KV_LORA_RANK,
-            dtype=mla.kv_b_proj.weight.dtype,
-            device=mla.kv_b_proj.weight.device,
-        )
+        v_weight = torch.empty(NUM_HEADS, V_HEAD_DIM, KV_LORA_RANK, dtype=dt, device=dev)
         v_weight.normal_(mean=0.0, std=NN_INIT_STD)
 
-        # kv_b_proj.weight: [num_heads*(qk_nope+v_head), kv_lora_rank]
-        # Loaded layout: first num_heads*qk_nope rows are k_nope, rest are v.
         mla.kv_b_proj.weight.data = torch.cat(
             [
                 k_nope_weight.reshape(NUM_HEADS * QK_NOPE_HEAD_DIM, KV_LORA_RANK),
@@ -341,11 +290,7 @@ def _init_mla_weights(mla):
             ],
             dim=0,
         )
-
-        # k_b_proj_trans: [num_heads, kv_lora_rank, qk_nope_head_dim]
         mla.k_b_proj_trans.data = k_nope_weight.transpose(1, 2).contiguous()
-
-        # v_b_proj: [num_heads, v_head_dim, kv_lora_rank]
         mla.v_b_proj.data = v_weight.contiguous()
 
         mla.mqa.indexer.wq_b.weight.normal_(mean=0.0, std=NN_INIT_STD)
@@ -355,26 +300,20 @@ def _init_mla_weights(mla):
 
 def _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device):
     """Build a DSACacheManager for the given batch."""
-    max_seqlen = max(seq_lens)
-    max_tokens = 16384
-
-    cache_dtype = torch.bfloat16
     kv_cache_manager = DSACacheManager(
-        KvCacheConfig(max_tokens=max_tokens, enable_block_reuse=False),
+        KvCacheConfig(max_tokens=16384, enable_block_reuse=False),
         tensorrt_llm.bindings.internal.batch_manager.CacheType.SELFKONLY,
         num_layers=NUM_LAYERS,
         num_kv_heads=1,
         head_dim=KV_LORA_RANK + QK_ROPE_HEAD_DIM,
         tokens_per_block=TOKENS_PER_BLOCK,
-        max_seq_len=max_seqlen,
+        max_seq_len=max(seq_lens),
         max_batch_size=len(seq_lens),
         mapping=mapping,
-        dtype=str_dtype_to_binding(torch_dtype_to_str(cache_dtype)),
+        dtype=str_dtype_to_binding(torch_dtype_to_str(torch.bfloat16)),
         sparse_attn_config=sparse_config,
         model_config=model_config,
     )
-
-    # Allocate cache for all requests as pure prefill.
     for req_idx, seq_len in enumerate(seq_lens):
         kv_cache_manager.add_dummy_requests(
             request_ids=[req_idx],
@@ -382,171 +321,113 @@ def _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, devi
             is_gen=False,
             prepare_resource=True,
         )
-
     return kv_cache_manager
 
 
-def _build_kv_cache_manager_with_cached(
-    mapping, sparse_config, model_config, cached_per_seq, new_per_seq, device
+def _make_inputs(seq_lens, device, dtype=torch.bfloat16):
+    """Generate random MLA inputs for the given sequence lengths."""
+    total = sum(seq_lens)
+    q = torch.randn(total, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
+    compressed_kv = torch.randn(total, KV_LORA_RANK, dtype=dtype, device=device)
+    k_pe = torch.randn(total, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
+    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+    position_ids = torch.cat([torch.arange(s, device=device, dtype=torch.int32) for s in seq_lens])
+    return q, compressed_kv, k_pe, latent_cache, position_ids
+
+
+def _make_metadata(
+    attn_cls,
+    seq_lens,
+    kv_cache_manager,
+    mapping,
+    sparse_config,
+    cached_per_seq=None,
+    enable_cached_kv=False,
 ):
-    """Build a DSACacheManager with blocks allocated for cached + new tokens.
-
-    The cache manager allocates enough blocks for the full sequence
-    (cached + new tokens per request), which is needed so that
-    DSAMetadata.prepare() can compute correct kv_lens and
-    num_ctx_cached_tokens.
-    """
-    total_per_seq = [c + n for c, n in zip(cached_per_seq, new_per_seq)]
-    max_seqlen = max(total_per_seq)
-    max_tokens = 16384
-
-    cache_dtype = torch.bfloat16
-    kv_cache_manager = DSACacheManager(
-        KvCacheConfig(max_tokens=max_tokens, enable_block_reuse=False),
-        tensorrt_llm.bindings.internal.batch_manager.CacheType.SELFKONLY,
-        num_layers=NUM_LAYERS,
-        num_kv_heads=1,
-        head_dim=KV_LORA_RANK + QK_ROPE_HEAD_DIM,
-        tokens_per_block=TOKENS_PER_BLOCK,
-        max_seq_len=max_seqlen,
-        max_batch_size=len(cached_per_seq),
+    """Build and prepare attention metadata."""
+    num_ctx = len(seq_lens)
+    kwargs = {"enable_context_mla_with_cached_kv": True} if enable_cached_kv else {}
+    metadata = attn_cls.Metadata(
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
+        request_ids=list(range(num_ctx)),
+        max_num_requests=num_ctx,
+        num_contexts=num_ctx,
+        prompt_lens=seq_lens,
+        max_num_tokens=sum(seq_lens),
+        kv_cache_manager=kv_cache_manager,
+        kv_cache_params=KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=cached_per_seq or [0] * num_ctx,
+        ),
         mapping=mapping,
-        dtype=str_dtype_to_binding(torch_dtype_to_str(cache_dtype)),
-        sparse_attn_config=sparse_config,
-        model_config=model_config,
+        sparse_attention_config=sparse_config,
+        **kwargs,
     )
-
-    for req_idx, total in enumerate(total_per_seq):
-        kv_cache_manager.add_dummy_requests(
-            request_ids=[req_idx],
-            token_nums=[total],
-            is_gen=False,
-            prepare_resource=True,
-        )
-
-    return kv_cache_manager
+    metadata.prepare()
+    return metadata
 
 
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
+def _run_forward(
+    mla, q, compressed_kv, k_pe, latent_cache, position_ids, metadata, topk_indices=None
+):
+    """Run forward_context_dsa on cloned inputs and return the output tensor."""
+    output = torch.empty(q.shape[0], NUM_HEADS * V_HEAD_DIM, dtype=q.dtype, device=q.device)
+    mla.forward_context_dsa(
+        q=q.clone(),
+        compressed_kv=compressed_kv.clone(),
+        k_pe=k_pe.clone(),
+        attn_metadata=metadata,
+        output=output,
+        latent_cache=latent_cache.clone(),
+        topk_indices=topk_indices,
+        position_ids=position_ids.clone(),
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
 @pytest.mark.parametrize("batch_name,seq_lens", BATCH_SPECS, ids=[b[0] for b in BATCH_SPECS])
 def test_forward_context_short_mha(batch_name: str, seq_lens: List[int]):
-    """Test that the short-seq MHA path produces correct attention output.
-
-    Compares the output of the short-seq MHA path (forward_context_default)
-    against a standalone reference implementation that performs the same math:
-    kv_b_proj expansion, RoPE application, and causal attention.
-    """
+    """Short-seq MHA output vs standalone reference (kv_b_proj + RoPE + SDPA)."""
     device = torch.device("cuda")
-    dtype = torch.bfloat16
-
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
     rope_config = _make_rope_config()
-    rope_cos_sin = _make_rope_cos_sin(rope_config, device)
-    softmax_scale = _compute_softmax_scale(rope_config)
-
-    # Set threshold high enough that total packed tokens take the short MHA path.
-    threshold = sum(seq_lens) + 100
+    # "boundary_exact" tests threshold == total; others use threshold > total.
+    threshold = sum(seq_lens) if batch_name == "boundary_exact" else sum(seq_lens) + 100
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
 
-    # Verify short-seq MHA is configured.
-    assert mla.short_seq_mha_threshold == threshold
-    assert mla.mha is not None
-    assert not mla.apply_rotary_emb, "Expected rope_fusion=True for DSA"
+    kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
+    attn_cls = get_attention_backend("TRTLLM", sparse_config)
+    q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
+    metadata = _make_metadata(attn_cls, seq_lens, kv_mgr, mapping, sparse_config)
 
-    kv_cache_manager = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, seq_lens, device
-    )
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+    output = _run_forward(mla, q, compressed_kv, k_pe, latent_cache, position_ids, metadata)
 
-    # Generate inputs.
-    total_tokens = sum(seq_lens)
-    num_contexts = len(seq_lens)
-    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
-    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
-    position_ids = torch.cat(
-        [torch.arange(slen, device=device, dtype=torch.int32) for slen in seq_lens]
-    )
-    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-
-    attn_metadata = AttentionCls.Metadata(
-        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
-        request_ids=list(range(num_contexts)),
-        max_num_requests=num_contexts,
-        num_contexts=num_contexts,
-        prompt_lens=seq_lens,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_manager,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_contexts,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata.prepare()
-
-    # Verify the threshold guard will trigger (total packed tokens <= threshold).
-    assert total_tokens <= threshold
-
-    # Clone inputs since forward_context_dsa may modify them in-place.
-    q_for_ref = q.clone()
-    compressed_kv_for_ref = compressed_kv.clone()
-    k_pe_for_ref = k_pe.clone()
-
-    # Run the actual forward (should dispatch to forward_context_default).
-    # topk_indices=None: the short MHA path does not use sparse routing,
-    # so the indexer computation can be skipped entirely for short sequences.
-    mla.forward_context_dsa(
-        q=q,
-        compressed_kv=compressed_kv,
-        k_pe=k_pe,
-        attn_metadata=attn_metadata,
-        output=output,
-        latent_cache=latent_cache,
-        topk_indices=None,
-        position_ids=position_ids,
-    )
-
-    # Compute reference.
-    kv_b_proj_weight = mla.kv_b_proj.weight.data
-    ref_output = calculate_reference_output(
-        q_for_ref,
-        compressed_kv_for_ref,
-        k_pe_for_ref,
-        kv_b_proj_weight,
+    rope_cos_sin = _make_rope_cos_sin(rope_config, device)
+    softmax_scale = _compute_softmax_scale(rope_config)
+    ref = _reference_attention(
+        q,
+        compressed_kv,
+        k_pe,
+        mla.kv_b_proj.weight.data,
         rope_cos_sin,
         seq_lens,
-        NUM_HEADS,
-        KV_LORA_RANK,
-        QK_NOPE_HEAD_DIM,
-        QK_ROPE_HEAD_DIM,
-        V_HEAD_DIM,
         softmax_scale,
-        device,
     )
 
-    # Compare.
-    assert output.shape == ref_output.shape
-    assert torch.isfinite(output).all(), "Output contains non-finite values"
-    assert torch.isfinite(ref_output).all(), "Reference contains non-finite values"
-
-    abs_error = (output - ref_output).abs()
-    torch.testing.assert_close(output, ref_output, rtol=0.05, atol=0.05)
-    print(
-        f"[{batch_name}] PASSED: max_error={abs_error.max():.4f}, mean_error={abs_error.mean():.6f}"
-    )
-
-    kv_cache_manager.shutdown()
+    torch.testing.assert_close(output, ref, rtol=0.05, atol=0.05)
+    kv_mgr.shutdown()
 
 
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_not_triggered_when_threshold_zero():
-    """Verify that with threshold=0, the short MHA path is NOT active."""
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
+def test_threshold_zero_disables_mha():
+    """With threshold=0, the short MHA path is NOT active."""
     device = torch.device("cuda")
     rope_config = _make_rope_config()
     mla, _, _, _ = _build_mla(rope_config, device, threshold=0)
@@ -555,117 +436,9 @@ def test_short_mha_not_triggered_when_threshold_zero():
     assert mla.mha is None
 
 
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_boundary_threshold_equals_max_seq():
-    """Test the boundary condition where threshold == total packed tokens.
-
-    The dispatch guard uses `<=`, so threshold == num_ctx_tokens should still
-    trigger the short MHA path. This verifies correctness at the exact boundary.
-    """
-    device = torch.device("cuda")
-    dtype = torch.bfloat16
-    torch.manual_seed(42)
-    torch.cuda.manual_seed(42)
-
-    rope_config = _make_rope_config()
-    rope_cos_sin = _make_rope_cos_sin(rope_config, device)
-    softmax_scale = _compute_softmax_scale(rope_config)
-
-    seq_lens = [24, 16]
-    # Threshold exactly equals total packed tokens — short MHA should trigger.
-    threshold = sum(seq_lens)
-    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
-    _init_mla_weights(mla)
-
-    kv_cache_manager = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, seq_lens, device
-    )
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
-
-    total_tokens = sum(seq_lens)
-    num_contexts = len(seq_lens)
-    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
-    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
-    position_ids = torch.cat(
-        [torch.arange(slen, device=device, dtype=torch.int32) for slen in seq_lens]
-    )
-    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-
-    attn_metadata = AttentionCls.Metadata(
-        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
-        request_ids=list(range(num_contexts)),
-        max_num_requests=num_contexts,
-        num_contexts=num_contexts,
-        prompt_lens=seq_lens,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_manager,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_contexts,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata.prepare()
-
-    # Verify boundary: total packed tokens == threshold.
-    assert total_tokens == threshold
-
-    q_for_ref = q.clone()
-    compressed_kv_for_ref = compressed_kv.clone()
-    k_pe_for_ref = k_pe.clone()
-
-    # topk_indices=None: the short MHA path does not use sparse routing.
-    mla.forward_context_dsa(
-        q=q,
-        compressed_kv=compressed_kv,
-        k_pe=k_pe,
-        attn_metadata=attn_metadata,
-        output=output,
-        latent_cache=latent_cache,
-        topk_indices=None,
-        position_ids=position_ids,
-    )
-
-    kv_b_proj_weight = mla.kv_b_proj.weight.data
-    ref_output = calculate_reference_output(
-        q_for_ref,
-        compressed_kv_for_ref,
-        k_pe_for_ref,
-        kv_b_proj_weight,
-        rope_cos_sin,
-        seq_lens,
-        NUM_HEADS,
-        KV_LORA_RANK,
-        QK_NOPE_HEAD_DIM,
-        QK_ROPE_HEAD_DIM,
-        V_HEAD_DIM,
-        softmax_scale,
-        device,
-    )
-
-    abs_error = (output - ref_output).abs()
-    torch.testing.assert_close(output, ref_output, rtol=0.05, atol=0.05)
-    print(
-        f"[boundary_threshold] PASSED: max_error={abs_error.max():.4f}, "
-        f"mean_error={abs_error.mean():.6f}"
-    )
-
-    kv_cache_manager.shutdown()
-
-
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_not_triggered_when_seq_exceeds_threshold():
-    """Verify that when total packed tokens > threshold, the standard path is used.
-
-    We set threshold=16 but use seq_len=32 (total_tokens=32 > 16). The output
-    should match the standard absorption path (not the short MHA path). We
-    verify this indirectly: since both paths must produce the same result for
-    correctness, we just confirm the module runs without error and produces
-    finite output.
-    """
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
+def test_standard_path_when_exceeds_threshold():
+    """When total tokens > threshold, the standard absorption path is used."""
     device = torch.device("cuda")
     dtype = torch.bfloat16
     torch.manual_seed(42)
@@ -673,86 +446,37 @@ def test_short_mha_not_triggered_when_seq_exceeds_threshold():
 
     rope_config = _make_rope_config()
     seq_lens = [32]
-
-    # Threshold is below total packed tokens — short MHA should NOT trigger.
     threshold = 16
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
 
-    kv_cache_manager = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, seq_lens, device
-    )
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+    kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
+    attn_cls = get_attention_backend("TRTLLM", sparse_config)
+    q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
 
     total_tokens = sum(seq_lens)
-    num_contexts = len(seq_lens)
-    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
     hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype, device=device)
     qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
-    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
-    position_ids = torch.cat(
-        [torch.arange(slen, device=device, dtype=torch.int32) for slen in seq_lens]
-    )
-    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
 
-    attn_metadata = AttentionCls.Metadata(
-        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
-        request_ids=list(range(num_contexts)),
-        max_num_requests=num_contexts,
-        num_contexts=num_contexts,
-        prompt_lens=seq_lens,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_manager,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_contexts,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata.prepare()
-
-    # Threshold is below total packed tokens; standard path should be used.
-    assert total_tokens > threshold
-
+    metadata = _make_metadata(attn_cls, seq_lens, kv_mgr, mapping, sparse_config)
     topk_indices = mla.mqa.indexer(
         qr,
         hidden_states,
-        attn_metadata,
+        metadata,
         position_ids,
         indexer_k=mla.mqa.indexer.wk(hidden_states),
     )
 
-    mla.forward_context_dsa(
-        q=q,
-        compressed_kv=compressed_kv,
-        k_pe=k_pe,
-        attn_metadata=attn_metadata,
-        output=output,
-        latent_cache=latent_cache,
-        topk_indices=topk_indices,
-        position_ids=position_ids,
+    output = _run_forward(
+        mla, q, compressed_kv, k_pe, latent_cache, position_ids, metadata, topk_indices
     )
-
-    assert torch.isfinite(output).all(), "Output contains non-finite values"
-    print(
-        f"[threshold_exceeded] PASSED: standard path ran without error, "
-        f"output mean={output.abs().mean():.4f}"
-    )
-
-    kv_cache_manager.shutdown()
+    assert torch.isfinite(output).all()
+    kv_mgr.shutdown()
 
 
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_agrees_with_absorption_path():
-    """Compare short MHA path output against the absorption path output.
-
-    Both paths should produce numerically close results for the same inputs.
-    This is an A/B test: run the same inputs through both paths and verify
-    they agree within tolerance.
-    """
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
+def test_agrees_with_absorption_path():
+    """Short MHA and absorption paths produce numerically close results."""
     device = torch.device("cuda")
     dtype = torch.bfloat16
     torch.manual_seed(42)
@@ -762,632 +486,131 @@ def test_short_mha_agrees_with_absorption_path():
     seq_lens = [16]
     total_tokens = sum(seq_lens)
 
-    # Build two MLA instances: one with short MHA, one without.
     mla_short, mapping, sparse_config, model_config = _build_mla(
         rope_config, device, threshold=total_tokens + 100
     )
-    mla_absorption, _, _, _ = _build_mla(rope_config, device, threshold=0)
+    mla_absorb, _, _, _ = _build_mla(rope_config, device, threshold=0)
 
-    # Copy weights from short to absorption so they are identical.
+    _init_mla_weights(mla_short)
     with torch.no_grad():
-        _init_mla_weights(mla_short)
-        # Copy all nn.Module parameters (registered on MLA directly).
-        for (name_s, param_s), (name_a, param_a) in zip(
-            mla_short.named_parameters(), mla_absorption.named_parameters()
+        for (_, ps), (_, pa) in zip(mla_short.named_parameters(), mla_absorb.named_parameters()):
+            pa.data.copy_(ps.data)
+        for (_, ps), (_, pa) in zip(
+            mla_short.mqa.indexer.named_parameters(),
+            mla_absorb.mqa.indexer.named_parameters(),
         ):
-            assert name_s == name_a, f"Parameter name mismatch: {name_s} vs {name_a}"
-            param_a.data.copy_(param_s.data)
-        # mla.mqa is NOT an nn.Module, so named_parameters() above misses the
-        # indexer weights. Copy them explicitly so both paths use the same
-        # sparse routing (topk_indices).
-        for (name_s, param_s), (name_a, param_a) in zip(
-            mla_short.mqa.indexer.named_parameters(), mla_absorption.mqa.indexer.named_parameters()
-        ):
-            assert name_s == name_a, f"Indexer param mismatch: {name_s} vs {name_a}"
-            param_a.data.copy_(param_s.data)
+            pa.data.copy_(ps.data)
 
-    # Shared KV cache managers (need separate ones since they have state).
-    kv_cache_manager_short = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, seq_lens, device
-    )
-    kv_cache_manager_absorption = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, seq_lens, device
-    )
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
-
-    num_contexts = len(seq_lens)
-    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
+    q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
     hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype, device=device)
     qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
-    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
-    position_ids = torch.cat(
-        [torch.arange(slen, device=device, dtype=torch.int32) for slen in seq_lens]
-    )
+    attn_cls = get_attention_backend("TRTLLM", sparse_config)
 
-    def _run_forward(mla_module, kv_cache_mgr):
-        output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-        attn_metadata = AttentionCls.Metadata(
-            seq_lens=torch.tensor(seq_lens, dtype=torch.int),
-            request_ids=list(range(num_contexts)),
-            max_num_requests=num_contexts,
-            num_contexts=num_contexts,
-            prompt_lens=seq_lens,
-            max_num_tokens=total_tokens,
-            kv_cache_manager=kv_cache_mgr,
-            kv_cache_params=KVCacheParams(
-                use_cache=True,
-                num_cached_tokens_per_seq=[0] * num_contexts,
-            ),
-            mapping=mapping,
-            sparse_attention_config=sparse_config,
-        )
-        attn_metadata.prepare()
-
-        # Only compute topk_indices when needed: the short MHA path
-        # does not use sparse routing, so the indexer can be skipped.
-        use_short_mha = (
+    def _run(mla_module):
+        kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
+        meta = _make_metadata(attn_cls, seq_lens, kv_mgr, mapping, sparse_config)
+        use_short = (
             mla_module.short_seq_mha_threshold > 0
             and total_tokens <= mla_module.short_seq_mha_threshold
         )
-        if use_short_mha:
-            topk_indices = None
-        else:
-            topk_indices = mla_module.mqa.indexer(
+        topk = None
+        if not use_short:
+            topk = mla_module.mqa.indexer(
                 qr.clone(),
                 hidden_states.clone(),
-                attn_metadata,
+                meta,
                 position_ids.clone(),
                 indexer_k=mla_module.mqa.indexer.wk(hidden_states.clone()),
             )
-
-        mla_module.forward_context_dsa(
-            q=q.clone(),
-            compressed_kv=compressed_kv.clone(),
-            k_pe=k_pe.clone(),
-            attn_metadata=attn_metadata,
-            output=output,
-            latent_cache=latent_cache.clone(),
-            topk_indices=topk_indices,
-            position_ids=position_ids.clone(),
+        out = _run_forward(
+            mla_module, q, compressed_kv, k_pe, latent_cache, position_ids, meta, topk
         )
-        return output
+        kv_mgr.shutdown()
+        return out
 
-    output_short = _run_forward(mla_short, kv_cache_manager_short)
-    output_absorption = _run_forward(mla_absorption, kv_cache_manager_absorption)
-
-    assert torch.isfinite(output_short).all()
-    assert torch.isfinite(output_absorption).all()
-
-    abs_error = (output_short - output_absorption).abs()
-    # The two paths use different intermediate representations (kv_b_proj
-    # expansion + dense attention vs absorption BMMs + sparse MLA kernel),
-    # so bf16 accumulation differences are expected. The tolerance is set
-    # based on observed max errors (~0.06) with headroom for variance.
-    torch.testing.assert_close(output_short, output_absorption, rtol=0.08, atol=0.08)
-    print(f"[a_b_test] PASSED: max_error={abs_error.max():.4f}, mean_error={abs_error.mean():.6f}")
-
-    kv_cache_manager_short.shutdown()
-    kv_cache_manager_absorption.shutdown()
+    out_short = _run(mla_short)
+    out_absorb = _run(mla_absorb)
+    torch.testing.assert_close(out_short, out_absorb, rtol=0.08, atol=0.08)
 
 
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_cached_kv_correctness():
-    """Verify forward_context_with_cached_kv produces correct output.
-
-    Runs chunk 1 (pure prefill, 200 tokens) to populate the KV cache,
-    then chunk 2 (100 new tokens with 200 cached) through the
-    forward_context_with_cached_kv path.  Compares against a single-pass
-    reference over all 300 tokens.
-    """
-    device = torch.device("cuda")
-    dtype = torch.bfloat16
-    torch.manual_seed(42)
-    torch.cuda.manual_seed(42)
-
-    rope_config = _make_rope_config()
-
-    cached_per_seq = [200]
-    new_per_seq = [100]
-    total_per_seq = [c + n for c, n in zip(cached_per_seq, new_per_seq)]
-    num_seqs = len(cached_per_seq)
-    total_tokens = sum(total_per_seq)
-    total_chunk1 = sum(cached_per_seq)
-    total_chunk2 = sum(new_per_seq)
-    threshold = total_tokens + 100
-
-    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
-    _init_mla_weights(mla)
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
-
-    # ---- Generate full-sequence input data ----
-    q_full = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv_full = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe_full = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
-    latent_cache_full = torch.cat([compressed_kv_full, k_pe_full], dim=-1)
-    position_ids_full = torch.cat(
-        [torch.arange(t, device=device, dtype=torch.int32) for t in total_per_seq]
-    )
-
-    chunk1_idx = torch.arange(total_chunk1, dtype=torch.long, device=device)
-    chunk2_idx = torch.arange(total_chunk1, total_tokens, dtype=torch.long, device=device)
-
-    # ---- Reference: single-pass full prefill ----
-    kv_cache_ref = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, total_per_seq, device
-    )
-    output_ref = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_ref = AttentionCls.Metadata(
-        seq_lens=torch.tensor(total_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=total_per_seq,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_ref,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata_ref.prepare()
-    mla.forward_context_dsa(
-        q=q_full.clone(),
-        compressed_kv=compressed_kv_full.clone(),
-        k_pe=k_pe_full.clone(),
-        attn_metadata=attn_metadata_ref,
-        output=output_ref,
-        latent_cache=latent_cache_full.clone(),
-        topk_indices=None,
-        position_ids=position_ids_full.clone(),
-    )
-    assert torch.isfinite(output_ref).all(), "Reference output has non-finite values"
-    ref_chunk2_output = output_ref[chunk2_idx]
-
-    # ---- Chunk 1: pure prefill to populate KV cache ----
-    kv_cache_chunked = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, total_per_seq, device
-    )
-    output_c1 = torch.empty(total_chunk1, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c1 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(cached_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=cached_per_seq,
-        max_num_tokens=total_chunk1,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata_c1.prepare()
-    position_ids_c1 = torch.cat(
-        [torch.arange(c, device=device, dtype=torch.int32) for c in cached_per_seq]
-    )
-    mla.forward_context_dsa(
-        q=q_full[chunk1_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk1_idx].clone(),
-        k_pe=k_pe_full[chunk1_idx].clone(),
-        attn_metadata=attn_metadata_c1,
-        output=output_c1,
-        latent_cache=latent_cache_full[chunk1_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c1,
-    )
-
-    # ---- Chunk 2: cached KV → forward_context_with_cached_kv ----
-    output_c2 = torch.empty(total_chunk2, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c2 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(new_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=new_per_seq,
-        max_num_tokens=total_chunk2,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=cached_per_seq,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-        enable_context_mla_with_cached_kv=True,
-    )
-    attn_metadata_c2.prepare()
-    assert attn_metadata_c2.num_ctx_cached_tokens == sum(cached_per_seq)
-
-    position_ids_c2 = torch.cat(
-        [
-            torch.arange(c, c + n, device=device, dtype=torch.int32)
-            for c, n in zip(cached_per_seq, new_per_seq)
-        ]
-    )
-    mla.forward_context_dsa(
-        q=q_full[chunk2_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk2_idx].clone(),
-        k_pe=k_pe_full[chunk2_idx].clone(),
-        attn_metadata=attn_metadata_c2,
-        output=output_c2,
-        latent_cache=latent_cache_full[chunk2_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c2,
-    )
-
-    assert torch.isfinite(output_c2).all(), "Chunk 2 output has non-finite values"
-    abs_error = (output_c2 - ref_chunk2_output).abs()
-    torch.testing.assert_close(output_c2, ref_chunk2_output, rtol=0.08, atol=0.08)
-    print(
-        f"[cached_kv_single] PASSED: max_error={abs_error.max():.4f}, "
-        f"mean_error={abs_error.mean():.6f}"
-    )
-
-    kv_cache_ref.shutdown()
-    kv_cache_chunked.shutdown()
-
-
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
-def test_short_mha_cached_kv_multi_seq_correctness():
-    """Multi-sequence variant of forward_context_with_cached_kv correctness.
-
-    Two sequences with different cached/new counts processed through
-    chunk 1 + chunk 2, compared against a single-pass reference.
-    """
-    device = torch.device("cuda")
-    dtype = torch.bfloat16
-    torch.manual_seed(42)
-    torch.cuda.manual_seed(42)
-
-    rope_config = _make_rope_config()
-
-    cached_per_seq = [128, 64]
-    new_per_seq = [32, 16]
-    total_per_seq = [c + n for c, n in zip(cached_per_seq, new_per_seq)]
-    num_seqs = len(cached_per_seq)
-    total_tokens = sum(total_per_seq)
-    total_chunk1 = sum(cached_per_seq)
-    total_chunk2 = sum(new_per_seq)
-    threshold = total_tokens + 100
-
-    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
-    _init_mla_weights(mla)
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
-
-    # ---- Generate full-sequence input data ----
-    q_full = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv_full = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe_full = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
-    latent_cache_full = torch.cat([compressed_kv_full, k_pe_full], dim=-1)
-    position_ids_full = torch.cat(
-        [torch.arange(t, device=device, dtype=torch.int32) for t in total_per_seq]
-    )
-
-    # Build per-sequence index arrays.
-    chunk1_indices, chunk2_indices = [], []
-    offset = 0
-    for c, n in zip(cached_per_seq, new_per_seq):
-        chunk1_indices.extend(range(offset, offset + c))
-        chunk2_indices.extend(range(offset + c, offset + c + n))
-        offset += c + n
-    chunk1_idx = torch.tensor(chunk1_indices, dtype=torch.long, device=device)
-    chunk2_idx = torch.tensor(chunk2_indices, dtype=torch.long, device=device)
-
-    # ---- Reference: single-pass full prefill ----
-    kv_cache_ref = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, total_per_seq, device
-    )
-    output_ref = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_ref = AttentionCls.Metadata(
-        seq_lens=torch.tensor(total_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=total_per_seq,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_ref,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata_ref.prepare()
-    mla.forward_context_dsa(
-        q=q_full.clone(),
-        compressed_kv=compressed_kv_full.clone(),
-        k_pe=k_pe_full.clone(),
-        attn_metadata=attn_metadata_ref,
-        output=output_ref,
-        latent_cache=latent_cache_full.clone(),
-        topk_indices=None,
-        position_ids=position_ids_full.clone(),
-    )
-    assert torch.isfinite(output_ref).all(), "Reference output has non-finite values"
-    ref_chunk2_output = output_ref[chunk2_idx]
-
-    # ---- Chunk 1: pure prefill ----
-    kv_cache_chunked = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, total_per_seq, device
-    )
-    output_c1 = torch.empty(total_chunk1, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c1 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(cached_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=cached_per_seq,
-        max_num_tokens=total_chunk1,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata_c1.prepare()
-    position_ids_c1 = torch.cat(
-        [torch.arange(c, device=device, dtype=torch.int32) for c in cached_per_seq]
-    )
-    mla.forward_context_dsa(
-        q=q_full[chunk1_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk1_idx].clone(),
-        k_pe=k_pe_full[chunk1_idx].clone(),
-        attn_metadata=attn_metadata_c1,
-        output=output_c1,
-        latent_cache=latent_cache_full[chunk1_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c1,
-    )
-
-    # ---- Chunk 2: cached KV → forward_context_with_cached_kv ----
-    output_c2 = torch.empty(total_chunk2, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c2 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(new_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=new_per_seq,
-        max_num_tokens=total_chunk2,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=cached_per_seq,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-        enable_context_mla_with_cached_kv=True,
-    )
-    attn_metadata_c2.prepare()
-    assert attn_metadata_c2.num_ctx_cached_tokens == sum(cached_per_seq)
-
-    position_ids_c2 = torch.cat(
-        [
-            torch.arange(c, c + n, device=device, dtype=torch.int32)
-            for c, n in zip(cached_per_seq, new_per_seq)
-        ]
-    )
-    mla.forward_context_dsa(
-        q=q_full[chunk2_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk2_idx].clone(),
-        k_pe=k_pe_full[chunk2_idx].clone(),
-        attn_metadata=attn_metadata_c2,
-        output=output_c2,
-        latent_cache=latent_cache_full[chunk2_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c2,
-    )
-
-    assert torch.isfinite(output_c2).all(), "Chunk 2 output has non-finite values"
-    abs_error = (output_c2 - ref_chunk2_output).abs()
-    torch.testing.assert_close(output_c2, ref_chunk2_output, rtol=0.08, atol=0.08)
-    print(
-        f"[cached_kv_multi] PASSED: max_error={abs_error.max():.4f}, "
-        f"mean_error={abs_error.mean():.6f}"
-    )
-
-    kv_cache_ref.shutdown()
-    kv_cache_chunked.shutdown()
-
-
-@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
 @pytest.mark.parametrize(
     "spec_name,chunk_specs",
     CHUNKED_CONTEXT_SPECS,
     ids=[s[0] for s in CHUNKED_CONTEXT_SPECS],
 )
 def test_chunked_context_correctness(spec_name: str, chunk_specs: List[Tuple[int, int]]):
-    """Verify that chunked context produces the same output as full prefill.
-
-    For each sequence, (C, N) means C tokens are processed in chunk 1
-    (populating the KV cache via short-seq MHA) and N tokens in chunk 2
-    (with C cached tokens, routed to forward_context_with_cached_kv via
-    forward_context).  The reference is a single pass of all C+N tokens
-    via the short-seq MHA path.
-    """
+    """Chunked context (chunk1 prefill + chunk2 cached KV) matches single-pass prefill."""
     device = torch.device("cuda")
-    dtype = torch.bfloat16
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
     rope_config = _make_rope_config()
-
-    cached_per_seq = [c for c, _n in chunk_specs]
-    new_per_seq = [n for _c, n in chunk_specs]
+    cached_per_seq = [c for c, _ in chunk_specs]
+    new_per_seq = [n for _, n in chunk_specs]
     total_per_seq = [c + n for c, n in chunk_specs]
-    num_seqs = len(chunk_specs)
-    total_tokens = sum(total_per_seq)
-    total_chunk1 = sum(cached_per_seq)
-    total_chunk2 = sum(new_per_seq)
-
-    # Threshold high enough for both full-prefill and chunk-1 passes to use
-    # the short-seq MHA path.
-    threshold = total_tokens + 100
+    threshold = sum(total_per_seq) + 100
 
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
-    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+    attn_cls = get_attention_backend("TRTLLM", sparse_config)
 
-    # ---- Generate full-sequence input data ----
-    q_full = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype, device=device)
-    compressed_kv_full = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype, device=device)
-    k_pe_full = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
-    latent_cache_full = torch.cat([compressed_kv_full, k_pe_full], dim=-1)
-    position_ids_full = torch.cat(
-        [torch.arange(t, device=device, dtype=torch.int32) for t in total_per_seq]
-    )
+    q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(total_per_seq, device)
 
-    # ---- Build index arrays for splitting packed data into chunks ----
-    chunk1_indices = []
-    chunk2_indices = []
+    # Build chunk index tensors.
+    c1_idx, c2_idx = [], []
     offset = 0
     for c, n in chunk_specs:
-        chunk1_indices.extend(range(offset, offset + c))
-        chunk2_indices.extend(range(offset + c, offset + c + n))
+        c1_idx.extend(range(offset, offset + c))
+        c2_idx.extend(range(offset + c, offset + c + n))
         offset += c + n
-    chunk1_idx = torch.tensor(chunk1_indices, dtype=torch.long, device=device)
-    chunk2_idx = torch.tensor(chunk2_indices, dtype=torch.long, device=device)
+    c1_idx = torch.tensor(c1_idx, dtype=torch.long, device=device)
+    c2_idx = torch.tensor(c2_idx, dtype=torch.long, device=device)
 
-    # ---- Reference pass: full prefill via short-seq MHA ----
-    kv_cache_ref = _build_kv_cache_manager(
+    # Reference: single-pass full prefill.
+    kv_ref = _build_kv_cache_manager(mapping, sparse_config, model_config, total_per_seq, device)
+    meta_ref = _make_metadata(attn_cls, total_per_seq, kv_ref, mapping, sparse_config)
+    out_ref = _run_forward(mla, q, compressed_kv, k_pe, latent_cache, position_ids, meta_ref)
+
+    # Chunk 1: pure prefill (populates KV cache).
+    kv_chunked = _build_kv_cache_manager(
         mapping, sparse_config, model_config, total_per_seq, device
     )
-    output_ref = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_ref = AttentionCls.Metadata(
-        seq_lens=torch.tensor(total_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=total_per_seq,
-        max_num_tokens=total_tokens,
-        kv_cache_manager=kv_cache_ref,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-    )
-    attn_metadata_ref.prepare()
-    assert total_tokens <= threshold, "Reference must use short-seq MHA"
-
-    mla.forward_context_dsa(
-        q=q_full.clone(),
-        compressed_kv=compressed_kv_full.clone(),
-        k_pe=k_pe_full.clone(),
-        attn_metadata=attn_metadata_ref,
-        output=output_ref,
-        latent_cache=latent_cache_full.clone(),
-        topk_indices=None,
-        position_ids=position_ids_full.clone(),
-    )
-    assert torch.isfinite(output_ref).all(), "Reference output has non-finite values"
-    ref_chunk2_output = output_ref[chunk2_idx]
-
-    # ---- Chunked pass: chunk 1 (pure prefill, populates KV cache) ----
-    kv_cache_chunked = _build_kv_cache_manager(
-        mapping, sparse_config, model_config, total_per_seq, device
+    meta_c1 = _make_metadata(attn_cls, cached_per_seq, kv_chunked, mapping, sparse_config)
+    pos_c1 = torch.cat([torch.arange(c, device=device, dtype=torch.int32) for c in cached_per_seq])
+    _run_forward(
+        mla, q[c1_idx], compressed_kv[c1_idx], k_pe[c1_idx], latent_cache[c1_idx], pos_c1, meta_c1
     )
 
-    output_chunk1 = torch.empty(total_chunk1, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c1 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(cached_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=cached_per_seq,
-        max_num_tokens=total_chunk1,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=[0] * num_seqs,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
+    # Chunk 2: cached KV path.
+    meta_c2 = _make_metadata(
+        attn_cls,
+        new_per_seq,
+        kv_chunked,
+        mapping,
+        sparse_config,
+        cached_per_seq=cached_per_seq,
+        enable_cached_kv=True,
     )
-    attn_metadata_c1.prepare()
-    assert total_chunk1 <= threshold, "Chunk 1 must use short-seq MHA"
-
-    position_ids_c1 = torch.cat(
-        [torch.arange(c, device=device, dtype=torch.int32) for c in cached_per_seq]
-    )
-    mla.forward_context_dsa(
-        q=q_full[chunk1_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk1_idx].clone(),
-        k_pe=k_pe_full[chunk1_idx].clone(),
-        attn_metadata=attn_metadata_c1,
-        output=output_chunk1,
-        latent_cache=latent_cache_full[chunk1_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c1,
-    )
-
-    # ---- Chunked pass: chunk 2 (cached tokens → MHA via forward_context) ----
-    output_chunk2 = torch.empty(total_chunk2, NUM_HEADS * V_HEAD_DIM, dtype=dtype, device=device)
-    attn_metadata_c2 = AttentionCls.Metadata(
-        seq_lens=torch.tensor(new_per_seq, dtype=torch.int),
-        request_ids=list(range(num_seqs)),
-        max_num_requests=num_seqs,
-        num_contexts=num_seqs,
-        prompt_lens=new_per_seq,
-        max_num_tokens=total_chunk2,
-        kv_cache_manager=kv_cache_chunked,
-        kv_cache_params=KVCacheParams(
-            use_cache=True,
-            num_cached_tokens_per_seq=cached_per_seq,
-        ),
-        mapping=mapping,
-        sparse_attention_config=sparse_config,
-        enable_context_mla_with_cached_kv=True,
-    )
-    attn_metadata_c2.prepare()
-    assert attn_metadata_c2.num_ctx_cached_tokens == sum(cached_per_seq)
-
-    position_ids_c2 = torch.cat(
+    pos_c2 = torch.cat(
         [torch.arange(c, c + n, device=device, dtype=torch.int32) for c, n in chunk_specs]
     )
-
-    # MHA path via forward_context does not need topk_indices.
-    mla.forward_context_dsa(
-        q=q_full[chunk2_idx].clone(),
-        compressed_kv=compressed_kv_full[chunk2_idx].clone(),
-        k_pe=k_pe_full[chunk2_idx].clone(),
-        attn_metadata=attn_metadata_c2,
-        output=output_chunk2,
-        latent_cache=latent_cache_full[chunk2_idx].clone(),
-        topk_indices=None,
-        position_ids=position_ids_c2,
+    out_c2 = _run_forward(
+        mla, q[c2_idx], compressed_kv[c2_idx], k_pe[c2_idx], latent_cache[c2_idx], pos_c2, meta_c2
     )
 
-    # ---- Compare chunk 2 output vs reference ----
-    assert torch.isfinite(output_chunk2).all(), "Chunk 2 output has non-finite values"
-    abs_error = (output_chunk2 - ref_chunk2_output).abs()
-    torch.testing.assert_close(output_chunk2, ref_chunk2_output, rtol=0.08, atol=0.08)
-    print(
-        f"[chunked_{spec_name}] PASSED: max_error={abs_error.max():.4f}, "
-        f"mean_error={abs_error.mean():.6f}"
-    )
+    torch.testing.assert_close(out_c2, out_ref[c2_idx], rtol=0.08, atol=0.08)
 
-    kv_cache_ref.shutdown()
-    kv_cache_chunked.shutdown()
+    kv_ref.shutdown()
+    kv_chunked.shutdown()
 
 
 if __name__ == "__main__":
     for batch_name, seq_lens in BATCH_SPECS:
         test_forward_context_short_mha(batch_name, seq_lens)
-    test_short_mha_not_triggered_when_threshold_zero()
-    test_short_mha_boundary_threshold_equals_max_seq()
-    test_short_mha_not_triggered_when_seq_exceeds_threshold()
-    test_short_mha_agrees_with_absorption_path()
-    test_short_mha_cached_kv_correctness()
-    test_short_mha_cached_kv_multi_seq_correctness()
+    test_threshold_zero_disables_mha()
+    test_standard_path_when_exceeds_threshold()
+    test_agrees_with_absorption_path()
     for spec_name, chunk_specs in CHUNKED_CONTEXT_SPECS:
         test_chunked_context_correctness(spec_name, chunk_specs)
     print("All tests passed!")

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -29,6 +29,10 @@ from typing import List
 import pytest
 import torch
 
+# DSACacheManager creates background ThreadPoolExecutor threads that outlive
+# the test. Disable pytest-threadleak for this entire module.
+pytestmark = pytest.mark.threadleak(enabled=False)
+
 import tensorrt_llm
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.attention_backend.interface import (

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -399,7 +399,7 @@ def test_forward_context_short_mha(batch_name: str, seq_lens: List[int]):
 
     # Verify short-seq MHA is configured.
     assert mla.short_seq_mha_threshold == threshold
-    assert mla._rotary_emb_mha is not None
+    assert mla.mha is not None
     assert not mla.apply_rotary_emb, "Expected rope_fusion=True for DSA"
 
     kv_cache_manager = _build_kv_cache_manager(
@@ -498,7 +498,7 @@ def test_short_mha_not_triggered_when_threshold_zero():
     mla, _, _, _ = _build_mla(rope_config, device, threshold=0)
 
     assert mla.short_seq_mha_threshold == 0
-    assert mla._rotary_emb_mha is None
+    assert mla.mha is None
 
 
 @pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90 (Hopper) or later")

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -1,0 +1,770 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test suite for the short-sequence MHA optimization path in MLA.
+
+When TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD is set and the max context sequence
+length is within the threshold, MLA.forward_context_dsa dispatches to
+forward_context_short_mha which uses dense MHA (kv_b_proj expansion + SDPA)
+instead of the absorption path.
+"""
+import math
+import os
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+import torch
+
+import tensorrt_llm
+import tensorrt_llm.bindings
+from tensorrt_llm._torch.attention_backend.interface import (
+    PositionalEmbeddingParams, RopeParams)
+from tensorrt_llm._torch.attention_backend.sparse.dsa import DSACacheManager
+from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.modules.attention import MLA
+from tensorrt_llm._utils import (get_sm_version, str_dtype_to_binding,
+                                 torch_dtype_to_str)
+from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.functional import PositionEmbeddingType, RopeEmbeddingUtils
+from tensorrt_llm.llmapi.llm_args import DeepSeekSparseAttentionConfig
+from tensorrt_llm.mapping import Mapping
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., :x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_embedding(x, cos_sin):
+    """Apply rotary position embedding to x."""
+    original_dtype = x.dtype
+    cos, sin = cos_sin.chunk(2, dim=-2)
+    cos = cos.squeeze(1)
+    sin = sin.squeeze(1)
+    x_interleaved = x.unflatten(-1, [-1, 2]).transpose(-2,
+                                                        -1).flatten(start_dim=-2)
+    cos_expanded = cos.view(cos.shape[0], *([1] * (x.ndim - 2)), cos.shape[-1])
+    sin_expanded = sin.view(sin.shape[0], *([1] * (x.ndim - 2)), sin.shape[-1])
+    x_rotated = (x_interleaved * cos_expanded) + (rotate_half(x_interleaved) *
+                                                   sin_expanded)
+    return x_rotated.to(original_dtype)
+
+
+def calculate_reference_output(q, compressed_kv, k_pe, kv_b_proj_weight,
+                               rope_cos_sin, sequence_lengths, num_heads,
+                               kv_lora_rank, qk_nope_head_dim,
+                               qk_rope_head_dim, v_head_dim, softmax_scale,
+                               device):
+    """Reference implementation using kv_b_proj expansion + SDPA.
+
+    This mirrors forward_context_short_mha:
+    1. Apply RoPE to q (rope portion) and k_pe.
+    2. Expand compressed_kv via kv_b_proj to get k_nope and v.
+    3. Construct K = [k_nope, RoPE(k_pe)] per head.
+    4. Run causal SDPA per sequence.
+    """
+    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+    results = []
+    offset = 0
+
+    for seq_len in sequence_lengths:
+        q_seq = q[offset:offset + seq_len].view(-1, num_heads, qk_head_dim)
+        compressed_kv_seq = compressed_kv[offset:offset + seq_len]
+        k_pe_seq = k_pe[offset:offset + seq_len]
+        cos_sin = rope_cos_sin[:seq_len]
+
+        # Apply RoPE to q rope portion
+        q_nope = q_seq[..., :qk_nope_head_dim]
+        q_pe = q_seq[..., qk_nope_head_dim:]
+        q_pe_roped = apply_rotary_embedding(q_pe, cos_sin)
+        q_full = torch.cat([q_nope, q_pe_roped], dim=-1)
+
+        # Apply RoPE to k_pe
+        k_pe_roped = apply_rotary_embedding(k_pe_seq, cos_sin)
+
+        # Expand via kv_b_proj: weight is [out_features, kv_lora_rank]
+        kv = torch.nn.functional.linear(compressed_kv_seq, kv_b_proj_weight)
+        k_nope, v = kv.split(
+            [num_heads * qk_nope_head_dim, num_heads * v_head_dim], -1)
+
+        k_nope_r = k_nope.view(-1, num_heads, qk_nope_head_dim)
+        k_pe_expanded = k_pe_roped.view(-1, 1, qk_rope_head_dim).expand(
+            -1, num_heads, -1)
+        k_full = torch.cat([k_nope_r, k_pe_expanded], dim=-1)
+
+        v_r = v.view(-1, num_heads, v_head_dim)
+
+        # SDPA: [1, H, S, D]
+        q_b = q_full.unsqueeze(0).transpose(1, 2)
+        k_b = k_full.unsqueeze(0).transpose(1, 2)
+        v_b = v_r.unsqueeze(0).transpose(1, 2)
+
+        attn_out = torch.nn.functional.scaled_dot_product_attention(
+            q_b, k_b, v_b, is_causal=True, scale=softmax_scale)
+        attn_out = attn_out.transpose(1, 2).squeeze(0)
+        results.append(attn_out.reshape(seq_len, num_heads * v_head_dim))
+        offset += seq_len
+
+    return torch.cat(results, dim=0)
+
+
+@dataclass
+class RopeConfig:
+    hidden_size: int
+    num_attention_heads: int
+    rope_scaling: dict
+    max_position_embeddings: int
+    rope_theta: float
+    qk_rope_head_dim: int
+    model_type: str
+
+
+# Model configuration matching DeepSeek V3
+NUM_HEADS = 128
+Q_LORA_RANK = 512
+KV_LORA_RANK = 512
+QK_NOPE_HEAD_DIM = 128
+QK_ROPE_HEAD_DIM = 64
+V_HEAD_DIM = 128
+QK_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM
+HIDDEN_SIZE = 2048
+MAX_POSITION_EMBEDDINGS = 4096
+TOKENS_PER_BLOCK = 64
+NUM_LAYERS = 1
+LAYER_IDX = 0
+TOPK_TOKENS = 2048
+NN_INIT_STD = 0.02
+
+# Test batch specifications: (name, sequence_lengths)
+BATCH_SPECS = [
+    ("single_short", [16]),
+    ("single_medium", [64]),
+    ("multi_short", [8, 12, 16]),
+    ("multi_varied", [4, 32, 10]),
+    ("single_one_token", [1]),
+]
+
+
+def _make_rope_config():
+    return RopeConfig(
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        rope_scaling={
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "factor": 40,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "original_max_position_embeddings": 4096,
+            "type": "yarn",
+        },
+        max_position_embeddings=MAX_POSITION_EMBEDDINGS,
+        rope_theta=10000.0,
+        qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+        model_type="deepseek_v2",
+    )
+
+
+def _make_rope_cos_sin(rope_config, device):
+    return torch.tensor(
+        RopeEmbeddingUtils.create_sinusoidal_positions_yarn(
+            rope_config.max_position_embeddings,
+            rope_config.qk_rope_head_dim,
+            rope_config.rope_theta,
+            rope_config.rope_scaling['factor'],
+            rope_config.rope_scaling['original_max_position_embeddings'],
+            rope_config.rope_scaling['beta_fast'],
+            rope_config.rope_scaling['beta_slow'],
+            rope_config.rope_scaling['mscale'],
+            rope_config.rope_scaling['mscale_all_dim'],
+        )[1],
+        dtype=torch.float32,
+        device=device,
+    ).reshape(rope_config.max_position_embeddings, -1, 2).transpose(-2, -1)
+
+
+def _compute_softmax_scale(rope_config):
+    def yarn_get_mscale(scale=1, mscale=1):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * mscale * math.log(scale) + 1.0
+
+    mscale_all_dim = rope_config.rope_scaling['mscale_all_dim']
+    scaling_factor = rope_config.rope_scaling['factor']
+    mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
+    q_scaling = 1.0 / (mscale * mscale)
+    return 1.0 / (math.sqrt(QK_HEAD_DIM) * q_scaling)
+
+
+def _build_mla(rope_config, device, threshold):
+    """Build an MLA module with DSA config and the given threshold."""
+    mapping = Mapping(world_size=1, tp_size=1, rank=0)
+    sparse_config = DeepSeekSparseAttentionConfig(
+        index_n_heads=64,
+        index_head_dim=128,
+        index_topk=TOPK_TOKENS,
+    )
+    pretrained_config = SimpleNamespace(rms_norm_eps=1e-6)
+    model_config = ModelConfig(
+        mapping=mapping,
+        sparse_attention_config=sparse_config,
+        pretrained_config=pretrained_config,
+    )
+    pos_embd_params = PositionalEmbeddingParams(
+        type=PositionEmbeddingType.yarn,
+        rope=RopeParams.from_config(rope_config),
+        is_neox=False,
+    )
+
+    # Set env var BEFORE constructing MLA so __init__ picks it up.
+    old_val = os.environ.get('TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD')
+    os.environ['TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD'] = str(threshold)
+    try:
+        mla = MLA(
+            hidden_size=HIDDEN_SIZE,
+            num_attention_heads=NUM_HEADS,
+            num_key_value_heads=1,
+            qk_nope_head_dim=QK_NOPE_HEAD_DIM,
+            qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+            v_head_dim=V_HEAD_DIM,
+            q_lora_rank=Q_LORA_RANK,
+            kv_lora_rank=KV_LORA_RANK,
+            predicted_tokens_per_seq=1,
+            max_position_embeddings=MAX_POSITION_EMBEDDINGS,
+            bias=False,
+            pos_embd_params=pos_embd_params,
+            layer_idx=LAYER_IDX,
+            dtype=torch.bfloat16,
+            config=model_config,
+        ).to(device)
+    finally:
+        # Restore env var.
+        if old_val is None:
+            os.environ.pop('TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD', None)
+        else:
+            os.environ['TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD'] = old_val
+
+    return mla, mapping, sparse_config, model_config
+
+
+def _init_mla_weights(mla):
+    """Initialize MLA weights deterministically."""
+    with torch.no_grad():
+        mla.kv_b_proj.weight.normal_(mean=0.0, std=NN_INIT_STD)
+        kv_b_weight = mla.kv_b_proj.weight.data
+        kv_b_weight_reshaped = kv_b_weight.view(
+            NUM_HEADS, QK_NOPE_HEAD_DIM + V_HEAD_DIM, KV_LORA_RANK)
+        mla.v_b_proj.data = kv_b_weight_reshaped[:,
+                                                  QK_NOPE_HEAD_DIM:, :].contiguous()
+        mla.k_b_proj_trans.data = kv_b_weight_reshaped[:, :QK_NOPE_HEAD_DIM, :].transpose(
+            1, 2).contiguous()
+        mla.mqa.indexer.wq_b.weight.normal_(mean=0.0, std=NN_INIT_STD)
+        mla.mqa.indexer.wk.weight.normal_(mean=0.0, std=NN_INIT_STD)
+        mla.mqa.indexer.weights_proj.weight.normal_(mean=0.0, std=NN_INIT_STD)
+
+
+def _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens,
+                             device):
+    """Build a DSACacheManager for the given batch."""
+    max_seqlen = max(seq_lens)
+    max_tokens = 16384
+
+    cache_dtype = torch.bfloat16
+    kv_cache_manager = DSACacheManager(
+        KvCacheConfig(max_tokens=max_tokens, enable_block_reuse=False),
+        tensorrt_llm.bindings.internal.batch_manager.CacheType.SELFKONLY,
+        num_layers=NUM_LAYERS,
+        num_kv_heads=1,
+        head_dim=KV_LORA_RANK + QK_ROPE_HEAD_DIM,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        max_seq_len=max_seqlen,
+        max_batch_size=len(seq_lens),
+        mapping=mapping,
+        dtype=str_dtype_to_binding(torch_dtype_to_str(cache_dtype)),
+        sparse_attn_config=sparse_config,
+        model_config=model_config,
+    )
+
+    # Allocate cache for all requests as pure prefill.
+    for req_idx, seq_len in enumerate(seq_lens):
+        kv_cache_manager.add_dummy_requests(
+            request_ids=[req_idx],
+            token_nums=[seq_len],
+            is_gen=False,
+            prepare_resource=True,
+        )
+
+    return kv_cache_manager
+
+
+@pytest.mark.skipif(get_sm_version() < 90,
+                    reason="MLA requires SM90 (Hopper) or later")
+@pytest.mark.parametrize("batch_name,seq_lens",
+                         BATCH_SPECS,
+                         ids=[b[0] for b in BATCH_SPECS])
+def test_forward_context_short_mha(batch_name: str, seq_lens: List[int]):
+    """Test that forward_context_short_mha produces correct attention output.
+
+    Compares the output of the short-seq MHA path against a standalone
+    reference implementation that performs the same math: kv_b_proj expansion,
+    RoPE application, and causal SDPA.
+    """
+    device = torch.device('cuda')
+    dtype = torch.bfloat16
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    rope_config = _make_rope_config()
+    rope_cos_sin = _make_rope_cos_sin(rope_config, device)
+    softmax_scale = _compute_softmax_scale(rope_config)
+
+    # Set threshold high enough that all test sequences take the short MHA path.
+    threshold = max(seq_lens) + 100
+    mla, mapping, sparse_config, model_config = _build_mla(
+        rope_config, device, threshold)
+    _init_mla_weights(mla)
+
+    # Verify short-seq MHA is configured.
+    assert mla.short_seq_mha_threshold == threshold
+    assert mla._rotary_emb_mha is not None
+    assert not mla.apply_rotary_emb, "Expected rope_fusion=True for DSA"
+
+    kv_cache_manager = _build_kv_cache_manager(mapping, sparse_config,
+                                                model_config, seq_lens, device)
+    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+
+    # Generate inputs.
+    total_tokens = sum(seq_lens)
+    num_contexts = len(seq_lens)
+    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype,
+                     device=device)
+    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype,
+                                device=device)
+    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype,
+                        device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype,
+                                device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+    position_ids = torch.cat([
+        torch.arange(slen, device=device, dtype=torch.int32)
+        for slen in seq_lens
+    ])
+    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype,
+                          device=device)
+
+    attn_metadata = AttentionCls.Metadata(
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
+        request_ids=list(range(num_contexts)),
+        max_num_requests=num_contexts,
+        num_contexts=num_contexts,
+        prompt_lens=seq_lens,
+        max_num_tokens=total_tokens,
+        kv_cache_manager=kv_cache_manager,
+        kv_cache_params=KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=[0] * num_contexts,
+        ),
+        mapping=mapping,
+        sparse_attention_config=sparse_config,
+    )
+    attn_metadata.prepare()
+
+    # Verify the threshold guard will trigger.
+    assert attn_metadata.max_ctx_seq_len <= threshold
+
+    # Compute indexer topk_indices (required by forward_context_dsa API).
+    topk_indices = mla.mqa.indexer(
+        qr,
+        hidden_states,
+        attn_metadata,
+        position_ids,
+        indexer_k=mla.mqa.indexer.wk(hidden_states),
+    )
+
+    # Clone inputs since forward_context_dsa may modify them in-place.
+    q_for_ref = q.clone()
+    compressed_kv_for_ref = compressed_kv.clone()
+    k_pe_for_ref = k_pe.clone()
+
+    # Run the actual forward (should dispatch to forward_context_short_mha).
+    mla.forward_context_dsa(
+        q=q,
+        compressed_kv=compressed_kv,
+        k_pe=k_pe,
+        attn_metadata=attn_metadata,
+        output=output,
+        latent_cache=latent_cache,
+        topk_indices=topk_indices,
+        position_ids=position_ids,
+    )
+
+    # Compute reference.
+    kv_b_proj_weight = mla.kv_b_proj.weight.data
+    ref_output = calculate_reference_output(
+        q_for_ref, compressed_kv_for_ref, k_pe_for_ref, kv_b_proj_weight,
+        rope_cos_sin, seq_lens, NUM_HEADS, KV_LORA_RANK, QK_NOPE_HEAD_DIM,
+        QK_ROPE_HEAD_DIM, V_HEAD_DIM, softmax_scale, device)
+
+    # Compare.
+    assert output.shape == ref_output.shape
+    assert torch.isfinite(output).all(), "Output contains non-finite values"
+    assert torch.isfinite(ref_output).all(), "Reference contains non-finite values"
+
+    abs_error = (output - ref_output).abs()
+    torch.testing.assert_close(output, ref_output, rtol=0.05, atol=0.05)
+    print(f"[{batch_name}] PASSED: max_error={abs_error.max():.4f}, "
+          f"mean_error={abs_error.mean():.6f}")
+
+    kv_cache_manager.shutdown()
+
+
+@pytest.mark.skipif(get_sm_version() < 90,
+                    reason="MLA requires SM90 (Hopper) or later")
+def test_short_mha_not_triggered_when_threshold_zero():
+    """Verify that with threshold=0, the short MHA path is NOT active."""
+    device = torch.device('cuda')
+    rope_config = _make_rope_config()
+    mla, _, _, _ = _build_mla(rope_config, device, threshold=0)
+
+    assert mla.short_seq_mha_threshold == 0
+    assert mla._rotary_emb_mha is None
+
+
+@pytest.mark.skipif(get_sm_version() < 90,
+                    reason="MLA requires SM90 (Hopper) or later")
+def test_short_mha_boundary_threshold_equals_max_seq():
+    """Test the boundary condition where threshold == max(seq_lens).
+
+    The dispatch guard uses `<=`, so threshold == max_ctx_seq_len should still
+    trigger the short MHA path. This verifies correctness at the exact boundary.
+    """
+    device = torch.device('cuda')
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    rope_config = _make_rope_config()
+    rope_cos_sin = _make_rope_cos_sin(rope_config, device)
+    softmax_scale = _compute_softmax_scale(rope_config)
+
+    seq_lens = [24, 16]
+    # Threshold exactly equals max seq len — short MHA should trigger.
+    threshold = max(seq_lens)
+    mla, mapping, sparse_config, model_config = _build_mla(
+        rope_config, device, threshold)
+    _init_mla_weights(mla)
+
+    kv_cache_manager = _build_kv_cache_manager(mapping, sparse_config,
+                                                model_config, seq_lens, device)
+    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+
+    total_tokens = sum(seq_lens)
+    num_contexts = len(seq_lens)
+    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype,
+                     device=device)
+    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype,
+                                device=device)
+    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype,
+                        device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype,
+                                device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+    position_ids = torch.cat([
+        torch.arange(slen, device=device, dtype=torch.int32)
+        for slen in seq_lens
+    ])
+    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype,
+                          device=device)
+
+    attn_metadata = AttentionCls.Metadata(
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
+        request_ids=list(range(num_contexts)),
+        max_num_requests=num_contexts,
+        num_contexts=num_contexts,
+        prompt_lens=seq_lens,
+        max_num_tokens=total_tokens,
+        kv_cache_manager=kv_cache_manager,
+        kv_cache_params=KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=[0] * num_contexts,
+        ),
+        mapping=mapping,
+        sparse_attention_config=sparse_config,
+    )
+    attn_metadata.prepare()
+
+    # Verify boundary: max_ctx_seq_len == threshold.
+    assert attn_metadata.max_ctx_seq_len == threshold
+
+    topk_indices = mla.mqa.indexer(
+        qr,
+        hidden_states,
+        attn_metadata,
+        position_ids,
+        indexer_k=mla.mqa.indexer.wk(hidden_states),
+    )
+
+    q_for_ref = q.clone()
+    compressed_kv_for_ref = compressed_kv.clone()
+    k_pe_for_ref = k_pe.clone()
+
+    mla.forward_context_dsa(
+        q=q,
+        compressed_kv=compressed_kv,
+        k_pe=k_pe,
+        attn_metadata=attn_metadata,
+        output=output,
+        latent_cache=latent_cache,
+        topk_indices=topk_indices,
+        position_ids=position_ids,
+    )
+
+    kv_b_proj_weight = mla.kv_b_proj.weight.data
+    ref_output = calculate_reference_output(
+        q_for_ref, compressed_kv_for_ref, k_pe_for_ref, kv_b_proj_weight,
+        rope_cos_sin, seq_lens, NUM_HEADS, KV_LORA_RANK, QK_NOPE_HEAD_DIM,
+        QK_ROPE_HEAD_DIM, V_HEAD_DIM, softmax_scale, device)
+
+    abs_error = (output - ref_output).abs()
+    torch.testing.assert_close(output, ref_output, rtol=0.05, atol=0.05)
+    print(f"[boundary_threshold] PASSED: max_error={abs_error.max():.4f}, "
+          f"mean_error={abs_error.mean():.6f}")
+
+    kv_cache_manager.shutdown()
+
+
+@pytest.mark.skipif(get_sm_version() < 90,
+                    reason="MLA requires SM90 (Hopper) or later")
+def test_short_mha_not_triggered_when_seq_exceeds_threshold():
+    """Verify that when max_ctx_seq_len > threshold, the standard path is used.
+
+    We set threshold=16 but use seq_len=32. The output should match the
+    standard absorption path (not the short MHA path). We verify this
+    indirectly: since both paths must produce the same result for correctness,
+    we just confirm the module runs without error and produces finite output.
+    """
+    device = torch.device('cuda')
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    rope_config = _make_rope_config()
+    seq_lens = [32]
+
+    # Threshold is below max seq len — short MHA should NOT trigger.
+    threshold = 16
+    mla, mapping, sparse_config, model_config = _build_mla(
+        rope_config, device, threshold)
+    _init_mla_weights(mla)
+
+    kv_cache_manager = _build_kv_cache_manager(mapping, sparse_config,
+                                                model_config, seq_lens, device)
+    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+
+    total_tokens = sum(seq_lens)
+    num_contexts = len(seq_lens)
+    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype,
+                     device=device)
+    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype,
+                                device=device)
+    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype,
+                        device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype,
+                                device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+    position_ids = torch.cat([
+        torch.arange(slen, device=device, dtype=torch.int32)
+        for slen in seq_lens
+    ])
+    output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype,
+                          device=device)
+
+    attn_metadata = AttentionCls.Metadata(
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int),
+        request_ids=list(range(num_contexts)),
+        max_num_requests=num_contexts,
+        num_contexts=num_contexts,
+        prompt_lens=seq_lens,
+        max_num_tokens=total_tokens,
+        kv_cache_manager=kv_cache_manager,
+        kv_cache_params=KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=[0] * num_contexts,
+        ),
+        mapping=mapping,
+        sparse_attention_config=sparse_config,
+    )
+    attn_metadata.prepare()
+
+    # Threshold is below max_ctx_seq_len; standard path should be used.
+    assert attn_metadata.max_ctx_seq_len > threshold
+
+    topk_indices = mla.mqa.indexer(
+        qr,
+        hidden_states,
+        attn_metadata,
+        position_ids,
+        indexer_k=mla.mqa.indexer.wk(hidden_states),
+    )
+
+    mla.forward_context_dsa(
+        q=q,
+        compressed_kv=compressed_kv,
+        k_pe=k_pe,
+        attn_metadata=attn_metadata,
+        output=output,
+        latent_cache=latent_cache,
+        topk_indices=topk_indices,
+        position_ids=position_ids,
+    )
+
+    assert torch.isfinite(output).all(), "Output contains non-finite values"
+    print(f"[threshold_exceeded] PASSED: standard path ran without error, "
+          f"output mean={output.abs().mean():.4f}")
+
+    kv_cache_manager.shutdown()
+
+
+@pytest.mark.skipif(get_sm_version() < 90,
+                    reason="MLA requires SM90 (Hopper) or later")
+def test_short_mha_agrees_with_absorption_path():
+    """Compare short MHA path output against the absorption path output.
+
+    Both paths should produce numerically close results for the same inputs.
+    This is an A/B test: run the same inputs through both paths and verify
+    they agree within tolerance.
+    """
+    device = torch.device('cuda')
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    rope_config = _make_rope_config()
+    seq_lens = [16]
+    total_tokens = sum(seq_lens)
+
+    # Build two MLA instances: one with short MHA, one without.
+    mla_short, mapping, sparse_config, model_config = _build_mla(
+        rope_config, device, threshold=total_tokens + 100)
+    mla_absorption, _, _, _ = _build_mla(rope_config, device, threshold=0)
+
+    # Copy weights from short to absorption so they are identical.
+    with torch.no_grad():
+        _init_mla_weights(mla_short)
+        # Copy all parameters.
+        for (name_s, param_s), (name_a, param_a) in zip(
+                mla_short.named_parameters(), mla_absorption.named_parameters()):
+            assert name_s == name_a, f"Parameter name mismatch: {name_s} vs {name_a}"
+            param_a.data.copy_(param_s.data)
+
+    # Shared KV cache managers (need separate ones since they have state).
+    kv_cache_manager_short = _build_kv_cache_manager(
+        mapping, sparse_config, model_config, seq_lens, device)
+    kv_cache_manager_absorption = _build_kv_cache_manager(
+        mapping, sparse_config, model_config, seq_lens, device)
+    AttentionCls = get_attention_backend("TRTLLM", sparse_config)
+
+    num_contexts = len(seq_lens)
+    q = torch.randn(total_tokens, NUM_HEADS * QK_HEAD_DIM, dtype=dtype,
+                     device=device)
+    compressed_kv = torch.randn(total_tokens, KV_LORA_RANK, dtype=dtype,
+                                device=device)
+    k_pe = torch.randn(total_tokens, QK_ROPE_HEAD_DIM, dtype=dtype,
+                        device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype,
+                                device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+    position_ids = torch.cat([
+        torch.arange(slen, device=device, dtype=torch.int32)
+        for slen in seq_lens
+    ])
+
+    def _run_forward(mla_module, kv_cache_mgr):
+        output = torch.empty(total_tokens, NUM_HEADS * V_HEAD_DIM, dtype=dtype,
+                              device=device)
+        attn_metadata = AttentionCls.Metadata(
+            seq_lens=torch.tensor(seq_lens, dtype=torch.int),
+            request_ids=list(range(num_contexts)),
+            max_num_requests=num_contexts,
+            num_contexts=num_contexts,
+            prompt_lens=seq_lens,
+            max_num_tokens=total_tokens,
+            kv_cache_manager=kv_cache_mgr,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[0] * num_contexts,
+            ),
+            mapping=mapping,
+            sparse_attention_config=sparse_config,
+        )
+        attn_metadata.prepare()
+
+        topk_indices = mla_module.mqa.indexer(
+            qr.clone(),
+            hidden_states.clone(),
+            attn_metadata,
+            position_ids.clone(),
+            indexer_k=mla_module.mqa.indexer.wk(hidden_states.clone()),
+        )
+
+        mla_module.forward_context_dsa(
+            q=q.clone(),
+            compressed_kv=compressed_kv.clone(),
+            k_pe=k_pe.clone(),
+            attn_metadata=attn_metadata,
+            output=output,
+            latent_cache=latent_cache.clone(),
+            topk_indices=topk_indices,
+            position_ids=position_ids.clone(),
+        )
+        return output
+
+    output_short = _run_forward(mla_short, kv_cache_manager_short)
+    output_absorption = _run_forward(mla_absorption, kv_cache_manager_absorption)
+
+    assert torch.isfinite(output_short).all()
+    assert torch.isfinite(output_absorption).all()
+
+    abs_error = (output_short - output_absorption).abs()
+    # Use relaxed tolerance because the two paths use different math
+    # (kv_b_proj expansion + SDPA vs absorption BMMs + sparse MLA kernel).
+    torch.testing.assert_close(output_short, output_absorption, rtol=0.15,
+                               atol=0.15)
+    print(f"[a_b_test] PASSED: max_error={abs_error.max():.4f}, "
+          f"mean_error={abs_error.mean():.6f}")
+
+    kv_cache_manager_short.shutdown()
+    kv_cache_manager_absorption.shutdown()
+
+
+if __name__ == "__main__":
+    for batch_name, seq_lens in BATCH_SPECS:
+        test_forward_context_short_mha(batch_name, seq_lens)
+    test_short_mha_not_triggered_when_threshold_zero()
+    test_short_mha_boundary_threshold_equals_max_seq()
+    test_short_mha_not_triggered_when_seq_exceeds_threshold()
+    test_short_mha_agrees_with_absorption_path()
+    print("All tests passed!")

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -15,10 +15,10 @@
 """
 Test suite for the short-sequence MHA optimization path in MLA.
 
-When TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD is set and the max context sequence
-length is within the threshold, MLA.forward_context_dsa dispatches to
-forward_context_short_mha which uses dense MHA (kv_b_proj expansion + SDPA)
-instead of the absorption path.
+When TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD is set and the total number of
+packed context tokens is within the threshold, MLA.forward_context_dsa
+dispatches to forward_context_short_mha which uses dense MHA (kv_b_proj
+expansion + SDPA) instead of the absorption path.
 """
 import math
 import os

--- a/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/test_short_seq_mha.py
@@ -70,20 +70,18 @@ NN_INIT_STD = 0.02
 # ---------------------------------------------------------------------------
 # Parametrized test specs
 # ---------------------------------------------------------------------------
-# Each entry exercises a distinct code path: single-seq, multi-seq, boundary.
-BATCH_SPECS = [
-    ("single", [16]),
-    ("multi", [8, 12, 16]),
-    ("boundary_exact", [24, 16]),
+# (name, seq_lens, threshold_offset): threshold = sum(seq_lens) + offset.
+# offset=0 tests the boundary condition (threshold == total tokens).
+PREFILL_SPECS = [
+    ("single", [16], 100),
+    ("multi_boundary", [8, 12, 16], 0),
 ]
 
 # (name, [(cached_tokens, new_tokens), ...], chunk_size or None)
 # chunk_size=None -> cached-KV path; chunk_size=int -> chunked-prefill path.
 CHUNKED_SPECS = [
-    ("cached_kv_single", [(64, 32)], None),
-    ("cached_kv_multi", [(64, 32), (32, 16)], None),
-    ("chunked_prefill_single", [(64, 8)], 16),
-    ("chunked_prefill_multi", [(64, 16), (64, 8)], 32),
+    ("cached_kv", [(64, 32), (32, 16)], None),
+    ("chunked_prefill", [(64, 16), (64, 8)], 32),
 ]
 
 
@@ -344,12 +342,16 @@ def _make_metadata(
     mapping,
     sparse_config,
     cached_per_seq=None,
-    enable_cached_kv=False,
     runtime_features=None,
 ):
-    """Build and prepare attention metadata."""
+    """Build and prepare attention metadata.
+
+    When cached_per_seq is provided, enables the cached-KV context path.
+    """
     num_ctx = len(seq_lens)
-    kwargs = {"enable_context_mla_with_cached_kv": True} if enable_cached_kv else {}
+    kwargs = {}
+    if cached_per_seq is not None:
+        kwargs["enable_context_mla_with_cached_kv"] = True
     if runtime_features is not None:
         kwargs["runtime_features"] = runtime_features
     metadata = attn_cls.Metadata(
@@ -394,16 +396,19 @@ def _run_forward(
 # Tests
 # ---------------------------------------------------------------------------
 @pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
-@pytest.mark.parametrize("batch_name,seq_lens", BATCH_SPECS, ids=[b[0] for b in BATCH_SPECS])
-def test_forward_context_short_mha(batch_name: str, seq_lens: List[int]):
+@pytest.mark.parametrize(
+    "name,seq_lens,threshold_offset",
+    PREFILL_SPECS,
+    ids=[s[0] for s in PREFILL_SPECS],
+)
+def test_forward_context_short_mha(name: str, seq_lens: List[int], threshold_offset: int):
     """Short-seq MHA output vs standalone reference (kv_b_proj + RoPE + SDPA)."""
     device = torch.device("cuda")
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
     rope_config = _make_rope_config()
-    # "boundary_exact" tests threshold == total; others use threshold > total.
-    threshold = sum(seq_lens) if batch_name == "boundary_exact" else sum(seq_lens) + 100
+    threshold = sum(seq_lens) + threshold_offset
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
 
@@ -417,13 +422,7 @@ def test_forward_context_short_mha(batch_name: str, seq_lens: List[int]):
     rope_cos_sin = _make_rope_cos_sin(rope_config, device)
     softmax_scale = _compute_softmax_scale(rope_config)
     ref = _reference_attention(
-        q,
-        compressed_kv,
-        k_pe,
-        mla.kv_b_proj.weight.data,
-        rope_cos_sin,
-        seq_lens,
-        softmax_scale,
+        q, compressed_kv, k_pe, mla.kv_b_proj.weight.data, rope_cos_sin, seq_lens, softmax_scale
     )
 
     torch.testing.assert_close(output, ref, rtol=0.05, atol=0.05)
@@ -445,14 +444,12 @@ def test_threshold_zero_disables_mha():
 def test_standard_path_when_exceeds_threshold():
     """When total tokens > threshold, the standard absorption path is used."""
     device = torch.device("cuda")
-    dtype = torch.bfloat16
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
     rope_config = _make_rope_config()
     seq_lens = [32]
-    threshold = 16
-    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
+    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold=16)
     _init_mla_weights(mla)
 
     kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
@@ -460,8 +457,8 @@ def test_standard_path_when_exceeds_threshold():
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
 
     total_tokens = sum(seq_lens)
-    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype, device=device)
-    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=torch.bfloat16, device=device)
 
     metadata = _make_metadata(attn_cls, seq_lens, kv_mgr, mapping, sparse_config)
     topk_indices = mla.mqa.indexer(
@@ -483,7 +480,6 @@ def test_standard_path_when_exceeds_threshold():
 def test_agrees_with_absorption_path():
     """Short MHA and absorption paths produce numerically close results."""
     device = torch.device("cuda")
-    dtype = torch.bfloat16
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
@@ -496,6 +492,7 @@ def test_agrees_with_absorption_path():
     )
     mla_absorb, _, _, _ = _build_mla(rope_config, device, threshold=0)
 
+    # Share identical weights between the two modules.
     _init_mla_weights(mla_short)
     with torch.no_grad():
         for (_, ps), (_, pa) in zip(mla_short.named_parameters(), mla_absorb.named_parameters()):
@@ -507,8 +504,8 @@ def test_agrees_with_absorption_path():
             pa.data.copy_(ps.data)
 
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
-    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=dtype, device=device)
-    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=dtype, device=device)
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device)
+    qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=torch.bfloat16, device=device)
     attn_cls = get_attention_backend("TRTLLM", sparse_config)
 
     def _run(mla_module):
@@ -540,17 +537,12 @@ def test_agrees_with_absorption_path():
 
 @pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
 @pytest.mark.parametrize(
-    "spec_name,chunk_specs,chunk_size",
+    "name,chunk_specs,chunk_size",
     CHUNKED_SPECS,
     ids=[s[0] for s in CHUNKED_SPECS],
 )
-def test_chunked_correctness(spec_name: str, chunk_specs: List[Tuple[int, int]], chunk_size):
-    """Chunked context (cached KV or chunked prefill) matches single-pass prefill.
-
-    When chunk_size is None, exercises the cached-KV path
-    (forward_context_with_cached_kv). When chunk_size is set, exercises the
-    chunked-prefill path (forward_context_with_chunked_prefill).
-    """
+def test_chunked_correctness(name: str, chunk_specs: List[Tuple[int, int]], chunk_size):
+    """Chunked context (cached KV or chunked prefill) matches single-pass prefill."""
     device = torch.device("cuda")
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
@@ -607,7 +599,6 @@ def test_chunked_correctness(spec_name: str, chunk_specs: List[Tuple[int, int]],
         mapping,
         sparse_config,
         cached_per_seq=cached_per_seq,
-        enable_cached_kv=True,
         runtime_features=runtime_features,
     )
     pos_c2 = torch.cat(
@@ -623,12 +614,52 @@ def test_chunked_correctness(spec_name: str, chunk_specs: List[Tuple[int, int]],
     kv_chunked.shutdown()
 
 
-if __name__ == "__main__":
-    for name, seq_lens in BATCH_SPECS:
-        test_forward_context_short_mha(name, seq_lens)
-    test_threshold_zero_disables_mha()
-    test_standard_path_when_exceeds_threshold()
-    test_agrees_with_absorption_path()
-    for name, specs, cs in CHUNKED_SPECS:
-        test_chunked_correctness(name, specs, cs)
-    print("All tests passed!")
+@pytest.mark.skipif(get_sm_version() < 90, reason="MLA requires SM90+")
+def test_chunked_context_rejects_when_kv_exceeds_threshold():
+    """When max KV length (cached + new) exceeds threshold, short MHA is not used.
+
+    Regression test: previously, only new token count was checked against
+    the threshold.  With cached tokens, the effective attention span can far
+    exceed the threshold even when new_tokens is small.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    rope_config = _make_rope_config()
+    # 1 sequence: 64 cached + 32 new = 96 total KV.
+    # threshold=80: chunk 1 (64 tokens) passes, chunk 2's max KV (96) exceeds.
+    cached_per_seq = [64]
+    new_per_seq = [32]
+    total_per_seq = [96]
+    threshold = 80
+
+    mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
+    _init_mla_weights(mla)
+    attn_cls = get_attention_backend("TRTLLM", sparse_config)
+
+    q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(total_per_seq, device)
+
+    # Chunk 1: populate KV cache with cached tokens.
+    kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, total_per_seq, device)
+    meta_c1 = _make_metadata(attn_cls, cached_per_seq, kv_mgr, mapping, sparse_config)
+    c1_idx = torch.arange(cached_per_seq[0], dtype=torch.long, device=device)
+    pos_c1 = torch.arange(cached_per_seq[0], device=device, dtype=torch.int32)
+    _run_forward(
+        mla, q[c1_idx], compressed_kv[c1_idx], k_pe[c1_idx], latent_cache[c1_idx], pos_c1, meta_c1
+    )
+
+    # Chunk 2: cached KV path — threshold check matters here.
+    meta_c2 = _make_metadata(
+        attn_cls, new_per_seq, kv_mgr, mapping, sparse_config, cached_per_seq=cached_per_seq
+    )
+    pos_c2 = torch.arange(cached_per_seq[0], total_per_seq[0], device=device, dtype=torch.int32)
+
+    # max_ctx_kv_len (96) > threshold (80) -> short MHA should NOT be used.
+    assert not mla._should_use_short_mha(meta_c2, pos_c2)
+
+    # With threshold large enough for the full KV -> short MHA IS used.
+    mla.short_seq_mha_threshold = total_per_seq[0] + 100
+    assert mla._should_use_short_mha(meta_c2, pos_c2)
+
+    kv_mgr.shutdown()


### PR DESCRIPTION
## Summary

For DSA models (DeepSeek V3.2), the MLA prefill absorption path requires two extra BMMs (Q-absorption and V-projection) and uses a larger head_dim (`kv_lora_rank + qk_rope_head_dim` = 576 vs 192). For short sequences, this overhead dominates. This PR adds an alternative dense MHA path that bypasses the absorption path for short context batches.

**Key changes:**
- When total packed context tokens <= threshold, `forward_context_dsa` dispatches to `forward_context()` (kv_b_proj expansion + standard attention) instead of the absorption/sparse MLA path
- `forward_context()` handles both fresh and cached tokens by dispatching to `forward_context_with_cached_kv` or `forward_context_with_chunked_prefill` as needed
- A dedicated `TrtllmAttention` dense backend (`self.mha`) is initialized with `sparse_attention_config=None` for the standard MHA path, unified with the existing non-DSA MHA creation
- When the short MHA path handles all context and there are no generation tokens, the DSA indexer (linear projections + attention + top-k selection) is skipped entirely
- Enabled by default: `TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD=10240` (total packed tokens). Only activates when `rope_fusion=True` and `cp_size == 1`

## Details

**Dispatch guard** (`_should_use_short_mha`; all must be true):
- `short_seq_mha_threshold > 0`
- `apply_rotary_emb is False` (rope_fusion path — prevents double-RoPE)
- `cp_size == 1` (Context Parallelism not active)
- `position_ids` available
- `num_ctx_tokens <= threshold`

**Files changed:**
- `tensorrt_llm/_torch/modules/attention.py` — `_should_use_short_mha` guard, short-MHA dispatch in `forward_context_dsa`, unified `self.mha` initialization, indexer skip logic
- `tests/unittest/_torch/attention/sparse/test_short_seq_mha.py` — unit tests covering single/multi-sequence correctness, chunked context correctness, threshold boundary conditions, and A/B comparison against the absorption path

## Test plan

- [x] Unit tests pass (`pytest tests/unittest/_torch/attention/sparse/test_short_seq_mha.py`)
- [x] Verify correctness: run DeepSeek V3 inference with `TRTLLM_MLA_SHORT_SEQ_MHA_THRESHOLD=0` (disabled) and compare outputs with threshold enabled (default `10240`)
- [x] Benchmark short-sequence prefill latency with threshold enabled vs disabled
- [x] Verify generation quality is unaffected (KV cache populated correctly)
- [x] Test with TP > 1 to ensure head partitioning is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)