### PR TITLE
[TRTLLM-11067][feat] Make MoE/MLP modules CP-aware

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -714,7 +714,6 @@ class DeepseekV3Attention(MLA):
         model_config: ModelConfig[PretrainedConfig],
         layer_idx: Optional[int] = None,
         aux_stream: Optional[torch.cuda.Stream] = None,
-        mapping_with_cp: Optional[Mapping] = None,
         reduce_output: bool = True,
     ):
         config = model_config.pretrained_config
@@ -739,7 +738,6 @@ class DeepseekV3Attention(MLA):
                          dtype=config.torch_dtype,
                          config=model_config,
                          aux_stream=aux_stream,
-                         mapping_with_cp=mapping_with_cp,
                          reduce_output=reduce_output)
         self.kv_a_proj_with_mqa = DeepseekV3Linear(
             config.hidden_size,
@@ -929,7 +927,14 @@ class Deepseekv3MoE(nn.Module):
         super().__init__()
         config = model_config.pretrained_config
         self.top_k = top_k
-        self.use_dp = model_config.mapping.enable_attention_dp
+
+        # For HELIX CP, attention TP+CP ranks become MoE TP/EP ranks.
+        ffn_mapping = model_config.mapping
+        if ffn_mapping.has_cp_helix():
+            ffn_mapping = ffn_mapping.repurpose_helix_cp_to_tp()
+        self.mapping = ffn_mapping
+
+        self.use_dp = ffn_mapping.enable_attention_dp
         self.use_cute_dsl_blockscaling_mm = model_config.use_cute_dsl_blockscaling_mm
         gate_cls = DeepseekV3Gate
         if hasattr(model_config.pretrained_config, "gate_cls"):
@@ -966,8 +971,6 @@ class Deepseekv3MoE(nn.Module):
                 else MoEWeightLoadingMode.VANILLA),
         )
 
-        self.mapping = model_config.mapping
-
         # FIXME: incompatible with mixed quantization mode (including excluding modules from quantization)
         block_size = 1
         if model_config.quant_config and model_config.quant_config.group_size is not None:
@@ -989,7 +992,7 @@ class Deepseekv3MoE(nn.Module):
 
         self.allreduce = None
         if not self.use_dp and self.mapping.tp_size > 1:
-            self.allreduce = AllReduce(mapping=model_config.mapping,
+            self.allreduce = AllReduce(mapping=ffn_mapping,
                                        strategy=model_config.allreduce_strategy)
         self.aux_stream = aux_stream_dict[AuxStreamType.MoeShared]
         self.event_dict = {
@@ -1006,7 +1009,7 @@ class Deepseekv3MoE(nn.Module):
             precompute_common_perfect_router_logits(
                 num_experts=num_experts,
                 experts_per_token=top_k,
-                moe_ep_size=model_config.mapping.moe_ep_size,
+                moe_ep_size=self.mapping.moe_ep_size,
                 dtype=dtype)
 
     def _compute_shared_expert_tp_size(
@@ -1067,7 +1070,7 @@ class Deepseekv3MoE(nn.Module):
             num_tokens=num_tokens,
             num_experts=num_experts,
             experts_per_token=self.top_k,
-            moe_ep_size=self.model_config.mapping.moe_ep_size,
+            moe_ep_size=self.mapping.moe_ep_size,
             device=device,
             dtype=self.dtype)
 
@@ -1172,8 +1175,7 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                  model_config: ModelConfig[PretrainedConfig],
                  layer_idx: int,
                  aux_stream_dict: Dict[AuxStreamType, torch.cuda.Stream],
-                 is_separate_draft_engine: bool = False,
-                 mapping_with_cp: Optional[Mapping] = None):
+                 is_separate_draft_engine: bool = False):
         super().__init__()
         self.model_config = model_config
         self.config = model_config.pretrained_config
@@ -1188,12 +1190,15 @@ class DeepseekV3DecoderLayer(DecoderLayer):
         self.mapping = model_config.mapping
         mapping = self.mapping
         self.enable_attention_dp = mapping.enable_attention_dp
-        self.mlp_tp_size = mapping.tp_size
+
+        # For HELIX CP, attention TP+CP ranks become FFN TP ranks.
+        ffn_mapping = mapping.repurpose_helix_cp_to_tp(
+        ) if mapping.has_cp_helix() else mapping
+        self.mlp_tp_size = ffn_mapping.tp_size
         self.is_p2p_supported = can_access_peer(mapping)
 
         layer_idx_for_attention = layer_idx
         if is_separate_draft_engine:
-            #KVCacheManager only support 1 layer for separate draft engine
             layer_idx_for_attention = layer_idx - model_config.pretrained_config.num_hidden_layers
 
         if config.model_type == "deepseek_v32":
@@ -1204,18 +1209,12 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 reduce_output=not self.enable_attention_dp
                 and self.mapping.tp_size > 1)
         else:
-            # When enable_attention_dp is True, TP reduction is skipped since each DP rank
-            # works on different batch elements. However, with CP > 1, attention is split
-            # across CP ranks for the SAME batch element, so reduction is still needed
-            # within the CP group.
-            needs_tp_reduce = not self.enable_attention_dp and self.mapping.tp_size > 1
-            needs_cp_reduce = mapping_with_cp is not None and mapping_with_cp.has_cp_helix(
-            )
+            needs_tp_reduce = not self.enable_attention_dp and mapping.tp_size > 1
+            needs_cp_reduce = mapping.has_cp_helix()
             self.self_attn = DeepseekV3Attention(
                 model_config,
                 layer_idx=layer_idx_for_attention,
                 aux_stream=aux_stream_dict[AuxStreamType.Attention],
-                mapping_with_cp=mapping_with_cp,
                 reduce_output=needs_tp_reduce or needs_cp_reduce)
 
         self.fusion_config = EagerFusionConfig()
@@ -1233,13 +1232,13 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
         self.allreduce = None
         self.moe_allreduce = None
-        if not self.enable_attention_dp and self.mapping.tp_size > 1:
-            self.allreduce = AllReduce(mapping=model_config.mapping,
+        if not self.enable_attention_dp and ffn_mapping.tp_size > 1:
+            self.allreduce = AllReduce(mapping=ffn_mapping,
                                        strategy=model_config.allreduce_strategy,
                                        dtype=config.torch_dtype)
-            self.moe_allreduce = MoEAllReduce(self.mapping)
+            self.moe_allreduce = MoEAllReduce(ffn_mapping)
 
-        has_tp = mapping.has_tp()
+        has_tp = ffn_mapping.has_tp()
         if (config.n_routed_experts is not None
                 and layer_idx >= config.first_k_dense_replace
                 and layer_idx % config.moe_layer_freq == 0):
@@ -1286,14 +1285,13 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                                        eps=config.rms_norm_eps,
                                        dtype=config.torch_dtype)
 
-        # When enable_attention_dp is True, we normally skip attention all-reduce since each
-        # DP rank works on different batch elements. However, with CP > 1, attention is split
-        # across CP ranks for the SAME batch element, so all-reduce is still needed.
-        has_cp = mapping_with_cp is not None and mapping_with_cp.cp_size > 1
+        has_cp = mapping.has_cp_helix()
         can_skip_for_attention_dp = self.enable_attention_dp and not has_cp
+        needs_any_attn_reduce = (not self.enable_attention_dp and
+                                 mapping.tp_size > 1) or mapping.has_cp_helix()
         self.disable_attn_allreduce = (self.fusion_config.PRE_MOE_FUSION
                                        or self.fusion_config.PRE_MLP_FUSION
-                                       or self.mapping.tp_size == 1
+                                       or not needs_any_attn_reduce
                                        or can_skip_for_attention_dp)
 
         self.post_attention_layernorm = RMSNorm(hidden_size=config.hidden_size,
@@ -1337,20 +1335,19 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
         assert intermediate_size % block_size == 0, "intermediate_size must be divisible by block_size."
         if self.enable_attention_dp:
-            # If using attention DP, the MLP also uses DP instead of TP.
             mlp_tp_size = 1
         else:
-            # The two math.gcd operations ensure that mlp_tp_size falls in the candidate TP sizes.
+            # self.mlp_tp_size is the effective FFN TP size (tp*cp for HELIX).
             tp = math.gcd(
                 intermediate_size // block_size,
-                self.mapping.tp_size,
+                self.mlp_tp_size,
             )
 
             if tp > self.mapping.gpus_per_node:
                 mlp_tp_size = math.gcd(
                     tp,
                     self.mapping.gpus_per_node,
-                )  # Avoid costly inter-node TP
+                )
             else:
                 mlp_tp_size = tp
         return mlp_tp_size
@@ -1690,9 +1687,7 @@ class DeepseekV3MTP(DeepseekV3DecoderLayer):
 
 class DeepseekV3Model(DecoderModel):
 
-    def __init__(self,
-                 model_config: ModelConfig[PretrainedConfig],
-                 mapping_with_cp: Optional[Mapping] = None):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         super().__init__(model_config)
         config = model_config.pretrained_config
         self.vocab_size = config.vocab_size
@@ -1713,10 +1708,8 @@ class DeepseekV3Model(DecoderModel):
         )
 
         self.layers = nn.ModuleList([
-            DeepseekV3DecoderLayer(model_config,
-                                   layer_idx,
-                                   self.aux_stream_dict,
-                                   mapping_with_cp=mapping_with_cp)
+            DeepseekV3DecoderLayer(model_config, layer_idx,
+                                   self.aux_stream_dict)
             for layer_idx in range(config.num_hidden_layers)
         ])
         self.norm = RMSNorm(hidden_size=config.hidden_size,
@@ -1762,23 +1755,6 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                                         PretrainedConfig]):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
-        self.mapping_with_cp = None
-        # Note: Currently the usage of mapping is all over the place making its usage brittle
-        # in this file. As a temporary WAR, we hold on to an original copy of mapping when CP
-        # is in action. This shall be passed on to attention which is the only layer that's
-        # affected by CP. For other layers, CP ranks are repurposed to TP. This shall be undone
-        # at the end of __init__.
-        if model_config.mapping.has_cp_helix():
-            print(
-                f"[DeepseekV3ForCausalLM::__init__] Repurposing KVP ranks to TP while keeping other details the same."
-            )
-            self.mapping_with_cp = copy.deepcopy(model_config.mapping)
-            # Repurpose KVP ranks to TP while keeping other details the same.
-            model_config._frozen = False
-            model_config.mapping = model_config.mapping.repurpose_helix_cp_to_tp(
-            )
-            model_config._frozen = True
-
         # Rename some keys of quant_config_dict to support legacy checkpoints
         if model_config.quant_config_dict is not None:
             model_config = copy.deepcopy(model_config)
@@ -1792,8 +1768,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
             model_config.quant_config_dict = quant_config_dict
             model_config._frozen = True
 
-        super().__init__(model=DeepseekV3Model(
-            model_config, mapping_with_cp=self.mapping_with_cp),
+        super().__init__(model=DeepseekV3Model(model_config),
                          model_config=model_config)
 
         self.model_nextn = 0
@@ -1824,15 +1799,6 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                     self.model_config.quant_config.exclude_modules.extend(
                         extend_exclude_modules)
             self.model.layers.extend(self.draft_model.mtp_layers)
-
-        # Undo any manipulations done to mapping.
-        if self.mapping_with_cp is not None:
-            print(
-                f"[DeepseekV3ForCausalLM::__init__] Restoring original mapping."
-            )
-            model_config._frozen = False
-            model_config.mapping = self.mapping_with_cp
-            model_config._frozen = True
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -751,7 +751,6 @@ class MLA(nn.Module):
         dense_bias: Optional[bool] = None,
         config: Optional[ModelConfig] = None,
         enable_helix_test: bool = False,
-        mapping_with_cp: Optional[Mapping] = None,
         reduce_output: bool = True,
     ):
         """
@@ -824,13 +823,7 @@ class MLA(nn.Module):
 
         # tensor parallel
         config = config or ModelConfig()
-        if mapping_with_cp is not None:
-            logger.warning_once(
-                "[MLA::__init__] Overriding mapping with CP detected.",
-                key="mla_init_mapping_with_cp")
-            self.mapping = mapping_with_cp
-        else:
-            self.mapping = config.mapping
+        self.mapping = config.mapping
         tp_size = self.mapping.tp_size
         pp_size = self.mapping.pp_size
         cp_size = self.mapping.cp_size

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
@@ -85,8 +85,12 @@ class CommunicationFactory:
             Most parameters are extracted from model_config. Only MoE-specific parameters
             (num_experts, num_slots, top_k, expert_size_per_partition) need to be provided separately.
         """
-        # Extract parameters from model_config
+        # Extract parameters from model_config.
+        # For HELIX CP, fold the CP dimension into TP so that MoE
+        # communication uses the correct effective parallelism.
         mapping = model_config.mapping
+        if mapping.has_cp_helix():
+            mapping = mapping.repurpose_helix_cp_to_tp()
         hidden_size = model_config.pretrained_config.hidden_size
         act_dtype = model_config.torch_dtype
         quant_config = model_config.quant_config
@@ -211,8 +215,12 @@ class CommunicationFactory:
             RuntimeError: If the forced method is not supported on this platform
             ValueError: If method name is unknown
         """
-        # Extract parameters from model_config
+        # Extract parameters from model_config.
+        # For HELIX CP, fold the CP dimension into TP so that MoE
+        # communication uses the correct effective parallelism.
         mapping = model_config.mapping
+        if mapping.has_cp_helix():
+            mapping = mapping.repurpose_helix_cp_to_tp()
         hidden_size = model_config.pretrained_config.hidden_size
         act_dtype = model_config.torch_dtype
         quant_config = model_config.quant_config

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -234,7 +234,7 @@ class ConfigurableMoE(MoE):
         # moe_max_num_tokens is set in ModelConfig.__post_init__ if not specified
         # The default value is max_num_tokens * dp_size
         self.moe_max_num_tokens = model_config.moe_max_num_tokens
-        default_moe_max_num_tokens = model_config.max_num_tokens * model_config.mapping.dp_size
+        default_moe_max_num_tokens = model_config.max_num_tokens * self.mapping.dp_size
 
         # Auxiliary stream for chunking overlap
         if self.moe_max_num_tokens < default_moe_max_num_tokens:

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -264,7 +264,7 @@ class CutlassFusedMoE(MoE):
         # The default value is max_num_tokens * dp_size
         self.moe_max_num_tokens = model_config.moe_max_num_tokens
         # The auxiliary CUDA stream and CUDA events are only used when MoE chunking is applied
-        default_moe_max_num_tokens = model_config.max_num_tokens * model_config.mapping.dp_size
+        default_moe_max_num_tokens = model_config.max_num_tokens * self.mapping.dp_size
         if self.moe_max_num_tokens < default_moe_max_num_tokens:
             self.aux_stream = aux_stream_dict[
                 AuxStreamType.
@@ -303,9 +303,9 @@ class CutlassFusedMoE(MoE):
                 if self.alltoall_method_type == AlltoallMethodType.NVLinkTwoSided:
                     MnnvlMemory.initialize()
                     self.alltoall_workspace = MnnvlMoe.get_moe_workspaces(
-                        model_config.mapping)
+                        self.mapping)
                     self.alltoall_prepare_workspace = MnnvlMoe.get_moe_prepare_workspace(
-                        model_config.mapping)
+                        self.mapping)
                 elif self.alltoall_method_type == AlltoallMethodType.NVLinkOneSided:
                     # Calculate required workspace size
                     ep_size = self.mapping.moe_ep_size

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -229,9 +229,9 @@ class TRTLLMGenFusedMoE(MoE):
                 if self.alltoall_method_type == AlltoallMethodType.NVLinkTwoSided:
                     MnnvlMemory.initialize()
                     self.alltoall_workspace = MnnvlMoe.get_moe_workspaces(
-                        model_config.mapping)
+                        self.mapping)
                     self.alltoall_prepare_workspace = MnnvlMoe.get_moe_prepare_workspace(
-                        model_config.mapping)
+                        self.mapping)
                 elif self.alltoall_method_type == AlltoallMethodType.NVLinkOneSided:
                     # Calculate required workspace size
                     ep_size = self.mapping.moe_ep_size

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -236,25 +236,29 @@ class MoE(nn.Module):
         # could be modified later
         self.quant_config = model_config.quant_config
 
-        self.cluster_rank = model_config.mapping.moe_cluster_rank
-        self.cluster_size = model_config.mapping.moe_cluster_size
+        # For HELIX CP, attention TP+CP ranks become MoE TP/EP ranks.
+        ffn_mapping = model_config.mapping
+        if ffn_mapping.has_cp_helix():
+            ffn_mapping = ffn_mapping.repurpose_helix_cp_to_tp()
+
+        self.cluster_rank = ffn_mapping.moe_cluster_rank
+        self.cluster_size = ffn_mapping.moe_cluster_size
         self.smart_router = True if self.cluster_size > 1 else False
 
-        self.rank = model_config.mapping.rank
+        self.rank = ffn_mapping.rank
 
-        self.tp_rank = model_config.mapping.moe_tp_rank
-        self.tp_size = model_config.mapping.moe_tp_size
+        self.tp_rank = ffn_mapping.moe_tp_rank
+        self.tp_size = ffn_mapping.moe_tp_size
 
-        self.ep_size = model_config.mapping.moe_ep_size
-        self.ep_rank = model_config.mapping.moe_ep_rank
+        self.ep_size = ffn_mapping.moe_ep_size
+        self.ep_rank = ffn_mapping.moe_ep_rank
 
         self.moe_backend = model_config.moe_backend
-        self.use_dp = model_config.mapping.enable_attention_dp
+        self.use_dp = ffn_mapping.enable_attention_dp
 
-        # All ranks participate in allreduce regardless of EP/TP combination
-        self.mapping = model_config.mapping
-        self.parallel_rank = self.mapping.tp_rank
-        self.parallel_size = self.mapping.tp_size
+        self.mapping = ffn_mapping
+        self.parallel_rank = ffn_mapping.tp_rank
+        self.parallel_size = ffn_mapping.tp_size
         self.intermediate_size_per_partition = intermediate_size // self.tp_size
 
         self.all_reduce = None

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -34,25 +34,28 @@ class MLP(nn.Module):
         self.activation = activation
 
         config = config or ModelConfig()
-        self.mapping = config.mapping
+        # For HELIX CP, attention TP+CP ranks become MLP TP ranks.
+        effective_mapping = config.mapping
+        if effective_mapping.has_cp_helix():
+            effective_mapping = effective_mapping.repurpose_helix_cp_to_tp()
+        self.mapping = effective_mapping
         if overridden_tp_size is not None:
-            assert config.mapping.tp_size % overridden_tp_size == 0
+            assert effective_mapping.tp_size % overridden_tp_size == 0
             tp_size = overridden_tp_size
-            # "Misuse" pp_size here to perform all-reduce within smaller groups
-            pp_size = config.mapping.pp_size * config.mapping.tp_size // overridden_tp_size
+            pp_size = effective_mapping.pp_size * effective_mapping.tp_size // overridden_tp_size
             mapping = Mapping(
                 world_size=tp_size * pp_size,
-                rank=self.mapping.rank,
-                gpus_per_node=self.mapping.gpus_per_node,
+                rank=effective_mapping.rank,
+                gpus_per_node=effective_mapping.gpus_per_node,
                 tp_size=tp_size,
                 pp_size=pp_size,
             )
         else:
-            mapping = config.mapping
+            mapping = effective_mapping
 
         self.up_lora = LoraLayer(
             [LoraModuleType.MLP_H_TO_4H],
-            [self.intermediate_size // config.mapping.tp_size])
+            [self.intermediate_size // effective_mapping.tp_size])
 
         self.up_proj = Linear(
             self.hidden_size,


### PR DESCRIPTION
## Description

This MR makes changes to make MoE/MLP modules CP-aware.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
