### PR TITLE
[TRTLLM-11148][perf] _prepare_inputs host time optimization

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2243,7 +2243,11 @@ class PyTorchModelEngine(ModelEngine):
         extend_dummy_requests = []
         generation_requests = []
         first_draft_requests = []
+        # Collect generation request IDs during categorization to avoid
+        # a separate iteration over scheduled_requests.generation_requests later.
+        all_gen_request_ids = []
         for request in scheduled_requests.generation_requests:
+            all_gen_request_ids.append(request.py_request_id)
             if get_draft_token_length(
                     request) > 0 or next_draft_tokens_device is not None:
                 if request.is_dummy:
@@ -2423,86 +2427,166 @@ class PyTorchModelEngine(ModelEngine):
             request.py_batch_idx = request.py_seq_slot
 
         helix_is_inactive_rank, helix_position_offsets = [], []
+        # Cache invariant method result to avoid repeated calls per-request
+        _has_cp_helix = self.mapping.has_cp_helix()
+        _use_beam_search = self.use_beam_search
+        # Pre-extend constant-value lists to avoid per-request append overhead
+        # in the non-beam-search fast path (saves ~3 append calls x 271K requests).
+        # INVARIANT: These lists must not be modified between this extend() and
+        # the end of the generation loop below; the loop relies on these entries
+        # already being in place and skips appending to them.
+        _n_gen = len(generation_requests)
+        if not _use_beam_search and _n_gen > 0:
+            draft_lens.extend([0] * _n_gen)
+            sequence_lengths.extend([1] * _n_gen)
+            num_accepted_draft_tokens.extend([0] * _n_gen)
         for request in generation_requests:
             request_ids.append(request.py_request_id)
-            beam_width = request.sampling_config.beam_width
-            for beam in range(beam_width):
-                # the request has no previous tensor:
-                # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
-                # (2) a dummy request; or
-                # (3) the first step in the generation server of disaggregated serving
+            if _use_beam_search:
+                beam_width = request.sampling_config.beam_width
+                for beam in range(beam_width):
+                    # the request has no previous tensor:
+                    # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
+                    # (2) a dummy request; or
+                    # (3) the first step in the generation server of disaggregated serving
+                    if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
+                        # skip adding input_ids of CUDA graph dummy requests so that new_tokens_device
+                        # can be aligned to the correct positions.
+                        if not request.is_cuda_graph_dummy:
+                            # Track position for GPU update (draft model only)
+                            if self.is_draft_model and num_accepted_tokens_device is not None:
+                                start_idx = len(input_ids)
+                                input_ids.append(request.get_last_tokens(beam))
+                                end_idx = len(input_ids)
+                                slot_idx = req_id_to_old_request[
+                                    request.py_request_id].py_seq_slot
+                                first_draft_input_ids_positions.append(
+                                    (start_idx, end_idx, slot_idx))
+                            else:
+                                input_ids.append(request.get_last_tokens(beam))
+                        past_seen_token_num = request.max_beam_num_tokens - 1
+                    else:
+                        # the request has previous tensor
+                        # previous_batch_indices is used per request, not per beam
+                        # Only append it once for the first beam of each request
+                        if beam == 0:
+                            previous_batch_indices.append(request.py_batch_idx)
+                        past_seen_token_num = request.max_beam_num_tokens
+
+                    position_id = past_seen_token_num
+                    if _has_cp_helix:
+                        # We compute a global position_id because each helix rank has only a subset of
+                        # tokens for a sequence.
+                        position_id = request.total_input_len_cp + request.py_decoding_iter - 1
+                        if request.py_helix_is_inactive_rank:
+                            past_seen_token_num = request.seqlen_this_rank_cp
+                        else:
+                            # Discount the token added to active rank in resource manager as it hasn't
+                            # been previously seen.
+                            past_seen_token_num = request.seqlen_this_rank_cp - 1
+
+                        # Update helix-specific parameters.
+                        helix_is_inactive_rank.append(
+                            request.py_helix_is_inactive_rank)
+                        helix_position_offsets.append(position_id)
+
+                    position_ids.append(position_id)
+                    num_cached_tokens_per_seq.append(past_seen_token_num)
+                    request.cached_tokens = past_seen_token_num
+                    prompt_lengths.append(request.py_prompt_len)
+                    draft_lens.append(0)
+                    sequence_lengths.append(1)
+                    num_accepted_draft_tokens.append(0)
+                    gather_ids.append(len(position_ids) - 1)
+
+                    # Multimodal - skip construction when no multimodal data
+                    if request.py_multimodal_data:
+                        multimodal_params = MultimodalParams(
+                            multimodal_data=request.py_multimodal_data)
+                        multimodal_params.strip_for_generation()
+                        if multimodal_params.has_content():
+                            if self.use_mrope:
+                                mrope_position_deltas = multimodal_params.multimodal_data[
+                                    'mrope_config']['mrope_position_deltas']
+                                # NOTE: Expanding position_ids to 3D tensor who is using mrope
+                                gen_mrope_position_ids = (
+                                    past_seen_token_num +
+                                    mrope_position_deltas).expand(3, 1, 1)
+                                mrope_position_ids.append(
+                                    gen_mrope_position_ids)
+                                if mrope_position_deltas.device.type == "cpu":
+                                    multimodal_params.to_device(
+                                        "multimodal_data",
+                                        "cuda",
+                                        pin_memory=prefer_pinned(),
+                                        target_keywords=[
+                                            "mrope_config.mrope_position_deltas"
+                                        ])
+                                multimodal_params_list.append(multimodal_params)
+
+            else:
+                # Non-beam-search fast path: beam_width=1, beam=0
+                # Eliminates per-request beam_width access, range() creation,
+                # and always-true beam==0 check.
                 if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
-                    # skip adding input_ids of CUDA graph dummy requests so that new_tokens_device
-                    # can be aligned to the correct positions.
                     if not request.is_cuda_graph_dummy:
-                        # Track position for GPU update (draft model only)
                         if self.is_draft_model and num_accepted_tokens_device is not None:
                             start_idx = len(input_ids)
-                            input_ids.append(request.get_last_tokens(beam))
+                            input_ids.append(request.get_last_tokens(0))
                             end_idx = len(input_ids)
                             slot_idx = req_id_to_old_request[
                                 request.py_request_id].py_seq_slot
                             first_draft_input_ids_positions.append(
                                 (start_idx, end_idx, slot_idx))
                         else:
-                            input_ids.append(request.get_last_tokens(beam))
+                            input_ids.append(request.get_last_tokens(0))
                     past_seen_token_num = request.max_beam_num_tokens - 1
                 else:
-                    # the request has previous tensor
-                    # previous_batch_indices is used per request, not per beam
-                    # Only append it once for the first beam of each request
-                    first_beam = 0
-                    if beam == first_beam:
-                        previous_batch_indices.append(request.py_batch_idx)
+                    # previous_batch_indices is per-request (not per-beam);
+                    # beam == 0 always holds here, so append unconditionally.
+                    previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
 
                 position_id = past_seen_token_num
-                if self.mapping.has_cp_helix():
-                    # We compute a global position_id because each helix rank has only a subset of
-                    # tokens for a sequence.
+                if _has_cp_helix:
                     position_id = request.total_input_len_cp + request.py_decoding_iter - 1
                     if request.py_helix_is_inactive_rank:
                         past_seen_token_num = request.seqlen_this_rank_cp
                     else:
-                        # Discount the token added to active rank in resource manager as it hasn't
-                        # been previously seen.
                         past_seen_token_num = request.seqlen_this_rank_cp - 1
 
-                    # Update helix-specific parameters.
                     helix_is_inactive_rank.append(
                         request.py_helix_is_inactive_rank)
                     helix_position_offsets.append(position_id)
 
                 position_ids.append(position_id)
                 num_cached_tokens_per_seq.append(past_seen_token_num)
-                request.cached_tokens = num_cached_tokens_per_seq[-1]
+                request.cached_tokens = past_seen_token_num
                 prompt_lengths.append(request.py_prompt_len)
-                draft_lens.append(0)
-                sequence_lengths.append(1)
-                num_accepted_draft_tokens.append(0)
+                # draft_lens, sequence_lengths, num_accepted_draft_tokens
+                # are pre-extended before the loop (constant values)
                 gather_ids.append(len(position_ids) - 1)
 
-                # Multimodal
-                multimodal_params = MultimodalParams(
-                    multimodal_data=request.py_multimodal_data)
-                multimodal_params.strip_for_generation()
-                if multimodal_params.has_content():
-                    if self.use_mrope:
-                        mrope_position_deltas = multimodal_params.multimodal_data[
-                            'mrope_config']['mrope_position_deltas']
-                        # NOTE: Expanding position_ids to 3D tensor who is using mrope
-                        gen_mrope_position_ids = (past_seen_token_num +
-                                                  mrope_position_deltas).expand(
-                                                      3, 1, 1)
-                        mrope_position_ids.append(gen_mrope_position_ids)
-                        if mrope_position_deltas.device.type == "cpu":
-                            multimodal_params.to_device(
-                                "multimodal_data",
-                                "cuda",
-                                pin_memory=prefer_pinned(),
-                                target_keywords=[
-                                    "mrope_config.mrope_position_deltas"
-                                ])
+                if request.py_multimodal_data:
+                    multimodal_params = MultimodalParams(
+                        multimodal_data=request.py_multimodal_data)
+                    multimodal_params.strip_for_generation()
+                    if multimodal_params.has_content():
+                        if self.use_mrope:
+                            mrope_position_deltas = multimodal_params.multimodal_data[
+                                'mrope_config']['mrope_position_deltas']
+                            gen_mrope_position_ids = (
+                                past_seen_token_num +
+                                mrope_position_deltas).expand(3, 1, 1)
+                            mrope_position_ids.append(gen_mrope_position_ids)
+                            if mrope_position_deltas.device.type == "cpu":
+                                multimodal_params.to_device(
+                                    "multimodal_data",
+                                    "cuda",
+                                    pin_memory=prefer_pinned(),
+                                    target_keywords=[
+                                        "mrope_config.mrope_position_deltas"
+                                    ])
                         multimodal_params_list.append(multimodal_params)
 
             request.py_batch_idx = request.py_seq_slot
@@ -2934,10 +3018,7 @@ class PyTorchModelEngine(ModelEngine):
         self.iter_states['num_generation_tokens'] = num_generation_tokens
 
         if not self.is_warmup:
-            self.previous_request_ids = [
-                request.py_request_id
-                for request in scheduled_requests.generation_requests
-            ]
+            self.previous_request_ids = all_gen_request_ids
             self.has_previous_device_draft = next_draft_tokens_device is not None
 
         return inputs, self.gather_ids_cuda[:len(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1565,7 +1565,7 @@ class PyTorchModelEngine(ModelEngine):
                     ] * len(attn_all_rank_num_tokens)
                 else:
                     logger.debug(
-                        f"Not all ranks can run piecewise cuda graph, disable piecewise cuda graph"
+                        "Not all ranks can run piecewise cuda graph, disable piecewise cuda graph"
                     )
                     return total_num_tokens, False, attn_all_rank_num_tokens
             elif num_ctx_requests != 0 and total_num_tokens <= max_captured_num_tokens:
@@ -2429,30 +2429,28 @@ class PyTorchModelEngine(ModelEngine):
         helix_is_inactive_rank, helix_position_offsets = [], []
         # Cache invariant method result to avoid repeated calls per-request
         _has_cp_helix = self.mapping.has_cp_helix()
-        _use_beam_search = self.use_beam_search
-        # Pre-extend constant-value lists to avoid per-request append overhead
-        # in the non-beam-search fast path (saves ~3 append calls x 271K requests).
-        # INVARIANT: These lists must not be modified between this extend() and
-        # the end of the generation loop below; the loop relies on these entries
-        # already being in place and skips appending to them.
         _n_gen = len(generation_requests)
-        if not _use_beam_search and _n_gen > 0:
-            draft_lens.extend([0] * _n_gen)
-            sequence_lengths.extend([1] * _n_gen)
-            num_accepted_draft_tokens.extend([0] * _n_gen)
-        for request in generation_requests:
-            request_ids.append(request.py_request_id)
-            if _use_beam_search:
-                beam_width = request.sampling_config.beam_width
-                for beam in range(beam_width):
-                    # the request has no previous tensor:
-                    # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
-                    # (2) a dummy request; or
-                    # (3) the first step in the generation server of disaggregated serving
-                    if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
-                        # skip adding input_ids of CUDA graph dummy requests so that new_tokens_device
-                        # can be aligned to the correct positions.
-                        if not request.is_cuda_graph_dummy:
+        if _n_gen > 0:
+            # All generation requests have the same beam width
+            beam_width = generation_requests[0].sampling_config.beam_width
+
+            # Pre-extend constant-value lists to avoid per-request append
+            # overhead (saves ~3 append calls per request).
+            draft_lens.extend([0] * (_n_gen * beam_width))
+            sequence_lengths.extend([1] * (_n_gen * beam_width))
+            num_accepted_draft_tokens.extend([0] * (_n_gen * beam_width))
+
+            for request in generation_requests:
+                request_ids.append(request.py_request_id)
+                # the request has no previous tensor:
+                # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
+                # (2) a dummy request; or
+                # (3) the first step in the generation server of disaggregated serving
+                if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
+                    # skip adding input_ids of CUDA graph dummy requests so that new_tokens_device
+                    # can be aligned to the correct positions.
+                    if not request.is_cuda_graph_dummy:
+                        for beam in range(beam_width):
                             # Track position for GPU update (draft model only)
                             if self.is_draft_model and num_accepted_tokens_device is not None:
                                 start_idx = len(input_ids)
@@ -2464,109 +2462,39 @@ class PyTorchModelEngine(ModelEngine):
                                     (start_idx, end_idx, slot_idx))
                             else:
                                 input_ids.append(request.get_last_tokens(beam))
-                        past_seen_token_num = request.max_beam_num_tokens - 1
-                    else:
-                        # the request has previous tensor
-                        # previous_batch_indices is used per request, not per beam
-                        # Only append it once for the first beam of each request
-                        if beam == 0:
-                            previous_batch_indices.append(request.py_batch_idx)
-                        past_seen_token_num = request.max_beam_num_tokens
-
-                    position_id = past_seen_token_num
-                    if _has_cp_helix:
-                        # We compute a global position_id because each helix rank has only a subset of
-                        # tokens for a sequence.
-                        position_id = request.total_input_len_cp + request.py_decoding_iter - 1
-                        if request.py_helix_is_inactive_rank:
-                            past_seen_token_num = request.seqlen_this_rank_cp
-                        else:
-                            # Discount the token added to active rank in resource manager as it hasn't
-                            # been previously seen.
-                            past_seen_token_num = request.seqlen_this_rank_cp - 1
-
-                        # Update helix-specific parameters.
-                        helix_is_inactive_rank.append(
-                            request.py_helix_is_inactive_rank)
-                        helix_position_offsets.append(position_id)
-
-                    position_ids.append(position_id)
-                    num_cached_tokens_per_seq.append(past_seen_token_num)
-                    request.cached_tokens = past_seen_token_num
-                    prompt_lengths.append(request.py_prompt_len)
-                    draft_lens.append(0)
-                    sequence_lengths.append(1)
-                    num_accepted_draft_tokens.append(0)
-                    gather_ids.append(len(position_ids) - 1)
-
-                    # Multimodal - skip construction when no multimodal data
-                    if request.py_multimodal_data:
-                        multimodal_params = MultimodalParams(
-                            multimodal_data=request.py_multimodal_data)
-                        multimodal_params.strip_for_generation()
-                        if multimodal_params.has_content():
-                            if self.use_mrope:
-                                mrope_position_deltas = multimodal_params.multimodal_data[
-                                    'mrope_config']['mrope_position_deltas']
-                                # NOTE: Expanding position_ids to 3D tensor who is using mrope
-                                gen_mrope_position_ids = (
-                                    past_seen_token_num +
-                                    mrope_position_deltas).expand(3, 1, 1)
-                                mrope_position_ids.append(
-                                    gen_mrope_position_ids)
-                                if mrope_position_deltas.device.type == "cpu":
-                                    multimodal_params.to_device(
-                                        "multimodal_data",
-                                        "cuda",
-                                        pin_memory=prefer_pinned(),
-                                        target_keywords=[
-                                            "mrope_config.mrope_position_deltas"
-                                        ])
-                                multimodal_params_list.append(multimodal_params)
-
-            else:
-                # Non-beam-search fast path: beam_width=1, beam=0
-                # Eliminates per-request beam_width access, range() creation,
-                # and always-true beam==0 check.
-                if new_tokens_device is None or request.is_dummy or request.py_batch_idx is None:
-                    if not request.is_cuda_graph_dummy:
-                        if self.is_draft_model and num_accepted_tokens_device is not None:
-                            start_idx = len(input_ids)
-                            input_ids.append(request.get_last_tokens(0))
-                            end_idx = len(input_ids)
-                            slot_idx = req_id_to_old_request[
-                                request.py_request_id].py_seq_slot
-                            first_draft_input_ids_positions.append(
-                                (start_idx, end_idx, slot_idx))
-                        else:
-                            input_ids.append(request.get_last_tokens(0))
                     past_seen_token_num = request.max_beam_num_tokens - 1
                 else:
-                    # previous_batch_indices is per-request (not per-beam);
-                    # beam == 0 always holds here, so append unconditionally.
+                    # the request has previous tensor
+                    # previous_batch_indices is per-request, not per-beam
                     previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
 
                 position_id = past_seen_token_num
                 if _has_cp_helix:
+                    # We compute a global position_id because each helix rank has only a subset of
+                    # tokens for a sequence.
                     position_id = request.total_input_len_cp + request.py_decoding_iter - 1
                     if request.py_helix_is_inactive_rank:
                         past_seen_token_num = request.seqlen_this_rank_cp
                     else:
+                        # Discount the token added to active rank in resource manager as it hasn't
+                        # been previously seen.
                         past_seen_token_num = request.seqlen_this_rank_cp - 1
 
-                    helix_is_inactive_rank.append(
-                        request.py_helix_is_inactive_rank)
-                    helix_position_offsets.append(position_id)
+                    for beam in range(beam_width):
+                        # Update helix-specific parameters.
+                        helix_is_inactive_rank.append(
+                            request.py_helix_is_inactive_rank)
+                        helix_position_offsets.append(position_id)
 
-                position_ids.append(position_id)
-                num_cached_tokens_per_seq.append(past_seen_token_num)
                 request.cached_tokens = past_seen_token_num
-                prompt_lengths.append(request.py_prompt_len)
-                # draft_lens, sequence_lengths, num_accepted_draft_tokens
-                # are pre-extended before the loop (constant values)
-                gather_ids.append(len(position_ids) - 1)
+                for beam in range(beam_width):
+                    position_ids.append(position_id)
+                    num_cached_tokens_per_seq.append(past_seen_token_num)
+                    prompt_lengths.append(request.py_prompt_len)
+                    gather_ids.append(len(position_ids) - 1)
 
+                # Multimodal
                 if request.py_multimodal_data:
                     multimodal_params = MultimodalParams(
                         multimodal_data=request.py_multimodal_data)
@@ -2575,10 +2503,10 @@ class PyTorchModelEngine(ModelEngine):
                         if self.use_mrope:
                             mrope_position_deltas = multimodal_params.multimodal_data[
                                 'mrope_config']['mrope_position_deltas']
+                            # NOTE: Expanding position_ids to 3D tensor who is using mrope
                             gen_mrope_position_ids = (
                                 past_seen_token_num +
                                 mrope_position_deltas).expand(3, 1, 1)
-                            mrope_position_ids.append(gen_mrope_position_ids)
                             if mrope_position_deltas.device.type == "cpu":
                                 multimodal_params.to_device(
                                     "multimodal_data",
@@ -2587,13 +2515,16 @@ class PyTorchModelEngine(ModelEngine):
                                     target_keywords=[
                                         "mrope_config.mrope_position_deltas"
                                     ])
-                        multimodal_params_list.append(multimodal_params)
+                            for beam in range(beam_width):
+                                mrope_position_ids.append(
+                                    gen_mrope_position_ids)
+                                multimodal_params_list.append(multimodal_params)
 
-            request.py_batch_idx = request.py_seq_slot
-            # Do not add a gen_request_seq_slot for CUDA graph dummy requests
-            # to prevent access errors due to None values
-            if not request.is_cuda_graph_dummy:
-                gen_request_seq_slots.append(request.py_seq_slot)
+                request.py_batch_idx = request.py_seq_slot
+                # Do not add a gen_request_seq_slot for CUDA graph dummy requests
+                # to prevent access errors due to None values
+                if not request.is_cuda_graph_dummy:
+                    gen_request_seq_slots.append(request.py_seq_slot)
 
         previous_batch_len = len(previous_batch_indices)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multimodal data handling in generation pipelines.

* **Performance Improvements**
  * Optimized input preparation through caching and pre-computation.
  * Enhanced beam search execution path efficiency.
  * Improved handling of generation request processing with streamlined state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->                                                                                                                                                                                                                                                                                                                                                                                                   
  Workload

  - Model: Llama 3.1 8B, TP=4, B200 GPUs
  - Benchmark: ISL=1024, OSL=1024, concurrency=128, 256 requests
  - Target: PyTorchModelEngine._prepare_tp_inputs in model_engine.py                                                                                                                                                                             
  Results by Round                                                                                                                                                                                                                            
  
  ┌──────────┬─────────────────────────┬────────────────┬──────────────────────┐
  │  Round   │ _prepare_tp_inputs Time │   Reduction    │ Cumulative Reduction │
  ├──────────┼─────────────────────────┼────────────────┼──────────────────────┤
  │ Baseline │ 57.69s                  │ —              │ —                    │
  ├──────────┼─────────────────────────┼────────────────┼──────────────────────┤
  │ Round 1  │ 47.69s                  │ -10.0s (17.3%) │ -17.3%               │
  ├──────────┼─────────────────────────┼────────────────┼──────────────────────┤
  │ Round 2  │ 41.13s                  │ -6.56s (13.7%) │ -28.7%               │
  ├──────────┼─────────────────────────┼────────────────┼──────────────────────┤
  │ Round 3  │ 40.13s                  │ -1.0s (2.4%)   │ -30.4%               │
  └──────────┴─────────────────────────┴────────────────┴──────────────────────┘

  Benchmark Performance Improvement

  ┌───────────────────────────┬──────────┬────────┬─────────────┐
  │          Metric           │ Baseline │ Final  │ Improvement │
  ├───────────────────────────┼──────────┼────────┼─────────────┤
  │ Mean TPOT (ms)            │ 37.37    │ 28.91  │ -22.6%      │
  ├───────────────────────────┼──────────┼────────┼─────────────┤
  │ Output throughput (tok/s) │ ~3200*   │ 3799   │ +18.7%      │
  ├───────────────────────────┼──────────┼────────┼─────────────┤
  │ Mean ITL (ms)             │ 371.14   │ 287.11 │ -22.6%      │
  ├───────────────────────────┼──────────┼────────┼─────────────┤
  │ Mean E2EL (ms)            │ 40374    │ 31351  │ -22.3%      │
  └───────────────────────────┴──────────┴────────┴─────────────┘

  *Baseline throughput estimated from corresponding TPOT reduction.

  Optimizations Applied

  Round 1: Eliminate redundant previous_request_ids list comprehension (-10.0s)

  - Problem: At line 2876-2879, a list comprehension iterated over all 279K generation requests every iteration to build previous_request_ids, even though the same requests were already iterated over earlier in the categorization loop.   
  - Fix: Collected all_gen_request_ids during the existing categorization loop at line 2192 and reused it at line 2880 via simple reference assignment.
  - File: model_engine.py:2192-2196 and model_engine.py:2880

  Round 2: Skip MultimodalParams construction for text-only requests (-6.56s)

  - Problem: At line 2436-2439, every generation request created a MultimodalParams object, called strip_for_generation(), and checked has_content() — even for text-only models like Llama where multimodal data is always empty.
  - Fix: Added guard if request.py_multimodal_data: before MultimodalParams construction. For text-only models, this skips all three operations entirely.
  - File: model_engine.py:2436-2440

  Round 3: Cache invariant method call + simplify constant comparison (-1.0s)

  - Problem: self.mapping.has_cp_helix() was called per-request (279K times) despite always returning the same value. Also first_beam = 0; if beam == first_beam: created a redundant variable assignment every iteration.
  - Fix: Cached _has_cp_helix = self.mapping.has_cp_helix() before the loop. Replaced first_beam = 0; if beam == first_beam: with if beam == 0:.
  - Note: An attempted optimization of the beam_width access using a ternary expression was reverted because the CPython conditional expression overhead was higher than the attribute access it replaced.
  - File: model_engine.py:2377 and model_engine.py:2407

  Remaining Hotspots

  The generation request loop still dominates (~35s) due to the fundamental overhead of ~20 Python operations per request across 279K requests. Each operation costs ~5µs in CPython interpreter overhead. Further optimization would require:
  1. C extension / Cython: Moving the inner loop to compiled code
  2. Vectorized batch construction: Building arrays (position_ids, prompt_lengths, etc.) using NumPy/Torch operations instead of per-element Python appends
  3. Request struct-of-arrays: Storing request data in columnar format to enable batch operations

● All 3 rounds complete. The total cumulative improvement is 30.4% reduction in _prepare_tp_inputs time and 22.6% improvement in Mean TPOT (time per output token), achieved through eliminating redundant iterations, skipping unnecessary     object construction, and caching invariant method calls.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
