### PR TITLE
[TRTLLM-11163][feat] Introduce a fast path (token IDs + MM) for VLMs instead of de-tokenizing already encoded prompt

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -95,6 +95,46 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         image_token = processor.image_token
         return image_token * num_images
 
+    def _expand_image_placeholders_in_token_ids(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_image: List[int],
+    ) -> Tuple[List[int], List[int], List[int]]:
+        """
+        Shared logic: replace each image placeholder token in prompt_token_ids
+        with placeholder_id repeated num_mm_tokens_per_image[i] times.
+
+        Returns:
+            (expanded_ids, mm_token_length, mm_token_offsets)
+        """
+        image_token_id = self.config.image_token_index
+        placeholder_id = self.vocab_size + 1
+
+        expanded: List[int] = []
+        mm_token_length: List[int] = []
+        mm_token_offsets: List[int] = []
+        image_idx = 0
+        for tok in prompt_token_ids:
+            if tok == image_token_id:
+                if image_idx >= len(num_mm_tokens_per_image):
+                    raise ValueError(
+                        "More image placeholder tokens in prompt than "
+                        "num_mm_tokens_per_image entries")
+                n = num_mm_tokens_per_image[image_idx]
+                mm_token_offsets.append(len(expanded))
+                expanded.extend([placeholder_id] * n)
+                mm_token_length.append(n)
+                image_idx += 1
+            else:
+                expanded.append(tok)
+
+        if image_idx != len(num_mm_tokens_per_image):
+            raise ValueError(
+                f"Expected {len(num_mm_tokens_per_image)} image placeholders, "
+                f"found {image_idx}. Ensure the prompt contains the model image "
+                f"placeholder (token id {image_token_id}).")
+        return expanded, mm_token_length, mm_token_offsets
+
     def expand_prompt_token_ids_for_mm(
         self,
         prompt_token_ids: List[int],
@@ -107,29 +147,8 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
 
         hf_processor_mm_kwargs is optional; LLaVA does not use it for expansion.
         """
-        image_token_id = self.config.image_token_index
-        vocab_size = self.config.vocab_size
-        placeholder_id = vocab_size + 1
-
-        expanded: List[int] = []
-        image_idx = 0
-        for tok in prompt_token_ids:
-            if tok == image_token_id:
-                if image_idx >= len(num_mm_tokens_per_image):
-                    raise ValueError(
-                        "More image placeholder tokens in prompt than "
-                        "num_mm_tokens_per_image entries")
-                n = num_mm_tokens_per_image[image_idx]
-                expanded.extend([placeholder_id] * n)
-                image_idx += 1
-            else:
-                expanded.append(tok)
-
-        if image_idx != len(num_mm_tokens_per_image):
-            raise ValueError(
-                f"Expected {len(num_mm_tokens_per_image)} image placeholders, "
-                f"found {image_idx}. Ensure the prompt contains the model image "
-                f"placeholder (token id {image_token_id}).")
+        expanded, _, _ = self._expand_image_placeholders_in_token_ids(
+            prompt_token_ids, num_mm_tokens_per_image)
         return expanded
 
     def _postprocess(
@@ -215,14 +234,16 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         return fused_input_ids, mm_features
 
     def get_prompt_token_ids(
-        self, inputs: TextPrompt,
+        self, prompt_token_ids: List[int],
         mm_handles: List[Dict[str,
                               Any]]) -> Tuple[List[int], List[int], List[int]]:
         """
         Build input token ids with multimodal placeholders expanded to the number of MM tokens.
 
+        Uses an already tokenized prompt. Delegates expansion to _expand_image_placeholders_in_token_ids.
+
         Args:
-            inputs: Text prompt input container. Must contain a non-empty prompt string.
+            prompt_token_ids: An already tokenized text prompt.
             mm_handles: List of multimodal embedding handles.
 
         Returns:
@@ -231,11 +252,6 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 - mm_token_length: per-image MM token lengths
                 - mm_token_offsets: start offsets (positions) for each image's MM tokens within expanded_ids
         """
-        # TODO: Move this function to the base input processor class when extending for more models
-        text_prompt = inputs.get("prompt")
-        if not text_prompt:
-            raise ValueError("Text prompt is required but not provided")
-
         if not isinstance(mm_handles, list):
             raise ValueError("mm_handles must be a list")
 
@@ -246,49 +262,27 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 raise RuntimeError(
                     f"Multimodal embedding {i} hidden size {hidden_size} must match model hidden size {expected_hidden_size}"
                 )
-        input_ids = self.tokenizer(text_prompt,
-                                   return_tensors="pt").input_ids[0]
 
-        vocab_size = self.config.text_config.vocab_size
-        image_token_index = self.config.image_token_index
+        num_mm_tokens_per_image = [h["tensor_size"][0] for h in mm_handles]
+        expanded_ids, mm_token_length, mm_token_offsets = (
+            self._expand_image_placeholders_in_token_ids(
+                prompt_token_ids, num_mm_tokens_per_image))
 
-        image_mask = input_ids == image_token_index
-        image_positions = torch.where(image_mask)[0]
-        num_images = len(image_positions)
-        assert num_images == len(
-            mm_handles), "Number of images must match number of mm_handles"
-        total_mm_tokens = sum(mm_handle["tensor_size"][0]
-                              for mm_handle in mm_handles)
-        final_length = len(input_ids) - num_images + total_mm_tokens
-        # Create output tensor
-        expanded_ids = torch.empty(final_length, dtype=input_ids.dtype)
-        placeholder_id = vocab_size + 1
-
-        # Fill the expanded sequence
-        write_pos = 0
-        image_cnt = 0
-        mm_token_length = []
-        mm_token_offsets = []
-        for read_pos in range(len(input_ids)):
-            if input_ids[read_pos] == image_token_index:
-                # Replace with placeholder id
-                mm_token_num = mm_handles[image_cnt]["tensor_size"][0]
-                expanded_ids[write_pos:write_pos + mm_token_num] = \
-                    placeholder_id
-                mm_token_offsets.append(write_pos)
-                mm_token_length.append(mm_token_num)
-                write_pos += mm_token_num
-                image_cnt += 1
-            else:
-                # Copy text token as-is
-                expanded_ids[write_pos] = input_ids[read_pos]
-                write_pos += 1
-
-        assert write_pos == final_length, f"Write position mismatch: {write_pos} != {final_length}"
-        assert mm_token_length[-1] + mm_token_offsets[
-            -1] <= final_length, f"mm_token_length[-1] + mm_token_offsets[-1] ({mm_token_length[-1] + mm_token_offsets[-1]}) should be less than or equal to final_length ({final_length})"
-        return expanded_ids.to(
-            torch.int32).tolist(), mm_token_length, mm_token_offsets
+        # Final assertions to check the correctness of the expanded ids.
+        final_length = len(expanded_ids)
+        expected_final_length = (len(prompt_token_ids) -
+                                 len(num_mm_tokens_per_image) +
+                                 sum(num_mm_tokens_per_image))
+        assert final_length == expected_final_length, (
+            f"Write position mismatch: {final_length} != {expected_final_length}"
+        )
+        if mm_token_length:
+            assert mm_token_length[-1] + mm_token_offsets[-1] <= final_length, (
+                f"mm_token_length[-1] + mm_token_offsets[-1] "
+                f"({mm_token_length[-1] + mm_token_offsets[-1]}) should be less "
+                f"than or equal to final_length ({final_length})")
+        logger.info(f"expanded_ids: {expanded_ids}")
+        return expanded_ids, mm_token_length, mm_token_offsets
 
     def attach_multimodal_embeddings(
         self, inputs: TextPrompt,

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -86,7 +86,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
     def dtype(self) -> torch.dtype:
         return self._dtype
 
-    def get_dummy_text(self, mm_counts: Dict[str, int]) -> str:
+    def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
         """
         Return minimal placeholder text for tokenized + MM path.
         """
@@ -98,11 +98,11 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
     def _expand_image_placeholders_in_token_ids(
         self,
         prompt_token_ids: List[int],
-        num_mm_tokens_per_image: List[int],
+        num_mm_tokens_per_placeholder: List[int],
     ) -> Tuple[List[int], List[int], List[int]]:
         """
         Shared logic: replace each image placeholder token in prompt_token_ids
-        with placeholder_id repeated num_mm_tokens_per_image[i] times.
+        with placeholder_id repeated num_mm_tokens_per_placeholder[i] times.
 
         Returns:
             (expanded_ids, mm_token_length, mm_token_offsets)
@@ -116,11 +116,11 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         image_idx = 0
         for tok in prompt_token_ids:
             if tok == image_token_id:
-                if image_idx >= len(num_mm_tokens_per_image):
+                if image_idx >= len(num_mm_tokens_per_placeholder):
                     raise ValueError(
                         "More image placeholder tokens in prompt than "
-                        "num_mm_tokens_per_image entries")
-                n = num_mm_tokens_per_image[image_idx]
+                        "num_mm_tokens_per_placeholder entries")
+                n = num_mm_tokens_per_placeholder[image_idx]
                 mm_token_offsets.append(len(expanded))
                 expanded.extend([placeholder_id] * n)
                 mm_token_length.append(n)
@@ -128,9 +128,9 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
             else:
                 expanded.append(tok)
 
-        if image_idx != len(num_mm_tokens_per_image):
+        if image_idx != len(num_mm_tokens_per_placeholder):
             raise ValueError(
-                f"Expected {len(num_mm_tokens_per_image)} image placeholders, "
+                f"Expected {len(num_mm_tokens_per_placeholder)} image placeholders, "
                 f"found {image_idx}. Ensure the prompt contains the model image "
                 f"placeholder (token id {image_token_id}).")
         return expanded, mm_token_length, mm_token_offsets
@@ -138,7 +138,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
     def expand_prompt_token_ids_for_mm(
         self,
         prompt_token_ids: List[int],
-        num_mm_tokens_per_image: List[int],
+        num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[int]:
         """
@@ -148,7 +148,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         hf_processor_mm_kwargs is optional; LLaVA does not use it for expansion.
         """
         expanded, _, _ = self._expand_image_placeholders_in_token_ids(
-            prompt_token_ids, num_mm_tokens_per_image)
+            prompt_token_ids, num_mm_tokens_per_placeholder)
         return expanded
 
     def _postprocess(
@@ -281,7 +281,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 f"mm_token_length[-1] + mm_token_offsets[-1] "
                 f"({mm_token_length[-1] + mm_token_offsets[-1]}) should be less "
                 f"than or equal to final_length ({final_length})")
-        logger.info(f"expanded_ids: {expanded_ids}")
+
         return expanded_ids, mm_token_length, mm_token_offsets
 
     def attach_multimodal_embeddings(

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -86,6 +86,52 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
     def dtype(self) -> torch.dtype:
         return self._dtype
 
+    def get_dummy_text(self, mm_counts: Dict[str, int]) -> str:
+        """
+        Return minimal placeholder text for tokenized + MM path.
+        """
+        num_images = mm_counts.get("image", 0)
+        processor = self.processor
+        image_token = processor.image_token
+        return image_token * num_images
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_image: List[int],
+        hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> List[int]:
+        """
+        Apply prompt update: replace each single image token in prompt_token_ids
+        with the corresponding number of MM placeholder tokens.
+
+        hf_processor_mm_kwargs is optional; LLaVA does not use it for expansion.
+        """
+        image_token_id = self.config.image_token_index
+        vocab_size = self.config.vocab_size
+        placeholder_id = vocab_size + 1
+
+        expanded: List[int] = []
+        image_idx = 0
+        for tok in prompt_token_ids:
+            if tok == image_token_id:
+                if image_idx >= len(num_mm_tokens_per_image):
+                    raise ValueError(
+                        "More image placeholder tokens in prompt than "
+                        "num_mm_tokens_per_image entries")
+                n = num_mm_tokens_per_image[image_idx]
+                expanded.extend([placeholder_id] * n)
+                image_idx += 1
+            else:
+                expanded.append(tok)
+
+        if image_idx != len(num_mm_tokens_per_image):
+            raise ValueError(
+                f"Expected {len(num_mm_tokens_per_image)} image placeholders, "
+                f"found {image_idx}. Ensure the prompt contains the model image "
+                f"placeholder (token id {image_token_id}).")
+        return expanded
+
     def _postprocess(
         self, input_ids: torch.Tensor, mm_features: Union[torch.Tensor,
                                                           List[torch.Tensor]]
@@ -255,17 +301,13 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         It replaces/expands image placeholders in the text with appropriate tokens and prepares
         the embeddings for model forward pass.
         Args:
-            inputs: Text prompt containing image placeholders
+            inputs: Text prompt containing image placeholders, or prompt_token_ids (list of int)
             multimodal_embedding: Dictionary containing pre-processed image embedding data
         Returns:
             Tuple of (token_ids, extra_processed_inputs) where:
             - token_ids: List of processed token IDs with image placeholders
             - extra_processed_inputs: Optional dictionary containing multimodal embeddings
         """
-        text_prompt = inputs.get("prompt")
-        if not text_prompt:
-            raise ValueError("Text prompt is required but not provided")
-
         if not isinstance(multimodal_embedding, dict):
             raise ValueError("multimodal_embedding must be a dictionary")
 
@@ -274,9 +316,19 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 "Only image modality is supported for external multimodal embedding"
             )
 
-        input_ids = self.tokenizer(text_prompt,
-                                   return_tensors="pt").input_ids[0]
-        mm_features = multimodal_embedding['image']
+        prompt_token_ids = inputs.get("prompt_token_ids")
+        if prompt_token_ids is not None:
+            # Token IDs already provided (e.g. tokenized+MM path): use directly, skip tokenization.
+            input_ids = torch.tensor(prompt_token_ids, dtype=torch.long)
+        else:
+            text_prompt = inputs.get("prompt")
+            if not text_prompt:
+                raise ValueError(
+                    "Either 'prompt' (text) or 'prompt_token_ids' is required")
+            input_ids = self.tokenizer(text_prompt,
+                                       return_tensors="pt").input_ids[0]
+
+        mm_features = multimodal_embedding["image"]
         fused_input_ids, mm_features = self._postprocess(input_ids, mm_features)
         multimodal_data = {}
         multimodal_data["multimodal_embedding"] = mm_features

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -111,17 +111,20 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         num_mm_tokens_per_placeholder: List[int],
     ) -> Tuple[List[int], List[int], List[int]]:
         """
-        Shared logic: replace each image placeholder token in prompt_token_ids
+        Shared logic (called by expand_prompt_token_ids_for_mm and get_prompt_token_ids):
+        replace each image placeholder token in prompt_token_ids
         with placeholder_id repeated num_mm_tokens_per_placeholder[i] times.
 
         Returns:
-            (expanded_ids, mm_token_length, mm_token_offsets)
+            expanded_ids (List[int]): The new prompt token IDs with each image placeholder replaced by the correct number of MM tokens.
+            mm_token_lengths (List[int]): Number of MM tokens inserted for each placeholder, in order.
+            mm_token_offsets (List[int]): Offset (position) in the expanded sequence where each MM token group (for each placeholder) begins.
         """
         image_token_id = self.config.image_token_index
         placeholder_id = self.vocab_size + 1
 
         expanded: List[int] = []
-        mm_token_length: List[int] = []
+        mm_token_lengths: List[int] = []
         mm_token_offsets: List[int] = []
         image_idx = 0
         for tok in prompt_token_ids:
@@ -129,11 +132,14 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 if image_idx >= len(num_mm_tokens_per_placeholder):
                     raise ValueError(
                         "More image placeholder tokens in prompt than "
-                        "num_mm_tokens_per_placeholder entries")
+                        "num_mm_tokens_per_placeholder entries: "
+                        f"found {image_idx + 1} placeholders, "
+                        f"num_mm_tokens_per_placeholder has {len(num_mm_tokens_per_placeholder)} entries."
+                    )
                 n = num_mm_tokens_per_placeholder[image_idx]
                 mm_token_offsets.append(len(expanded))
                 expanded.extend([placeholder_id] * n)
-                mm_token_length.append(n)
+                mm_token_lengths.append(n)
                 image_idx += 1
             else:
                 expanded.append(tok)
@@ -143,7 +149,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 f"Expected {len(num_mm_tokens_per_placeholder)} image placeholders, "
                 f"found {image_idx}. Ensure the prompt contains the model image "
                 f"placeholder (token id {image_token_id}).")
-        return expanded, mm_token_length, mm_token_offsets
+        return expanded, mm_token_lengths, mm_token_offsets
 
     def expand_prompt_token_ids_for_mm(
         self,
@@ -265,7 +271,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         """
         Build input token ids with multimodal placeholders expanded to the number of MM tokens.
 
-        Uses an already tokenized prompt or tokenizes the txt prompt first. Delegates expansion to _expand_image_placeholders_in_token_ids.
+        Uses an already tokenized prompt or tokenizes the txt prompt first.
 
         Args:
             inputs: Inputs containing an already tokenized text prompt or a text prompt string.
@@ -283,9 +289,9 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         if text_prompt:
             prompt_token_ids = self.tokenizer(
                 text_prompt, return_tensors="pt").input_ids[0].tolist()
-        elif not prompt_token_ids and not text_prompt:
+        elif not prompt_token_ids:
             raise ValueError(
-                "Text prompt or token IDs are required but not provided")
+                "Text prompt or token IDs are required but neither is provided")
 
         if not isinstance(mm_handles, list):
             raise ValueError("mm_handles must be a list")

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -20,7 +20,7 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
                        BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        MultimodalPlaceholderMetadata,
-                       MultimodalPlaceholderPlacement, TextPrompt,
+                       MultimodalPlaceholderPlacement, TextPrompt, TokensPrompt,
                        register_input_processor,
                        support_multimodal_disaggregated)
 from ...logger import logger
@@ -259,16 +259,16 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         return fused_input_ids, mm_features
 
     def get_prompt_token_ids(
-        self, prompt_token_ids: List[int],
+        self, inputs: Union[TextPrompt, TokensPrompt],
         mm_handles: List[Dict[str,
                               Any]]) -> Tuple[List[int], List[int], List[int]]:
         """
         Build input token ids with multimodal placeholders expanded to the number of MM tokens.
 
-        Uses an already tokenized prompt. Delegates expansion to _expand_image_placeholders_in_token_ids.
+        Uses an already tokenized prompt or tokenizes the txt prompt first. Delegates expansion to _expand_image_placeholders_in_token_ids.
 
         Args:
-            prompt_token_ids: An already tokenized text prompt.
+            inputs: Inputs containing an already tokenized text prompt or a text prompt string.
             mm_handles: List of multimodal embedding handles.
 
         Returns:
@@ -277,6 +277,16 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 - mm_token_length: per-image MM token lengths
                 - mm_token_offsets: start offsets (positions) for each image's MM tokens within expanded_ids
         """
+        # TODO: Move this function to the base input processor class when extending for more models
+        text_prompt = inputs.get("prompt")
+        prompt_token_ids = inputs.get("prompt_token_ids")
+        if text_prompt:
+            prompt_token_ids = self.tokenizer(
+                text_prompt, return_tensors="pt").input_ids[0].tolist()
+        elif not prompt_token_ids and not text_prompt:
+            raise ValueError(
+                "Text prompt or token IDs are required but not provided")
+
         if not isinstance(mm_handles, list):
             raise ValueError("mm_handles must be a list")
 

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -88,7 +88,17 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
 
     def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
         """
-        Return minimal placeholder text for tokenized + MM path.
+        Return minimal placeholder text for the given multimodal item counts,
+        so that the HF processor can be called with (dummy_text, mm_data) without error.
+        Used when processing tokenized prompt + MM data.
+
+        Args:
+            mm_counts (Dict[str, int]): A mapping of each multimodal modality name (e.g., 'image', 'video')
+                to the count of items for that modality that need corresponding placeholders in the dummy text.
+
+        Returns:
+            str: A minimal placeholder string containing the correct number and type of multimodal placeholders,
+                suitable for passing along with mm_data to the Hugging Face processor.
         """
         num_images = mm_counts.get("image", 0)
         processor = self.processor
@@ -142,10 +152,25 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[int]:
         """
-        Apply prompt update: replace each single image token in prompt_token_ids
-        with the corresponding number of MM placeholder tokens.
+        Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
+        is replaced by the corresponding number of multimodal feature tokens.
 
-        hf_processor_mm_kwargs is optional; LLaVA does not use it for expansion.
+        This is used when processing a tokenized prompt plus multimodal data, without calling the full
+        HuggingFace processor.
+
+        Subclasses that require the HuggingFace processor or feature extractor (for example,
+        to determine image-size-dependent token counts) can use `hf_processor_mm_kwargs` if provided.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with image placeholder tokens.
+            num_mm_tokens_per_placeholder (List[int]): For each MM placeholder in prompt_token_ids,
+                specifies the number of MM feature tokens to expand/repeat for that placeholder.
+            hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional dictionary of arguments
+                to pass to the HuggingFace processor, if needed for token expansion.
+
+        Returns:
+            List[int]: The prompt token IDs where each MM placeholder token has been
+                replaced/expanded with the appropriate number of MM feature tokens.
         """
         expanded, _, _ = self._expand_image_placeholders_in_token_ids(
             prompt_token_ids, num_mm_tokens_per_placeholder)

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -692,6 +692,8 @@ def _get_single_mm_token_lengths(
 ) -> Optional[List[int]]:
     """Get the single set of MM token lengths (first value from find_mm_token_lengths). Returns None if empty."""
     num_mm_tokens_by_key = find_mm_token_lengths(mm_data, input_processor)
+    if not num_mm_tokens_by_key:
+        return None
     # find_mm_token_lengths returns Dict[modality, List[int]], e.g. {"image": [2928, 2928]}.
     # We need the list of per-item lengths (for find_mm_token_positions), We take the first modality's
     # list; multi-modality is not yet supported (see TODO in multimodal_hashing_process).

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -126,6 +126,12 @@ class BaseMultimodalInputProcessor(ABC):
 
     This class provides default implementations that work with most AutoProcessor-based
     models. Specific processors can override these methods if they need custom logic.
+
+    Optional tokenized+MM fast path: to support prompt_token_ids + multi_modal_data
+    without detokenizing, implement get_text_with_mm_placeholders(mm_counts) and
+    expand_prompt_token_ids_for_mm(prompt_token_ids, num_mm_tokens_per_placeholder, ...).
+    If these are not implemented, the pipeline detokenizes the text prompt first and then
+    processes the multimodal inputs.
     """
 
     def __init__(self,
@@ -253,65 +259,6 @@ class BaseMultimodalInputProcessor(ABC):
         so they need to be returned separately.
         """
         return getattr(self.processor, "mm_special_token_ids", None)
-
-    def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
-        """
-        Return minimal placeholder text for the given multimodal item counts,
-        so that the HF processor can be called with (dummy_text, mm_data) without error.
-        Used when processing tokenized prompt + MM data.
-
-        Args:
-            mm_counts (Dict[str, int]): A mapping of each multimodal modality name (e.g., 'image', 'video')
-                to the count of items for that modality that need corresponding placeholders in the dummy text.
-
-        Returns:
-            str: A minimal placeholder string containing the correct number and type of multimodal placeholders,
-                suitable for passing along with mm_data to the Hugging Face processor.
-
-        Default raises NotImplementedError. Override in model-specific processors
-        that support the token_ids + multi_modal_data path.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support token_ids + multi_modal_data "
-            "without detokenization. Implement get_text_with_mm_placeholders(mm_counts) to enable it."
-        )
-
-    def expand_prompt_token_ids_for_mm(
-        self,
-        prompt_token_ids: List[int],
-        num_mm_tokens_per_placeholder: List[int],
-        hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> List[int]:
-        """
-        Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
-        is replaced by the corresponding number of multimodal feature tokens.
-
-        This is used when processing a tokenized prompt plus multimodal data, without calling the full
-        HuggingFace processor.
-
-        Subclasses that require the HuggingFace processor or feature extractor (for example,
-        to determine image-size-dependent token counts) can use `hf_processor_mm_kwargs` if provided.
-
-        Args:
-            prompt_token_ids (List[int]): The input prompt token IDs with image placeholder tokens.
-            num_mm_tokens_per_placeholder (List[int]): For each MM placeholder in prompt_token_ids,
-                specifies the number of MM feature tokens to expand/repeat for that placeholder.
-            hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional dictionary of arguments
-                to pass to the HuggingFace processor, if needed for token expansion.
-
-        Returns:
-            List[int]: The prompt token IDs where each MM placeholder token has been
-                replaced/expanded with the appropriate number of MM feature tokens.
-
-        Raises:
-            NotImplementedError: If the method is not implemented in the subclass.
-
-        Default implementation raises NotImplementedError. Override in model-specific processors.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support expand_prompt_token_ids_for_mm. "
-            "Implement it to enable token_ids + multi_modal_data without detokenization."
-        )
 
     @property
     def get_num_multimodal_tokens(self):

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -254,35 +254,59 @@ class BaseMultimodalInputProcessor(ABC):
         """
         return getattr(self.processor, "mm_special_token_ids", None)
 
-    def get_dummy_text(self, mm_counts: Dict[str, int]) -> str:
+    def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
         """
         Return minimal placeholder text for the given multimodal item counts,
         so that the HF processor can be called with (dummy_text, mm_data) without error.
-        Used when processing tokenized prompt + MM data without detokenizing (token IDs path).
+        Used when processing tokenized prompt + MM data.
+
+        Args:
+            mm_counts (Dict[str, int]): A mapping of each multimodal modality name (e.g., 'image', 'video')
+                to the count of items for that modality that need corresponding placeholders in the dummy text.
+
+        Returns:
+            str: A minimal placeholder string containing the correct number and type of multimodal placeholders,
+                suitable for passing along with mm_data to the Hugging Face processor.
 
         Default raises NotImplementedError. Override in model-specific processors
         that support the token_ids + multi_modal_data path.
         """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support token_ids + multi_modal_data "
-            "without detokenization. Implement get_dummy_text(mm_counts) to enable it."
+            "without detokenization. Implement get_text_with_mm_placeholders(mm_counts) to enable it."
         )
 
     def expand_prompt_token_ids_for_mm(
         self,
         prompt_token_ids: List[int],
-        num_mm_tokens_per_image: List[int],
+        num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[int]:
         """
-        Expand image placeholder tokens in prompt_token_ids so each single image token
-        is replaced by the corresponding number of MM placeholder tokens.
-        Used when processing tokenized prompt + MM data without calling the full HF processor.
+        Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
+        is replaced by the corresponding number of multimodal feature tokens.
 
-        Subclasses that need the HF processor or feature extractor (e.g. for
-        image-size-dependent token counts) can use hf_processor_mm_kwargs when provided.
+        This is used when processing a tokenized prompt plus multimodal data, without calling the full
+        HuggingFace processor.
 
-        Default raises NotImplementedError. Override in model-specific processors.
+        Subclasses that require the HuggingFace processor or feature extractor (for example,
+        to determine image-size-dependent token counts) can use `hf_processor_mm_kwargs` if provided.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with image placeholder tokens.
+            num_mm_tokens_per_placeholder (List[int]): For each MM placeholder in prompt_token_ids,
+                specifies the number of MM feature tokens to expand/repeat for that placeholder.
+            hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional dictionary of arguments
+                to pass to the HuggingFace processor, if needed for token expansion.
+
+        Returns:
+            List[int]: The prompt token IDs where each MM placeholder token has been
+                replaced/expanded with the appropriate number of MM feature tokens.
+
+        Raises:
+            NotImplementedError: If the method is not implemented in the subclass.
+
+        Default implementation raises NotImplementedError. Override in model-specific processors.
         """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support expand_prompt_token_ids_for_mm. "
@@ -683,6 +707,47 @@ def create_input_processor(
     return DefaultInputProcessor(None, None, tokenizer)
 
 
+def _mm_data_to_counts(mm_data: Dict[str, Any]) -> Dict[str, int]:
+    """Normalize multi_modal_data to per-key counts (each value as list length)."""
+    mm_items = {
+        k: (v if isinstance(v, list) else [v])
+        for k, v in mm_data.items()
+    }
+    return {k: len(v) for k, v in mm_items.items()}
+
+
+def _process_multimodal_with_dummy_placeholders(
+    input_processor: BaseMultimodalInputProcessor,
+    mm_data: Dict[str, Any],
+    mm_counts: Dict[str, int],
+    mm_processor_kwargs: Optional[Dict[str, Any]],
+    sampling_params: SamplingParams,
+) -> ExtraProcessedInputs:
+    """Run input_processor with dummy text placeholders for multi-modal slots; return extra processed inputs."""
+    dummy_text = input_processor.get_text_with_mm_placeholders(mm_counts)
+    dummy_inputs = TextPrompt(
+        prompt=dummy_text,
+        multi_modal_data=mm_data,
+        mm_processor_kwargs=mm_processor_kwargs,
+    )
+    _, extra_processed_inputs = input_processor(dummy_inputs, sampling_params)
+    if extra_processed_inputs is None:
+        return {}
+    return extra_processed_inputs
+
+
+def _get_single_mm_token_lengths(
+    mm_data: Dict[str, Any],
+    input_processor: BaseMultimodalInputProcessor,
+) -> Optional[List[int]]:
+    """Get the single set of MM token lengths (first value from find_mm_token_lengths). Returns None if empty."""
+    num_mm_tokens_by_key = find_mm_token_lengths(mm_data, input_processor)
+    num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
+    if len(num_mm_tokens) <= 0:
+        return None
+    return num_mm_tokens
+
+
 def create_input_processor_with_hash(
     input_processor: BaseMultimodalInputProcessor,
     hash_lib=default_hasher,
@@ -702,33 +767,32 @@ def create_input_processor_with_hash(
         inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """
-        Process token_ids + multi_modal_data without detokenizing, by:
-        1. Processing multi-modal inputs with dummy inputs (for media placeholder tokens to match the number of multi-modal inputs),
-        2. Replacing the placeholder token IDs for the multi-modal inputs with the actual feature token IDs.
-        Delegate to multimodal_hashing_process afterwards.
+        Process prompt_token_ids and multi_modal_data without detokenizing.
+
+        Runs the input processor with dummy text placeholders for multi-modal slots,
+        then replaces placeholder token IDs with the actual feature token IDs and
+        delegates to multimodal_hashing_process.
+
+        Args:
+            inputs: TextPrompt with "prompt_token_ids" and "multi_modal_data" (and optional "mm_processor_kwargs").
+            sampling_params: Sampling parameters for the input processor.
+
+        Returns:
+            (prompt_token_ids, extra_processed_inputs) from multimodal_hashing_process.
+            ([], None) if multi-modal token lengths cannot be determined.
         """
         prompt_token_ids = inputs["prompt_token_ids"]
         mm_data = inputs["multi_modal_data"]
-        mm_items = {
-            k: (v if isinstance(v, list) else [v])
-            for k, v in mm_data.items()
-        }
-        mm_counts = {k: len(v) for k, v in mm_items.items()}
-
-        dummy_text = input_processor.get_dummy_text(mm_counts)
-        dummy_inputs = TextPrompt(
-            prompt=dummy_text,
-            multi_modal_data=mm_data,
-            mm_processor_kwargs=inputs.get("mm_processor_kwargs"),
+        mm_counts = _mm_data_to_counts(mm_data)
+        extra_processed_inputs = _process_multimodal_with_dummy_placeholders(
+            input_processor,
+            mm_data,
+            mm_counts,
+            inputs.get("mm_processor_kwargs"),
+            sampling_params,
         )
-        _, extra_processed_inputs = input_processor(dummy_inputs,
-                                                    sampling_params)
-        if extra_processed_inputs is None:
-            extra_processed_inputs = {}
-
-        num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
-        num_mm_tokens = next(iter(num_mm_tokens.values()))
-        if len(num_mm_tokens) <= 0:
+        num_mm_tokens = _get_single_mm_token_lengths(mm_data, input_processor)
+        if num_mm_tokens is None:
             logger.warning(
                 "tokenized_multimodal_process: no mm tokens from find_mm_token_lengths, returning [], None"
             )
@@ -755,8 +819,9 @@ def create_input_processor_with_hash(
         """
         Process multimodal hashing for media tokens if possible.
 
-        When precomputed_token_ids and precomputed_extra are provided (tokenized+MM path),
-        skips the input_processor call and uses them; otherwise calls input_processor.
+        precomputed_token_ids and precomputed_extra must be provided together or
+        both be None. When both are provided (tokenized+MM path), skips the
+        input_processor call and uses them; when both are None, calls input_processor.
 
         Supports optional user-provided UUIDs via 'multi_modal_uuids' in inputs.
         When a UUID is provided for a multimodal item, it will be used as the
@@ -773,9 +838,13 @@ def create_input_processor_with_hash(
         if precomputed_token_ids is not None and precomputed_extra is not None:
             prompt_token_ids = precomputed_token_ids
             extra_processed_inputs = precomputed_extra
-        else:
+        elif precomputed_token_ids is None and precomputed_extra is None:
             prompt_token_ids, extra_processed_inputs = input_processor(
                 inputs, sampling_params)
+        else:
+            raise ValueError(
+                "precomputed_token_ids and precomputed_extra must be provided "
+                "together or both be None; got one without the other.")
 
         num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
         # TODO: here we assume there is only one modality for now
@@ -822,14 +891,13 @@ def create_input_processor_with_hash(
         if (inputs.get("prompt_token_ids") is not None
                 and inputs.get("multi_modal_data") is not None
                 and inputs.get("prompt") is None):
-            if hasattr(input_processor, "get_dummy_text") and hasattr(
-                    input_processor, "expand_prompt_token_ids_for_mm"):
+            if hasattr(input_processor,
+                       "get_text_with_mm_placeholders") and hasattr(
+                           input_processor, "expand_prompt_token_ids_for_mm"):
                 try:
                     return tokenized_multimodal_process(inputs, sampling_params)
                 except Exception as e:
-                    logger.warning(
-                        f"Tokenized+MM path failed ({e}), falling back to detokenize path if applicable."
-                    )
+                    logger.warning(f"Tokenized+MM path failed: {e}")
                     raise
 
         try_multimodal_hashing = False  # only used for first time

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -254,6 +254,41 @@ class BaseMultimodalInputProcessor(ABC):
         """
         return getattr(self.processor, "mm_special_token_ids", None)
 
+    def get_dummy_text(self, mm_counts: Dict[str, int]) -> str:
+        """
+        Return minimal placeholder text for the given multimodal item counts,
+        so that the HF processor can be called with (dummy_text, mm_data) without error.
+        Used when processing tokenized prompt + MM data without detokenizing (token IDs path).
+
+        Default raises NotImplementedError. Override in model-specific processors
+        that support the token_ids + multi_modal_data path.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support token_ids + multi_modal_data "
+            "without detokenization. Implement get_dummy_text(mm_counts) to enable it."
+        )
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_image: List[int],
+        hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> List[int]:
+        """
+        Expand image placeholder tokens in prompt_token_ids so each single image token
+        is replaced by the corresponding number of MM placeholder tokens.
+        Used when processing tokenized prompt + MM data without calling the full HF processor.
+
+        Subclasses that need the HF processor or feature extractor (e.g. for
+        image-size-dependent token counts) can use hf_processor_mm_kwargs when provided.
+
+        Default raises NotImplementedError. Override in model-specific processors.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support expand_prompt_token_ids_for_mm. "
+            "Implement it to enable token_ids + multi_modal_data without detokenization."
+        )
+
     @property
     def get_num_multimodal_tokens(self):
         """
@@ -663,11 +698,65 @@ def create_input_processor_with_hash(
         A wrapped processor that modifies prompts before processing.
     """
 
-    def multimodal_hashing_process(
+    def tokenized_multimodal_process(
         inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """
-        Process the multinmodal hashing for media tokens if possible.
+        Process token_ids + multi_modal_data without detokenizing, by:
+        1. Processing multi-modal inputs with dummy inputs (for media placeholder tokens to match the number of multi-modal inputs),
+        2. Replacing the placeholder token IDs for the multi-modal inputs with the actual feature token IDs.
+        Delegate to multimodal_hashing_process afterwards.
+        """
+        prompt_token_ids = inputs["prompt_token_ids"]
+        mm_data = inputs["multi_modal_data"]
+        mm_items = {
+            k: (v if isinstance(v, list) else [v])
+            for k, v in mm_data.items()
+        }
+        mm_counts = {k: len(v) for k, v in mm_items.items()}
+
+        dummy_text = input_processor.get_dummy_text(mm_counts)
+        dummy_inputs = TextPrompt(
+            prompt=dummy_text,
+            multi_modal_data=mm_data,
+            mm_processor_kwargs=inputs.get("mm_processor_kwargs"),
+        )
+        _, extra_processed_inputs = input_processor(dummy_inputs,
+                                                    sampling_params)
+        if extra_processed_inputs is None:
+            extra_processed_inputs = {}
+
+        num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
+        num_mm_tokens = next(iter(num_mm_tokens.values()))
+        if len(num_mm_tokens) <= 0:
+            logger.warning(
+                "tokenized_multimodal_process: no mm tokens from find_mm_token_lengths, returning [], None"
+            )
+            return [], None
+
+        expanded_ids = input_processor.expand_prompt_token_ids_for_mm(
+            prompt_token_ids,
+            num_mm_tokens,
+            hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"))
+        return multimodal_hashing_process(
+            inputs,
+            sampling_params,
+            precomputed_token_ids=expanded_ids,
+            precomputed_extra=extra_processed_inputs,
+        )
+
+    def multimodal_hashing_process(
+        inputs: TextPrompt,
+        sampling_params: SamplingParams,
+        *,
+        precomputed_token_ids: Optional[List[int]] = None,
+        precomputed_extra: Optional[ExtraProcessedInputs] = None,
+    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        """
+        Process multimodal hashing for media tokens if possible.
+
+        When precomputed_token_ids and precomputed_extra are provided (tokenized+MM path),
+        skips the input_processor call and uses them; otherwise calls input_processor.
 
         Supports optional user-provided UUIDs via 'multi_modal_uuids' in inputs.
         When a UUID is provided for a multimodal item, it will be used as the
@@ -680,8 +769,13 @@ def create_input_processor_with_hash(
         mm_uuids = inputs.get('multi_modal_uuids', None)
 
         mm_hashes, mm_uuid_list = apply_mm_hashes(mm_data, mm_uuids, hash_lib)
-        prompt_token_ids, extra_processed_inputs = input_processor(
-            inputs, sampling_params)
+
+        if precomputed_token_ids is not None and precomputed_extra is not None:
+            prompt_token_ids = precomputed_token_ids
+            extra_processed_inputs = precomputed_extra
+        else:
+            prompt_token_ids, extra_processed_inputs = input_processor(
+                inputs, sampling_params)
 
         num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
         # TODO: here we assume there is only one modality for now
@@ -724,6 +818,20 @@ def create_input_processor_with_hash(
     def input_processor_wrapper(
         inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        # Tokenized prompt + multi_modal_data
+        if (inputs.get("prompt_token_ids") is not None
+                and inputs.get("multi_modal_data") is not None
+                and inputs.get("prompt") is None):
+            if hasattr(input_processor, "get_dummy_text") and hasattr(
+                    input_processor, "expand_prompt_token_ids_for_mm"):
+                try:
+                    return tokenized_multimodal_process(inputs, sampling_params)
+                except Exception as e:
+                    logger.warning(
+                        f"Tokenized+MM path failed ({e}), falling back to detokenize path if applicable."
+                    )
+                    raise
+
         try_multimodal_hashing = False  # only used for first time
         use_multimodal_hashing = False  # used for subsequent calls
         modalities = list(set(inputs['multi_modal_data'].keys())

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -655,7 +655,7 @@ def create_input_processor(
 
 
 def _mm_data_to_counts(mm_data: Dict[str, Any]) -> Dict[str, int]:
-    """Normalize multi_modal_data to per-key counts (each value as list length)."""
+    """Normalize multimodal data to per-key counts (each value as list length)."""
     mm_items = {
         k: (v if isinstance(v, list) else [v])
         for k, v in mm_data.items()
@@ -677,6 +677,9 @@ def _process_multimodal_with_dummy_placeholders(
         multi_modal_data=mm_data,
         mm_processor_kwargs=mm_processor_kwargs,
     )
+    # input_processor runs the HF processor / vision encoder on mm_data (e.g. images).
+    # extra_processed_inputs contains the processed MM data keyed under "multimodal_data";
+    # it is reused later with the real token IDs so we do not run the vision encoder again.
     _, extra_processed_inputs = input_processor(dummy_inputs, sampling_params)
     if extra_processed_inputs is None:
         return {}
@@ -689,6 +692,9 @@ def _get_single_mm_token_lengths(
 ) -> Optional[List[int]]:
     """Get the single set of MM token lengths (first value from find_mm_token_lengths). Returns None if empty."""
     num_mm_tokens_by_key = find_mm_token_lengths(mm_data, input_processor)
+    # find_mm_token_lengths returns Dict[modality, List[int]], e.g. {"image": [2928, 2928]}.
+    # We need the list of per-item lengths (for find_mm_token_positions), We take the first modality's
+    # list; multi-modality is not yet supported (see TODO in multimodal_hashing_process).
     num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
     if len(num_mm_tokens) <= 0:
         return None

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -746,10 +746,9 @@ def create_input_processor_with_hash(
         )
         num_mm_tokens = _get_single_mm_token_lengths(mm_data, input_processor)
         if num_mm_tokens is None:
-            logger.warning(
-                "tokenized_multimodal_process: no mm tokens from find_mm_token_lengths, returning [], None"
-            )
-            return [], None
+            raise ValueError(
+                "tokenized_multimodal_process: find_mm_token_lengths returned "
+                "no token lengths for the provided multi_modal_data.")
 
         expanded_ids = input_processor.expand_prompt_token_ids_for_mm(
             prompt_token_ids,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -491,13 +491,17 @@ class BaseLLM:
         prompt = None
 
         if is_mm_disagg:
+            logger.info(f"[preprocess] is_mm_disagg: {is_mm_disagg}")
             if not getattr(self.input_processor, "support_mm_disagg", False):
                 raise ValueError(
                     "Multimodal disaggregated inference is not supported for this model"
                 )
             mm_handles = disaggregated_params.multimodal_embedding_handles
             prompt_token_ids, mm_token_length, mm_token_positions = self.input_processor.get_prompt_token_ids(
-                inputs, mm_handles)
+                inputs["prompt_token_ids"], mm_handles)
+            logger.info(
+                f"After returning from get_prompt_token_ids: {prompt_token_ids}"
+            )
             prompt = inputs.get("prompt", None)
             query_token_ids = inputs.get("query_token_ids", None)
             if is_gen_only:
@@ -525,7 +529,13 @@ class BaseLLM:
         elif "prompt" in inputs or ("prompt_token_ids" in inputs and
                                     (("multi_modal_data" in inputs
                                       or "multi_modal_embeddings" in inputs))):
-            if 'multi_modal_data' in inputs and inputs['multi_modal_data']:
+            # _mm_data = inputs.get('multi_modal_data')
+            # _has_mm_data = (_mm_data is not None and
+            #                 (not isinstance(_mm_data, dict) or len(_mm_data) > 0))
+            # _mm_emb = inputs.get('multi_modal_embeddings')
+            # _has_mm_emb = (_mm_emb is not None and
+            #                (not isinstance(_mm_emb, dict) or len(_mm_emb) > 0))
+            if 'multi_modal_data' in inputs:  #and _has_mm_data:
                 logger.info(
                     f"[preprocess] multi_modal_data: {inputs['multi_modal_data']}"
                 )
@@ -539,8 +549,7 @@ class BaseLLM:
                 with nvtx_range_debug("input_processor_with_hash"):
                     prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
                         inputs, sampling_params)
-            elif 'multi_modal_embeddings' in inputs and inputs[
-                    'multi_modal_embeddings']:
+            elif 'multi_modal_embeddings' in inputs:  #and _has_mm_emb:
                 logger.info(
                     f"[preprocess] multi_modal_embeddings: {inputs['multi_modal_embeddings']}"
                 )

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -484,15 +484,19 @@ class BaseLLM:
 
         # A fast path for token IDs & MM data is available for a VLM if the input processor has the following methods.
         # TODO: Once all the VLMs support the fast path, remove this flag and modify the remaining logic accordingly.
-        vlm_fast_path_for_token_ids_and_mm_data_available = (
+        use_token_ids_for_mm_placeholders = (
             hasattr(self.input_processor, "get_text_with_mm_placeholders")
             and hasattr(self.input_processor, "expand_prompt_token_ids_for_mm"))
 
+        # This IF branch is applicable, whenever:
+        # - multimodal data is present (whether through embeddings or as preprocessed data), AND
+        # - token IDs are present, AND
+        # - two methods defining the placeholder token IDs expansion logic are not available.
         if not inputs.get("prompt") and inputs.get("prompt_token_ids") and (
                 inputs.get("multi_modal_data")
                 or inputs.get("multi_modal_embeddings")) and not isinstance(
                     self.input_processor, DefaultInputProcessor
-                ) and not vlm_fast_path_for_token_ids_and_mm_data_available:
+                ) and not use_token_ids_for_mm_placeholders:
             # VLMs need to process/tokenize the prompt in their own way,
             # if they don't have the fast path for token IDs & MM data implemented yet.
             # TODO: Once all the VLMs support the fast path, we can remove this detokenization step entirely.
@@ -517,6 +521,8 @@ class BaseLLM:
         multimodal_params = None
         prompt = None
 
+        # This branch is applicable for Encode --> Prefill handoff scenario,
+        # in E/P/D/ and E/PD settings. Prefill worker executes this code path.
         if is_mm_disagg:
             if not getattr(self.input_processor, "support_mm_disagg", False):
                 raise ValueError(
@@ -549,6 +555,8 @@ class BaseLLM:
                     multimodal_input=multimodal_input,
                     multimodal_data=multimodal_data,
                 )
+        # This condition is to ensure that this branch is not hit for models that expand
+        # placeholder token IDs with MM data.
         elif ("prompt_token_ids" in inputs
               and inputs.get("multi_modal_data") is None
               and inputs.get("multi_modal_embeddings") is None):
@@ -571,6 +579,8 @@ class BaseLLM:
             if multimodal_data:
                 multimodal_params = MultimodalParams(
                     multimodal_data=multimodal_data)
+        # This is the fast path for token IDs & MM data, as well as the slow path for text prompt and/or MM data,
+        # for both encode or aggregated workers.
         elif "prompt" in inputs or ("prompt_token_ids" in inputs and
                                     (("multi_modal_data" in inputs
                                       or "multi_modal_embeddings" in inputs))):
@@ -595,7 +605,8 @@ class BaseLLM:
                 with nvtx_range_debug("input_processor"):
                     prompt_token_ids, extra_processed_inputs = self.input_processor(
                         inputs, sampling_params)
-            prompt = inputs.get("prompt")
+            prompt = inputs.get(
+                "prompt")  # This is the text prompt, if present.
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
                 # Create unified MultimodalParams

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -16,10 +16,8 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
 from tensorrt_llm._utils import mpi_disabled
-from tensorrt_llm.inputs.data import TextPrompt
 from tensorrt_llm.inputs.multimodal import MultimodalInput, MultimodalParams
-from tensorrt_llm.inputs.registry import (BaseMultimodalInputProcessor,
-                                          DefaultInputProcessor)
+from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
 from tensorrt_llm.llmapi import tracing
 from tensorrt_llm.metrics.enums import MetricNames
 
@@ -482,22 +480,6 @@ class BaseLLM:
         """
         inputs = prompt_inputs(inputs)
 
-        if not inputs.get("prompt") and inputs.get("prompt_token_ids") and (
-                inputs.get("multi_modal_data")
-                or inputs.get("multi_modal_embeddings")) and not isinstance(
-                    self.input_processor, DefaultInputProcessor):
-            # VLMs need to process/tokenize the prompt in their own way
-            prompt = self.tokenizer.decode(inputs['prompt_token_ids'])
-            inputs = TextPrompt(
-                prompt=prompt,
-                multi_modal_data=inputs.get("multi_modal_data"),
-                mm_processor_kwargs=inputs.get("mm_processor_kwargs") or {})
-            if sampling_params.add_special_tokens:
-                logger.debug(
-                    "Setting add_special_tokens to False because prompt_token_ids were provided to generate. VLMs will re-encode the prompt."
-                )
-                sampling_params.add_special_tokens = False
-
         is_mm_disagg = (disaggregated_params is not None
                         and disaggregated_params.multimodal_embedding_handles
                         is not None)
@@ -540,28 +522,13 @@ class BaseLLM:
                     multimodal_input=multimodal_input,
                     multimodal_data=multimodal_data,
                 )
-        elif "prompt_token_ids" in inputs:
-            prompt_token_ids = inputs['prompt_token_ids']
-            query_token_ids = inputs.get("query_token_ids", None)
-            multimodal_data = {}
-            # NOTE: when running in `generation_only` for disagg, this is the code path we expect to hit.
-            if disaggregated_params is not None and disaggregated_params.mrope_position_ids_handle is not None:
-                # PyTorchModelEngine assumes both are present when using mrope.
-                if disaggregated_params.mrope_position_deltas_handle is None:
-                    raise RuntimeError(
-                        "`mrope_position_ids_handle` and `mrope_position_deltas_handle` must both "
-                        "be provided, or both `None`.")
-                mrope_config = {}
-                mrope_config[
-                    "mrope_position_ids"] = disaggregated_params.mrope_position_ids_handle
-                mrope_config[
-                    "mrope_position_deltas"] = disaggregated_params.mrope_position_deltas_handle
-                multimodal_data["mrope_config"] = mrope_config
-            if multimodal_data:
-                multimodal_params = MultimodalParams(
-                    multimodal_data=multimodal_data)
-        elif "prompt" in inputs:
-            if 'multi_modal_data' in inputs:
+        elif "prompt" in inputs or ("prompt_token_ids" in inputs and
+                                    (("multi_modal_data" in inputs
+                                      or "multi_modal_embeddings" in inputs))):
+            if 'multi_modal_data' in inputs and inputs['multi_modal_data']:
+                logger.info(
+                    f"[preprocess] multi_modal_data: {inputs['multi_modal_data']}"
+                )
                 # TODO: The current design uses a wrapper for existing input processor (input_processor_with_hash)
                 # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
                 # In the future, we should refactor this to:
@@ -572,7 +539,11 @@ class BaseLLM:
                 with nvtx_range_debug("input_processor_with_hash"):
                     prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
                         inputs, sampling_params)
-            elif 'multi_modal_embeddings' in inputs:
+            elif 'multi_modal_embeddings' in inputs and inputs[
+                    'multi_modal_embeddings']:
+                logger.info(
+                    f"[preprocess] multi_modal_embeddings: {inputs['multi_modal_embeddings']}"
+                )
                 mm_embedding_info = inputs['multi_modal_embeddings']
                 prompt_token_ids, extra_processed_inputs = cast(
                     BaseMultimodalInputProcessor,
@@ -582,7 +553,7 @@ class BaseLLM:
                 with nvtx_range_debug("input_processor"):
                     prompt_token_ids, extra_processed_inputs = self.input_processor(
                         inputs, sampling_params)
-            prompt = inputs['prompt']
+            prompt = inputs.get("prompt")
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
                 # Create unified MultimodalParams
@@ -614,6 +585,26 @@ class BaseLLM:
                                 mrope_position_ids)
                             disaggregated_params.mrope_position_deltas_handle = (
                                 mrope_position_deltas)
+        elif "prompt_token_ids" in inputs:
+            prompt_token_ids = inputs['prompt_token_ids']
+            query_token_ids = inputs.get("query_token_ids", None)
+            multimodal_data = {}
+            # NOTE: when running in `generation_only` for disagg, this is the code path we expect to hit.
+            if disaggregated_params is not None and disaggregated_params.mrope_position_ids_handle is not None:
+                # PyTorchModelEngine assumes both are present when using mrope.
+                if disaggregated_params.mrope_position_deltas_handle is None:
+                    raise RuntimeError(
+                        "`mrope_position_ids_handle` and `mrope_position_deltas_handle` must both "
+                        "be provided, or both `None`.")
+                mrope_config = {}
+                mrope_config[
+                    "mrope_position_ids"] = disaggregated_params.mrope_position_ids_handle
+                mrope_config[
+                    "mrope_position_deltas"] = disaggregated_params.mrope_position_deltas_handle
+                multimodal_data["mrope_config"] = mrope_config
+            if multimodal_data:
+                multimodal_params = MultimodalParams(
+                    multimodal_data=multimodal_data)
         else:
             raise TypeError(
                 f"The inputs must be type str or list of int, but got {type(inputs)}"

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -490,9 +490,7 @@ class BaseLLM:
         multimodal_params = None
         prompt = None
 
-        logger.info(f"is_mm_disagg: {is_mm_disagg}")
         if is_mm_disagg:
-            logger.info(f"[INSIDE IF] is_mm_disagg: {is_mm_disagg}")
             if not getattr(self.input_processor, "support_mm_disagg", False):
                 raise ValueError(
                     "Multimodal disaggregated inference is not supported for this model"
@@ -549,7 +547,6 @@ class BaseLLM:
         elif "prompt" in inputs or ("prompt_token_ids" in inputs and
                                     (("multi_modal_data" in inputs
                                       or "multi_modal_embeddings" in inputs))):
-            logger.info(f"inputs: {inputs}")
             if 'multi_modal_data' in inputs:
                 # TODO: The current design uses a wrapper for existing input processor (input_processor_with_hash)
                 # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
@@ -563,10 +560,6 @@ class BaseLLM:
                         inputs, sampling_params)
             elif 'multi_modal_embeddings' in inputs:
                 mm_embedding_info = inputs['multi_modal_embeddings']
-                if isinstance(mm_embedding_info, dict):
-                    logger.info(
-                        f"mm_embedding_info is a dict: {mm_embedding_info}")
-                logger.info(f"mm_embedding_info: {type(mm_embedding_info)}")
                 prompt_token_ids, extra_processed_inputs = cast(
                     BaseMultimodalInputProcessor,
                     self.input_processor).attach_multimodal_embeddings(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -524,9 +524,7 @@ class BaseLLM:
                 )
             mm_handles = disaggregated_params.multimodal_embedding_handles
             prompt_token_ids, mm_token_length, mm_token_positions = self.input_processor.get_prompt_token_ids(
-                inputs["prompt_token_ids"] if
-                vlm_fast_path_for_token_ids_and_mm_data_available else inputs,
-                mm_handles)
+                inputs, mm_handles)
             prompt = inputs.get("prompt", None)
             query_token_ids = inputs.get("query_token_ids", None)
             if is_gen_only:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -490,8 +490,9 @@ class BaseLLM:
         multimodal_params = None
         prompt = None
 
+        logger.info(f"is_mm_disagg: {is_mm_disagg}")
         if is_mm_disagg:
-            logger.info(f"[preprocess] is_mm_disagg: {is_mm_disagg}")
+            logger.info(f"[INSIDE IF] is_mm_disagg: {is_mm_disagg}")
             if not getattr(self.input_processor, "support_mm_disagg", False):
                 raise ValueError(
                     "Multimodal disaggregated inference is not supported for this model"
@@ -499,9 +500,6 @@ class BaseLLM:
             mm_handles = disaggregated_params.multimodal_embedding_handles
             prompt_token_ids, mm_token_length, mm_token_positions = self.input_processor.get_prompt_token_ids(
                 inputs["prompt_token_ids"], mm_handles)
-            logger.info(
-                f"After returning from get_prompt_token_ids: {prompt_token_ids}"
-            )
             prompt = inputs.get("prompt", None)
             query_token_ids = inputs.get("query_token_ids", None)
             if is_gen_only:
@@ -526,19 +524,33 @@ class BaseLLM:
                     multimodal_input=multimodal_input,
                     multimodal_data=multimodal_data,
                 )
+        elif ("prompt_token_ids" in inputs
+              and inputs.get("multi_modal_data") is None
+              and inputs.get("multi_modal_embeddings") is None):
+            prompt_token_ids = inputs['prompt_token_ids']
+            query_token_ids = inputs.get("query_token_ids", None)
+            multimodal_data = {}
+            # NOTE: when running in `generation_only` for disagg, this is the code path we expect to hit.
+            if disaggregated_params is not None and disaggregated_params.mrope_position_ids_handle is not None:
+                # PyTorchModelEngine assumes both are present when using mrope.
+                if disaggregated_params.mrope_position_deltas_handle is None:
+                    raise RuntimeError(
+                        "`mrope_position_ids_handle` and `mrope_position_deltas_handle` must both "
+                        "be provided, or both `None`.")
+                mrope_config = {}
+                mrope_config[
+                    "mrope_position_ids"] = disaggregated_params.mrope_position_ids_handle
+                mrope_config[
+                    "mrope_position_deltas"] = disaggregated_params.mrope_position_deltas_handle
+                multimodal_data["mrope_config"] = mrope_config
+            if multimodal_data:
+                multimodal_params = MultimodalParams(
+                    multimodal_data=multimodal_data)
         elif "prompt" in inputs or ("prompt_token_ids" in inputs and
                                     (("multi_modal_data" in inputs
                                       or "multi_modal_embeddings" in inputs))):
-            # _mm_data = inputs.get('multi_modal_data')
-            # _has_mm_data = (_mm_data is not None and
-            #                 (not isinstance(_mm_data, dict) or len(_mm_data) > 0))
-            # _mm_emb = inputs.get('multi_modal_embeddings')
-            # _has_mm_emb = (_mm_emb is not None and
-            #                (not isinstance(_mm_emb, dict) or len(_mm_emb) > 0))
-            if 'multi_modal_data' in inputs:  #and _has_mm_data:
-                logger.info(
-                    f"[preprocess] multi_modal_data: {inputs['multi_modal_data']}"
-                )
+            logger.info(f"inputs: {inputs}")
+            if 'multi_modal_data' in inputs:
                 # TODO: The current design uses a wrapper for existing input processor (input_processor_with_hash)
                 # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
                 # In the future, we should refactor this to:
@@ -549,11 +561,12 @@ class BaseLLM:
                 with nvtx_range_debug("input_processor_with_hash"):
                     prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
                         inputs, sampling_params)
-            elif 'multi_modal_embeddings' in inputs:  #and _has_mm_emb:
-                logger.info(
-                    f"[preprocess] multi_modal_embeddings: {inputs['multi_modal_embeddings']}"
-                )
+            elif 'multi_modal_embeddings' in inputs:
                 mm_embedding_info = inputs['multi_modal_embeddings']
+                if isinstance(mm_embedding_info, dict):
+                    logger.info(
+                        f"mm_embedding_info is a dict: {mm_embedding_info}")
+                logger.info(f"mm_embedding_info: {type(mm_embedding_info)}")
                 prompt_token_ids, extra_processed_inputs = cast(
                     BaseMultimodalInputProcessor,
                     self.input_processor).attach_multimodal_embeddings(
@@ -594,26 +607,6 @@ class BaseLLM:
                                 mrope_position_ids)
                             disaggregated_params.mrope_position_deltas_handle = (
                                 mrope_position_deltas)
-        elif "prompt_token_ids" in inputs:
-            prompt_token_ids = inputs['prompt_token_ids']
-            query_token_ids = inputs.get("query_token_ids", None)
-            multimodal_data = {}
-            # NOTE: when running in `generation_only` for disagg, this is the code path we expect to hit.
-            if disaggregated_params is not None and disaggregated_params.mrope_position_ids_handle is not None:
-                # PyTorchModelEngine assumes both are present when using mrope.
-                if disaggregated_params.mrope_position_deltas_handle is None:
-                    raise RuntimeError(
-                        "`mrope_position_ids_handle` and `mrope_position_deltas_handle` must both "
-                        "be provided, or both `None`.")
-                mrope_config = {}
-                mrope_config[
-                    "mrope_position_ids"] = disaggregated_params.mrope_position_ids_handle
-                mrope_config[
-                    "mrope_position_deltas"] = disaggregated_params.mrope_position_deltas_handle
-                multimodal_data["mrope_config"] = mrope_config
-            if multimodal_data:
-                multimodal_params = MultimodalParams(
-                    multimodal_data=multimodal_data)
         else:
             raise TypeError(
                 f"The inputs must be type str or list of int, but got {type(inputs)}"

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -16,8 +16,10 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
 from tensorrt_llm._utils import mpi_disabled
+from tensorrt_llm.inputs.data import TextPrompt
 from tensorrt_llm.inputs.multimodal import MultimodalInput, MultimodalParams
-from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
+from tensorrt_llm.inputs.registry import (BaseMultimodalInputProcessor,
+                                          DefaultInputProcessor)
 from tensorrt_llm.llmapi import tracing
 from tensorrt_llm.metrics.enums import MetricNames
 
@@ -480,6 +482,31 @@ class BaseLLM:
         """
         inputs = prompt_inputs(inputs)
 
+        # A fast path for token IDs & MM data is available for a VLM if the input processor has the following methods.
+        # TODO: Once all the VLMs support the fast path, remove this flag and modify the remaining logic accordingly.
+        vlm_fast_path_for_token_ids_and_mm_data_available = (
+            hasattr(self.input_processor, "get_text_with_mm_placeholders")
+            and hasattr(self.input_processor, "expand_prompt_token_ids_for_mm"))
+
+        if not inputs.get("prompt") and inputs.get("prompt_token_ids") and (
+                inputs.get("multi_modal_data")
+                or inputs.get("multi_modal_embeddings")) and not isinstance(
+                    self.input_processor, DefaultInputProcessor
+                ) and not vlm_fast_path_for_token_ids_and_mm_data_available:
+            # VLMs need to process/tokenize the prompt in their own way,
+            # if they don't have the fast path for token IDs & MM data implemented yet.
+            # TODO: Once all the VLMs support the fast path, we can remove this detokenization step entirely.
+            prompt = self.tokenizer.decode(inputs['prompt_token_ids'])
+            inputs = TextPrompt(
+                prompt=prompt,
+                multi_modal_data=inputs.get("multi_modal_data"),
+                mm_processor_kwargs=inputs.get("mm_processor_kwargs") or {})
+            if sampling_params.add_special_tokens:
+                logger.debug(
+                    "Setting add_special_tokens to False because prompt_token_ids were provided to generate. VLMs will re-encode the prompt."
+                )
+                sampling_params.add_special_tokens = False
+
         is_mm_disagg = (disaggregated_params is not None
                         and disaggregated_params.multimodal_embedding_handles
                         is not None)
@@ -497,7 +524,9 @@ class BaseLLM:
                 )
             mm_handles = disaggregated_params.multimodal_embedding_handles
             prompt_token_ids, mm_token_length, mm_token_positions = self.input_processor.get_prompt_token_ids(
-                inputs["prompt_token_ids"], mm_handles)
+                inputs["prompt_token_ids"] if
+                vlm_fast_path_for_token_ids_and_mm_data_available else inputs,
+                mm_handles)
             prompt = inputs.get("prompt", None)
             query_token_ids = inputs.get("query_token_ids", None)
             if is_gen_only:

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -21,6 +21,7 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_nemotron_nano_v2_vl"
   - unittest/_torch/modeling -k "modeling_phi4mm"
   - unittest/_torch/modeling/test_modeling_llava_next.py::TestLlavaNext::test_all
+  - unittest/_torch/modeling/test_modeling_llava_next.py::test_llava_next_expand_prompt_token_ids_for_mm
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all
   - unittest/_torch/modeling/test_modeling_qwen3vl_moe.py::TestQwen3VLMoe::test_all
   - unittest/_torch/modeling/test_modeling_qwen3vl.py::TestQwen3VL::test_all

--- a/tests/unittest/_torch/modeling/test_modeling_llava_next.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llava_next.py
@@ -1,15 +1,18 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 
+import pytest
 from test_modeling_multimodal import MultimodalScenario, TestModelingMultimodal, llm_models_root
-from transformers import LlavaNextConfig
+from transformers import AutoTokenizer, LlavaNextConfig
 from transformers import LlavaNextForConditionalGeneration as HFLlavaNextForConditionalGeneration
 
 from tensorrt_llm._torch.models.checkpoints.hf.llava_next_weight_mapper import (
     LlavaNextHfWeightMapper,
 )
 from tensorrt_llm._torch.models.modeling_llava_next import LlavaNextModel
+from tensorrt_llm.inputs import create_input_processor
 
 LLAVA_NEXT_7B_CONFIG = {
     "architectures": ["LlavaNextForConditionalGeneration"],
@@ -96,3 +99,34 @@ class TestLlavaNext(TestModelingMultimodal):
             ),
         ]
         return scenarios
+
+
+def test_llava_next_expand_prompt_token_ids_for_mm():
+    """Test LlavaNextInputProcessor.expand_prompt_token_ids_for_mm replaces image placeholders correctly."""
+    model_path = LLAVA_NEXT_7B_CONFIG["_name_or_path"]
+    if not Path(model_path).exists():
+        pytest.skip(f"LLaVA-Next model not found at {model_path} (set LLM_MODELS_ROOT)")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    input_processor = create_input_processor(model_path, tokenizer=tokenizer)
+
+    image_token_id = LLAVA_NEXT_7B_CONFIG["image_token_index"]
+    vocab_size = LLAVA_NEXT_7B_CONFIG["vocab_size"]
+    placeholder_id = vocab_size + 1
+
+    # prompt_token_ids: two image placeholders with text tokens in between
+    prompt_token_ids = [1, 2, image_token_id, 3, image_token_id, 4]
+    num_mm_tokens_per_placeholder = [10, 20]
+
+    expanded = input_processor.expand_prompt_token_ids_for_mm(
+        prompt_token_ids, num_mm_tokens_per_placeholder
+    )
+
+    # Expected: [1, 2] + 10 * placeholder_id + [3] + 20 * placeholder_id + [4]
+    expected_len = 2 + 10 + 1 + 20 + 1
+    assert len(expanded) == expected_len
+    assert expanded[:2] == [1, 2]
+    assert expanded[2:12] == [placeholder_id] * 10
+    assert expanded[12] == 3
+    assert expanded[13:33] == [placeholder_id] * 20
+    assert expanded[33] == 4


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fast-path support for processing pre-tokenized prompts with multimodal data, eliminating unnecessary detokenization steps for improved performance.
  * Enhanced image placeholder expansion and handling for multimodal inputs.

* **Refactor**
  * Improved input processing pipeline to seamlessly support both text-based and pre-tokenized prompt paths with unified multimodal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Process token IDs + MM data without de-tokenizing, that is, by instead:

1. Processing multi-modal inputs with dummy inputs (for media placeholder tokens to match the number of multi-modal inputs),
2. Replacing the placeholder token IDs for the multi-modal inputs with the actual feature token IDs.

See: https://docs.vllm.ai/en/latest/design/mm_processing/#multi-modal-data-processing

Currently implemented only for `tensorrt_llm/_torch/models/modeling_llava_next.py`

## Test Coverage

Tested for:

- `pytest -sv tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py::TestLlava_V1_6_Mistral_7B::test_auto_dtype`
- `pytest -sv tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3VL::test_auto_dtype`
- `llava-v1.6-mistral-7b-hf` in Dynamo with https://github.com/ai-dynamo/dynamo/pull/6567/:
    - image URL:
        - AGG, E/P/D
    - embeddings:
        - AGG, E/P/D, E/PD
    - text only:
        - AGG, E/P/D
- `Qwen/Qwen3-VL-2B-Instruct` in Dynamo with https://github.com/ai-dynamo/dynamo/pull/6567/:
    - image URL:
        - E/P/D

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
