### PR TITLE
[None][feat] Add --served-model-name option to serve command

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -718,12 +718,13 @@ class ChoiceWithAlias(click.Choice):
     help="Run gRPC server instead of OpenAI HTTP server. "
     "gRPC server accepts pre-tokenized requests and returns raw token IDs.")
 @click.option(
-    "--served-model-name",
+    "--served_model_name",
     type=str,
     default=None,
-    help="The model name used in the API. If not specified, the model path is "
-    "used as the model name. This is useful when the model path is long or "
-    "when you want to expose a custom name to clients.")
+    help=help_info_with_stability_tag(
+        "The model name used in the API. If not specified, the model path is "
+        "used as the model name. This is useful when the model path is long or "
+        "when you want to expose a custom name to clients.", "prototype"))
 @click.option("--extra_visual_gen_options",
               type=str,
               default=None,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -255,10 +255,11 @@ def launch_server(
         metadata_server_cfg: Optional[MetadataServerConfig] = None,
         server_role: Optional[ServerRole] = None,
         disagg_cluster_config: Optional[DisaggClusterConfig] = None,
-        multimodal_server_config: Optional[MultimodalServerConfig] = None):
+        multimodal_server_config: Optional[MultimodalServerConfig] = None,
+        served_model_name: Optional[str] = None):
 
     backend = llm_args["backend"]
-    model = llm_args["model"]
+    model = served_model_name or llm_args["model"]
     addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
                                    socket.SOCK_STREAM)
     address_family = socket.AF_INET6 if all(
@@ -306,7 +307,10 @@ def launch_server(
         asyncio.run(server(host, port, sockets=[s]))
 
 
-def launch_grpc_server(host: str, port: int, llm_args: dict):
+def launch_grpc_server(host: str,
+                       port: int,
+                       llm_args: dict,
+                       served_model_name: Optional[str] = None):
     """
     Launch a gRPC server for TensorRT-LLM.
 
@@ -317,6 +321,7 @@ def launch_grpc_server(host: str, port: int, llm_args: dict):
         host: Host to bind to
         port: Port to bind to
         llm_args: Arguments for LLM initialization (from get_llm_args)
+        served_model_name: Custom model name for API responses (defaults to model path)
     """
     import grpc
 
@@ -334,7 +339,7 @@ def launch_grpc_server(host: str, port: int, llm_args: dict):
         logger.info("Initializing TensorRT-LLM gRPC server...")
 
         backend = llm_args.get("backend")
-        model_path = llm_args.get("model", "")
+        model_path = served_model_name or llm_args.get("model", "")
 
         if backend == "pytorch":
             llm_args.pop("build_config", None)
@@ -712,6 +717,13 @@ class ChoiceWithAlias(click.Choice):
     default=False,
     help="Run gRPC server instead of OpenAI HTTP server. "
     "gRPC server accepts pre-tokenized requests and returns raw token IDs.")
+@click.option(
+    "--served-model-name",
+    type=str,
+    default=None,
+    help="The model name used in the API. If not specified, the model path is "
+    "used as the model name. This is useful when the model path is long or "
+    "when you want to expose a custom name to clients.")
 @click.option("--extra_visual_gen_options",
               type=str,
               default=None,
@@ -734,7 +746,8 @@ def serve(
         otlp_traces_endpoint: Optional[str], enable_chunked_prefill: bool,
         disagg_cluster_uri: Optional[str], media_io_kwargs: Optional[str],
         custom_module_dirs: list[Path], chat_template: Optional[str],
-        grpc: bool, extra_visual_gen_options: Optional[str]):
+        grpc: bool, served_model_name: Optional[str],
+        extra_visual_gen_options: Optional[str]):
     """Running an OpenAI API compatible server
 
     MODEL: model name | HF checkpoint path | TensorRT engine path
@@ -832,12 +845,22 @@ def serve(
                         f"Argument '{name}' is not supported when running in gRPC mode. "
                         f"The gRPC server is designed for use with external routers that handle "
                         f"these features (e.g., tool parsing, chat templates).")
-            launch_grpc_server(host, port, llm_args)
+            launch_grpc_server(host,
+                               port,
+                               llm_args,
+                               served_model_name=served_model_name)
         else:
             # Default: launch OpenAI HTTP server
-            launch_server(host, port, llm_args, tool_parser, chat_template,
-                          metadata_server_cfg, server_role,
-                          disagg_cluster_config, multimodal_server_config)
+            launch_server(host,
+                          port,
+                          llm_args,
+                          tool_parser,
+                          chat_template,
+                          metadata_server_cfg,
+                          server_role,
+                          disagg_cluster_config,
+                          multimodal_server_config,
+                          served_model_name=served_model_name)
 
     def _serve_visual_gen():
         visual_gen_config = {


### PR DESCRIPTION
## Summary

Add `--served-model-name` CLI option to the `serve` command, consistent with the same option available in both [SGLang](https://docs.sglang.ai/backend/server_arguments.html) and [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html). This is a standard argument across inference serving frameworks for controlling the model name exposed to clients.

When set, the served model name is used as the model identifier in:
- **HTTP mode**: `/v1/models` endpoint and all response payloads (`model` field in chat completions, completions, etc.)
- **gRPC mode**: `GetModelInfo` RPC response (`model_id` field)

When not set, the behavior is unchanged — the model path is used as the model name (with directory basename extraction for local paths in HTTP mode).

### Use cases
- Expose a short, user-friendly model name (e.g. `llama-3.1-8b`) instead of a long filesystem path
- Match the model name expected by external routers (e.g. [Shepherd Model Gateway](https://github.com/lightseekorg/smg)) that use the served name for request routing

## Changes
- Add `--served-model-name` click option to `serve()` (defaults to `None`)
- Pass through to `launch_server()` and `launch_grpc_server()`
- Override model name when provided, preserving existing behavior when not

## Test plan
- [x] `python -m tensorrt_llm.commands.serve <model> --served-model-name my-model` → `/v1/models` returns `my-model`
- [x] `python -m tensorrt_llm.commands.serve <model> --grpc --served-model-name my-model` → `GetModelInfo` returns `model_id=my-model`
- [x] Without `--served-model-name`, behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--served-model-name` CLI option to the serve command, allowing users to specify a custom name for the served model. When provided, this name takes precedence over the model parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->