### PR TITLE
[None][fix] Make KVCacheManagerV2 release mem immediately on shutdown

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -837,6 +837,11 @@ class GpuCacheLevelStorage(CacheLevelStorage):
     def pool_size_granularity(self) -> int:
         return self.shared_phys_mem_pool.phys_mem_size
 
+    @override
+    def destroy(self) -> None:
+        super().destroy()
+        self.shared_phys_mem_pool.clear()
+
 
 class HostCacheLevelStorage(CacheLevelStorage):
     TIER: ClassVar[CacheTier] = CacheTier.HOST_MEM


### PR DESCRIPTION
Previously, physical pages are collected back to a pool. But we forgot to clear that pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU memory resource cleanup to ensure pooled physical memory is properly released when cache storage is destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->