### PR TITLE
[#11666][fix] Fix inmemory model dir detection

### DIFF
--- a/tensorrt_llm/models/model_weights_loader.py
+++ b/tensorrt_llm/models/model_weights_loader.py
@@ -163,10 +163,10 @@ class ModelWeightsLoader:
             shard_files = [dict(self.model_dir.named_parameters())]
         elif isinstance(self.model_dir, dict):
             shard_files = [self.model_dir]
-        elif os.path.isdir(self.model_dir):
-            shard_files = glob.glob(self.model_dir + "/*." + self.format.value)
         elif os.path.isfile(self.model_dir):
             shard_files = [self.model_dir]
+        elif os.path.isdir(self.model_dir):
+            shard_files = glob.glob(self.model_dir + "/*." + self.format.value)
         else:
             raise NotImplementedError(
                 "args.model_dir is not a directory, a file or an in-memory module!"

--- a/tensorrt_llm/models/model_weights_loader.py
+++ b/tensorrt_llm/models/model_weights_loader.py
@@ -128,7 +128,10 @@ class ModelWeightsLoader:
         return tllm_keys[0] if len(tllm_keys) == 1 else tllm_keys
 
     def detect_format(self):
-        if os.path.isfile(self.model_dir):
+        if isinstance(self.model_dir, dict) or isinstance(
+                self.model_dir, PreTrainedModel):
+            self.format = ModelWeightsFormat.IN_MEMORY
+        elif os.path.isfile(self.model_dir):
             if self.model_dir.endswith(".safetensors"):
                 self.format = ModelWeightsFormat.SAFETENSORS
             elif self.model_dir.endswith(".bin"):
@@ -149,9 +152,6 @@ class ModelWeightsLoader:
             else:
                 raise NotImplementedError(
                     "Only safetensors/pickle/binary directories are supported.")
-        elif isinstance(self.model_dir, dict) or isinstance(
-                self.model_dir, PreTrainedModel):
-            self.format = ModelWeightsFormat.IN_MEMORY
         else:
             raise NotImplementedError(
                 "args.model_dir is not a directory, a file or an in-memory module!"
@@ -159,14 +159,14 @@ class ModelWeightsLoader:
 
     def preload(self):
         # Initialize shards and load_func
-        if os.path.isdir(self.model_dir):
+        if isinstance(self.model_dir, PreTrainedModel):
+            shard_files = [dict(self.model_dir.named_parameters())]
+        elif isinstance(self.model_dir, dict):
+            shard_files = [self.model_dir]
+        elif os.path.isdir(self.model_dir):
             shard_files = glob.glob(self.model_dir + "/*." + self.format.value)
         elif os.path.isfile(self.model_dir):
             shard_files = [self.model_dir]
-        elif isinstance(self.model_dir, dict):
-            shard_files = [self.model_dir]
-        elif isinstance(self.model_dir, PreTrainedModel):
-            shard_files = [dict(self.model_dir.named_parameters())]
         else:
             raise NotImplementedError(
                 "args.model_dir is not a directory, a file or an in-memory module!"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized model weights loading by improving the order of input type detection and handling. This enhancement prioritizes in-memory model inputs during the loading process, which may result in faster load times for certain scenarios while maintaining existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[None][fix] Fix model_dir format detection order for in-memory models

## Description

This PR fixes an incorrect detection order in `detect_format()` and `preload()` that could cause
in-memory models (`dict` or `PreTrainedModel`) to be incorrectly treated as filesystem paths.
The fix prioritizes in-memory type checks before filesystem-based checks and aligns the branching
logic between `detect_format()` and `preload()` to ensure consistent and robust behavior.
The change is minimal and backward-compatible.

## Test Coverage

- Verified loading behavior with `model_dir` as:
  - `dict` (in-memory state dict)
  - `PreTrainedModel` instance

## PR Checklist

- [x] PR description clearly explains what and why
- [x] PR follows TRT-LLM coding guidelines
- [x] No new dependencies introduced
- [x] No ownership or architecture changes
- [x] Documentation changes not required for this fix