### PR TITLE
[None][feat] Add Kimi-K2.5 text model support (NVFP4)

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -48,7 +48,7 @@ def config_file_lock(timeout: int = 10):
     try:
         with lock:
             yield
-    except (PermissionError, filelock.Timeout):
+    except (PermissionError, filelock.Timeout, OSError):
         # Fallback to tempdir
         tmp_dir = Path(tempfile.gettempdir())
         tmp_dir.mkdir(parents=True, exist_ok=True)

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -48,7 +48,7 @@ def config_file_lock(timeout: int = 10):
     try:
         with lock:
             yield
-    except (PermissionError, filelock.Timeout, OSError):
+    except (PermissionError, filelock.Timeout):
         # Fallback to tempdir
         tmp_dir = Path(tempfile.gettempdir())
         tmp_dir.mkdir(parents=True, exist_ok=True)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1875,6 +1875,9 @@ class KimiK25ForConditionalGeneration(DeepseekV3ForCausalLM):
     Extracts the DeepSeek-V3 text backbone from the composite config
     and strips the ``language_model.`` weight prefix so that the
     standard DeepseekV3ForCausalLM loading path works unchanged.
+
+    NOTE: Kimi-K2.5's text backbone sets ``num_nextn_predict_layers = 0``,
+    so MTP-based speculative decoding is not applicable to this model.
     """
 
     _LANG_PREFIX = "language_model."

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1866,3 +1866,43 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
             else:
                 layer.next_layer_layernorm = self.model.layers[
                     idx + 1].input_layernorm
+
+
+@register_auto_model("KimiK25ForConditionalGeneration")
+class KimiK25ForConditionalGeneration(DeepseekV3ForCausalLM):
+    """Kimi-K2.5 multimodal model (text-only path).
+
+    Extracts the DeepSeek-V3 text backbone from the composite config
+    and strips the ``language_model.`` weight prefix so that the
+    standard DeepseekV3ForCausalLM loading path works unchanged.
+    """
+
+    _LANG_PREFIX = "language_model."
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        model_config = copy.copy(model_config)
+        if hasattr(model_config.pretrained_config, 'text_config'):
+            model_config._frozen = False
+            model_config.pretrained_config = model_config.pretrained_config.text_config
+            if model_config.quant_config.exclude_modules:
+                model_config.quant_config = copy.copy(model_config.quant_config)
+                p = self._LANG_PREFIX
+                mapped = []
+                for m in model_config.quant_config.exclude_modules:
+                    if m.startswith(p):
+                        rest = m[len(p):]
+                        if rest.startswith('layers.'):
+                            rest = 'model.' + rest
+                        mapped.append(rest)
+                    else:
+                        mapped.append(m)
+                model_config.quant_config.exclude_modules = mapped
+            model_config._frozen = True
+        super().__init__(model_config)
+
+    def load_weights(self, weights: ConsumableWeightsDict):
+        has_prefix = any(k.startswith("language_model.") for k in weights)
+        if has_prefix:
+            weights = filter_weights("language_model", weights)
+            weights = ConsumableWeightsDict(weights)
+        super().load_weights(weights)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1884,23 +1884,24 @@ class KimiK25ForConditionalGeneration(DeepseekV3ForCausalLM):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         model_config = copy.copy(model_config)
-        if hasattr(model_config.pretrained_config, 'text_config'):
-            model_config._frozen = False
-            model_config.pretrained_config = model_config.pretrained_config.text_config
-            if model_config.quant_config.exclude_modules:
-                model_config.quant_config = copy.copy(model_config.quant_config)
-                p = self._LANG_PREFIX
-                mapped = []
-                for m in model_config.quant_config.exclude_modules:
-                    if m.startswith(p):
-                        rest = m[len(p):]
-                        if rest.startswith('layers.'):
-                            rest = 'model.' + rest
-                        mapped.append(rest)
-                    else:
-                        mapped.append(m)
-                model_config.quant_config.exclude_modules = mapped
-            model_config._frozen = True
+        assert hasattr(model_config.pretrained_config, 'text_config'), \
+            "KimiK25 config must have text_config"
+        model_config._frozen = False
+        model_config.pretrained_config = model_config.pretrained_config.text_config
+        if model_config.quant_config.exclude_modules:
+            model_config.quant_config = copy.copy(model_config.quant_config)
+            p = self._LANG_PREFIX
+            mapped = []
+            for m in model_config.quant_config.exclude_modules:
+                if m.startswith(p):
+                    rest = m[len(p):]
+                    if rest.startswith('layers.'):
+                        rest = 'model.' + rest
+                    mapped.append(rest)
+                else:
+                    mapped.append(m)
+            model_config.quant_config.exclude_modules = mapped
+        model_config._frozen = True
         super().__init__(model_config)
 
     def load_weights(self, weights: ConsumableWeightsDict):

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1885,7 +1885,7 @@ class KimiK25ForConditionalGeneration(DeepseekV3ForCausalLM):
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         model_config = copy.copy(model_config)
         assert hasattr(model_config.pretrained_config, 'text_config'), \
-            "KimiK25 config must have text_config"
+            "Kimi K2.5 config must have text_config"
         model_config._frozen = False
         model_config.pretrained_config = model_config.pretrained_config.text_config
         if model_config.quant_config.exclude_modules:

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -171,6 +171,9 @@ moonshotai/Kimi-K2-Thinking:
     accuracy: 90.84
   - quant_algo: NVFP4
     accuracy: 90.84
+moonshotai/Kimi-K2.5:
+  - quant_algo: NVFP4
+    accuracy: 93.06
 nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 92.57
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -273,6 +273,9 @@ moonshotai/Kimi-K2-Thinking:
   - quant_algo: NVFP4
     kv_cache_quant_algo: FP8
     accuracy: 85.83
+moonshotai/Kimi-K2.5:
+  - quant_algo: NVFP4
+    accuracy: 89.67
 nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 79.43
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3405,6 +3405,39 @@ class TestKimiK2(LlmapiAccuracyTestHarness):
                 assert not all(tid == 0 for tid in token_ids)
 
 
+@pytest.mark.threadleak(enabled=False)
+@pytest.mark.timeout(10800)
+@pytest.mark.skip_less_device_memory(100000)
+class TestKimiK25(LlmapiAccuracyTestHarness):
+
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_less_device_memory(120000)
+    @pytest.mark.parametrize("ep_size,attention_dp", [(1, False), (1, True),
+                                                      (8, False), (8, True)],
+                             ids=["ep1", "ep1_dp", "ep8", "ep8_dp"])
+    def test_nvfp4(self, ep_size, attention_dp):
+        model_name = "moonshotai/Kimi-K2.5"
+        model_path = f"{llm_models_root()}/Kimi-K2.5-NVFP4"
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
+
+        with LLM(model_path,
+                 tensor_parallel_size=8,
+                 max_batch_size=16,
+                 pipeline_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
+                 kv_cache_config=kv_cache_config,
+                 enable_attention_dp=attention_dp,
+                 trust_remote_code=True,
+                 speculative_config=None) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
+
+            task = MMLU(model_name)
+            task.evaluate(llm)
+            task = GSM8K(model_name)
+            task.evaluate(llm)
+
+
 class TestMinitron4BBaseInstruct(LlmapiAccuracyTestHarness):
     MODEL_NAME = "nvidia/Nemotron-Mini-4B-Instruct"
     MODEL_PATH = f"{llm_models_root()}/nemotron/nemotron-mini-4b-instruct_vfp8-fp8-bf16-export"

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3413,10 +3413,7 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
     @skip_pre_blackwell
     @pytest.mark.skip_less_device(8)
     @pytest.mark.skip_less_device_memory(120000)
-    @pytest.mark.parametrize("ep_size,attention_dp", [(1, False), (1, True),
-                                                      (8, False), (8, True)],
-                             ids=["ep1", "ep1_dp", "ep8", "ep8_dp"])
-    def test_nvfp4(self, ep_size, attention_dp):
+    def test_nvfp4(self):
         model_name = "moonshotai/Kimi-K2.5"
         model_path = f"{llm_models_root()}/Kimi-K2.5-NVFP4"
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
@@ -3425,9 +3422,9 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
                  tensor_parallel_size=8,
                  max_batch_size=16,
                  pipeline_parallel_size=1,
-                 moe_expert_parallel_size=ep_size,
+                 moe_expert_parallel_size=1,
                  kv_cache_config=kv_cache_config,
-                 enable_attention_dp=attention_dp,
+                 enable_attention_dp=True,
                  trust_remote_code=True,
                  speculative_config=None) as llm:
             assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3412,7 +3412,12 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
     @skip_pre_blackwell
     @pytest.mark.skip_less_device(8)
     @pytest.mark.skip_less_device_memory(120000)
-    def test_nvfp4(self):
+    @pytest.mark.parametrize(
+        "ep_size,attention_dp",
+        [(1, False), (1, True), (8, False), (8, True)],
+        ids=["tp8", "tp8_attn_dp", "ep8", "dep8"],
+    )
+    def test_nvfp4(self, ep_size, attention_dp):
         model_name = "moonshotai/Kimi-K2.5"
         model_path = f"{llm_models_root()}/Kimi-K2.5-NVFP4"
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
@@ -3421,9 +3426,9 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
                  tensor_parallel_size=8,
                  max_batch_size=16,
                  pipeline_parallel_size=1,
-                 moe_expert_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
                  kv_cache_config=kv_cache_config,
-                 enable_attention_dp=True,
+                 enable_attention_dp=attention_dp,
                  trust_remote_code=True,
                  speculative_config=None) as llm:
             assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3405,7 +3405,6 @@ class TestKimiK2(LlmapiAccuracyTestHarness):
                 assert not all(tid == 0 for tid in token_ids)
 
 
-@pytest.mark.threadleak(enabled=False)
 @pytest.mark.timeout(10800)
 @pytest.mark.skip_less_device_memory(100000)
 class TestKimiK25(LlmapiAccuracyTestHarness):

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -255,10 +255,7 @@ accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_fp8_blockscale[latency]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[8gpus]
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep1]
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep1_dp]
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8]
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8_dp]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_fp8
 accuracy/test_llm_api_pytorch.py::TestPhi4MM::test_auto_dtype

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -255,6 +255,10 @@ accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_fp8_blockscale[latency]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[8gpus]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep1]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep1_dp]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8_dp]
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_fp8
 accuracy/test_llm_api_pytorch.py::TestPhi4MM::test_auto_dtype

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -255,7 +255,10 @@ accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_fp8_blockscale[latency]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus]
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[8gpus]
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8]
+accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8]
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_fp8
 accuracy/test_llm_api_pytorch.py::TestPhi4MM::test_auto_dtype

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -114,6 +114,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_mtp1] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-cutlass] TIMEOUT (60)
@@ -145,6 +146,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[disable_skip_indexer] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_pp4_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[baseline_fp8kv] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B::test_fp8[latency_moe_deepgemm] TIMEOUT (60)
   - test_e2e.py::test_deepseek_r1_mtp_bench TIMEOUT(60) # Cover https://nvbugs/5670108
 - condition:

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -146,7 +146,6 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[disable_skip_indexer] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_pp4_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[baseline_fp8kv] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B::test_fp8[latency_moe_deepgemm] TIMEOUT (60)
   - test_e2e.py::test_deepseek_r1_mtp_bench TIMEOUT(60) # Cover https://nvbugs/5670108
 - condition:

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -114,7 +114,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_mtp1] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-cutlass] TIMEOUT (60)
@@ -146,6 +146,9 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[disable_skip_indexer] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_pp4_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[baseline_fp8kv] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B::test_fp8[latency_moe_deepgemm] TIMEOUT (60)
   - test_e2e.py::test_deepseek_r1_mtp_bench TIMEOUT(60) # Cover https://nvbugs/5670108
 - condition:

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes.yml
@@ -18,6 +18,7 @@ l0_gb200_multi_nodes:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] TIMEOUT (180)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (180)
 - condition:
     ranges:
       # 2 nodes with each node has 4 GPUs

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes.yml
@@ -18,7 +18,7 @@ l0_gb200_multi_nodes:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] TIMEOUT (180)
-  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4 TIMEOUT (180)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (180)
 - condition:
     ranges:
       # 2 nodes with each node has 4 GPUs
@@ -40,3 +40,6 @@ l0_gb200_multi_nodes:
   - accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_cutlass] TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm] TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm_attention_dp] TIMEOUT (90)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp] TIMEOUT (180)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8] TIMEOUT (180)
+  - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (180)


### PR DESCRIPTION
## Summary

Add text-only inference support for [Kimi-K2.5](https://huggingface.co/nvidia/Kimi-K2.5-NVFP4),
a multimodal model built on the DeepSeek-V3 text backbone.

### Changes
- Register `KimiK25ForConditionalGeneration` architecture in `modeling_deepseekv3.py`,
  inheriting from `DeepseekV3ForCausalLM`
- Extract `text_config` from the composite multimodal config and remap quant
  `exclude_modules` by stripping the `language_model.` prefix
- Add accuracy references: MMLU 89.67%, GSM8K 93.06% (NVFP4)
- Add `TestKimiK25` accuracy tests with EP=1/8 × attention_dp on/off configurations
- Add test entries to QA `llm_function_core.txt`

### Notes
- Kimi-K2.5's text backbone sets `num_nextn_predict_layers = 0`,
  so MTP speculative decoding is not applicable.
- Vision/multimodal path is not included in this PR (text-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kimi-K2.5 model with NVFP4 quantization.
  * Enabled text backbone extraction from composite model configurations.

* **Tests**
  * Added integration tests for Kimi-K2.5 with NVFP4 quantization on MMLU (89.67) and GSM8K (93.06) benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->