### PR TITLE
[TRTLLM-11093][feat] add 5D A2A for fused ulysses

### DIFF
--- a/tensorrt_llm/_torch/distributed/__init__.py
+++ b/tensorrt_llm/_torch/distributed/__init__.py
@@ -4,11 +4,12 @@ from .communicator import Distributed, MPIDist, TorchDist
 from .moe_alltoall import MoeAlltoAll
 from .ops import (AllReduce, AllReduceParams, AllReduceStrategy,
                   HelixAllToAllNative, MoEAllReduce, MoEAllReduceParams,
-                  all_to_all_4d, allgather, alltoall_helix, cp_allgather,
-                  reducescatter, userbuffers_allreduce_finalize)
+                  all_to_all_4d, all_to_all_5d, allgather, alltoall_helix,
+                  cp_allgather, reducescatter, userbuffers_allreduce_finalize)
 
 __all__ = [
     "all_to_all_4d",
+    "all_to_all_5d",
     "allgather",
     "alltoall_helix",
     "cp_allgather",

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -1151,8 +1151,8 @@ def all_to_all_5d(
                                             group=process_group)
         out = out_flat.view_as(inp)
 
-        out = out.permute(1, 2, 0, 3, 4,
-                          5).contiguous()  # [B, S/P, P, 3, H/P, D]
+        out = out.permute(1, 2, 3, 0, 4,
+                          5).contiguous()  # [B, S/P, 3, P, H/P, D]
         gathered_heads = heads * world_size
         return out.reshape(batch, sharded_seq, qkv_count, gathered_heads,
                            head_dim)

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/trtllm.py
@@ -211,8 +211,8 @@ class TrtllmAttention(BaseTrtllmAttention):
     def forward(
         self,
         q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
         batch_size: int,
         seq_len: int,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.FULL,
@@ -241,7 +241,10 @@ class TrtllmAttention(BaseTrtllmAttention):
         # Handle cross-attention where K/V have different sequence length than Q
         kv_seq_len = seq_len_kv if seq_len_kv is not None else seq_len
 
-        qkv = self._concat_qkv(q, k, v, batch_size, seq_len, kv_seq_len)
+        if k is None and v is None:
+            qkv = q.reshape(batch_size * seq_len, -1)
+        else:
+            qkv = self._concat_qkv(q, k, v, batch_size, seq_len, kv_seq_len)
         prepared_metadata = self._prepare_metadata(batch_size, seq_len)
         output = super().forward(
             q=qkv,

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
@@ -23,6 +23,7 @@ try:
     from tensorrt_llm._torch.attention_backend.interface import PredefinedAttentionMask
     from tensorrt_llm._torch.distributed import all_to_all_4d, all_to_all_5d
     from tensorrt_llm._torch.visual_gen.attention_backend import UlyssesAttention, VanillaAttention
+    from tensorrt_llm._torch.visual_gen.attention_backend.interface import AttentionTensorLayout
     from tensorrt_llm._utils import get_free_port
 
     MODULES_AVAILABLE = True
@@ -449,8 +450,38 @@ def _logic_a2a_5d_roundtrip(rank, world_size):
     torch.testing.assert_close(reconstructed, original, rtol=1e-5, atol=1e-5)
 
 
+class _FusedVanillaAttention(torch.nn.Module):
+    """Test-only backend that supports fused QKV to exercise the 5D A2A path."""
+
+    def __init__(self, num_heads: int, head_dim: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.scale = 1.0 / math.sqrt(head_dim)
+        self._preferred_layout = AttentionTensorLayout.NHD
+
+    def forward(self, q, k=None, v=None, batch_size=None, seq_len=None, **kwargs):
+        if k is None and v is None:
+            q_t, k_t, v_t = q[:, :, 0], q[:, :, 1], q[:, :, 2]
+        else:
+            q_t, k_t, v_t = q, k, v
+        q_t = q_t.transpose(1, 2)
+        k_t = k_t.transpose(1, 2)
+        v_t = v_t.transpose(1, 2)
+        out = F.scaled_dot_product_attention(q_t, k_t, v_t, scale=self.scale)
+        return out.transpose(1, 2).contiguous()
+
+    @property
+    def preferred_layout(self) -> AttentionTensorLayout:
+        return self._preferred_layout
+
+    @classmethod
+    def support_fused_qkv(cls) -> bool:
+        return True
+
+
 def _logic_ulysses_fused_vs_unfused(rank, world_size):
-    """Fused QKV A2A (fuse_qkv_a2a=True) matches unfused path."""
+    """Fused 5D A2A (auto-selected via support_fused_qkv) matches unfused 4D path."""
     batch = 2
     seq_per_rank = 8
     seq_full = seq_per_rank * world_size
@@ -468,14 +499,12 @@ def _logic_ulysses_fused_vs_unfused(rank, world_size):
     attn_unfused = UlyssesAttention(
         inner_backend=inner_unfused,
         process_group=None,
-        fuse_qkv_a2a=False,
     ).to(device)
 
-    inner_fused = VanillaAttention(num_heads=num_heads // world_size, head_dim=head_dim)
+    inner_fused = _FusedVanillaAttention(num_heads=num_heads // world_size, head_dim=head_dim)
     attn_fused = UlyssesAttention(
         inner_backend=inner_fused,
         process_group=None,
-        fuse_qkv_a2a=True,
     ).to(device)
 
     out_unfused = attn_unfused(q, k, v, batch_size=batch, seq_len=seq_full)
@@ -486,12 +515,12 @@ def _logic_ulysses_fused_vs_unfused(rank, world_size):
         out_unfused,
         rtol=1e-4,
         atol=1e-4,
-        msg=f"Rank {rank}: Fused QKV A2A output differs from unfused",
+        msg=f"Rank {rank}: Fused 5D A2A output differs from unfused 4D path",
     )
 
 
 def _logic_ulysses_fused_vs_standard(rank, world_size):
-    """Fused QKV A2A matches standard full-sequence attention."""
+    """Fused 5D A2A matches standard full-sequence attention."""
     batch = 2
     seq_per_rank = 8
     seq_full = seq_per_rank * world_size
@@ -509,11 +538,10 @@ def _logic_ulysses_fused_vs_standard(rank, world_size):
     k_shard = k_full[:, rank * seq_per_rank : (rank + 1) * seq_per_rank].contiguous()
     v_shard = v_full[:, rank * seq_per_rank : (rank + 1) * seq_per_rank].contiguous()
 
-    inner = VanillaAttention(num_heads=num_heads // world_size, head_dim=head_dim)
+    inner = _FusedVanillaAttention(num_heads=num_heads // world_size, head_dim=head_dim)
     attn_fused = UlyssesAttention(
         inner_backend=inner,
         process_group=None,
-        fuse_qkv_a2a=True,
     ).to(device)
 
     fused_output = attn_fused(q_shard, k_shard, v_shard, batch_size=batch, seq_len=seq_full)
@@ -532,7 +560,7 @@ def _logic_ulysses_fused_vs_standard(rank, world_size):
         expected_shard,
         rtol=1e-4,
         atol=1e-4,
-        msg=f"Rank {rank}: Fused Ulysses output differs from standard attention",
+        msg=f"Rank {rank}: Fused 5D Ulysses output differs from standard attention",
     )
 
 
@@ -647,13 +675,13 @@ class TestUlyssesAttention:
         run_test_in_distributed(world_size=2, test_fn=_logic_ulysses_invalid_heads, use_cuda=False)
 
     def test_ulysses_fused_vs_unfused(self):
-        """Test fused QKV A2A matches unfused path."""
+        """Test fused 5D A2A (auto-selected) matches unfused 4D path."""
         run_test_in_distributed(
             world_size=2, test_fn=_logic_ulysses_fused_vs_unfused, use_cuda=True
         )
 
     def test_ulysses_fused_vs_standard_attention(self):
-        """Test fused QKV A2A matches standard full-sequence attention."""
+        """Test fused 5D A2A matches standard full-sequence attention."""
         run_test_in_distributed(
             world_size=2, test_fn=_logic_ulysses_fused_vs_standard, use_cuda=True
         )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 5D all-to-all tensor operations for optimized parallel computations
  * Enabled fused QKV attention mode, reducing the number of collective operations required
  * Extended method signatures to support optional key/value inputs for improved flexibility

* **Tests**
  * Added comprehensive test coverage for new 5D operations and attention backend comparisons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

5D A2A for fused ulysses parallel. 5D is more efficient than 4D with dim=0 or dim=-1 concat. Currently defaults to True when using an attention backend that supports fused QKV like TRTLLM. This helps to reduce redundant ops from the A2A to attention achieving ~1% speedup for WAN 2.2 over 2-8 GPUs.
This PR also sets up future work for adding custom kernels for fused QK norm + rope which will feed directly into fused A2A leading to a 3-9% perf gain.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
