### PR TITLE
[#11726][feat] AutoDeploy: Fuse gemms of mixed children

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -17,7 +17,6 @@ transforms:
   export_to_gm:
     num_moe_experts_for_export: 2
   fuse_gemms_mixed_children:
-    stage: post_load_fusion
     enabled: true
   detect_sharding:
     sharding_dims: ['tp','ep', 'bmm']

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -16,6 +16,9 @@ model_kwargs:
 transforms:
   export_to_gm:
     num_moe_experts_for_export: 2
+  fuse_gdn_gemms:
+    stage: post_load_fusion
+    enabled: true
   detect_sharding:
     sharding_dims: ['tp','ep', 'bmm']
     # use only manual config for TP sharding

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -16,7 +16,7 @@ model_kwargs:
 transforms:
   export_to_gm:
     num_moe_experts_for_export: 2
-  fuse_gdn_gemms:
+  fuse_gemms_mixed_children:
     stage: post_load_fusion
     enabled: true
   detect_sharding:

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -127,6 +127,9 @@ transforms:
   ############################################################################################
   # RUN POST-LOAD FUSION AND OPTIMIZATIONS
   ############################################################################################
+  fuse_gdn_gemms:
+    stage: post_load_fusion
+    enabled: false
   fuse_gemms:
     stage: post_load_fusion
     enabled: false # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/4674 this is causing OOMs

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -127,7 +127,7 @@ transforms:
   ############################################################################################
   # RUN POST-LOAD FUSION AND OPTIMIZATIONS
   ############################################################################################
-  fuse_gdn_gemms:
+  fuse_gemms_mixed_children:
     stage: post_load_fusion
     enabled: false
   fuse_gemms:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gemm_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gemm_fusion.py
@@ -413,12 +413,12 @@ class Qwen35GdnMixedQuantModel(TestModel):
         self.num_heads = num_heads
         self.head_dim = head_dim
 
-        # FP8 quantized projections
+        # FP8 quantized projections (handle dtype internally via custom op)
         self.in_proj_qkv = FakeFP8Linear(hidden, qkv_dim, bias=False)
         self.in_proj_z = FakeFP8Linear(hidden, z_dim, bias=False)
-        # bf16 projections
-        self.in_proj_b = nn.Linear(hidden, num_heads, bias=False)
-        self.in_proj_a = nn.Linear(hidden, num_heads, bias=False)
+        # bf16 projections (cast to half to match FP8 input dtype)
+        self.in_proj_b = nn.Linear(hidden, num_heads, bias=False).half()
+        self.in_proj_a = nn.Linear(hidden, num_heads, bias=False).half()
 
     def get_input(self, **kwargs) -> torch.Tensor:
         return torch.randn(self.batch_size, self.seq_len, self.hidden, **kwargs)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gemm_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gemm_fusion.py
@@ -296,7 +296,7 @@ def test_fusion(get_model: Callable[[], TestModel], dtype: str):
 
 
 # ===========================================================================
-# Tests for fuse_gdn_gemms (relaxed fusion with narrow / zero-copy views)
+# Tests for fuse_gemms_mixed_children (relaxed fusion with narrow / zero-copy views)
 # ===========================================================================
 
 
@@ -443,7 +443,7 @@ class Qwen35GdnMixedQuantModel(TestModel):
 
 @pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
 @torch.inference_mode()
-def test_fuse_gdn_gemms_mixed_quant():
+def test_fuse_gemms_mixed_children_mixed_quant():
     model = Qwen35GdnMixedQuantModel().to(device="cuda")
     x = model.get_input(device="cuda", dtype=torch.half)
 
@@ -462,7 +462,7 @@ def test_fuse_gdn_gemms_mixed_quant():
     gm_transformed = InferenceOptimizer(
         None,
         {
-            "fuse_gdn_gemms": {
+            "fuse_gemms_mixed_children": {
                 "stage": "post_load_fusion",
             },
         },
@@ -496,7 +496,7 @@ def test_fuse_gdn_gemms_mixed_quant():
 
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 @torch.inference_mode()
-def test_fuse_gdn_gemms_qwen35_like(dtype: str):
+def test_fuse_gemms_mixed_children_qwen35_like(dtype: str):
     torch_dtype = getattr(torch, dtype)
     model = Qwen35GdnLikeFusableModel().to(device="cuda", dtype=torch_dtype)
     x = model.get_input(device="cuda", dtype=torch_dtype)
@@ -512,7 +512,7 @@ def test_fuse_gdn_gemms_qwen35_like(dtype: str):
     gm_transformed = InferenceOptimizer(
         None,
         {
-            "fuse_gdn_gemms": {
+            "fuse_gemms_mixed_children": {
                 "stage": "post_load_fusion",
             },
         },
@@ -544,7 +544,7 @@ def test_fuse_gdn_gemms_qwen35_like(dtype: str):
 
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 @torch.inference_mode()
-def test_fuse_gdn_gemms(dtype: str):
+def test_fuse_gemms_mixed_children(dtype: str):
     torch_dtype = getattr(torch, dtype)
     model = GdnLikeFusableModel().to(device="cuda", dtype=torch_dtype)
     x = model.get_input(device="cuda", dtype=torch_dtype)
@@ -560,7 +560,7 @@ def test_fuse_gdn_gemms(dtype: str):
     gm_transformed = InferenceOptimizer(
         None,
         {
-            "fuse_gdn_gemms": {
+            "fuse_gemms_mixed_children": {
                 "stage": "post_load_fusion",
             },
         },


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Fused gemms of a parent whose children are not same types of gemm 
- Target pattern is Qwen3.5 model's GDN layer
<img width="1939" height="432" alt="image" src="https://github.com/user-attachments/assets/2f1c4ca2-a4d4-4e7d-867c-987a0b97ddbd" />


## Test Coverage
- tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gemm_fusion.py
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
