### PR TITLE
[None][refactor] Revisit attention interface for AutoDeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -131,4 +131,4 @@ The table below lists the operators grouped by category.
 | Operator Name | Description |
 |--------------|-------------|
 | `torch.ops.auto_deploy.triton_utils_fused_gather_scatter` | Triton fused gather + scatter for overlap scheduling input_ids reordering |
-| `torch.ops.auto_deploy.gather_tokens` | Gather hidden states using logits indices before LM head |
+| `torch.ops.auto_deploy.gather_tokens` | Gather hidden states using token indices before LM head |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -131,4 +131,4 @@ The table below lists the operators grouped by category.
 | Operator Name | Description |
 |--------------|-------------|
 | `torch.ops.auto_deploy.triton_utils_fused_gather_scatter` | Triton fused gather + scatter for overlap scheduling input_ids reordering |
-| `torch.ops.auto_deploy.gather_logits_before_lm_head` | Gather hidden states using logits indices before LM head |
+| `torch.ops.auto_deploy.gather_tokens` | Gather hidden states using logits indices before LM head |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -84,6 +84,11 @@ class _TrtllmPlanner:
         # Persistent block_offsets buffer for CUDA graph compatibility.
         # Pre-allocated to max size so the tensor address is stable across replays.
         self.block_offsets: Optional[torch.Tensor] = None
+        # Per-layer cache for tensors that must survive CUDA graph replay.
+        # Keyed by kv_cache.data_ptr() (stable and unique per layer).
+        self._layer_cache: dict[
+            int, Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        ] = {}
 
     def reset(self, device: torch.device, max_batch: int, max_blocks_per_seq: int) -> None:
         """One-time allocation of ALL persistent buffers.
@@ -115,6 +120,39 @@ class _TrtllmPlanner:
         self.host_context_lengths = torch.zeros(
             max_batch, dtype=torch.int32, device="cpu", pin_memory=prefer_pinned()
         )
+
+    def get_layer_tensors(
+        self,
+        kv_cache: torch.Tensor,
+        kv_scale_orig_quant: float,
+        kv_scale_quant_orig: float,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], int]:
+        """Return (pool_pointers, kv_scale_oq, kv_scale_qo, quant_mode) for a layer.
+
+        Lazily creates and caches the tensors on first call per layer to avoid
+        dynamic allocations during CUDA graph capture.
+        """
+        key = kv_cache.data_ptr()
+        if key not in self._layer_cache:
+            pool_ptrs = torch.zeros(
+                1, 2, dtype=torch.int64, device="cpu", pin_memory=prefer_pinned()
+            )
+            pool_ptrs[0, 0] = key
+            if kv_cache.dtype == torch.float8_e4m3fn:
+                scale_oq = torch.tensor(
+                    [kv_scale_orig_quant], dtype=torch.float32, device=kv_cache.device
+                )
+                scale_qo = torch.tensor(
+                    [kv_scale_quant_orig], dtype=torch.float32, device=kv_cache.device
+                )
+            else:
+                scale_oq = None
+                scale_qo = None
+            self._layer_cache[key] = (pool_ptrs, scale_oq, scale_qo)
+
+        pool_ptrs, scale_oq, scale_qo = self._layer_cache[key]
+        quant_mode = int(QuantMode.FP8_KV_CACHE) if scale_oq is not None else 0
+        return pool_ptrs, scale_oq, scale_qo, quant_mode
 
     def plan_host(
         self,
@@ -313,21 +351,11 @@ def trtllm_mha_with_cache(
         else max_context_length
     )
 
-    # Per-layer pool pointer tensor (created per invocation from kv_cache.data_ptr())
-    host_kv_cache_pool_pointers = torch.zeros(
-        1, 2, dtype=torch.int64, device="cpu", pin_memory=prefer_pinned()
+    # Per-layer tensors (pool pointers + optional FP8 scale tensors).
+    # Cached on first call to avoid allocations during CUDA graph capture.
+    host_kv_cache_pool_pointers, kv_scale_oq, kv_scale_qo, quant_mode = (
+        _GlobalTrtllmPlanner.get_layer_tensors(kv_cache, kv_scale_orig_quant, kv_scale_quant_orig)
     )
-    host_kv_cache_pool_pointers[0, 0] = kv_cache.data_ptr()
-
-    # FP8 KV cache scale tensors
-    if kv_cache.dtype == torch.float8_e4m3fn:
-        kv_scale_oq = torch.tensor([kv_scale_orig_quant], dtype=torch.float32, device=q.device)
-        kv_scale_qo = torch.tensor([kv_scale_quant_orig], dtype=torch.float32, device=q.device)
-        quant_mode = int(QuantMode.FP8_KV_CACHE)
-    else:
-        kv_scale_oq = None
-        kv_scale_qo = None
-        quant_mode = 0
 
     # Reshape Q, K, V to [num_tokens, num_heads * head_dim] and fuse
     # Input is always [bs, 1] (generate-only) or [1, total_seq_len] (prefill/mixed),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -184,16 +184,21 @@ class InputBuffer:
         """Return the device of the device buffer."""
         return self._device_buffer.device
 
-    def get_view(self, name: str) -> torch.Tensor:
+    @property
+    def host_device(self) -> torch.device:
+        """Return the device of the host buffer."""
+        return self._host_buffer.device
+
+    def get_view(self, name: str, truncate: bool = False) -> torch.Tensor:
         """Get the device tensor view for the specified name."""
+        if truncate:
+            return self._device_views[name][: self.get_current_length(name)]
         return self._device_views[name]
 
-    def get_view_at_current_length(self, name: str) -> torch.Tensor:
-        """Get the device tensor view truncated to the current stored length."""
-        return self._device_views[name][: self._current_lengths[name]]
-
-    def get_host_view(self, name: str) -> torch.Tensor:
+    def get_host_view(self, name: str, truncate: bool = False) -> torch.Tensor:
         """Get the host tensor view for the specified name."""
+        if truncate:
+            return self._host_views[name][: self.get_current_length(name)]
         return self._host_views[name]
 
     def get_capacity(self, name: str) -> int:
@@ -205,13 +210,13 @@ class InputBuffer:
         """Get the current stored length for the specified tensor."""
         return self._current_lengths[name]
 
-    def store(
+    def stage(
         self,
         name: str,
-        data: torch.Tensor,
+        data: Union[torch.Tensor, List[Number]],
         fill_value: Optional[Number] = None,
     ) -> int:
-        """Store a tensor into the pinned host buffer.
+        """Stage data into the pinned host buffer.
 
         Args:
             name: Name of the tensor to store to.
@@ -227,6 +232,10 @@ class InputBuffer:
         if fill_value is not None:
             host_view.fill_(fill_value)
 
+        # convert to tensor via numpy (numpy is ~2-3x faster than torch.tensor for large lists)
+        if not isinstance(data, torch.Tensor):
+            data = _list_to_tensor(data, dtype)
+
         length = data.numel()
         assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
         # Use numpy for the memcpy into pinned memory — avoids torch dispatcher overhead
@@ -237,6 +246,25 @@ class InputBuffer:
         self._current_lengths[name] = length
         return length
 
+    def copy_(self, name: str, src: torch.Tensor) -> None:
+        """Copy a tensor into the buffer.
+
+        NOTE: only the buffer that matches the source device is updated!
+
+        Args:
+            name: Name of the tensor in the buffer.
+            src: host-side or device-side source tensor whose elements are copied into the first
+                ``src.numel()`` positions of the buffer views.
+        """
+        n = src.numel()
+        if src.device == self._host_buffer.device:
+            self._host_views[name][:n].copy_(src)
+        elif src.device == self._device_buffer.device:
+            self._device_views[name][:n].copy_(src, non_blocking=True)
+        else:
+            raise RuntimeError(f"Unexpected device: {src.device=}")
+        self._current_lengths[name] = n
+
     def copy_to_device(self) -> None:
         """Copy from host buffers to device buffers.
 
@@ -246,19 +274,42 @@ class InputBuffer:
         with nvtx_range("ad_input_buffer_h2d_copy"):
             # Copy contiguous buffer in one shot
             if self._total_bytes > 0:
-                self._device_buffer[: self._total_bytes].copy_(
-                    self._host_buffer[: self._total_bytes], non_blocking=True
-                )
+                h_buffer = self._host_buffer[: self._total_bytes]
+                d_buffer = self._device_buffer[: self._total_bytes]
+                d_buffer.copy_(h_buffer, non_blocking=True)
 
             # Copy each truncatable tensor independently, truncated to current length
             for name in self._truncatable_names:
-                length = self._current_lengths[name]
+                length = self.get_current_length(name)
                 if length > 0:
                     _, dtype = self._tensor_specs[name]
                     copy_bytes = length * dtype.itemsize
-                    self._trunc_device_bufs[name][:copy_bytes].copy_(
-                        self._trunc_host_bufs[name][:copy_bytes], non_blocking=True
-                    )
+                    trunc_d_buf = self._trunc_device_bufs[name][:copy_bytes]
+                    trunc_h_buf = self._trunc_host_bufs[name][:copy_bytes]
+                    trunc_d_buf.copy_(trunc_h_buf, non_blocking=True)
+
+    def copy_to_host(self) -> None:
+        """Copy from device buffer to host buffer.
+
+        Mirrors ``copy_to_device``: uses the current length of the truncatable tensor
+        (last in spec) to minimize transfer size.
+        """
+        with nvtx_range("ad_input_buffer_d2h_copy"):
+            # Copy contiguous buffer in one shot
+            if self._total_bytes > 0:
+                h_buffer = self._host_buffer[: self._total_bytes]
+                d_buffer = self._device_buffer[: self._total_bytes]
+                h_buffer.copy_(d_buffer, non_blocking=True)
+
+            # Copy each truncatable tensor independently, truncated to current length
+            for name in self._truncatable_names:
+                length = self.get_current_length(name)
+                if length > 0:
+                    _, dtype = self._tensor_specs[name]
+                    copy_bytes = length * dtype.itemsize
+                    trunc_d_buf = self._trunc_device_bufs[name][:copy_bytes]
+                    trunc_h_buf = self._trunc_host_bufs[name][:copy_bytes]
+                    trunc_h_buf.copy_(trunc_d_buf, non_blocking=True)
 
     def resize(self, name: str, new_capacity: int) -> None:
         """Resize a truncatable tensor's capacity.
@@ -329,7 +380,8 @@ class SequenceInfo:
       flattened sequence of [b, 1] or [1, s_total]. We use [b, 1] to denote generate-only batches.
     - position_ids: [pos_0, ..., pos_{s_total-1}]
       flattened sequence of [b, 1] or [1, s_total] indicating absolute position ids for every token
-      in the input_ids sequence. We use [b, 1] to denote generate-only batches.
+      in the input_ids sequence. We use [b, 1] to denote generate-only batches. Usually derived from
+      input_pos.
 
     NOTE: ``input_ids`` and ``position_ids`` are initially expected to be of shape [b, seq_len]
     before we switch to cached+flattened attention.
@@ -338,69 +390,62 @@ class SequenceInfo:
     Those are extra arguments that can be provided to the interface and they are stored as follows:
     - _extra_args: dictionary of extra arguments with currently active values.
 
-    ### AVAILABLE ARGUMENTS TO BE ADDED BY THE TRANSFORMS IF NEEDED ################################
-    - seq_len: [s_0, s_1, ..., s_{b-1}] such that s_total = sum(s_i)
-      Describes how long each sequence is. For example,
-      input_ids[:s_0] will correspond to sequence 0 in the batch and input_ids[s_0:s_1] will
-      correspond to sequence 1 in the batch.
-    - cu_seqlen: [0, s_0, s_0+s_1, ..., s_total]
-      Cumulative sequence lengths of shape [b+1]. cu_seqlen[i+1] - cu_seqlen[i] gives the length
-      of sequence i.
+    ### BASIC ARGUMENTS TO DESCRIBE RAGGED ATTENTION+CACHE INPUTS ##################################
     - input_pos: [pos_0, ..., pos_{b-1}]
       Corresponds to the total number of tokens that have already been cached for each sequence
       in the batch (i.e., the starting position in the cache for new tokens).
-    - pages_per_seq: [ps_0, ps_1, ..., ps_{b-1}] where ps_i is the number of pages allocated for
-      sequence i. Note that, for example, cache_loc[sum(ps_0:ps_{i-1}):sum(ps_0:ps_i)] will
-      correspond to the pages associated with sequence i in the batch.
+    - cu_seqlen: [0, s_0, s_0+s_1, ..., s_total]
+      Cumulative sequence lengths of shape [b+1]. cu_seqlen[i+1] - cu_seqlen[i] gives the length
+      of sequence i.
+    - cache_loc: [c_0, c_1, ..., c_{np-1}] where np is total number of pages allocated to describe
+      all sequences in the batch. Each value is a page index in the cache.
     - cu_num_pages: [0, ps_0, ps_0+ps_1, ..., sum(ps_i)]
       Cumulative number of pages of shape [b+1]. cu_num_pages[i+1] - cu_num_pages[i] gives the
       number of pages for sequence i.
-    - seq_len_with_cache: [pos_0+s_0, pos_1+s_1, ..., pos_{b-1}+s_{b-1}]
-      Total sequence length including cached tokens for each sequence (input_pos + seq_len).
     - last_page_len: [lpl_0, lpl_1, ..., lpl_{b-1}]
       Number of valid tokens in the last page for each sequence. Computed as
       (seq_len_with_cache - 1) % page_size + 1.
     - slot_idx: [slot_0, slot_1, ..., slot_{b-1}]
       Corresponds to the slot index of each sequence in the batch.
-    - use_initial_states: [bool_0, bool_1, ..., bool_{b-1}]
-      Per-sequence boolean indicating whether initial states should be used (True if input_pos > 0).
-    - batch_info: [num_prefill, num_prefill_tokens, num_decode]
-      Batch metadata containing the number of prefill sequences, total prefill tokens, and number
-      of decode sequences.
+
+    ### INFO OBJECTS THAT ARE AVAILABLE TO DESCRIBE THE INPUTS IN A MORE COMPACT WAY ###############
+    - batch_info: [num_prefill, num_prefill_tokens, num_extend, num_extend_tokens, num_decode, num_decode_tokens]
+      Batch metadata containing the number of requests and tokens for each of the three request
+      types: prefill, extend (spec dec), and decode.
     - max_seq_info: [max_context_length, max_blocks_per_seq, block_offset_multiplier, max_batch_size]
       Model-level constants for the attention kernel: maximum context length (equal to max_seq_len),
       maximum number of KV cache blocks per sequence (ceil(max_seq_len / tokens_per_block)),
       block offset multiplier derived from kv_cache strides, and maximum batch size. These are
       set once via update_cache_information() after cache initialization and remain constant.
-    - page_seq_indices: [si_0, si_1, ..., si_{np-1}] where si_j is the sequence index that page j
-      belongs to. For example, if seq 0 has 2 pages and seq 1 has 3, then
-      page_seq_indices = [0, 0, 1, 1, 1].
-    - page_in_seq: [pi_0, pi_1, ..., pi_{np-1}] where pi_j is the page index within its sequence.
-      For example, if seq 0 has 2 pages and seq 1 has 3, then page_in_seq = [0, 1, 0, 1, 2].
-    - cache_loc: [c_0, c_1, ..., c_{np-1}] where np is total number of pages allocated to describe
-      all sequences in the batch. Each value is a page index in the cache.
-    - logits_gather_indices: [g_0, g_1, ..., g_{s_total-1}]
-      Gather indices used by the gather_logits_before_lm_head custom op to gather logits before the LM head.
-    - logits_gather_info: [num_tokens_to_gather, gather_required]. Info for the
-      gather_logits_before_lm_head custom op to gather logits before the LM head.
+
+    ### ADDITIONAL ARGUMENTS AVAILABLE THAT ARE DERIVED FROM THE BASIC ARGUMENTS ###################
+    - seq_len: [s_0, s_1, ..., s_{b-1}] such that s_total = sum(s_i)
+      Describes how long each sequence is. For example,
+      input_ids[:s_0] will correspond to sequence 0 in the batch and input_ids[s_0:s_1] will
+      correspond to sequence 1 in the batch.
+    - pages_per_seq: [ps_0, ps_1, ..., ps_{b-1}] where ps_i is the number of pages allocated for
+      sequence i. Note that, for example, cache_loc[sum(ps_0:ps_{i-1}):sum(ps_0:ps_i)] will
+      correspond to the pages associated with sequence i in the batch.
+    - seq_len_with_cache: [pos_0+s_0, pos_1+s_1, ..., pos_{b-1}+s_{b-1}]
+      Total sequence length including cached tokens for each sequence (input_pos + seq_len).
+    - use_initial_states: [bool_0, bool_1, ..., bool_{b-1}]
+      Per-sequence boolean indicating whether initial states should be used (True if input_pos > 0).
+
+    ### OTHER ARGUMENTS USED BY THE RUNTIME ########################################################
+    - extra_page_per_seq: [ep_0, ep_1, ..., ep_{b-1}]
+      Extra page per sequence for deferred page insertion. If no extra pages is needed, this is -1.
+    - token_gather_indices: [g_0, g_1, ..., g_{s_total-1}]
+      Gather indices used by the gather_tokens custom op to gather logits before the LM head.
+    - tokens_gather_info: [num_tokens_to_gather, gather_required]. Info for the
+      gather_tokens custom op to gather tokens for which we don't need the output logits.
     - _gather_idx: [g_0, g_1, ..., g_{s_total-1}]
       Gather indices used by the overlap scheduler to reorder input tokens.
     - _mask_scatter_indices: [m_0, m_1, ..., m_{s_total-1}]
       Mask scatter indices used by the overlap scheduler to scatter results back.
 
-    NOTE: all tensors are also accessible as host tensors with the suffix "_host". For example,
-    the tensor "batch_info" is accessible as "batch_info_host" on the host.
+    NOTE: all tensors are also accessible as host tensors with the host suffix as host version. For
+    example, the tensor "batch_info" is accessible as "batch_info_host" on the host.
 
-    ################################################################################################
-
-    Here are a couple of notes to emphasize this notation:
-
-    - The total number of allocated token space for sequence i is given by ps_i * page_size. This is
-      the total number of tokens that can be cached for each sequence.
-
-    - NOTE: It must hold that pos_i + s_i <= ps_i * page_size for all i in [0, b-1]. Moreover, it is
-      the responsibility of the cache manager and/or runtime to ensure sufficient page allocation
-      for each sequence.
 
     """
 
@@ -432,7 +477,8 @@ class SequenceInfo:
         """
         # set up basic attributes
         self.max_seq_len = max_seq_len
-        self.max_batch_size = max_batch_size
+        # Buffer capacity must accommodate at least bs=2 (used by set_example_sequence for export)
+        self.max_batch_size = max(2, max_batch_size)
         self.tokens_per_block = tokens_per_block or max_seq_len
         self.max_blocks_per_seq = math.ceil(max_seq_len / self.tokens_per_block)
         # NOTE (lucaslie): +1 is a WAR to address issue when using flashinfer attention with
@@ -469,62 +515,46 @@ class SequenceInfo:
         # Order matters: cache_loc is placed LAST for truncation optimization during H2D copy
         # Format: (name, max_numel, dtype)
         tensor_specs: List[Tuple[str, int, torch.dtype]] = [
-            # TENSOR FIELDS FOR UNCACHED ATTENTION
+            ### ORIGINAL MODEL ARGUMENTS ###########################################################
             ("input_ids", self.max_num_tokens, torch.int),
             ("position_ids", self.max_num_tokens, torch.long),
-            # TENSOR FIELDS FOR CACHED ATTENTION
-            ("seq_len", self.max_batch_size, torch.int),
-            ("cu_seqlen", self.max_batch_size + 1, torch.int),
+            ### BASIC ARGUMENTS TO DESCRIBE RAGGED ATTENTION+CACHE INPUTS ##########################
             ("input_pos", self.max_batch_size, torch.int),
-            ("pages_per_seq", self.max_batch_size, torch.int),
+            ("cu_seqlen", self.max_batch_size + 1, torch.int),
+            ("cache_loc", self.max_num_tokens, torch.int, True),
             ("cu_num_pages", self.max_batch_size + 1, torch.int),
-            ("seq_len_with_cache", self.max_batch_size, torch.int),
             ("last_page_len", self.max_batch_size, torch.int),
             ("slot_idx", self.max_batch_size, torch.long),
-            ("use_initial_states", self.max_batch_size, torch.bool),
+            ### INFO OBJECTS THAT ARE AVAILABLE TO DESCRIBE THE INPUTS IN A MORE COMPACT WAY #######
             ("batch_info", 3, torch.int),
-            # [max_context_length, max_blocks_per_seq, block_offset_multiplier, max_batch_size]
             ("max_seq_info", 4, torch.int),
-            ("logits_gather_indices", self.max_num_tokens, torch.long),
-            ("logits_gather_info", 2, torch.int),
-            # OTHER FIELDS WHERE WE NEED EFFICIENT HOST<>DEVICE TRANSFER
+            ### ADDITIONAL ARGUMENTS AVAILABLE THAT ARE DERIVED FROM THE BASIC ARGUMENTS ###########
+            ("seq_len", self.max_batch_size, torch.int),
+            ("pages_per_seq", self.max_batch_size, torch.int),
+            ("seq_len_with_cache", self.max_batch_size, torch.int),
+            ("use_initial_states", self.max_batch_size, torch.bool),
+            ### OTHER ARGUMENTS USED BY THE RUNTIME ################################################
+            ("extra_page_per_seq", self.max_batch_size, torch.int),
+            ("token_gather_indices", self.max_num_tokens, torch.long),
+            ("tokens_gather_info", 2, torch.int),
             ("_gather_idx", self.max_num_tokens, torch.int),
             ("_mask_scatter_indices", self.max_num_tokens, torch.int),
-            # TRUNCATABLE TENSORS: large, variable-length, each independently truncated during
-            # H2D copy to avoid copying unused capacity.
-            # NOTE: sufficient for max_num_tokens forward pass. will be resized when KVCacheManager
-            # is created.
-            ("cache_loc", self.max_num_tokens, torch.int, True),
-            ("page_seq_indices", self.max_num_tokens, torch.int, True),
-            ("page_in_seq", self.max_num_tokens, torch.int, True),
         ]
 
         # Create the InputBuffer that manages contiguous host and device memory
         # Starts on default device; use to() to move to target device
         self._input_buffer = InputBuffer(tensor_specs)
         self._available_args = set(self._input_buffer.tensor_names) | {
-            f"{name}_host" for name in self._input_buffer.tensor_names
+            name + self._host_suffix for name in self._input_buffer.tensor_names
         }
 
-        # Initialize args_list from tensor specs (all entries are tensors)
-        self._args_list: Dict[str, torch.Tensor] = {
-            spec[0]: torch.zeros(spec[1], dtype=spec[2]) for spec in tensor_specs
-        }
-
+        # active args that are included in the graph inputs
         self._active_args = ("input_ids", "position_ids")
-        self._shapeable_args = ("input_ids", "position_ids", "input_ids_host", "position_ids_host")
+        # args out of the active args that are shapeable
+        self._shapeable_args = {"input_ids", "position_ids"}
 
-        # Args that require copy to InputBuffer but are NOT included in named_args / graph inputs.
-        # Pre-populated with args that are always needed regardless of graph inclusion.
-        self._requires_copy: Set[str] = {
-            "max_seq_info",  # written once at cache init (update_cache_information)
-            "page_seq_indices",  # used by host-prepare (not a graph input)
-            "page_in_seq",  # used by host-prepare (not a graph input)
-            "logits_gather_indices",  # always needed for logits gathering
-            "logits_gather_info",  # always needed for logits gathering
-            "_gather_idx",  # overlap scheduler metadata
-            "_mask_scatter_indices",  # overlap scheduler metadata
-        }
+        # args that are required by the host-side prepare function
+        self._active_host_prep_args: Set[str] = set()
         ############################################################################################
 
         # EXTRA TENSOR FIELDS ######################################################################
@@ -541,7 +571,15 @@ class SequenceInfo:
     def device(self) -> torch.device:
         return self._input_buffer.device
 
-    def _shape_for_forward(self, tnsr: torch.Tensor) -> torch.Tensor:
+    @property
+    def host_device(self) -> torch.device:
+        return self._input_buffer.host_device
+
+    @property
+    def _host_suffix(self) -> str:
+        return "_host"
+
+    def unflatten(self, tnsr: torch.Tensor) -> torch.Tensor:
         """Shape the tensor for the forward pass based on the current attention mode.
 
         Args:
@@ -553,26 +591,57 @@ class SequenceInfo:
         # check if we are still running uncached attention in which case we are also still
         # operate on unflattened tensors with explicit [batch_size, seq_len, ...] shape
         # generate-only batches are also formatted like this (i.e. [b, 1])
-        if not self._use_flattened_layout or self.is_generate:
-            bs = len(self.seq_len)
-            sl = self.seq_len[0]
+        total_num_tokens = self.total_num_tokens
+        if not self._use_flattened_layout or self.is_generate_only:
+            bs = self.num_sequences
+            sl = total_num_tokens // bs
         # use [1,total_len] shape to indicate non-generate-only batch for cached attention
         else:
-            bs, sl = 1, self.total_num_tokens
+            bs, sl = 1, total_num_tokens
 
         # truncate to total tokens now, reshape, and return
-        return tnsr[: self.total_num_tokens].view(bs, sl, *tnsr.shape[1:])
+        return tnsr[:total_num_tokens].view(bs, sl, *tnsr.shape[1:])
 
-    def _get_arg(self, name: str) -> torch.Tensor:
-        """Get the argument from the input buffer either on device or host."""
-        if name.endswith("_host"):
-            arg = self._input_buffer.get_host_view(name.replace("_host", ""))
+    def flatten(self, tnsr: torch.Tensor) -> torch.Tensor:
+        """Flatten the tensor after the forward pass based on the current attention mode.
+
+        Args:
+            tnsr: The tensor to flatten.
+
+        Returns:
+            The flattened tensor.
+        """
+        return tnsr.squeeze(int(self.is_generate_only))
+
+    def get_arg(
+        self, name: str, truncate: Optional[bool] = None, unflatten: Optional[bool] = None
+    ) -> torch.Tensor:
+        """Get the argument from the input buffer either on device or host.
+
+        Args:
+            name: The name of the argument.
+            truncate: Whether to truncate the tensor to the current length. Default is None, which
+                means we will truncate when unflattening and no truncation otherwise.
+            unflatten: Whether to unflatten the tensor. Default is None, which means we will use
+                _shapeable_args to determine if we should unflatten.
+
+        Returns:
+            The argument tensor.
+        """
+
+        is_host = name.endswith(self._host_suffix)
+        name = name.removesuffix(self._host_suffix)
+        if is_host:
+            arg = self._input_buffer.get_host_view(name, truncate=truncate)
         else:
-            arg = self._input_buffer.get_view(name)
-        return self._shape_for_forward(arg) if name in self._shapeable_args else arg
+            arg = self._input_buffer.get_view(name, truncate=truncate)
+        if unflatten is True or (unflatten is None and name in self._shapeable_args):
+            assert truncate is not False, "unflattening requires truncation"
+            arg = self.unflatten(arg)
+        return arg
 
     def _named_args(self, include_extra_args: bool = True) -> Dict[str, torch.Tensor]:
-        args = {k: self._get_arg(k) for k in self._active_args}
+        args = {k: self.get_arg(k) for k in self._active_args}
 
         # check other args to include
         if include_extra_args:
@@ -603,37 +672,16 @@ class SequenceInfo:
         return tuple(self.named_args.values())
 
     @property
-    def seq_len(self) -> List[int]:
-        return self._args_list["seq_len"].tolist()
-
-    @property
-    def input_pos(self) -> List[int]:
-        return self._args_list["input_pos"].tolist()
-
-    @property
-    def cache_loc(self) -> List[int]:
-        return self._args_list["cache_loc"].tolist()
-
-    @property
-    def pages_per_seq(self) -> List[int]:
-        return self._args_list["pages_per_seq"].tolist()
-
-    @property
     def num_sequences(self) -> int:
-        return len(self.seq_len)
+        return self.get_arg("batch_info_host")[::2].sum().item()
 
     @property
     def total_num_tokens(self) -> int:
-        return sum(self.seq_len)
+        return self.get_arg("batch_info_host")[1:].sum().item()
 
     @property
-    def is_generate(self) -> bool:
-        return all(sl == 1 for sl in self.seq_len)
-
-    @property
-    def page_assignments(self) -> List[List[int]]:
-        """Return the page assignments for each sequence."""
-        return self._get_page_assignments(self.cache_loc, self.pages_per_seq)
+    def is_generate_only(self) -> bool:
+        return self.get_arg("batch_info_host")[0].item() == 0
 
     @property
     def num_blocks(self) -> int:
@@ -666,18 +714,13 @@ class SequenceInfo:
             block_offset_multiplier,
             self.max_batch_size,
         ]
-        self._store_arg("max_seq_info", max_seq_info)
+        self._stage_arg("max_seq_info", max_seq_info)
 
         # get current capacity
         cache_loc_capacity = self._input_buffer.get_capacity("cache_loc")
 
-        # cache_loc requires some special treatment due to block reuse. Note that the constraint for
-        # cache_loc with block_reuse is as follows:
-        # 0 <= cache_loc < num_blocks
-        # len(cache_loc) <= num_blocks * max_batch_size
-        # NOTE: # However, num_blocks * max_batch_size may be a potentially very large number and an
-        # overestimation, see we assume at most 10x reuse of blocks.
-        estimated_capacity = num_blocks * min(10, self.max_batch_size)
+        # take estimated capacity from provided information
+        estimated_capacity = self.max_batch_size * self.max_blocks_per_seq
 
         # NOTE (lucaslie): WAR to address issue when using flashinfer attention with
         # (max_batch_size, max_seq_len) input in trtllm runtime.
@@ -685,54 +728,7 @@ class SequenceInfo:
         estimated_capacity = estimated_capacity + 1
 
         if estimated_capacity > cache_loc_capacity:
-            # Resize all truncatable page tensors together (they share the same max size)
-            for tensor_name in ("cache_loc", "page_seq_indices", "page_in_seq"):
-                self._input_buffer.resize(tensor_name, estimated_capacity)
-                self._args_list[tensor_name] = torch.zeros(estimated_capacity, dtype=torch.int)
-
-    @staticmethod
-    def _get_page_assignments(
-        cache_locations: List[int], pages_per_sequence: List[int]
-    ) -> List[List[int]]:
-        """Get nested page assignments from cache locations and pages per sequence as list of lists.
-
-        Args:
-            cache_locations: A flat list of cache locations for each sequence ordered by sequence.
-            pages_per_sequence: A list of number of pages per sequence.
-
-        Returns:
-            A list of page assignments for each sequence ordered by sequence.
-            For example:
-                cache_locations: [0, 4, 2]
-                pages_per_sequence: [2, 1]
-                --> returns [[0, 4], [2]]
-        """
-        return [
-            c_loc_one_seq.tolist()
-            for c_loc_one_seq in torch.split(torch.tensor(cache_locations), pages_per_sequence)
-        ]
-
-    @staticmethod
-    def _get_cache_locations_and_pages_per_sequence(
-        page_assignments: List[List[int]],
-    ) -> Tuple[List[int], List[int]]:
-        """Get cache locations and pages per sequence from nested page assignments (lists of lists).
-
-        Args:
-            page_assignments: A list of page assignments for each sequence ordered by sequence.
-        Returns:
-            A tuple of:
-                cache_locations: A flat list of cache locations for each sequence ordered by sequence.
-                pages_per_sequence: A list of number of pages per sequence.
-
-        Example:
-            page_assignments: [[0, 4], [2]]
-            --> returns ([0, 4, 2], [2, 1])
-
-        """
-        cache_loc_flat = [p_idx for pages in page_assignments for p_idx in pages]
-        pages_per_seq = [len(p) for p in page_assignments]
-        return cache_loc_flat, pages_per_seq
+            self._input_buffer.resize("cache_loc", estimated_capacity)
 
     def activate_arg(self, arg_name: str) -> bool:
         """Activate a desired argument.
@@ -749,25 +745,6 @@ class SequenceInfo:
             return True
         return False
 
-    def require_copy(self, arg_name: str) -> bool:
-        """Mark an argument as requiring copy to InputBuffer.
-
-        Unlike activate_arg, this does NOT add the arg to _named_args / graph inputs.
-        It only ensures _store_arg writes to InputBuffer so _get_arg returns updated values.
-
-        Use cases:
-        - Host-prepare functions that need args outside the CUDA graph
-        - Args that are always needed in InputBuffer regardless of graph inclusion
-
-        Returns:
-            True if the argument was newly marked, False if already marked.
-        """
-        assert arg_name in self.available_args, f"{arg_name=} not found in {self.available_args}"
-        if arg_name not in self._requires_copy:
-            self._requires_copy.add(arg_name)
-            return True
-        return False
-
     def to(self, *args, **kwargs) -> None:
         # Move the InputBuffer (which recreates views automatically)
         self._input_buffer.to(*args, **kwargs)
@@ -779,8 +756,10 @@ class SequenceInfo:
 
     def set_example_sequence(
         self,
-        input_ids: Optional[Sequence[Sequence[int]]] = None,
-        position_ids: Optional[Sequence[Sequence[int]]] = None,
+        input_ids: Optional[torch.Tensor] = None,
+        cache_loc: Optional[Sequence[int]] = None,
+        cu_num_pages: Optional[Sequence[int]] = None,
+        slot_idx: Optional[Sequence[int]] = None,
         **extra_args,
     ) -> None:
         """Set an example sequence useful for testing and export purposes without cache history."""
@@ -789,25 +768,28 @@ class SequenceInfo:
             # Use batch_size >= 2 for export to prevent torch.export from specializing
             # the batch dimension when max_batch_size=1 (dimension value 1 triggers static optimization)
             bs, seq_len = max(2, min(2, self.max_batch_size)), min(4, self.max_seq_len)
-            input_ids = torch.ones(bs, seq_len, dtype=torch.int).tolist()
+            input_ids = torch.ones(bs, seq_len, dtype=torch.int)
+        assert input_ids.ndim == 2, f"input_ids must be 2D, got {input_ids.ndim}"
 
-        # figure out page assignments
-        pages_per_seq = [
-            len(ids_one_seq) // self.tokens_per_block
-            + (len(ids_one_seq) % self.tokens_per_block > 0)
-            for ids_one_seq in input_ids
-        ]
-        cache_loc = list(range(sum(pages_per_seq)))
+        bs, seq_len = input_ids.shape
 
-        # vanilla slot indices
-        slot_idx = list(range(len(input_ids)))
+        # heuristic for cache assignment
+        if cu_num_pages is None:
+            num_pages = seq_len // self.tokens_per_block + (seq_len % self.tokens_per_block > 0)
+            cu_num_pages = torch.arange(bs + 1, dtype=torch.int) * num_pages
+        if cache_loc is None:
+            cache_loc = torch.arange(cu_num_pages[-1])
+        assert len(cache_loc) >= cu_num_pages[-1]
+        if slot_idx is None:
+            slot_idx = torch.arange(bs)
+        assert len(slot_idx) >= bs
 
         self.nest_sequences(
-            input_ids,
-            position_ids,  # will be auto-inferred if None
+            input_ids.flatten(),
+            cu_seqlen=torch.arange(bs + 1, dtype=torch.int) * seq_len,
             input_pos=0,  # no cache history
             cache_loc=cache_loc,  # vanilla page assignments
-            pages_per_seq=pages_per_seq,  # vanilla page assignments
+            cu_num_pages=cu_num_pages,  # vanilla page assignments
             slot_idx=slot_idx,  # vanilla slot indices
             **extra_args,
         )
@@ -820,15 +802,14 @@ class SequenceInfo:
         """
         max_cache_tokens_per_seq = self.max_blocks_per_seq * self.tokens_per_block
         seq_len = min(self.max_num_tokens // self.max_batch_size, max_cache_tokens_per_seq)
-        input_ids = torch.ones(self.max_batch_size, seq_len, dtype=torch.int).tolist()
+        input_ids = torch.ones(self.max_batch_size, seq_len, dtype=torch.int)
         self.set_example_sequence(input_ids)
 
     def set_generate_only_batch(self, batch_size: Optional[int] = None) -> None:
         """Set an example sequence for generate-only batch."""
         batch_size = batch_size or self.max_batch_size
         self.set_example_sequence(
-            [[1]] * batch_size,
-            logits_gather_info=[batch_size, 0],
+            torch.ones(batch_size, 1, dtype=torch.int), tokens_gather_info=[batch_size, 0]
         )
 
     def reset(self) -> None:
@@ -847,13 +828,40 @@ class SequenceInfo:
             for val in (lst.detach().tolist() if isinstance(lst, torch.Tensor) else lst)
         ]
 
-    def _store_arg(
+    def _is_active(self, name: str, check_both: bool = True) -> bool:
+        """Check if the host or device-side argument is an active model argument."""
+        if check_both:
+            name = name.removesuffix(self._host_suffix)
+            name_host = name + self._host_suffix
+        else:
+            name_host = None
+        return name in self._active_args or name_host in self._active_args
+
+    def _is_active_host_prep(self, name: str, check_both: bool = True) -> bool:
+        """Check if the host-side argument is an active host-side prepare argument."""
+        if check_both:
+            name = name.removesuffix(self._host_suffix)
+            name_host = name + self._host_suffix
+        else:
+            name_host = None
+        return name in self._active_host_prep_args or name_host in self._active_host_prep_args
+
+    def _is_required(self, name: str, check_both: bool = True) -> bool:
+        """Check if the argument is required anywhere.
+
+        Returns:
+            True if the device or host argument is required for either the graph inputs or the
+            host-side prepare function.
+        """
+        return self._is_active(name, check_both) or self._is_active_host_prep(name, check_both)
+
+    def _stage_arg(
         self,
         name: str,
-        data: "Union[List[Number], torch.Tensor]",
+        data: Union[List[Number], torch.Tensor, None],
         reset_val: Optional[Number] = None,
-    ) -> None:
-        """Store the argument into the pinned host buffer for later batch transfer to device.
+    ):
+        """Stage the argument into the pinned host buffer for later batch transfer to device.
 
         The data is stored in the host-side pinned memory buffer managed by InputBuffer.
         The actual H2D transfer happens in a single batch at the end of nest_sequences().
@@ -866,23 +874,17 @@ class SequenceInfo:
             data: List of values or a 1-D torch.Tensor to store.
             reset_val: Value to reset/fill the tensor with before writing data.
         """
-        with nvtx_range(f"ad_store_on_host_seq_info_arg_{name}"):
-            # Convert to tensor at the boundary (numpy is ~2-3x faster than torch.tensor for large lists)
-            # TODO: move this to self._input_buffer.store() when _args_list get deprecated
-            if not isinstance(data, torch.Tensor):
-                _, dtype = self._input_buffer._tensor_specs[name]
-                data = _list_to_tensor(data, dtype)
+        # make sure it is provided if required
+        if self._is_required(name):
+            assert data is not None, f"data is required for {name}"
 
-            self._args_list[name] = data
+        if data is None:
+            return None
 
-            # Only store to buffer when the argument is active or requires copy
-            is_active = name in self._active_args or f"{name}_host" in self._active_args
-            is_required = name in self._requires_copy or f"{name}_host" in self._requires_copy
-            if not (is_active or is_required):
-                return
-
+        with nvtx_range(f"ad_stage_{name}_on_host"):
             # Store to the InputBuffer's pinned host memory
-            self._input_buffer.store(name, data, fill_value=reset_val)
+            name = name.removesuffix(self._host_suffix)
+            self._input_buffer.stage(name, data, fill_value=reset_val)
 
     def _store_extra_arg(
         self, name: str, tnsr_like: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]]
@@ -910,54 +912,44 @@ class SequenceInfo:
     @nvtx_range("ad_nest_sequences")
     def nest_sequences(
         self,
-        input_ids: Sequence[Sequence[int]],
-        position_ids: Optional[Sequence[Sequence[int]]] = None,
-        seq_len: Optional[Sequence[int]] = None,
-        input_pos: Optional[Union[Sequence[int], int]] = None,
-        batch_info: Optional[Sequence[int]] = None,
-        cu_seqlen: Optional[Sequence[int]] = None,
-        cache_loc: Optional[Sequence[int]] = None,
-        pages_per_seq: Optional[Sequence[int]] = None,
-        cu_num_pages: Optional[Sequence[int]] = None,
-        seq_len_with_cache: Optional[Sequence[int]] = None,
-        last_page_len: Optional[Sequence[int]] = None,
-        slot_idx: Optional[Sequence[int]] = None,
-        use_initial_states: Optional[Sequence[bool]] = None,
-        logits_gather_indices: Optional[Sequence[int]] = None,
-        logits_gather_info: Optional[Sequence[int]] = None,
-        _gather_idx: Optional[Sequence[int]] = None,
-        _mask_scatter_indices: Optional[Sequence[int]] = None,
+        ### BASIC INPUTS FOR RAGGED ATTENTION + CACHES #############################################
+        input_ids: Union[Sequence[int], torch.Tensor],
+        cu_seqlen: Union[Sequence[int], torch.Tensor],
+        input_pos: Union[Sequence[int], int, torch.Tensor],
+        batch_info: Union[Sequence[int], torch.Tensor, None] = None,
+        cache_loc: Union[Sequence[int], torch.Tensor, None] = None,
+        cu_num_pages: Union[Sequence[int], torch.Tensor, None] = None,
+        extra_page_per_seq: Optional[Sequence[int]] = None,
+        slot_idx: Union[Sequence[int], torch.Tensor, None] = None,
+        ### RUNTIME ARGUMENTS ######################################################################
+        token_gather_indices: Union[Sequence[int], torch.Tensor, None] = None,
+        tokens_gather_info: Union[Sequence[int], torch.Tensor, None] = None,
+        _gather_idx: Union[Sequence[int], torch.Tensor, None] = None,
+        _mask_scatter_indices: Union[Sequence[int], torch.Tensor, None] = None,
         _ungathered_input_ids: Optional[torch.Tensor] = None,
+        ### EXTRA INPUTS FOR MULTIMODAL MODELS #####################################################
         **extra_args: Dict[str, Union[torch.Tensor, Sequence[torch.Tensor]]],
     ) -> None:
         """Create and store sequence information for the next forward pass.
 
         Args:
-            input_ids: List of sequences of input_ids.
-            position_ids: List of sequences of position_ids for each token. If None, auto-inferred
-                from input_pos and seq_len.
-            seq_len: List of sequence lengths for each sequence. If None, inferred from input_ids.
+            input_ids: Flattened list of input_ids.
+            cu_seqlen: Cumulative sequence lengths for all sequences.
             input_pos: Absolute starting position in the cache for each sequence. Can be a single
                 int (applied to all sequences) or a list of ints.
-            batch_info: Batch metadata as [num_prefill, num_prefill_tokens, num_decode]. If None,
-                auto-computed from seq_len.
-            cu_seqlen: Cumulative sequence lengths of shape [b+1]. If None, auto-computed from
-                seq_len.
+            batch_info: Batch metadata as [num_prefill, num_prefill_tokens, num_extend,
+                num_extend_tokens, num_decode, num_decode_tokens]. If None, heuristic is used to
+                compute it from seq_len. NOTE: the heuristic makes potentially incorrect assumptions
+                about the batch composition. batch_info should be provided explicitly to ensure
+                correctness.
             cache_loc: Flat list of page indices for all sequences. Must be provided together with
-                pages_per_seq.
-            pages_per_seq: Number of pages allocated per sequence. Must be provided together with
+                cu_num_pages.
+            cu_num_pages: Cumulative number of pages for all sequences. Must be provided together with
                 cache_loc.
-            cu_num_pages: Cumulative number of pages of shape [b+1]. If None, auto-computed from
-                pages_per_seq.
-            seq_len_with_cache: Total sequence length including cached tokens (input_pos + seq_len)
-                for each sequence. If None, auto-computed.
-            last_page_len: Number of valid tokens in the last page for each sequence. If None,
-                auto-computed from seq_len_with_cache.
+            extra_page_per_seq: Extra page per sequence for deferred page insertion.
             slot_idx: Slot index for each sequence in the batch.
-            use_initial_states: Per-sequence boolean indicating if the initial states should be
-                used. If None, auto-computed as (input_pos > 0).
-            logits_gather_indices: Gather indices for the logits before/after the LM head.
-            logits_gather_info: Info list containing [num_tokens_to_gather, gather_required].
+            token_gather_indices: Gather indices for the logits before/after the LM head.
+            tokens_gather_info: Info list containing [num_tokens_to_gather, gather_required].
             _gather_idx: Gather indices for the overlap scheduler to reorder input tokens.
             _mask_scatter_indices: Mask scatter indices for the overlap scheduler.
             _ungathered_input_ids: Optional tensor of ungathered input ids from the overlap
@@ -968,122 +960,103 @@ class SequenceInfo:
         chosen as "neutral" values so that for cases like rounding up batch sizes for cudagraph we
         only write to unused caches.
         """
-        ### UPDATE SEQUENCE LENGTH AND INPUT POSITION FIRST SINCE IT'S USED FOR OTHER UPDATES ######
-        if seq_len is None:
-            seq_len = [len(ids) for ids in input_ids]
-        self._store_arg("seq_len", seq_len)
+        ### UPDATE CU_SEQLEN, BATCH INFO, AND INPUT_POS FIRST SINCE IT'S USED FOR OTHER UPDATES ####
+        self._stage_arg("cu_seqlen", cu_seqlen)
+        csl_host = self.get_arg("cu_seqlen_host", truncate=True)
 
-        # check for updated input_pos (i.e. cache start position)
-        if input_pos is not None:
-            self._store_arg(
-                "input_pos",
-                [input_pos] * self.num_sequences if isinstance(input_pos, int) else input_pos,
-            )
+        sl_host = csl_host[1:] - csl_host[:-1]
+        self._stage_arg("seq_len", sl_host)
 
-        ### UPDATE MAIN INPUTS #####################################################################
-        # set new input_ids and make sure to flatten it
-        self._store_arg("input_ids", self._flatten(input_ids))
-
-        # set new position_ids and make sure to flatten it
-        if position_ids is None:
-            position_ids = [
-                [num for num in range(in_pos, in_pos + seq_len)]
-                for in_pos, seq_len in zip(self.input_pos, self.seq_len)
-            ]
-        self._store_arg("position_ids", self._flatten(position_ids))
-
-        ### UPDATE OTHER (DERIVATIVE) METADATA #####################################################
         # check for updated batch_info_tensor
         if batch_info is None:
-            num_prefill = sum(s_l > 1 for s_l in seq_len)
-            num_prefill_tokens = sum(s_l for s_l in seq_len if s_l > 1)
-            num_decode = len(seq_len) - num_prefill
+            # NOTE: assumes no extend requests, decode requests are all of length 1 and come after
+            # prefill requests.
+            num_decode = int((sl_host.flip(0) == 1).cumprod(0).sum())
+            num_prefill = len(sl_host) - num_decode
+            num_prefill_tokens = int(sl_host.sum()) - num_decode
             batch_info = [num_prefill, num_prefill_tokens, num_decode]
-        self._store_arg("batch_info", batch_info)
+        self._stage_arg("batch_info", batch_info)
 
-        if cu_seqlen is None:
-            cu_seqlen = torch.zeros(len(seq_len) + 1, dtype=torch.int)
-            cu_seqlen[1:] = torch.cumsum(torch.tensor(seq_len), dim=0)
-            cu_seqlen = cu_seqlen.tolist()
-        self._store_arg("cu_seqlen", cu_seqlen)
+        # check for updated input_pos (i.e. cache start position)
+        if isinstance(input_pos, int):
+            input_pos = torch.full((self.num_sequences,), input_pos, dtype=torch.int)
+        self._stage_arg("input_pos", input_pos)
+        ip_host = self.get_arg("input_pos_host", truncate=True)
 
-        # check for updated page_assignments
-        assert (cache_loc is None) == (pages_per_seq is None), (
-            "cache_loc and pages_per_seq must beeither both None or both set"
-        )
-        if cache_loc is not None and pages_per_seq is not None:
-            self._store_arg("cache_loc", cache_loc)
-            self._store_arg("pages_per_seq", pages_per_seq)
-
-            # Resolve cu_num_pages: use caller-provided value or derive from pages_per_seq
-            if cu_num_pages is None:
-                pps_t = self._args_list["pages_per_seq"]
-                cu_num_pages = torch.zeros(len(pps_t) + 1, dtype=torch.int)
-                cu_num_pages[1:] = pps_t.cumsum(0)
-            self._store_arg("cu_num_pages", cu_num_pages)
-
-            # Compute page_seq_indices and page_in_seq using vectorized torch ops,
-            # reusing the stored cu_num_pages tensor instead of recomputing the cumsum.
-            # page_seq_indices[j] = which sequence page j belongs to
-            # page_in_seq[j] = which page within that sequence (0-indexed)
-            pages_per_seq_t = self._args_list["pages_per_seq"]
-            cu_pages_t = self._args_list["cu_num_pages"]
-            seq_indices = torch.arange(len(pages_per_seq), dtype=torch.int)
-            page_seq_indices_t = torch.repeat_interleave(seq_indices, pages_per_seq_t)
-            total_pages = cu_pages_t[-1].item()
-            page_in_seq_t = torch.arange(total_pages, dtype=torch.int) - torch.repeat_interleave(
-                cu_pages_t[:-1], pages_per_seq_t
-            )
-            self._store_arg("page_seq_indices", page_seq_indices_t)
-            self._store_arg("page_in_seq", page_in_seq_t)
-
-        # update sequence length with cache
-        if seq_len_with_cache is None:
-            seq_len_with_cache = [i_p + s_l for i_p, s_l in zip(self.input_pos, self.seq_len)]
-        self._store_arg("seq_len_with_cache", seq_len_with_cache)
-
-        # update last page length
-        if last_page_len is None:
-            last_page_len = [(slwc - 1) % self.tokens_per_block + 1 for slwc in seq_len_with_cache]
-        self._store_arg("last_page_len", last_page_len)
-
-        # check for updated slot_idx
-        if slot_idx is not None:
-            self._store_arg("slot_idx", slot_idx)
-
-        # check for updated use_initial_states
-        if use_initial_states is None:
-            use_initial_states = [i_p > 0 for i_p in self.input_pos]
-        self._store_arg("use_initial_states", use_initial_states)
-
-        # check for updated logits_gather_indices
-        if logits_gather_indices is None:
-            # default is to gather all logits
-            logits_gather_indices = list(range(self.total_num_tokens))
-        self._store_arg("logits_gather_indices", logits_gather_indices)
-
-        # check for updated logits_gather_info
-        if logits_gather_info is None:
-            logits_gather_info = [len(logits_gather_indices), 1]
-        self._store_arg("logits_gather_info", logits_gather_info)
-
-        ### UPDATE OVERLAP SCHEDULER METADATA ######################################################
-        # check for updated _gather_idx
-        if _gather_idx is not None:
-            self._store_arg("_gather_idx", _gather_idx)
-
-        # check for updated _mask_scatter_indices
-        if _mask_scatter_indices is not None:
-            self._store_arg("_mask_scatter_indices", _mask_scatter_indices)
+        ### UPDATE REQUIRED INPUTS #################################################################
+        # set new input_ids and make sure to flatten it
+        self._stage_arg("input_ids", input_ids)
 
         ### UPDATE EXTRA INPUTS ####################################################################
         self._extra_args = {}
         for key, value in extra_args.items():
             self._store_extra_arg(key, value)
 
+        ### UPDATE CACHE ASSIGNMENTS (needs to be provided if required!) ###########################
+        # check for updated page assignments
+        assert (cache_loc is None) == (cu_num_pages is None), "Both must be provided together!"
+        self._stage_arg("cache_loc", cache_loc)
+        self._stage_arg("cu_num_pages", cu_num_pages)
+        lpl_host = (ip_host + sl_host - 1) % self.tokens_per_block + 1
+        self._stage_arg("last_page_len", lpl_host)
+
+        # check for updated slot_idx
+        self._stage_arg("slot_idx", slot_idx)
+
+        # check for updated extra_page_per_seq
+        self._stage_arg("extra_page_per_seq", extra_page_per_seq)
+
+        ### UPDATE OPTIONAL DERIVATIVE METADATA ####################################################
+        if self._is_required("position_ids"):
+            # set new position_ids and make sure to flatten it
+            # position_ids for each sequence is in the range [input_pos, input_pos + seq_len - 1]
+            ip_np = ip_host.numpy()
+            sl_np = sl_host.numpy()
+            base = np.repeat(ip_np, sl_np)
+            group_starts = np.repeat(np.cumsum(sl_np) - sl_np, sl_np)
+            offsets = np.arange(sl_np.sum()) - group_starts
+            position_ids = torch.from_numpy(base + offsets)  # zero-copy back
+            self._stage_arg("position_ids", position_ids)
+
+        # update cumulative number of pages
+        if self._is_required("pages_per_seq"):
+            assert cu_num_pages is not None, "cu_num_pages is required for pages_per_seq"
+            cu_num_pages_host = self.get_arg("cu_num_pages_host", truncate=True)
+            pages_per_seq = cu_num_pages_host[1:] - cu_num_pages_host[:-1]
+            self._stage_arg("pages_per_seq", pages_per_seq)
+
+        # update sequence length with cache
+        if self._is_required("seq_len_with_cache"):
+            seq_len_with_cache = ip_host + sl_host
+            self._stage_arg("seq_len_with_cache", seq_len_with_cache)
+
+        # check for updated use_initial_states
+        if self._is_required("use_initial_states"):
+            use_initial_states = ip_host > 0
+            self._stage_arg("use_initial_states", use_initial_states)
+
+        ### UPDATE LOGITS GATHERING METADATA using heuristic if not provided #######################
+        # default is to gather all logits
+        if token_gather_indices is None:
+            token_gather_indices = torch.arange(self.total_num_tokens, dtype=torch.long)
+        self._stage_arg("token_gather_indices", token_gather_indices)
+
+        # check for updated tokens_gather_info
+        if tokens_gather_info is None:
+            tokens_gather_info = [len(token_gather_indices), 1]
+        self._stage_arg("tokens_gather_info", tokens_gather_info)
+
+        ### UPDATE OVERLAP SCHEDULER METADATA ######################################################
+        # check for updated _gather_idx
+        if _gather_idx is not None:
+            self._stage_arg("_gather_idx", _gather_idx)
+
+        # check for updated _mask_scatter_indices
+        if _mask_scatter_indices is not None:
+            self._stage_arg("_mask_scatter_indices", _mask_scatter_indices)
+
         ### BATCH COPY TO DEVICE ###################################################################
         # Perform a single async H2D copy for all device tensors
-        # The copy is truncated at the end of cache_loc to minimize transfer size
         self._input_buffer.copy_to_device()
 
         ### RESCATTER + HOST PREPARE ###############################################################
@@ -1107,54 +1080,41 @@ class SequenceInfo:
 
         This function will assume that we are in a generate-only batch.
         """
-        # retrieve input_ids and gather_ids on device
-        input_ids_device = self._input_buffer.get_view_at_current_length("input_ids")
-        gather_ids_device = self._input_buffer.get_view_at_current_length("_gather_idx")
-        mask_scatter_indices_device = self._input_buffer.get_view_at_current_length(
-            "_mask_scatter_indices"
-        )
-
         torch.ops.auto_deploy.triton_utils_fused_gather_scatter(
-            ungathered_input_ids, gather_ids_device, mask_scatter_indices_device, input_ids_device
+            ungathered_input=ungathered_input_ids,
+            gather_ids=self.get_arg("_gather_idx", truncate=True),
+            mask_indices=self.get_arg("_mask_scatter_indices", truncate=True),
+            out=self.get_arg("input_ids", truncate=True, unflatten=False),
         )
 
     # TODO: remove once https://github.com/NVIDIA/TensorRT-LLM/issues/9878 is fixed and
     # logits gather is enabled by default (only keep squeeze_logits)
-    @nvtx_range("ad_maybe_gather_logits")
-    def maybe_gather_and_squeeze_logits(self, logits: torch.Tensor) -> torch.Tensor:
-        """Maybe gather the logits if logits have not been gathered yet."""
-        if logits.dim() == 3:
-            num_tokens = logits.shape[0] * logits.shape[1]
-        elif logits.dim() == 2:
-            num_tokens = logits.shape[0]
-        else:
-            raise AssertionError(
-                f"Unexpected logits rank in AD gather path: shape={tuple(logits.shape)}"
-            )
-        num_tokens_to_gather, gather_required = self._get_arg("logits_gather_info_host").tolist()
+    @nvtx_range("ad_maybe_gather_and_squeeze")
+    def maybe_gather_and_squeeze(self, token_tnsr: torch.Tensor) -> torch.Tensor:
+        """Maybe gather the tokens in the tensor if they have not been gathered yet.
+
+        Args:
+            token_tnsr: The tensor to maybe gather. Must be in shape [b, 1, *other_dims] or
+                [1, s_total, *other_dims] where other_dims = token_tnsr.shape[2:].
+
+        Returns:
+            The gathered tensor in shape [num_gathered_tokens, *other_dims].
+        """
+        num_tokens = token_tnsr.shape[0] * token_tnsr.shape[1]
+        num_tokens_to_gather, gather_required = self.get_arg("tokens_gather_info_host").tolist()
         if gather_required and num_tokens_to_gather < num_tokens:
-            logits = torch.ops.auto_deploy.gather_logits_before_lm_head(
-                logits,
-                self._get_arg("logits_gather_indices"),
-                self._get_arg("logits_gather_info_host"),
+            token_tnsr = torch.ops.auto_deploy.gather_tokens(
+                token_tnsr,
+                self.get_arg("token_gather_indices"),
+                self.get_arg("tokens_gather_info_host"),
             )
-        # Keep canonical 2D logits [tokens, vocab] unchanged.
-        # Only squeeze layout dimensions when logits are still 3D:
-        # - generate layout: [batch, 1, vocab] -> [batch, vocab]
-        # - packed layout:   [1, tokens, vocab] -> [tokens, vocab]
-        if logits.dim() == 3:
-            logits = logits.squeeze(1 if self.is_generate else 0)
-        elif logits.dim() != 2:
-            raise AssertionError(
-                f"Unexpected logits rank after AD gather path: shape={tuple(logits.shape)}"
-            )
-        assert logits.shape[-1] > 1, f"Invalid logits vocab axis: shape={tuple(logits.shape)}"
-        return logits
+        return self.flatten(token_tnsr)
 
     @nvtx_range("ad_unnest_sequences")
     def unnest_sequences(self, t_nested: torch.Tensor) -> List[torch.Tensor]:
-        t_squeezed = t_nested.squeeze(int(self.is_generate))
-        return list(torch.split(t_squeezed, self.seq_len))
+        t_squeezed = self.flatten(t_nested)
+        seq_len_list = self.get_arg("seq_len_host", truncate=True).tolist()
+        return list(torch.split(t_squeezed, seq_len_list))
 
     def register_host_prepare_for_attention_forward(
         self, host_function: PrepareMetadataHostCallable, args: List[str]
@@ -1162,11 +1122,11 @@ class SequenceInfo:
         self._host_prepare_functions.append((host_function, args))
         # Ensure all host-prepare args are stored to InputBuffer via _requires_copy
         for arg in args:
-            self.require_copy(arg)
+            self._active_host_prep_args.add(arg)
 
     def run_host_prepare_for_attention_forward(self) -> None:
         for host_function, args in self._host_prepare_functions:
-            host_function(**{arg: self._get_arg(arg) for arg in args})
+            host_function(**{arg: self.get_arg(arg) for arg in args})
 
 
 class ResourceHandler(ABC):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/__init__.py
@@ -16,11 +16,13 @@
 """Utility operations.
 
 This module provides utility functions and helpers:
+- block_table_ragged: Block table <-> ragged tensor conversions
 - torch_gather_logits: Logit gathering operations
 - triton_utils: Triton utility functions and helpers
 """
 
 __all__ = [
+    "block_table_ragged",
     "torch_gather_logits",
     "triton_utils",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/block_table_ragged.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/block_table_ragged.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/block_table_ragged.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/block_table_ragged.py
@@ -1,0 +1,485 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bidirectional conversion between block table and ragged tensor formats.
+
+Block table format: [max_batch_size, max_blocks_per_seq] padded 2D tensor
+Ragged format: flat 1D cache_loc + cumulative offset vector cu_num_blocks
+
+Provides both PyTorch reference (tensorized, loop-free) and Triton kernel
+implementations (one program per sequence row), registered as custom ops.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+# ========================================================================================
+# Triton kernels (internal)
+# ========================================================================================
+
+
+@triton.jit
+def _block_table_to_ragged_kernel(
+    block_table_ptr,
+    num_blocks_ptr,
+    cu_num_blocks_ptr,
+    cache_loc_ptr,
+    M: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Pack one row of block_table into the correct offset in cache_loc."""
+    seq_id = tl.program_id(0)
+
+    n_valid = tl.load(num_blocks_ptr + seq_id)
+    dst_start = tl.load(cu_num_blocks_ptr + seq_id)
+
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_valid
+
+    vals = tl.load(block_table_ptr + seq_id * M + offs, mask=mask, other=0)
+    tl.store(cache_loc_ptr + dst_start + offs, vals, mask=mask)
+
+
+@triton.jit
+def _ragged_to_block_table_kernel(
+    cache_loc_ptr,
+    cu_num_blocks_ptr,
+    block_table_ptr,
+    M: tl.constexpr,
+    STRIDE_ROW,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Unpack one segment of cache_loc into a zero-padded row of block_table."""
+    seq_id = tl.program_id(0)
+
+    src_start = tl.load(cu_num_blocks_ptr + seq_id)
+    src_end = tl.load(cu_num_blocks_ptr + seq_id + 1)
+    n_valid = src_end - src_start
+
+    offs = tl.arange(0, BLOCK_SIZE)
+
+    vals = tl.load(cache_loc_ptr + src_start + offs, mask=offs < n_valid, other=0)
+    tl.store(block_table_ptr + seq_id * STRIDE_ROW + offs, vals, mask=offs < M)
+
+
+@triton.jit
+def _adjust_block_table_kernel(
+    block_table_ptr,
+    num_blocks_ptr,
+    extra_idx_ptr,
+    delta_ptr,
+    M: tl.constexpr,
+):
+    """Adjust one block_table row: append (delta=+1), remove last (delta=-1), or no-op (delta=0)."""
+    seq_id = tl.program_id(0)
+    d = tl.load(delta_ptr + seq_id)
+
+    if d != 0:
+        n = tl.load(num_blocks_ptr + seq_id)
+        if d > 0:
+            extra = tl.load(extra_idx_ptr + seq_id)
+            tl.store(block_table_ptr + seq_id * M + n, extra)
+        tl.store(num_blocks_ptr + seq_id, n + d)
+
+
+@triton.jit
+def _adjust_ragged_kernel(
+    cache_loc_ptr,
+    temp_ptr,
+    old_cu_ptr,
+    new_cu_ptr,
+    extra_idx_ptr,
+    delta_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Copy one sequence's segment, adjusting length by delta: +1 appends, -1 drops last."""
+    seq_id = tl.program_id(0)
+
+    old_start = tl.load(old_cu_ptr + seq_id)
+    old_end = tl.load(old_cu_ptr + seq_id + 1)
+    n_old = old_end - old_start
+
+    new_start = tl.load(new_cu_ptr + seq_id)
+
+    d = tl.load(delta_ptr + seq_id)
+    n_copy = n_old + tl.minimum(d, 0)
+
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_copy
+    vals = tl.load(cache_loc_ptr + old_start + offs, mask=mask, other=0)
+    tl.store(temp_ptr + new_start + offs, vals, mask=mask)
+
+    if d > 0:
+        extra = tl.load(extra_idx_ptr + seq_id)
+        tl.store(temp_ptr + new_start + n_old, extra)
+
+
+# ========================================================================================
+# Custom ops: block table <-> ragged conversion
+# ========================================================================================
+
+
+@torch.library.custom_op(
+    "auto_deploy::block_table_to_ragged_torch", mutates_args=("cache_loc", "cu_num_blocks")
+)
+def block_table_to_ragged_torch(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    """Convert block table (padded 2D) to ragged (packed 1D) format using PyTorch."""
+    N = num_sequences
+    M = block_table.shape[1]
+
+    cu_num_blocks[0] = 0
+    cu_num_blocks[1 : N + 1] = torch.cumsum(num_blocks[:N], dim=0)
+
+    col = torch.arange(M, device=block_table.device)
+    mask = col.unsqueeze(0) < num_blocks[:N].unsqueeze(1)
+
+    total = cu_num_blocks[N].item()
+    cache_loc[:total] = block_table[:N][mask]
+
+    return total
+
+
+@block_table_to_ragged_torch.register_fake
+def _block_table_to_ragged_torch_fake(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    return 0
+
+
+@torch.library.custom_op(
+    "auto_deploy::ragged_to_block_table_torch",
+    mutates_args=("block_table", "num_blocks"),
+)
+def ragged_to_block_table_torch(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    """Convert ragged (packed 1D) to block table (padded 2D) format using PyTorch."""
+    N = num_sequences
+    M = block_table.shape[1]
+
+    num_blocks[:N] = (cu_num_blocks[1 : N + 1] - cu_num_blocks[:N]).to(num_blocks.dtype)
+
+    col = torch.arange(M, device=cache_loc.device)
+    mask = col.unsqueeze(0) < num_blocks[:N].unsqueeze(1)
+
+    src = cu_num_blocks[:N].unsqueeze(1) + col.unsqueeze(0)
+
+    total = int(cu_num_blocks[N].item())
+    src_safe = src.clamp(max=max(total - 1, 0))
+
+    zero = torch.zeros(1, device=cache_loc.device, dtype=cache_loc.dtype)
+    block_table[:N] = torch.where(mask, cache_loc[src_safe], zero)
+
+
+@ragged_to_block_table_torch.register_fake
+def _ragged_to_block_table_torch_fake(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    pass
+
+
+@torch.library.custom_op(
+    "auto_deploy::block_table_to_ragged_triton", mutates_args=("cache_loc", "cu_num_blocks")
+)
+def block_table_to_ragged_triton(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    """Convert block table to ragged format using Triton."""
+    N = num_sequences
+    M = block_table.shape[1]
+
+    cu_num_blocks[0] = 0
+    cu_num_blocks[1 : N + 1] = torch.cumsum(num_blocks[:N], dim=0)
+
+    if N == 0:
+        return 0
+
+    BLOCK_SIZE = triton.next_power_of_2(M)
+    _block_table_to_ragged_kernel[(N,)](
+        block_table, num_blocks, cu_num_blocks, cache_loc, M=M, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    total = cu_num_blocks[N].item()
+    return total
+
+
+@block_table_to_ragged_triton.register_fake
+def _block_table_to_ragged_triton_fake(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    return 0
+
+
+@torch.library.custom_op("auto_deploy::ragged_to_block_table_triton", mutates_args=("block_table",))
+def ragged_to_block_table_triton(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    block_table: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    """Convert ragged format to block table using Triton."""
+    N = num_sequences
+    M = block_table.shape[1]
+
+    if N == 0:
+        return
+
+    BLOCK_SIZE = triton.next_power_of_2(M)
+    _ragged_to_block_table_kernel[(N,)](
+        cache_loc,
+        cu_num_blocks,
+        block_table,
+        M=M,
+        STRIDE_ROW=block_table.stride(0),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+@ragged_to_block_table_triton.register_fake
+def _ragged_to_block_table_triton_fake(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    block_table: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    pass
+
+
+# ========================================================================================
+# Custom ops: adjust block index (append / remove / no-op per sequence)
+# ========================================================================================
+
+
+@torch.library.custom_op(
+    "auto_deploy::adjust_block_table_torch", mutates_args=("block_table", "num_blocks")
+)
+def adjust_block_table_torch(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    """Adjust block_table per sequence: append (delta=+1), remove last (delta=-1), or no-op."""
+    N = num_sequences
+    if N == 0:
+        return
+
+    device = block_table.device
+    seq_idx = torch.arange(N, device=device)
+
+    append_mask = delta[:N] > 0
+    row_append = seq_idx[append_mask]
+    col_append = num_blocks[row_append].long()
+    block_table[row_append, col_append] = extra_idx[row_append]
+
+    nonzero_mask = delta[:N] != 0
+    row_nonzero = seq_idx[nonzero_mask]
+    num_blocks[row_nonzero] += delta[row_nonzero]
+
+
+@adjust_block_table_torch.register_fake
+def _adjust_block_table_torch_fake(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    pass
+
+
+@torch.library.custom_op(
+    "auto_deploy::adjust_ragged_torch", mutates_args=("cache_loc", "cu_num_blocks")
+)
+def adjust_ragged_torch(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    """Adjust ragged cache_loc per sequence: append (+1), remove last (-1), or no-op (0)."""
+    N = num_sequences
+    device = cache_loc.device
+
+    if N == 0:
+        return 0
+
+    d = delta[:N]
+
+    old_lens = (cu_num_blocks[1 : N + 1] - cu_num_blocks[:N]).to(torch.int32)
+    new_lens = old_lens + d
+
+    new_cu = torch.zeros(N + 1, device=device, dtype=cu_num_blocks.dtype)
+    new_cu[1:] = torch.cumsum(new_lens, dim=0)
+    total_new = int(new_cu[N].item())
+
+    if total_new == 0:
+        cu_num_blocks[: N + 1] = new_cu
+        return 0
+
+    copy_lens = old_lens + torch.clamp(d, max=0)
+    max_new_len = int(new_lens.max().item())
+    col = torch.arange(max_new_len, device=device)
+
+    copy_mask = col.unsqueeze(0) < copy_lens.unsqueeze(1)
+    append_mask = (col.unsqueeze(0) == old_lens.unsqueeze(1)) & (d > 0).unsqueeze(1)
+
+    old_cu = cu_num_blocks[:N]
+    src = old_cu.unsqueeze(1) + col.unsqueeze(0)
+    old_total = int(cu_num_blocks[N].item())
+    src_safe = src.clamp(max=max(old_total - 1, 0))
+
+    zero = torch.zeros(1, device=device, dtype=cache_loc.dtype)
+    vals = torch.where(copy_mask, cache_loc[src_safe], zero)
+    vals = torch.where(append_mask, extra_idx[:N].unsqueeze(1).expand_as(vals), vals)
+
+    dst = new_cu[:N].unsqueeze(1) + col.unsqueeze(0)
+
+    write_mask = copy_mask | append_mask
+    temp = torch.zeros(total_new, device=device, dtype=cache_loc.dtype)
+    temp[dst[write_mask].long()] = vals[write_mask]
+
+    cache_loc[:total_new] = temp
+    cu_num_blocks[: N + 1] = new_cu
+
+    return total_new
+
+
+@adjust_ragged_torch.register_fake
+def _adjust_ragged_torch_fake(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    return 0
+
+
+@torch.library.custom_op(
+    "auto_deploy::adjust_block_table_triton", mutates_args=("block_table", "num_blocks")
+)
+def adjust_block_table_triton(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    """Adjust block_table using Triton. In-place on block_table and num_blocks."""
+    N = num_sequences
+    M = block_table.shape[1]
+
+    if N == 0:
+        return
+
+    _adjust_block_table_kernel[(N,)](block_table, num_blocks, extra_idx, delta, M=M)
+
+
+@adjust_block_table_triton.register_fake
+def _adjust_block_table_triton_fake(
+    block_table: torch.Tensor,
+    num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> None:
+    pass
+
+
+@torch.library.custom_op(
+    "auto_deploy::adjust_ragged_triton", mutates_args=("cache_loc", "cu_num_blocks")
+)
+def adjust_ragged_triton(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    """Adjust ragged cache_loc using Triton. Uses temp buffer + copy back."""
+    N = num_sequences
+    device = cache_loc.device
+
+    if N == 0:
+        return 0
+
+    d = delta[:N]
+    old_lens = (cu_num_blocks[1 : N + 1] - cu_num_blocks[:N]).to(torch.int32)
+    new_lens = old_lens + d
+
+    old_cu = cu_num_blocks[: N + 1].clone()
+
+    new_cu = torch.zeros(N + 1, device=device, dtype=cu_num_blocks.dtype)
+    new_cu[1:] = torch.cumsum(new_lens, dim=0)
+    total_new = int(new_cu[N].item())
+
+    if total_new == 0:
+        cu_num_blocks[: N + 1] = new_cu
+        return 0
+
+    temp = torch.zeros(total_new, device=device, dtype=cache_loc.dtype)
+
+    max_old_len = int(old_lens.max().item())
+    BLOCK_SIZE = triton.next_power_of_2(max(max_old_len, 1))
+
+    _adjust_ragged_kernel[(N,)](
+        cache_loc, temp, old_cu, new_cu, extra_idx, delta, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    cache_loc[:total_new] = temp
+    cu_num_blocks[: N + 1] = new_cu
+
+    return total_new
+
+
+@adjust_ragged_triton.register_fake
+def _adjust_ragged_triton_fake(
+    cache_loc: torch.Tensor,
+    cu_num_blocks: torch.Tensor,
+    extra_idx: torch.Tensor,
+    delta: torch.Tensor,
+    num_sequences: int,
+) -> int:
+    return 0

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/torch_gather_logits.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/utils/torch_gather_logits.py
@@ -16,61 +16,47 @@
 import torch
 
 
-@torch.library.custom_op("auto_deploy::gather_logits_before_lm_head", mutates_args=())
-def gather_logits_before_lm_head(
+@torch.library.custom_op("auto_deploy::gather_tokens", mutates_args=())
+def gather_tokens(
     hidden_states: torch.Tensor,
-    logits_gather_indices: torch.Tensor,  # long tensor
-    logits_gather_info_host: torch.Tensor,  # int tensor
+    token_gather_indices: torch.Tensor,  # long tensor
+    tokens_gather_info_host: torch.Tensor,  # int tensor
 ) -> torch.Tensor:
-    """Gather hidden states using logits_gather_indices before LM head.
+    """Gather hidden states using token_gather_indices before LM head.
 
     Args:
-        hidden_states: Hidden states tensor in one of the supported layouts:
-            - [b, 1, hidden]
-            - [1, s_total, hidden]
-            - [tokens, hidden]
-        logits_gather_indices: indices for gathering logits.
-        logits_gather_info_host: info for gathering logits.
+        hidden_states: Hidden states tensor of shape [batch_size, 1, *other_dims] or
+            [1, total_token_length, *other_dims]
+        token_gather_indices: indices for gathering logits.
+        tokens_gather_info_host: info for gathering logits.
     Returns:
         Gathered and flattened hidden states [num_gathered_tokens, hidden]
     """
-    # Normalize to [tokens, hidden] for gather.
-    # NOTE: 2D [tokens, hidden] is already canonical and must not be squeezed on dim 0.
-    if hidden_states.dim() == 3:
-        input_was_3d = True
-        is_decode_only = hidden_states.shape[1] == 1
-        if is_decode_only:
-            # [b, 1, hidden] -> [b, hidden]
-            hidden_states = hidden_states.squeeze(1)
-        else:
-            # [1, s_total, hidden] -> [s_total, hidden]
-            hidden_states = hidden_states.squeeze(0)
-    elif hidden_states.dim() == 2:
-        input_was_3d = False
-        is_decode_only = False
-    else:
-        raise AssertionError(
-            "gather_logits_before_lm_head expects 2D/3D hidden states, "
-            f"got shape={tuple(hidden_states.shape)}"
-        )
+    # final shape is [total_tokens, *other_dims]
+    bsz, sl, *other_dims = hidden_states.shape
+    assert bsz == 1 or sl == 1, "expected batch size or sequence length to be 1"
+    hidden_states = hidden_states.view(bsz * sl, *other_dims)
 
     # info object
-    num_tokens_to_gather, gather_required = logits_gather_info_host.tolist()
+    num_tokens_to_gather, gather_required = tokens_gather_info_host.tolist()
 
     if gather_required:
-        out = hidden_states.index_select(0, logits_gather_indices[:num_tokens_to_gather])
+        out = hidden_states.index_select(0, token_gather_indices[:num_tokens_to_gather])
+        num_tokens_final = num_tokens_to_gather
     else:
         out = hidden_states.clone(memory_format=torch.contiguous_format)
-    if input_was_3d:
-        out = out.unsqueeze(1 if is_decode_only else 0)
-    return out
+        num_tokens_final = bsz * sl
+    if bsz == 1:
+        return out.view(1, num_tokens_final, *other_dims)
+    else:
+        return out.view(num_tokens_final, 1, *other_dims)
 
 
-@gather_logits_before_lm_head.register_fake
-def gather_logits_before_lm_head_fake(
+@gather_tokens.register_fake
+def gather_tokens_fake(
     hidden_states: torch.Tensor,
-    logits_gather_indices: torch.Tensor,
-    logits_gather_info_host: torch.Tensor,
+    token_gather_indices: torch.Tensor,
+    tokens_gather_info_host: torch.Tensor,
 ) -> torch.Tensor:
     # NOTE: shape is not correct in fake mode
     # see https://github.com/NVIDIA/TensorRT-LLM/issues/9878

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -119,8 +119,8 @@ class ADHiddenStateManager(Eagle3ResourceManager):
         self, ordered_requests: RequestList, cache_seq_interface: CachedSequenceInterface
     ) -> None:
         """Prepare the hidden states for capture by establishing indices that the hidden states will be written to."""
-        seq_lens = cache_seq_interface.info.seq_len
-        num_tokens = sum(seq_lens)
+        seq_lens = cache_seq_interface.info.get_arg("seq_len", truncate=True).tolist()
+        num_tokens = cache_seq_interface.info.total_num_tokens
 
         start_idx = 0
         hidden_states_write_indices = []
@@ -156,7 +156,7 @@ class ADHiddenStateManager(Eagle3ResourceManager):
         if not full_hidden_states:
             return
 
-        num_tokens = sum(cache_seq_interface.info.seq_len)
+        num_tokens = cache_seq_interface.info.total_num_tokens
 
         hidden_states = [hidden_state[:num_tokens] for hidden_state in full_hidden_states]
         hidden_states = torch.cat(hidden_states, dim=1)
@@ -586,19 +586,11 @@ class ADEngine(ModelEngine):
         ]
         gen_requests = extend_requests + generation_requests
         ordered_requests = context_requests + gen_requests
-        # info to be extracted
-        input_ids: List[List[int]] = []
-        position_ids: List[List[int]] = []
-        input_pos: List[int] = []
-        seq_len: List[int] = []
+
+        # sequence information
+        input_ids: List[int] = []
         cu_seqlen: List[int] = [0]
-        cache_loc: List[int] = []
-        pages_per_seq: List[int] = []
-        cu_num_pages: List[int] = [0]
-        seq_len_with_cache: List[int] = []
-        last_page_len: List[int] = []
-        slot_idx: List[int] = []
-        use_initial_states: List[bool] = []
+        input_pos: List[int] = []
 
         # gather indices are used to gather tokens in new_tokens into input_ids
         flat_gather_indices: List[int] = []
@@ -606,194 +598,129 @@ class ADEngine(ModelEngine):
         extra_args: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         # gather indices for logits
-        logits_gather_indices: List[int] = []
-
-        page_size = kv_cache_manager.tokens_per_block
+        token_gather_indices = None if gather_context_logits else []
         dummy_token = -1
-        num_ctx_requests = len(context_requests)
-        num_ctx_tokens = 0
-        num_generation_tokens = 0
-
-        # Helper to get slot index - use mamba_cache_index if available (MambaHybridCacheManager)
-        def _get_slot_idx(request) -> int:
-            if hasattr(kv_cache_manager, "mamba_cache_index"):
-                return kv_cache_manager.mamba_cache_index[request.py_request_id]
-            return request.seq_slot
 
         # look at context requests first
         for request in context_requests:
             # store input ids and pos of first token in sequence
             # NOTE: begin_compute > 0 indicates block reuse
-            # NOTE: end_compute will be used in the future for chunked prefill
+            # NOTE: end_compute is used for chunked prefill
             all_prompt_tokens = request.get_tokens(0)
             begin_compute = request.context_current_position
             end_compute = begin_compute + request.context_chunk_size
             prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
-            num_ctx_tokens += len(prompt_tokens)
 
-            input_ids.append(prompt_tokens)
+            input_ids.extend(prompt_tokens)
+            cu_seqlen.append(len(input_ids))
             input_pos.append(begin_compute)
 
-            seq_len.append(len(input_ids[-1]))
-            cu_seqlen.append(cu_seqlen[-1] + seq_len[-1])
-
-            request.py_batch_idx = request.seq_slot
-
-            if gather_context_logits:
-                logits_gather_indices.extend(range(cu_seqlen[-2], cu_seqlen[-1]))
-            else:
-                logits_gather_indices.append(cu_seqlen[-1] - 1)
-
-            # get cache indices and truncate the number of blocks according to end_compute
-            cache_indices = kv_cache_manager.get_cache_indices(request)
-            num_active_blocks = kv_cache_manager.get_num_kv_blocks(end_compute)
-            cache_loc.extend(cache_indices[:num_active_blocks])
-            pages_per_seq.append(num_active_blocks)
-            cu_num_pages.append(cu_num_pages[-1] + pages_per_seq[-1])
-            seq_len_with_cache.append(input_pos[-1] + seq_len[-1])
-            last_page_len.append((seq_len_with_cache[-1] - 1) % page_size + 1)
-
-            position_ids.append(list(range(input_pos[-1], seq_len_with_cache[-1])))
-
-            # store seq slot idx (use mamba_cache_index if available)
-            slot_idx.append(_get_slot_idx(request))
-            use_initial_states.append(input_pos[-1] > 0)
+            if token_gather_indices is not None:
+                token_gather_indices.append(len(input_ids) - 1)
 
             # store extra arguments
             if request.py_multimodal_data is not None:
                 for k, v in request.py_multimodal_data.items():
                     extra_args[k].append(v)
 
-        def _use_overlap_scheduler(request) -> bool:
-            """Check if we should use overlap scheduler behavior."""
-            return (
+        # store num_prefill and num_prefill_tokens
+        num_prefill = len(context_requests)
+        num_prefill_tokens = len(input_ids)
+
+        for request in gen_requests:
+            # check if need overlap and draft length
+            is_overlap = (
                 not self._disable_overlap_scheduler
                 and new_tokens is not None
                 and not request.is_dummy
                 and request.py_batch_idx is not None
             )
 
-        def _compute_num_tokens_seen(request) -> int:
-            """Compute num_tokens_seen based on request. Note that we treat extend requests
-            (corresponding to running target model in speculative decoding) differently from
-            normal generation requests.
-            """
-            is_extend = get_draft_token_length(request) > 0
+            # check draft length
+            draft_len = get_draft_token_length(request)
 
-            if is_extend:
-                return request.max_beam_num_tokens - 1
+            # there are cases:
+            # 1. No overlap: we are preparing for the current iteration --> use previous token count
+            # 2. Overlap: we are preparing for the next iteration --> use max_beam_num_tokens
+            # 3. Draft request (overlap or not) --> use previous token counts, overlap scheduler is
+            #    accounted for by incrementing position/cache in-place based on new_tokens_lens.
+            num_tokens_seen = request.max_beam_num_tokens
+            if draft_len > 0 or not is_overlap:
+                num_tokens_seen -= 1
+
+            # build input ids
+            if is_overlap:
+                input_ids.extend([dummy_token] * (1 + draft_len))
+                flat_gather_indices.extend(
+                    [request.py_batch_idx + i * new_tokens.shape[1] for i in range(draft_len + 1)]
+                )
             else:
-                # When overlap scheduler is disabled, or when new_tokens is not available,
-                # we use the previous token count
-                use_overlap = _use_overlap_scheduler(request)
-                if use_overlap:
-                    return request.max_beam_num_tokens
-                else:
-                    return request.max_beam_num_tokens - 1
+                input_ids.append(request.get_token(0, request.get_num_tokens(0) - 1))
+                input_ids.extend([] if draft_len == 0 else request.py_draft_tokens)
 
-        def _build_input_ids(request) -> Tuple[List[int], List[int], bool]:
-            """Build input_ids and gather indices for a request.
-            Gather indices are used to gather tokens from new_tokens into input_ids when we run the overlap scheduler.
-            """
-            is_extend = get_draft_token_length(request) > 0
-
-            # Check if we should use overlap scheduler behavior
-            use_overlap = _use_overlap_scheduler(request)
-
-            if not use_overlap:
-                # No overlap scheduler or dummy request
-                if is_extend:
-                    input_ids = [request.get_token(0, request.get_num_tokens(0) - 1)] + [
-                        token for token in request.py_draft_tokens
-                    ]
-                else:
-                    input_ids = [request.get_token(0, request.get_num_tokens(0) - 1)]
-                gather_indices = []
-            else:
-                # Overlap scheduler enabled
-                if is_extend:
-                    gather_indices = [
-                        x * new_tokens.shape[1] + request.py_batch_idx
-                        for x in range(len(request.py_draft_tokens) + 1)
-                    ]
-
-                    dummy_draft_tokens = [dummy_token for _ in range(len(request.py_draft_tokens))]
-                    input_ids = [dummy_token] + dummy_draft_tokens
-                else:
-                    gather_indices = [request.py_batch_idx]
-                    input_ids = [dummy_token]
-
-            return input_ids, gather_indices, use_overlap
-
-        for request in gen_requests:
-            num_tokens_seen = _compute_num_tokens_seen(request)
-            input_ids_for_request, gather_indices_to_append, use_overlap = _build_input_ids(request)
-
-            input_ids.append(input_ids_for_request)
+            cu_seqlen.append(len(input_ids))
             input_pos.append(num_tokens_seen)
-            flat_gather_indices.extend(gather_indices_to_append)
-
-            num_generation_tokens += 1 + get_draft_token_length(request)
-            request.py_batch_idx = request.seq_slot
-            # store seq slot idx (use mamba_cache_index if available)
-            slot_idx.append(_get_slot_idx(request))
-            use_initial_states.append(input_pos[-1] > 0)
-
-            seq_len.append(len(input_ids[-1]))
-            cu_seqlen.append(cu_seqlen[-1] + seq_len[-1])
 
             # for generate requests, we always keep all logits (target logits + draft logits)
-            logits_gather_indices.extend(range(cu_seqlen[-2], cu_seqlen[-1]))
+            if token_gather_indices is not None:
+                token_gather_indices.extend(range(cu_seqlen[-2], cu_seqlen[-1]))
 
-            if use_overlap:
+            if is_overlap:
                 mask_scatter_indices.extend(list(range(cu_seqlen[-2], cu_seqlen[-1])))
 
-            # get cache indices and truncate the number of blocks according to total tokens
+        # store cache information for all requests now
+        cache_loc: List[int] = []
+        cu_num_pages: List[int] = [0]
+        extra_page_per_seq: List[int] = []
+        slot_idx: List[int] = []
+        for i, request in enumerate(ordered_requests):
+            # store seq slot idx (use mamba_cache_index if available)
+            request.py_batch_idx = request.seq_slot
+            if hasattr(kv_cache_manager, "mamba_cache_index"):
+                slot_idx_i = kv_cache_manager.mamba_cache_index[request.py_request_id]
+            else:
+                slot_idx_i = request.seq_slot
+            slot_idx.append(slot_idx_i)
+
+            # get some info on the current request
+            seq_len_i = cu_seqlen[i + 1] - cu_seqlen[i]
+            end_compute_i = input_pos[i] + seq_len_i
+            num_active_blocks_i = kv_cache_manager.get_num_kv_blocks(end_compute_i)
+
+            # construct cache information for the current request
             cache_indices = kv_cache_manager.get_cache_indices(request)
-            cache_loc.extend(cache_indices)
-            pages_per_seq.append(len(cache_indices))
-            cu_num_pages.append(cu_num_pages[-1] + pages_per_seq[-1])
-            seq_len_with_cache.append(input_pos[-1] + seq_len[-1])
-            last_page_len.append((seq_len_with_cache[-1] - 1) % page_size + 1)
+            cache_loc.extend(cache_indices[:num_active_blocks_i])
+            cu_num_pages.append(cu_num_pages[i] + num_active_blocks_i)
+            if len(cache_indices) > num_active_blocks_i:
+                extra_page_per_seq.append(cache_indices[num_active_blocks_i])
+            else:
+                extra_page_per_seq.append(-1)
 
-            position_ids.append(list(range(input_pos[-1], seq_len_with_cache[-1])))
-
-        # check for logits_gather_info
+        # check for tokens_gather_info
         # we only need to gather in the following situation:
         # 1. there are context requests and
-        # 2. we are not gathering context logits
         # In other cases (decode-only) or when we keep all logits, we do not need to gather.
-        gather_required = len(context_requests) > 0 and not gather_context_logits
-        logits_gather_info = [len(logits_gather_indices), int(gather_required)]
+        gather_required = num_prefill > 0 and not gather_context_logits
+        num_gather_tokens = len(token_gather_indices) if gather_required else 0
+        tokens_gather_info = [num_gather_tokens, int(gather_required)]
 
-        # Compute batch_info explicitly based on actual request ordering rather than
-        # relying on the seq_len > 1 heuristic in nest_sequences. With chunked prefill,
-        # a context request may have context_chunk_size=1, giving seq_len=1. The heuristic
-        # would misclassify it as decode, causing host_request_types to be inconsistent
-        # with the actual request ordering (context + extend first, then generation).
-        # This mismatch leads to incorrect token splitting in thop.attention.
-        num_prefill_seqs = num_ctx_requests + len(extend_requests)
-        num_prefill_tokens = sum(seq_len[:num_prefill_seqs])
-        num_decode_seqs = len(generation_requests)
-        batch_info = [num_prefill_seqs, num_prefill_tokens, num_decode_seqs]
+        # Store batch information based on prefill, extend, and decode requests.
+        num_decode = len(generation_requests)
+        num_decode_tokens = num_decode
+        batch_info = [num_prefill, num_prefill_tokens, num_decode]
 
-        # update the sequence info object now (also triggers rescatter + host_prepare internally)
+        # update the sequence info object now
         self.cache_seq_interface.info.nest_sequences(
             input_ids,
-            position_ids=position_ids,
-            seq_len=seq_len,
+            cu_seqlen=cu_seqlen,
             input_pos=input_pos,
             batch_info=batch_info,
-            cu_seqlen=cu_seqlen,
             cache_loc=cache_loc,
-            pages_per_seq=pages_per_seq,
             cu_num_pages=cu_num_pages,
-            seq_len_with_cache=seq_len_with_cache,
-            last_page_len=last_page_len,
+            extra_page_per_seq=extra_page_per_seq,
             slot_idx=slot_idx,
-            use_initial_states=use_initial_states,
-            logits_gather_indices=logits_gather_indices,
-            logits_gather_info=logits_gather_info,
+            token_gather_indices=token_gather_indices,
+            tokens_gather_info=tokens_gather_info,
             _gather_idx=None if new_tokens is None else flat_gather_indices,
             _mask_scatter_indices=None if new_tokens is None else mask_scatter_indices,
             _ungathered_input_ids=new_tokens.flatten() if new_tokens is not None else None,
@@ -807,16 +734,16 @@ class ADEngine(ModelEngine):
                 ordered_requests, self.cache_seq_interface
             )
 
-        self.iter_states["num_ctx_requests"] = num_ctx_requests
-        self.iter_states["num_ctx_tokens"] = num_ctx_tokens
+        self.iter_states["num_ctx_requests"] = num_prefill
+        self.iter_states["num_ctx_tokens"] = num_prefill_tokens
         # TODO: handle extend requests and draft requests for specdec
-        self.iter_states["num_generation_tokens"] = num_generation_tokens
+        self.iter_states["num_generation_tokens"] = num_decode_tokens
 
     @nvtx_range("ad_compute_logits")
     def _compute_logits(self) -> List[torch.Tensor]:
         # run the model
         logits: torch.Tensor = self.model(**self.cache_seq_interface.named_args)[0]
-        logits = self.cache_seq_interface.info.maybe_gather_and_squeeze_logits(logits)
+        logits = self.cache_seq_interface.info.maybe_gather_and_squeeze(logits)
 
         # TRTLLMSampler expects float32 logits. PyTorchModelEngine always casts to float32 regardless.
         return logits.float()

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -108,6 +108,15 @@ class CachedSequenceInterface:
         """Return all the named arguments owned by this interface."""
         return {**self.info.named_args, **self._caches}
 
+    def get_arg(
+        self, name: str, truncate: Optional[bool] = None, unflatten: Optional[bool] = None
+    ) -> torch.Tensor:
+        """Get the argument from the sequence info or caches."""
+        if name in self._caches:
+            assert not (truncate or unflatten), "truncate or unflatten is not supported for caches"
+            return self._caches[name]
+        return self.info.get_arg(name, truncate=truncate, unflatten=unflatten)
+
     def to(self, *args, **kwargs) -> None:
         self.info.to(*args, **kwargs)
         # Only move locally-allocated caches (paged/state caches are managed by cache managers)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/gather_logits_before_lm_head.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/gather_logits_before_lm_head.py
@@ -66,14 +66,14 @@ class GatherLogitsBeforeLmHeadTransform(BaseTransform):
             self._log_info("lm_head node is not linear, using it as the node to gather")
 
         # Add logits_gather_mask as input in the graph and the sequence info interface
-        logits_gather_indices_node = self._add_or_retrieve_input(gm, cm, "logits_gather_indices")
+        logits_gather_indices_node = self._add_or_retrieve_input(gm, cm, "token_gather_indices")
         logits_gather_info_host_node = self._add_or_retrieve_input(
-            gm, cm, "logits_gather_info_host"
+            gm, cm, "tokens_gather_info_host"
         )
 
         with gm.graph.inserting_after(node_to_gather):
             gathered_node = gm.graph.call_function(
-                torch.ops.auto_deploy.gather_logits_before_lm_head.default,
+                torch.ops.auto_deploy.gather_tokens.default,
                 args=(node_to_gather, logits_gather_indices_node, logits_gather_info_host_node),
             )
         node_to_gather.replace_all_uses_with(gathered_node)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/attention/test_trtllm_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/attention/test_trtllm_attention_op.py
@@ -77,33 +77,26 @@ def _prepare_and_run(
         dtype=torch.int32,
     ).pin_memory()
 
-    # --- paging metadata for host prepare -------------------------------------
+    # --- paging metadata -------------------------------------------------------
     cache_loc_d = torch.tensor(cache_locs, dtype=torch.int32, device=device)
 
     cu_num_pages = [0]
     for pps in pages_per_seq:
         cu_num_pages.append(cu_num_pages[-1] + pps)
-    cu_num_pages_h = torch.tensor(cu_num_pages, dtype=torch.int32).pin_memory()
+    cu_num_pages_d = torch.tensor(cu_num_pages, dtype=torch.int32, device=device)
 
-    page_seq_indices_list = []
-    page_in_seq_list = []
-    for i, np_ in enumerate(pages_per_seq):
-        page_seq_indices_list.extend([i] * np_)
-        page_in_seq_list.extend(range(np_))
-    page_seq_indices_d = torch.tensor(page_seq_indices_list, dtype=torch.int32, device=device)
-    page_in_seq_d = torch.tensor(page_in_seq_list, dtype=torch.int32, device=device)
-
-    # --- host prepare ---------------------------------------------------------
+    # --- host prepare (pinned host tensors) ------------------------------------
     prepare_trtllm_metadata_host(
         batch_info_host=batch_info_host.cpu(),
         max_seq_info_host=max_seq_info_h,
         seq_len_with_cache_host=slwc_h,
-        cu_num_pages_host=cu_num_pages_h,
-        cache_loc=cache_loc_d,
-        page_seq_indices=page_seq_indices_d,
-        page_in_seq=page_in_seq_d,
         input_pos_host=input_pos_h,
         seq_len_host=seq_len_h,
+    )
+
+    # --- device prepare (block_offsets via Triton kernel) ---------------------
+    (block_offsets,) = torch.ops.auto_deploy.trtllm_attention_prepare_metadata(
+        batch_info_host, max_seq_info_h, cu_num_pages_d, cache_loc_d
     )
 
     # --- call op --------------------------------------------------------------
@@ -113,10 +106,9 @@ def _prepare_and_run(
         v,
         batch_info_host,
         seq_len_d,
-        seq_len_h,
-        input_pos_h,
         slwc_d,
         max_seq_info_h,
+        block_offsets,
         kv_cache,
         scale,
     )
@@ -599,3 +591,85 @@ def test_trtllm_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, device
         atol=1e-2,
         rtol=1e-2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Block offsets computation test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_sequences, pages_per_seq_list, block_offset_multiplier",
+    [
+        (1, [1], 2),
+        (3, [2, 3, 1], 2),
+        (4, [1, 4, 2, 3], 2),
+        (2, [5, 5], 4),
+    ],
+)
+def test_block_offsets_computation(num_sequences, pages_per_seq_list, block_offset_multiplier):
+    """Verify block_offsets produced by prepare_trtllm_metadata device-side op."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    _reset_trtllm_planner()
+
+    max_batch_size = max(num_sequences, 4)
+    total_pages = sum(pages_per_seq_list)
+    max_blocks_per_seq = max(pages_per_seq_list)
+    max_seq_len = max_blocks_per_seq * 64
+
+    cache_locs = list(range(100, 100 + total_pages))
+    cache_loc_d = torch.tensor(cache_locs, dtype=torch.int32, device=device)
+
+    cu_num_pages = [0]
+    for pps in pages_per_seq_list:
+        cu_num_pages.append(cu_num_pages[-1] + pps)
+    cu_num_pages_d = torch.tensor(cu_num_pages, dtype=torch.int32, device=device)
+
+    batch_info_host = torch.tensor(
+        [num_sequences, num_sequences, 0], dtype=torch.int32
+    ).pin_memory()
+    max_seq_info_h = torch.tensor(
+        [max_seq_len, max_blocks_per_seq, block_offset_multiplier, max_batch_size],
+        dtype=torch.int32,
+    ).pin_memory()
+
+    prepare_trtllm_metadata_host(
+        batch_info_host=batch_info_host,
+        max_seq_info_host=max_seq_info_h,
+        seq_len_with_cache_host=torch.ones(num_sequences, dtype=torch.int32).pin_memory(),
+        input_pos_host=torch.zeros(num_sequences, dtype=torch.int32).pin_memory(),
+        seq_len_host=torch.ones(num_sequences, dtype=torch.int32).pin_memory(),
+    )
+
+    torch.ops.auto_deploy.trtllm_attention_prepare_metadata(
+        batch_info_host, max_seq_info_h, cu_num_pages_d, cache_loc_d
+    )
+
+    block_offsets = _GlobalTrtllmPlanner.block_offsets
+    bo = block_offsets[0].cpu()
+
+    # Python reference: for each sequence and page, verify K and V offsets
+    offset = 0
+    for seq_id, n_pages in enumerate(pages_per_seq_list):
+        for pg in range(n_pages):
+            raw = cache_locs[offset]
+            expected_k = raw * block_offset_multiplier
+            expected_v = expected_k + 1
+            assert bo[seq_id, 0, pg].item() == expected_k, (
+                f"K mismatch at seq={seq_id} pg={pg}: "
+                f"got {bo[seq_id, 0, pg].item()}, expected {expected_k}"
+            )
+            assert bo[seq_id, 1, pg].item() == expected_v, (
+                f"V mismatch at seq={seq_id} pg={pg}: "
+                f"got {bo[seq_id, 1, pg].item()}, expected {expected_v}"
+            )
+            offset += 1
+
+    # Verify zero-padding in unused slots
+    for seq_id, n_pages in enumerate(pages_per_seq_list):
+        for pg in range(n_pages, max_blocks_per_seq):
+            assert bo[seq_id, 0, pg].item() == 0, f"K padding non-zero at seq={seq_id} pg={pg}"
+            assert bo[seq_id, 1, pg].item() == 1, f"V padding not 1 at seq={seq_id} pg={pg}"

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/utils/test_block_table_ragged_conversion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/utils/test_block_table_ragged_conversion.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/utils/test_block_table_ragged_conversion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/utils/test_block_table_ragged_conversion.py
@@ -1,0 +1,889 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests and benchmarks for block table <-> ragged tensor conversions.
+
+Tests two implementations of bidirectional conversion between:
+- Block table format: [max_batch_size, max_blocks_per_seq] padded 2D tensor
+- Ragged format: flat 1D cache_loc + cumulative offset vector cu_num_blocks
+
+Implementations:
+1. PyTorch reference (tensorized, loop-free)
+2. Triton kernels (one program per sequence row)
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops.utils.block_table_ragged  # noqa: F401
+
+ops = torch.ops.auto_deploy
+
+# ========================================================================================
+# Test helpers
+# ========================================================================================
+
+
+def _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device="cuda"):
+    """Create randomized test data for block table / ragged conversion tests.
+
+    Returns:
+        block_table: [max_batch_size, max_blocks_per_seq] with random page IDs.
+        num_blocks: [max_batch_size] with random valid lengths in [1, max_blocks_per_seq].
+    """
+    num_blocks = torch.randint(
+        1, max_blocks_per_seq + 1, (max_batch_size,), device=device, dtype=torch.int32
+    )
+
+    block_table = torch.randint(
+        1, 10000, (max_batch_size, max_blocks_per_seq), device=device, dtype=torch.int32
+    )
+
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    block_table[:num_sequences][pad_mask] = 0
+
+    return block_table, num_blocks
+
+
+def _make_extra_idx(
+    max_batch_size, num_sequences, max_val=10000, valid_fraction=0.5, device="cuda"
+):
+    """Create extra_idx tensor with a mix of valid values and -1 sentinels."""
+    extra_idx = torch.full((max_batch_size,), -1, device=device, dtype=torch.int32)
+    if num_sequences > 0:
+        valid_mask = torch.rand(num_sequences, device=device) < valid_fraction
+        valid_values = torch.randint(1, max_val, (num_sequences,), device=device, dtype=torch.int32)
+        extra_idx[:num_sequences] = torch.where(
+            valid_mask, valid_values, torch.tensor(-1, device=device, dtype=torch.int32)
+        )
+    return extra_idx
+
+
+# ========================================================================================
+# Correctness tests
+# ========================================================================================
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 1), (4, 8), (32, 64), (128, 256), (512, 4096)],
+)
+def test_block_table_to_ragged(max_batch_size, max_blocks_per_seq):
+    """Test block_table -> ragged: Triton matches PyTorch reference (exact int match)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+
+    max_capacity = max_batch_size * max_blocks_per_seq
+
+    # --- PyTorch reference ---
+    cache_loc_ref = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_ref = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_ref = ops.block_table_to_ragged_torch(
+        bt, num_blocks, cache_loc_ref, cu_ref, num_sequences
+    )
+
+    # --- Triton ---
+    cache_loc_tri = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_tri = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_tri = ops.block_table_to_ragged_triton(
+        bt, num_blocks, cache_loc_tri, cu_tri, num_sequences
+    )
+
+    # --- Verify ---
+    assert total_ref == total_tri, f"Total mismatch: {total_ref} vs {total_tri}"
+    torch.testing.assert_close(
+        cu_tri[: num_sequences + 1], cu_ref[: num_sequences + 1], rtol=0, atol=0
+    )
+    torch.testing.assert_close(cache_loc_tri[:total_ref], cache_loc_ref[:total_ref], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 1), (4, 8), (32, 64), (128, 256)],
+)
+def test_ragged_to_block_table(max_batch_size, max_blocks_per_seq):
+    """Test ragged -> block_table: Triton matches PyTorch reference (exact int match)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_src, num_blocks_src = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    max_capacity = max_batch_size * max_blocks_per_seq
+    cache_loc = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_num_blocks = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(
+        block_table_src, num_blocks_src, cache_loc, cu_num_blocks, num_sequences
+    )
+
+    # --- PyTorch reference (ragged -> block_table) ---
+    bt_ref = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+    nb_ref = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    ops.ragged_to_block_table_torch(cache_loc, cu_num_blocks, bt_ref, nb_ref, num_sequences)
+
+    # --- Triton (ragged -> block_table) ---
+    bt_tri = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+    ops.ragged_to_block_table_triton(cache_loc, cu_num_blocks, bt_tri, num_sequences)
+
+    # --- Verify ---
+    torch.testing.assert_close(bt_tri[:num_sequences], bt_ref[:num_sequences], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 1), (4, 8), (32, 64), (128, 256)],
+)
+def test_ragged_to_block_table_strided(max_batch_size, max_blocks_per_seq):
+    """Test ragged -> strided block_table: kernel writes correctly into non-contiguous slice."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_src, num_blocks_src = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    max_capacity = max_batch_size * max_blocks_per_seq
+    cache_loc = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_num_blocks = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(
+        block_table_src, num_blocks_src, cache_loc, cu_num_blocks, num_sequences
+    )
+
+    # Contiguous reference
+    bt_ref = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+    ops.ragged_to_block_table_triton(cache_loc, cu_num_blocks, bt_ref, num_sequences)
+
+    # Strided output: [B, 2, M] tensor, write into [:, 0, :] slice (stride [2*M, 1])
+    sentinel = -1
+    strided_buf = torch.full(
+        (max_batch_size, 2, max_blocks_per_seq), sentinel, device=device, dtype=torch.int32
+    )
+    strided_slice = strided_buf[:, 0, :]
+    assert strided_slice.stride() == (2 * max_blocks_per_seq, 1)
+    ops.ragged_to_block_table_triton(cache_loc, cu_num_blocks, strided_slice, num_sequences)
+
+    # Verify: strided slice matches contiguous reference
+    torch.testing.assert_close(
+        strided_buf[:num_sequences, 0, :], bt_ref[:num_sequences], rtol=0, atol=0
+    )
+    # Verify: interleaved rows ([:, 1, :]) are untouched
+    torch.testing.assert_close(
+        strided_buf[:, 1, :],
+        torch.full_like(strided_buf[:, 1, :], sentinel),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 1), (4, 8), (32, 64), (128, 256)],
+)
+def test_roundtrip(max_batch_size, max_blocks_per_seq):
+    """Test block_table -> ragged -> block_table roundtrip (exact recovery)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_orig, num_blocks_orig = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+
+    max_capacity = max_batch_size * max_blocks_per_seq
+
+    # Forward: block_table -> ragged (Triton)
+    cache_loc = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_num_blocks = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_triton(
+        block_table_orig, num_blocks_orig, cache_loc, cu_num_blocks, num_sequences
+    )
+
+    # Inverse: ragged -> block_table (Triton)
+    block_table_recovered = torch.zeros(
+        max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32
+    )
+    ops.ragged_to_block_table_triton(cache_loc, cu_num_blocks, block_table_recovered, num_sequences)
+
+    # Verify exact recovery of the active region
+    torch.testing.assert_close(
+        block_table_recovered[:num_sequences],
+        block_table_orig[:num_sequences],
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq, num_sequences",
+    [(8, 16, 3), (32, 64, 10), (128, 256, 1)],
+)
+def test_partial_batch(max_batch_size, max_blocks_per_seq, num_sequences):
+    """Test with num_sequences < max_batch_size (partial batch)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+
+    max_capacity = max_batch_size * max_blocks_per_seq
+
+    # --- PyTorch reference ---
+    cache_loc_ref = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_ref = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_ref = ops.block_table_to_ragged_torch(
+        bt, num_blocks, cache_loc_ref, cu_ref, num_sequences
+    )
+
+    # --- Triton ---
+    cache_loc_tri = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_tri = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_tri = ops.block_table_to_ragged_triton(
+        bt, num_blocks, cache_loc_tri, cu_tri, num_sequences
+    )
+
+    assert total_ref == total_tri
+    torch.testing.assert_close(cache_loc_tri[:total_ref], cache_loc_ref[:total_ref], rtol=0, atol=0)
+
+    # Also roundtrip the partial batch
+    bt_recovered = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+    ops.ragged_to_block_table_triton(cache_loc_tri, cu_tri, bt_recovered, num_sequences)
+    torch.testing.assert_close(bt_recovered[:num_sequences], bt[:num_sequences], rtol=0, atol=0)
+
+
+# ========================================================================================
+# Correctness tests -- adjust block index (append / remove / no-op)
+# ========================================================================================
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 4), (4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_append_block_table(max_batch_size, max_blocks_per_seq):
+    """Test append (delta=+1) to block_table: Triton matches PyTorch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, device=device)
+    delta = (extra_idx[:num_sequences] >= 0).to(torch.int32)
+    delta_full = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta_full[:num_sequences] = delta
+
+    bt_ref = bt.clone()
+    nb_ref = num_blocks.clone()
+    ops.adjust_block_table_torch(bt_ref, nb_ref, extra_idx, delta_full, num_sequences)
+
+    bt_tri = bt.clone()
+    nb_tri = num_blocks.clone()
+    ops.adjust_block_table_triton(bt_tri, nb_tri, extra_idx, delta_full, num_sequences)
+
+    torch.testing.assert_close(bt_tri[:num_sequences], bt_ref[:num_sequences], rtol=0, atol=0)
+    torch.testing.assert_close(nb_tri[:num_sequences], nb_ref[:num_sequences], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(1, 4), (4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_append_ragged(max_batch_size, max_blocks_per_seq):
+    """Test append (delta=+1) to ragged: Triton matches PyTorch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_src, num_blocks_src = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    buffer_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+
+    cache_loc_base = torch.zeros(buffer_capacity, device=device, dtype=torch.int32)
+    cu_base = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(
+        block_table_src, num_blocks_src, cache_loc_base, cu_base, num_sequences
+    )
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, device=device)
+    delta = (extra_idx[:num_sequences] >= 0).to(torch.int32)
+    delta_full = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta_full[:num_sequences] = delta
+
+    cl_ref = cache_loc_base.clone()
+    cu_ref = cu_base.clone()
+    total_ref = ops.adjust_ragged_torch(cl_ref, cu_ref, extra_idx, delta_full, num_sequences)
+
+    cl_tri = cache_loc_base.clone()
+    cu_tri = cu_base.clone()
+    total_tri = ops.adjust_ragged_triton(cl_tri, cu_tri, extra_idx, delta_full, num_sequences)
+
+    assert total_ref == total_tri, f"Total mismatch: {total_ref} vs {total_tri}"
+    torch.testing.assert_close(
+        cu_tri[: num_sequences + 1], cu_ref[: num_sequences + 1], rtol=0, atol=0
+    )
+    torch.testing.assert_close(cl_tri[:total_ref], cl_ref[:total_ref], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64)],
+)
+def test_adjust_all_zero_delta(max_batch_size, max_blocks_per_seq):
+    """Test adjust with all delta=0 (no-op)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    extra_idx = torch.full((max_batch_size,), -1, device=device, dtype=torch.int32)
+    delta = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+
+    bt_before = bt.clone()
+    nb_before = num_blocks.clone()
+    ops.adjust_block_table_triton(bt, num_blocks, extra_idx, delta, num_sequences)
+    torch.testing.assert_close(bt[:num_sequences], bt_before[:num_sequences], rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_blocks[:num_sequences], nb_before[:num_sequences], rtol=0, atol=0
+    )
+
+    max_capacity = max_batch_size * max_blocks_per_seq
+    cache_loc = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt_before, nb_before, cache_loc, cu, num_sequences)
+    cl_before = cache_loc.clone()
+    cu_before = cu.clone()
+    ops.adjust_ragged_triton(cache_loc, cu, extra_idx, delta, num_sequences)
+    old_total = int(cu_before[num_sequences].item())
+    torch.testing.assert_close(cache_loc[:old_total], cl_before[:old_total], rtol=0, atol=0)
+    torch.testing.assert_close(
+        cu[: num_sequences + 1], cu_before[: num_sequences + 1], rtol=0, atol=0
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64)],
+)
+def test_adjust_all_append(max_batch_size, max_blocks_per_seq):
+    """Test adjust with all delta=+1 (every sequence gets one append)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = torch.ones(max_batch_size, device=device, dtype=torch.int32)
+
+    bt_ref, nb_ref = bt.clone(), num_blocks.clone()
+    bt_tri, nb_tri = bt.clone(), num_blocks.clone()
+    ops.adjust_block_table_torch(bt_ref, nb_ref, extra_idx, delta, num_sequences)
+    ops.adjust_block_table_triton(bt_tri, nb_tri, extra_idx, delta, num_sequences)
+    torch.testing.assert_close(bt_tri[:num_sequences], bt_ref[:num_sequences], rtol=0, atol=0)
+    torch.testing.assert_close(nb_tri[:num_sequences], nb_ref[:num_sequences], rtol=0, atol=0)
+
+    max_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+    cache_loc_base = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_base = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt, num_blocks, cache_loc_base, cu_base, num_sequences)
+
+    cl_ref, cu_ref = cache_loc_base.clone(), cu_base.clone()
+    cl_tri, cu_tri = cache_loc_base.clone(), cu_base.clone()
+    total_ref = ops.adjust_ragged_torch(cl_ref, cu_ref, extra_idx, delta, num_sequences)
+    total_tri = ops.adjust_ragged_triton(cl_tri, cu_tri, extra_idx, delta, num_sequences)
+    assert total_ref == total_tri
+    torch.testing.assert_close(cl_tri[:total_ref], cl_ref[:total_ref], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_append_roundtrip(max_batch_size, max_blocks_per_seq):
+    """Test: adjust block_table then to ragged == to ragged then adjust (append only)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, device=device)
+    delta = (extra_idx[:num_sequences] >= 0).to(torch.int32)
+    delta_full = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta_full[:num_sequences] = delta
+    max_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+
+    bt_a = bt.clone()
+    nb_a = num_blocks.clone()
+    ops.adjust_block_table_torch(bt_a, nb_a, extra_idx, delta_full, num_sequences)
+    cl_a = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_a = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_a = ops.block_table_to_ragged_torch(bt_a, nb_a, cl_a, cu_a, num_sequences)
+
+    cl_b = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_b = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt, num_blocks, cl_b, cu_b, num_sequences)
+    total_b = ops.adjust_ragged_torch(cl_b, cu_b, extra_idx, delta_full, num_sequences)
+
+    assert total_a == total_b, f"Total mismatch: {total_a} vs {total_b}"
+    torch.testing.assert_close(cl_a[:total_a], cl_b[:total_b], rtol=0, atol=0)
+    torch.testing.assert_close(cu_a[: num_sequences + 1], cu_b[: num_sequences + 1], rtol=0, atol=0)
+
+
+# ========================================================================================
+# Correctness tests -- adjust with removal (delta=-1) and mixed delta
+# ========================================================================================
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_remove_block_table(max_batch_size, max_blocks_per_seq):
+    """Test removal (delta=-1) on block_table: Triton matches PyTorch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(min=2)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta = torch.full((max_batch_size,), -1, device=device, dtype=torch.int32)
+
+    bt_ref = bt.clone()
+    nb_ref = num_blocks.clone()
+    ops.adjust_block_table_torch(bt_ref, nb_ref, extra_idx, delta, num_sequences)
+
+    bt_tri = bt.clone()
+    nb_tri = num_blocks.clone()
+    ops.adjust_block_table_triton(bt_tri, nb_tri, extra_idx, delta, num_sequences)
+
+    torch.testing.assert_close(nb_tri[:num_sequences], nb_ref[:num_sequences], rtol=0, atol=0)
+    assert (nb_ref[:num_sequences] == num_blocks[:num_sequences] - 1).all()
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_remove_ragged(max_batch_size, max_blocks_per_seq):
+    """Test removal (delta=-1) on ragged: Triton matches PyTorch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(min=2)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    max_capacity = max_batch_size * max_blocks_per_seq
+    cache_loc_base = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_base = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt, num_blocks, cache_loc_base, cu_base, num_sequences)
+
+    extra_idx = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta = torch.full((max_batch_size,), -1, device=device, dtype=torch.int32)
+
+    cl_ref = cache_loc_base.clone()
+    cu_ref = cu_base.clone()
+    total_ref = ops.adjust_ragged_torch(cl_ref, cu_ref, extra_idx, delta, num_sequences)
+
+    cl_tri = cache_loc_base.clone()
+    cu_tri = cu_base.clone()
+    total_tri = ops.adjust_ragged_triton(cl_tri, cu_tri, extra_idx, delta, num_sequences)
+
+    assert total_ref == total_tri, f"Total mismatch: {total_ref} vs {total_tri}"
+    torch.testing.assert_close(
+        cu_tri[: num_sequences + 1], cu_ref[: num_sequences + 1], rtol=0, atol=0
+    )
+    torch.testing.assert_close(cl_tri[:total_ref], cl_ref[:total_ref], rtol=0, atol=0)
+
+
+def _make_mixed_delta(num_sequences, max_batch_size, device="cuda"):
+    """Create a delta tensor with a mix of -1, 0, +1 values."""
+    choices = torch.tensor([-1, 0, 1], device=device, dtype=torch.int32)
+    indices = torch.randint(0, 3, (num_sequences,), device=device)
+    delta = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+    delta[:num_sequences] = choices[indices]
+    return delta
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_mixed_delta_block_table(max_batch_size, max_blocks_per_seq):
+    """Test mixed delta (-1, 0, +1) on block_table: Triton matches PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(min=2, max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = _make_mixed_delta(num_sequences, max_batch_size, device=device)
+
+    bt_ref = bt.clone()
+    nb_ref = num_blocks.clone()
+    ops.adjust_block_table_torch(bt_ref, nb_ref, extra_idx, delta, num_sequences)
+
+    bt_tri = bt.clone()
+    nb_tri = num_blocks.clone()
+    ops.adjust_block_table_triton(bt_tri, nb_tri, extra_idx, delta, num_sequences)
+
+    torch.testing.assert_close(bt_tri[:num_sequences], bt_ref[:num_sequences], rtol=0, atol=0)
+    torch.testing.assert_close(nb_tri[:num_sequences], nb_ref[:num_sequences], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_mixed_delta_ragged(max_batch_size, max_blocks_per_seq):
+    """Test mixed delta (-1, 0, +1) on ragged: Triton matches PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(min=2, max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    max_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+    cache_loc_base = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_base = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt, num_blocks, cache_loc_base, cu_base, num_sequences)
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = _make_mixed_delta(num_sequences, max_batch_size, device=device)
+
+    cl_ref = cache_loc_base.clone()
+    cu_ref = cu_base.clone()
+    total_ref = ops.adjust_ragged_torch(cl_ref, cu_ref, extra_idx, delta, num_sequences)
+
+    cl_tri = cache_loc_base.clone()
+    cu_tri = cu_base.clone()
+    total_tri = ops.adjust_ragged_triton(cl_tri, cu_tri, extra_idx, delta, num_sequences)
+
+    assert total_ref == total_tri, f"Total mismatch: {total_ref} vs {total_tri}"
+    torch.testing.assert_close(
+        cu_tri[: num_sequences + 1], cu_ref[: num_sequences + 1], rtol=0, atol=0
+    )
+    torch.testing.assert_close(cl_tri[:total_ref], cl_ref[:total_ref], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(4, 8), (32, 64), (128, 256)],
+)
+def test_adjust_mixed_roundtrip(max_batch_size, max_blocks_per_seq):
+    """Test: adjust block_table then to ragged == to ragged then adjust (mixed delta)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    num_blocks[:num_sequences] = num_blocks[:num_sequences].clamp(min=2, max=max_blocks_per_seq - 1)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks[:num_sequences].unsqueeze(1)
+    bt[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = _make_mixed_delta(num_sequences, max_batch_size, device=device)
+    max_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+
+    bt_a = bt.clone()
+    nb_a = num_blocks.clone()
+    ops.adjust_block_table_torch(bt_a, nb_a, extra_idx, delta, num_sequences)
+    cl_a = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_a = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    total_a = ops.block_table_to_ragged_torch(bt_a, nb_a, cl_a, cu_a, num_sequences)
+
+    cl_b = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_b = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(bt, num_blocks, cl_b, cu_b, num_sequences)
+    total_b = ops.adjust_ragged_torch(cl_b, cu_b, extra_idx, delta, num_sequences)
+
+    assert total_a == total_b, f"Total mismatch: {total_a} vs {total_b}"
+    torch.testing.assert_close(cl_a[:total_a], cl_b[:total_b], rtol=0, atol=0)
+    torch.testing.assert_close(cu_a[: num_sequences + 1], cu_b[: num_sequences + 1], rtol=0, atol=0)
+
+
+# ========================================================================================
+# Performance benchmarks
+# ========================================================================================
+
+
+def _benchmark_fn(fn, num_warmup=10, num_runs=100):
+    """Benchmark a callable using torch.cuda.Event timing.
+
+    Returns:
+        Average latency in microseconds.
+    """
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    for _ in range(num_warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    latencies_ms = []
+    for _ in range(num_runs):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        latencies_ms.append(start.elapsed_time(end))
+
+    avg_us = sum(latencies_ms) / len(latencies_ms) * 1000.0
+    return avg_us
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(64, 128), (256, 256), (512, 512), (1024, 4096)],
+)
+def test_benchmark_block_table_to_ragged(max_batch_size, max_blocks_per_seq):
+    """Benchmark block_table -> ragged: Triton vs PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    bt, num_blocks = _make_test_data(max_batch_size, max_blocks_per_seq, num_sequences, device)
+    max_capacity = max_batch_size * max_blocks_per_seq
+
+    def run_torch():
+        cl = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+        cu = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+        ops.block_table_to_ragged_torch(bt, num_blocks, cl, cu, num_sequences)
+
+    def run_triton():
+        cl = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+        cu = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+        ops.block_table_to_ragged_triton(bt, num_blocks, cl, cu, num_sequences)
+
+    torch_us = _benchmark_fn(run_torch)
+    triton_us = _benchmark_fn(run_triton)
+
+    speedup = torch_us / triton_us if triton_us > 0 else float("inf")
+    print(
+        f"\n  block_table -> ragged  [{max_batch_size}x{max_blocks_per_seq}]"
+        f"\n    PyTorch: {torch_us:8.1f} us"
+        f"\n    Triton:  {triton_us:8.1f} us"
+        f"\n    Speedup: {speedup:8.2f}x"
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(64, 128), (256, 256), (512, 512)],
+)
+def test_benchmark_ragged_to_block_table(max_batch_size, max_blocks_per_seq):
+    """Benchmark ragged -> block_table: Triton vs PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_src, num_blocks_src = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    max_capacity = max_batch_size * max_blocks_per_seq
+    cache_loc = torch.zeros(max_capacity, device=device, dtype=torch.int32)
+    cu_num_blocks = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(
+        block_table_src, num_blocks_src, cache_loc, cu_num_blocks, num_sequences
+    )
+
+    def run_torch():
+        bt = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+        nb = torch.zeros(max_batch_size, device=device, dtype=torch.int32)
+        ops.ragged_to_block_table_torch(cache_loc, cu_num_blocks, bt, nb, num_sequences)
+
+    def run_triton():
+        bt = torch.zeros(max_batch_size, max_blocks_per_seq, device=device, dtype=torch.int32)
+        ops.ragged_to_block_table_triton(cache_loc, cu_num_blocks, bt, num_sequences)
+
+    torch_us = _benchmark_fn(run_torch)
+    triton_us = _benchmark_fn(run_triton)
+
+    speedup = torch_us / triton_us if triton_us > 0 else float("inf")
+    print(
+        f"\n  ragged -> block_table  [{max_batch_size}x{max_blocks_per_seq}]"
+        f"\n    PyTorch: {torch_us:8.1f} us"
+        f"\n    Triton:  {triton_us:8.1f} us"
+        f"\n    Speedup: {speedup:8.2f}x"
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(64, 128), (256, 256), (512, 512)],
+)
+def test_benchmark_adjust_block_table(max_batch_size, max_blocks_per_seq):
+    """Benchmark adjust block_table: Triton vs PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_base, num_blocks_base = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    num_blocks_base[:num_sequences] = num_blocks_base[:num_sequences].clamp(
+        min=2, max=max_blocks_per_seq - 1
+    )
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks_base[:num_sequences].unsqueeze(1)
+    block_table_base[:num_sequences][pad_mask] = 0
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = _make_mixed_delta(num_sequences, max_batch_size, device=device)
+
+    def run_torch():
+        bt = block_table_base.clone()
+        nb = num_blocks_base.clone()
+        ops.adjust_block_table_torch(bt, nb, extra_idx, delta, num_sequences)
+
+    def run_triton():
+        bt = block_table_base.clone()
+        nb = num_blocks_base.clone()
+        ops.adjust_block_table_triton(bt, nb, extra_idx, delta, num_sequences)
+
+    torch_us = _benchmark_fn(run_torch)
+    triton_us = _benchmark_fn(run_triton)
+
+    speedup = torch_us / triton_us if triton_us > 0 else float("inf")
+    print(
+        f"\n  adjust block_table  [{max_batch_size}x{max_blocks_per_seq}]"
+        f"\n    PyTorch: {torch_us:8.1f} us"
+        f"\n    Triton:  {triton_us:8.1f} us"
+        f"\n    Speedup: {speedup:8.2f}x"
+    )
+
+
+@pytest.mark.parametrize(
+    "max_batch_size, max_blocks_per_seq",
+    [(64, 128), (256, 256), (512, 512)],
+)
+def test_benchmark_adjust_ragged(max_batch_size, max_blocks_per_seq):
+    """Benchmark adjust ragged: Triton vs PyTorch."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    device = "cuda"
+    num_sequences = max_batch_size
+
+    block_table_src, num_blocks_src = _make_test_data(
+        max_batch_size, max_blocks_per_seq, num_sequences, device
+    )
+    num_blocks_src[:num_sequences] = num_blocks_src[:num_sequences].clamp(min=2)
+    col = torch.arange(max_blocks_per_seq, device=device)
+    pad_mask = col.unsqueeze(0) >= num_blocks_src[:num_sequences].unsqueeze(1)
+    block_table_src[:num_sequences][pad_mask] = 0
+
+    buffer_capacity = max_batch_size * max_blocks_per_seq + num_sequences
+    cache_loc_base = torch.zeros(buffer_capacity, device=device, dtype=torch.int32)
+    cu_base = torch.zeros(max_batch_size + 1, device=device, dtype=torch.int32)
+    ops.block_table_to_ragged_torch(
+        block_table_src, num_blocks_src, cache_loc_base, cu_base, num_sequences
+    )
+
+    extra_idx = _make_extra_idx(max_batch_size, num_sequences, valid_fraction=1.0, device=device)
+    delta = _make_mixed_delta(num_sequences, max_batch_size, device=device)
+
+    def run_torch():
+        cl = cache_loc_base.clone()
+        cu = cu_base.clone()
+        ops.adjust_ragged_torch(cl, cu, extra_idx, delta, num_sequences)
+
+    def run_triton():
+        cl = cache_loc_base.clone()
+        cu = cu_base.clone()
+        ops.adjust_ragged_triton(cl, cu, extra_idx, delta, num_sequences)
+
+    torch_us = _benchmark_fn(run_torch)
+    triton_us = _benchmark_fn(run_triton)
+
+    speedup = torch_us / triton_us if triton_us > 0 else float("inf")
+    print(
+        f"\n  adjust ragged  [{max_batch_size}x{max_blocks_per_seq}]"
+        f"\n    PyTorch: {torch_us:8.1f} us"
+        f"\n    Triton:  {triton_us:8.1f} us"
+        f"\n    Speedup: {speedup:8.2f}x"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gated_delta_rule_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gated_delta_rule_cache.py
@@ -212,7 +212,16 @@ def test_gated_delta_rule_with_cache():
 
     # Helper function to call the model with proper sequence nesting
     def _call_and_unnest(x, input_pos):
-        cm.info.nest_sequences(x, input_pos=input_pos)
+        bs, sl = x.shape
+        cu_seqlen = list(range(0, bs * sl + 1, sl))
+        if isinstance(input_pos, int):
+            input_pos = [input_pos] * bs
+        cm.info.nest_sequences(
+            x.flatten().tolist(),
+            cu_seqlen=cu_seqlen,
+            input_pos=input_pos,
+            slot_idx=list(range(bs)),
+        )
         y = gm(**cm.named_args)
         return torch.stack(cm.info.unnest_sequences(y))
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
@@ -96,10 +96,10 @@ class TestGatherTokensOp:
         expected = hidden_states[:, gather_indices, :]
         torch.testing.assert_close(output, expected)
 
-    def test_2d_singleton_token_format(self):
-        """Test gather op with 2D singleton input [tokens, hidden]."""
+    def test_singleton_token_format(self):
+        """Test gather op with 3D singleton input [1, 1, hidden]."""
         hidden_size = 128
-        hidden_states = torch.randn(1, hidden_size, device="cuda", dtype=torch.float16)
+        hidden_states = torch.randn(1, 1, hidden_size, device="cuda", dtype=torch.float16)
         gather_indices = torch.tensor([0], dtype=torch.long, device="cuda")
         logits_gather_info_host = torch.tensor([1, 1], dtype=torch.int32, device="cpu")
 
@@ -108,7 +108,7 @@ class TestGatherTokensOp:
         )
 
         # 2D input should stay 2D to preserve vocab axis after LM head.
-        assert output.shape == (1, hidden_size)
+        assert output.shape == (1, 1, hidden_size)
         torch.testing.assert_close(output, hidden_states)
 
     def test_fake_implementation_generate_format(self):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_gather_logits_before_lm_head.py
@@ -44,7 +44,7 @@ class SimpleLMHeadModel(torch.nn.Module):
         return logits
 
 
-class TestGatherLogitsBeforeLmHeadOp:
+class TestGatherTokensOp:
     """Test the custom op directly."""
 
     @pytest.mark.parametrize("batch_size", [1, 4, 8])
@@ -54,11 +54,11 @@ class TestGatherLogitsBeforeLmHeadOp:
         hidden_states = torch.randn(batch_size, 1, hidden_size, device="cuda", dtype=torch.float16)
 
         # Create gather info: num_tokens_to_gather=batch_size, gather_required=0 (False)
-        logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
+        token_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
+        tokens_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
 
-        output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-            hidden_states, logits_gather_indices, logits_gather_info_host
+        output = torch.ops.auto_deploy.gather_tokens.default(
+            hidden_states, token_gather_indices, tokens_gather_info_host
         )
 
         # Should return [batch, 1, hidden] for generate format (3D shape preserved)
@@ -81,10 +81,10 @@ class TestGatherLogitsBeforeLmHeadOp:
         gather_indices = torch.arange(0, num_gather, dtype=torch.long, device="cuda")
 
         # Create gather info: num_tokens_to_gather=num_gather, gather_required=1 (True)
-        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
+        tokens_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
 
-        output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-            hidden_states, gather_indices, logits_gather_info_host
+        output = torch.ops.auto_deploy.gather_tokens.default(
+            hidden_states, gather_indices, tokens_gather_info_host
         )
 
         # Should return [1, num_gather, hidden] for packed format (3D shape preserved)
@@ -103,7 +103,7 @@ class TestGatherLogitsBeforeLmHeadOp:
         gather_indices = torch.tensor([0], dtype=torch.long, device="cuda")
         logits_gather_info_host = torch.tensor([1, 1], dtype=torch.int32, device="cpu")
 
-        output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
+        output = torch.ops.auto_deploy.gather_tokens.default(
             hidden_states, gather_indices, logits_gather_info_host
         )
 
@@ -118,16 +118,16 @@ class TestGatherLogitsBeforeLmHeadOp:
         hidden_states = torch.randn(batch_size, 1, hidden_size, device="cuda", dtype=torch.float16)
 
         # Create gather info
-        logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
+        token_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
+        tokens_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
 
         # Use fake implementation directly
         with FakeTensorMode() as mode:
             hidden_states_fake = mode.from_tensor(hidden_states)
-            logits_gather_indices_fake = mode.from_tensor(logits_gather_indices)
-            logits_gather_info_host_fake = mode.from_tensor(logits_gather_info_host)
-            output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_host_fake
+            token_gather_indices_fake = mode.from_tensor(token_gather_indices)
+            tokens_gather_info_host_fake = mode.from_tensor(tokens_gather_info_host)
+            output = torch.ops.auto_deploy.gather_tokens.default(
+                hidden_states_fake, token_gather_indices_fake, tokens_gather_info_host_fake
             )
 
         # Should return [batch, 1, hidden_size] (fake returns empty_like which preserves 3D shape)
@@ -145,16 +145,16 @@ class TestGatherLogitsBeforeLmHeadOp:
         )
 
         # Create gather info
-        logits_gather_indices = torch.arange(num_gather, dtype=torch.long, device="cuda")
-        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
+        token_gather_indices = torch.arange(num_gather, dtype=torch.long, device="cuda")
+        tokens_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
 
         # Use fake implementation directly
         with FakeTensorMode() as mode:
             hidden_states_fake = mode.from_tensor(hidden_states)
-            logits_gather_indices_fake = mode.from_tensor(logits_gather_indices)
-            logits_gather_info_host_fake = mode.from_tensor(logits_gather_info_host)
-            output = torch.ops.auto_deploy.gather_logits_before_lm_head.default(
-                hidden_states_fake, logits_gather_indices_fake, logits_gather_info_host_fake
+            token_gather_indices_fake = mode.from_tensor(token_gather_indices)
+            tokens_gather_info_host_fake = mode.from_tensor(tokens_gather_info_host)
+            output = torch.ops.auto_deploy.gather_tokens.default(
+                hidden_states_fake, token_gather_indices_fake, tokens_gather_info_host_fake
             )
 
         # The fake implementation returns empty_like which preserves input shape [1, total_tokens, hidden]
@@ -176,10 +176,8 @@ class TestGatherLogitsBeforeLmHeadTransform:
         )
 
     def _check_gather_op_in_graph(self, gm: GraphModule) -> bool:
-        """Check if gather_logits_before_lm_head op is in the graph."""
-        return any(
-            is_op(n, torch.ops.auto_deploy.gather_logits_before_lm_head) for n in gm.graph.nodes
-        )
+        """Check if gather_tokens op is in the graph."""
+        return any(is_op(n, torch.ops.auto_deploy.gather_tokens) for n in gm.graph.nodes)
 
     @pytest.mark.parametrize("batch_size", [1, 4, 8])
     def test_transform_generate_format(self, batch_size):
@@ -228,15 +226,14 @@ class TestGatherLogitsBeforeLmHeadTransform:
         assert self._check_gather_op_in_graph(gm_transformed), "Gather op not found in graph"
 
         # Test forward pass
-        # We must pass the new graph inputs manually since we are running the graph directly
-        logits_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
-        logits_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
+        token_gather_indices = torch.arange(batch_size, dtype=torch.long, device="cuda")
+        tokens_gather_info_host = torch.tensor([batch_size, 0], dtype=torch.int32, device="cpu")
         output = gm_transformed(
             hidden_states,
             logit_gather_ids,
             seq_len,
-            logits_gather_indices=logits_gather_indices,
-            logits_gather_info_host=logits_gather_info_host,
+            token_gather_indices=token_gather_indices,
+            tokens_gather_info_host=tokens_gather_info_host,
         )
         # Output should be [batch_size, 1, vocab_size] since gather now returns 3D
         assert output.shape == (batch_size, 1, vocab_size)
@@ -288,16 +285,15 @@ class TestGatherLogitsBeforeLmHeadTransform:
         assert self._check_gather_op_in_graph(gm_transformed), "Gather op not found in graph"
 
         # Test forward pass
-        # We must pass the new graph inputs manually since we are running the graph directly
         num_gather = len(logit_gather_ids)
-        logits_gather_indices = logit_gather_ids
-        logits_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
+        token_gather_indices = logit_gather_ids
+        tokens_gather_info_host = torch.tensor([num_gather, 1], dtype=torch.int32, device="cpu")
         output = gm_transformed(
             hidden_states,
             logit_gather_ids_padded,
             seq_len,
-            logits_gather_indices=logits_gather_indices,
-            logits_gather_info_host=logits_gather_info_host,
+            token_gather_indices=token_gather_indices,
+            tokens_gather_info_host=tokens_gather_info_host,
         )
         # Output should be [1, num_gather, vocab_size] since gather now returns 3D
         assert output.shape == (1, num_gather, vocab_size)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
@@ -200,7 +200,16 @@ def test_torch_gated_delta_rule_cache():
 
     # Helper function to call the model with proper sequence nesting
     def _call_and_unnest(x, input_pos):
-        cm.info.nest_sequences(x, input_pos=input_pos)
+        bs, sl = x.shape
+        cu_seqlen = list(range(0, bs * sl + 1, sl))
+        if isinstance(input_pos, int):
+            input_pos = [input_pos] * bs
+        cm.info.nest_sequences(
+            x.flatten().tolist(),
+            cu_seqlen=cu_seqlen,
+            input_pos=input_pos,
+            slot_idx=list(range(bs)),
+        )
         y = gm(**cm.named_args)
         return torch.stack(cm.info.unnest_sequences(y))
 


### PR DESCRIPTION
## Summary
- Refactored `SequenceInfo` to use flat/ragged representations (`cu_seqlen`, `cu_num_pages`) instead of nested lists (`pages_per_seq`, list-of-lists `input_ids`) for sequence and page tracking
- Removed `get_nested_page_assignments` and `_get_cache_locations_and_pages_per_sequence` from `SequenceInfo`, moved ragged <-> nested conversion helpers to `DemoEngine`
- Renamed `gather_logits_before_lm_head` op to `gather_tokens` for clarity
- Added `block_table_ragged.py` utility module with comprehensive tests
- Enforced minimum `max_batch_size=2` in `SequenceInfo` to accommodate export requirements
- Updated all unit tests to use the new flat/ragged `nest_sequences` API
- Improve trtllm attention integration

## Test plan
- [x] Unit tests: `pytest tests/unittest/_torch/auto_deploy/unit/singlegpu/`
- [x] Integration test: `accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[trtllm-False-4]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device-side metadata preparation for improved attention handling and block offset computation.
  * Introduced bidirectional block table conversion utilities for better cache management.
  * Added `get_arg()` accessor for unified argument retrieval across cached sequences.

* **Refactor**
  * Reorganized metadata flow from host-based to device-driven execution model.
  * Renamed token gathering operation for improved clarity.
  * Simplified argument handling with truncation-aware views and staging mechanism.

* **Tests**
  * Expanded test coverage for block table conversions, cache operations, and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->