### PR TITLE
[None][perf] Use F.rms_norm for per-head QK normalization in visual gen

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
@@ -57,6 +57,7 @@ class FluxJointAttention(Attention):
             head_dim=head_dim,
             qkv_mode=QKVMode.FUSE_QKV,
             qk_norm=True,
+            qk_norm_mode="per_head",
             eps=eps,
             bias=bias,
             config=config,
@@ -65,10 +66,6 @@ class FluxJointAttention(Attention):
 
         self.pre_only = pre_only
         self.added_kv_proj_dim = added_kv_proj_dim
-
-        # Override base class full-dim norms with per-head norms (head_dim=128).
-        self.norm_q = RMSNorm(hidden_size=head_dim, eps=eps, dtype=self.dtype, has_weights=True)
-        self.norm_k = RMSNorm(hidden_size=head_dim, eps=eps, dtype=self.dtype, has_weights=True)
 
         # Delete output projection for single-stream blocks
         if self.pre_only:

--- a/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
@@ -147,8 +147,18 @@ class FluxJointAttention(Attention):
             enc_k = enc_k.view(batch_size, -1, self.num_attention_heads, self.head_dim)
             enc_v = enc_v.view(batch_size, -1, self.num_attention_heads, self.head_dim)
 
-            enc_q = self.norm_added_q(enc_q.reshape(-1, enc_q.shape[-1])).view(enc_q.shape)
-            enc_k = self.norm_added_k(enc_k.reshape(-1, enc_k.shape[-1])).view(enc_k.shape)
+            enc_q = torch.nn.functional.rms_norm(
+                enc_q,
+                (enc_q.shape[-1],),
+                self.norm_added_q.weight,
+                self.norm_added_q.variance_epsilon,
+            )
+            enc_k = torch.nn.functional.rms_norm(
+                enc_k,
+                (enc_k.shape[-1],),
+                self.norm_added_k.weight,
+                self.norm_added_k.variance_epsilon,
+            )
 
             # Concatenate text + image for joint attention
             query = torch.cat([enc_q, query], dim=1)


### PR DESCRIPTION
  ## Summary
  - Replace flashinfer RMSNorm with `F.rms_norm` for per-head QK normalization (dim=128) in FLUX models
  - Keep flashinfer for full-dim normalization (WAN 14B dim=5120) where it is 1.77x faster even under torch.compile
  - Use `F.rms_norm` for `norm_added_q/k` in FluxJointAttention

  ## Motivation
  Kernel-level benchmarks on B200 show:
  - **per_head (FLUX, dim=128):** F.rms_norm is 1.5-1.7x faster and fusible by torch.compile (Inductor)
  - **full-dim (WAN 14B, dim=5120):** flashinfer is 1.77x faster even under torch.compile for large sequences

  ## Test plan
  - [x] FLUX.1 BF16 quality check (PSNR vs baseline)
  - [x] FLUX.2 BF16 quality check
  - [x] WAN T2V inference (unchanged code path)
  - [x] torch.compile pipeline timing


# F.rms_norm Per-Head QK Norm: Benchmark Results

**GPU:** NVIDIA B200
**Date:** 2026-02-28 00:26:28
**Resolution:** 1024×1024, 50 steps, compiled (`torch.compile default`), VANILLA attention (cuDNN SDPA)

## E2E Pipeline Speedup

Comparison of full pipeline wall-clock time: flashinfer `RMSNormKernel` (baseline on `main`) vs `F.rms_norm` per-head (this PR).
Each config: 1 warmup + 3 timed runs, average reported.

| Config | Baseline (s) | New (s) | Speedup | Saved (s) | Saved/step (ms) |
|--------|-------------|---------|---------|-----------|-----------------|
| FLUX.2 BF16 | 12.295 | 11.742 | **1.047x** | 0.553 | 11.1 |
| FLUX.2 FP8 | 8.611 | 8.019 | **1.074x** | 0.592 | 11.8 |
| FLUX.2 NVFP4 | 6.896 | 6.296 | **1.095x** | 0.600 | 12.0 |
| FLUX.1 BF16 | 4.213 | 3.829 | **1.100x** | 0.384 | 7.7 |
| FLUX.1 FP8 | 4.387 | 4.174 | **1.051x** | 0.213 | 4.3 |
| FLUX.1 NVFP4 | 4.743 | 4.614 | **1.028x** | 0.129 | 2.6 |

## Kernel-Level Speedup

`F.rms_norm` vs `flashinfer_rmsnorm` on isolated tensors (no torch.compile fusion).
BF16, 20 warmup + 100 measured iterations, median reported.

| Case | Shape | F.rms_norm (μs) | flashinfer (μs) | Speedup |
|------|-------|----------------|----------------|---------|
| FLUX.1 img QK (dual) | 1×4096×24×128 | 69.9 | 116.6 | **1.67x** |
| FLUX.1 txt QK (dual) | 1×512×24×128 | 18.0 | 27.8 | **1.54x** |
| FLUX.1 concat QK (single) | 1×4608×24×128 | 77.9 | 128.9 | **1.66x** |
| FLUX.2 img QK (dual) | 1×4096×48×128 | 145.2 | 218.3 | **1.50x** |
| FLUX.2 txt QK (dual) | 1×512×48×128 | 25.1 | 40.4 | **1.61x** |
| FLUX.2 concat QK (single) | 1×4608×48×128 | 163.7 | 242.9 | **1.48x** |

### Per-Pipeline Kernel Savings (50 steps)

| Model | Saving/step (μs) | Saving/pipeline (ms) |
|-------|-----------------|---------------------|
| FLUX.1 | 8,176 | 408.8 |
| FLUX.2 | 10,430 | 521.5 |

## Analysis

- **Kernel level:** `F.rms_norm` is **1.48–1.67× faster** than flashinfer for per-head norm (dim=128, 4D tensors)
- **E2E level:** Translates to **3–10% pipeline speedup** depending on config
- **Largest relative gain:** FLUX.1 BF16 (10.0%), FLUX.2 NVFP4 (9.5%)
- **Largest absolute saving:** FLUX.2 NVFP4 (0.60s), FLUX.2 FP8 (0.59s)
- **Why <10% e2e from 1.5× kernel speedup:** RMSNorm is ~5–15% of total GPU time; the rest is attention (cuDNN SDPA) and GEMM (nvjet/cutlass)
- **Additional benefit:** `F.rms_norm` is fusible by `torch.compile` — Inductor merges it into surrounding Triton kernels, eliminating kernel launch overhead entirely
~
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the normalization approach in the attention mechanism of the visual generation model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
