### PR TITLE
[#11578][feat] support multimodal image input in gRPC server

### DIFF
--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -74,6 +74,7 @@ class GrpcRequestManager:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
         disaggregated_params: Optional[DisaggregatedParams] = None,
+        multimodal_images: Optional[List] = None,
     ) -> AsyncGenerator[GenerationResult, None]:
         """Submit a generation request and stream outputs.
 
@@ -94,8 +95,12 @@ class GrpcRequestManager:
         try:
             # Submit to LLM.generate_async which returns a GenerationResult
             # that is an async iterator
+            inputs = {"prompt_token_ids": prompt_token_ids}
+            if multimodal_images:
+                inputs["multi_modal_data"] = {"image": multimodal_images}
+
             gen_result = self.llm.generate_async(
-                {"prompt_token_ids": prompt_token_ids},
+                inputs,
                 sampling_params,
                 lora_request=lora_request,
                 prompt_adapter_request=prompt_adapter_request,

--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -74,7 +74,7 @@ class GrpcRequestManager:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
         disaggregated_params: Optional[DisaggregatedParams] = None,
-        multimodal_images: Optional[List] = None,
+        multi_modal_data: Optional[Dict[str, Any]] = None,
     ) -> AsyncGenerator[GenerationResult, None]:
         """Submit a generation request and stream outputs.
 
@@ -87,6 +87,7 @@ class GrpcRequestManager:
             prompt_adapter_request: Optional prompt adapter request
             kv_cache_retention_config: KV cache retention config
             disaggregated_params: Disaggregated inference params
+            multi_modal_data: Multimodal data dict (e.g. {"image": [PIL images]})
 
         Yields:
             GenerationResult objects containing token IDs (text will be empty
@@ -96,8 +97,8 @@ class GrpcRequestManager:
             # Submit to LLM.generate_async which returns a GenerationResult
             # that is an async iterator
             inputs = {"prompt_token_ids": prompt_token_ids}
-            if multimodal_images:
-                inputs["multi_modal_data"] = {"image": multimodal_images}
+            if multi_modal_data:
+                inputs["multi_modal_data"] = multi_modal_data
 
             gen_result = self.llm.generate_async(
                 inputs,

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -20,11 +20,13 @@ with external routers (e.g., sgl-router) using pre-tokenized input.
 """
 
 import asyncio
+import io
 import time
 from collections.abc import AsyncGenerator
-from typing import List, Union
+from typing import List, Optional, Union
 
 import grpc
+from PIL import Image
 
 from tensorrt_llm.executor.result import Logprob, TokenLogprobs
 from tensorrt_llm.logger import logger
@@ -118,6 +120,17 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 request.disaggregated_params if request.HasField("disaggregated_params") else None
             )
 
+            # Extract multimodal images if present
+            multimodal_images: Optional[List[Image.Image]] = None
+            if request.HasField("multimodal_input") and request.multimodal_input.image_data:
+                multimodal_images = [
+                    Image.open(io.BytesIO(img_bytes))
+                    for img_bytes in request.multimodal_input.image_data
+                ]
+                logger.info(
+                    f"Request {request_id}: extracted {len(multimodal_images)} multimodal images"
+                )
+
             # Track tokens sent per sequence index to avoid duplicates
             # TRT-LLM's token_ids_diff doesn't clear between iterations for n>1
             sent_token_counts: dict[int, int] = {}
@@ -131,6 +144,7 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 streaming=request.streaming,
                 lora_request=lora_request,
                 disaggregated_params=disaggregated_params,
+                multimodal_images=multimodal_images,
             ):
                 # Check if client disconnected
                 if context.cancelled():

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -120,16 +120,15 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 request.disaggregated_params if request.HasField("disaggregated_params") else None
             )
 
-            # Extract multimodal images if present
-            multimodal_images = None
+            # Extract multimodal data if present
+            multi_modal_data = None
             if request.HasField("multimodal_input") and request.multimodal_input.image_data:
-                multimodal_images = [
+                images = [
                     _load_and_convert_image(io.BytesIO(img_bytes))
                     for img_bytes in request.multimodal_input.image_data
                 ]
-                logger.info(
-                    f"Request {request_id}: extracted {len(multimodal_images)} multimodal images"
-                )
+                multi_modal_data = {"image": images}
+                logger.info(f"Request {request_id}: extracted {len(images)} multimodal images")
 
             # Track tokens sent per sequence index to avoid duplicates
             # TRT-LLM's token_ids_diff doesn't clear between iterations for n>1
@@ -144,7 +143,7 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 streaming=request.streaming,
                 lora_request=lora_request,
                 disaggregated_params=disaggregated_params,
-                multimodal_images=multimodal_images,
+                multi_modal_data=multi_modal_data,
             ):
                 # Check if client disconnected
                 if context.cancelled():

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -120,7 +120,9 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 request.disaggregated_params if request.HasField("disaggregated_params") else None
             )
 
-            # Extract multimodal data if present
+            # Extract multimodal data if present.
+            # Images arrive as raw bytes from the external router (already fetched),
+            # so we only need to decode and convert to PIL RGB here.
             multi_modal_data = None
             if request.HasField("multimodal_input") and request.multimodal_input.image_data:
                 images = [

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -23,12 +23,12 @@ import asyncio
 import io
 import time
 from collections.abc import AsyncGenerator
-from typing import List, Optional, Union
+from typing import List, Union
 
 import grpc
-from PIL import Image
 
 from tensorrt_llm.executor.result import Logprob, TokenLogprobs
+from tensorrt_llm.inputs.utils import _load_and_convert_image
 from tensorrt_llm.logger import logger
 
 from . import trtllm_service_pb2, trtllm_service_pb2_grpc
@@ -121,10 +121,10 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
             )
 
             # Extract multimodal images if present
-            multimodal_images: Optional[List[Image.Image]] = None
+            multimodal_images = None
             if request.HasField("multimodal_input") and request.multimodal_input.image_data:
                 multimodal_images = [
-                    Image.open(io.BytesIO(img_bytes))
+                    _load_and_convert_image(io.BytesIO(img_bytes))
                     for img_bytes in request.multimodal_input.image_data
                 ]
                 logger.info(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -491,7 +491,7 @@ class BaseLLM:
             inputs = TextPrompt(
                 prompt=prompt,
                 multi_modal_data=inputs.get("multi_modal_data"),
-                mm_processor_kwargs=inputs.get("mm_processor_kwargs"))
+                mm_processor_kwargs=inputs.get("mm_processor_kwargs") or {})
             if sampling_params.add_special_tokens:
                 logger.debug(
                     "Setting add_special_tokens to False because prompt_token_ids were provided to generate. VLMs will re-encode the prompt."

--- a/tests/unittest/llmapi/test_grpc.py
+++ b/tests/unittest/llmapi/test_grpc.py
@@ -23,6 +23,7 @@ import pytest
 import torch
 from PIL import Image
 
+from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm.grpc import trtllm_service_pb2 as pb2
 from tensorrt_llm.grpc.grpc_request_manager import (
     GrpcRequestManager,
@@ -728,13 +729,12 @@ def grpc_vlm_service():
     Uses Qwen3-VL-8B-Instruct for vision-language model testing.
     Shared across all tests in this module.
     """
-    from tensorrt_llm._tensorrt_engine import LLM
-
     model_path = get_model_path(vlm_model_name)
     llm = LLM(
         model=model_path,
         kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.6),
         fast_build=True,
+        load_format="dummy",
     )
     tokenizer = llm.tokenizer
 
@@ -771,8 +771,9 @@ class TestGrpcMultimodalEndToEnd:
         with open(image_path, "rb") as f:
             image_bytes = f.read()
 
+        request_id = "e2e-mm-single"
         request = pb2.GenerateRequest(
-            request_id="e2e-mm-single",
+            request_id=request_id,
             tokenized=pb2.TokenizedInput(input_token_ids=prompt_token_ids),
             multimodal_input=pb2.MultimodalInput(image_data=[image_bytes]),
             sampling_config=pb2.SamplingConfig(temperature=0.0),
@@ -792,7 +793,7 @@ class TestGrpcMultimodalEndToEnd:
         assert len(completes) == 1
 
         resp = completes[0]
-        assert resp.request_id == "e2e-mm-single"
+        assert resp.request_id == request_id
         assert len(resp.complete.output_token_ids) > 0
         assert resp.complete.finish_reason in ("stop", "length")
 
@@ -810,8 +811,9 @@ class TestGrpcMultimodalEndToEnd:
         with open(image_path, "rb") as f:
             image_bytes = f.read()
 
+        request_id = "e2e-mm-stream"
         request = pb2.GenerateRequest(
-            request_id="e2e-mm-stream",
+            request_id=request_id,
             tokenized=pb2.TokenizedInput(input_token_ids=prompt_token_ids),
             multimodal_input=pb2.MultimodalInput(image_data=[image_bytes]),
             sampling_config=pb2.SamplingConfig(temperature=0.0),

--- a/tests/unittest/llmapi/test_grpc.py
+++ b/tests/unittest/llmapi/test_grpc.py
@@ -15,11 +15,13 @@
 """Unit tests for gRPC server components."""
 
 import asyncio
+import io
 import os
 import sys
 
 import pytest
 import torch
+from PIL import Image
 
 from tensorrt_llm.grpc import trtllm_service_pb2 as pb2
 from tensorrt_llm.grpc.grpc_request_manager import (
@@ -706,3 +708,174 @@ class TestGrpcServiceEndToEnd:
         response = _run_async(run())
         assert response.backend == "tensorrt-llm"
         assert response.world_size >= 1
+
+
+# ============================================================================
+# End-to-end multimodal gRPC service tests (with VLM model)
+# ============================================================================
+
+vlm_model_name = "Qwen3/Qwen3-VL-8B-Instruct"
+
+
+def get_test_image_path():
+    return str(llm_models_root() / "multimodals" / "test_data" / "seashore.png")
+
+
+@pytest.fixture(scope="module")
+def grpc_vlm_service():
+    """Create a real VLM LLM, request manager, and servicer for multimodal e2e testing.
+
+    Uses Qwen3-VL-8B-Instruct for vision-language model testing.
+    Shared across all tests in this module.
+    """
+    from tensorrt_llm._tensorrt_engine import LLM
+
+    model_path = get_model_path(vlm_model_name)
+    llm = LLM(
+        model=model_path,
+        kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.6),
+        fast_build=True,
+    )
+    tokenizer = llm.tokenizer
+
+    request_manager = GrpcRequestManager(llm)
+    servicer = TrtllmServiceServicer(request_manager, model_path=model_path)
+
+    yield llm, tokenizer, request_manager, servicer
+
+    llm.shutdown()
+
+
+@skip_no_gpu
+class TestGrpcMultimodalEndToEnd:
+    """End-to-end tests for multimodal gRPC service flow.
+
+    Tests the full pipeline: gRPC request with image bytes -> servicer ->
+    request manager -> VLM -> response.
+    Uses Qwen3-VL-8B-Instruct with test images from LLM_MODELS_ROOT.
+    """
+
+    def test_generate_with_image(self, grpc_vlm_service):
+        """Test non-streaming generation with a single image input."""
+        llm, tokenizer, request_manager, servicer = grpc_vlm_service
+
+        # Build a chat prompt with image placeholder
+        prompt = (
+            "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+            "Describe this image briefly.<|im_end|>\n<|im_start|>assistant\n"
+        )
+        prompt_token_ids = tokenizer.encode(prompt)
+
+        # Load test image as raw bytes
+        image_path = get_test_image_path()
+        with open(image_path, "rb") as f:
+            image_bytes = f.read()
+
+        request = pb2.GenerateRequest(
+            request_id="e2e-mm-single",
+            tokenized=pb2.TokenizedInput(input_token_ids=prompt_token_ids),
+            multimodal_input=pb2.MultimodalInput(image_data=[image_bytes]),
+            sampling_config=pb2.SamplingConfig(temperature=0.0),
+            max_tokens=32,
+            streaming=False,
+        )
+
+        async def run():
+            responses = []
+            async for resp in servicer.Generate(request, _MockContext()):
+                responses.append(resp)
+            return responses
+
+        responses = _run_async(run())
+
+        completes = [r for r in responses if r.HasField("complete")]
+        assert len(completes) == 1
+
+        resp = completes[0]
+        assert resp.request_id == "e2e-mm-single"
+        assert len(resp.complete.output_token_ids) > 0
+        assert resp.complete.finish_reason in ("stop", "length")
+
+    def test_generate_with_image_streaming(self, grpc_vlm_service):
+        """Test streaming generation with a single image input."""
+        llm, tokenizer, request_manager, servicer = grpc_vlm_service
+
+        prompt = (
+            "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+            "What do you see?<|im_end|>\n<|im_start|>assistant\n"
+        )
+        prompt_token_ids = tokenizer.encode(prompt)
+
+        image_path = get_test_image_path()
+        with open(image_path, "rb") as f:
+            image_bytes = f.read()
+
+        request = pb2.GenerateRequest(
+            request_id="e2e-mm-stream",
+            tokenized=pb2.TokenizedInput(input_token_ids=prompt_token_ids),
+            multimodal_input=pb2.MultimodalInput(image_data=[image_bytes]),
+            sampling_config=pb2.SamplingConfig(temperature=0.0),
+            max_tokens=32,
+            streaming=True,
+        )
+
+        async def run():
+            responses = []
+            async for resp in servicer.Generate(request, _MockContext()):
+                responses.append(resp)
+            return responses
+
+        responses = _run_async(run())
+
+        chunks = [r for r in responses if r.HasField("chunk")]
+        completes = [r for r in responses if r.HasField("complete")]
+
+        assert len(chunks) >= 1
+        for chunk_resp in chunks:
+            assert len(chunk_resp.chunk.token_ids) > 0
+
+        # Reassemble all delta tokens and verify they match the complete response
+        all_streamed_tokens = []
+        for chunk_resp in chunks:
+            all_streamed_tokens.extend(chunk_resp.chunk.token_ids)
+
+        assert len(completes) == 1
+        complete_tokens = list(completes[0].complete.output_token_ids)
+        assert all_streamed_tokens == complete_tokens
+
+    def test_generate_with_rgba_image(self, grpc_vlm_service):
+        """Test that RGBA images (PNG with alpha) are handled correctly via RGB conversion."""
+        llm, tokenizer, request_manager, servicer = grpc_vlm_service
+
+        prompt = (
+            "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+            "Describe this image.<|im_end|>\n<|im_start|>assistant\n"
+        )
+        prompt_token_ids = tokenizer.encode(prompt)
+
+        # Create a synthetic RGBA image to test RGB conversion
+        rgba_image = Image.new("RGBA", (64, 64), (255, 0, 0, 128))
+        buf = io.BytesIO()
+        rgba_image.save(buf, format="PNG")
+        image_bytes = buf.getvalue()
+
+        request = pb2.GenerateRequest(
+            request_id="e2e-mm-rgba",
+            tokenized=pb2.TokenizedInput(input_token_ids=prompt_token_ids),
+            multimodal_input=pb2.MultimodalInput(image_data=[image_bytes]),
+            sampling_config=pb2.SamplingConfig(temperature=0.0),
+            max_tokens=16,
+            streaming=False,
+        )
+
+        async def run():
+            responses = []
+            async for resp in servicer.Generate(request, _MockContext()):
+                responses.append(resp)
+            return responses
+
+        responses = _run_async(run())
+
+        completes = [r for r in responses if r.HasField("complete")]
+        assert len(completes) == 1
+        assert len(completes[0].complete.output_token_ids) > 0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal image support added to the API. Users can now submit images alongside text prompts for processing.

* **Bug Fixes**
  * Improved multimodal processor configuration handling for consistent pipeline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add multimodal (VLM) image support to the TensorRT-LLM gRPC server, enabling external routers like smg to send pre-tokenized prompts with raw image bytes for vision-language models.

**Changes:**
- **gRPC servicer**: Extract raw image bytes from the `MultimodalInput` proto message, decode them as PIL images with proper RGB conversion using `_load_and_convert_image`, and pass them to the LLM API via `multi_modal_data`
- **gRPC request manager**: Accept `multimodal_images` parameter and build the `multi_modal_data` dict for `generate_async`
- **LLM API**: Fix `mm_processor_kwargs=None` causing `TypeError` when unpacked as `**kwargs` in VLM input processors — default to empty dict

The gRPC server relies on `#11578` for proto definitions that include `MultimodalInput` with `image_data` fields.

## Test Coverage

- Tested end-to-end with smg routing multimodal requests to TensorRT-LLM gRPC server running Qwen3-VL-8B-Instruct
- Verified correct image description output for JPEG and PNG images
- Verified RGB conversion handles RGBA (PNG with alpha) images correctly

<img width="2033" height="1682" alt="trt-log" src="https://github.com/user-attachments/assets/3e0c2e27-579b-423c-91d7-34fc1dfcba5e" />
<img width="1378" height="867" alt="trt-e2e" src="https://github.com/user-attachments/assets/a341d0ab-f090-4ab1-aa17-10af1dac6faa" />


## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.