### PR TITLE
[None][fix] Fix nemotron super MTP crash on SM90

### DIFF
--- a/tensorrt_llm/_torch/cute_dsl_kernels/argmax.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/argmax.py
@@ -597,9 +597,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             x: Input tensor of shape (M, N)
 
         Returns:
-            Output tensor of shape (M, 2) where:
-            - Column 0: Maximum value in each row
-            - Column 1: Index of maximum value in each row (argmax)
+            Output tensor of shape (M, 2) in float32 dtype where:
+            - Column 0: Maximum value in each row (converted to float32)
+            - Column 1: Index of maximum value in each row (argmax, stored as float32)
+
         """
         assert x.dim() == 2, "Input must be 2D"
         assert x.is_cuda, "Tensor must be on CUDA device"
@@ -609,9 +610,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
         if _should_use_torch_fallback(N, x.dtype):
             max_vals, max_indices = torch.max(x, dim=-1, keepdim=True)
-            return torch.cat([max_vals, max_indices.to(x.dtype)], dim=-1)
+            # Use float32 for indices to avoid precision loss with large vocab sizes
+            return torch.cat([max_vals.to(torch.float32), max_indices.to(torch.float32)], dim=-1)
 
-        out = torch.empty((M, 2), dtype=x.dtype, device=x.device)
+        # Use float32 for output to preserve argmax index precision.
+        # Float32 can exactly represent all integers up to 2^24 = 16,777,216.
+        # Typical vocab sizes (e.g. 131072 = 2^17) are well within this range.
+        out = torch.empty((M, 2), dtype=torch.float32, device=x.device)
         dtype = torch2cute_dtype_map[x.dtype]
 
         def convert_from_dlpack(tensor):
@@ -645,4 +650,4 @@ else:
     def argmax(x: torch.Tensor) -> torch.Tensor:
         """Fallback argmax using PyTorch when CUTLASS DSL is not available."""
         max_vals, max_indices = torch.max(x, dim=-1, keepdim=True)
-        return torch.cat([max_vals, max_indices.to(x.dtype)], dim=-1)
+        return torch.cat([max_vals.to(torch.float32), max_indices.to(torch.float32)], dim=-1)

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -268,7 +268,8 @@ class NemotronHMOE(nn.Module):
         assert hidden_states_hp.shape[-1] == self.hidden_dim
         orig_shape = hidden_states_hp.shape
         hidden_states_hp_2d = hidden_states_hp.view(-1, self.hidden_dim)
-        all_rank_num_tokens = attn_metadata.all_rank_num_tokens
+        all_rank_num_tokens = kwargs.get('all_rank_num_tokens',
+                                         attn_metadata.all_rank_num_tokens)
 
         def _compute_shared_output():
             if self.shared_experts is not None:
@@ -725,6 +726,7 @@ class NemotronHMTPDecoderLayer(NemotronHLayer):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self.has_start_projections:
             assert inputs_embeds is not None
@@ -753,6 +755,7 @@ class NemotronHMTPDecoderLayer(NemotronHLayer):
         hidden_states = self.mixer(
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
+            **kwargs,
         )
 
         if self.has_end_norm:
@@ -859,6 +862,7 @@ class NemotronHMTP(nn.Module):
                 hidden_states=hidden_states,
                 residual=residual,
                 attn_metadata=attn_metadata,
+                all_rank_num_tokens=all_rank_num_tokens,
             )
         return hidden_states
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import re
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import torch
@@ -801,14 +802,14 @@ class NemotronHMTP(nn.Module):
             sublayer_quant_config = self._get_mtp_sublayer_quant_config(
                 model_config, self.layer_idx)
 
-            # Create a temporary model_config with the override quant_config
-            sublayer_model_config = ModelConfig(
-                pretrained_config=model_config.pretrained_config,
-                mapping=model_config.mapping,
-                quant_config=sublayer_quant_config,
-                skip_create_weights_in_init=model_config.
-                skip_create_weights_in_init,
-            )
+            # Create a model_config copy with quant_config overridden and
+            # spec_config cleared. All other fields (use_cuda_graph,
+            # moe_backend, moe_max_num_tokens, etc.) must be inherited
+            # so MoE layers are configured correctly for CUDA graph
+            # capture and communication (e.g., DeepEP).
+            sublayer_model_config = replace(model_config,
+                                            quant_config=sublayer_quant_config,
+                                            spec_config=None)
 
             self.layers[str(step_rel_idx)] = NemotronHMTPDecoderLayer(
                 model_config=sublayer_model_config,

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -269,6 +269,8 @@ class NemotronHMOE(nn.Module):
         assert hidden_states_hp.shape[-1] == self.hidden_dim
         orig_shape = hidden_states_hp.shape
         hidden_states_hp_2d = hidden_states_hp.view(-1, self.hidden_dim)
+        # MTP sublayer may pass a corrected all_rank_num_tokens via kwargs,
+        # since attn_metadata still holds the main model's token count.
         all_rank_num_tokens = kwargs.get('all_rank_num_tokens',
                                          attn_metadata.all_rank_num_tokens)
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -783,6 +783,18 @@ def _create_kv_cache_manager(
             mamba_layer_mask = [
                 char == "M" for char in config.hybrid_override_pattern
             ]
+            # For hybrid models, hybrid_layer_mask is always passed as
+            # layer_mask to KVCacheManager, which means get_pp_layers
+            # sees a non-None layer_mask and won't auto-add spec layers.
+            # We must extend the masks here to include MTP spec layers
+            # (attention-only, no Mamba states) so they get KV cache entries.
+            if spec_config is not None:
+                from ..speculative.utils import get_num_spec_layers
+                num_spec_layers = get_num_spec_layers(spec_config)
+                if num_spec_layers > 0:
+                    hybrid_layer_mask.extend([True] * num_spec_layers)
+                    mamba_layer_mask.extend([False] * num_spec_layers)
+                    num_layers += num_spec_layers
         kv_cache_manager = kv_cache_manager_cls(
             # mamba cache parameters
             config.ssm_state_size,

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -452,6 +452,8 @@ class SpecWorkerBase(nn.Module, ABC):
         """
         Restore attention metadata after speculative decoding draft token generation.
         """
+        if hasattr(attn_metadata, 'use_spec_decoding'):
+            attn_metadata.use_spec_decoding = attn_metadata.is_spec_decoding_enabled
         attn_metadata.restore_from_spec_dec()
         attn_metadata.on_update()
 

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -452,8 +452,6 @@ class SpecWorkerBase(nn.Module, ABC):
         """
         Restore attention metadata after speculative decoding draft token generation.
         """
-        if hasattr(attn_metadata, 'use_spec_decoding'):
-            attn_metadata.use_spec_decoding = attn_metadata.is_spec_decoding_enabled
         attn_metadata.restore_from_spec_dec()
         attn_metadata.on_update()
 

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1365,7 +1365,8 @@ class MTPEagleWorker(MTPWorker):
                     # update metadata
                     # some attention metadata needs to be updated when changing seq_lens/kv_lens
                     attn_metadata.update_for_spec_dec()
-                    # Disable spec-dec mode for subsequent iterations (i>0).
+                    # Disable spec-dec mode for subsequent iterations (i>0)
+                    # as draft model only infer 1 token for the subsequent inference.
                     if hasattr(attn_metadata, 'use_spec_decoding'):
                         attn_metadata.use_spec_decoding = False
                 elif hasattr(attn_metadata, 'kv_lens_cuda'):

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1367,8 +1367,7 @@ class MTPEagleWorker(MTPWorker):
                     attn_metadata.update_for_spec_dec()
                     # Disable spec-dec mode for subsequent iterations (i>0)
                     # as draft model only infer 1 token for the subsequent inference.
-                    if hasattr(attn_metadata, 'use_spec_decoding'):
-                        attn_metadata.use_spec_decoding = False
+                    attn_metadata.use_spec_decoding = False
                 elif hasattr(attn_metadata, 'kv_lens_cuda'):
 
                     @torch.compile(options={"max-autotune": True})
@@ -1388,6 +1387,7 @@ class MTPEagleWorker(MTPWorker):
 
         # restore attn_metadata to support cuda graph
         self._restore_attn_metadata_from_spec_dec(attn_metadata)
+        attn_metadata.use_spec_decoding = True
 
         next_draft_tokens, next_new_tokens = self._prepare_next_tokens(
             next_draft_tokens, accepted_tokens, spec_metadata, batch_size,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1370,10 +1370,12 @@ class MTPEagleWorker(MTPWorker):
                     if hasattr(attn_metadata, 'use_spec_decoding'):
                         attn_metadata.use_spec_decoding = False
                 elif hasattr(attn_metadata, 'kv_lens_cuda'):
-                    # NOTE: do NOT wrap this in @torch.compile defined inside the loop —
-                    # creating a new compiled function object each iteration with max-autotune
-                    # triggers autotuning with live tensors and can corrupt adjacent GPU memory.
-                    attn_metadata.kv_lens_cuda[:batch_size] += 1
+
+                    @torch.compile(options={"max-autotune": True})
+                    def update_kv_lens(kv_lens_cuda, batch_size):
+                        kv_lens_cuda[:batch_size] += 1
+
+                    update_kv_lens(attn_metadata.kv_lens_cuda, batch_size)
                     # update metadata
                     # some attention metadata needs to be updated when changing kv_lens
                     attn_metadata.update_for_spec_dec()

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -5905,6 +5905,139 @@ class TestNemotronV3Super(LlmapiAccuracyTestHarness):
             task.evaluate(llm,
                           extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device(4)
+    @pytest.mark.skip_less_device_memory(80000)
+    def test_nvfp4_4gpu_mtp_ar(self):
+        max_draft_len = 7
+        mtp_config = MTPDecodingConfig(
+            num_nextn_predict_layers=max_draft_len,
+            mtp_eagle_one_model=True,
+        )
+        model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-NVFP4-FP8KV-011526"
+
+        llm_common_config = dict(
+            model=model_path,
+            tensor_parallel_size=4,
+            moe_expert_parallel_size=4,
+            kv_cache_config=KvCacheConfig(
+                enable_block_reuse=False,
+                mamba_ssm_cache_dtype="float16",
+                free_gpu_memory_fraction=0.5,
+            ),
+            max_batch_size=4,
+            enable_attention_dp=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=32,
+                                              enable_padding=True),
+            disable_overlap_scheduler=False,
+            moe_config=MoeConfig(backend="CUTLASS"),
+        )
+
+        llm_spec = LLM(**llm_common_config, speculative_config=mtp_config)
+
+        raw_prompts = [
+            "The capital of France is",
+            "The president of the United States is",
+            "The future of AI is",
+        ]
+        prompts = [
+            llm_spec.tokenizer.apply_chat_template(
+                [{
+                    "role": "user",
+                    "content": p
+                }],
+                tokenize=False,
+                add_generation_prompt=True,
+            ) for p in raw_prompts
+        ]
+        tok_ids = [llm_spec.tokenizer.encode(p) for p in prompts]
+
+        sampling_params = SamplingParams(max_tokens=128, temperature=0)
+
+        for i in range(len(tok_ids)):
+            num_tokens = 0
+            num_drafted = 0
+            num_accepted = 0
+            for output in llm_spec.generate_async(tok_ids[i],
+                                                  sampling_params,
+                                                  streaming=True):
+                new_tokens = output.outputs[0].token_ids
+                num_drafted += max_draft_len
+                num_accepted += len(new_tokens) - num_tokens - 1
+                num_tokens = len(new_tokens)
+
+            accept_rate = num_accepted / num_drafted
+            assert accept_rate > 0.2, \
+                f"Acceptance rate too low for prompt {i}: {accept_rate:.2f}"
+
+    @pytest.mark.skip(reason="FP16 model checkpoint is not yet available")
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(4)
+    @pytest.mark.skip_less_device_memory(80000)
+    def test_fp16_4gpu_mtp_ar(self):
+        # TODO: FP16 model checkpoint is not yet available.
+        # Update model_path once the fp16 checkpoint is uploaded.
+        max_draft_len = 7
+        mtp_config = MTPDecodingConfig(
+            num_nextn_predict_layers=max_draft_len,
+            mtp_eagle_one_model=True,
+        )
+        model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-FP16"
+
+        llm_common_config = dict(
+            model=model_path,
+            tensor_parallel_size=4,
+            moe_expert_parallel_size=4,
+            kv_cache_config=KvCacheConfig(
+                enable_block_reuse=False,
+                mamba_ssm_cache_dtype="float16",
+                free_gpu_memory_fraction=0.5,
+            ),
+            max_batch_size=4,
+            enable_attention_dp=True,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=32,
+                                              enable_padding=True),
+            disable_overlap_scheduler=False,
+            moe_config=MoeConfig(backend="CUTLASS"),
+        )
+
+        llm_spec = LLM(**llm_common_config, speculative_config=mtp_config)
+
+        raw_prompts = [
+            "The capital of France is",
+            "The president of the United States is",
+            "The future of AI is",
+        ]
+        prompts = [
+            llm_spec.tokenizer.apply_chat_template(
+                [{
+                    "role": "user",
+                    "content": p
+                }],
+                tokenize=False,
+                add_generation_prompt=True,
+            ) for p in raw_prompts
+        ]
+        tok_ids = [llm_spec.tokenizer.encode(p) for p in prompts]
+
+        sampling_params = SamplingParams(max_tokens=128, temperature=0)
+
+        for i in range(len(tok_ids)):
+            num_tokens = 0
+            num_drafted = 0
+            num_accepted = 0
+            for output in llm_spec.generate_async(tok_ids[i],
+                                                  sampling_params,
+                                                  streaming=True):
+                new_tokens = output.outputs[0].token_ids
+                num_drafted += max_draft_len
+                num_accepted += len(new_tokens) - num_tokens - 1
+                num_tokens = len(new_tokens)
+
+            accept_rate = num_accepted / num_drafted
+            assert accept_rate > 0.2, \
+                f"Acceptance rate too low for prompt {i}: {accept_rate:.2f}"
+
 
 @skip_pre_hopper
 class TestMiniMaxM2(LlmapiAccuracyTestHarness):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -5926,7 +5926,7 @@ class TestNemotronV3Super(LlmapiAccuracyTestHarness):
                 free_gpu_memory_fraction=0.5,
             ),
             max_batch_size=4,
-            enable_attention_dp=False,
+            enable_attention_dp=True,
             cuda_graph_config=CudaGraphConfig(max_batch_size=32,
                                               enable_padding=True),
             disable_overlap_scheduler=False,

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -5970,20 +5970,16 @@ class TestNemotronV3Super(LlmapiAccuracyTestHarness):
             assert accept_rate > 0.2, \
                 f"Acceptance rate too low for prompt {i}: {accept_rate:.2f}"
 
-    @pytest.mark.skip(reason="FP16 model checkpoint is not yet available")
     @skip_pre_hopper
     @pytest.mark.skip_less_device(4)
     @pytest.mark.skip_less_device_memory(80000)
     def test_fp16_4gpu_mtp_ar(self):
-        # TODO: FP16 model checkpoint is not yet available.
-        # Update model_path once the fp16 checkpoint is uploaded.
         max_draft_len = 7
         mtp_config = MTPDecodingConfig(
             num_nextn_predict_layers=max_draft_len,
             mtp_eagle_one_model=True,
         )
-        model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-FP16"
-
+        model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-BF16-BF16KV-012726"
         llm_common_config = dict(
             model=model_path,
             tensor_parallel_size=4,

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -285,6 +285,9 @@ accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_dp_on-python_mamba_cache]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_dp_on-cpp_mamba_cache]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm]
+accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_4gpu_mtp_ar
+accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp16_4gpu_mtp_ar
+accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TP4_PP2]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TEP4_PP2]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TP8_PP1]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -42,6 +42,7 @@ l0_dgx_b200:
   # ---- end MoE tests ----
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_auto_dtype_4gpus[4-4-False-True-True]
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_auto_dtype_4gpus[4-4-True-True-True]
+  - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_4gpu_mtp_ar TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[tep4_latency_moe_trtllm-torch_compile=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[dep4_latency_moe_trtllm-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[dep4_latency_moe_cutlass-torch_compile=False]


### PR DESCRIPTION
## Summary
- Fix MTP speculative decoding crash on SM90 (H200) in `_torch/speculative/mtp.py`
- Fix Nemotron model MTP when enabling `enable_attention_dp`
- Add accuracy regression tests for Nemotron models (`test_llm_api_pytorch.py`)
- Update test lists and requirements

## Changes
- `tensorrt_llm/_torch/speculative/mtp.py`: Fix MTP speculative decoding crash on SM90
- `tensorrt_llm/_torch/models/modeling_nemotron_h.py`: Fix MTP with attention DP enabled
- `tensorrt_llm/_torch/cute_dsl_kernels/argmax.py`: Related kernel fixes
- `tests/integration/defs/accuracy/test_llm_api_pytorch.py`: Add Nemotron accuracy tests
- `tests/integration/test_lists/`: Update test lists and DB configs
- `requirements.txt`: Update dependencies

## Test plan
- [x] Verify MTP speculative decoding on H200 (SM90) no longer crashes
- [x] Verify Nemotron model with `enable_attention_dp` works correctly
- [x] Run added accuracy tests on DGX B200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test coverage for NVFP4 quantization with 4-GPU multi-token prediction setup.

* **Bug Fixes**
  * Improved speculative decoding state management and KV cache handling in multi-token prediction.

* **Performance Improvements**
  * Enhanced precision handling for argmax operations, ensuring float32 output for better accuracy.

* **Chores**
  * Pinned flashinfer-python dependency to exact version for stability.
  * Refactored internal function handling in selective state updates for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->