### PR TITLE
[https://nvbugs/5863912][fix] Fix with move launch_dependent_grids after tmem free

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/kernel/sm100_gemm_allreduce_tma_warpspecialized.hpp
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/kernel/sm100_gemm_allreduce_tma_warpspecialized.hpp
@@ -798,11 +798,6 @@ public:
                 cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
             } while (work_tile_info.is_valid());
 
-            // Hint on an early release of global memory resources.
-            // The timing of calling this function only influences performance,
-            // not functional correctness.
-            cutlass::arch::launch_dependent_grids();
-
             // Release the right to allocate before deallocations so that the next CTA can rasterize
             tmem_allocator.release_allocation_lock();
 
@@ -829,6 +824,9 @@ public:
 
             // Free entire tmem allocation
             tmem_allocator.free(tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+            // there are chances next kernel override tmem_base_ptr, so we need to hint the next kernel to launch after
+            // tmem free
+            cutlass::arch::launch_dependent_grids();
         }
 
         else if (is_participant.epi_load)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * There are chances next kernel override tmem_ptr in shared memory before tmem free.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
