### PR TITLE
[https://nvbugs/5941681][fix] Handle dict type for speculative_config

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -508,7 +508,12 @@ class ReportUtility:
               and self.kwargs["speculative_config"] is not None):
             # pytorch speculative decoding
             spec_decoding = True
-            decoding_mode = self.kwargs["speculative_config"].decoding_type
+            spec_config = self.kwargs["speculative_config"]
+            # Handle both dict (from YAML) and object types
+            if isinstance(spec_config, dict):
+                decoding_mode = spec_config.get("decoding_type")
+            else:
+                decoding_mode = spec_config.decoding_type
         if (spec_decoding):
             stats_dict["decoding_stats"] = {
                 "mode":
@@ -770,6 +775,10 @@ class ReportUtility:
         # Try to get from speculative_config
         if ("speculative_config" in self.kwargs
                 and self.kwargs["speculative_config"] is not None):
-            return self.kwargs["speculative_config"].max_draft_len or 0
+            spec_config = self.kwargs["speculative_config"]
+            # Handle both dict (from YAML) and object types
+            if isinstance(spec_config, dict):
+                return spec_config.get("max_draft_len") or 0
+            return spec_config.max_draft_len or 0
 
         return 0


### PR DESCRIPTION
When speculative_config is loaded from a YAML file via extra_llm_api_options, it remains as a dict instead of being converted to a SpeculativeConfig object. The reporting code was accessing attributes like .max_draft_len and .decoding_type directly, which fails on dict objects.

This fix checks if speculative_config is a dict and uses dict-style access (get()) instead of attribute access when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Enhanced speculative configuration parsing to robustly support both YAML dictionary and object input formats, eliminating compatibility errors. This fix improves overall system stability and enables seamless integration whether speculative configurations are loaded from YAML files or provided as object instances, significantly reducing parsing-related issues in speculative decoding workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
