### PR TITLE
[None][perf] Add Triton FP8 blockwise quant kernel and autotuner bucket-skip for visual gen

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -255,12 +255,18 @@ class TunableRunner(ABC):
 
 
 @contextlib.contextmanager
-def autotune(tune_mode: bool = True, cache_path: str = None):
+def autotune(tune_mode: bool = True,
+             cache_path: str = None,
+             skip_dynamic_tuning_buckets: bool = False):
     """Context manager for autotuning with distributed support.
 
     Args:
         tune_mode: Whether to enable tuning mode
         cache_path: Path to save/load cache files
+        skip_dynamic_tuning_buckets: When True, suppress bucket generation in
+            _optimization_profiles() so only actual input shapes from warmup
+            are profiled. Useful for workloads (e.g. diffusion) where the
+            LLM-oriented M-bucket sweep is unnecessary.
     """
     autotuner = AutoTuner.get()
     rank = autotuner.mapping.rank
@@ -277,7 +283,9 @@ def autotune(tune_mode: bool = True, cache_path: str = None):
 
     # record the old tuning mode
     old_mode = autotuner.is_tuning_mode
+    old_skip = autotuner.skip_dynamic_tuning_buckets
     autotuner.is_tuning_mode = tune_required
+    autotuner.skip_dynamic_tuning_buckets = skip_dynamic_tuning_buckets
     autotune_enabled = tune_required and not old_mode
 
     if autotune_enabled:
@@ -287,6 +295,7 @@ def autotune(tune_mode: bool = True, cache_path: str = None):
         yield
     finally:
         autotuner.is_tuning_mode = old_mode
+        autotuner.skip_dynamic_tuning_buckets = old_skip
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
 
@@ -726,7 +735,7 @@ class AutoTuner:
         self.stream_delay_micro_secs = stream_delay_micro_secs
         self.profiling_cache = AutoTunerProfilingCache()
         self.is_tuning_mode = False
-        self.tune_on_miss = False
+        self.skip_dynamic_tuning_buckets = False
 
         # Timing backend: globaltimer kernel vs cuda events.
         # TLLM_PROFILING_TIMER env var overrides auto-detection:
@@ -935,15 +944,9 @@ class AutoTuner:
 
         # Early return if it's not tuning, use cache found one or fallback one
         if not self.is_tuning_mode:
-            if not is_cache_hit and self.tune_on_miss:
-                self.is_tuning_mode = True
-                try:
-                    return self.choose_one(custom_op, runners, tuning_config,
-                                           inputs, **kwargs)
-                finally:
-                    self.is_tuning_mode = False
-
             best_runner = runners[best_runner_id]
+            # TODO: check the stored runner and tactic can implement this shape here
+            # Log the cache miss. Expect no cache miss in inference.
             if not is_cache_hit:
                 logger.warning_once(
                     f"[AutoTuner] {custom_op} using the fallback tactic, due to cache miss on input shapes={input_shapes}",
@@ -1298,7 +1301,9 @@ class AutoTuner:
         for spec in tuning_config.dynamic_tensor_specs:
             assert callable(spec.gen_tuning_buckets) or isinstance(spec.gen_tuning_buckets, (list, tuple)), \
                 "The given dynamic dimension must provide a opt value generation function or a list of opt values"
-            if callable(spec.gen_tuning_buckets):
+            if self.skip_dynamic_tuning_buckets:
+                opt_shapes = ()
+            elif callable(spec.gen_tuning_buckets):
                 if tuning_config.tune_max_num_tokens is None:
                     # Use the current input size as the opt value
                     opt_shapes = spec.gen_tuning_buckets(

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -726,6 +726,7 @@ class AutoTuner:
         self.stream_delay_micro_secs = stream_delay_micro_secs
         self.profiling_cache = AutoTunerProfilingCache()
         self.is_tuning_mode = False
+        self.tune_on_miss = False
 
         # Timing backend: globaltimer kernel vs cuda events.
         # TLLM_PROFILING_TIMER env var overrides auto-detection:
@@ -934,9 +935,15 @@ class AutoTuner:
 
         # Early return if it's not tuning, use cache found one or fallback one
         if not self.is_tuning_mode:
+            if not is_cache_hit and self.tune_on_miss:
+                self.is_tuning_mode = True
+                try:
+                    return self.choose_one(custom_op, runners, tuning_config,
+                                           inputs, **kwargs)
+                finally:
+                    self.is_tuning_mode = False
+
             best_runner = runners[best_runner_id]
-            # TODO: check the stored runner and tactic can implement this shape here
-            # Log the cache miss. Expect no cache miss in inference.
             if not is_cache_hit:
                 logger.warning_once(
                     f"[AutoTuner] {custom_op} using the fallback tactic, due to cache miss on input shapes={input_shapes}",

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1460,16 +1460,59 @@ def deep_gemm_gen_tuning_buckets(x: int):
     return buckets
 
 
+def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):
+    """Dispatch FP8 1x128 quantization to CUDA or Triton kernel."""
+    TACTIC_TRITON = 1
+    if tactic == TACTIC_TRITON:
+        a, a_sf = triton_fp8_quantize_1x128(input, use_ue8m0=True)
+    else:
+        a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
+    a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+        a_sf.transpose(0, 1))
+    return a, a_sf
+
+
+class Fp8QuantKernelRunner(TunableRunner):
+    """Profiles only the FP8 1x128 quantization kernel (no GEMM).
+
+    Selects between CUDA and Triton quantization backends.
+    Uses empty gen_tuning_buckets so only actual M values are profiled.
+    """
+
+    TACTIC_CUDA = 0
+    TACTIC_TRITON = 1
+
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        0, 0, ()), ), )
+
+    def get_valid_tactics(
+        self,
+        inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
+    ) -> List[int]:
+        return [self.TACTIC_CUDA, self.TACTIC_TRITON]
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: int = -1,
+    ) -> torch.Tensor:
+        input = inputs[0]
+        a, a_sf = _fp8_quantize_1x128_ue8m0(input, tactic)
+        return a
+
+
 class fp8SwapABGemmRunner(TunableRunner):
-    TACTIC_CUDA_QUANT = 0
-    TACTIC_TRITON_QUANT = 1
+    """Runs quantize + DeepGemm FP8 GEMM. Single tactic for JIT warmup."""
 
     tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
         0, 0, deep_gemm_gen_tuning_buckets), ), )
 
-    def __init__(self, output_dtype: torch.dtype, disable_ue8m0_cast: bool):
+    def __init__(self, output_dtype: torch.dtype, disable_ue8m0_cast: bool,
+                 quant_tactic: int):
         self.output_dtype = output_dtype
         self.disable_ue8m0_cast = disable_ue8m0_cast
+        self.quant_tactic = quant_tactic
 
     def unique_id(self):
         return (
@@ -1482,18 +1525,7 @@ class fp8SwapABGemmRunner(TunableRunner):
         inputs: List[torch.Tensor],
         profile: OptimizationProfile,
     ) -> List[int]:
-        return [self.TACTIC_CUDA_QUANT, self.TACTIC_TRITON_QUANT]
-
-    def _quantize(self, input: torch.Tensor, tactic: int):
-        # SM100-only: CUDA kernel returns scale as [scale_k, m] (2D) on SM100,
-        # but 1D with m_padded stride on SM90
-        if tactic == self.TACTIC_TRITON_QUANT:
-            a, a_sf = triton_fp8_quantize_1x128(input, use_ue8m0=True)
-        else:
-            a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
-        a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
-            a_sf.transpose(0, 1))
-        return a, a_sf
+        return [0]
 
     def forward(
         self,
@@ -1501,7 +1533,7 @@ class fp8SwapABGemmRunner(TunableRunner):
         tactic: int = -1,
     ) -> torch.Tensor:
         input, weight, weight_scale = inputs
-        a, a_sf = self._quantize(input, tactic)
+        a, a_sf = _fp8_quantize_1x128_ue8m0(input, self.quant_tactic)
         output = torch.empty(
             (input.size(0), weight.size(0)),
             device=input.device,
@@ -1526,18 +1558,31 @@ def fp8_swap_ab_gemm(
     disable_ue8m0_cast: bool = False,
 ) -> torch.Tensor:
     tuner = AutoTuner.get()
-    fp8_swap_ab_gemm_runner = fp8SwapABGemmRunner(
-        output_dtype,
-        disable_ue8m0_cast,
+
+    # Step 1: Select best quantization kernel (CUDA vs Triton).
+    # Profiles only _quantize (no GEMM), with empty M-buckets.
+    quant_runner = Fp8QuantKernelRunner()
+    _, quant_tactic = tuner.choose_one(
+        "trtllm::fp8_quant_1x128_tactic",
+        [quant_runner],
+        Fp8QuantKernelRunner.tuning_config,
+        [input],
     )
 
+    # Step 2: Run quantize + GEMM. Single tactic triggers DeepGemm JIT
+    # warmup across M-buckets without re-profiling the quant kernel.
+    gemm_runner = fp8SwapABGemmRunner(
+        output_dtype,
+        disable_ue8m0_cast,
+        quant_tactic=quant_tactic,
+    )
     _, best_tactic = tuner.choose_one(
         "trtllm::fp8_swap_ab_gemm",
-        [fp8_swap_ab_gemm_runner],
+        [gemm_runner],
         fp8SwapABGemmRunner.tuning_config,
         [input, weight, weight_scale],
     )
-    return fp8_swap_ab_gemm_runner(
+    return gemm_runner(
         inputs=[input, weight, weight_scale],
         tactic=best_tactic,
     )

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -11,8 +11,7 @@ from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import AllReduceFusionOp, AllReduceStrategy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
-from tensorrt_llm.quantization.utils.fp8_quantize import \
-    triton_fp8_quantize_1x128
+from tensorrt_llm.quantization.utils import fp8_quantize
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
                          DynamicTensorSpec, OptimizationProfile, TunableRunner,
@@ -1464,7 +1463,7 @@ def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):
     """Dispatch FP8 1x128 quantization to CUDA or Triton kernel."""
     TACTIC_TRITON = 1
     if tactic == TACTIC_TRITON:
-        a, a_sf = triton_fp8_quantize_1x128(input, use_ue8m0=True)
+        a, a_sf = fp8_quantize.triton_fp8_quantize_1x128(input, use_ue8m0=True)
     else:
         a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
     a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -11,6 +11,8 @@ from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import AllReduceFusionOp, AllReduceStrategy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
+from tensorrt_llm.quantization.utils.fp8_quantize import \
+    triton_fp8_quantize_1x128
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
                          DynamicTensorSpec, OptimizationProfile, TunableRunner,
@@ -1459,6 +1461,9 @@ def deep_gemm_gen_tuning_buckets(x: int):
 
 
 class fp8SwapABGemmRunner(TunableRunner):
+    TACTIC_CUDA_QUANT = 0
+    TACTIC_TRITON_QUANT = 1
+
     tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
         0, 0, deep_gemm_gen_tuning_buckets), ), )
 
@@ -1477,7 +1482,18 @@ class fp8SwapABGemmRunner(TunableRunner):
         inputs: List[torch.Tensor],
         profile: OptimizationProfile,
     ) -> List[int]:
-        return [0]
+        return [self.TACTIC_CUDA_QUANT, self.TACTIC_TRITON_QUANT]
+
+    def _quantize(self, input: torch.Tensor, tactic: int):
+        # SM100-only: CUDA kernel returns scale as [scale_k, m] (2D) on SM100,
+        # but 1D with m_padded stride on SM90
+        if tactic == self.TACTIC_TRITON_QUANT:
+            a, a_sf = triton_fp8_quantize_1x128(input, use_ue8m0=True)
+        else:
+            a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
+        a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+            a_sf.transpose(0, 1))
+        return a, a_sf
 
     def forward(
         self,
@@ -1485,9 +1501,7 @@ class fp8SwapABGemmRunner(TunableRunner):
         tactic: int = -1,
     ) -> torch.Tensor:
         input, weight, weight_scale = inputs
-        a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
-        a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
-            a_sf.transpose(0, 1))
+        a, a_sf = self._quantize(input, tactic)
         output = torch.empty(
             (input.size(0), weight.size(0)),
             device=input.device,

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -14,13 +14,12 @@ Dynamic Quantization:
   - Quantized weights are copied into model buffers
 """
 
-import contextlib
 import os
 from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from tensorrt_llm._torch.autotuner import DynamicTensorSpec, TuningConfig, autotune
+from tensorrt_llm._torch.autotuner import autotune
 from tensorrt_llm._torch.models.modeling_utils import MetaInitMode
 from tensorrt_llm.llmapi.utils import download_hf_model
 from tensorrt_llm.logger import logger
@@ -32,51 +31,6 @@ from .models import AutoPipeline
 
 if TYPE_CHECKING:
     from .models import BasePipeline
-
-
-@contextlib.contextmanager
-def _diffusion_tuning_config():
-    """Override autotuner bucket generation for diffusion models.
-
-    Diffusion models have fixed M dimensions (determined by resolution and
-    frame count), so the LLM-oriented M-bucket sweep for DeepGemm JIT warmup
-    is unnecessary. This patches GEMM runners to use gen_tuning_buckets=()
-    so only actual M values from warmup shapes are profiled.
-
-    The quant kernel runner (Fp8QuantKernelRunner) already uses empty buckets
-    and is unaffected.
-
-    Also enables tune_on_miss so unseen shapes at inference are auto-tuned
-    on-the-fly (like torch.compile recompilation).
-    """
-    from tensorrt_llm._torch.autotuner import AutoTuner, TunableRunner
-
-    runners_to_patch = [
-        cls
-        for cls in TunableRunner.__subclasses__()
-        if hasattr(cls, "tuning_config")
-        and cls.tuning_config is not None
-        and cls.tuning_config.dynamic_tensor_specs
-    ]
-
-    for cls in runners_to_patch:
-        old_cfg = cls.tuning_config
-        new_specs = tuple(
-            DynamicTensorSpec(s.input_idx, s.dim_idx, (), s.map_to_tuning_buckets)
-            for s in old_cfg.dynamic_tensor_specs
-        )
-        cls.tuning_config = TuningConfig(
-            dynamic_tensor_specs=new_specs,
-            constraint_specs=old_cfg.constraint_specs,
-            tune_max_num_tokens=old_cfg.tune_max_num_tokens,
-            inputs_pre_hook=old_cfg.inputs_pre_hook,
-            use_cold_l2_cache=old_cfg.use_cold_l2_cache,
-            use_cuda_graph=old_cfg.use_cuda_graph,
-            distributed_tuning_strategy=old_cfg.distributed_tuning_strategy,
-        )
-
-    AutoTuner.get().tune_on_miss = True
-    yield
 
 
 class PipelineLoader:
@@ -263,9 +217,9 @@ class PipelineLoader:
 
         if not skip_warmup:
             if config.torch_compile.enable_autotune:
-                with (
-                    _diffusion_tuning_config(),
-                    autotune(cache_path=os.environ.get("TLLM_AUTOTUNER_CACHE_PATH")),
+                with autotune(
+                    cache_path=os.environ.get("TLLM_AUTOTUNER_CACHE_PATH"),
+                    skip_dynamic_tuning_buckets=True,
                 ):
                     pipeline.warmup()
             else:

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -14,12 +14,13 @@ Dynamic Quantization:
   - Quantized weights are copied into model buffers
 """
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from tensorrt_llm._torch.autotuner import autotune
+from tensorrt_llm._torch.autotuner import DynamicTensorSpec, TuningConfig, autotune
 from tensorrt_llm._torch.models.modeling_utils import MetaInitMode
 from tensorrt_llm.llmapi.utils import download_hf_model
 from tensorrt_llm.logger import logger
@@ -31,6 +32,51 @@ from .models import AutoPipeline
 
 if TYPE_CHECKING:
     from .models import BasePipeline
+
+
+@contextlib.contextmanager
+def _diffusion_tuning_config():
+    """Override autotuner bucket generation for diffusion models.
+
+    Diffusion models have fixed M dimensions (determined by resolution and
+    frame count), so the LLM-oriented M-bucket sweep for DeepGemm JIT warmup
+    is unnecessary. This patches GEMM runners to use gen_tuning_buckets=()
+    so only actual M values from warmup shapes are profiled.
+
+    The quant kernel runner (Fp8QuantKernelRunner) already uses empty buckets
+    and is unaffected.
+
+    Also enables tune_on_miss so unseen shapes at inference are auto-tuned
+    on-the-fly (like torch.compile recompilation).
+    """
+    from tensorrt_llm._torch.autotuner import AutoTuner, TunableRunner
+
+    runners_to_patch = [
+        cls
+        for cls in TunableRunner.__subclasses__()
+        if hasattr(cls, "tuning_config")
+        and cls.tuning_config is not None
+        and cls.tuning_config.dynamic_tensor_specs
+    ]
+
+    for cls in runners_to_patch:
+        old_cfg = cls.tuning_config
+        new_specs = tuple(
+            DynamicTensorSpec(s.input_idx, s.dim_idx, (), s.map_to_tuning_buckets)
+            for s in old_cfg.dynamic_tensor_specs
+        )
+        cls.tuning_config = TuningConfig(
+            dynamic_tensor_specs=new_specs,
+            constraint_specs=old_cfg.constraint_specs,
+            tune_max_num_tokens=old_cfg.tune_max_num_tokens,
+            inputs_pre_hook=old_cfg.inputs_pre_hook,
+            use_cold_l2_cache=old_cfg.use_cold_l2_cache,
+            use_cuda_graph=old_cfg.use_cuda_graph,
+            distributed_tuning_strategy=old_cfg.distributed_tuning_strategy,
+        )
+
+    AutoTuner.get().tune_on_miss = True
+    yield
 
 
 class PipelineLoader:
@@ -217,7 +263,10 @@ class PipelineLoader:
 
         if not skip_warmup:
             if config.torch_compile.enable_autotune:
-                with autotune(cache_path=os.environ.get("TLLM_AUTOTUNER_CACHE_PATH")):
+                with (
+                    _diffusion_tuning_config(),
+                    autotune(cache_path=os.environ.get("TLLM_AUTOTUNER_CACHE_PATH")),
+                ):
                     pipeline.warmup()
             else:
                 pipeline.warmup()

--- a/tensorrt_llm/quantization/utils/__init__.py
+++ b/tensorrt_llm/quantization/utils/__init__.py
@@ -1,3 +1,3 @@
-from . import fp4_utils, fp8_utils
+from . import fp4_utils, fp8_quantize, fp8_utils
 
-__all__ = ['fp4_utils', 'fp8_utils']
+__all__ = ['fp4_utils', 'fp8_quantize', 'fp8_utils']

--- a/tensorrt_llm/quantization/utils/fp8_quantize.py
+++ b/tensorrt_llm/quantization/utils/fp8_quantize.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Triton FP8 quantization kernels.
+
+Contains:
+  - 1x128 block-scale quantization with optional UE8M0 scale rounding
+    (alternative to CUDA ``fp8_quantize_1x128`` on SM100+)
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+# ---------------------------------------------------------------------------
+# 1x128 block-scale quantization
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _fp8_1x128_quantize_kernel(
+    input_ptr,
+    stride_input_0,
+    stride_input_1,
+    output_ptr,
+    stride_output_0,
+    stride_output_1,
+    output_scale_ptr,
+    stride_output_scale_0,
+    stride_output_scale_1,
+    m,
+    k,
+    fp8_max,
+    fp8_min,
+    M_BLOCK: tl.constexpr,
+    K_BLOCK: tl.constexpr,
+    SCALE_UE8M0: tl.constexpr,
+):
+    k_block_idx = tl.program_id(0)
+    m_block_idx = tl.program_id(1)
+
+    offs_m = m_block_idx * M_BLOCK + tl.arange(0, M_BLOCK)
+    offs_k = k_block_idx * K_BLOCK + tl.arange(0, K_BLOCK)
+
+    in_ptrs = input_ptr + (offs_m[:, None] * stride_input_0 + offs_k[None, :] * stride_input_1)
+    out_ptrs = output_ptr + (offs_m[:, None] * stride_output_0 + offs_k[None, :] * stride_output_1)
+
+    valid = (offs_k[None, :] < k) & (offs_m[:, None] < m)
+    act = tl.load(in_ptrs, mask=valid, other=0.0).to(tl.float32)
+
+    absmax = tl.maximum(tl.max(tl.abs(act), axis=1), 1e-10)
+    scale = absmax / fp8_max
+    if SCALE_UE8M0:
+        scale = tl.exp2(tl.ceil(tl.log2(tl.abs(scale))))
+
+    qval = tl.clamp(act / scale.expand_dims(1), fp8_min, fp8_max).to(output_ptr.dtype.element_ty)
+
+    tl.store(out_ptrs, qval, mask=valid)
+
+    scale_ptrs = (
+        output_scale_ptr
+        + k_block_idx * stride_output_scale_0
+        + (m_block_idx * M_BLOCK + tl.arange(0, M_BLOCK)) * stride_output_scale_1
+    )
+    tl.store(scale_ptrs, scale, mask=(offs_m < m))
+
+
+@torch.compiler.disable()
+def triton_fp8_quantize_1x128(
+    input: torch.Tensor,
+    quant_group_size: int = 128,
+    use_ue8m0: bool = True,
+) -> tuple:
+    """FP8 E4M3 1x128 block-scale quantization via Triton.
+
+    Drop-in replacement for ``torch.ops.trtllm.fp8_quantize_1x128`` on SM89+.
+    Faster than the CUDA kernel when M is large (crossover ~2-4k rows on B200).
+
+    Args:
+        input: BF16 tensor of shape ``[m, k]`` (must be contiguous).
+        quant_group_size: Block size along K for scale computation (default 128).
+        use_ue8m0: If True, round scales to power-of-2 (UE8M0 format).
+
+    Returns:
+        ``(fp8_output, scale)`` where ``fp8_output`` is ``[m, k]`` float8_e4m3fn
+        and ``scale`` is ``[scale_k, m]`` float32.
+    """
+    assert input.is_contiguous() and input.dim() == 2
+    m, k = input.shape
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    fp8_max = finfo.max
+    fp8_min = -fp8_max
+
+    output = torch.empty((m, k), dtype=torch.float8_e4m3fn, device=input.device)
+    scale_k = (k + quant_group_size - 1) // quant_group_size
+    output_scale = torch.empty((scale_k, m), dtype=torch.float32, device=input.device)
+
+    K_BLOCK = quant_group_size
+    M_BLOCK = 128
+    grid = (triton.cdiv(k, K_BLOCK), triton.cdiv(m, M_BLOCK), 1)
+
+    _fp8_1x128_quantize_kernel[grid](
+        input,
+        *input.stride(),
+        output,
+        *output.stride(),
+        output_scale,
+        *output_scale.stride(),
+        m,
+        k,
+        fp8_max,
+        fp8_min,
+        M_BLOCK=M_BLOCK,
+        K_BLOCK=K_BLOCK,
+        SCALE_UE8M0=use_ue8m0,
+        num_warps=8,
+    )
+    return output, output_scale

--- a/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
@@ -17,8 +17,8 @@ import math
 import pytest
 import torch
 from parameterized import parameterized
-from utils.util import (getSMVersion, skip_pre_blackwell_unittest,
-                        unittest_name_func)
+from utils.util import (getSMVersion, isSM100Family,
+                        skip_pre_blackwell_unittest, unittest_name_func)
 
 from tensorrt_llm.quantization.utils.fp8_utils import \
     per_token_quant_and_transform
@@ -273,3 +273,103 @@ def test_fp8_quantize_ue8m0_vs_triton(dtype, m, k):
         atol=1e-10,
         rtol=0.01,
         msg=f"UE8M0 decoded scales mismatch for shape ({m}, {k})")
+
+
+# ---------------------------------------------------------------------------
+# Tests for triton_fp8_quantize_1x128 (library Triton quant kernel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not isSM100Family(),
+    reason="Triton-vs-CUDA scale layout comparison requires SM100+. "
+    "Current SM is %d." % getSMVersion(),
+)
+@pytest.mark.parametrize("use_ue8m0", [True, False])
+@pytest.mark.parametrize("k", [128, 256, 512, 576, 1024, 5120])
+@pytest.mark.parametrize("m", [4, 16, 64, 256, 1024, 4096])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_triton_fp8_quantize_1x128_vs_cuda(dtype, m, k, use_ue8m0):
+    """Validate triton_fp8_quantize_1x128 matches CUDA fp8_quantize_1x128.
+
+    Both kernels perform 1x128 block-scale FP8 E4M3 quantization.  We compare:
+      1. FP8 quantized values  (< 1% byte-level mismatch)
+      2. Float32 scale tensors (match within FP tolerance)
+
+    Tested with both use_ue8m0=True (power-of-2 scales) and False (raw scales).
+    """
+    from tensorrt_llm.quantization.utils.fp8_quantize import \
+        triton_fp8_quantize_1x128
+
+    torch.random.manual_seed(42)
+    input_tensor = torch.randn((m, k), device='cuda', dtype=dtype)
+
+    cuda_fp8, cuda_scale = torch.ops.trtllm.fp8_quantize_1x128(
+        input_tensor, use_ue8m0=use_ue8m0)
+
+    triton_fp8, triton_scale = triton_fp8_quantize_1x128(input_tensor,
+                                                         use_ue8m0=use_ue8m0)
+
+    # --- FP8 values ---
+    cuda_u8 = cuda_fp8.view(torch.uint8)[:m, :k]
+    triton_u8 = triton_fp8.view(torch.uint8)
+    fp8_mismatch = torch.sum(cuda_u8 != triton_u8).item()
+    fp8_total = cuda_u8.numel()
+    fp8_mismatch_pct = fp8_mismatch / fp8_total * 100
+    assert fp8_mismatch_pct < 1.0, (
+        f"FP8 byte mismatch {fp8_mismatch_pct:.2f}% >= 1.0% "
+        f"for shape ({m}, {k}) use_ue8m0={use_ue8m0}")
+
+    # --- Scale values ---
+    assert cuda_scale.shape == triton_scale.shape, (
+        f"Scale shape mismatch: CUDA {cuda_scale.shape} vs "
+        f"Triton {triton_scale.shape}")
+    torch.testing.assert_close(
+        triton_scale,
+        cuda_scale,
+        atol=1e-6,
+        rtol=1e-3,
+        msg=f"Scale mismatch for shape ({m}, {k}) use_ue8m0={use_ue8m0}")
+
+
+@pytest.mark.skipif(
+    not isSM100Family(),
+    reason="Triton-vs-CUDA scale layout comparison requires SM100+. "
+    "Current SM is %d." % getSMVersion(),
+)
+@pytest.mark.parametrize("use_ue8m0", [True, False])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_triton_fp8_quantize_1x128_large_m(dtype, use_ue8m0):
+    """Stress-test with large M values typical of visual-gen / long-prefill.
+
+    These are the shapes where the Triton kernel is expected to outperform
+    CUDA by ~3x.  We still validate correctness here, not performance.
+    """
+    from tensorrt_llm.quantization.utils.fp8_quantize import \
+        triton_fp8_quantize_1x128
+
+    torch.random.manual_seed(42)
+
+    for m, k in [(8192, 5120), (16384, 5120), (4096, 13824)]:
+        input_tensor = torch.randn((m, k), device='cuda', dtype=dtype)
+
+        cuda_fp8, cuda_scale = torch.ops.trtllm.fp8_quantize_1x128(
+            input_tensor, use_ue8m0=use_ue8m0)
+        triton_fp8, triton_scale = triton_fp8_quantize_1x128(
+            input_tensor, use_ue8m0=use_ue8m0)
+
+        cuda_u8 = cuda_fp8.view(torch.uint8)[:m, :k]
+        triton_u8 = triton_fp8.view(torch.uint8)
+        fp8_mismatch_pct = (torch.sum(cuda_u8 != triton_u8).item() /
+                            cuda_u8.numel() * 100)
+        assert fp8_mismatch_pct < 1.0, (
+            f"FP8 mismatch {fp8_mismatch_pct:.2f}% for ({m}, {k}) "
+            f"use_ue8m0={use_ue8m0}")
+
+        assert cuda_scale.shape == triton_scale.shape
+        torch.testing.assert_close(triton_scale,
+                                   cuda_scale,
+                                   atol=1e-6,
+                                   rtol=1e-3,
+                                   msg=f"Scale mismatch for shape ({m}, {k}) "
+                                   f"use_ue8m0={use_ue8m0}")


### PR DESCRIPTION
Motivation: with large M / K, our fp8_quantize_1x128 is capped at <2TB/s on b200. Added new triton fp8 quant kernel (from vision fly branch) to keep bw scaling up to ~6TB/s

```
## CUDA vs Triton Performance

### Large Shapes (mem BW wall) — Triton Wins

| Shape              | CUDA (µs) | Triton (µs) | Triton Speedup |
|--------------------|-----------|-------------|-----------------|
| [151200, 5120]     | 1306      | 402         | 3.2×            |
| [75600, 5120]      | 656       | 203         | 3.2×            |
| [151200, 13824]    | 3516      | 1079        | 3.3×            |
| [4096, 13824]      | 100       | 33          | 3.1×            |

---

### Small Shapes (Launch Overhead) — CUDA Wins

| Shape          | CUDA (µs) | Triton (µs) | CUDA Speedup |
|----------------|-----------|-------------|---------------|
| [4, 5120]      | 7.5       | 20.6        | 2.7×          |
| [64, 5120]     | 7.5       | 20.5        | 2.7×          |
| [512, 5120]    | 7.5       | 20.7        | 2.8×          |
```

### Wan-2.2-14B-5s w/ autotune


Steps | Baseline w/ cuda quant (s/step) | Autotune w/ triton quant (s/step) | Delta
-- | -- | -- | --
5 | 10.33 | 9.99 | -3.4%








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Triton-based quantization as an alternative implementation option for FP8 operations, providing users with multiple quantization strategies to choose from.

* **Tests**
  * Added comprehensive test coverage comparing Triton and CUDA-based FP8 quantization implementations across various configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
