### PR TITLE
[https://nvbugs/5946303][fix] Fix incorrect GPU timing in time breakdown under overlap scheduler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2136,9 +2136,6 @@ class PyExecutor:
                 if self.previous_batch is not None and should_process_previous_batch:
                     self._update_requests(self.previous_batch.sample_state)
 
-                    self.perf_manager.compute_batch_gpu_times(
-                        self.previous_batch.all_requests)
-
                     self._send_kv_async(self.previous_batch.all_requests)
 
                 if self.drafter is not None and self.use_spec_decode and should_process_previous_batch:
@@ -2160,11 +2157,6 @@ class PyExecutor:
                         sample_state = self._sample_async(
                             scheduled_batch, batch_outputs)
 
-                    self.perf_manager.save_timing_to_requests(
-                        scheduled_batch.all_requests(), gpu_forward_start,
-                        gpu_forward_end, gpu_sample_end, fwd_timing.start_time,
-                        fwd_timing.end_time, sample_timing.start_time,
-                        sample_timing.end_time)
                     assert sample_state is not None, "Sampling failed"
 
                     # Handle guided decoder errors after _sample_async to avoid state conflicts.
@@ -2176,10 +2168,17 @@ class PyExecutor:
 
                 if self.previous_batch is not None and should_process_previous_batch:
                     self._process_previous_batch()
+                    self.perf_manager.compute_batch_gpu_times(
+                        self.previous_batch.all_requests)
                 else:
                     self._enqueue_responses([])
 
                 if can_queue:
+                    self.perf_manager.save_timing_to_requests(
+                        scheduled_batch.all_requests(), gpu_forward_start,
+                        gpu_forward_end, gpu_sample_end, fwd_timing.start_time,
+                        fwd_timing.end_time, sample_timing.start_time,
+                        sample_timing.end_time)
                     if self.enable_iter_perf_stats:
                         iter_stats.inflight_batching_stats.num_ctx_tokens = self.model_engine.iter_states[
                             'num_ctx_tokens']

--- a/tensorrt_llm/serve/scripts/time_breakdown/time_breakdown.py
+++ b/tensorrt_llm/serve/scripts/time_breakdown/time_breakdown.py
@@ -390,10 +390,10 @@ class RequestTimeBreakdown:
         # Calculate e2e time for each request
         def get_e2e_time(data):
             """Calculate end-to-end time from arrival to last token."""
-            # Get arrival time
-            arrival = data.get('ctx_server_arrival_time', float('nan'))
+            # Get arrival time (executor arrival first, then server arrival)
+            arrival = data.get('ctx_arrival_time', float('nan'))
             if math.isnan(arrival):
-                arrival = data.get('ctx_arrival_time', float('nan'))
+                arrival = data.get('ctx_server_arrival_time', float('nan'))
             if math.isnan(arrival):
                 arrival = data.get('disagg_server_arrival_time', float('nan'))
 
@@ -407,9 +407,9 @@ class RequestTimeBreakdown:
             return 0
 
         def get_arrival_time(data):
-            arrival = data.get('ctx_server_arrival_time', float('nan'))
+            arrival = data.get('ctx_arrival_time', float('nan'))
             if math.isnan(arrival):
-                arrival = data.get('ctx_arrival_time', float('nan'))
+                arrival = data.get('ctx_server_arrival_time', float('nan'))
             if math.isnan(arrival):
                 arrival = data.get('disagg_server_arrival_time', float('inf'))
             return arrival


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved timing instrumentation in batch execution to capture GPU metrics at optimized points in the processing pipeline, enhancing the accuracy of performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix two issues in the per-request time breakdown metrics when overlap scheduler is enabled (the default for PyTorch backend):

1. **GPU timing 1-iteration shift** (`py_executor.py`): `compute_batch_gpu_times` and `save_timing_to_requests` were called in the wrong order relative to `_process_previous_batch()`. This caused a request's context `gpu_forward_time` to be filled with the *next* iteration's GPU timing instead of its own, because CUDA events were overwritten before being consumed. Fix: move both calls to after `_process_previous_batch()`.

2. **Default sorting in time breakdown HTML** (`time_breakdown.py`): Changed default request sorting to prioritize `ctx_arrival_time` (executor arrival) over `ctx_server_arrival_time` (HTTP server arrival), aligning the sort order with `request_id` assignment order.

## Test Coverage

- Manually verified with Qwen3-30B-A3B on B200 GPUs, IFB mode, overlap scheduler enabled
- Tested at concurrency=1 and concurrency=64
- Tested with and without chunked prefill
- Confirmed correct GPU timing attribution: ctx GPU timing 45-164ms (depending on concurrency), ~12x ratio vs gen GPU timing at concurrency=1

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.