### PR TITLE
[TRTLLM-11189][fix] Fix TeaCache broken caching for FLUX.1 and FLUX.2

### DIFF
--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -119,6 +119,12 @@ def parse_args():
         default=0.2,
         help="TeaCache similarity threshold (rel_l1_thresh)",
     )
+    parser.add_argument(
+        "--use_ret_steps",
+        action="store_true",
+        help="Use ret_steps mode for TeaCache. "
+        "Using Retention Steps will result in faster generation speed and better generation quality.",
+    )
 
     # Quantization
     parser.add_argument(
@@ -212,6 +218,7 @@ def build_diffusion_config(args):
         "teacache": {
             "enable_teacache": args.enable_teacache,
             "teacache_thresh": args.teacache_thresh,
+            "use_ret_steps": args.use_ret_steps,
         },
         "parallel": {
             "dit_ulysses_size": args.ulysses_size,

--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -214,7 +214,6 @@ def build_diffusion_config(args):
             "teacache_thresh": args.teacache_thresh,
         },
         "parallel": {
-            "dit_cfg_size": args.cfg_size,
             "dit_ulysses_size": args.ulysses_size,
         },
         "torch_compile": {
@@ -239,12 +238,11 @@ def build_diffusion_config(args):
 def main():
     args = parse_args()
 
-    n_workers = args.cfg_size * args.ulysses_size
+    n_workers = args.ulysses_size
     diffusion_config = build_diffusion_config(args)
 
     logger.info(
-        f"Initializing VisualGen: world_size={n_workers} "
-        f"(cfg_size={args.cfg_size}, ulysses_size={args.ulysses_size})"
+        f"Initializing VisualGen: world_size={n_workers} (ulysses_size={args.ulysses_size})"
     )
     visual_gen = VisualGen(
         model_path=args.model_path,

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -50,35 +50,36 @@ class FluxPipeline(BasePipeline):
         super().__init__(model_config)
 
     @staticmethod
-    def _compute_flux_timestep_embedding(module, timestep, guidance=None):
-        """Compute timestep embedding for FLUX.1 transformer.
+    def _compute_flux_timestep_embedding(
+        module, hidden_states=None, timestep=None, guidance=None,
+        pooled_projections=None, **kwargs,
+    ):
+        """Compute modulated input for FLUX.1 TeaCache (matches original paper).
 
-        FLUX.1 uses CombinedTimestepGuidanceTextProjEmbeddings which combines
-        timestep + guidance + pooled_projection. For TeaCache, we only need the
-        timestep + guidance components (pooled_projection is constant across steps).
-
-        Args:
-            module: FluxTransformer2DModel instance
-            timestep: Timestep tensor [B]
-            guidance: Guidance scale tensor [B] (optional)
-
-        Returns:
-            Combined timestep+guidance embedding for TeaCache distance calculation
+        Computes norm1(x_embedder(hidden_states), emb=temb) from the first
+        transformer block, which captures both temporal (timestep) and content
+        (hidden_states) changes for cache distance calculation.
         """
-        embed = module.time_text_embed
-        # Use timestep_embedder sub-component directly (avoids needing pooled_projection)
-        te_dtype = next(embed.timestep_embedder.parameters()).dtype
-        if te_dtype == torch.int8:
-            te_dtype = torch.bfloat16
 
-        timesteps_proj = embed.time_proj(timestep)
-        temb = embed.timestep_embedder(timesteps_proj.to(te_dtype))
+        # Embed hidden states through x_embedder (same as forward() line 790)
+        x = module.x_embedder(hidden_states.contiguous())
 
-        if hasattr(embed, "guidance_embedder") and guidance is not None:
-            guidance_proj = embed.time_proj(guidance)
-            temb = temb + embed.guidance_embedder(guidance_proj.to(te_dtype))
+        # Scale timestep/guidance (FLUX convention: multiply by 1000)
+        timestep = timestep.to(x.dtype) * 1000
+        if guidance is not None:
+            guidance = guidance.to(x.dtype) * 1000
 
-        return temb
+        # Compute full temb (timestep + guidance + pooled_projection)
+        if module.config.guidance_embeds and guidance is not None:
+            temb = module.time_text_embed(timestep, guidance, pooled_projections)
+        else:
+            temb = module.time_text_embed(timestep, pooled_projections)
+
+        # Apply AdaLayerNorm from first transformer block:
+        # norm1(x, emb=temb) -> (modulated_x, gate, shift_mlp, scale_mlp, gate_mlp)
+        modulated_input = module.transformer_blocks[0].norm1(x, emb=temb)[0]
+
+        return modulated_input
 
     @property
     def dtype(self):

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -51,9 +51,11 @@ class FluxPipeline(BasePipeline):
 
     @staticmethod
     def _compute_flux_timestep_embedding(module, timestep, guidance=None):
-        """Compute timestep embedding for FLUX transformer.
+        """Compute timestep embedding for FLUX.1 transformer.
 
-        FLUX combines timestep and guidance embeddings.
+        FLUX.1 uses CombinedTimestepGuidanceTextProjEmbeddings which combines
+        timestep + guidance + pooled_projection. For TeaCache, we only need the
+        timestep + guidance components (pooled_projection is constant across steps).
 
         Args:
             module: FluxTransformer2DModel instance
@@ -61,19 +63,20 @@ class FluxPipeline(BasePipeline):
             guidance: Guidance scale tensor [B] (optional)
 
         Returns:
-            Combined timestep embedding for TeaCache distance calculation
+            Combined timestep+guidance embedding for TeaCache distance calculation
         """
-        # Cast to embedder's dtype (avoid int8 quantized layers)
-        te_dtype = next(iter(module.time_text_embed.parameters())).dtype
-        if timestep.dtype != te_dtype and te_dtype != torch.int8:
-            timestep = timestep.to(te_dtype)
+        embed = module.time_text_embed
+        # Use timestep_embedder sub-component directly (avoids needing pooled_projection)
+        te_dtype = next(embed.timestep_embedder.parameters()).dtype
+        if te_dtype == torch.int8:
+            te_dtype = torch.bfloat16
 
-        temb = module.time_text_embed(timestep)
+        timesteps_proj = embed.time_proj(timestep)
+        temb = embed.timestep_embedder(timesteps_proj.to(te_dtype))
 
-        if module.guidance_embeds and guidance is not None:
-            if guidance.dtype != te_dtype and te_dtype != torch.int8:
-                guidance = guidance.to(te_dtype)
-            temb = temb + module.guidance_embed(guidance)
+        if hasattr(embed, "guidance_embedder") and guidance is not None:
+            guidance_proj = embed.time_proj(guidance)
+            temb = temb + embed.guidance_embedder(guidance_proj.to(te_dtype))
 
         return temb
 
@@ -209,8 +212,8 @@ class FluxPipeline(BasePipeline):
                 )
             )
 
-            # Enable TeaCache with FLUX-specific coefficients
-            self._setup_teacache(self.transformer, coefficients=FLUX_TEACACHE_COEFFICIENTS)
+            # Enable TeaCache with FLUX.1-specific polynomial coefficients
+            self._setup_teacache(self.transformer, FLUX_TEACACHE_COEFFICIENTS)
 
     def infer(self, req):
         """Run inference from DiffusionRequest."""

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -51,8 +51,12 @@ class FluxPipeline(BasePipeline):
 
     @staticmethod
     def _compute_flux_timestep_embedding(
-        module, hidden_states=None, timestep=None, guidance=None,
-        pooled_projections=None, **kwargs,
+        module,
+        hidden_states=None,
+        timestep=None,
+        guidance=None,
+        pooled_projections=None,
+        **kwargs,
     ):
         """Compute modulated input for FLUX.1 TeaCache (matches original paper).
 

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -122,34 +122,35 @@ class Flux2Pipeline(BasePipeline):
         super().__init__(model_config)
 
     @staticmethod
-    def _compute_flux2_timestep_embedding(module, timestep, guidance=None):
-        """Compute timestep embedding for FLUX.2 transformer.
+    def _compute_flux2_timestep_embedding(
+        module, hidden_states=None, timestep=None, guidance=None, **kwargs,
+    ):
+        """Compute modulated input for FLUX.2 TeaCache (matches original paper).
 
-        FLUX.2 uses TimeGuidanceEmbed which combines timestep + guidance.
-        For TeaCache, we compute this directly using the sub-components.
-
-        Args:
-            module: Flux2Transformer2DModel instance
-            timestep: Timestep tensor [B]
-            guidance: Guidance scale tensor [B] (optional)
-
-        Returns:
-            Combined timestep+guidance embedding for TeaCache distance calculation
+        Computes norm1(x_embedder(hidden_states)) * (1 + scale) + shift using
+        the first transformer block's modulation, which captures both temporal
+        (timestep) and content (hidden_states) changes.
         """
-        embed = module.time_guidance_embed
-        # Use timestep_embedder sub-component directly
-        te_dtype = next(embed.timestep_embedder.parameters()).dtype
-        if te_dtype == torch.int8:
-            te_dtype = torch.bfloat16
 
-        timesteps_proj = embed.time_proj(timestep)
-        temb = embed.timestep_embedder(timesteps_proj.to(te_dtype))
+        # Embed hidden states through x_embedder (same as forward() line 698)
+        x = module.x_embedder(hidden_states.contiguous())
 
-        if hasattr(embed, "guidance_embedder") and guidance is not None:
-            guidance_proj = embed.time_proj(guidance)
-            temb = temb + embed.guidance_embedder(guidance_proj.to(te_dtype))
+        # Scale timestep/guidance (FLUX convention: multiply by 1000)
+        timestep = timestep.to(x.dtype) * 1000
+        if guidance is not None:
+            guidance = guidance.to(x.dtype) * 1000
 
-        return temb
+        # Compute temb (timestep + optional guidance)
+        temb = module.time_guidance_embed(timestep, guidance)
+
+        # Compute modulation from first block: ((shift1, scale1, gate1), ...)
+        img_mod = module.double_stream_modulation_img(temb)
+        shift1, scale1, _gate1 = img_mod[0]
+
+        # Apply modulation: norm1(x) * (1 + scale) + shift (same as block line 293-294)
+        modulated_input = module.transformer_blocks[0].norm1(x) * (1 + scale1) + shift1
+
+        return modulated_input
 
     @property
     def dtype(self):

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -44,11 +44,11 @@ from tensorrt_llm.logger import logger
 
 from .transformer_flux2 import Flux2Transformer2DModel
 
-# TeaCache coefficients for FLUX.2
+# TeaCache coefficients for FLUX.2 (different from FLUX.1)
 FLUX2_TEACACHE_COEFFICIENTS = {
     "dev": {
-        "ret_steps": [2.57151496e05, -3.54229917e04, 1.40286849e03, -1.35890334e01, 1.32517977e-01],
-        "standard": [2.57151496e05, -3.54229917e04, 1.40286849e03, -1.35890334e01, 1.32517977e-01],
+        "ret_steps": [1.04582360e02, -6.87605554e00, -8.61659379e-02, 5.37600252e-02],
+        "standard": [1.04582360e02, -6.87605554e00, -8.61659379e-02, 5.37600252e-02],
     },
 }
 
@@ -125,24 +125,31 @@ class Flux2Pipeline(BasePipeline):
     def _compute_flux2_timestep_embedding(module, timestep, guidance=None):
         """Compute timestep embedding for FLUX.2 transformer.
 
-        Always uses time_guidance_embed (handles both guided and unguided variants).
+        FLUX.2 uses TimeGuidanceEmbed which combines timestep + guidance.
+        For TeaCache, we compute this directly using the sub-components.
 
         Args:
             module: Flux2Transformer2DModel instance
             timestep: Timestep tensor [B]
-            guidance: Guidance scale tensor [B] (optional, None for klein)
+            guidance: Guidance scale tensor [B] (optional)
 
         Returns:
-            Timestep embedding for TeaCache distance calculation
+            Combined timestep+guidance embedding for TeaCache distance calculation
         """
         embed = module.time_guidance_embed
-        te_dtype = next(embed.timestep_embedder.linear_1.parameters()).dtype
-        if te_dtype != torch.int8:
-            t = timestep.to(te_dtype)
-            g = guidance.to(te_dtype) if guidance is not None else None
-        else:
-            t, g = timestep, guidance
-        return embed(t, g)
+        # Use timestep_embedder sub-component directly
+        te_dtype = next(embed.timestep_embedder.parameters()).dtype
+        if te_dtype == torch.int8:
+            te_dtype = torch.bfloat16
+
+        timesteps_proj = embed.time_proj(timestep)
+        temb = embed.timestep_embedder(timesteps_proj.to(te_dtype))
+
+        if hasattr(embed, "guidance_embedder") and guidance is not None:
+            guidance_proj = embed.time_proj(guidance)
+            temb = temb + embed.guidance_embedder(guidance_proj.to(te_dtype))
+
+        return temb
 
     @property
     def dtype(self):
@@ -301,8 +308,8 @@ class Flux2Pipeline(BasePipeline):
                 )
             )
 
-            # Enable TeaCache with FLUX.2-specific coefficients
-            self._setup_teacache(self.transformer, coefficients=FLUX2_TEACACHE_COEFFICIENTS)
+            # Enable TeaCache with FLUX.2-specific polynomial coefficients
+            self._setup_teacache(self.transformer, FLUX2_TEACACHE_COEFFICIENTS)
 
     def infer(self, req):
         """Run inference from DiffusionRequest."""

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -123,7 +123,11 @@ class Flux2Pipeline(BasePipeline):
 
     @staticmethod
     def _compute_flux2_timestep_embedding(
-        module, hidden_states=None, timestep=None, guidance=None, **kwargs,
+        module,
+        hidden_states=None,
+        timestep=None,
+        guidance=None,
+        **kwargs,
     ):
         """Compute modulated input for FLUX.2 TeaCache (matches original paper).
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -86,21 +86,12 @@ class WanPipeline(BasePipeline):
 
         super().__init__(model_config)
 
-    def _compute_wan_timestep_embedding(self, module, timestep, guidance=None):
+    def _compute_wan_timestep_embedding(self, module, timestep=None, **kwargs):
         """Compute timestep embedding for WAN transformer.
 
         WAN uses a condition_embedder with timesteps_proj and time_embedder layers.
-        Handles dtype casting to match the embedder's dtype.
-
-        Args:
-            module: WanTransformer3DModel instance
-            timestep: Timestep tensor (shape: [batch_size])
-            guidance: Unused for WAN (no guidance embedding)
-
-        Returns:
-            Timestep embedding tensor used by TeaCache for distance calculation.
-            Returns timestep_proj when use_ret_steps=True (matches ret_steps coefficient
-            calibration), or temb when use_ret_steps=False (standard mode).
+        Returns timestep_proj when use_ret_steps=True (matches ret_steps coefficient
+        calibration), or temb when use_ret_steps=False (standard mode).
         """
         ce = module.condition_embedder
         t_freq = ce.timesteps_proj(timestep)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -107,7 +107,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
         super().__init__(model_config)
 
-    def _compute_wan_timestep_embedding(self, module, timestep, guidance=None):
+    def _compute_wan_timestep_embedding(self, module, timestep=None, **kwargs):
         """Compute timestep embedding for Wan I2V transformer.
 
         Returns timestep_proj when use_ret_steps=True (matches ret_steps coefficient

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -169,6 +169,12 @@ class BasePipeline(nn.Module):
                         teacache_cfg.coefficients = coeff_data
                         logger.info(f"TeaCache: Using {model_size} coefficients")
                     break
+            else:
+                raise ValueError(
+                    f"TeaCache: No coefficients found for checkpoint '{checkpoint_path}'. "
+                    f"Available variants: {list(coefficients.keys())}. "
+                    f"TeaCache is not supported for this model variant."
+                )
 
         # Initialize and enable TeaCache backend
         logger.info("TeaCache: Initializing...")

--- a/tensorrt_llm/_torch/visual_gen/teacache.py
+++ b/tensorrt_llm/_torch/visual_gen/teacache.py
@@ -66,7 +66,7 @@ class ExtractorConfig:
 
     Attributes:
         model_class_name: Model class name (e.g., "LTX2VideoTransformer3DModel")
-        timestep_embed_fn: Callable(module, timestep, guidance=None) -> Tensor
+        timestep_embed_fn: Callable(module, **forward_kwargs) -> Tensor
         timestep_param_name: Parameter name for timestep in forward() (default: "timestep")
         guidance_param_name: Parameter name for guidance if used (default: None)
         forward_params: List of parameter names (None = auto-introspect from forward signature)
@@ -115,19 +115,16 @@ class GenericExtractor:
         return extracted
 
     def _compute_timestep_embedding(self, module: torch.nn.Module, params: Dict) -> torch.Tensor:
-        """Compute timestep embedding using configured callable."""
+        """Compute timestep embedding using configured callable.
+
+        Unpacks the forward params as kwargs to the model-specific embed function,
+        which declares only the parameters it needs (e.g., timestep, hidden_states).
+        """
         timestep = params.get(self.config.timestep_param_name)
         if timestep is None:
             raise ValueError(f"Missing required parameter: {self.config.timestep_param_name}")
 
-        # Flatten timestep if needed (common pattern)
-        timestep_flat = timestep.flatten() if timestep.ndim == 2 else timestep
-        guidance = (
-            params.get(self.config.guidance_param_name) if self.config.guidance_param_name else None
-        )
-
-        # Call configured timestep embedding function
-        return self.config.timestep_embed_fn(module, timestep_flat, guidance)
+        return self.config.timestep_embed_fn(module, **params)
 
     def __call__(self, module: torch.nn.Module, *args, **kwargs) -> CacheContext:
         """Main extractor logic - called by TeaCacheHook.

--- a/tensorrt_llm/_torch/visual_gen/teacache.py
+++ b/tensorrt_llm/_torch/visual_gen/teacache.py
@@ -127,13 +127,7 @@ class GenericExtractor:
         )
 
         # Call configured timestep embedding function
-        try:
-            return self.config.timestep_embed_fn(module, timestep_flat, guidance)
-        except Exception as e:
-            logger.error(f"Timestep embedder failed: {e}")
-            # Last resort: use timestep as-is
-            logger.warning("Using timestep fallback")
-            return timestep_flat.unsqueeze(-1) if timestep_flat.ndim == 1 else timestep_flat
+        return self.config.timestep_embed_fn(module, timestep_flat, guidance)
 
     def __call__(self, module: torch.nn.Module, *args, **kwargs) -> CacheContext:
         """Main extractor logic - called by TeaCacheHook.

--- a/tests/unittest/_torch/visual_gen/test_teacache.py
+++ b/tests/unittest/_torch/visual_gen/test_teacache.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for TeaCache (CPU-only, no model weights needed)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, TeaCacheConfig
+from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
+from tensorrt_llm._torch.visual_gen.teacache import TeaCacheBackend
+
+
+class TestSetupTeacache:
+    """Tests for _setup_teacache coefficient matching and fail-early behavior."""
+
+    def _make_pipeline_mock(self, checkpoint_name, use_ret_steps=False):
+        pipeline = MagicMock()
+        pipeline.model_config = DiffusionModelConfig(
+            pretrained_config=SimpleNamespace(_name_or_path=f"/path/to/{checkpoint_name}/snapshot"),
+            teacache=TeaCacheConfig(
+                enable_teacache=True,
+                teacache_thresh=0.3,
+                use_ret_steps=use_ret_steps,
+            ),
+            skip_create_weights_in_init=True,
+        )
+        return pipeline
+
+    def test_matching_variant_selects_coefficients(self):
+        """Picks coefficients whose key appears in checkpoint path."""
+        pipeline = self._make_pipeline_mock("FLUX.1-dev")
+        coefficients = {
+            "dev": {"standard": [1.0, 2.0, 3.0], "ret_steps": [4.0, 5.0]},
+            "schnell": {"standard": [10.0, 20.0]},
+        }
+        with patch.object(TeaCacheBackend, "enable"):
+            BasePipeline._setup_teacache(pipeline, MagicMock(), coefficients)
+
+        assert pipeline.model_config.teacache.coefficients == [1.0, 2.0, 3.0]
+
+    def test_no_match_raises_valueerror(self):
+        """Raises ValueError (fail-early) when no variant matches checkpoint."""
+        pipeline = self._make_pipeline_mock("FLUX.1-unknown-variant")
+        coefficients = {
+            "dev": {"standard": [1.0, 2.0]},
+            "schnell": {"standard": [10.0, 20.0]},
+        }
+        with pytest.raises(ValueError, match="No coefficients found"):
+            BasePipeline._setup_teacache(pipeline, MagicMock(), coefficients)
+
+    def test_disabled_teacache_is_noop(self):
+        """No-op when enable_teacache=False."""
+        pipeline = self._make_pipeline_mock("FLUX.1-dev")
+        pipeline.model_config.teacache.enable_teacache = False
+
+        BasePipeline._setup_teacache(pipeline, MagicMock(), {"dev": [1.0]})
+        assert pipeline.cache_backend is None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved timestep and guidance embedding computation in FLUX.1 visual generation pipeline.
  * Enhanced TeaCache configuration to automatically select model-appropriate coefficients based on checkpoint identification.
  * Updated TeaCache coefficients for FLUX.2.

* **Bug Fixes**
  * Fixed TeaCache distance accumulation behavior to improve caching efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fix bugs that made TeaCache produce garbage images (FLUX.2) or use wrong distance signals (FLUX.1)
- **`teacache.py` (common)**: Remove spurious 0.95 decay on cache hits — not in original paper or feature branch, creates positive feedback loop increasing hit rate by ~30-50%
- **`pipeline_flux.py` (FLUX.1)**: Fix timestep embedder calling `time_text_embed(timestep)` which always raised TypeError (needs 3 args: timestep, guidance, pooled_projection), silently falling back to raw timestep values; set polynomial coefficients directly bypassing broken path matching in `_setup_teacache()`
- **`pipeline_flux2.py` (FLUX.2)**: Fix wrong polynomial coefficients (was using FLUX.1's values); set `use_ret_steps=False` (was defaulting to `True`); set polynomial coefficients directly bypassing broken path matching in `_setup_teacache()`
- **Root cause of coefficient loading failure (common)**: `_setup_teacache()` in `pipeline.py` matches `pretrained_config._name_or_path` against coefficient keys, but `pretrained_config` is a `SimpleNamespace` with no `_name_or_path` attribute — polynomial always defaulted to identity `[1.0, 0.0]`


| Model | Before PR | After PR | Impact |
|-------|-----------|----------|--------|
| **FLUX.2-dev** (50 steps, thresh=0.2) | 94% hit — garbage images | 72% hit — good quality | Major fix |
| **FLUX.1-dev** (50 steps, thresh=0.3) | 48% hit — wrong distance signal | 60% hit — correct embedder + polynomial | Embedder + coefficients fixed |
| **WAN 2.1 T2V 1.3B** (50 steps, thresh=0.2) | 74% hit | 72% hit | Minimal (decay removal only) |

## Test Coverage

- [x] FLUX.2-dev on B200: hit rate 94% → 72%, garbage images → good quality
- [x] FLUX.1-dev on B200: hit rate 48% (wrong signal) → 60% (correct embedder + polynomial)
- [x] WAN 2.1 T2V 1.3B on B200: hit rate 74% → 72%, minimal change (only decay removal applies)
- [x] Visual inspection of output images vs baseline (no TeaCache)

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
