### PR TITLE
[https://nvbugs/5930934][fix] Fix OOM hang with NCCL_SYMMETRIC fallback during long-context inference

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1769,7 +1769,11 @@ class AllReduceRunner(TunableRunner):
                                                 do_preparation=True)
             return input
         if tactic == -1:
-            tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
+            # tactic == -1 means the autotuner cache missed for this shape,
+            # so we fall back to plain NCCL instead of NCCL_SYMMETRIC.
+            # NCCL_SYMMETRIC requires ncclMemAlloc which can fail asymmetrically
+            # across ranks under OOM, causing a deadlock at ncclCommWindowRegister.
+            tactic = AllReduceStrategy.NCCL.value
 
         return torch.ops.trtllm.allreduce(
             input,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -139,7 +139,8 @@ def weight_dequant(x: torch.Tensor,
 @torch.compile(dynamic=True)
 def moe_reduce_add_shared_output(routed_output, shared_output):
     routed_output = torch.sum(routed_output, dim=1, keepdim=False)
-    return shared_output + routed_output
+    # In-place add to avoid allocating a temporary tensor, reducing peak memory
+    return shared_output.add_(routed_output)
 
 
 class DeepseekV3WeightLoader:
@@ -1157,7 +1158,8 @@ class Deepseekv3MoE(nn.Module):
             else:
                 assert shared_output.size() == routed_output.size(
                 ), 'unmatched tensor shape'
-                final_hidden_states = shared_output + routed_output
+                # In-place add to avoid allocating a temporary tensor, reducing peak memory
+                final_hidden_states = shared_output.add_(routed_output)
 
             if not self.use_dp and self.mapping.tp_size > 1:
                 final_hidden_states = self.allreduce(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential deadlock issues during distributed training that could occur under out-of-memory conditions by optimizing communication fallback behavior.

* **Performance**
  * Reduced peak memory consumption by eliminating unnecessary temporary tensor allocations during model inference operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fix NCCL deadlock hang during long-context multi-turn inference (131K ISL) and also subsequent CUDA OOM with DeepSeek-V3 on GB200. Confirmed on both 1.3.0rc3 and rc5.

1. **Plain NCCL fallback on AutoTuner cache miss** (`torch_custom_ops.py`): When autotuner cache misses, fallback must be plain NCCL instead of NCCL_SYMMETRIC (introduced by PR #11042). Without this, the run consistently fails around round 30-40 due to ncclMemAlloc. Once NCCL_SYMMETRIC runs, GPU memory gets reduced significantly over time across multi-turn rounds, likely due to the symmetric buffer pool accumulating and never releasing buffers.

  2. **In-place MoE addition** (`modeling_deepseekv3.py`): Replace `shared_output + routed_output` with
  `shared_output.add_(routed_output)`. The in-place add_ reuses shared_output's memory since it is not     
  referenced after the addition. This reduces peak memory during the MoE forward pass which is needed during CUDA OOM.

  3. **PyTorch allocator fragmentation mitigation** (env var, not in this PR): Even with plain NCCL and in-place add, CUDA OOM occurs around round 60-80 due to very tight GPU memory and PyTorch allocator fragmentation (13-16 GiB reserved but unusable). Setting`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` resolves this. Only with all three parts does the workload complete all 116 rounds. May look into setting the environment variable in code if necessary later after discussion within the team. 


## Test Coverage

N/A

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
