### PR TITLE
[https://nvbugs/5892646][perf] Long-sequence token-parallel optimization for DSA indexer prefill

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -11,6 +11,7 @@ from tensorrt_llm._torch.attention_backend.interface import (
     MLAParams, PositionalEmbeddingParams)
 from tensorrt_llm._torch.attention_backend.trtllm import (
     TrtllmAttention, TrtllmAttentionMetadata)
+from tensorrt_llm._torch.distributed.ops import allgather
 from tensorrt_llm._torch.modules.layer_norm import LayerNorm
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.modules.multi_stream_utils import \
@@ -1369,40 +1370,77 @@ class Indexer(nn.Module):
         if has_prefill and not metadata.skip_indexer_for_ctx_reqs:
             # Use chunked prefill to reduce memory footprint
             if metadata.indexer_prefill_chunks is not None:
+
+                # Default to 8192 if sparse_attention_config is not available (e.g., in unit tests)
+                q_split_threshold = metadata.sparse_attention_config.q_split_threshold if metadata.sparse_attention_config is not None else 8192
+                q_split_eligible = q_split_threshold >= 0 and metadata.mapping is not None and not metadata.mapping.enable_attention_dp and metadata.mapping.tp_size > 1
+
+                if q_split_eligible:
+                    tp_rank = metadata.mapping.tp_rank
+                    tp_size = metadata.mapping.tp_size
+
                 for chunk in metadata.indexer_prefill_chunks:
                     # Gather K from cache for this chunk (dual to _update_k_cache)
                     chunk_k_fp8, chunk_k_scale = self._gather_k_cache_for_chunk(
                         metadata, chunk)
+
+                    chunk_num_token = chunk.token_end - chunk.token_start
+                    apply_q_split = q_split_eligible and chunk_num_token >= q_split_threshold
+                    if apply_q_split:
+                        chunk_q_start = chunk_num_token * tp_rank // tp_size
+                        chunk_q_end = chunk_num_token * (tp_rank + 1) // tp_size
+                    else:
+                        chunk_q_start = 0
+                        chunk_q_end = chunk_num_token
+
+                    global_q_start = chunk.token_start + chunk_q_start
+                    global_q_end = chunk.token_start + chunk_q_end
+
                     logits = fp8_mqa_logits(
-                        q_fp8[chunk.token_start:chunk.token_end, ...],
+                        q_fp8[global_q_start:global_q_end, ...],
                         (chunk_k_fp8, chunk_k_scale),
-                        weights[chunk.token_start:chunk.token_end, ...],
-                        chunk.cu_seqlen_ks,
-                        chunk.cu_seqlen_ke,
+                        weights[global_q_start:global_q_end, ...],
+                        chunk.cu_seqlen_ks[chunk_q_start:chunk_q_end],
+                        chunk.cu_seqlen_ke[chunk_q_start:chunk_q_end],
                     )
                     if use_custom_topk:
                         torch.ops.trtllm.indexer_topk_prefill(
-                            logits, chunk.cu_seqlen_ks, chunk.cu_seqlen_ke,
-                            topk_indices_buffer[
-                                chunk.token_start:chunk.token_end, :])
+                            logits,
+                            chunk.cu_seqlen_ks[chunk_q_start:chunk_q_end],
+                            chunk.cu_seqlen_ke[chunk_q_start:chunk_q_end],
+                            topk_indices_buffer[global_q_start:global_q_end, :])
                     else:
                         topk_indices = logits.topk(min(self.index_topk,
                                                        logits.shape[-1]),
                                                    dim=-1)[1]
-                        topk_indices -= chunk.cu_seqlen_ks[:, None]
+                        topk_indices -= chunk.cu_seqlen_ks[
+                            chunk_q_start:chunk_q_end][:, None]
 
                         mask_lo = topk_indices >= 0
-                        mask_hi = topk_indices - (chunk.cu_seqlen_ke -
-                                                  chunk.cu_seqlen_ks)[:,
-                                                                      None] < 0
+                        mask_hi = topk_indices - (
+                            chunk.cu_seqlen_ke[chunk_q_start:chunk_q_end] -
+                            chunk.cu_seqlen_ks[chunk_q_start:chunk_q_end]
+                        )[:, None] < 0
                         mask = mask_lo & mask_hi
 
                         # local indices per sequence
                         topk_indices = topk_indices.masked_fill(~mask, -1)
 
                         topk_indices_buffer[
-                            chunk.token_start:chunk.token_end, :topk_indices.
+                            global_q_start:global_q_end, :topk_indices.
                             shape[-1]] = topk_indices.to(dtype=torch.int32)
+
+                    if apply_q_split:
+                        q_sizes = [(r + 1) * chunk_num_token // tp_size -
+                                   r * chunk_num_token // tp_size
+                                   for r in range(tp_size)]
+                        topk_indices_buffer[
+                            chunk.token_start:chunk.token_end, :] = allgather(
+                                topk_indices_buffer[
+                                    global_q_start:global_q_end, :],
+                                metadata.mapping,
+                                dim=0,
+                                sizes=q_sizes)
             else:
                 # Fallback: single-pass indexer prefill (TODO: remove this once chunked prefill is fully tested)
                 cu_seqlen_ks = metadata.cu_seqlen_ks[:num_ctx_tokens]

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -514,12 +514,14 @@ class ModelConfig(Generic[TConfig]):
                         index_topk = sparse_attention_config.index_topk or pretrained_config.index_topk
                         indexer_max_chunk_size = sparse_attention_config.indexer_max_chunk_size
                         skip_indexer_for_short_seqs = sparse_attention_config.skip_indexer_for_short_seqs
+                        q_split_threshold = sparse_attention_config.q_split_threshold
                     else:
                         index_n_heads = pretrained_config.index_n_heads
                         index_head_dim = pretrained_config.index_head_dim
                         index_topk = pretrained_config.index_topk
                         indexer_max_chunk_size = None
                         skip_indexer_for_short_seqs = True
+                        q_split_threshold = 8192
                     kwargs[
                         'sparse_attention_config'] = DeepSeekSparseAttentionConfig(
                             index_n_heads=index_n_heads,
@@ -527,7 +529,8 @@ class ModelConfig(Generic[TConfig]):
                             index_topk=index_topk,
                             indexer_max_chunk_size=indexer_max_chunk_size,
                             skip_indexer_for_short_seqs=
-                            skip_indexer_for_short_seqs)
+                            skip_indexer_for_short_seqs,
+                            q_split_threshold=q_split_threshold)
             else:
                 raise ValueError(
                     "checkpoint_dir is None. Cannot load model config without a valid checkpoint directory."

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -275,6 +275,12 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
         default=True,
         description=
         "Whether to skip the MQA and Top-K in the indexer for short sequences.")
+    q_split_threshold: int = Field(
+        default=8192,
+        description=
+        "If number of packed tokens in prefill chunk exceeds this threshold, \
+            q tokens will be evenly distributed across ranks for indexer computation. \
+            If negative, q split will always be disabled.")
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3031,16 +3031,18 @@ class TestDeepSeekV32(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_mpi_world_size(8)
     @skip_pre_blackwell
     @pytest.mark.parametrize(
-        "tp_size,pp_size,ep_size,mtp_nextn,fp8kv,attention_dp,cuda_graph,overlap_scheduler,max_batch_size,moe_backend",
+        "tp_size,pp_size,ep_size,mtp_nextn,fp8kv,attention_dp,cuda_graph,overlap_scheduler,max_batch_size,moe_backend,q_split_threshold",
         [
-            (8, 1, 8, 0, True, True, True, True, 32, "CUTLASS"),
-            (8, 1, 8, 3, False, False, True, True, 1, "TRTLLM"),
+            (8, 1, 8, 0, True, True, True, True, 32, "CUTLASS", None),
+            (8, 1, 8, 3, False, False, True, True, 1, "TRTLLM", None),
+            (8, 1, 8, 3, False, False, True, True, 1, "TRTLLM", 0),
         ],
-        ids=["baseline_fp8kv", "latency"])
+        ids=["baseline_fp8kv", "latency", "latency_qsplit"])
     def test_nvfp4_multi_gpus_chunked_prefill(self, tp_size, pp_size, ep_size,
                                               mtp_nextn, fp8kv, attention_dp,
                                               cuda_graph, overlap_scheduler,
-                                              max_batch_size, moe_backend):
+                                              max_batch_size, moe_backend,
+                                              q_split_threshold):
         sm_version = get_sm_version()
         if moe_backend == "TRTLLM" and sm_version in (120, 121):
             pytest.skip(f"{moe_backend} backend does not support SM 120 or 121")
@@ -3061,6 +3063,12 @@ class TestDeepSeekV32(LlmapiAccuracyTestHarness):
         mtp_config = None
         if mtp_nextn > 0:
             mtp_config = MTPDecodingConfig(num_nextn_predict_layers=mtp_nextn)
+
+        dsa_config = None
+        if q_split_threshold is not None:
+            dsa_config = DeepSeekSparseAttentionConfig(
+                q_split_threshold=q_split_threshold)
+
         with LLM(f"{llm_models_root()}/DeepSeek-V3.2-Exp-FP4-v2",
                  max_batch_size=max_batch_size,
                  tensor_parallel_size=tp_size,
@@ -3070,6 +3078,7 @@ class TestDeepSeekV32(LlmapiAccuracyTestHarness):
                  **pytorch_config,
                  enable_attention_dp=attention_dp,
                  speculative_config=mtp_config,
+                 sparse_attention_config=dsa_config,
                  enable_chunked_prefill=True,
                  max_num_tokens=512) as llm:
 

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -150,6 +150,7 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[disable
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_pp4_mtp1]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[baseline_fp8kv]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[latency]
+accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[latency_qsplit]
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen3_4B::test_eagle3
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_fp8_block_scales[latency]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sparse attention support for distributed tensor parallel inference configurations, improving efficiency for multi-GPU model execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
This PR introduces token parallelism to the DSA indexer during chunked prefill, eliminating duplicated computation across ranks in long-sequence prefill scenarios when Tensor Parallelism  is applied to attention, improving efficiency for long-context cases.

This feature does not maintain any state across iterations, thus the q-split mode can be dynamically enabled or disabled using customized logic on top. 

By default, q tokens are evenly distributed across ranks for indexer computation when the number of packed tokens in a prefill chunk exceeds 8192 in an iteration. The threshold is configurable through `DeepSeekSparseAttentionConfig`. Setting it to any negative integer value disables the feature entirely. 

Example configuration:

```bash
sparse_attention_config:
	algorithm: dsa
	q_split_threshold: 8192 #default
```

Performance reference: In long-context benchmarking, we observe clear performance gains. For a 150k ISL sequence, TTFT improves by up to 2.3× with 32k chunk size at concurrency = 1, using TEP8 (nvfp4 checkpoint) on a single DGX node with 8×B200 GPUs.
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage
The changes focus on workflow optimization and do not introduce new components. Validation adds a new DeepSeek v3.2 chunked prefill end-to-end test in `test_llm_api_pytorch.py`. The test forces q-split to be always enabled (threshold=0). For testing purposes, the maximum number of tokens (thus restrict max context chunk size) is set to 512, targeting correctness validation rather than performance measurement.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
