### PR TITLE
[TRTLLM-11045][feat] Integrate SA with EAGLE3 and PARD

### DIFF
--- a/docs/source/features/speculative-decoding.md
+++ b/docs/source/features/speculative-decoding.md
@@ -48,6 +48,8 @@ speculative_config = Eagle3DecodingConfig(
 llm = LLM(model, speculative_config=speculative_config)
 ```
 
+EAGLE 3 can be combined with the [Suffix Automaton enhancement](#suffix-automaton-sa-enhancement) for improved acceptance rates on repetitive content. See the SA section below for details.
+
 ### NGram
 
 The NGram method is an implementation of [this Prompt Lookup Decoding algorithm](https://github.com/apoorvumang/prompt-lookup-decoding).
@@ -88,6 +90,29 @@ speculative_config = MTPDecodingConfig(
 llm = LLM("/path/to/deepseek_model", speculative_config=speculative_config)
 ```
 
+MTP can be combined with the [Suffix Automaton enhancement](#suffix-automaton-sa-enhancement) for improved acceptance rates on repetitive content. See the SA section below for details.
+
+### PARD
+
+PARD (PARallel Draft) is a target-independent speculative decoding method that predicts all draft tokens in a single forward pass using mask tokens. Unlike MTP or EAGLE 3 which generate drafts one token at a time, PARD produces K draft tokens in parallel.
+
+Reference: [PARD: Parallel Drafting for Speculative Decoding](https://arxiv.org/pdf/2504.18583)
+
+* `max_draft_len`: Maximum draft candidate length.
+* `speculative_model`: Path or HuggingFace model ID for the PARD draft model.
+* `mask_token_id`: Token ID used as the mask token for parallel prediction. If not set, it is read from the draft model config.
+
+```python
+from tensorrt_llm.llmapi import PARDDecodingConfig
+
+speculative_config = PARDDecodingConfig(
+    max_draft_len=4, speculative_model="/path/to/pard_model")
+
+llm = LLM("/path/to/target_model", speculative_config=speculative_config)
+```
+
+PARD can be combined with the [Suffix Automaton enhancement](#suffix-automaton-sa-enhancement) for improved acceptance rates on repetitive content. See the SA section below for details.
+
 ### User-provided drafting
 A completely user-defined drafting method can be supplied with a `UserProvidedDecodingConfig` that includes
 * `max_draft_len`: Maximum draft candidate length.
@@ -99,6 +124,40 @@ from tensorrt_llm.llmapi import UserProvidedDecodingConfig
 
 speculative_config = UserProvidedDecodingConfig(
     max_draft_len=3, drafter=MyDrafter())
+
+llm = LLM("/path/to/target_model", speculative_config=speculative_config)
+```
+
+## Suffix Automaton (SA) Enhancement
+
+The Suffix Automaton (SA) is a model-free, GPU-based pattern-matching draft enhancer. It finds suffix matches in previously generated tokens and proposes draft tokens when the match is long enough. SA is very accurate when it matches (exact pattern repetition), while neural methods are better for novel content — combining them gives the best of both worlds.
+
+SA can be combined with the following speculative decoding techniques:
+
+* **MTP** (`MTPDecodingConfig`)
+* **EAGLE 3** (`Eagle3DecodingConfig`)
+* **PARD** (`PARDDecodingConfig`)
+
+To enable SA combination, set `use_sa_spec=True` on the speculative config. The `sa_spec_threshold` parameter controls the minimum suffix match length required to override the neural draft (default: 4).
+
+```python
+from tensorrt_llm.llmapi import Eagle3DecodingConfig
+
+speculative_config = Eagle3DecodingConfig(
+    max_draft_len=4,
+    speculative_model="/path/to/eagle3_model",
+    use_sa_spec=True,
+    sa_spec_threshold=4)
+
+llm = LLM("/path/to/target_model", speculative_config=speculative_config)
+```
+
+SA can also be used as a standalone speculative decoding technique via `SADecodingConfig`:
+
+```python
+from tensorrt_llm.llmapi import SADecodingConfig
+
+speculative_config = SADecodingConfig(max_draft_len=4)
 
 llm = LLM("/path/to/target_model", speculative_config=speculative_config)
 ```
@@ -117,6 +176,8 @@ Speculative decoding options must be specified via `--config config.yaml` for bo
 * `Eagle3`
 * `NGram`
 * `DraftTarget`
+* `PARD`
+* `SA`
 
 > Note: The PyTorch backend supports only `Eagle3`. `decoding_type: Eagle` is accepted as a backward-compatible alias for `Eagle3`, but EAGLE (v1/v2) draft checkpoints are incompatible.
 
@@ -136,6 +197,16 @@ speculative_config:
   decoding_type: Eagle3
   max_draft_len: 4
   speculative_model: /path/to/draft/model
+```
+
+```yaml
+# SA combination: enable Suffix Automaton enhancement with any supported technique
+speculative_config:
+  decoding_type: Eagle3
+  max_draft_len: 4
+  speculative_model: /path/to/draft/model
+  use_sa_spec: true
+  sa_spec_threshold: 4
 ```
 
 ```{note}

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3,7 +3,6 @@ import contextlib
 import functools
 import gc
 import inspect
-import itertools
 import math
 import os
 import weakref
@@ -3472,9 +3471,7 @@ class PyTorchModelEngine(ModelEngine):
                 else:
                     sa_manager = getattr(spec_rm, 'sa_manager', None)
             if sa_manager is not None:
-                for request in itertools.chain(
-                        scheduled_requests.context_requests,
-                        scheduled_requests.generation_requests):
+                for request in scheduled_requests.all_requests():
                     if request.py_request_id not in sa_manager._initialized_requests:
                         sa_manager.add_request(request.py_request_id,
                                                request.get_tokens(0))

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3456,21 +3456,24 @@ class PyTorchModelEngine(ModelEngine):
                 raise NotImplementedError(
                     f"Unsupported cp_type {getattr(cp_type, 'name', cp_type)}.")
 
-        # Initialize SA state for new requests (MTP+SA path)
+        # Initialize SA state for new requests (MTP+SA, EAGLE3+SA, etc.)
         use_sa_spec = (self.spec_config is not None
                        and getattr(self.spec_config, 'use_sa_spec', False))
-        if (use_sa_spec and spec_metadata is not None
-                and hasattr(spec_metadata, 'sa_manager')
-                and spec_metadata.sa_manager is not None
-                and self.mapping.is_last_pp_rank()):
-            sa_manager = spec_metadata.sa_manager
-            for request in itertools.chain(
-                    scheduled_requests.context_requests,
-                    scheduled_requests.generation_requests):
-                if request.py_request_id not in sa_manager._initialized_requests:
-                    sa_manager.add_request(request.py_request_id,
-                                           request.get_tokens(0))
-                    sa_manager._initialized_requests.add(request.py_request_id)
+        if use_sa_spec and resource_manager is not None and self.mapping.is_last_pp_rank(
+        ):
+            spec_rm = resource_manager.get_resource_manager(
+                ResourceManagerType.SPEC_RESOURCE_MANAGER)
+            sa_manager = getattr(spec_rm, 'sa_manager',
+                                 None) if spec_rm is not None else None
+            if sa_manager is not None:
+                for request in itertools.chain(
+                        scheduled_requests.context_requests,
+                        scheduled_requests.generation_requests):
+                    if request.py_request_id not in sa_manager._initialized_requests:
+                        sa_manager.add_request(request.py_request_id,
+                                               request.get_tokens(0))
+                        sa_manager._initialized_requests.add(
+                            request.py_request_id)
 
         return self._prepare_tp_inputs(
             scheduled_requests, kv_cache_manager, attn_metadata, spec_metadata,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3456,15 +3456,21 @@ class PyTorchModelEngine(ModelEngine):
                 raise NotImplementedError(
                     f"Unsupported cp_type {getattr(cp_type, 'name', cp_type)}.")
 
-        # Initialize SA state for new requests (MTP+SA, EAGLE3+SA, etc.)
+        # Initialize SA state for new requests (MTP+SA, EAGLE3+SA, PARD+SA, etc.)
         use_sa_spec = (self.spec_config is not None
                        and getattr(self.spec_config, 'use_sa_spec', False))
         if use_sa_spec and resource_manager is not None and self.mapping.is_last_pp_rank(
         ):
+            from tensorrt_llm._torch.speculative.suffix_automaton import \
+                SuffixAutomatonManager
             spec_rm = resource_manager.get_resource_manager(
                 ResourceManagerType.SPEC_RESOURCE_MANAGER)
-            sa_manager = getattr(spec_rm, 'sa_manager',
-                                 None) if spec_rm is not None else None
+            sa_manager = None
+            if spec_rm is not None:
+                if isinstance(spec_rm, SuffixAutomatonManager):
+                    sa_manager = spec_rm
+                else:
+                    sa_manager = getattr(spec_rm, 'sa_manager', None)
             if sa_manager is not None:
                 for request in itertools.chain(
                         scheduled_requests.context_requests,

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -5,6 +5,7 @@ from .interface import (SpecMetadata, SpecWorkerBase,
 from .mtp import MTPEagleWorker, MTPSampler, MTPSpecMetadata, MTPWorker
 from .ngram import NGramDrafter, NGramPoolManager
 from .pard import PARDSpecMetadata, PARDWorker
+from .sa_enhancer import SADraftEnhancer
 from .sa_worker import SASampler, SASpecMetadata, SAWorker
 from .save_hidden_state import (SaveHiddenStatesResourceManager,
                                 SaveHiddenStatesSpecMetadata)
@@ -27,6 +28,7 @@ __all__ = [
     "NGramPoolManager",
     "PARDSpecMetadata",
     "PARDWorker",
+    "SADraftEnhancer",
     "SASampler",
     "SASpecMetadata",
     "SAWorker",

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -565,6 +565,14 @@ class Eagle3OneModelWorker(SpecWorkerBase):
                 }
         next_draft_tokens = torch.stack(next_draft_tokens, dim=1)
 
+        # Override with SA draft tokens after all draft layers have run,
+        # so that draft layers never see SA tokens in their inputs.
+        if self.sa_enhancer is not None:
+            gen_draft_tokens = next_draft_tokens[num_contexts:]
+            gen_draft_tokens = self.sa_enhancer.maybe_override_all_draft_tokens(
+                gen_draft_tokens)
+            next_draft_tokens[num_contexts:] = gen_draft_tokens
+
         # restore attn_metadata to support cuda graph
         self._restore_attn_metadata_from_spec_dec(attn_metadata)
         # restore all_rank_num_tokens for attention DP
@@ -627,13 +635,6 @@ class Eagle3OneModelWorker(SpecWorkerBase):
 
         d2t = getattr(draft_model.model, "d2t", None)
         draft_tokens = self._draft_sampler_greedy(logits, d2t)
-
-        if self.sa_enhancer is not None:
-            num_contexts = draft_tokens.shape[0] - (
-                self.sa_enhancer.sa_match_len.shape[0]
-                if self.sa_enhancer.sa_match_len is not None else 0)
-            draft_tokens = self.sa_enhancer.maybe_override_draft_tokens(
-                draft_tokens, num_contexts)
 
         return draft_tokens
 

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -14,6 +14,7 @@ from ..pyexecutor.sampler import TorchSampler
 from ..pyexecutor.scheduler import ScheduledRequests
 from .interface import SpecMetadata, SpecWorkerBase
 from .mtp import MTPSampler
+from .sa_enhancer import SADraftEnhancer
 from .spec_tree_manager import SpecTreeManager
 
 if TYPE_CHECKING:
@@ -27,14 +28,21 @@ class Eagle3ResourceManager(BaseResourceManager):
     and one for the draft model. Use this class to manage the hidden states.
     """
 
-    def __init__(self, config: "EagleDecodingConfig", dtype: torch.dtype,
-                 hidden_size: int, max_num_requests: int, max_seq_len: int,
-                 max_num_tokens: int):
+    def __init__(self,
+                 config: "EagleDecodingConfig",
+                 dtype: torch.dtype,
+                 hidden_size: int,
+                 max_num_requests: int,
+                 max_seq_len: int,
+                 max_num_tokens: int,
+                 sa_manager=None):
         self.dtype = dtype
         self.max_draft_len = config.max_draft_len
         self.hidden_size = hidden_size
         self.max_num_requests = max_num_requests
         self.max_seq_len = max_seq_len
+        # Optional SA manager for EAGLE3+SA mode
+        self.sa_manager = sa_manager
         # There could be dummy request for padding batch when using CUDA graph.
         # Reserve one more slot for the dummy request.
         slot_size = self.max_seq_len + 1
@@ -94,13 +102,18 @@ class Eagle3ResourceManager(BaseResourceManager):
         self.seq_lens[slot_id] = 0
         self.start_indices[slot_id] = 0
         self.slot_manager.remove_slot(request.request_id)
+        if self.sa_manager is not None:
+            self.sa_manager.remove_request(request.request_id)
 
     def add_dummy_requests(self, request_ids: List[int]):
         for rid in request_ids:
             self.slot_manager.add_slot(rid)
+        if self.sa_manager is not None:
+            self.sa_manager.add_dummy_requests(request_ids)
 
     def shutdown(self):
-        pass
+        if self.sa_manager is not None:
+            self.sa_manager.shutdown()
 
     def get_max_resource_count(self) -> int:
         return self.max_num_requests
@@ -298,6 +311,8 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
     dtype: torch.dtype = torch.bfloat16
     # The index of the batche inputs
     batch_indices_cuda: Optional[torch.Tensor] = None
+    # Optional resource manager (used to access SA manager for EAGLE3+SA)
+    spec_resource_manager: Optional[Eagle3ResourceManager] = None
 
     def __post_init__(self):
         if self.layers_to_capture is None:
@@ -345,6 +360,12 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
                                                  non_blocking=True)
         self.num_tokens -= (self.num_generations) * self.max_draft_len
 
+        sa_manager = getattr(self.spec_resource_manager, 'sa_manager', None)
+        if sa_manager is not None:
+            gen_request_ids = self.request_ids[num_seqs - self.num_generations:]
+            if gen_request_ids:
+                sa_manager.prepare(gen_request_ids, self.max_draft_len)
+
     def maybe_capture_hidden_states(
             self,
             layer_id: int,
@@ -375,6 +396,9 @@ class Eagle3OneModelWorker(SpecWorkerBase):
         super().__init__(use_separate_draft_kv_cache)
         self.spec_config = spec_config
         self.mapping = mapping
+        self.sa_enhancer: Optional[SADraftEnhancer] = None
+        if getattr(spec_config, 'use_sa_spec', False):
+            self.sa_enhancer = SADraftEnhancer(spec_config.sa_spec_threshold)
 
     @property
     def max_draft_len(self) -> int:
@@ -423,6 +447,19 @@ class Eagle3OneModelWorker(SpecWorkerBase):
         # Sample and accept tokens
         accepted_tokens, num_accepted_tokens = self.sample_and_accept_draft_tokens(
             logits, attn_metadata, spec_metadata)
+
+        sa_manager = getattr(spec_metadata.spec_resource_manager, 'sa_manager',
+                             None)
+        if self.sa_enhancer is not None and sa_manager is not None:
+            self.sa_enhancer.extend_and_prepare(
+                sa_manager=sa_manager,
+                request_ids=spec_metadata.request_ids,
+                accepted_tokens=accepted_tokens,
+                num_accepted_tokens=num_accepted_tokens,
+                num_gens=num_gens,
+                num_contexts=num_contexts,
+                max_draft_len=self.max_draft_len,
+            )
 
         # Save the old attn_metadata and spec_metadata
         self._prepare_attn_metadata_for_spec_dec(attn_metadata)
@@ -588,11 +625,17 @@ class Eagle3OneModelWorker(SpecWorkerBase):
                 Draft token ids. Flattened.
         '''
 
-        # Note: using greedy for draft tokens is a bit easier to implement and
-        # faster. It doesn't affect the final output and seems to have a negligible
-        # impact on AR.
         d2t = getattr(draft_model.model, "d2t", None)
-        return self._draft_sampler_greedy(logits, d2t)
+        draft_tokens = self._draft_sampler_greedy(logits, d2t)
+
+        if self.sa_enhancer is not None:
+            num_contexts = draft_tokens.shape[0] - (
+                self.sa_enhancer.sa_match_len.shape[0]
+                if self.sa_enhancer.sa_match_len is not None else 0)
+            draft_tokens = self.sa_enhancer.maybe_override_draft_tokens(
+                draft_tokens, num_contexts)
+
+        return draft_tokens
 
     def prepare_1st_drafter_inputs(
         self,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -18,8 +18,8 @@ from ..pyexecutor.resource_manager import BaseResourceManager, SlotManager
 from ..pyexecutor.sampler import TorchSampler
 from ..pyexecutor.scheduler import ScheduledRequests
 from .interface import SpecMetadata, SpecWorkerBase
+from .sa_enhancer import SADraftEnhancer
 from .spec_sampler_base import SampleStateSpec, SpecSamplerBase
-from .suffix_automaton import SuffixAutomatonManager
 
 if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import MTPDecodingConfig
@@ -128,8 +128,6 @@ class MTPSpecMetadata(SpecMetadata):
     # CUDA graph, we use this tensor to store the number of input tokens for the
     # subsequence draft forward.
     subseq_all_rank_num_tokens: Optional[List[int]] = None
-    # Optional suffix automaton manager for MTP+SA speculative decoding
-    sa_manager: Optional[SuffixAutomatonManager] = None
 
     def __post_init__(self) -> None:
         if self.mtp_hidden_states_manager is not None:
@@ -221,12 +219,12 @@ class MTPSpecMetadata(SpecMetadata):
                                         pin_memory=prefer_pinned())
             self.slot_ids[:num_seqs].copy_(mtp_slot_ids, non_blocking=True)
 
-        # Prepare SA manager for MTP+SA path (copies pending states to GPU)
-        if self.sa_manager is not None:
+        sa_manager = getattr(self.mtp_hidden_states_manager, 'sa_manager', None)
+        if sa_manager is not None:
             num_contexts = num_seqs - self.num_generations
             gen_request_ids = self.request_ids[num_contexts:]
             if gen_request_ids:
-                self.sa_manager.prepare(gen_request_ids, self.max_draft_len)
+                sa_manager.prepare(gen_request_ids, self.max_draft_len)
 
 
 class MTPSampler(SpecSamplerBase):
@@ -272,10 +270,9 @@ class MTPWorker(SpecWorkerBase):
         self.spec_config = spec_config
         self.model_config = model_config
         self.is_thop = False
-        # Initialize SA spec attributes
-        self.sa_match_len = None
-        self.sa_draft_tokens = None
-        self.sa_spec_index = 0
+        self.sa_enhancer: Optional[SADraftEnhancer] = None
+        if spec_config.use_sa_spec:
+            self.sa_enhancer = SADraftEnhancer(spec_config.sa_spec_threshold)
 
     @property
     def max_draft_len(self) -> int:
@@ -834,30 +831,18 @@ class MTPWorker(SpecWorkerBase):
                     logits, draft_tokens, num_contexts, batch_size,
                     spec_metadata)
 
-        if self.spec_config.use_sa_spec and spec_metadata.sa_manager is not None:
-
-            # Initialize the output buffers
-            self.sa_match_len = torch.zeros((num_gens, ),
-                                            dtype=torch.int32,
-                                            device="cuda")
-            self.sa_draft_tokens = torch.zeros((num_gens, mtp_num_modules),
-                                               dtype=torch.int32,
-                                               device="cuda")
-
-            self.sa_spec_index = 0
-
-            # Invoke a batch update of the suffix automaton states
-            # and get the next suffix draft tokens
-            if num_gens > 0:
-                gen_request_ids = spec_metadata.request_ids[num_contexts:]
-                match_len, draft_tokens_sa = spec_metadata.sa_manager.extend(
-                    gen_request_ids,
-                    accepted_tokens[num_contexts:],
-                    num_accepted_tokens[num_contexts:],
-                    mtp_num_modules,
-                )
-                self.sa_match_len.copy_(match_len)
-                self.sa_draft_tokens.copy_(draft_tokens_sa)
+        sa_manager = getattr(spec_metadata.mtp_hidden_states_manager,
+                             'sa_manager', None)
+        if self.sa_enhancer is not None and sa_manager is not None:
+            self.sa_enhancer.extend_and_prepare(
+                sa_manager=sa_manager,
+                request_ids=spec_metadata.request_ids,
+                accepted_tokens=accepted_tokens,
+                num_accepted_tokens=num_accepted_tokens,
+                num_gens=num_gens,
+                num_contexts=num_contexts,
+                max_draft_len=mtp_num_modules,
+            )
 
         return accepted_tokens, num_accepted_tokens
 
@@ -1109,18 +1094,12 @@ class MTPWorker(SpecWorkerBase):
             # Simple argmax if no TP or no model config
             draft_tokens = self._draft_sampler_greedy(logits)
 
-        # select between MTP draft tokens and SA draft tokens
-        # Check sa_match_len is not None to handle case where use_sa_spec is True
-        if self.spec_config.use_sa_spec and self.sa_match_len is not None and (
-                num_gens := self.sa_match_len.shape[0]) > 0:
-            num_contexts = draft_tokens.shape[0] - num_gens
-
-            draft_tokens[num_contexts:] = torch.where(
-                self.sa_match_len >= self.spec_config.sa_spec_threshold,
-                self.sa_draft_tokens[:, self.sa_spec_index],
-                draft_tokens[num_contexts:])
-
-            self.sa_spec_index += 1
+        if self.sa_enhancer is not None:
+            num_contexts = draft_tokens.shape[0] - (
+                self.sa_enhancer.sa_match_len.shape[0]
+                if self.sa_enhancer.sa_match_len is not None else 0)
+            draft_tokens = self.sa_enhancer.maybe_override_draft_tokens(
+                draft_tokens, num_contexts)
 
         return draft_tokens
 

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -465,6 +465,15 @@ class MTPWorker(SpecWorkerBase):
                 }
             next_draft_tokens = torch.stack(next_draft_tokens, dim=1)
 
+        # Override with SA draft tokens after all MTP layers have run,
+        # so that MTP layers never see SA tokens in their inputs.
+        if self.sa_enhancer is not None:
+            num_contexts = attn_metadata.num_contexts
+            gen_draft_tokens = next_draft_tokens[num_contexts:]
+            gen_draft_tokens = self.sa_enhancer.maybe_override_all_draft_tokens(
+                gen_draft_tokens)
+            next_draft_tokens[num_contexts:] = gen_draft_tokens
+
         # restore attn metadata
         if attn_metadata is not None:
             self._restore_attn_metadata_from_spec_dec(attn_metadata)
@@ -1094,13 +1103,6 @@ class MTPWorker(SpecWorkerBase):
             # Simple argmax if no TP or no model config
             draft_tokens = self._draft_sampler_greedy(logits)
 
-        if self.sa_enhancer is not None:
-            num_contexts = draft_tokens.shape[0] - (
-                self.sa_enhancer.sa_match_len.shape[0]
-                if self.sa_enhancer.sa_match_len is not None else 0)
-            draft_tokens = self.sa_enhancer.maybe_override_draft_tokens(
-                draft_tokens, num_contexts)
-
         return draft_tokens
 
 
@@ -1307,6 +1309,17 @@ class MTPEagleWorker(MTPWorker):
 
         # restore attn_metadata to support cuda graph
         self._restore_attn_metadata_from_spec_dec(attn_metadata)
+
+        # Override with SA draft tokens after all MTP layers have run,
+        # so that MTP layers never see SA tokens in their inputs.
+        # Must happen before stacking since next_draft_tokens is still a list.
+        if self.sa_enhancer is not None:
+            stacked = torch.stack(next_draft_tokens, dim=1)
+            gen_draft_tokens = stacked[num_contexts:]
+            gen_draft_tokens = self.sa_enhancer.maybe_override_all_draft_tokens(
+                gen_draft_tokens)
+            stacked[num_contexts:] = gen_draft_tokens
+            next_draft_tokens = [stacked[:, i] for i in range(stacked.shape[1])]
 
         next_draft_tokens, next_new_tokens = self._prepare_next_tokens(
             next_draft_tokens, accepted_tokens, spec_metadata, batch_size,

--- a/tensorrt_llm/_torch/speculative/pard.py
+++ b/tensorrt_llm/_torch/speculative/pard.py
@@ -9,7 +9,9 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
+from ..pyexecutor.resource_manager import BaseResourceManager
 from .interface import SpecMetadata, SpecWorkerBase
+from .sa_enhancer import SADraftEnhancer
 
 if TYPE_CHECKING:
     from ...llmapi.llm_args import PARDDecodingConfig
@@ -20,6 +22,8 @@ class PARDSpecMetadata(SpecMetadata):
     """Metadata for PARD speculative decoding."""
 
     batch_indices_cuda: Optional[torch.Tensor] = None
+    # Optional resource manager (used to access SA manager for PARD+SA)
+    spec_resource_manager: Optional[BaseResourceManager] = None
 
     def __post_init__(self):
         self.batch_indices_cuda = torch.empty(
@@ -39,6 +43,27 @@ class PARDSpecMetadata(SpecMetadata):
             num_seqs, dtype=torch.int, device="cpu", pin_memory=prefer_pinned()
         )
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices, non_blocking=True)
+
+        sa_manager = self._get_sa_manager()
+        if sa_manager is not None:
+            gen_request_ids = self.request_ids[num_seqs - self.num_generations :]
+            if gen_request_ids:
+                sa_manager.prepare(gen_request_ids, self.max_draft_len)
+
+    def _get_sa_manager(self):
+        """Get SA manager from spec_resource_manager.
+
+        For PARD+SA the resource manager IS the SuffixAutomatonManager,
+        while for other techniques it's accessed via a .sa_manager attribute.
+        """
+        from .suffix_automaton import SuffixAutomatonManager
+
+        rm = self.spec_resource_manager
+        if rm is None:
+            return None
+        if isinstance(rm, SuffixAutomatonManager):
+            return rm
+        return getattr(rm, "sa_manager", None)
 
 
 class PARDWorker(SpecWorkerBase):
@@ -63,6 +88,9 @@ class PARDWorker(SpecWorkerBase):
         super().__init__(use_separate_draft_kv_cache)
         self.spec_config = spec_config
         self.mapping = mapping
+        self.sa_enhancer: Optional[SADraftEnhancer] = None
+        if getattr(spec_config, "use_sa_spec", False):
+            self.sa_enhancer = SADraftEnhancer(spec_config.sa_spec_threshold)
         logger.info(
             f"PARDWorker initialized with use_separate_draft_kv_cache={use_separate_draft_kv_cache}"
         )
@@ -193,6 +221,18 @@ class PARDWorker(SpecWorkerBase):
             )
             accepted_tokens = torch.cat([accepted_tokens, acc_padding], dim=1)
 
+        sa_manager = spec_metadata._get_sa_manager() if self.sa_enhancer else None
+        if self.sa_enhancer is not None and sa_manager is not None:
+            self.sa_enhancer.extend_and_prepare(
+                sa_manager=sa_manager,
+                request_ids=spec_metadata.request_ids,
+                accepted_tokens=accepted_tokens,
+                num_accepted_tokens=num_accepted_tokens,
+                num_gens=num_gens,
+                num_contexts=num_contexts,
+                max_draft_len=K,
+            )
+
         self._prepare_attn_metadata_for_pard(attn_metadata, spec_metadata)
         self._prepare_kv_for_draft_forward(
             attn_metadata, num_accepted_tokens, num_contexts, batch_size
@@ -251,6 +291,11 @@ class PARDWorker(SpecWorkerBase):
                     gen_draft_tokens = d2t[gen_draft_tokens] + gen_draft_tokens
 
                 gen_draft_tokens = gen_draft_tokens.type(torch.int32)
+
+                if self.sa_enhancer is not None and sa_manager is not None:
+                    gen_draft_tokens = self.sa_enhancer.maybe_override_all_draft_tokens(
+                        gen_draft_tokens
+                    )
 
                 # Pad from (num_gens, K) to (num_gens, 2K-1).
                 if K > 1:

--- a/tensorrt_llm/_torch/speculative/sa_enhancer.py
+++ b/tensorrt_llm/_torch/speculative/sa_enhancer.py
@@ -36,8 +36,8 @@ class SADraftEnhancer:
     Usage:
         1. Construct once during worker ``__init__`` when ``use_sa_spec`` is True.
         2. Call ``extend_and_prepare`` after ``sample_and_accept_draft_tokens``.
-        3. Call ``maybe_override_draft_tokens`` inside each draft step (per-layer
-           workers like MTP/EAGLE3) or once after all drafts are produced (PARD).
+        3. Call ``maybe_override_all_draft_tokens`` once after all draft layers
+           have finished, so that neural draft layers never see SA tokens.
     """
 
     def __init__(self, sa_spec_threshold: int):
@@ -87,41 +87,14 @@ class SADraftEnhancer:
             self.sa_match_len.copy_(match_len)
             self.sa_draft_tokens.copy_(draft_tokens_sa)
 
-    def maybe_override_draft_tokens(
-        self,
-        draft_tokens: torch.Tensor,
-        num_contexts: int,
-    ) -> torch.Tensor:
-        """Override neural draft tokens with SA draft tokens where match is strong.
-
-        For per-layer workers (MTP, EAGLE3), call this once per draft step —
-        it automatically advances ``sa_spec_index``.
-
-        Args:
-            draft_tokens: [batch_size] draft tokens from the neural drafter.
-            num_contexts: Number of context requests in the batch.
-
-        Returns:
-            The (potentially overridden) draft tokens tensor.
-        """
-        if self.sa_match_len is not None and self.sa_match_len.shape[0] > 0:
-            draft_tokens[num_contexts:] = torch.where(
-                self.sa_match_len >= self.sa_spec_threshold,
-                self.sa_draft_tokens[:, self.sa_spec_index],
-                draft_tokens[num_contexts:],
-            )
-            self.sa_spec_index += 1
-
-        return draft_tokens
-
     def maybe_override_all_draft_tokens(
         self,
         draft_tokens: torch.Tensor,
     ) -> torch.Tensor:
-        """Override all K draft positions at once (for parallel-draft workers like PARD).
+        """Override all K draft positions at once.
 
-        Unlike ``maybe_override_draft_tokens`` which overrides one position per
-        call, this method overrides all K columns in a single vectorized operation.
+        Used by all one-engine workers (MTP, EAGLE3, PARD) to override neural
+        draft tokens with SA tokens after the draft loop completes.
 
         Args:
             draft_tokens: [num_gens, K] draft tokens from the neural drafter.

--- a/tensorrt_llm/_torch/speculative/sa_enhancer.py
+++ b/tensorrt_llm/_torch/speculative/sa_enhancer.py
@@ -64,7 +64,8 @@ class SADraftEnhancer:
         Args:
             sa_manager: The SuffixAutomatonManager instance.
             request_ids: Full request ID list (contexts + generations).
-            accepted_tokens: [batch_size, max_draft_len + 1] accepted tokens.
+            accepted_tokens: [batch_size, padded_width] accepted tokens
+                (may be wider than max_draft_len + 1 due to caller padding).
             num_accepted_tokens: [batch_size] number of accepted tokens.
             num_gens: Number of generation requests in the batch.
             num_contexts: Number of context requests in the batch.
@@ -78,9 +79,16 @@ class SADraftEnhancer:
 
         if num_gens > 0:
             gen_request_ids = request_ids[num_contexts:]
+            # The CUDA kernel indexes accepted tokens as
+            #   acceptedTokensIn[i * (draftLength + 1) + j]
+            # so the physical stride must equal max_draft_len + 1.
+            # Callers like PARD pad accepted_tokens to [batch, 2K]; the
+            # slice + .contiguous() below compacts memory so the stride
+            # matches the kernel expectation.
+            gen_accepted = accepted_tokens[num_contexts:, : max_draft_len + 1].contiguous()
             match_len, draft_tokens_sa = sa_manager.extend(
                 gen_request_ids,
-                accepted_tokens[num_contexts:],
+                gen_accepted,
                 num_accepted_tokens[num_contexts:],
                 max_draft_len,
             )

--- a/tensorrt_llm/_torch/speculative/sa_enhancer.py
+++ b/tensorrt_llm/_torch/speculative/sa_enhancer.py
@@ -113,3 +113,27 @@ class SADraftEnhancer:
             self.sa_spec_index += 1
 
         return draft_tokens
+
+    def maybe_override_all_draft_tokens(
+        self,
+        draft_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Override all K draft positions at once (for parallel-draft workers like PARD).
+
+        Unlike ``maybe_override_draft_tokens`` which overrides one position per
+        call, this method overrides all K columns in a single vectorized operation.
+
+        Args:
+            draft_tokens: [num_gens, K] draft tokens from the neural drafter.
+
+        Returns:
+            The (potentially overridden) draft tokens tensor.
+        """
+        if self.sa_match_len is not None and self.sa_match_len.shape[0] > 0:
+            K = draft_tokens.shape[1]
+            mask = (
+                (self.sa_match_len >= self.sa_spec_threshold).unsqueeze(1).expand_as(draft_tokens)
+            )
+            draft_tokens = torch.where(mask, self.sa_draft_tokens[:, :K], draft_tokens)
+
+        return draft_tokens

--- a/tensorrt_llm/_torch/speculative/sa_enhancer.py
+++ b/tensorrt_llm/_torch/speculative/sa_enhancer.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Composable SA (Suffix Automaton) draft enhancer for one-engine speculative decoding workers.
+
+When enabled, SA pattern matching overrides neural draft tokens for requests
+where the suffix match length exceeds the configured threshold.
+"""
+
+from typing import List, Optional
+
+import torch
+
+from .suffix_automaton import SuffixAutomatonManager
+
+
+class SADraftEnhancer:
+    """Composable SA enhancement for any one-engine spec worker.
+
+    This class encapsulates all SA-specific logic (extend, prepare buffers,
+    override draft tokens) so that any worker (MTP, EAGLE3, PARD, etc.) can
+    opt into SA enhancement.
+
+    Usage:
+        1. Construct once during worker ``__init__`` when ``use_sa_spec`` is True.
+        2. Call ``extend_and_prepare`` after ``sample_and_accept_draft_tokens``.
+        3. Call ``maybe_override_draft_tokens`` inside each draft step (per-layer
+           workers like MTP/EAGLE3) or once after all drafts are produced (PARD).
+    """
+
+    def __init__(self, sa_spec_threshold: int):
+        self.sa_spec_threshold = sa_spec_threshold
+        self.sa_match_len: Optional[torch.Tensor] = None
+        self.sa_draft_tokens: Optional[torch.Tensor] = None
+        self.sa_spec_index: int = 0
+
+    def extend_and_prepare(
+        self,
+        sa_manager: SuffixAutomatonManager,
+        request_ids: List[int],
+        accepted_tokens: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        num_gens: int,
+        num_contexts: int,
+        max_draft_len: int,
+    ) -> None:
+        """Extend SA states with accepted tokens and prepare override buffers.
+
+        Must be called after ``sample_and_accept_draft_tokens`` and before the
+        draft generation loop.
+
+        Args:
+            sa_manager: The SuffixAutomatonManager instance.
+            request_ids: Full request ID list (contexts + generations).
+            accepted_tokens: [batch_size, max_draft_len + 1] accepted tokens.
+            num_accepted_tokens: [batch_size] number of accepted tokens.
+            num_gens: Number of generation requests in the batch.
+            num_contexts: Number of context requests in the batch.
+            max_draft_len: Number of draft positions to produce.
+        """
+        self.sa_match_len = torch.zeros((num_gens,), dtype=torch.int32, device="cuda")
+        self.sa_draft_tokens = torch.zeros(
+            (num_gens, max_draft_len), dtype=torch.int32, device="cuda"
+        )
+        self.sa_spec_index = 0
+
+        if num_gens > 0:
+            gen_request_ids = request_ids[num_contexts:]
+            match_len, draft_tokens_sa = sa_manager.extend(
+                gen_request_ids,
+                accepted_tokens[num_contexts:],
+                num_accepted_tokens[num_contexts:],
+                max_draft_len,
+            )
+            self.sa_match_len.copy_(match_len)
+            self.sa_draft_tokens.copy_(draft_tokens_sa)
+
+    def maybe_override_draft_tokens(
+        self,
+        draft_tokens: torch.Tensor,
+        num_contexts: int,
+    ) -> torch.Tensor:
+        """Override neural draft tokens with SA draft tokens where match is strong.
+
+        For per-layer workers (MTP, EAGLE3), call this once per draft step —
+        it automatically advances ``sa_spec_index``.
+
+        Args:
+            draft_tokens: [batch_size] draft tokens from the neural drafter.
+            num_contexts: Number of context requests in the batch.
+
+        Returns:
+            The (potentially overridden) draft tokens tensor.
+        """
+        if self.sa_match_len is not None and self.sa_match_len.shape[0] > 0:
+            draft_tokens[num_contexts:] = torch.where(
+                self.sa_match_len >= self.sa_spec_threshold,
+                self.sa_draft_tokens[:, self.sa_spec_index],
+                draft_tokens[num_contexts:],
+            )
+            self.sa_spec_index += 1
+
+        return draft_tokens

--- a/tensorrt_llm/_torch/speculative/sa_worker.py
+++ b/tensorrt_llm/_torch/speculative/sa_worker.py
@@ -81,7 +81,6 @@ class SASpecMetadata(SpecMetadata):
         )
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices, non_blocking=True)
 
-        # Prepare SA manager (copies pending states to GPU)
         if self.sa_manager is not None:
             self.sa_manager.prepare(self.request_ids, self.max_draft_len)
         else:

--- a/tensorrt_llm/_torch/speculative/suffix_automaton.py
+++ b/tensorrt_llm/_torch/speculative/suffix_automaton.py
@@ -126,6 +126,11 @@ class SuffixAutomatonManager(BaseResourceManager):
         # Track which requests have been initialized (for prepare_resources)
         self._initialized_requests: Set[int] = set()
 
+        # Reserved slot for CUDA graph dummy requests — shared by all dummies
+        # so they never consume slots from the real pool.
+        self._dummy_slot_index: int = max_num_requests
+        self._dummy_request_ids: Set[int] = set()
+
     def _ensure_workspace(self, max_draft_len: int):
         """Ensure GPU workspace is allocated with sufficient capacity.
 
@@ -146,9 +151,19 @@ class SuffixAutomatonManager(BaseResourceManager):
             self._gpu_batch_indices = torch.zeros(
                 (self.max_num_requests,), dtype=torch.int32, device="cuda"
             )
+            # Mask: 1 for real requests, 0 for dummies. Populated by
+            # prepare() (outside CUDA graph) and used by extend() (inside
+            # CUDA graph) to zero out dummy entries without Python control
+            # flow that would break graph capture.
+            self._gpu_nondummy_mask = torch.ones(
+                (self.max_num_requests,), dtype=torch.int32, device="cuda"
+            )
 
-            # Allocate GPU workspace for SA states with dynamic size
-            self._gpu_slots = _sa_native.allocate_workspace(self.max_num_requests, self.max_seq_len)
+            # Allocate one extra slot beyond max_num_requests for the shared
+            # CUDA graph dummy (slot index = max_num_requests).
+            self._gpu_slots = _sa_native.allocate_workspace(
+                self.max_num_requests + 1, self.max_seq_len
+            )
 
             self._allocated_max_draft_len = max_draft_len
             self._workspace_allocated = True
@@ -200,13 +215,17 @@ class SuffixAutomatonManager(BaseResourceManager):
             return
 
         slot = self._request_to_slot.pop(request_id)
-        self._free_slots.append(slot)
+
+        if request_id in self._dummy_request_ids:
+            # Dummy slot is reserved; never return it to the free pool.
+            self._dummy_request_ids.discard(request_id)
+        else:
+            self._free_slots.append(slot)
 
         self._host_states_native.pop(request_id, None)
         self._pending_copies.discard(request_id)
         self._initialized_requests.discard(request_id)
 
-        # Clear the GPU slot
         if self._gpu_slots is not None:
             _sa_native.clear_slot(self._gpu_slots, slot, self.max_seq_len)
 
@@ -235,24 +254,27 @@ class SuffixAutomatonManager(BaseResourceManager):
                     )
             self._pending_copies.clear()
 
-        # Validate request_ids and prepare batch indices
-        # Do not use a default fallback - unknown request IDs would corrupt slot 0's state
-        unknown_rids = [rid for rid in request_ids if rid not in self._request_to_slot]
-        if unknown_rids:
-            raise KeyError(
-                f"SuffixAutomatonManager.prepare(): Unknown request IDs {unknown_rids}. "
-                f"All request IDs must be added via add_request() before calling prepare(). "
-                f"Known request IDs: {list(self._request_to_slot.keys())}"
-            )
-
+        # Map each request ID to its slot. Unknown IDs (e.g. CUDA graph
+        # warmup dummies that skipped the context phase) are routed to the
+        # reserved dummy slot so the kernel still runs on valid memory.
+        slots = [self._request_to_slot.get(rid, self._dummy_slot_index) for rid in request_ids]
         batch_indices = torch.tensor(
-            [self._request_to_slot[rid] for rid in request_ids],
+            slots,
+            dtype=torch.int32,
+            pin_memory=prefer_pinned(),
+        )
+        # Build a non-dummy mask (1 = real, 0 = dummy) on CPU, then copy to
+        # the pre-allocated GPU buffer.  extend() will use this mask via a
+        # simple element-wise multiply which is CUDA-graph-safe.
+        nondummy_mask = torch.tensor(
+            [0 if s == self._dummy_slot_index else 1 for s in slots],
             dtype=torch.int32,
             pin_memory=prefer_pinned(),
         )
 
         num_requests = len(request_ids)
         self._gpu_batch_indices[:num_requests].copy_(batch_indices, non_blocking=True)
+        self._gpu_nondummy_mask[:num_requests].copy_(nondummy_mask, non_blocking=True)
         torch.cuda.synchronize()
 
     def extend(
@@ -295,10 +317,16 @@ class SuffixAutomatonManager(BaseResourceManager):
         if num_accepted_tokens.dtype != torch.int32:
             num_accepted_tokens = num_accepted_tokens.to(torch.int32)
 
+        # Zero out accepted-token counts for dummy entries so the kernel's
+        # extend() loop is a no-op for them, avoiding the concurrent-write
+        # race when multiple dummies share one slot.  The mask is populated
+        # by prepare() (outside CUDA graph); the multiply is graph-safe.
+        num_accepted_tokens = num_accepted_tokens * self._gpu_nondummy_mask[:batch_size]
+
         _sa_native.invoke_extend(
             batch_size,
             max_draft_len,
-            self.max_num_requests,
+            self.max_num_requests + 1,
             self.max_seq_len,
             self._gpu_slots,
             self._gpu_batch_indices[:batch_size],
@@ -351,11 +379,14 @@ class SuffixAutomatonManager(BaseResourceManager):
         if num_accepted_tokens.dtype != torch.int32:
             num_accepted_tokens = num_accepted_tokens.to(torch.int32)
 
+        # Zero out dummy entries (see extend() for rationale).
+        num_accepted_tokens = num_accepted_tokens * self._gpu_nondummy_mask[:batch_size]
+
         _sa_native.invoke_extend_ngram(
             batch_size,
             max_draft_len,
             max_ngram_size,
-            self.max_num_requests,
+            self.max_num_requests + 1,
             self.max_seq_len,
             self._gpu_slots,
             self._gpu_batch_indices[:batch_size],
@@ -387,9 +418,22 @@ class SuffixAutomatonManager(BaseResourceManager):
         self.remove_request(request.request_id)
 
     def add_dummy_requests(self, request_ids: List[int]):
-        """Add dummy requests for CUDA graph warmup."""
+        """Add dummy requests for CUDA graph padding.
+
+        Dummy requests are mapped to a single reserved slot
+        (index = max_num_requests) that lives outside the real slot pool.
+        This prevents CUDA graph padding from exhausting slots that real
+        requests need.
+
+        No host automaton is built -- the GPU slot is already zeroed by
+        allocate_workspace (at::zeros), so the kernel safely produces
+        match_len = 0 for dummies.
+        """
         for rid in request_ids:
-            self.add_request(rid, [1])  # Dummy token
+            if rid in self._request_to_slot:
+                continue
+            self._request_to_slot[rid] = self._dummy_slot_index
+            self._dummy_request_ids.add(rid)
 
     def shutdown(self):
         """Clean up all resources."""
@@ -398,6 +442,7 @@ class SuffixAutomatonManager(BaseResourceManager):
 
         self._request_to_slot.clear()
         self._free_slots = list(range(self.max_num_requests))
+        self._dummy_request_ids.clear()
 
         self._host_states_native.clear()
         self._pending_copies.clear()

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -95,6 +95,7 @@ def get_spec_metadata(spec_config,
             spec_dec_mode=spec_config.spec_dec_mode,
             max_num_requests=max_num_requests,
             allow_advanced_sampling=spec_config.allow_advanced_sampling,
+            spec_resource_manager=spec_resource_manager,
         )
     if spec_config.spec_dec_mode.is_save_hidden_states():
         return SaveHiddenStatesSpecMetadata(
@@ -200,6 +201,11 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
             max_num_requests,
             max_num_tokens,
         )
+    if spec_dec_mode.is_pard():
+        if getattr(spec_config, 'use_sa_spec', False):
+            return SuffixAutomatonManager(spec_config, max_num_requests,
+                                          max_seq_len)
+        return None
     if spec_dec_mode.is_ngram():
         return NGramPoolManager(spec_config, max_num_requests)
     if spec_dec_mode.is_sa():

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -32,11 +32,6 @@ def get_spec_metadata(spec_config,
                       is_draft_model=False,
                       max_seq_len=262144):
     if spec_config.spec_dec_mode.is_mtp_one_model():
-        # Get SA manager from spec_resource_manager if MTP+SA mode
-        sa_manager = None
-        if spec_resource_manager is not None and hasattr(
-                spec_resource_manager, 'sa_manager'):
-            sa_manager = spec_resource_manager.sa_manager
         return MTPSpecMetadata(
             max_draft_len=spec_config.max_draft_len,
             max_total_draft_tokens=spec_config.tokens_per_gen_step - 1,
@@ -44,7 +39,6 @@ def get_spec_metadata(spec_config,
             mtp_num_modules=spec_config.num_nextn_predict_layers,
             max_num_requests=max_num_requests,
             mtp_hidden_states_manager=spec_resource_manager,
-            sa_manager=sa_manager,
             allow_advanced_sampling=spec_config.allow_advanced_sampling,
         )
     if spec_config.spec_dec_mode.is_mtp_eagle():
@@ -92,6 +86,7 @@ def get_spec_metadata(spec_config,
             max_num_tokens=max_num_tokens,
             layers_to_capture=spec_config.eagle3_layers_to_capture,
             allow_advanced_sampling=spec_config.allow_advanced_sampling,
+            spec_resource_manager=spec_resource_manager,
         )
     if spec_config.spec_dec_mode.is_pard():
         return PARDSpecMetadata(
@@ -171,6 +166,22 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
             max_num_requests,
             sa_manager=sa_manager,
         )
+    if spec_dec_mode.is_eagle3_one_model():
+        sa_manager = None
+        if getattr(spec_config, 'use_sa_spec', False):
+            sa_manager = SuffixAutomatonManager(spec_config, max_num_requests,
+                                                max_seq_len)
+        if sa_manager is not None:
+            return Eagle3ResourceManager(
+                spec_config,
+                model_config.torch_dtype,
+                model_config.hidden_size,
+                max_num_requests,
+                max_seq_len,
+                max_num_tokens,
+                sa_manager=sa_manager,
+            )
+        return None
     if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
         assert draft_model_engine is not None, "Draft model engine is required for Eagle3 and MTP Eagle two model flow."
         return Eagle3ResourceManager(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1017,6 +1017,17 @@ class EagleDecodingConfig(DecodingBaseConfig):
 class Eagle3DecodingConfig(EagleDecodingConfig):
     decoding_type: Literal["Eagle3"] = "Eagle3"
 
+    # Suffix Automaton speculative decoding settings
+    use_sa_spec: Optional[bool] = Field(
+        default=False,
+        status="beta",
+        description="Combine with Suffix Automaton Decoding")
+    sa_spec_threshold: int = Field(
+        default=4,
+        description="The threshold for the Suffix Automaton Decoding. If the"
+        " length of the suffix match exceeds the threshold, use"
+        " the suffix automaton output for the next draft tokens.")
+
 
 class SaveHiddenStatesDecodingConfig(DecodingBaseConfig):
     decoding_type: Literal["SaveState"] = "SaveState"

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1330,6 +1330,17 @@ class PARDDecodingConfig(DecodingBaseConfig):
 
     decoding_type: Literal["PARD"] = "PARD"
 
+    # Suffix Automaton speculative decoding settings
+    use_sa_spec: Optional[bool] = Field(
+        default=False,
+        status="beta",
+        description="Combine with Suffix Automaton Decoding")
+    sa_spec_threshold: int = Field(
+        default=4,
+        description="The threshold for the Suffix Automaton Decoding. If the"
+        " length of the suffix match exceeds the threshold, use"
+        " the suffix automaton output for the next draft tokens.")
+
     @model_validator(mode="after")
     def set_max_total_draft_tokens(self):
         self.max_total_draft_tokens = self.max_draft_len

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1022,7 +1022,7 @@ class Eagle3DecodingConfig(EagleDecodingConfig):
         default=False,
         status="beta",
         description="Combine with Suffix Automaton Decoding")
-    sa_spec_threshold: int = Field(
+    sa_spec_threshold: PositiveInt = Field(
         default=4,
         description="The threshold for the Suffix Automaton Decoding. If the"
         " length of the suffix match exceeds the threshold, use"
@@ -1245,7 +1245,7 @@ class MTPDecodingConfig(DecodingBaseConfig):
         default=False,
         status="beta",
         description="Combine with Suffix Automaton Decoding")
-    sa_spec_threshold: int = Field(
+    sa_spec_threshold: PositiveInt = Field(
         default=4,
         description="The threshold for the Suffix Automaton Decoding. If the"
         " length of the suffix match exceeds the threshold, use"
@@ -1335,7 +1335,7 @@ class PARDDecodingConfig(DecodingBaseConfig):
         default=False,
         status="beta",
         description="Combine with Suffix Automaton Decoding")
-    sa_spec_threshold: int = Field(
+    sa_spec_threshold: PositiveInt = Field(
         default=4,
         description="The threshold for the Suffix Automaton Decoding. If the"
         " length of the suffix match exceeds the threshold, use"

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -13,6 +13,9 @@ meta-llama/Llama-3.1-8B-Instruct:
     accuracy: 74.20
   - spec_dec_algo: PARD
     accuracy: 74.20
+  - spec_dec_algo: PARD
+    extra_acc_spec: use_sa_spec
+    accuracy: 74.20
   - quant_algo: FP8
     accuracy: 74.30
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -8,6 +8,9 @@ meta-llama/Llama-3.1-8B-Instruct:
     accuracy: 74.20
   - spec_dec_algo: Eagle3
     accuracy: 74.20
+  - spec_dec_algo: Eagle3
+    extra_acc_spec: use_sa_spec
+    accuracy: 74.20
   - spec_dec_algo: PARD
     accuracy: 74.20
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -368,6 +368,31 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
     @skip_pre_hopper
+    def test_pard_sa(self):
+        """Accuracy test for PARD + Suffix Automaton speculative decoding."""
+        pytorch_config = dict(
+            max_batch_size=1,
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=1,
+                                              enable_padding=True),
+        )
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
+
+        pard_model_dir = f"{llm_models_root()}/PARD-Llama-3.2-1B"
+        target_model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct"
+
+        spec_config = PARDDecodingConfig(max_draft_len=4,
+                                         speculative_model=pard_model_dir,
+                                         use_sa_spec=True)
+
+        with LLM(model=target_model_dir,
+                 **pytorch_config,
+                 kv_cache_config=kv_cache_config,
+                 speculative_config=spec_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm, extra_acc_spec="use_sa_spec")
+
+    @skip_pre_hopper
     def test_ngram(self):
         max_bs = 16
 

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -312,6 +312,32 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
     @skip_pre_hopper
+    def test_eagle3_sa(self):
+        """Accuracy test for EAGLE3 One-Model + Suffix Automaton speculative decoding."""
+        pytorch_config = dict(
+            max_batch_size=1,
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=1,
+                                              enable_padding=True),
+        )
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
+
+        eagle_model_dir = f"{llm_models_root()}/EAGLE3-LLaMA3.1-Instruct-8B"
+        target_model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct"
+
+        spec_config = Eagle3DecodingConfig(max_draft_len=4,
+                                           speculative_model=eagle_model_dir,
+                                           eagle3_one_model=True,
+                                           use_sa_spec=True)
+
+        with LLM(model=target_model_dir,
+                 **pytorch_config,
+                 kv_cache_config=kv_cache_config,
+                 speculative_config=spec_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm, extra_acc_spec="use_sa_spec")
+
+    @skip_pre_hopper
     @parametrize_with_ids("overlap_scheduler", [True, False])
     def test_pard(self, overlap_scheduler):
         pytorch_config = dict(
@@ -1508,8 +1534,6 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
                  **pytorch_config,
                  speculative_config=mtp_config) as llm:
             task = GSM8K(self.MODEL_NAME)
-            task.evaluate(llm, extra_acc_spec="use_sa_spec")
-            task = MMLU(self.MODEL_NAME)
             task.evaluate(llm, extra_acc_spec="use_sa_spec")
 
     @pytest.mark.skip_less_device(4)

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -8,6 +8,7 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_llm_sampler
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_eagle3[sampler_async_worker=False-eagle3_one_model=True-overlap_scheduler=True]
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_eagle3[sampler_async_worker=False-eagle3_one_model=False-overlap_scheduler=False]
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_eagle3[sampler_async_worker=True-eagle3_one_model=True-overlap_scheduler=True]
+accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_eagle3_sa
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_ngram
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_guided_decoding[xgrammar]
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_guided_decoding[llguidance]
@@ -35,6 +36,7 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_beam_search[
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_beam_search[enable_cuda_graph=True-enable_padding=True-disable_overlap_scheduler=False-sampler_async_worker=True]
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=True]
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=False]
+accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard_sa
 accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_fp8_prequantized
 accuracy/test_llm_api_pytorch.py::TestLlama3_2_3B::test_auto_dtype


### PR DESCRIPTION
## Description

Integrate SA with EAGLE3 and PARD

Usage example 
```
eagle_model_dir = f"{llm_models_root()}/EAGLE3-LLaMA3.1-Instruct-8B"
target_model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct"

spec_config = Eagle3DecodingConfig(max_draft_len=4,
                                    speculative_model=eagle_model_dir,
                                    eagle3_one_model=True,
                                    use_sa_spec=True)
llm = LLM(model=target_model_dir,
            **pytorch_config,
            kv_cache_config=kv_cache_config,
            speculative_config=spec_config)            
```

## Benchmark
### Configuration

| Setting | Value |
|---------|-------|
| **EAGLE3 Target/Draft** | Llama-3.1-8B-Instruct / EAGLE3-LLaMA3.1-Instruct-8B with draft length = 4 |
| **PARD Target/Draft** | Llama-3.1-8B-Instruct / PARD-Llama-3.2-1B with draft length = 4 |
| **SA Threshold** | 4 |
| **GPU** | single H100 |

### Dataset Details

| Metric | Value |
|--------|-------|
| **Dataset** | glaiveai/code_edits_sample |
| **Number of Requests** | 100 (randomly sampled) |
| **Average Input Length** | 390.9 tokens |
| **Average Output Length** | 256.0 tokens |

### Comparison Table

| Configuration | Total Output Throughput (tok/s) | TTFT (ms) | TPOT (ms) | Accept Rate | Accept Length |
|---------------|--------------------------------|-----------|-----------|-------------|---------------|
| EAGLE3 | 321.21 | 32.41 | 3.00 | 0.4726 | 2.89 |
| EAGLE3 + SA | **386.33** | 32.30 | **2.47** | **0.6459** | **3.58** |
| PARD | 343.63 | 35.85 | 2.78 | 0.5335 | 3.13 |
| PARD + SA | **415.48** | 36.13 | **2.27** | **0.7248** | **3.90** |
| Baseline | 150.33 | 25.00 | 6.58 | N/A | N/A |

### Key Observations

### EAGLE3 + SA Improvement over EAGLE3
- **Total Output Throughput:** +20.3%
- **TPOT:** +17.6%
- **Acceptance Rate:** 64.59% vs 47.26% (+36.7%)
- **Acceptance Length:** 3.58 vs 2.89 tokens (+24.0%)

#### PARD + SA Improvement over PARD
- **Total Output Throughput:** +20.9%
- **TPOT:** +18.2% 
- **Acceptance Rate:** 72.48% vs 53.35% (+35.8%)
- **Acceptance Length:** 3.90 vs 3.13 tokens (+24.4%)

### Speedup vs Baseline
| Configuration | Speedup over Baseline (150.33 tok/s) |
|---------------|---------|
| EAGLE3 | **2.14x** |
| EAGLE3 + SA | **2.57x** |
| PARD | **2.29x** |
| PARD + SA | **2.76x** |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Suffix Automaton (SA) speculative decoding enhancement can now be combined with EAGLE3, PARD, and MTP decoders through new configuration flags (use_sa_spec, sa_spec_threshold)

* **Documentation**
  * Added comprehensive guidance on configuring and using SA speculative decoding across different decoding methods

* **Tests**
  * Added accuracy verification tests for SA speculative decoding with EAGLE3 and PARD decoders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->