### PR TITLE
[#11578][fix] Use string stop/bad words in gRPC proto instead of pre-tokenized TokenSequence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,4 +84,4 @@ cuda-tile>=1.0.1
 nvidia-cuda-tileiras>=13.1
 etcd-sdk-python==0.0.7
 python-multipart
-smg-grpc-proto>=0.3.3
+smg-grpc-proto>=0.4.2

--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -233,10 +233,11 @@ def create_sampling_params_from_proto(
     proto_config: pb2.SamplingConfig,
     output_config: pb2.OutputConfig,
     max_tokens: int,
-    end_id: Optional[int] = None,
-    pad_id: Optional[int] = None,
-    bad_words: Optional[List[pb2.TokenSequence]] = None,
-    stop_words: Optional[List[pb2.TokenSequence]] = None,
+    stop: Optional[List[str]] = None,
+    stop_token_ids: Optional[List[int]] = None,
+    ignore_eos: bool = False,
+    bad: Optional[List[str]] = None,
+    bad_token_ids: Optional[List[int]] = None,
     guided_decoding: Optional[pb2.GuidedDecodingParams] = None,
     embedding_bias: Optional[List[float]] = None,
 ) -> SamplingParams:
@@ -246,10 +247,11 @@ def create_sampling_params_from_proto(
         proto_config: Protobuf SamplingConfig message
         output_config: Protobuf OutputConfig message
         max_tokens: Maximum tokens to generate
-        end_id: End-of-sequence token ID
-        pad_id: Padding token ID
-        bad_words: Bad word token sequences
-        stop_words: Stop word token sequences
+        stop: Stop strings (tokenized by TRT-LLM's _setup())
+        stop_token_ids: Stop token IDs
+        ignore_eos: Whether to ignore end-of-sequence token
+        bad: Bad word strings (tokenized by TRT-LLM's _setup())
+        bad_token_ids: Bad word token IDs
         guided_decoding: Guided decoding parameters
         embedding_bias: Embedding bias tensor
 
@@ -317,13 +319,19 @@ def create_sampling_params_from_proto(
     if proto_config.HasField("no_repeat_ngram_size"):
         kwargs["no_repeat_ngram_size"] = proto_config.no_repeat_ngram_size
 
-    # End/pad tokens
-    if end_id is not None:
-        kwargs["end_id"] = end_id
-        if end_id == -1:
-            kwargs["ignore_eos"] = True
-    if pad_id is not None:
-        kwargs["pad_id"] = pad_id
+    # Stop sequences and ignore_eos (TRT-LLM's _setup() tokenizes stop strings)
+    if stop:
+        kwargs["stop"] = stop
+    if stop_token_ids:
+        kwargs["stop_token_ids"] = stop_token_ids
+    if ignore_eos:
+        kwargs["ignore_eos"] = True
+
+    # Bad words (TRT-LLM's _setup() tokenizes bad word strings)
+    if bad:
+        kwargs["bad"] = bad
+    if bad_token_ids:
+        kwargs["bad_token_ids"] = bad_token_ids
 
     # Output configuration - logprobs
     if output_config.HasField("logprobs"):
@@ -336,11 +344,6 @@ def create_sampling_params_from_proto(
         kwargs["return_generation_logits"] = True
     if output_config.exclude_input_from_output:
         kwargs["exclude_input_from_output"] = True
-
-    # Pre-tokenized stop/bad word sequences (set after construction since
-    # SamplingParams._stop_word_ids/_bad_word_ids are init=False fields)
-    stop_word_ids = [list(seq.token_ids) for seq in stop_words] if stop_words else None
-    bad_word_ids = [list(seq.token_ids) for seq in bad_words] if bad_words else None
 
     # Embedding bias
     if embedding_bias:
@@ -362,16 +365,6 @@ def create_sampling_params_from_proto(
             kwargs["guided_decoding"] = GuidedDecodingParams(grammar=guide_content)
 
     params = SamplingParams(**kwargs)
-
-    # Set pre-tokenized stop/bad word IDs directly. _get_stop_words() and
-    # _get_bad_words() only read _stop_word_ids/_bad_word_ids when self.stop
-    # /self.bad is not None, so set them to empty lists to enable that path.
-    if stop_word_ids:
-        params._stop_word_ids = stop_word_ids
-        params.stop = []
-    if bad_word_ids:
-        params._bad_word_ids = bad_word_ids
-        params.bad = []
 
     return params
 

--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -363,12 +363,15 @@ def create_sampling_params_from_proto(
 
     params = SamplingParams(**kwargs)
 
-    # Set pre-tokenized stop/bad word IDs directly (these come pre-tokenized
-    # from the router, so we bypass the tokenizer-based setup path)
+    # Set pre-tokenized stop/bad word IDs directly. _get_stop_words() and
+    # _get_bad_words() only read _stop_word_ids/_bad_word_ids when self.stop
+    # /self.bad is not None, so set them to empty lists to enable that path.
     if stop_word_ids:
         params._stop_word_ids = stop_word_ids
+        params.stop = []
     if bad_word_ids:
         params._bad_word_ids = bad_word_ids
+        params.bad = []
 
     return params
 

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -485,7 +485,7 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
             complete = trtllm_service_pb2.GenerateComplete(
                 output_token_ids=output_tokens,
                 sequence_index=completion.index,
-                finish_reason=completion.finish_reason or "stop",
+                finish_reason=completion.finish_reason or "",
                 prompt_tokens=len(prompt_token_ids),
                 completion_tokens=len(output_tokens),
                 cached_tokens=cached_tokens,

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -97,10 +97,11 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 proto_config=request.sampling_config,
                 output_config=request.output_config,
                 max_tokens=request.max_tokens,
-                end_id=request.end_id if request.HasField("end_id") else None,
-                pad_id=request.pad_id if request.HasField("pad_id") else None,
-                bad_words=list(request.bad_words) if request.bad_words else None,
-                stop_words=list(request.stop_words) if request.stop_words else None,
+                stop=list(request.stop) if request.stop else None,
+                stop_token_ids=list(request.stop_token_ids) if request.stop_token_ids else None,
+                ignore_eos=request.ignore_eos,
+                bad=list(request.bad) if request.bad else None,
+                bad_token_ids=list(request.bad_token_ids) if request.bad_token_ids else None,
                 guided_decoding=request.guided_decoding
                 if request.HasField("guided_decoding")
                 else None,

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -491,9 +491,12 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 cached_tokens=cached_tokens,
             )
 
-            # Add stop reason if available
-            if hasattr(completion, "stop_reason") and completion.stop_reason:
-                complete.stop_reason = str(completion.stop_reason)
+            # Add matched stop if available (int token ID or str stop sequence)
+            if hasattr(completion, "stop_reason") and completion.stop_reason is not None:
+                if isinstance(completion.stop_reason, int):
+                    complete.matched_token_id = completion.stop_reason
+                else:
+                    complete.matched_stop_str = str(completion.stop_reason)
 
             # Add generation logprobs if available
             if completion.logprobs:

--- a/tests/unittest/llmapi/test_grpc.py
+++ b/tests/unittest/llmapi/test_grpc.py
@@ -376,23 +376,17 @@ class TestComprehensiveSamplingParamsConversion:
             return_generation_logits=True,
             exclude_input_from_output=True,
         )
-        stop_words = [
-            pb2.TokenSequence(token_ids=[50256]),
-            pb2.TokenSequence(token_ids=[50257, 50258]),
-        ]
-        bad_words = [
-            pb2.TokenSequence(token_ids=[100, 101]),
-        ]
         embedding_bias = [0.0] * 10 + [1.5, -1.5]
 
         params = create_sampling_params_from_proto(
             proto_config=proto_config,
             output_config=output_config,
             max_tokens=256,
-            end_id=50256,
-            pad_id=50257,
-            stop_words=stop_words,
-            bad_words=bad_words,
+            stop=["<|endoftext|>", "<|end|>"],
+            stop_token_ids=[50256],
+            ignore_eos=True,
+            bad=["badword1"],
+            bad_token_ids=[100, 101],
             embedding_bias=embedding_bias,
         )
 
@@ -432,20 +426,21 @@ class TestComprehensiveSamplingParamsConversion:
 
         # Other params
         assert params.max_tokens == 256
-        assert params.end_id == 50256
-        assert params.pad_id == 50257
         assert params.detokenize is False  # key optimization
+        assert params.ignore_eos is True
 
-        # Stop/bad words (set as pre-tokenized word IDs)
-        assert params._stop_word_ids == [[50256], [50257, 50258]]
-        assert params._bad_word_ids == [[100, 101]]
+        # Stop/bad words (passed as strings/token IDs for TRT-LLM's _setup() to tokenize)
+        assert params.stop == ["<|endoftext|>", "<|end|>"]
+        assert params.stop_token_ids == [50256]
+        assert params.bad == ["badword1"]
+        assert params.bad_token_ids == [100, 101]
 
         # Embedding bias converted to torch.Tensor
         assert params.embedding_bias is not None
         assert len(params.embedding_bias) == 12
 
-    def test_end_id_minus_one_sets_ignore_eos(self):
-        """Test that end_id=-1 correctly sets ignore_eos=True."""
+    def test_ignore_eos_flag(self):
+        """Test that ignore_eos=True correctly sets ignore_eos on SamplingParams."""
         proto_config = pb2.SamplingConfig(temperature=0.7)
         output_config = pb2.OutputConfig()
 
@@ -453,10 +448,9 @@ class TestComprehensiveSamplingParamsConversion:
             proto_config=proto_config,
             output_config=output_config,
             max_tokens=100,
-            end_id=-1,
+            ignore_eos=True,
         )
 
-        assert params.end_id == -1
         assert params.ignore_eos is True
 
     def test_defaults_when_fields_unset(self):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Updated sampling parameters: `stop`, `stop_token_ids`, `ignore_eos`, `bad`, and `bad_token_ids` for enhanced stop/bad word configuration and EOS control
  * Completion responses now include matched stop token ID or matched stop string field for improved stop reason visibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Follow-up to #11578. The gRPC proto uses `repeated TokenSequence stop_words` which requires the router to pre-tokenize stop strings before sending them to TRT-LLM. This is broken: when `end_id` is not sent (which is always in the router path), TRT-LLM's `_setup()` overwrites the manually-set `_stop_word_ids` with an empty list, silently disabling stop sequences.

The fix replaces pre-tokenized fields with string-based fields that let TRT-LLM's `_setup()` handle tokenization internally:
- Remove `end_id`, `pad_id`, `stop_words` (TokenSequence), `bad_words` (TokenSequence) from proto
- Add `stop` (repeated string), `stop_token_ids` (repeated uint32), `ignore_eos` (bool), `bad` (repeated string), `bad_token_ids` (repeated uint32)
- Remove `TokenSequence` message (no longer used)
- Update `create_sampling_params_from_proto()` to pass strings directly to `SamplingParams()` constructor, removing the manual `_stop_word_ids`/`_bad_word_ids` hack

## Dependency Update

- Bump `smg-grpc-proto` from `>=0.3.3` to `>=0.4.2` to pick up the updated proto definitions with the new string-based stop/bad word fields

## Test Coverage

- `tests/unittest/llmapi/test_grpc.py::TestComprehensiveSamplingParamsConversion::test_all_sampling_config_fields` — updated to use new string-based fields
- `tests/unittest/llmapi/test_grpc.py::TestComprehensiveSamplingParamsConversion::test_ignore_eos_flag` — updated (was `test_end_id_minus_one_sets_ignore_eos`)
- e2e test with `smg`
  - Manual e2e: non-streaming + `stop`
<img width="814" height="60" alt="Screenshot 2026-03-03 at 7 49 01 PM" src="https://github.com/user-attachments/assets/265bffe2-cb2c-4e09-b053-d9a5dd4d21a6" />

  - Manual e2e: streaming + `stop`
<img width="834" height="852" alt="Screenshot 2026-03-03 at 7 49 23 PM" src="https://github.com/user-attachments/assets/4afaad53-0c39-4ff9-b27b-34fa10abbd76" />

  - Manual e2e: `ignore_eos`
<img width="810" height="300" alt="Screenshot 2026-03-03 at 9 42 25 PM" src="https://github.com/user-attachments/assets/b7a81d1c-691b-4a19-bb33-4badad9ad64d" />


## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.