### PR TITLE
[None][fix] Refine tests/unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py to reduce jit-compile time

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -103,6 +103,8 @@ l0_b200:
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "TRTLLM"
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "CUTEDSL"
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "DEEPGEMM"
+  # ------------- MoE: FlashInfer & TRTLLM symbol collision tests ---------------
+  - unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
   # --- MoE end
   - unittest/_torch/multimodal
   - unittest/_torch/sampler

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -42,7 +42,6 @@ l0_h100:
   - unittest/_torch/speculative -k "not eagle3"
   - unittest/_torch/thop/parallel
   - unittest/_torch/thop/serial
-  - unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
   # Only key models in H100: llama/mixtral/nemotron/deepseek
   - unittest/_torch/modeling -k "modeling_llama"
   - unittest/_torch/modeling -k "modeling_mixtral"

--- a/tests/unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
+++ b/tests/unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
@@ -1,84 +1,80 @@
-"""Unit tests for FlashInfer fused MOE custom op."""
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests verifying no symbol collision between TensorRT-LLM and FlashInfer.
 
-import flashinfer.fused_moe
+FlashInfer copies several TensorRT-LLM CUTLASS MOE kernel source files
+(under nv_internal/tensorrt_llm/) and JIT-compiles them. Without the
+inline-namespace fix (TRTLLM_ABI_NAMESPACE _v1), the resulting .so exports
+symbols with identical mangled names as libth_common.so (loaded with
+RTLD_GLOBAL), causing heap corruption when the dynamic linker resolves
+to the wrong implementation.
+
+This test triggers the FlashInfer CUTLASS fused-MOE JIT build (with
+use_fast_build=True to minimize compilation time), then calls into the
+compiled module to verify no symbol collision occurs.
+"""
+
 import pytest
 import torch
 
-import tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.torch_moe  # noqa: F401
 import tensorrt_llm._torch.custom_ops.torch_custom_ops as trt_ops  # noqa: F401
-from tensorrt_llm._torch.utils import ActivationType
 
 
-def test_flashinfer_fused_moe_matches_torch_moe():
-    """Test that flashinfer_fused_moe matches torch_moe reference."""
-    torch.manual_seed(0)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_flashinfer_cutlass_fused_moe_jit_no_collision():
+    """
+    JIT-compiling and calling FlashInfer CUTLASS fused-MOE must not crash.
 
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for flashinfer_fused_moe test")
+    get_cutlass_fused_moe_module JIT-compiles TensorRT-LLM CUTLASS MOE
+    kernels that share the tensorrt_llm:: namespace with libth_common.so.
+    use_fast_build=True reduces template instantiations for speed.
+    The actual collision manifests when module.init() is called (inside
+    cutlass_fused_moe), so we must invoke the operation with small tensors.
+    """
+    from flashinfer.fused_moe.core import get_cutlass_fused_moe_module
+
+    sm = torch.cuda.get_device_capability()
+    backend = str(sm[0] * 10 + sm[1])
+    fused_moe_ns = get_cutlass_fused_moe_module(backend, use_fast_build=True)
 
     device = "cuda"
     dtype = torch.bfloat16
+    num_tokens, hidden, inter, num_experts, top_k = 128, 128, 128, 4, 2
 
-    # Small test case
-    M = 8  # tokens
-    HIDDEN_SIZE = 64
-    INTERMEDIATE_SIZE = 128
-    E = 4  # experts
-    top_k = 2
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden, device=device, dtype=dtype)
+    w1_w3 = torch.randn(num_experts, 2 * inter, hidden, device=device, dtype=dtype)
+    w2 = torch.randn(num_experts, hidden, inter, device=device, dtype=dtype)
 
-    # Input
-    x = torch.randn(M, HIDDEN_SIZE, device=device, dtype=dtype)
+    logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    weights, experts = torch.topk(torch.softmax(logits, -1), top_k)
+    weights = weights / weights.sum(-1, keepdim=True)
 
-    # Expert weights for gated MLP (SwiGLU)
-    # w1 = gate projection, w3 = up projection, w2 = down projection
-    w1_list = [
-        torch.randn(INTERMEDIATE_SIZE, HIDDEN_SIZE, device=device, dtype=dtype) for _ in range(E)
-    ]
-    w2_list = [
-        torch.randn(HIDDEN_SIZE, INTERMEDIATE_SIZE, device=device, dtype=dtype) for _ in range(E)
-    ]
-    w3_list = [
-        torch.randn(INTERMEDIATE_SIZE, HIDDEN_SIZE, device=device, dtype=dtype) for _ in range(E)
-    ]
-
-    # FlashInfer expects fc1 (gate + up concatenated) and fc2 (down)
-    # fc1_expert_weights: [E, 2*INTERMEDIATE_SIZE, HIDDEN_SIZE]
-    w1_w3_stacked = torch.stack(
-        [torch.cat([w3, w1], dim=0) for w1, w3 in zip(w1_list, w3_list)], dim=0
-    ).contiguous()
-
-    # fc2_expert_weights: [E, HIDDEN_SIZE, INTERMEDIATE_SIZE]
-    w2_stacked = torch.stack(w2_list, dim=0).contiguous()
-
-    # Random routing with top-k normalization
-    router_logits = torch.randn(M, E, device=device, dtype=torch.float32)
-    routing_full = torch.softmax(router_logits, dim=-1)
-    routing_weights, selected_experts = torch.topk(routing_full, k=top_k, dim=-1)
-    routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
-    routing_weights = routing_weights.to(torch.float32)
-
-    # FlashInfer fused MOE - call directly
-    out_flashinfer = flashinfer.fused_moe.cutlass_fused_moe(
+    out = fused_moe_ns.cutlass_fused_moe(
+        output=torch.empty(num_tokens, hidden, device=device, dtype=dtype),
         input=x,
-        token_selected_experts=selected_experts.to(torch.int32),
-        token_final_scales=routing_weights,
-        fc1_expert_weights=w1_w3_stacked,
-        fc2_expert_weights=w2_stacked,
+        token_selected_experts=experts.to(torch.int32),
+        token_final_scales=weights,
+        fc1_expert_weights=w1_w3,
+        fc1_expert_biases=None,
+        fc2_expert_weights=w2,
+        fc2_expert_biases=None,
         output_dtype=dtype,
         quant_scales=[],
     )
 
-    # Reference Torch MoE (gated_mlp with SwiGLU)
-    out_torch = torch.ops.auto_deploy.torch_moe(
-        x,
-        selected_experts,
-        routing_weights,
-        w1_weight=w1_list,  # gate projection
-        w2_weight=w2_list,  # down projection
-        w3_weight=w3_list,  # up projection
-        is_gated_mlp=True,
-        act_fn=int(ActivationType.Silu),
-    )
-
-    # Compare outputs
-    torch.testing.assert_close(out_flashinfer[0], out_torch, rtol=5e-1, atol=5e-1)
+    assert out[0].shape == (num_tokens, hidden)
+    assert not torch.isnan(out[0]).any()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated FlashInfer symbol collision test with simplified validation logic for device compatibility across different hardware configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

- Use fast build flag to jit compile cutlass fused MoE module, this may reduce the compile time from 35min+ to 23min.
- Move test from H100 test suite to B200 test suite, The number of kernels reduced from 132 to 82:
```
yihwang@*****-devel:/code/tensorrt_llm$ ll ~/.cache/flashinfer/100_120_75_80_86_90/cached_ops/fused_moe_90/ | grep generated.cuda.o | wc -l
132
yihwang@*****-devel:/code/tensorrt_llm$ ll ~/.cache/flashinfer/100_120_75_80_86_90/cached_ops/fused_moe_100/ | grep gener
ated.cuda.o | wc -l
82
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
