### PR TITLE
[TRTLLM-10407][feat] Integrate CuTE DSL top-k kernel for Blackwell

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2836,6 +2836,62 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def __init__(self):
             pass
 
+        @classmethod
+        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n,
+                     return_val, num_copy_bits, load_balance,
+                     large_occupancy):
+            """Compile and cache a single-CTA top-k kernel for the given config."""
+            key = (
+                dtype, bucketed_num_cols, top_k, next_n,
+                return_val, num_copy_bits, load_balance, large_occupancy,
+            )
+            if key in cls.kernel_cache:
+                return
+            n = cute.sym_int()
+            n_div_32 = cute.sym_int(divisibility=32)
+            input_fake = cute.runtime.make_fake_compact_tensor(
+                dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+            buffer_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                stride_order=(2, 1, 0),
+                assumed_align=32,
+            )
+            seqlen_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, ), stride_order=(0, ),
+            )
+            output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, top_k), stride_order=(1, 0),
+            )
+            if return_val:
+                output_values_fake = cute.runtime.make_fake_compact_tensor(
+                    dtype, (n, top_k), stride_order=(1, 0),
+                )
+            else:
+                output_values_fake = None
+            fake_stream = cute.runtime.make_fake_stream()
+
+            filtered_topk_func = FilteredTopKKernelVarlenDecode(
+                dtype, bucketed_num_cols, top_k, next_n,
+                num_copy_bits=num_copy_bits,
+                return_val=return_val,
+                large_occupancy=large_occupancy,
+            )
+            compiled_kernel = cute.compile(
+                filtered_topk_func,
+                input_fake,
+                None,  # indices_fake
+                buffer_fake,
+                None,  # g_global_counter_fake
+                seqlen_fake,
+                output_indices_fake,
+                output_values_fake,
+                stream=fake_stream,
+                enable_persistent_dynamic_scheduling=load_balance,
+                min_blocks_per_mp=1,
+            )
+            cls.kernel_cache[key] = compiled_kernel
+
         def forward(
             self,
             input_values: torch.Tensor,
@@ -2845,42 +2901,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: bool = False,
             num_copy_bits: int = 256,
         ):
-            """Execute filtered top-k selection on input logits.
-
-            This method compiles (if not cached) and executes the CuTE DSL top-k kernel.
-            It selects the top_k largest values per row using a radix-based filtering
-            algorithm optimized for Blackwell architecture.
-
-            Args:
-                input_values: Input logits tensor [batch_size * next_n, vocab_size].
-                             Must be 2D with dtype in {float16, bfloat16, float32}.
-                seq_lens: Sequence lengths for each batch [batch_size].
-                         Must be 1D int32 tensor. Used to determine valid range per row.
-                top_k: Number of top elements to select per row (1 to 2048).
-                      Must be divisible by vectorization width.
-                next_n: Number of candidates per sequence (for speculative decoding).
-                       Must be positive integer. Total rows = batch_size * next_n.
-                return_val: If True, return both indices and values.
-                           If False, return only indices (values will be None).
-                           Setting to False saves memory and computation.
-                num_copy_bits: Vectorization width for memory copy (128 or 256).
-
-            Returns:
-                tuple: (indices, values) where:
-                    - indices: Top-k indices [batch_size * next_n, top_k], int32.
-                    - values: Top-k values [batch_size * next_n, top_k] if return_val=True,
-                             else None.
-
-            Raises:
-                ValueError: If inputs have invalid shape, dtype, or parameter values.
-                KeyError: If unsupported dtype is provided.
-
-            Note:
-                - Kernel is compiled on first use for each unique configuration
-                - Compilation cache grows unbounded (consider clearing periodically)
-                - Uses current CUDA stream for asynchronous execution
-                - Occupancy is automatically optimized when batch_size > num_SMs
-            """
+            """Execute filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
             torch_dtype_to_cutlass_dtype = {
                 torch.float16: cutlass.Float16,
@@ -2908,66 +2929,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
 
             if key not in self.__class__.kernel_cache:
-                # Create fake tensors for compilation
-                n = cute.sym_int()
-                # Do we need div=32? no.
-                n_div_32 = cute.sym_int(divisibility=32)
-                input_fake = cute.runtime.make_fake_compact_tensor(
-                    dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
-                buffer_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    # TODO: (n, cute.sym_int(), n_div_32)
-                    (cute.sym_int(), cute.sym_int(), cute.sym_int()),
-                    stride_order=(2, 1, 0),
-                    assumed_align=32,
+                self.__class__._compile(
+                    dtype, bucketed_num_cols, top_k, next_n,
+                    return_val, num_copy_bits, load_balance, large_occupancy,
                 )
-                seqlen_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, ),
-                    stride_order=(0, ),
-                )
-                output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, top_k),
-                    stride_order=(1, 0),
-                )
-                if return_val:
-                    output_values_fake = cute.runtime.make_fake_compact_tensor(
-                        dtype,
-                        (n, top_k),
-                        stride_order=(1, 0),
-                    )
-                else:
-                    output_values_fake = None
-                fake_stream = cute.runtime.make_fake_stream()
-
-                filtered_topk_func = FilteredTopKKernelVarlenDecode(
-                    dtype,
-                    bucketed_num_cols,
-                    top_k,
-                    next_n,
-                    num_copy_bits=num_copy_bits,
-                    return_val=return_val,
-                    large_occupancy=large_occupancy,
-                )
-
-                # Compile the kernel
-                compiled_kernel = cute.compile(
-                    filtered_topk_func,
-                    input_fake,
-                    None,  # indices_fake
-                    buffer_fake,
-                    None,  # g_global_counter_fake
-                    seqlen_fake,
-                    output_indices_fake,
-                    output_values_fake,
-                    stream=fake_stream,
-                    enable_persistent_dynamic_scheduling=load_balance,
-                    min_blocks_per_mp=1,
-                )
-                self.__class__.kernel_cache[key] = compiled_kernel
-            else:
-                compiled_kernel = self.__class__.kernel_cache[key]
+            compiled_kernel = self.__class__.kernel_cache[key]
 
             # Prepare output tensors
             output_indices_torch = torch.empty(num_rows,
@@ -3131,6 +3097,107 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def __init__(self):
             pass
 
+        @classmethod
+        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n,
+                     return_val, num_copy_bits, load_balance,
+                     large_occupancy, chunk_size_per_cta,
+                     num_ctas_per_row):
+            """Compile and cache multi-CTA top-k kernels for the given config."""
+            key = (
+                dtype, bucketed_num_cols, top_k, next_n,
+                return_val, num_copy_bits, load_balance, large_occupancy,
+                True, chunk_size_per_cta, num_ctas_per_row,
+            )
+            if key in cls.kernel_cache:
+                return
+            n = cute.sym_int()
+            n_div_32 = cute.sym_int(divisibility=32)
+            input_fake = cute.runtime.make_fake_compact_tensor(
+                dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+            buffer_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                stride_order=(2, 1, 0),
+                assumed_align=32,
+            )
+            seqlen_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, ), stride_order=(0, ),
+            )
+            first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, n_div_32), stride_order=(1, 0),
+            )
+            first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
+                dtype, (n, n_div_32), stride_order=(1, 0),
+                assumed_align=32,
+            )
+            fake_stream = cute.runtime.make_fake_stream()
+
+            # First kernel: process each chunk independently
+            filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
+                dtype,
+                chunk_size_per_cta,  # num_cols
+                top_k, next_n,
+                num_copy_bits=num_copy_bits,
+                return_val=True,  # first kernel must return values
+                large_occupancy=large_occupancy,
+                enable_multi_cta=True,
+                chunk_size_per_cta=chunk_size_per_cta,
+                num_ctas_per_row=num_ctas_per_row,
+                merge_blocks=False,
+            )
+            compiled_kernel_first = cute.compile(
+                filtered_topk_func_first,
+                input_fake,
+                None,  # indices_fake
+                buffer_fake,
+                None,  # g_global_counter_fake
+                seqlen_fake,
+                first_kernel_output_indices_fake,
+                first_kernel_output_values_fake,
+                stream=fake_stream,
+                enable_persistent_dynamic_scheduling=load_balance,
+                min_blocks_per_mp=1,
+            )
+
+            # Second kernel: merge partial results
+            indices_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, n_div_32), stride_order=(1, 0),
+            )
+            output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (n, top_k), stride_order=(1, 0),
+            )
+            if return_val:
+                output_values_fake = cute.runtime.make_fake_compact_tensor(
+                    dtype, (n, top_k), stride_order=(1, 0),
+                )
+            else:
+                output_values_fake = None
+            filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
+                dtype,
+                num_ctas_per_row * top_k,  # num_cols
+                top_k, next_n,
+                num_copy_bits=num_copy_bits,
+                return_val=return_val,
+                large_occupancy=large_occupancy,
+                enable_multi_cta=False,
+                merge_blocks=True,
+            )
+            compiled_kernel_second = cute.compile(
+                filtered_topk_func_second,
+                input_fake,
+                indices_fake,
+                buffer_fake,
+                None,  # g_global_counter_fake
+                seqlen_fake,
+                output_indices_fake,
+                output_values_fake,
+                stream=fake_stream,
+                enable_persistent_dynamic_scheduling=load_balance,
+                min_blocks_per_mp=1,
+            )
+            cls.kernel_cache[key] = (compiled_kernel_first,
+                                     compiled_kernel_second)
+
         def forward(
             self,
             input_values: torch.Tensor,
@@ -3141,30 +3208,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             num_copy_bits: int = 256,
             chunk_size_per_cta: int = 16384,
         ):
-            """Execute multi-CTA filtered top-k selection on input logits.
-
-            Each row is split into chunks of chunk_size_per_cta columns, with each
-            chunk processed by a separate CTA. A second merge kernel combines the
-            partial top-k results into the final output.
-
-            Args:
-                input_values: Input logits tensor [batch_size * next_n, vocab_size].
-                             Must be 2D with dtype in {float16, bfloat16, float32}.
-                seq_lens: Sequence lengths for each batch [batch_size].
-                         Must be 1D int32 tensor.
-                top_k: Number of top elements to select per row (1 to 2048).
-                next_n: Number of candidates per sequence (for speculative decoding).
-                return_val: If True, return both indices and values.
-                           If False, return only indices (values will be None).
-                num_copy_bits: Vectorization width for memory copy (128 or 256).
-                chunk_size_per_cta: Number of columns each CTA processes.
-
-            Returns:
-                tuple: (indices, values) where:
-                    - indices: Top-k indices [batch_size * next_n, top_k], int32.
-                    - values: Top-k values [batch_size * next_n, top_k] if return_val=True,
-                             else None.
-            """
+            """Execute multi-CTA filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
             torch_dtype_to_cutlass_dtype = {
                 torch.float16: cutlass.Float16,
@@ -3198,112 +3242,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
 
             if key not in self.__class__.kernel_cache:
-                # Create fake tensors for compilation
-                n = cute.sym_int()
-                n_div_32 = cute.sym_int(divisibility=32)
-                input_fake = cute.runtime.make_fake_compact_tensor(
-                    dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
-                buffer_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (cute.sym_int(), cute.sym_int(), cute.sym_int()),
-                    stride_order=(2, 1, 0),
-                    assumed_align=32,
+                self.__class__._compile(
+                    dtype, bucketed_num_cols, top_k, next_n,
+                    return_val, num_copy_bits, load_balance, large_occupancy,
+                    chunk_size_per_cta, num_ctas_per_row,
                 )
-                seqlen_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, ),
-                    stride_order=(0, ),
-                )
-                first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, n_div_32),
-                    stride_order=(1, 0),
-                )
-                first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
-                    dtype,
-                    (n, n_div_32),
-                    stride_order=(1, 0),
-                    assumed_align=32,
-                )
-                fake_stream = cute.runtime.make_fake_stream()
-
-                # First kernel: process each chunk independently
-                filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
-                    dtype,
-                    chunk_size_per_cta,  # num_cols
-                    top_k,
-                    next_n,
-                    num_copy_bits=num_copy_bits,
-                    return_val=True,  # first kernel must return values
-                    large_occupancy=large_occupancy,
-                    enable_multi_cta=True,
-                    chunk_size_per_cta=chunk_size_per_cta,
-                    num_ctas_per_row=num_ctas_per_row,
-                    merge_blocks=False,
-                )
-                compiled_kernel_first = cute.compile(
-                    filtered_topk_func_first,
-                    input_fake,
-                    None,  # indices_fake
-                    buffer_fake,
-                    None,  # g_global_counter_fake
-                    seqlen_fake,
-                    first_kernel_output_indices_fake,
-                    first_kernel_output_values_fake,
-                    stream=fake_stream,
-                    enable_persistent_dynamic_scheduling=load_balance,
-                    min_blocks_per_mp=1,
-                )
-
-                # Second kernel: merge partial results
-                indices_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, n_div_32),
-                    stride_order=(1, 0),
-                )
-                output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (n, top_k),
-                    stride_order=(1, 0),
-                )
-                if return_val:
-                    output_values_fake = cute.runtime.make_fake_compact_tensor(
-                        dtype,
-                        (n, top_k),
-                        stride_order=(1, 0),
-                    )
-                else:
-                    output_values_fake = None
-                filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
-                    dtype,
-                    num_ctas_per_row * top_k,  # num_cols
-                    top_k,
-                    next_n,
-                    num_copy_bits=num_copy_bits,
-                    return_val=return_val,
-                    large_occupancy=large_occupancy,
-                    enable_multi_cta=False,
-                    merge_blocks=True,
-                )
-                compiled_kernel_second = cute.compile(
-                    filtered_topk_func_second,
-                    input_fake,
-                    indices_fake,
-                    buffer_fake,
-                    None,  # g_global_counter_fake
-                    seqlen_fake,
-                    output_indices_fake,
-                    output_values_fake,
-                    stream=fake_stream,
-                    enable_persistent_dynamic_scheduling=load_balance,
-                    min_blocks_per_mp=1,
-                )
-
-                self.__class__.kernel_cache[key] = (compiled_kernel_first,
-                                                    compiled_kernel_second)
-            else:
-                compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[
-                    key]
+            compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[key]
 
             # Prepare intermediate output tensors for first kernel
             first_kernel_output_indices_torch = torch.empty(num_rows,
@@ -3564,3 +3508,63 @@ if IS_CUTLASS_DSL_AVAILABLE:
         num_rows = input_values.shape[0]
         indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
         return indices
+
+    # Default bucketed num_cols values to warmup (powers of 2 from 4096 to 262144).
+    _TOPK_WARMUP_BUCKETED_NUM_COLS = [1 << i for i in range(12, 19)]
+
+    def warmup_cute_dsl_topk_kernels(
+        dtype=cutlass.BFloat16,
+        top_k: int = 2048,
+        next_n: int = 1,
+        return_val: bool = False,
+        num_copy_bits: int = 256,
+        bucketed_num_cols_list: list | None = None,
+        chunk_size_per_cta: int = 16384,
+    ):
+        """Pre-compile CuTE DSL top-k kernels for common configurations.
+
+        Enumerates all combinations of (bucketed_num_cols, large_occupancy)
+        and compiles both single-CTA and multi-CTA kernels. This avoids
+        compilation latency on the first decode request.
+
+        Args:
+            dtype: Cutlass data type (default BFloat16).
+            top_k: Number of top-k elements (default 2048).
+            next_n: Speculative decoding candidates (default 1).
+            return_val: Whether kernels should return values (default False).
+            num_copy_bits: Vectorization width (default 256).
+            bucketed_num_cols_list: List of bucketed num_cols to warmup.
+                If None, uses powers of 2 from 4096 to 131072.
+            chunk_size_per_cta: Chunk size for multi-CTA (default 16384).
+        """
+        if bucketed_num_cols_list is None:
+            bucketed_num_cols_list = _TOPK_WARMUP_BUCKETED_NUM_COLS
+
+        load_balance = False
+        count = 0
+        for bucketed_num_cols in bucketed_num_cols_list:
+            for large_occupancy in [False, True]:
+                # Single-CTA kernel
+                CuteDSLTopKDecodeSingleCTARunner._compile(
+                    dtype, bucketed_num_cols, top_k, next_n,
+                    return_val, num_copy_bits, load_balance,
+                    large_occupancy,
+                )
+                count += 1
+
+                # Multi-CTA kernel (only when num_cols > chunk_size_per_cta)
+                num_ctas_per_row = math.ceil(
+                    bucketed_num_cols / chunk_size_per_cta)
+                if num_ctas_per_row > 1:
+                    CuteDSLTopKDecodeMultiCTARunner._compile(
+                        dtype, bucketed_num_cols, top_k, next_n,
+                        return_val, num_copy_bits, load_balance,
+                        large_occupancy, chunk_size_per_cta,
+                        num_ctas_per_row,
+                    )
+                    count += 1
+
+        logger.info(
+            f"Warmup: pre-compiled {count} CuTE DSL top-k kernels "
+            f"(dtype={dtype}, top_k={top_k}, next_n={next_n})"
+        )

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2789,3 +2789,229 @@ if IS_CUTLASS_DSL_AVAILABLE:
         assert output.dtype == torch.bfloat16, "CuTe DSL fp8 bmm output dtype must be bf16"
         assert output.shape == (batch_size, m,
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
+
+    # ========================================================================
+    # CuTE DSL Top-K Operations
+    # ========================================================================
+
+    import cutlass
+    import cutlass.cute as cute
+
+    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
+        FilteredTopKKernelVarlenDecode
+
+    class CuteDSLTopKDecodeSingleCTARunner:
+        """Runner for CuTE DSL Top-K decode kernel (single CTA version)."""
+        kernel_cache = dict()
+
+        def __init__(self):
+            pass
+
+        def forward(
+            self,
+            input_values: torch.Tensor,
+            seq_lens: torch.Tensor,
+            top_k: int,
+            next_n: int,
+            return_val: bool = True,
+            num_copy_bits: int = 256,
+        ):
+            torch_dtype = input_values.dtype
+            torch_dtype_to_cutlass_dtype = {
+                torch.float16: cutlass.Float16,
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float32: cutlass.Float32,
+            }
+            dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+            num_rows, num_cols = input_values.shape
+
+            large_occupancy = num_rows > 148
+            load_balance = False
+
+            # Compilation key
+            key = (
+                dtype,
+                num_cols,
+                top_k,
+                next_n,
+                return_val,
+                num_copy_bits,
+                load_balance,
+                large_occupancy,
+            )
+
+            if key not in self.__class__.kernel_cache:
+                # Create fake tensors for compilation
+                n = cute.sym_int()
+                n_div_32 = cute.sym_int(divisibility=32)
+                input_fake = cute.runtime.make_fake_compact_tensor(
+                    dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+                buffer_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                    stride_order=(2, 1, 0),
+                    assumed_align=32,
+                )
+                seqlen_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, ),
+                    stride_order=(0, ),
+                )
+                output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, top_k),
+                    stride_order=(1, 0),
+                )
+                if return_val:
+                    output_values_fake = cute.runtime.make_fake_compact_tensor(
+                        dtype,
+                        (n, top_k),
+                        stride_order=(1, 0),
+                    )
+                else:
+                    output_values_fake = None
+                fake_stream = cute.runtime.make_fake_stream()
+
+                filtered_topk_func = FilteredTopKKernelVarlenDecode(
+                    dtype,
+                    num_cols,
+                    top_k,
+                    next_n,
+                    num_copy_bits=num_copy_bits,
+                    return_val=return_val,
+                    large_occupancy=large_occupancy,
+                )
+
+                # Compile the kernel
+                compiled_kernel = cute.compile(
+                    filtered_topk_func,
+                    input_fake,
+                    None,  # indices_fake
+                    buffer_fake,
+                    None,  # g_global_counter_fake
+                    seqlen_fake,
+                    output_indices_fake,
+                    output_values_fake,
+                    stream=fake_stream,
+                    enable_persistent_dymamic_scheduling=load_balance,
+                    min_blocks_per_mp=1,
+                )
+                self.__class__.kernel_cache[key] = compiled_kernel
+            else:
+                compiled_kernel = self.__class__.kernel_cache[key]
+
+            # Prepare output tensors
+            output_indices_torch = torch.empty(num_rows,
+                                               top_k,
+                                               dtype=torch.int32,
+                                               device="cuda")
+            if return_val:
+                output_values_torch = torch.empty(num_rows,
+                                                  top_k,
+                                                  dtype=torch_dtype,
+                                                  device="cuda")
+            else:
+                output_values_torch = None
+
+            # Prepare buffer
+            if dtype == cutlass.Float32:
+                buffer_numbers = 2
+            else:
+                buffer_numbers = 1
+            buffer_torch = torch.empty(num_rows,
+                                       buffer_numbers,
+                                       num_cols,
+                                       dtype=torch.int32,
+                                       device="cuda")
+
+            # Get current CUDA stream
+            torch_stream = torch.cuda.current_stream()
+            current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+            # Execute kernel
+            compiled_kernel(
+                input_values,
+                None,  # indices
+                buffer_torch,
+                None,  # g_global_counter_torch
+                seq_lens,
+                output_indices_torch,
+                output_values_torch,
+                current_stream,
+            )
+
+            return output_indices_torch, output_values_torch
+
+    @torch.library.custom_op("trtllm::cute_dsl_topk_decode_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
+    def cute_dsl_topk_decode_blackwell(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+    ) -> torch.Tensor:
+        """CuteDSL-based Top-K selection optimized for Blackwell decode phase.
+
+        Args:
+            input_values: Input logits tensor [batch_size * next_n, vocab_size]
+            seq_lens: Sequence lengths for each batch [batch_size]
+            top_k: Number of top elements to select (max 2048)
+            next_n: Number of candidates per sequence (for speculative decoding)
+            num_copy_bits: Number of bits for vectorized memory copy (128 or 256)
+
+        Returns:
+            indices: Top-k indices [batch_size * next_n, top_k]
+
+        Note:
+            This function requires Blackwell architecture (SM100+) and CuTE DSL support.
+            Maximum supported top_k is 2048.
+        """
+        # Validate SM version
+        sm_version = get_sm_version()
+        if sm_version < 100:
+            raise ValueError(
+                f"CuTE DSL top-k requires Blackwell (SM100+), but got SM {sm_version}. "
+            )
+
+        # Validate inputs
+        if top_k > 2048:
+            raise ValueError(
+                f"CuTE DSL top-k supports max top_k=2048, but got {top_k}")
+
+        if input_values.dim() != 2:
+            raise ValueError(
+                f"input_values must be 2D [num_rows, vocab_size], got shape {input_values.shape}"
+            )
+
+        if seq_lens.dim() != 1:
+            raise ValueError(
+                f"seq_lens must be 1D [batch_size], got shape {seq_lens.shape}")
+
+        # Use the Runner class
+        runner = CuteDSLTopKDecodeSingleCTARunner()
+        indices, _ = runner.forward(
+            input_values=input_values,
+            seq_lens=seq_lens,
+            top_k=top_k,
+            next_n=next_n,
+            return_val=False,  # Only return indices
+            num_copy_bits=num_copy_bits,
+        )
+        return indices
+
+    @torch.library.register_fake("trtllm::cute_dsl_topk_decode_blackwell")
+    def _(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+    ):
+        num_rows = input_values.shape[0]
+        input_values.dtype
+
+        # Create output tensors matching the custom op return signature: (values, indices)
+        indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
+        return indices

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3262,7 +3262,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: bool = False,
             num_copy_bits: int = 256,
             chunk_size_per_cta: int = 16384,
-            dynamic: bool = False,
+            dynamic: bool = True,
         ):
             """Execute multi-CTA filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
@@ -3317,28 +3317,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 buffer_numbers = 1
 
             if dynamic:
-                # Bounds check: num_rows must fit in the in-kernel prefix sum
-                _DYNAMIC_MAX_NUM_ROWS = 512
-                if num_rows > _DYNAMIC_MAX_NUM_ROWS:
-                    raise ValueError(
-                        f"dynamic multi-CTA top-k: num_rows ({num_rows}) "
-                        f"exceeds limit ({_DYNAMIC_MAX_NUM_ROWS}). "
-                        f"Reduce batch_size * next_n to "
-                        f"<= {_DYNAMIC_MAX_NUM_ROWS}.")
-
-                # Use upper-bound allocation to avoid DtoH sync (.item()).
-                # The first kernel early-exits CTAs beyond actual total_ctas.
-                max_total_ctas = num_rows * num_ctas_per_row
-
+                # Dynamic mode: 2D grid (num_rows, num_ctas_per_row) with
+                # per-CTA early exit for rows needing fewer chunks.
                 # Intermediate buffers: 2D (num_rows, merge_cols)
                 first_output_indices = torch.empty(
                     num_rows, merge_cols, dtype=torch.int32, device="cuda")
                 first_output_values = torch.empty(
                     num_rows, merge_cols, dtype=torch_dtype, device="cuda")
 
-                # Buffer sized by upper bound
+                # Shared buffer for both kernels (they run sequentially)
+                buffer_dim2 = max(chunk_size_per_cta, merge_cols)
                 buffer_torch = torch.empty(
-                    max_total_ctas, buffer_numbers, chunk_size_per_cta,
+                    num_rows * num_ctas_per_row, buffer_numbers,
+                    buffer_dim2,
                     dtype=torch.int32, device="cuda")
 
                 # Final output tensors
@@ -3350,8 +3341,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 else:
                     output_values_torch = None
 
-                # Execute first kernel: dynamic per-chunk top-k
-                # Offsets are computed in-kernel via shared memory prefix sum.
+                # Execute first kernel: per-chunk top-k with early exit
                 compiled_kernel_first(
                     input_values,
                     None,  # indices
@@ -3362,17 +3352,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     first_output_values,
                 )
 
-                # Merge buffer (one per row)
-                merge_buffer_torch = torch.empty(
-                    num_rows, buffer_numbers, merge_cols,
-                    dtype=torch.int32, device="cuda")
-
-                # Execute second kernel: varlen merge
+                # Execute second kernel: varlen merge (reuses buffer_torch)
                 # merge_width computed in-kernel from seqlen.
                 compiled_kernel_second(
                     first_output_values,
                     first_output_indices,
-                    merge_buffer_torch,
+                    buffer_torch,
                     None,  # g_global_counter_torch
                     seq_lens,
                     output_indices_torch,
@@ -3435,7 +3420,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         next_n: int = 1,
         num_copy_bits: int = 256,
         chunk_size_per_cta: int = 16384,
-        dynamic: bool = False,
+        dynamic: bool = True,
     ) -> torch.Tensor:
         """CuteDSL-based multi-CTA Top-K selection optimized for Blackwell decode phase.
 
@@ -3517,7 +3502,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         next_n: int = 1,
         num_copy_bits: int = 256,
         chunk_size_per_cta: int = 16384,
-        dynamic: bool = False,
+        dynamic: bool = True,
     ):
         num_rows = input_values.shape[0]
 
@@ -3537,17 +3522,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> torch.Tensor:
         """Unified CuTE DSL Top-K that auto-selects single-CTA or multi-CTA.
 
-        Automatically chooses the faster kernel based on a dual-condition:
-          1. dtype threshold: fp16/bf16 >= 32768, fp32 >= 65536
-          2. SM utilization < 15% AND multi-CTA waves <= 2
+        Automatically chooses the faster kernel based on:
+          1. dtype threshold: fp16/bf16 >= 131072, fp32 >= 65536
+          2. SM utilization < 25% (num_rows < num_sms // 4)
         Multi-CTA is only used when both conditions are met, ensuring it
-        only activates when single-CTA occupancy is genuinely low and
-        multi-CTA overhead is bounded.
+        only activates when single-CTA occupancy is genuinely low.
         Uses chunk_size_per_cta=16384 for multi-CTA.
 
         Based on benchmark results (Blackwell SM100, top_k=2048).
-        See bench_cute_dsl_multi_cta_vs_single_cta_topk_results.txt
-        and bench_cute_dsl_indexer_topk_results.txt.
+        See bench_cute_dsl_single_vs_multi_cta_topk.py.
 
         Args:
             input_values: Input logits tensor [batch_size * next_n, vocab_size]
@@ -3563,25 +3546,20 @@ if IS_CUTLASS_DSL_AVAILABLE:
         num_tokens = input_values.shape[1]
         chunk_size_per_cta = 16384
 
-        # Multi-CTA thresholds by dtype (num_tokens above which multi-CTA is faster)
+        # Multi-CTA vocab thresholds by dtype.
+        # fp32: multi-CTA wins at vocab >= 65536 (4+ CTAs per row)
+        # fp16/bf16: multi-CTA wins at vocab >= 131072 (8+ CTAs per row)
         if input_values.dtype == torch.float32:
             use_multi_cta = num_tokens >= 65536
         else:
-            # fp16 / bf16
-            use_multi_cta = num_tokens >= 32768
+            use_multi_cta = num_tokens >= 131072
 
-        # Only use multi-CTA when both conditions are met:
-        # 1. Single CTA SM utilization is low (< 15%) — not enough rows
-        #    to keep SMs busy with one block each.
-        # 2. Multi-CTA total blocks fit within 2 waves — beyond that the
-        #    2-pass overhead (kernel launch + intermediate buffer I/O)
-        #    outweighs the parallelism gain.
+        # Only use multi-CTA when SM utilization from single-CTA is low
+        # (< 25%). Beyond this, single-CTA already saturates the SMs and
+        # multi-CTA 2-pass overhead hurts.
         if use_multi_cta:
             num_sms = _get_num_sms()
-            num_ctas_per_row = math.ceil(num_tokens / chunk_size_per_cta)
-            sm_util_low = num_rows < num_sms * 15 // 100  # < 15%
-            multi_waves = math.ceil(num_rows * num_ctas_per_row / num_sms)
-            use_multi_cta = sm_util_low and multi_waves <= 2
+            use_multi_cta = num_rows < num_sms // 4
 
         if use_multi_cta:
             indices, _ = CuteDSLTopKDecodeMultiCTARunner.forward(

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2793,7 +2793,26 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
 
     class CuteDSLTopKDecodeSingleCTARunner:
-        """Runner for CuTE DSL Top-K decode kernel (single CTA version)."""
+        """Runner for CuTE DSL Top-K decode kernel (single CTA version).
+
+        This runner manages compilation and execution of the filtered top-k kernel
+        optimized for Blackwell architecture using CuTE DSL. It implements a
+        radix-based filtering algorithm for efficient top-k selection.
+
+        The runner caches compiled kernels based on configuration (dtype, shape, top_k)
+        to avoid redundant recompilation. Cache is shared across all instances.
+
+        Attributes:
+            kernel_cache: Class-level dict mapping configuration tuples to compiled kernels.
+                         Keys are (dtype, num_cols, top_k, next_n, return_val, num_copy_bits,
+                         load_balance, large_occupancy).
+
+        Note:
+            - Requires Blackwell architecture (SM100+)
+            - Maximum tested top_k is 2048 (see kernel documentation for larger values)
+            - Supports fp16, bf16, and fp32 dtypes
+            - Automatically selects occupancy optimization based on batch size
+        """
         kernel_cache = dict()
 
         def __init__(self):
@@ -2808,6 +2827,44 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: bool = True,
             num_copy_bits: int = 256,
         ):
+            """Execute filtered top-k selection on input logits.
+
+            This method compiles (if not cached) and executes the CuTE DSL top-k kernel.
+            It selects the top_k largest values per row using a radix-based filtering
+            algorithm optimized for Blackwell architecture.
+
+            Args:
+                input_values: Input logits tensor [batch_size * next_n, vocab_size].
+                             Must be 2D with dtype in {float16, bfloat16, float32}.
+                seq_lens: Sequence lengths for each batch [batch_size].
+                         Must be 1D int32 tensor. Used to determine valid range per row.
+                top_k: Number of top elements to select per row (1 to 2048).
+                      Must be divisible by vectorization width.
+                next_n: Number of candidates per sequence (for speculative decoding).
+                       Must be positive integer. Total rows = batch_size * next_n.
+                return_val: If True, return both indices and values.
+                           If False, return only indices (values will be None).
+                           Setting to False saves memory and computation.
+                num_copy_bits: Vectorization width for memory copy (128 or 256).
+                              Higher values may improve bandwidth utilization.
+
+            Returns:
+                tuple: (indices, values) where:
+                    - indices: Top-k indices [batch_size * next_n, top_k], int32.
+                              Values are relative to start of each row.
+                    - values: Top-k values [batch_size * next_n, top_k] if return_val=True,
+                             else None. Sorted in descending order per row.
+
+            Raises:
+                ValueError: If inputs have invalid shape, dtype, or parameter values.
+                KeyError: If unsupported dtype is provided.
+
+            Note:
+                - Kernel is compiled on first use for each unique configuration
+                - Compilation cache grows unbounded (consider clearing periodically)
+                - Uses current CUDA stream for asynchronous execution
+                - Occupancy is automatically optimized for batch_size > 148
+            """
             torch_dtype_to_cutlass_dtype = {
                 torch.float16: cutlass.Float16,
                 torch.bfloat16: cutlass.BFloat16,

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2861,7 +2861,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 - Kernel is compiled on first use for each unique configuration
                 - Compilation cache grows unbounded (consider clearing periodically)
                 - Uses current CUDA stream for asynchronous execution
-                - Occupancy is automatically optimized for batch_size > 148
+                - Occupancy is automatically optimized when batch_size > num_SMs
             """
             torch_dtype = input_values.dtype
             torch_dtype_to_cutlass_dtype = {
@@ -2872,9 +2872,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
             num_rows, num_cols = input_values.shape
 
-            # 148 is the number of SMs in Blackwell GPU.
-            # TODO: replace with api query sm count.
-            large_occupancy = num_rows > 148
+            num_sms = torch.cuda.get_device_properties().multi_processor_count
+            large_occupancy = num_rows > num_sms
             load_balance = False
 
             # Compilation key
@@ -2944,7 +2943,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     output_indices_fake,
                     output_values_fake,
                     stream=fake_stream,
-                    enable_persistent_dymamic_scheduling=load_balance,
+                    enable_persistent_dynamic_scheduling=load_balance,
                     min_blocks_per_mp=1,
                 )
                 self.__class__.kernel_cache[key] = compiled_kernel
@@ -2969,6 +2968,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 buffer_numbers = 2
             else:
                 buffer_numbers = 1
+            buffer_bytes = num_rows * buffer_numbers * num_cols * 4
+            if buffer_bytes > 1 << 30:  # > 1 GB
+                logger.warning(
+                    f"CuTE DSL top-k: intermediate buffer is {buffer_bytes / (1 << 30):.1f} GB "
+                    f"(num_rows={num_rows}, num_cols={num_cols}). "
+                    "Consider reducing batch size or vocab size to avoid OOM."
+                )
             buffer_torch = torch.empty(num_rows,
                                        buffer_numbers,
                                        num_cols,
@@ -3149,9 +3155,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
             num_rows, num_cols = input_values.shape
 
-            # 148 is the number of SMs in Blackwell GPU.
-            # TODO: replace with api query sm count.
-            large_occupancy = num_rows > 148
+            num_sms = torch.cuda.get_device_properties().multi_processor_count
+            large_occupancy = num_rows > num_sms
             load_balance = False
 
             num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
@@ -3224,7 +3229,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     first_kernel_output_indices_fake,
                     first_kernel_output_values_fake,
                     stream=fake_stream,
-                    enable_persistent_dymamic_scheduling=load_balance,
+                    enable_persistent_dynamic_scheduling=load_balance,
                     min_blocks_per_mp=1,
                 )
 
@@ -3268,7 +3273,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     output_indices_fake,
                     output_values_fake,
                     stream=fake_stream,
-                    enable_persistent_dymamic_scheduling=load_balance,
+                    enable_persistent_dynamic_scheduling=load_balance,
                     min_blocks_per_mp=1,
                 )
 
@@ -3308,10 +3313,18 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 buffer_numbers = 2
             else:
                 buffer_numbers = 1
+            buffer_dim2 = max(chunk_size_per_cta, num_ctas_per_row * top_k)
+            buffer_bytes = num_rows * num_ctas_per_row * buffer_numbers * buffer_dim2 * 4
+            if buffer_bytes > 1 << 30:  # > 1 GB
+                logger.warning(
+                    f"CuTE DSL multi-CTA top-k: intermediate buffer is "
+                    f"{buffer_bytes / (1 << 30):.1f} GB "
+                    f"(num_rows={num_rows}, num_ctas_per_row={num_ctas_per_row}). "
+                    "Consider reducing batch size or vocab size to avoid OOM."
+                )
             buffer_torch = torch.empty(num_rows * num_ctas_per_row,
                                        buffer_numbers,
-                                       max(chunk_size_per_cta,
-                                           num_ctas_per_row * top_k),
+                                       buffer_dim2,
                                        dtype=torch.int32,
                                        device="cuda")
 
@@ -3460,7 +3473,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Multi-CTA is only used when both conditions are met, ensuring it
         only activates when single-CTA occupancy is genuinely low and
         multi-CTA overhead is bounded.
-        Uses chunk_size_per_cta=16384 for multi-CTA, num_sms=148 (Blackwell).
+        Uses chunk_size_per_cta=16384 for multi-CTA.
 
         Based on benchmark results (Blackwell SM100, top_k=2048).
         See bench_cute_dsl_multi_cta_vs_single_cta_topk_results.txt
@@ -3493,10 +3506,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         # 2. Multi-CTA total blocks fit within 2 waves — beyond that the
         #    2-pass overhead (kernel launch + intermediate buffer I/O)
         #    outweighs the parallelism gain.
-        # 148 is the number of SMs in Blackwell GPU.
-        # See bench_cute_dsl_multi_cta_vs_single_cta_topk_results.txt.
         if use_multi_cta:
-            num_sms = 148
+            num_sms = torch.cuda.get_device_properties().multi_processor_count
             num_ctas_per_row = math.ceil(num_tokens / chunk_size_per_cta)
             sm_util_low = num_rows < num_sms * 15 // 100  # < 15%
             multi_waves = math.ceil(num_rows * num_ctas_per_row / num_sms)

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3279,16 +3279,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     key]
 
             # Prepare intermediate output tensors for first kernel
-            first_kernel_output_indices_torch = torch.empty(
-                num_rows,
-                num_ctas_per_row * top_k,
-                dtype=torch.int32,
-                device="cuda")
-            first_kernel_output_values_torch = torch.empty(
-                num_rows,
-                num_ctas_per_row * top_k,
-                dtype=torch_dtype,
-                device="cuda")
+            first_kernel_output_indices_torch = torch.empty(num_rows,
+                                                            num_ctas_per_row *
+                                                            top_k,
+                                                            dtype=torch.int32,
+                                                            device="cuda")
+            first_kernel_output_values_torch = torch.empty(num_rows,
+                                                           num_ctas_per_row *
+                                                           top_k,
+                                                           dtype=torch_dtype,
+                                                           device="cuda")
 
             # Prepare final output tensors
             output_indices_torch = torch.empty(num_rows,
@@ -3308,12 +3308,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 buffer_numbers = 2
             else:
                 buffer_numbers = 1
-            buffer_torch = torch.empty(
-                num_rows * num_ctas_per_row,
-                buffer_numbers,
-                max(chunk_size_per_cta, num_ctas_per_row * top_k),
-                dtype=torch.int32,
-                device="cuda")
+            buffer_torch = torch.empty(num_rows * num_ctas_per_row,
+                                       buffer_numbers,
+                                       max(chunk_size_per_cta,
+                                           num_ctas_per_row * top_k),
+                                       dtype=torch.int32,
+                                       device="cuda")
 
             # Get current CUDA stream
             torch_stream = torch.cuda.current_stream()
@@ -3345,10 +3345,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             return output_indices_torch, output_values_torch
 
-    @torch.library.custom_op(
-        "trtllm::cute_dsl_topk_decode_multi_cta_blackwell",
-        mutates_args=(),
-        device_types="cuda")
+    @torch.library.custom_op("trtllm::cute_dsl_topk_decode_multi_cta_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
     def cute_dsl_topk_decode_multi_cta_blackwell(
         input_values: torch.Tensor,
         seq_lens: torch.Tensor,
@@ -3440,5 +3439,95 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ):
         num_rows = input_values.shape[0]
 
+        indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
+        return indices
+
+    @torch.library.custom_op("trtllm::cute_dsl_indexer_topk_decode",
+                             mutates_args=(),
+                             device_types="cuda")
+    def cute_dsl_indexer_topk_decode(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+    ) -> torch.Tensor:
+        """Unified CuTE DSL Top-K that auto-selects single-CTA or multi-CTA.
+
+        Automatically chooses the faster kernel based on a dual-condition:
+          1. dtype threshold: fp16/bf16 >= 32768, fp32 >= 65536
+          2. SM utilization < 15% AND multi-CTA waves <= 2
+        Multi-CTA is only used when both conditions are met, ensuring it
+        only activates when single-CTA occupancy is genuinely low and
+        multi-CTA overhead is bounded.
+        Uses chunk_size_per_cta=16384 for multi-CTA, num_sms=148 (Blackwell).
+
+        Based on benchmark results (Blackwell SM100, top_k=2048).
+        See bench_cute_dsl_multi_cta_vs_single_cta_topk_results.txt
+        and bench_cute_dsl_indexer_topk_results.txt.
+
+        Args:
+            input_values: Input logits tensor [batch_size * next_n, vocab_size]
+            seq_lens: Sequence lengths for each batch [batch_size]
+            top_k: Number of top elements to select (max 2048)
+            next_n: Number of candidates per sequence (for speculative decoding)
+            num_copy_bits: Number of bits for vectorized memory copy (128 or 256)
+
+        Returns:
+            indices: Top-k indices [batch_size * next_n, top_k]
+        """
+        num_rows = input_values.shape[0]
+        num_tokens = input_values.shape[1]
+        chunk_size_per_cta = 16384
+
+        # Multi-CTA thresholds by dtype (num_tokens above which multi-CTA is faster)
+        if input_values.dtype == torch.float32:
+            use_multi_cta = num_tokens >= 65536
+        else:
+            # fp16 / bf16
+            use_multi_cta = num_tokens >= 32768
+
+        # Only use multi-CTA when both conditions are met:
+        # 1. Single CTA SM utilization is low (< 15%) — not enough rows
+        #    to keep SMs busy with one block each.
+        # 2. Multi-CTA total blocks fit within 2 waves — beyond that the
+        #    2-pass overhead (kernel launch + intermediate buffer I/O)
+        #    outweighs the parallelism gain.
+        # 148 is the number of SMs in Blackwell GPU.
+        # See bench_cute_dsl_multi_cta_vs_single_cta_topk_results.txt.
+        if use_multi_cta:
+            num_sms = 148
+            num_ctas_per_row = math.ceil(num_tokens / chunk_size_per_cta)
+            sm_util_low = num_rows < num_sms * 15 // 100  # < 15%
+            multi_waves = math.ceil(num_rows * num_ctas_per_row / num_sms)
+            use_multi_cta = sm_util_low and multi_waves <= 2
+
+        if use_multi_cta:
+            return cute_dsl_topk_decode_multi_cta_blackwell(
+                input_values=input_values,
+                seq_lens=seq_lens,
+                top_k=top_k,
+                next_n=next_n,
+                num_copy_bits=num_copy_bits,
+                chunk_size_per_cta=chunk_size_per_cta,
+            )
+        else:
+            return cute_dsl_topk_decode_blackwell(
+                input_values=input_values,
+                seq_lens=seq_lens,
+                top_k=top_k,
+                next_n=next_n,
+                num_copy_bits=num_copy_bits,
+            )
+
+    @torch.library.register_fake("trtllm::cute_dsl_indexer_topk_decode")
+    def _(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+    ):
+        num_rows = input_values.shape[0]
         indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
         return indices

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2891,20 +2891,26 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 num_copy_bits=num_copy_bits,
                 return_val=return_val,
                 large_occupancy=large_occupancy,
+                num_sms=_get_num_sms(),
             )
+            if load_balance:
+                g_global_counter_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32, (1,), stride_order=(0,))
+            else:
+                g_global_counter_fake = None
             compiled_kernel = cute.compile(
                 filtered_topk_func,
                 input_fake,
                 None,  # indices_fake
                 buffer_fake,
-                None,  # g_global_counter_fake
+                g_global_counter_fake,
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
 
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
-                min_blocks_per_mp=1,
+                min_blocks_per_mp=4 if large_occupancy else 1,
                 options="--enable-tvm-ffi",
             )
             cls.kernel_cache[key] = compiled_kernel
@@ -2918,6 +2924,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             next_n: int,
             return_val: bool = False,
             num_copy_bits: int = 256,
+            load_balance: bool = False,
         ):
             """Execute filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
@@ -2927,7 +2934,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_sms = _get_num_sms()
             large_occupancy = num_rows > num_sms
-            load_balance = False
 
             # Compilation key
             key = (
@@ -2984,12 +2990,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                        dtype=torch.int32,
                                        device="cuda")
 
+            # Prepare global counter for persistent dynamic scheduling
+            if load_balance:
+                g_global_counter_torch = torch.zeros(
+                    1, dtype=torch.int32, device="cuda")
+            else:
+                g_global_counter_torch = None
+
             # Execute kernel (TVM FFI uses env stream automatically)
             compiled_kernel(
                 input_values,
                 None,  # indices
                 buffer_torch,
-                None,  # g_global_counter_torch
+                g_global_counter_torch,
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
@@ -3007,6 +3020,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         top_k: int,
         next_n: int = 1,
         num_copy_bits: int = 256,
+        load_balance: bool = False,
     ) -> torch.Tensor:
         """CuteDSL-based Top-K selection optimized for Blackwell decode phase.
 
@@ -3016,6 +3030,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             top_k: Number of top elements to select (max 2048)
             next_n: Number of candidates per sequence (for speculative decoding)
             num_copy_bits: Number of bits for vectorized memory copy (128 or 256)
+            load_balance: Enable persistent dynamic scheduling for load balancing
 
         Returns:
             indices: Top-k indices [batch_size * next_n, top_k]
@@ -3065,6 +3080,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             next_n=next_n,
             return_val=False,  # Only return indices
             num_copy_bits=num_copy_bits,
+            load_balance=load_balance,
         )
         return indices
 
@@ -3075,6 +3091,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         top_k: int,
         next_n: int = 1,
         num_copy_bits: int = 256,
+        load_balance: bool = False,
     ):
         num_rows = input_values.shape[0]
         input_values.dtype

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2895,7 +2895,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             if load_balance:
                 g_global_counter_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32, (1,), stride_order=(0,))
+                    cutlass.Int32, (1, ), stride_order=(0, ))
             else:
                 g_global_counter_fake = None
             compiled_kernel = cute.compile(
@@ -2907,7 +2907,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
-
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=4 if large_occupancy else 1,
@@ -2992,8 +2991,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             # Prepare global counter for persistent dynamic scheduling
             if load_balance:
-                g_global_counter_torch = torch.zeros(
-                    1, dtype=torch.int32, device="cuda")
+                g_global_counter_torch = torch.zeros(1,
+                                                     dtype=torch.int32,
+                                                     device="cuda")
             else:
                 g_global_counter_torch = None
 
@@ -3006,7 +3006,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
-
             )
 
             return output_indices_torch, output_values_torch
@@ -3134,9 +3133,17 @@ if IS_CUTLASS_DSL_AVAILABLE:
         kernel_cache = dict()
 
         @classmethod
-        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
-                     num_copy_bits, load_balance, large_occupancy,
-                     chunk_size_per_cta, num_ctas_per_row,
+        def _compile(cls,
+                     dtype,
+                     bucketed_num_cols,
+                     top_k,
+                     next_n,
+                     return_val,
+                     num_copy_bits,
+                     load_balance,
+                     large_occupancy,
+                     chunk_size_per_cta,
+                     num_ctas_per_row,
                      dynamic=False):
             """Compile and cache multi-CTA top-k kernels for the given config."""
             key = (
@@ -3337,24 +3344,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 # Dynamic mode: 2D grid (num_rows, num_ctas_per_row) with
                 # per-CTA early exit for rows needing fewer chunks.
                 # Intermediate buffers: 2D (num_rows, merge_cols)
-                first_output_indices = torch.empty(
-                    num_rows, merge_cols, dtype=torch.int32, device="cuda")
-                first_output_values = torch.empty(
-                    num_rows, merge_cols, dtype=torch_dtype, device="cuda")
+                first_output_indices = torch.empty(num_rows,
+                                                   merge_cols,
+                                                   dtype=torch.int32,
+                                                   device="cuda")
+                first_output_values = torch.empty(num_rows,
+                                                  merge_cols,
+                                                  dtype=torch_dtype,
+                                                  device="cuda")
 
                 # Shared buffer for both kernels (they run sequentially)
                 buffer_dim2 = max(chunk_size_per_cta, merge_cols)
-                buffer_torch = torch.empty(
-                    num_rows * num_ctas_per_row, buffer_numbers,
-                    buffer_dim2,
-                    dtype=torch.int32, device="cuda")
+                buffer_torch = torch.empty(num_rows * num_ctas_per_row,
+                                           buffer_numbers,
+                                           buffer_dim2,
+                                           dtype=torch.int32,
+                                           device="cuda")
 
                 # Final output tensors
-                output_indices_torch = torch.empty(
-                    num_rows, top_k, dtype=torch.int32, device="cuda")
+                output_indices_torch = torch.empty(num_rows,
+                                                   top_k,
+                                                   dtype=torch.int32,
+                                                   device="cuda")
                 if return_val:
-                    output_values_torch = torch.empty(
-                        num_rows, top_k, dtype=torch_dtype, device="cuda")
+                    output_values_torch = torch.empty(num_rows,
+                                                      top_k,
+                                                      dtype=torch_dtype,
+                                                      device="cuda")
                 else:
                     output_values_torch = None
 
@@ -3389,19 +3405,25 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     num_rows, merge_cols, dtype=torch_dtype, device="cuda")
 
                 # Prepare final output tensors
-                output_indices_torch = torch.empty(
-                    num_rows, top_k, dtype=torch.int32, device="cuda")
+                output_indices_torch = torch.empty(num_rows,
+                                                   top_k,
+                                                   dtype=torch.int32,
+                                                   device="cuda")
                 if return_val:
-                    output_values_torch = torch.empty(
-                        num_rows, top_k, dtype=torch_dtype, device="cuda")
+                    output_values_torch = torch.empty(num_rows,
+                                                      top_k,
+                                                      dtype=torch_dtype,
+                                                      device="cuda")
                 else:
                     output_values_torch = None
 
                 # Prepare buffer
                 buffer_dim2 = max(chunk_size_per_cta, merge_cols)
-                buffer_torch = torch.empty(
-                    num_rows * num_ctas_per_row, buffer_numbers, buffer_dim2,
-                    dtype=torch.int32, device="cuda")
+                buffer_torch = torch.empty(num_rows * num_ctas_per_row,
+                                           buffer_numbers,
+                                           buffer_dim2,
+                                           dtype=torch.int32,
+                                           device="cuda")
 
                 # Execute first kernel: per-chunk top-k
                 compiled_kernel_first(

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -318,8 +318,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Sm100BlockwiseGemmKernel
     from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
         Sm100BlockScaledPersistentDenseGemmKernel
-    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
-        FilteredTopKKernelVarlenDecode
+    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import (
+        ComputeDynamicCTAOffsets,
+        FilteredTopKKernelVarlenDecode,
+    )
     from ..cute_dsl_kernels.blackwell.utils import make_ptr
 
     class CuteDSLNVFP4BlackwellRunner(TunableRunner):
@@ -2901,6 +2903,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
+                None,  # row_cta_offsets
+                None,  # row_output_offsets
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
@@ -2992,6 +2996,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
+                None,  # row_cta_offsets
+                None,  # row_output_offsets
             )
 
             return output_indices_torch, output_values_torch
@@ -3089,6 +3095,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
         CuTE DSL. It splits each row into chunks processed by separate CTAs,
         then merges partial results in a second kernel pass.
 
+        Supports two modes:
+        - **Static** (dynamic=False): Fixed grid (num_rows, num_ctas_per_row).
+          All rows get the same number of CTAs.
+        - **Dynamic** (dynamic=True): 1D grid with binary search task mapping.
+          Each row gets only the CTAs it needs. Merge kernel reads per-row
+          valid length from an offset table.
+
         The runner caches compiled kernel pairs (first pass + merge pass) based on
         configuration to avoid redundant recompilation.
 
@@ -3110,7 +3123,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         @classmethod
         def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
                      num_copy_bits, load_balance, large_occupancy,
-                     chunk_size_per_cta, num_ctas_per_row):
+                     chunk_size_per_cta, num_ctas_per_row,
+                     dynamic=False):
             """Compile and cache multi-CTA top-k kernels for the given config."""
             key = (
                 dtype,
@@ -3124,6 +3138,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 True,
                 chunk_size_per_cta,
                 num_ctas_per_row,
+                dynamic,
             )
             if key in cls.kernel_cache:
                 return
@@ -3161,6 +3176,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
             fake_stream = cute.runtime.make_fake_stream(
                 use_tvm_ffi_env_stream=True)
 
+            # Dynamic mode: 1D grid with binary search; needs row_cta_offsets
+            row_cta_offsets_fake = None
+            if dynamic:
+                row_cta_offsets_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(),),
+                    stride_order=(0,),
+                )
+
             # First kernel: process each chunk independently
             filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
                 dtype,
@@ -3174,6 +3198,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 chunk_size_per_cta=chunk_size_per_cta,
                 num_ctas_per_row=num_ctas_per_row,
                 merge_blocks=False,
+                enable_dynamic_multi_cta=dynamic,
             )
             compiled_kernel_first = cute.compile(
                 filtered_topk_func_first,
@@ -3184,6 +3209,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 first_kernel_output_indices_fake,
                 first_kernel_output_values_fake,
+                row_cta_offsets_fake,
+                None,  # row_output_offsets
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
@@ -3191,6 +3218,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
 
             # Second kernel: merge partial results
+            merge_num_cols = num_ctas_per_row * top_k
             indices_fake = cute.runtime.make_fake_compact_tensor(
                 cutlass.Int32,
                 (n_rows, n_first_kernel_output_cols),
@@ -3209,9 +3237,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 )
             else:
                 output_values_fake = None
+
+            # Dynamic mode: varlen merge with per-row offset table
+            row_output_offsets_fake = None
+            if dynamic:
+                row_output_offsets_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(),),
+                    stride_order=(0,),
+                )
+
             filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
                 dtype,
-                num_ctas_per_row * top_k,  # num_cols
+                merge_num_cols,  # num_cols
                 top_k,
                 next_n,
                 num_copy_bits=num_copy_bits,
@@ -3219,6 +3257,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 large_occupancy=large_occupancy,
                 enable_multi_cta=False,
                 merge_blocks=True,
+                varlen_merge_input=dynamic,
             )
             compiled_kernel_second = cute.compile(
                 filtered_topk_func_second,
@@ -3229,13 +3268,43 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
+                None,  # row_cta_offsets
+                row_output_offsets_fake,
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
                 options="--enable-tvm-ffi",
             )
+            # Compile offset computation kernel for dynamic mode
+            compiled_offsets_kernel = None
+            if dynamic:
+                offsets_func = ComputeDynamicCTAOffsets(
+                    next_n=next_n,
+                    chunk_size_per_cta=chunk_size_per_cta,
+                    top_k=top_k,
+                )
+                offsets_row_cta_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(),),
+                    stride_order=(0,),
+                )
+                offsets_row_output_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(),),
+                    stride_order=(0,),
+                )
+                compiled_offsets_kernel = cute.compile(
+                    offsets_func,
+                    seqlen_fake,
+                    offsets_row_cta_fake,
+                    offsets_row_output_fake,
+                    stream=fake_stream,
+                    options="--enable-tvm-ffi",
+                )
+
             cls.kernel_cache[key] = (compiled_kernel_first,
-                                     compiled_kernel_second)
+                                     compiled_kernel_second,
+                                     compiled_offsets_kernel)
 
         @classmethod
         def forward(
@@ -3247,6 +3316,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: bool = False,
             num_copy_bits: int = 256,
             chunk_size_per_cta: int = 16384,
+            dynamic: bool = False,
         ):
             """Execute multi-CTA filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
@@ -3259,6 +3329,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             load_balance = False
 
             num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
+            merge_cols = num_ctas_per_row * top_k
 
             # Compilation key (use bucketed_num_cols to reduce recompilations;
             # include num_ctas_per_row since it depends on actual num_cols)
@@ -3274,6 +3345,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 True,  # enable_multi_cta
                 chunk_size_per_cta,
                 num_ctas_per_row,
+                dynamic,
             )
 
             if key not in cls.kernel_cache:
@@ -3288,75 +3360,127 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     large_occupancy,
                     chunk_size_per_cta,
                     num_ctas_per_row,
+                    dynamic,
                 )
-            compiled_kernel_first, compiled_kernel_second = cls.kernel_cache[key]
+            compiled_kernel_first, compiled_kernel_second, \
+                compiled_offsets_kernel = cls.kernel_cache[key]
 
-            # Prepare intermediate output tensors for first kernel
-            first_kernel_output_indices_torch = torch.empty(num_rows,
-                                                            num_ctas_per_row *
-                                                            top_k,
-                                                            dtype=torch.int32,
-                                                            device="cuda")
-            first_kernel_output_values_torch = torch.empty(num_rows,
-                                                           num_ctas_per_row *
-                                                           top_k,
-                                                           dtype=torch_dtype,
-                                                           device="cuda")
-
-            # Prepare final output tensors
-            output_indices_torch = torch.empty(num_rows,
-                                               top_k,
-                                               dtype=torch.int32,
-                                               device="cuda")
-            if return_val:
-                output_values_torch = torch.empty(num_rows,
-                                                  top_k,
-                                                  dtype=torch_dtype,
-                                                  device="cuda")
-            else:
-                output_values_torch = None
-
-            # Prepare buffer
             if dtype == cutlass.Float32:
                 buffer_numbers = 2
             else:
                 buffer_numbers = 1
-            buffer_dim2 = max(chunk_size_per_cta, num_ctas_per_row * top_k)
-            buffer_bytes = num_rows * num_ctas_per_row * buffer_numbers * buffer_dim2 * 4
-            if buffer_bytes > 1 << 30:  # > 1 GB
-                logger.warning(
-                    f"CuTE DSL multi-CTA top-k: intermediate buffer is "
-                    f"{buffer_bytes / (1 << 30):.1f} GB "
-                    f"(num_rows={num_rows}, num_ctas_per_row={num_ctas_per_row}). "
-                    "Consider reducing batch size or vocab size to avoid OOM.")
-            buffer_torch = torch.empty(num_rows * num_ctas_per_row,
-                                       buffer_numbers,
-                                       buffer_dim2,
-                                       dtype=torch.int32,
-                                       device="cuda")
 
-            # Execute first kernel: per-chunk top-k
-            # (TVM FFI uses env stream automatically)
-            compiled_kernel_first(
-                input_values,
-                None,  # indices, used for merge blocks kernel
-                buffer_torch,
-                None,  # g_global_counter_torch
-                seq_lens,
-                first_kernel_output_indices_torch,
-                first_kernel_output_values_torch,
-            )
+            if dynamic:
+                # Compute offsets with a single CuTE DSL kernel
+                row_cta_offsets = torch.empty(
+                    num_rows + 1, dtype=torch.int32, device="cuda")
+                row_output_offsets = torch.empty(
+                    num_rows + 1, dtype=torch.int32, device="cuda")
+                compiled_offsets_kernel(
+                    seq_lens, row_cta_offsets, row_output_offsets)
 
-            # Execute second kernel: merge partial results
-            compiled_kernel_second(
-                first_kernel_output_values_torch,
-                first_kernel_output_indices_torch,
-                buffer_torch,
-                None,  # g_global_counter_torch
-                seq_lens,
-                output_indices_torch,
-                output_values_torch,
-            )
+                # Use upper-bound allocation to avoid DtoH sync (.item()).
+                # The first kernel early-exits CTAs beyond actual total_ctas.
+                max_total_ctas = num_rows * num_ctas_per_row
+
+                # Intermediate buffers: 2D (num_rows, merge_cols)
+                first_output_indices = torch.empty(
+                    num_rows, merge_cols, dtype=torch.int32, device="cuda")
+                first_output_values = torch.empty(
+                    num_rows, merge_cols, dtype=torch_dtype, device="cuda")
+
+                # Buffer sized by upper bound
+                buffer_torch = torch.empty(
+                    max_total_ctas, buffer_numbers, chunk_size_per_cta,
+                    dtype=torch.int32, device="cuda")
+
+                # Final output tensors
+                output_indices_torch = torch.empty(
+                    num_rows, top_k, dtype=torch.int32, device="cuda")
+                if return_val:
+                    output_values_torch = torch.empty(
+                        num_rows, top_k, dtype=torch_dtype, device="cuda")
+                else:
+                    output_values_torch = None
+
+                # Execute first kernel: dynamic per-chunk top-k
+                compiled_kernel_first(
+                    input_values,
+                    None,  # indices
+                    buffer_torch,
+                    None,  # g_global_counter_torch
+                    seq_lens,
+                    first_output_indices,
+                    first_output_values,
+                    row_cta_offsets,
+                    None,  # row_output_offsets
+                )
+
+                # Merge buffer (one per row)
+                merge_buffer_torch = torch.empty(
+                    num_rows, buffer_numbers, merge_cols,
+                    dtype=torch.int32, device="cuda")
+
+                # Execute second kernel: varlen merge
+                compiled_kernel_second(
+                    first_output_values,
+                    first_output_indices,
+                    merge_buffer_torch,
+                    None,  # g_global_counter_torch
+                    seq_lens,
+                    output_indices_torch,
+                    output_values_torch,
+                    None,  # row_cta_offsets
+                    row_output_offsets,
+                )
+            else:
+                # Static mode: fixed grid (num_rows, num_ctas_per_row)
+                # Prepare intermediate output tensors for first kernel
+                first_kernel_output_indices_torch = torch.empty(
+                    num_rows, merge_cols, dtype=torch.int32, device="cuda")
+                first_kernel_output_values_torch = torch.empty(
+                    num_rows, merge_cols, dtype=torch_dtype, device="cuda")
+
+                # Prepare final output tensors
+                output_indices_torch = torch.empty(
+                    num_rows, top_k, dtype=torch.int32, device="cuda")
+                if return_val:
+                    output_values_torch = torch.empty(
+                        num_rows, top_k, dtype=torch_dtype, device="cuda")
+                else:
+                    output_values_torch = None
+
+                # Prepare buffer
+                buffer_dim2 = max(chunk_size_per_cta, merge_cols)
+                buffer_torch = torch.empty(
+                    num_rows * num_ctas_per_row, buffer_numbers, buffer_dim2,
+                    dtype=torch.int32, device="cuda")
+
+                # Execute first kernel: per-chunk top-k
+                compiled_kernel_first(
+                    input_values,
+                    None,  # indices, used for merge blocks kernel
+                    buffer_torch,
+                    None,  # g_global_counter_torch
+                    seq_lens,
+                    first_kernel_output_indices_torch,
+                    first_kernel_output_values_torch,
+                    None,  # row_cta_offsets
+                    None,  # row_output_offsets
+                )
+
+                # Execute second kernel: merge partial results
+                compiled_kernel_second(
+                    first_kernel_output_values_torch,
+                    first_kernel_output_indices_torch,
+                    buffer_torch,
+                    None,  # g_global_counter_torch
+                    seq_lens,
+                    output_indices_torch,
+                    output_values_torch,
+                    None,  # row_cta_offsets
+                    None,  # row_output_offsets
+                )
 
             return output_indices_torch, output_values_torch
 
@@ -3370,6 +3494,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         next_n: int = 1,
         num_copy_bits: int = 256,
         chunk_size_per_cta: int = 16384,
+        dynamic: bool = False,
     ) -> torch.Tensor:
         """CuteDSL-based multi-CTA Top-K selection optimized for Blackwell decode phase.
 
@@ -3383,6 +3508,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             next_n: Number of candidates per sequence (for speculative decoding)
             num_copy_bits: Number of bits for vectorized memory copy (128 or 256)
             chunk_size_per_cta: Number of columns each CTA processes
+            dynamic: Use dynamic multi-CTA scheduling (1D grid + binary search)
 
         Returns:
             indices: Top-k indices [batch_size * next_n, top_k]
@@ -3437,6 +3563,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val=False,  # Only return indices
             num_copy_bits=num_copy_bits,
             chunk_size_per_cta=chunk_size_per_cta,
+            dynamic=dynamic,
         )
         return indices
 
@@ -3449,6 +3576,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         next_n: int = 1,
         num_copy_bits: int = 256,
         chunk_size_per_cta: int = 16384,
+        dynamic: bool = False,
     ):
         num_rows = input_values.shape[0]
 
@@ -3522,6 +3650,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 return_val=False,
                 num_copy_bits=num_copy_bits,
                 chunk_size_per_cta=chunk_size_per_cta,
+                dynamic=True,
             )
         else:
             indices, _ = CuteDSLTopKDecodeSingleCTARunner.forward(
@@ -3611,6 +3740,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         large_occupancy,
                         chunk_size_per_cta,
                         num_ctas_per_row,
+                    )
+                    count += 1
+
+                    # Dynamic multi-CTA kernel
+                    CuteDSLTopKDecodeMultiCTARunner._compile(
+                        dtype,
+                        bucketed_num_cols,
+                        top_k,
+                        next_n,
+                        return_val,
+                        num_copy_bits,
+                        load_balance,
+                        large_occupancy,
+                        chunk_size_per_cta,
+                        num_ctas_per_row,
+                        dynamic=True,
                     )
                     count += 1
 

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2824,7 +2824,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             seq_lens: torch.Tensor,
             top_k: int,
             next_n: int,
-            return_val: bool = True,
+            return_val: bool = False,
             num_copy_bits: int = 256,
         ):
             """Execute filtered top-k selection on input logits.
@@ -2846,14 +2846,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                            If False, return only indices (values will be None).
                            Setting to False saves memory and computation.
                 num_copy_bits: Vectorization width for memory copy (128 or 256).
-                              Higher values may improve bandwidth utilization.
 
             Returns:
                 tuple: (indices, values) where:
                     - indices: Top-k indices [batch_size * next_n, top_k], int32.
-                              Values are relative to start of each row.
                     - values: Top-k values [batch_size * next_n, top_k] if return_val=True,
-                             else None. Sorted in descending order per row.
+                             else None.
 
             Raises:
                 ValueError: If inputs have invalid shape, dtype, or parameter values.
@@ -2894,11 +2892,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if key not in self.__class__.kernel_cache:
                 # Create fake tensors for compilation
                 n = cute.sym_int()
+                # Do we need div=32? no.
                 n_div_32 = cute.sym_int(divisibility=32)
                 input_fake = cute.runtime.make_fake_compact_tensor(
                     dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
                 buffer_fake = cute.runtime.make_fake_compact_tensor(
                     cutlass.Int32,
+                    # TODO: (n, cute.sym_int(), n_div_32)
                     (cute.sym_int(), cute.sym_int(), cute.sym_int()),
                     stride_order=(2, 1, 0),
                     assumed_align=32,
@@ -3077,5 +3077,368 @@ if IS_CUTLASS_DSL_AVAILABLE:
         input_values.dtype
 
         # Create output tensors matching the custom op return signature: (values, indices)
+        indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
+        return indices
+
+    class CuteDSLTopKDecodeMultiCTARunner:
+        """Runner for CuTE DSL Top-K decode kernel (multi CTA version).
+
+        This runner manages compilation and execution of the filtered top-k kernel
+        using multiple CTAs per row, optimized for Blackwell architecture using
+        CuTE DSL. It splits each row into chunks processed by separate CTAs,
+        then merges partial results in a second kernel pass.
+
+        The runner caches compiled kernel pairs (first pass + merge pass) based on
+        configuration to avoid redundant recompilation.
+
+        Attributes:
+            kernel_cache: Class-level dict mapping configuration tuples to compiled
+                         kernel pairs (first_kernel, second_kernel).
+
+        Note:
+            - Requires Blackwell architecture (SM100+)
+            - Maximum tested top_k is 2048
+            - Supports fp16, bf16, and fp32 dtypes
+            - Automatically selects occupancy optimization based on batch size
+        """
+        kernel_cache = dict()
+
+        def __init__(self):
+            pass
+
+        def forward(
+            self,
+            input_values: torch.Tensor,
+            seq_lens: torch.Tensor,
+            top_k: int,
+            next_n: int,
+            return_val: bool = False,
+            num_copy_bits: int = 256,
+            chunk_size_per_cta: int = 16384,
+        ):
+            """Execute multi-CTA filtered top-k selection on input logits.
+
+            Each row is split into chunks of chunk_size_per_cta columns, with each
+            chunk processed by a separate CTA. A second merge kernel combines the
+            partial top-k results into the final output.
+
+            Args:
+                input_values: Input logits tensor [batch_size * next_n, vocab_size].
+                             Must be 2D with dtype in {float16, bfloat16, float32}.
+                seq_lens: Sequence lengths for each batch [batch_size].
+                         Must be 1D int32 tensor.
+                top_k: Number of top elements to select per row (1 to 2048).
+                next_n: Number of candidates per sequence (for speculative decoding).
+                return_val: If True, return both indices and values.
+                           If False, return only indices (values will be None).
+                num_copy_bits: Vectorization width for memory copy (128 or 256).
+                chunk_size_per_cta: Number of columns each CTA processes.
+
+            Returns:
+                tuple: (indices, values) where:
+                    - indices: Top-k indices [batch_size * next_n, top_k], int32.
+                    - values: Top-k values [batch_size * next_n, top_k] if return_val=True,
+                             else None.
+            """
+            torch_dtype = input_values.dtype
+            torch_dtype_to_cutlass_dtype = {
+                torch.float16: cutlass.Float16,
+                torch.bfloat16: cutlass.BFloat16,
+                torch.float32: cutlass.Float32,
+            }
+            dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+            num_rows, num_cols = input_values.shape
+
+            # 148 is the number of SMs in Blackwell GPU.
+            # TODO: replace with api query sm count.
+            large_occupancy = num_rows > 148
+            load_balance = False
+
+            num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
+
+            # Compilation key
+            key = (
+                dtype,
+                num_cols,
+                top_k,
+                next_n,
+                return_val,
+                num_copy_bits,
+                load_balance,
+                large_occupancy,
+                True,  # enable_multi_cta
+                chunk_size_per_cta,
+            )
+
+            if key not in self.__class__.kernel_cache:
+                # Create fake tensors for compilation
+                n = cute.sym_int()
+                n_div_32 = cute.sym_int(divisibility=32)
+                input_fake = cute.runtime.make_fake_compact_tensor(
+                    dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+                buffer_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                    stride_order=(2, 1, 0),
+                    assumed_align=32,
+                )
+                seqlen_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, ),
+                    stride_order=(0, ),
+                )
+                first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, n_div_32),
+                    stride_order=(1, 0),
+                )
+                first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
+                    dtype,
+                    (n, n_div_32),
+                    stride_order=(1, 0),
+                    assumed_align=32,
+                )
+                fake_stream = cute.runtime.make_fake_stream()
+
+                # First kernel: process each chunk independently
+                filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
+                    dtype,
+                    chunk_size_per_cta,  # num_cols
+                    top_k,
+                    next_n,
+                    num_copy_bits=num_copy_bits,
+                    return_val=True,  # first kernel must return values
+                    large_occupancy=large_occupancy,
+                    enable_multi_cta=True,
+                    chunk_size_per_cta=chunk_size_per_cta,
+                    num_ctas_per_row=num_ctas_per_row,
+                    merge_blocks=False,
+                )
+                compiled_kernel_first = cute.compile(
+                    filtered_topk_func_first,
+                    input_fake,
+                    None,  # indices_fake
+                    buffer_fake,
+                    None,  # g_global_counter_fake
+                    seqlen_fake,
+                    first_kernel_output_indices_fake,
+                    first_kernel_output_values_fake,
+                    stream=fake_stream,
+                    enable_persistent_dymamic_scheduling=load_balance,
+                    min_blocks_per_mp=1,
+                )
+
+                # Second kernel: merge partial results
+                indices_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, n_div_32),
+                    stride_order=(1, 0),
+                )
+                output_indices_fake = cute.runtime.make_fake_compact_tensor(
+                    cutlass.Int32,
+                    (n, top_k),
+                    stride_order=(1, 0),
+                )
+                if return_val:
+                    output_values_fake = cute.runtime.make_fake_compact_tensor(
+                        dtype,
+                        (n, top_k),
+                        stride_order=(1, 0),
+                    )
+                else:
+                    output_values_fake = None
+                filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
+                    dtype,
+                    num_ctas_per_row * top_k,  # num_cols
+                    top_k,
+                    next_n,
+                    num_copy_bits=num_copy_bits,
+                    return_val=return_val,
+                    large_occupancy=large_occupancy,
+                    enable_multi_cta=False,
+                    merge_blocks=True,
+                )
+                compiled_kernel_second = cute.compile(
+                    filtered_topk_func_second,
+                    input_fake,
+                    indices_fake,
+                    buffer_fake,
+                    None,  # g_global_counter_fake
+                    seqlen_fake,
+                    output_indices_fake,
+                    output_values_fake,
+                    stream=fake_stream,
+                    enable_persistent_dymamic_scheduling=load_balance,
+                    min_blocks_per_mp=1,
+                )
+
+                self.__class__.kernel_cache[key] = (compiled_kernel_first,
+                                                    compiled_kernel_second)
+            else:
+                compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[
+                    key]
+
+            # Prepare intermediate output tensors for first kernel
+            first_kernel_output_indices_torch = torch.empty(
+                num_rows,
+                num_ctas_per_row * top_k,
+                dtype=torch.int32,
+                device="cuda")
+            first_kernel_output_values_torch = torch.empty(
+                num_rows,
+                num_ctas_per_row * top_k,
+                dtype=torch_dtype,
+                device="cuda")
+
+            # Prepare final output tensors
+            output_indices_torch = torch.empty(num_rows,
+                                               top_k,
+                                               dtype=torch.int32,
+                                               device="cuda")
+            if return_val:
+                output_values_torch = torch.empty(num_rows,
+                                                  top_k,
+                                                  dtype=torch_dtype,
+                                                  device="cuda")
+            else:
+                output_values_torch = None
+
+            # Prepare buffer
+            if dtype == cutlass.Float32:
+                buffer_numbers = 2
+            else:
+                buffer_numbers = 1
+            buffer_torch = torch.empty(
+                num_rows * num_ctas_per_row,
+                buffer_numbers,
+                max(chunk_size_per_cta, num_ctas_per_row * top_k),
+                dtype=torch.int32,
+                device="cuda")
+
+            # Get current CUDA stream
+            torch_stream = torch.cuda.current_stream()
+            current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+            # Execute first kernel: per-chunk top-k
+            compiled_kernel_first(
+                input_values,
+                None,  # indices, used for merge blocks kernel
+                buffer_torch,
+                None,  # g_global_counter_torch
+                seq_lens,
+                first_kernel_output_indices_torch,
+                first_kernel_output_values_torch,
+                current_stream,
+            )
+
+            # Execute second kernel: merge partial results
+            compiled_kernel_second(
+                first_kernel_output_values_torch,
+                first_kernel_output_indices_torch,
+                buffer_torch,
+                None,  # g_global_counter_torch
+                seq_lens,
+                output_indices_torch,
+                output_values_torch,
+                current_stream,
+            )
+
+            return output_indices_torch, output_values_torch
+
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_topk_decode_multi_cta_blackwell",
+        mutates_args=(),
+        device_types="cuda")
+    def cute_dsl_topk_decode_multi_cta_blackwell(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+        chunk_size_per_cta: int = 16384,
+    ) -> torch.Tensor:
+        """CuteDSL-based multi-CTA Top-K selection optimized for Blackwell decode phase.
+
+        Splits each row into chunks processed by separate CTAs, then merges results.
+        Suitable for large vocabulary sizes where single-CTA is insufficient.
+
+        Args:
+            input_values: Input logits tensor [batch_size * next_n, vocab_size]
+            seq_lens: Sequence lengths for each batch [batch_size]
+            top_k: Number of top elements to select (max 2048)
+            next_n: Number of candidates per sequence (for speculative decoding)
+            num_copy_bits: Number of bits for vectorized memory copy (128 or 256)
+            chunk_size_per_cta: Number of columns each CTA processes
+
+        Returns:
+            indices: Top-k indices [batch_size * next_n, top_k]
+
+        Note:
+            This function requires Blackwell architecture (SM100+) and CuTE DSL support.
+        """
+        # Validate SM version
+        sm_version = get_sm_version()
+        if sm_version < 100:
+            raise ValueError(
+                f"CuTE DSL top-k requires Blackwell (SM100+), but got SM {sm_version}. "
+                "Use standard top-k implementation for older architectures.")
+
+        # Validate inputs
+        if top_k <= 0 or top_k > 2048:
+            raise ValueError(
+                f"top_k must be in range [1, 2048], got {top_k}. "
+                "Maximum supported top_k is 2048 for Blackwell architecture.")
+
+        if next_n <= 0:
+            raise ValueError(f"next_n must be positive, got {next_n}")
+
+        if num_copy_bits not in [128, 256]:
+            raise ValueError(
+                f"num_copy_bits must be 128 or 256, got {num_copy_bits}")
+
+        if chunk_size_per_cta <= 0:
+            raise ValueError(
+                f"chunk_size_per_cta must be positive, got {chunk_size_per_cta}"
+            )
+
+        if input_values.dim() != 2:
+            raise ValueError(
+                f"input_values must be 2D [num_rows, vocab_size], got shape {input_values.shape}"
+            )
+
+        if seq_lens.dim() != 1:
+            raise ValueError(
+                f"seq_lens must be 1D [batch_size], got shape {seq_lens.shape}")
+
+        supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+        if input_values.dtype not in supported_dtypes:
+            raise ValueError(f"Unsupported dtype {input_values.dtype}. "
+                             f"Supported dtypes: {supported_dtypes}")
+
+        # Use the Runner class
+        runner = CuteDSLTopKDecodeMultiCTARunner()
+        indices, _ = runner.forward(
+            input_values=input_values,
+            seq_lens=seq_lens,
+            top_k=top_k,
+            next_n=next_n,
+            return_val=False,  # Only return indices
+            num_copy_bits=num_copy_bits,
+            chunk_size_per_cta=chunk_size_per_cta,
+        )
+        return indices
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_topk_decode_multi_cta_blackwell")
+    def _(
+        input_values: torch.Tensor,
+        seq_lens: torch.Tensor,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+        chunk_size_per_cta: int = 16384,
+    ):
+        num_rows = input_values.shape[0]
+
         indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
         return indices

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -318,6 +318,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Sm100BlockwiseGemmKernel
     from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
         Sm100BlockScaledPersistentDenseGemmKernel
+    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
+        FilteredTopKKernelVarlenDecode
     from ..cute_dsl_kernels.blackwell.utils import make_ptr
 
     class CuteDSLNVFP4BlackwellRunner(TunableRunner):
@@ -2789,16 +2791,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
         assert output.dtype == torch.bfloat16, "CuTe DSL fp8 bmm output dtype must be bf16"
         assert output.shape == (batch_size, m,
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
-
-    # ========================================================================
-    # CuTE DSL Top-K Operations
-    # ========================================================================
-
-    import cutlass
-    import cutlass.cute as cute
-
-    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
-        FilteredTopKKernelVarlenDecode
 
     class CuteDSLTopKDecodeSingleCTARunner:
         """Runner for CuTE DSL Top-K decode kernel (single CTA version)."""

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -14,7 +14,8 @@ from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..utils import (fp4_scale_infer_shape, fp8_scale_infer_shape,
                      get_last_power_of_2_num_tokens_buckets,
-                     last_positive_power_of_2)
+                     last_positive_power_of_2,
+                     next_positive_power_of_2)
 
 try:
     from cuda.bindings import driver as cuda
@@ -2792,6 +2793,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
         assert output.shape == (batch_size, m,
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
 
+    def _bucket_num_cols(num_cols: int) -> int:
+        """Bucket num_cols to the next power of 2 for compilation caching.
+
+        This reduces recompilations when num_cols changes slightly (e.g.,
+        KV cache length growing each decode step). Safe because num_cols
+        only affects compile-time config; actual data access is bounded
+        by seq_lens.
+        """
+        return next_positive_power_of_2(num_cols)
+
     class CuteDSLTopKDecodeSingleCTARunner:
         """Runner for CuTE DSL Top-K decode kernel (single CTA version).
 
@@ -2871,6 +2882,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             }
             dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
             num_rows, num_cols = input_values.shape
+            bucketed_num_cols = _bucket_num_cols(num_cols)
 
             num_sms = torch.cuda.get_device_properties().multi_processor_count
             large_occupancy = num_rows > num_sms
@@ -2879,7 +2891,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             # Compilation key
             key = (
                 dtype,
-                num_cols,
+                bucketed_num_cols,
                 top_k,
                 next_n,
                 return_val,
@@ -2924,7 +2936,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
                 filtered_topk_func = FilteredTopKKernelVarlenDecode(
                     dtype,
-                    num_cols,
+                    bucketed_num_cols,
                     top_k,
                     next_n,
                     num_copy_bits=num_copy_bits,
@@ -3154,6 +3166,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             }
             dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
             num_rows, num_cols = input_values.shape
+            bucketed_num_cols = _bucket_num_cols(num_cols)
 
             num_sms = torch.cuda.get_device_properties().multi_processor_count
             large_occupancy = num_rows > num_sms
@@ -3161,10 +3174,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
 
-            # Compilation key
+            # Compilation key (use bucketed_num_cols to reduce recompilations;
+            # include num_ctas_per_row since it depends on actual num_cols)
             key = (
                 dtype,
-                num_cols,
+                bucketed_num_cols,
                 top_k,
                 next_n,
                 return_val,
@@ -3173,6 +3187,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 large_occupancy,
                 True,  # enable_multi_cta
                 chunk_size_per_cta,
+                num_ctas_per_row,
             )
 
             if key not in self.__class__.kernel_cache:

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -318,10 +318,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Sm100BlockwiseGemmKernel
     from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
         Sm100BlockScaledPersistentDenseGemmKernel
-    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import (
-        ComputeDynamicCTAOffsets,
-        FilteredTopKKernelVarlenDecode,
-    )
+    from ..cute_dsl_kernels.blackwell.top_k.filtered_top_k_decode_varlen import \
+        FilteredTopKKernelVarlenDecode
     from ..cute_dsl_kernels.blackwell.utils import make_ptr
 
     class CuteDSLNVFP4BlackwellRunner(TunableRunner):
@@ -2903,8 +2901,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
-                None,  # row_cta_offsets
-                None,  # row_output_offsets
+
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
@@ -2996,8 +2993,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
-                None,  # row_cta_offsets
-                None,  # row_output_offsets
+
             )
 
             return output_indices_torch, output_values_torch
@@ -3176,15 +3172,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
             fake_stream = cute.runtime.make_fake_stream(
                 use_tvm_ffi_env_stream=True)
 
-            # Dynamic mode: 1D grid with binary search; needs row_cta_offsets
-            row_cta_offsets_fake = None
-            if dynamic:
-                row_cta_offsets_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (cute.sym_int(),),
-                    stride_order=(0,),
-                )
-
             # First kernel: process each chunk independently
             filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
                 dtype,
@@ -3209,8 +3196,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 first_kernel_output_indices_fake,
                 first_kernel_output_values_fake,
-                row_cta_offsets_fake,
-                None,  # row_output_offsets
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
@@ -3238,15 +3223,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
             else:
                 output_values_fake = None
 
-            # Dynamic mode: varlen merge with per-row offset table
-            row_output_offsets_fake = None
-            if dynamic:
-                row_output_offsets_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (cute.sym_int(),),
-                    stride_order=(0,),
-                )
-
             filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
                 dtype,
                 merge_num_cols,  # num_cols
@@ -3268,43 +3244,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seqlen_fake,
                 output_indices_fake,
                 output_values_fake,
-                None,  # row_cta_offsets
-                row_output_offsets_fake,
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
                 options="--enable-tvm-ffi",
             )
-            # Compile offset computation kernel for dynamic mode
-            compiled_offsets_kernel = None
-            if dynamic:
-                offsets_func = ComputeDynamicCTAOffsets(
-                    next_n=next_n,
-                    chunk_size_per_cta=chunk_size_per_cta,
-                    top_k=top_k,
-                )
-                offsets_row_cta_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (cute.sym_int(),),
-                    stride_order=(0,),
-                )
-                offsets_row_output_fake = cute.runtime.make_fake_compact_tensor(
-                    cutlass.Int32,
-                    (cute.sym_int(),),
-                    stride_order=(0,),
-                )
-                compiled_offsets_kernel = cute.compile(
-                    offsets_func,
-                    seqlen_fake,
-                    offsets_row_cta_fake,
-                    offsets_row_output_fake,
-                    stream=fake_stream,
-                    options="--enable-tvm-ffi",
-                )
-
             cls.kernel_cache[key] = (compiled_kernel_first,
-                                     compiled_kernel_second,
-                                     compiled_offsets_kernel)
+                                     compiled_kernel_second)
 
         @classmethod
         def forward(
@@ -3362,8 +3308,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     num_ctas_per_row,
                     dynamic,
                 )
-            compiled_kernel_first, compiled_kernel_second, \
-                compiled_offsets_kernel = cls.kernel_cache[key]
+            compiled_kernel_first, compiled_kernel_second = \
+                cls.kernel_cache[key]
 
             if dtype == cutlass.Float32:
                 buffer_numbers = 2
@@ -3371,13 +3317,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 buffer_numbers = 1
 
             if dynamic:
-                # Compute offsets with a single CuTE DSL kernel
-                row_cta_offsets = torch.empty(
-                    num_rows + 1, dtype=torch.int32, device="cuda")
-                row_output_offsets = torch.empty(
-                    num_rows + 1, dtype=torch.int32, device="cuda")
-                compiled_offsets_kernel(
-                    seq_lens, row_cta_offsets, row_output_offsets)
+                # Bounds check: num_rows must fit in the in-kernel prefix sum
+                _DYNAMIC_MAX_NUM_ROWS = 512
+                if num_rows > _DYNAMIC_MAX_NUM_ROWS:
+                    raise ValueError(
+                        f"dynamic multi-CTA top-k: num_rows ({num_rows}) "
+                        f"exceeds limit ({_DYNAMIC_MAX_NUM_ROWS}). "
+                        f"Reduce batch_size * next_n to "
+                        f"<= {_DYNAMIC_MAX_NUM_ROWS}.")
 
                 # Use upper-bound allocation to avoid DtoH sync (.item()).
                 # The first kernel early-exits CTAs beyond actual total_ctas.
@@ -3404,6 +3351,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     output_values_torch = None
 
                 # Execute first kernel: dynamic per-chunk top-k
+                # Offsets are computed in-kernel via shared memory prefix sum.
                 compiled_kernel_first(
                     input_values,
                     None,  # indices
@@ -3412,8 +3360,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     seq_lens,
                     first_output_indices,
                     first_output_values,
-                    row_cta_offsets,
-                    None,  # row_output_offsets
                 )
 
                 # Merge buffer (one per row)
@@ -3422,6 +3368,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     dtype=torch.int32, device="cuda")
 
                 # Execute second kernel: varlen merge
+                # merge_width computed in-kernel from seqlen.
                 compiled_kernel_second(
                     first_output_values,
                     first_output_indices,
@@ -3430,8 +3377,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     seq_lens,
                     output_indices_torch,
                     output_values_torch,
-                    None,  # row_cta_offsets
-                    row_output_offsets,
                 )
             else:
                 # Static mode: fixed grid (num_rows, num_ctas_per_row)
@@ -3465,8 +3410,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     seq_lens,
                     first_kernel_output_indices_torch,
                     first_kernel_output_values_torch,
-                    None,  # row_cta_offsets
-                    None,  # row_output_offsets
                 )
 
                 # Execute second kernel: merge partial results
@@ -3478,8 +3421,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     seq_lens,
                     output_indices_torch,
                     output_values_torch,
-                    None,  # row_cta_offsets
-                    None,  # row_output_offsets
                 )
 
             return output_indices_torch, output_values_torch
@@ -3592,6 +3533,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         top_k: int,
         next_n: int = 1,
         num_copy_bits: int = 256,
+        dynamic: bool = True,
     ) -> torch.Tensor:
         """Unified CuTE DSL Top-K that auto-selects single-CTA or multi-CTA.
 
@@ -3650,7 +3592,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 return_val=False,
                 num_copy_bits=num_copy_bits,
                 chunk_size_per_cta=chunk_size_per_cta,
-                dynamic=True,
+                dynamic=dynamic,
             )
         else:
             indices, _ = CuteDSLTopKDecodeSingleCTARunner.forward(
@@ -3670,6 +3612,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         top_k: int,
         next_n: int = 1,
         num_copy_bits: int = 256,
+        dynamic: bool = True,
     ):
         num_rows = input_values.shape[0]
         indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2808,7 +2808,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: bool = True,
             num_copy_bits: int = 256,
         ):
-            torch_dtype = input_values.dtype
             torch_dtype_to_cutlass_dtype = {
                 torch.float16: cutlass.Float16,
                 torch.bfloat16: cutlass.BFloat16,
@@ -2965,12 +2964,20 @@ if IS_CUTLASS_DSL_AVAILABLE:
         if sm_version < 100:
             raise ValueError(
                 f"CuTE DSL top-k requires Blackwell (SM100+), but got SM {sm_version}. "
-            )
+                "Use standard top-k implementation for older architectures.")
 
         # Validate inputs
-        if top_k > 2048:
+        if top_k <= 0 or top_k > 2048:
             raise ValueError(
-                f"CuTE DSL top-k supports max top_k=2048, but got {top_k}")
+                f"top_k must be in range [1, 2048], got {top_k}. "
+                "Maximum supported top_k is 2048 for Blackwell architecture.")
+
+        if next_n <= 0:
+            raise ValueError(f"next_n must be positive, got {next_n}")
+
+        if num_copy_bits not in [128, 256]:
+            raise ValueError(
+                f"num_copy_bits must be 128 or 256, got {num_copy_bits}")
 
         if input_values.dim() != 2:
             raise ValueError(
@@ -2980,6 +2987,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
         if seq_lens.dim() != 1:
             raise ValueError(
                 f"seq_lens must be 1D [batch_size], got shape {seq_lens.shape}")
+
+        supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+        if input_values.dtype not in supported_dtypes:
+            raise ValueError(f"Unsupported dtype {input_values.dtype}. "
+                             f"Supported dtypes: {supported_dtypes}")
 
         # Use the Runner class
         runner = CuteDSLTopKDecodeSingleCTARunner()

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -14,8 +14,7 @@ from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..utils import (fp4_scale_infer_shape, fp8_scale_infer_shape,
                      get_last_power_of_2_num_tokens_buckets,
-                     last_positive_power_of_2,
-                     next_positive_power_of_2)
+                     last_positive_power_of_2, next_positive_power_of_2)
 
 try:
     from cuda.bindings import driver as cuda
@@ -2810,6 +2809,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 torch.cuda.get_device_properties().multi_processor_count)
         return _get_num_sms._value
 
+    # Module-level dtype mapping (avoid recreating per call)
+    _TORCH_TO_CUTLASS_DTYPE = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+
     class CuteDSLTopKDecodeSingleCTARunner:
         """Runner for CuTE DSL Top-K decode kernel (single CTA version).
 
@@ -2837,42 +2843,61 @@ if IS_CUTLASS_DSL_AVAILABLE:
             pass
 
         @classmethod
-        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n,
-                     return_val, num_copy_bits, load_balance,
-                     large_occupancy):
+        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
+                     num_copy_bits, load_balance, large_occupancy):
             """Compile and cache a single-CTA top-k kernel for the given config."""
             key = (
-                dtype, bucketed_num_cols, top_k, next_n,
-                return_val, num_copy_bits, load_balance, large_occupancy,
+                dtype,
+                bucketed_num_cols,
+                top_k,
+                next_n,
+                return_val,
+                num_copy_bits,
+                load_balance,
+                large_occupancy,
             )
             if key in cls.kernel_cache:
                 return
-            n = cute.sym_int()
-            n_div_32 = cute.sym_int(divisibility=32)
-            input_fake = cute.runtime.make_fake_compact_tensor(
-                dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+            n_rows = cute.sym_int()
+            n_cols = cute.sym_int()
+            n_batch = cute.sym_int()
+            input_fake = cute.runtime.make_fake_compact_tensor(dtype,
+                                                               (n_rows, n_cols),
+                                                               stride_order=(1,
+                                                                             0),
+                                                               assumed_align=32)
             buffer_fake = cute.runtime.make_fake_compact_tensor(
                 cutlass.Int32,
-                (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                (n_rows, cute.sym_int(), n_cols),
                 stride_order=(2, 1, 0),
                 assumed_align=32,
             )
             seqlen_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, ), stride_order=(0, ),
+                cutlass.Int32,
+                (n_batch, ),
+                stride_order=(0, ),
             )
             output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, top_k), stride_order=(1, 0),
+                cutlass.Int32,
+                (n_rows, top_k),
+                stride_order=(1, 0),
             )
             if return_val:
                 output_values_fake = cute.runtime.make_fake_compact_tensor(
-                    dtype, (n, top_k), stride_order=(1, 0),
+                    dtype,
+                    (n_rows, top_k),
+                    stride_order=(1, 0),
                 )
             else:
                 output_values_fake = None
-            fake_stream = cute.runtime.make_fake_stream()
+            fake_stream = cute.runtime.make_fake_stream(
+                use_tvm_ffi_env_stream=True)
 
             filtered_topk_func = FilteredTopKKernelVarlenDecode(
-                dtype, bucketed_num_cols, top_k, next_n,
+                dtype,
+                bucketed_num_cols,
+                top_k,
+                next_n,
                 num_copy_bits=num_copy_bits,
                 return_val=return_val,
                 large_occupancy=large_occupancy,
@@ -2889,6 +2914,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
+                options="--enable-tvm-ffi",
             )
             cls.kernel_cache[key] = compiled_kernel
 
@@ -2903,12 +2929,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         ):
             """Execute filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
-            torch_dtype_to_cutlass_dtype = {
-                torch.float16: cutlass.Float16,
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float32: cutlass.Float32,
-            }
-            dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+            dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
             num_rows, num_cols = input_values.shape
             bucketed_num_cols = _bucket_num_cols(num_cols)
 
@@ -2930,8 +2951,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             if key not in self.__class__.kernel_cache:
                 self.__class__._compile(
-                    dtype, bucketed_num_cols, top_k, next_n,
-                    return_val, num_copy_bits, load_balance, large_occupancy,
+                    dtype,
+                    bucketed_num_cols,
+                    top_k,
+                    next_n,
+                    return_val,
+                    num_copy_bits,
+                    load_balance,
+                    large_occupancy,
                 )
             compiled_kernel = self.__class__.kernel_cache[key]
 
@@ -2958,19 +2985,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 logger.warning(
                     f"CuTE DSL top-k: intermediate buffer is {buffer_bytes / (1 << 30):.1f} GB "
                     f"(num_rows={num_rows}, num_cols={num_cols}). "
-                    "Consider reducing batch size or vocab size to avoid OOM."
-                )
+                    "Consider reducing batch size or vocab size to avoid OOM.")
             buffer_torch = torch.empty(num_rows,
                                        buffer_numbers,
                                        num_cols,
                                        dtype=torch.int32,
                                        device="cuda")
 
-            # Get current CUDA stream
-            torch_stream = torch.cuda.current_stream()
-            current_stream = cuda.CUstream(torch_stream.cuda_stream)
-
-            # Execute kernel
+            # Execute kernel (TVM FFI uses env stream automatically)
             compiled_kernel(
                 input_values,
                 None,  # indices
@@ -2979,7 +3001,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
-                current_stream,
             )
 
             return output_indices_torch, output_values_torch
@@ -3098,22 +3119,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
             pass
 
         @classmethod
-        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n,
-                     return_val, num_copy_bits, load_balance,
-                     large_occupancy, chunk_size_per_cta,
-                     num_ctas_per_row):
+        def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
+                     num_copy_bits, load_balance, large_occupancy,
+                     chunk_size_per_cta, num_ctas_per_row):
             """Compile and cache multi-CTA top-k kernels for the given config."""
             key = (
-                dtype, bucketed_num_cols, top_k, next_n,
-                return_val, num_copy_bits, load_balance, large_occupancy,
-                True, chunk_size_per_cta, num_ctas_per_row,
+                dtype,
+                bucketed_num_cols,
+                top_k,
+                next_n,
+                return_val,
+                num_copy_bits,
+                load_balance,
+                large_occupancy,
+                True,
+                chunk_size_per_cta,
+                num_ctas_per_row,
             )
             if key in cls.kernel_cache:
                 return
-            n = cute.sym_int()
-            n_div_32 = cute.sym_int(divisibility=32)
-            input_fake = cute.runtime.make_fake_compact_tensor(
-                dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32)
+            n_rows = cute.sym_int()
+            n_cols = cute.sym_int()
+            n_batch = cute.sym_int()
+            input_fake = cute.runtime.make_fake_compact_tensor(dtype,
+                                                               (n_rows, n_cols),
+                                                               stride_order=(1,
+                                                                             0),
+                                                               assumed_align=32)
             buffer_fake = cute.runtime.make_fake_compact_tensor(
                 cutlass.Int32,
                 (cute.sym_int(), cute.sym_int(), cute.sym_int()),
@@ -3121,22 +3153,31 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 assumed_align=32,
             )
             seqlen_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, ), stride_order=(0, ),
+                cutlass.Int32,
+                (n_batch, ),
+                stride_order=(0, ),
             )
+            n_first_kernel_output_cols = cute.sym_int()
             first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, n_div_32), stride_order=(1, 0),
+                cutlass.Int32,
+                (n_rows, n_first_kernel_output_cols),
+                stride_order=(1, 0),
             )
             first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
-                dtype, (n, n_div_32), stride_order=(1, 0),
+                dtype,
+                (n_rows, n_first_kernel_output_cols),
+                stride_order=(1, 0),
                 assumed_align=32,
             )
-            fake_stream = cute.runtime.make_fake_stream()
+            fake_stream = cute.runtime.make_fake_stream(
+                use_tvm_ffi_env_stream=True)
 
             # First kernel: process each chunk independently
             filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
                 dtype,
                 chunk_size_per_cta,  # num_cols
-                top_k, next_n,
+                top_k,
+                next_n,
                 num_copy_bits=num_copy_bits,
                 return_val=True,  # first kernel must return values
                 large_occupancy=large_occupancy,
@@ -3157,25 +3198,33 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
+                options="--enable-tvm-ffi",
             )
 
             # Second kernel: merge partial results
             indices_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, n_div_32), stride_order=(1, 0),
+                cutlass.Int32,
+                (n_rows, n_first_kernel_output_cols),
+                stride_order=(1, 0),
             )
             output_indices_fake = cute.runtime.make_fake_compact_tensor(
-                cutlass.Int32, (n, top_k), stride_order=(1, 0),
+                cutlass.Int32,
+                (n_rows, top_k),
+                stride_order=(1, 0),
             )
             if return_val:
                 output_values_fake = cute.runtime.make_fake_compact_tensor(
-                    dtype, (n, top_k), stride_order=(1, 0),
+                    dtype,
+                    (n_rows, top_k),
+                    stride_order=(1, 0),
                 )
             else:
                 output_values_fake = None
             filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
                 dtype,
                 num_ctas_per_row * top_k,  # num_cols
-                top_k, next_n,
+                top_k,
+                next_n,
                 num_copy_bits=num_copy_bits,
                 return_val=return_val,
                 large_occupancy=large_occupancy,
@@ -3194,6 +3243,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 stream=fake_stream,
                 enable_persistent_dynamic_scheduling=load_balance,
                 min_blocks_per_mp=1,
+                options="--enable-tvm-ffi",
             )
             cls.kernel_cache[key] = (compiled_kernel_first,
                                      compiled_kernel_second)
@@ -3210,12 +3260,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         ):
             """Execute multi-CTA filtered top-k selection on input logits."""
             torch_dtype = input_values.dtype
-            torch_dtype_to_cutlass_dtype = {
-                torch.float16: cutlass.Float16,
-                torch.bfloat16: cutlass.BFloat16,
-                torch.float32: cutlass.Float32,
-            }
-            dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+            dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
             num_rows, num_cols = input_values.shape
             bucketed_num_cols = _bucket_num_cols(num_cols)
 
@@ -3243,11 +3288,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             if key not in self.__class__.kernel_cache:
                 self.__class__._compile(
-                    dtype, bucketed_num_cols, top_k, next_n,
-                    return_val, num_copy_bits, load_balance, large_occupancy,
-                    chunk_size_per_cta, num_ctas_per_row,
+                    dtype,
+                    bucketed_num_cols,
+                    top_k,
+                    next_n,
+                    return_val,
+                    num_copy_bits,
+                    load_balance,
+                    large_occupancy,
+                    chunk_size_per_cta,
+                    num_ctas_per_row,
                 )
-            compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[key]
+            compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[
+                key]
 
             # Prepare intermediate output tensors for first kernel
             first_kernel_output_indices_torch = torch.empty(num_rows,
@@ -3286,19 +3339,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     f"CuTE DSL multi-CTA top-k: intermediate buffer is "
                     f"{buffer_bytes / (1 << 30):.1f} GB "
                     f"(num_rows={num_rows}, num_ctas_per_row={num_ctas_per_row}). "
-                    "Consider reducing batch size or vocab size to avoid OOM."
-                )
+                    "Consider reducing batch size or vocab size to avoid OOM.")
             buffer_torch = torch.empty(num_rows * num_ctas_per_row,
                                        buffer_numbers,
                                        buffer_dim2,
                                        dtype=torch.int32,
                                        device="cuda")
 
-            # Get current CUDA stream
-            torch_stream = torch.cuda.current_stream()
-            current_stream = cuda.CUstream(torch_stream.cuda_stream)
-
             # Execute first kernel: per-chunk top-k
+            # (TVM FFI uses env stream automatically)
             compiled_kernel_first(
                 input_values,
                 None,  # indices, used for merge blocks kernel
@@ -3307,7 +3356,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 first_kernel_output_indices_torch,
                 first_kernel_output_values_torch,
-                current_stream,
             )
 
             # Execute second kernel: merge partial results
@@ -3319,7 +3367,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 seq_lens,
                 output_indices_torch,
                 output_values_torch,
-                current_stream,
             )
 
             return output_indices_torch, output_values_torch
@@ -3480,22 +3527,25 @@ if IS_CUTLASS_DSL_AVAILABLE:
             use_multi_cta = sm_util_low and multi_waves <= 2
 
         if use_multi_cta:
-            return cute_dsl_topk_decode_multi_cta_blackwell(
+            indices, _ = CuteDSLTopKDecodeMultiCTARunner().forward(
                 input_values=input_values,
                 seq_lens=seq_lens,
                 top_k=top_k,
                 next_n=next_n,
+                return_val=False,
                 num_copy_bits=num_copy_bits,
                 chunk_size_per_cta=chunk_size_per_cta,
             )
         else:
-            return cute_dsl_topk_decode_blackwell(
+            indices, _ = CuteDSLTopKDecodeSingleCTARunner().forward(
                 input_values=input_values,
                 seq_lens=seq_lens,
                 top_k=top_k,
                 next_n=next_n,
+                return_val=False,
                 num_copy_bits=num_copy_bits,
             )
+        return indices
 
     @torch.library.register_fake("trtllm::cute_dsl_indexer_topk_decode")
     def _(
@@ -3509,9 +3559,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         indices = input_values.new_empty((num_rows, top_k), dtype=torch.int32)
         return indices
 
-    # Default bucketed num_cols values to warmup (powers of 2 from 4096 to 262144).
-    _TOPK_WARMUP_BUCKETED_NUM_COLS = [1 << i for i in range(12, 19)]
-
+    # TODO: call this warmup in DSL initialization or autotune warmup to compile all the dsl top-k kernels.
     def warmup_cute_dsl_topk_kernels(
         dtype=cutlass.BFloat16,
         top_k: int = 2048,
@@ -3537,8 +3585,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 If None, uses powers of 2 from 4096 to 131072.
             chunk_size_per_cta: Chunk size for multi-CTA (default 16384).
         """
+        # Default bucketed num_cols values to warmup (powers of 2 from 4096 to 262144).
+        _CUTE_DSL_TOPK_WARMUP_BUCKETED_NUM_COLS = [
+            1 << i for i in range(12, 19)
+        ]
         if bucketed_num_cols_list is None:
-            bucketed_num_cols_list = _TOPK_WARMUP_BUCKETED_NUM_COLS
+            bucketed_num_cols_list = _CUTE_DSL_TOPK_WARMUP_BUCKETED_NUM_COLS
 
         load_balance = False
         count = 0
@@ -3546,25 +3598,34 @@ if IS_CUTLASS_DSL_AVAILABLE:
             for large_occupancy in [False, True]:
                 # Single-CTA kernel
                 CuteDSLTopKDecodeSingleCTARunner._compile(
-                    dtype, bucketed_num_cols, top_k, next_n,
-                    return_val, num_copy_bits, load_balance,
+                    dtype,
+                    bucketed_num_cols,
+                    top_k,
+                    next_n,
+                    return_val,
+                    num_copy_bits,
+                    load_balance,
                     large_occupancy,
                 )
                 count += 1
 
                 # Multi-CTA kernel (only when num_cols > chunk_size_per_cta)
-                num_ctas_per_row = math.ceil(
-                    bucketed_num_cols / chunk_size_per_cta)
+                num_ctas_per_row = math.ceil(bucketed_num_cols /
+                                             chunk_size_per_cta)
                 if num_ctas_per_row > 1:
                     CuteDSLTopKDecodeMultiCTARunner._compile(
-                        dtype, bucketed_num_cols, top_k, next_n,
-                        return_val, num_copy_bits, load_balance,
-                        large_occupancy, chunk_size_per_cta,
+                        dtype,
+                        bucketed_num_cols,
+                        top_k,
+                        next_n,
+                        return_val,
+                        num_copy_bits,
+                        load_balance,
+                        large_occupancy,
+                        chunk_size_per_cta,
                         num_ctas_per_row,
                     )
                     count += 1
 
-        logger.info(
-            f"Warmup: pre-compiled {count} CuTE DSL top-k kernels "
-            f"(dtype={dtype}, top_k={top_k}, next_n={next_n})"
-        )
+        logger.info(f"Warmup: pre-compiled {count} CuTE DSL top-k kernels "
+                    f"(dtype={dtype}, top_k={top_k}, next_n={next_n})")

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2792,16 +2792,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
         assert output.shape == (batch_size, m,
                                 n), "CuTe DSL fp8 bmm output shape is incorrect"
 
-    def _bucket_num_cols(num_cols: int) -> int:
-        """Bucket num_cols to the next power of 2 for compilation caching.
-
-        This reduces recompilations when num_cols changes slightly (e.g.,
-        KV cache length growing each decode step). Safe because num_cols
-        only affects compile-time config; actual data access is bounded
-        by seq_lens.
-        """
-        return next_positive_power_of_2(num_cols)
-
     def _get_num_sms() -> int:
         """Return the number of SMs on the current device (cached)."""
         if not hasattr(_get_num_sms, "_value"):
@@ -2824,7 +2814,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
         radix-based filtering algorithm for efficient top-k selection.
 
         The runner caches compiled kernels based on configuration (dtype, shape, top_k)
-        to avoid redundant recompilation. Cache is shared across all instances.
+        to avoid redundant recompilation.
+
+        All methods are class-level — no instantiation needed. Call methods directly
+        via ``CuteDSLTopKDecodeSingleCTARunner.forward(...)``.
 
         Attributes:
             kernel_cache: Class-level dict mapping configuration tuples to compiled kernels.
@@ -2838,9 +2831,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
             - Automatically selects occupancy optimization based on batch size
         """
         kernel_cache = dict()
-
-        def __init__(self):
-            pass
 
         @classmethod
         def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
@@ -2918,8 +2908,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             )
             cls.kernel_cache[key] = compiled_kernel
 
+        @classmethod
         def forward(
-            self,
+            cls,
             input_values: torch.Tensor,
             seq_lens: torch.Tensor,
             top_k: int,
@@ -2931,7 +2922,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             torch_dtype = input_values.dtype
             dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
             num_rows, num_cols = input_values.shape
-            bucketed_num_cols = _bucket_num_cols(num_cols)
+            bucketed_num_cols = next_positive_power_of_2(num_cols)
 
             num_sms = _get_num_sms()
             large_occupancy = num_rows > num_sms
@@ -2949,8 +2940,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 large_occupancy,
             )
 
-            if key not in self.__class__.kernel_cache:
-                self.__class__._compile(
+            if key not in cls.kernel_cache:
+                cls._compile(
                     dtype,
                     bucketed_num_cols,
                     top_k,
@@ -2960,7 +2951,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     load_balance,
                     large_occupancy,
                 )
-            compiled_kernel = self.__class__.kernel_cache[key]
+            compiled_kernel = cls.kernel_cache[key]
 
             # Prepare output tensors
             output_indices_torch = torch.empty(num_rows,
@@ -3065,9 +3056,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             raise ValueError(f"Unsupported dtype {input_values.dtype}. "
                              f"Supported dtypes: {supported_dtypes}")
 
-        # Use the Runner class
-        runner = CuteDSLTopKDecodeSingleCTARunner()
-        indices, _ = runner.forward(
+        indices, _ = CuteDSLTopKDecodeSingleCTARunner.forward(
             input_values=input_values,
             seq_lens=seq_lens,
             top_k=top_k,
@@ -3103,6 +3092,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
         The runner caches compiled kernel pairs (first pass + merge pass) based on
         configuration to avoid redundant recompilation.
 
+        All methods are class-level — no instantiation needed. Call methods directly
+        via ``CuteDSLTopKDecodeMultiCTARunner.forward(...)``.
+
         Attributes:
             kernel_cache: Class-level dict mapping configuration tuples to compiled
                          kernel pairs (first_kernel, second_kernel).
@@ -3114,9 +3106,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
             - Automatically selects occupancy optimization based on batch size
         """
         kernel_cache = dict()
-
-        def __init__(self):
-            pass
 
         @classmethod
         def _compile(cls, dtype, bucketed_num_cols, top_k, next_n, return_val,
@@ -3248,8 +3237,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             cls.kernel_cache[key] = (compiled_kernel_first,
                                      compiled_kernel_second)
 
+        @classmethod
         def forward(
-            self,
+            cls,
             input_values: torch.Tensor,
             seq_lens: torch.Tensor,
             top_k: int,
@@ -3262,7 +3252,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             torch_dtype = input_values.dtype
             dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
             num_rows, num_cols = input_values.shape
-            bucketed_num_cols = _bucket_num_cols(num_cols)
+            bucketed_num_cols = next_positive_power_of_2(num_cols)
 
             num_sms = _get_num_sms()
             large_occupancy = num_rows > num_sms
@@ -3286,8 +3276,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 num_ctas_per_row,
             )
 
-            if key not in self.__class__.kernel_cache:
-                self.__class__._compile(
+            if key not in cls.kernel_cache:
+                cls._compile(
                     dtype,
                     bucketed_num_cols,
                     top_k,
@@ -3299,8 +3289,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     chunk_size_per_cta,
                     num_ctas_per_row,
                 )
-            compiled_kernel_first, compiled_kernel_second = self.__class__.kernel_cache[
-                key]
+            compiled_kernel_first, compiled_kernel_second = cls.kernel_cache[key]
 
             # Prepare intermediate output tensors for first kernel
             first_kernel_output_indices_torch = torch.empty(num_rows,
@@ -3440,9 +3429,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             raise ValueError(f"Unsupported dtype {input_values.dtype}. "
                              f"Supported dtypes: {supported_dtypes}")
 
-        # Use the Runner class
-        runner = CuteDSLTopKDecodeMultiCTARunner()
-        indices, _ = runner.forward(
+        indices, _ = CuteDSLTopKDecodeMultiCTARunner.forward(
             input_values=input_values,
             seq_lens=seq_lens,
             top_k=top_k,
@@ -3527,7 +3514,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             use_multi_cta = sm_util_low and multi_waves <= 2
 
         if use_multi_cta:
-            indices, _ = CuteDSLTopKDecodeMultiCTARunner().forward(
+            indices, _ = CuteDSLTopKDecodeMultiCTARunner.forward(
                 input_values=input_values,
                 seq_lens=seq_lens,
                 top_k=top_k,
@@ -3537,7 +3524,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 chunk_size_per_cta=chunk_size_per_cta,
             )
         else:
-            indices, _ = CuteDSLTopKDecodeSingleCTARunner().forward(
+            indices, _ = CuteDSLTopKDecodeSingleCTARunner.forward(
                 input_values=input_values,
                 seq_lens=seq_lens,
                 top_k=top_k,
@@ -3582,7 +3569,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             return_val: Whether kernels should return values (default False).
             num_copy_bits: Vectorization width (default 256).
             bucketed_num_cols_list: List of bucketed num_cols to warmup.
-                If None, uses powers of 2 from 4096 to 131072.
+                If None, uses powers of 2 from 4096 to 262144.
             chunk_size_per_cta: Chunk size for multi-CTA (default 16384).
         """
         # Default bucketed num_cols values to warmup (powers of 2 from 4096 to 262144).

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2865,6 +2865,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 - Uses current CUDA stream for asynchronous execution
                 - Occupancy is automatically optimized for batch_size > 148
             """
+            torch_dtype = input_values.dtype
             torch_dtype_to_cutlass_dtype = {
                 torch.float16: cutlass.Float16,
                 torch.bfloat16: cutlass.BFloat16,

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2803,6 +2803,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
         """
         return next_positive_power_of_2(num_cols)
 
+    def _get_num_sms() -> int:
+        """Return the number of SMs on the current device (cached)."""
+        if not hasattr(_get_num_sms, "_value"):
+            _get_num_sms._value = (
+                torch.cuda.get_device_properties().multi_processor_count)
+        return _get_num_sms._value
+
     class CuteDSLTopKDecodeSingleCTARunner:
         """Runner for CuTE DSL Top-K decode kernel (single CTA version).
 
@@ -2884,7 +2891,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             num_rows, num_cols = input_values.shape
             bucketed_num_cols = _bucket_num_cols(num_cols)
 
-            num_sms = torch.cuda.get_device_properties().multi_processor_count
+            num_sms = _get_num_sms()
             large_occupancy = num_rows > num_sms
             load_balance = False
 
@@ -3168,7 +3175,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             num_rows, num_cols = input_values.shape
             bucketed_num_cols = _bucket_num_cols(num_cols)
 
-            num_sms = torch.cuda.get_device_properties().multi_processor_count
+            num_sms = _get_num_sms()
             large_occupancy = num_rows > num_sms
             load_balance = False
 
@@ -3522,7 +3529,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         #    2-pass overhead (kernel launch + intermediate buffer I/O)
         #    outweighs the parallelism gain.
         if use_multi_cta:
-            num_sms = torch.cuda.get_device_properties().multi_processor_count
+            num_sms = _get_num_sms()
             num_ctas_per_row = math.ceil(num_tokens / chunk_size_per_cta)
             sm_util_low = num_rows < num_sms * 15 // 100  # < 15%
             multi_waves = math.ceil(num_rows * num_ctas_per_row / num_sms)

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2873,6 +2873,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
             num_rows, num_cols = input_values.shape
 
+            # 148 is the number of SMs in Blackwell GPU.
+            # TODO: replace with api query sm count.
             large_occupancy = num_rows > 148
             load_balance = False
 

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -14,14 +14,10 @@
 
 """CuTE DSL Top-K kernels for Blackwell architecture."""
 
-from .filtered_top_k_decode_varlen import (
-    ComputeDynamicCTAOffsets,
-    FilteredTopKKernelVarlenDecode,
-)
+from .filtered_top_k_decode_varlen import FilteredTopKKernelVarlenDecode
 from .filtered_top_k_varlen_util import FilteredTopKKernelVarlen
 
 __all__ = [
-    "ComputeDynamicCTAOffsets",
     "FilteredTopKKernelVarlen",
     "FilteredTopKKernelVarlenDecode",
 ]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -14,10 +14,14 @@
 
 """CuTE DSL Top-K kernels for Blackwell architecture."""
 
-from .filtered_top_k_decode_varlen import FilteredTopKKernelVarlenDecode
+from .filtered_top_k_decode_varlen import (
+    ComputeDynamicCTAOffsets,
+    FilteredTopKKernelVarlenDecode,
+)
 from .filtered_top_k_varlen_util import FilteredTopKKernelVarlen
 
 __all__ = [
+    "ComputeDynamicCTAOffsets",
     "FilteredTopKKernelVarlen",
     "FilteredTopKKernelVarlenDecode",
 ]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CuTE DSL Top-K kernels for Blackwell architecture."""
+
+from .filtered_top_k_decode_varlen import (
+    FilteredTopKKernelVarlenDecode,
+    cute_dsl_topk_multi_cta_wrapper,
+    cute_dsl_topk_wrapper,
+    run_topk_decode,
+)
+from .filtered_top_k_varlen_util import (
+    FilteredTopKKernelVarlen,
+    compare_top_k_results,
+    create_random_logits,
+    run_reference_top_k,
+)
+
+__all__ = [
+    "FilteredTopKKernelVarlenDecode",
+    "FilteredTopKKernelVarlen",
+    "cute_dsl_topk_wrapper",
+    "cute_dsl_topk_multi_cta_wrapper",
+    "run_topk_decode",
+    "create_random_logits",
+    "run_reference_top_k",
+    "compare_top_k_results",
+]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -14,9 +14,7 @@
 
 """CuTE DSL Top-K kernels for Blackwell architecture."""
 
-from .filtered_top_k_decode_varlen import (
-    FilteredTopKKernelVarlenDecode,
-)
+from .filtered_top_k_decode_varlen import FilteredTopKKernelVarlenDecode
 from .filtered_top_k_varlen_util import FilteredTopKKernelVarlen
 
 __all__ = [

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/__init__.py
@@ -16,24 +16,10 @@
 
 from .filtered_top_k_decode_varlen import (
     FilteredTopKKernelVarlenDecode,
-    cute_dsl_topk_multi_cta_wrapper,
-    cute_dsl_topk_wrapper,
-    run_topk_decode,
 )
-from .filtered_top_k_varlen_util import (
-    FilteredTopKKernelVarlen,
-    compare_top_k_results,
-    create_random_logits,
-    run_reference_top_k,
-)
+from .filtered_top_k_varlen_util import FilteredTopKKernelVarlen
 
 __all__ = [
-    "FilteredTopKKernelVarlenDecode",
     "FilteredTopKKernelVarlen",
-    "cute_dsl_topk_wrapper",
-    "cute_dsl_topk_multi_cta_wrapper",
-    "run_topk_decode",
-    "create_random_logits",
-    "run_reference_top_k",
-    "compare_top_k_results",
+    "FilteredTopKKernelVarlenDecode",
 ]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/block_scan.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/block_scan.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/block_scan.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/block_scan.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.runtime import from_dlpack
+from cutlass.utils.smem_allocator import SmemAllocator
+
+"""
+block prefix sum kernel (input is loading from shared memory) in CuTe DSL.
+The parallel strategy is one thread process one element from shared memory.
+"""
+
+
+@cute.jit
+def fence_acq_rel_cta(*, loc=None, ip=None):
+    llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string="membar.cta;",
+        constraints="",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def warp_scan(val: cutlass.Int32, tidx, lane_id, num_threads_per_warp: cutlass.Constexpr):
+    """Warp scan kernel"""
+    mask_val = cutlass.const_expr(((1 << num_threads_per_warp) - 1) & 0xFFFFFFFF)
+    mask_and_clamp_val = 0
+    iteration = cute.arch.log2_of_pow2_int(cutlass.Int32(num_threads_per_warp))
+    for i in cutlass.range(iteration, unroll_full=True):
+        offset = 1 << i
+        other = cute.arch.shuffle_sync_up(
+            val, offset, mask=mask_val, mask_and_clamp=mask_and_clamp_val
+        )
+        if lane_id >= offset:
+            val = val + other
+    return val
+
+
+@cute.jit
+def block_prefix_sum_kernel(
+    val: cutlass.Int32,
+    warp_sums: cute.Tensor,
+    tidx,
+    num_threads,
+    num_warps,
+    barrier_id=1,
+    need_total_sum=False,
+):
+    """Block prefix sum kernel in CuTe DSL"""
+    # Thread and warp id
+    warp_id = tidx // 32
+    lane_id = tidx % 32
+
+    # Currently, we only support num_warps > 1, will support num_warps <= 1 logic later.
+    assert num_threads % 32 == 0, "num_threads must be divisible by 32, but got {}".format(
+        num_threads
+    )
+    assert num_warps > 1, "num_warps must be > 1, but got {}".format(num_warps)
+    assert num_warps == 2 ** int(math.log2(num_warps)), "num_warps must be a power of 2"
+
+    # Step 1: Warp-level prefix sum using shuffle
+    val = warp_scan(val, tidx, lane_id, num_threads_per_warp=32)
+
+    # Step 2: Store warp prefix sums
+    if lane_id == 31:  # Last thread in warp stores warp sum
+        warp_sums[warp_id] = val
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+
+    # Step 3: Prefix sum across warps
+    if warp_id == 0:
+        if lane_id < num_warps:
+            warp_val = warp_sums[lane_id]
+            # call warp-level prefix sum
+            warp_val = warp_scan(warp_val, tidx, lane_id, num_threads_per_warp=num_warps)
+            warp_sums[lane_id] = warp_val
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+
+    # Step 4: Add warp-level prefix
+    if warp_id > 0:
+        val = val + warp_sums[warp_id - 1]
+
+    # Step 5: Get total sum if need_total_sum is True
+    total_sum = 0
+    if need_total_sum:
+        total_sum = warp_sums[num_warps - 1]
+
+    return val, total_sum
+
+
+@cute.kernel
+def block_prefix_sum(
+    num_bins: cutlass.Constexpr,
+    num_threads_per_block: cutlass.Constexpr,
+    input: cute.Tensor,
+    output: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+
+    num_warps = cutlass.const_expr(min(num_bins, num_threads_per_block) // 32)
+    # Shared memory allocation used for cross-warp communication.
+    smem = SmemAllocator()
+    s_warp_sums = smem.allocate_tensor(
+        element_type=cute.Int32,
+        layout=cute.make_ordered_layout((num_warps,), order=(0,)),
+        byte_alignment=128,
+    )
+
+    if cutlass.const_expr(num_bins < num_threads_per_block):
+        if tidx < num_bins:
+            val = input[tidx]
+            val, total_sum = block_prefix_sum_kernel(
+                val, s_warp_sums, tidx, num_bins, num_warps, barrier_id=1
+            )
+            output[tidx] = val
+    elif cutlass.const_expr(num_bins == num_threads_per_block):
+        val = input[tidx]
+        val, total_sum = block_prefix_sum_kernel(
+            val, s_warp_sums, tidx, num_bins, num_warps, barrier_id=1
+        )
+        output[tidx] = val
+    else:
+        assert num_bins % num_threads_per_block == 0
+        previous_sum = 0
+        val = 0
+        total_sum = 0
+        """
+        i = 0: total_sum = 1th_tile sum; previous_sum = 0; out = 1st_tile scan + 0;
+        i = 1: total_sum = 2th_tile sum; previous_sum = 1th_tile sum; out = 2nd_tile scan + previous_sum
+        i = 2: total_sum = 3th_tile sum; previous_sum = 1th_tile sum + 2th_tile sum; out = 3rd_tile scan + previous_sum
+        ...
+        """
+        for i in range(tidx, num_bins, num_threads_per_block):
+            val = input[i]
+            val, total_sum = block_prefix_sum_kernel(
+                val,
+                s_warp_sums,
+                tidx,
+                num_threads_per_block,
+                num_warps,
+                barrier_id=0,
+                need_total_sum=True,
+            )
+            output[i] = val + previous_sum
+            previous_sum = previous_sum + total_sum
+
+
+# host function for testing
+@cute.jit
+def host_block_prefix_sum(
+    num_bins: cutlass.Constexpr,
+    num_threads_per_block: cutlass.Constexpr,
+    input: cute.Tensor,
+    output: cute.Tensor,
+):
+    block_prefix_sum(num_bins, num_threads_per_block, input, output).launch(
+        grid=(1, 1, 1), block=(num_threads_per_block, 1, 1)
+    )
+    return output
+
+
+def test_block_prefix_sum(num_bins=1024, num_threads_per_block=1024):
+    import torch
+
+    input = torch.randint(0, 100, (num_bins,), device="cuda").to(torch.int32)
+    # input = torch.arange(1, num_bins + 1, dtype=torch.int32, device='cuda')
+    # input = torch.ones(num_bins, dtype=torch.int32, device='cuda')
+    output = torch.empty_like(input)
+
+    input_cute_tensor = from_dlpack(input)
+    output_cute_tensor = from_dlpack(output)
+
+    compiled_func = cute.compile(
+        host_block_prefix_sum,
+        num_bins,
+        num_threads_per_block,
+        input_cute_tensor,
+        output_cute_tensor,
+    )
+    compiled_func(input_cute_tensor, output_cute_tensor)
+
+    torch_output = torch.cumsum(input, dim=0)
+
+    torch.testing.assert_close(output.to(torch_output.dtype), torch_output)
+    print(
+        "Test passed for num_bins: {}, num_threads_per_block: {}".format(
+            num_bins, num_threads_per_block
+        )
+    )
+
+
+if __name__ == "__main__":
+    test_block_prefix_sum(num_bins=1024, num_threads_per_block=1024)
+    test_block_prefix_sum(num_bins=256, num_threads_per_block=1024)
+    test_block_prefix_sum(num_bins=512, num_threads_per_block=1024)
+    test_block_prefix_sum(num_bins=2048, num_threads_per_block=512)
+    test_block_prefix_sum(num_bins=1024, num_threads_per_block=512)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -165,6 +165,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         merge_blocks: bool = False,
         enable_dynamic_multi_cta: bool = False,
         varlen_merge_input: bool = False,
+        num_sms: int = 148,
         debug: bool = False,
     ):
         super().__init__(
@@ -185,6 +186,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         self.num_ctas_per_row = num_ctas_per_row
         self.enable_dynamic_multi_cta = enable_dynamic_multi_cta
         self.varlen_merge_input = varlen_merge_input
+        self.num_sms = num_sms
 
         if cutlass.const_expr(large_occupancy):
             # tuned value, could be tuned further.
@@ -466,20 +468,56 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             length = cutlass.Int32(0)
             seq_len = cutlass.Int32(0)
 
-            # dynamic scheduler.
-            work_remaining = True
-
+            # Persistent dynamic scheduler.
+            # First task: use bidx directly (no atomic needed).
+            # Subsequent tasks: use atomicAdd (counter pre-initialized
+            # to grid_size on host, so values start from grid_size).
             s_row_id = smem.allocate_tensor(
                 element_type=cute.Int32,
                 layout=cute.make_ordered_layout((1,), order=(0,)),
                 byte_alignment=128,
             )
 
-            # version-1: dynamic scheduler.
+            # First task: deterministic assignment by block index.
+            task_id = bidx
+            if task_id < num_rows:
+                row_start = 0
+                seq_len = seqlen[task_id // self.next_n]
+                row_end = seq_len - self.next_n + (task_id % self.next_n) + 1
+                length = row_end - row_start
+
+                self.filtered_topk_kernel_per_row(
+                    input,
+                    indices,
+                    extra_buffer,
+                    output_indices,
+                    output_values,
+                    tiler_mn,
+                    copy_atom,
+                    tiled_copy,
+                    row_start,
+                    length,
+                    task_id,
+                    s_histogram,
+                    s_counter,
+                    s_threshold_bin_id,
+                    s_num_input,
+                    g_num_input,
+                    s_indices,
+                    s_input_idx,
+                    s_last_remain,
+                    num_warps,
+                    s_warp_sums,
+                )
+
+            # Subsequent tasks: dynamic work stealing via atomic counter.
+            # Counter starts at 0, so offset by grid_size to skip
+            # the first-round tasks already handled by bidx.
+            grid_size_x, _, _ = cute.arch.grid_dim()
+            work_remaining = task_id < num_rows
             while work_remaining:
-                # let tidx 0 dynamic get the next task
                 if tidx == 0:
-                    s_row_id[0] = atomicAdd(g_global_counter.iterator, 1)
+                    s_row_id[0] = atomicAdd(g_global_counter.iterator, cutlass.Int32(1)) + grid_size_x
                 cute.arch.barrier()
 
                 row_id = s_row_id[0]
@@ -487,11 +525,9 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
 
                 if has_work:
                     task_id = row_id
-
                     row_start = 0
                     seq_len = seqlen[task_id // self.next_n]
                     row_end = seq_len - self.next_n + (task_id % self.next_n) + 1
-
                     length = row_end - row_start
 
                     self.filtered_topk_kernel_per_row(
@@ -517,7 +553,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
                         num_warps,
                         s_warp_sums,
                     )
-                # use the result of the task to update the while loop condition
                 work_remaining = has_work
 
     @cute.jit
@@ -547,7 +582,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         elif cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             blocks = (num_rows, self.num_ctas_per_row, 1)
         else:
-            blocks = (min(148 * min_blocks_per_mp, num_rows), self.num_ctas_per_row, 1)
+            blocks = (min(self.num_sms * min_blocks_per_mp, num_rows), self.num_ctas_per_row, 1)
 
         (
             copy_atom,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -1,0 +1,1216 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import math
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import torch
+from cutlass.torch import dtype as torch_dtype
+from cutlass.utils.distributed import atomicAdd
+
+from .filtered_top_k_varlen_util import (
+    FilteredTopKKernelVarlen,
+    compare_top_k_results,
+    create_random_logits,
+    run_reference_top_k,
+)
+
+"""
+A high-performance topk kernel example based on radix-based filter algorithm for
+the NVIDIA Blackwell SM100 architecture based on CuTe DSL.
+
+The radix-based filter top-k algorithm mainly includes two phases: coarse filter and multi-round fine-grained filter.
+For each phase:
+1. histogram: Build a histogram of the input values using vectorized loads.
+2. prefix sum: Find the threshold bin using prefix sum.
+3. find target bin id: Find the target bin id using multiple rounds.
+Finally, write the top-k values and indices to the output tensor.
+
+Supported data types:
+- Float32
+- Float16
+- BFloat16
+
+To run this example:
+.. code-block:: bash
+    python examples/blackwell/sort/filter_top_k_decode_varlen.py  \
+      --dtype Float32 --batch_size 1 --max_num_cols 4096 --next_n 3 \
+      --top_k 2048 --do_ref_check --return_val --do_benchmark
+
+Constraints for this example:
+* The problem size of top_k <= 2048.
+* The input tensor has data contiguous on the n dimension (row-major).
+* The supported input data types are Float32, Float16, or BFloat16.
+"""
+
+
+class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
+    def __init__(
+        self,
+        dtype: cutlass.Numeric,
+        max_num_cols: int,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+        return_val: bool = True,
+        large_occupancy: bool = False,
+        # for multi-cta version.
+        enable_multi_cta: bool = False,
+        chunk_size_per_cta: int = 16384,
+        num_ctas_per_row: int = 1,
+        merge_blocks: bool = False,
+    ):
+        super().__init__(
+            dtype,
+            max_num_cols,
+            top_k,
+            num_copy_bits,
+            return_val,
+            enable_multi_cta,
+            chunk_size_per_cta,
+            num_ctas_per_row,
+            merge_blocks,
+        )
+        self.next_n = next_n
+        self.enable_multi_cta = enable_multi_cta
+        self.chunk_size_per_cta = chunk_size_per_cta
+        self.merge_blocks = merge_blocks
+        self.num_ctas_per_row = num_ctas_per_row
+
+        print(f"large_occupancy: {large_occupancy}")
+        if cutlass.const_expr(large_occupancy):
+            # reduce the smem usage and improve occupancy.
+            if self.max_num_cols >= 262144:
+                self.filtered_topk_smem_input_size = 4096
+            elif self.max_num_cols >= 131072:
+                self.filtered_topk_smem_input_size = 3072
+            elif self.max_num_cols >= 65536:
+                self.filtered_topk_smem_input_size = 2048
+            elif self.max_num_cols >= 32768:
+                self.filtered_topk_smem_input_size = 1024
+            elif self.max_num_cols >= 16384:
+                self.filtered_topk_smem_input_size = 1024
+            elif self.max_num_cols >= 8192:
+                self.filtered_topk_smem_input_size = 512
+            else:
+                self.filtered_topk_smem_input_size = 256
+
+            if cutlass.const_expr(self.max_num_cols > self.filtered_topk_smem_input_size):
+                self.enable_gmem_store = True
+            else:
+                self.enable_gmem_store = False
+
+            # set the number of threads per cta to 512.
+            self.num_threads_per_cta = 512
+
+            print(f"return_val: {return_val}")
+            print(f"limin: max_num_cols: {self.max_num_cols}")
+            print(f"limin: num_threads_per_cta: {self.num_threads_per_cta}")
+            print(
+                f"limin: filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}",
+            )
+            print(f"limin: enable_gmem_store: {self.enable_gmem_store}")
+
+    @cute.jit
+    def run_kernel(
+        self,
+        input,
+        indices,
+        extra_buffer,
+        output_indices,
+        output_values,
+        tiler_mn,
+        copy_atom,
+        tiled_copy,
+        seqlen,
+        task_id,
+        s_histogram,
+        s_counter,
+        s_threshold_bin_id,
+        s_num_input,
+        g_num_input,
+        s_indices,
+        s_input_idx,
+        s_last_remain,
+        num_warps,
+        s_warp_sums,
+    ):
+        # TODO: update row_start to align with multi-cta version.
+        row_start = 0
+        seq_len = seqlen[task_id // self.next_n]
+        row_end = seq_len - self.next_n + (task_id % self.next_n) + 1
+
+        length = row_end - row_start
+
+        self.filtered_topk_kernel_per_row(
+            input,
+            indices,
+            extra_buffer,
+            output_indices,
+            output_values,
+            tiler_mn,
+            copy_atom,
+            tiled_copy,
+            row_start,
+            length,
+            task_id,
+            s_histogram,
+            s_counter,
+            s_threshold_bin_id,
+            s_num_input,
+            g_num_input,
+            s_indices,
+            s_input_idx,
+            s_last_remain,
+            num_warps,
+            s_warp_sums,
+        )
+
+    @cute.kernel
+    def filtered_topk_kernel(
+        self,
+        input: cute.Tensor,
+        indices: cute.Tensor,
+        extra_buffer: cute.Tensor,
+        g_global_counter: cute.Tensor,
+        seqlen: cute.Tensor,
+        output_indices: cute.Tensor,
+        output_values: cute.Tensor,
+        tiler_mn: cute.Shape,
+        copy_atom: cute.CopyAtom,
+        tiled_copy: cute.TiledCopy,
+        enable_persistent_dymamic_scheduling: cutlass.Constexpr[bool] = False,
+        min_blocks_per_mp: cutlass.Constexpr[int] = 1,
+    ):
+        """CuTe DSL implementation of TopK kernel based on radix-based filter algorithm."""
+        smem = utils.SmemAllocator()
+        # TODO: how to simplify the smem allocate codes?
+        s_histogram_buf_layout = cute.make_ordered_layout((self.radix + 1), order=(0))
+        s_histogram = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=s_histogram_buf_layout,
+            byte_alignment=128,
+        )
+        s_counter = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1), order=(0)),
+            byte_alignment=128,
+        )
+        s_threshold_bin_id = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1), order=(0)),
+            byte_alignment=128,
+        )
+        s_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0)),
+            byte_alignment=128,
+        )
+        if cutlass.const_expr(self.enable_gmem_store):
+            g_num_input = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout((2), order=(0)),
+                byte_alignment=128,
+            )
+        else:
+            g_num_input = None
+        s_indices = smem.allocate_tensor(
+            element_type=self.index_type,
+            layout=cute.make_ordered_layout((self.filtered_topk_max_k,), order=(0)),
+            byte_alignment=128,
+        )
+        s_input_idx = smem.allocate_tensor(
+            element_type=self.index_type,
+            layout=cute.make_ordered_layout(
+                (
+                    self.num_buffer_smem_input_idx,
+                    self.filtered_topk_smem_input_size,
+                ),
+                order=(1, 0),
+            ),
+            byte_alignment=128,
+        )
+        s_last_remain = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1), order=(0)),
+            byte_alignment=128,
+        )
+        num_warps = cutlass.const_expr(
+            min(self.radix, self.num_threads_per_cta) // cutlass.Int32(32)
+        )
+        s_warp_sums = smem.allocate_tensor(
+            element_type=cute.Int32,
+            layout=cute.make_ordered_layout((num_warps,), order=(0,)),
+            byte_alignment=128,
+        )
+
+        if cutlass.const_expr(not enable_persistent_dymamic_scheduling):
+            # Thread and block indexing
+            bidx, bidy, _ = cute.arch.block_idx()
+
+            row_start = 0
+            row_end = 0
+            length = 0
+            seq_len = 0
+
+            if not cutlass.const_expr(self.merge_blocks):
+                seq_len = seqlen[bidx // self.next_n]
+                row_end = seq_len - self.next_n + (bidx % self.next_n) + 1
+                length = row_end - row_start
+
+            if cutlass.const_expr(self.enable_multi_cta):
+                # update row_start and row_end.
+                row_start = self.chunk_size_per_cta * bidy
+                row_end = min(row_end, row_start + self.chunk_size_per_cta)
+                length = row_end - row_start
+                output_indices = cute.flat_divide(output_indices, (1, self.top_k))[
+                    0, None, bidx, bidy
+                ]
+                output_values = cute.flat_divide(output_values, (1, self.top_k))[
+                    0, None, bidx, bidy
+                ]
+
+            if cutlass.const_expr(self.merge_blocks):
+                # Note, after 1st kernel, the output is fix-lenght.
+                row_end = self.max_num_cols
+                length = self.max_num_cols
+
+            self.filtered_topk_kernel_per_row(
+                input,
+                indices,
+                extra_buffer,
+                output_indices,
+                output_values,
+                tiler_mn,
+                copy_atom,
+                tiled_copy,
+                row_start,
+                length,
+                bidx,
+                s_histogram,
+                s_counter,
+                s_threshold_bin_id,
+                s_num_input,
+                g_num_input,
+                s_indices,
+                s_input_idx,
+                s_last_remain,
+                num_warps,
+                s_warp_sums,
+            )
+        else:
+            num_rows = input.shape[0]
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx, _, _ = cute.arch.block_idx()
+
+            row_start = cutlass.Int32(0)
+            row_end = cutlass.Int32(0)
+            length = cutlass.Int32(0)
+            seq_len = cutlass.Int32(0)
+
+            # dynamic scheduler.
+            work_remaining = True
+
+            s_row_id = smem.allocate_tensor(
+                element_type=cute.Int32,
+                layout=cute.make_ordered_layout((1,), order=(0,)),
+                byte_alignment=128,
+            )
+
+            # version-1: dynamic scheduler.
+            while work_remaining:
+                # let tidx 0 dynamic get the next task
+                if tidx == 0:
+                    s_row_id[0] = atomicAdd(g_global_counter.iterator, 1)
+                cute.arch.barrier()
+
+                row_id = s_row_id[0]
+                has_work = row_id < num_rows
+
+                if has_work:
+                    task_id = row_id
+
+                    row_start = 0
+                    seq_len = seqlen[task_id // self.next_n]
+                    row_end = seq_len - self.next_n + (task_id % self.next_n) + 1
+
+                    length = row_end - row_start
+
+                    self.filtered_topk_kernel_per_row(
+                        input,
+                        indices,
+                        extra_buffer,
+                        output_indices,
+                        output_values,
+                        tiler_mn,
+                        copy_atom,
+                        tiled_copy,
+                        row_start,
+                        length,
+                        task_id,
+                        s_histogram,
+                        s_counter,
+                        s_threshold_bin_id,
+                        s_num_input,
+                        g_num_input,
+                        s_indices,
+                        s_input_idx,
+                        s_last_remain,
+                        num_warps,
+                        s_warp_sums,
+                    )
+                # use the result of the task to update the while loop condition
+                work_remaining = has_work
+
+    @cute.jit
+    def __call__(
+        self,
+        input_values,
+        indices,
+        extra_buffer,
+        g_global_counter,
+        seqlen,
+        output_indices,
+        output_values,
+        stream: cuda.CUstream,
+        enable_persistent_dymamic_scheduling: cutlass.Constexpr[bool] = False,
+        min_blocks_per_mp: cutlass.Constexpr[int] = 1,
+    ):
+        """Host function for the filtered topk kernel"""
+        # now we don't support it.
+        assert not (self.enable_multi_cta and enable_persistent_dymamic_scheduling), (
+            "enable_multi_cta and enable_persistent_dymamic_scheduling cannot both be True"
+        )
+
+        num_rows = input_values.shape[0]
+        # each cta processes one row of input.
+        if cutlass.const_expr(not enable_persistent_dymamic_scheduling):
+            blocks = (num_rows, self.num_ctas_per_row, 1)
+        else:
+            blocks = (min(148 * min_blocks_per_mp, num_rows), self.num_ctas_per_row, 1)
+
+        (
+            copy_atom,
+            tiled_copy,
+            tiler_mn,
+        ) = self._get_tiled_copy()
+        self.filtered_topk_kernel(
+            input_values,
+            indices,
+            extra_buffer,
+            g_global_counter,
+            seqlen,
+            output_indices,
+            output_values,
+            tiler_mn,
+            copy_atom,
+            tiled_copy,
+            enable_persistent_dymamic_scheduling,
+            min_blocks_per_mp,
+        ).launch(
+            grid=blocks,
+            block=(tiled_copy.size, 1, 1),
+            stream=stream,
+        )
+        return
+
+
+# This function is used for integration of framework, e.g. trtllm.
+compiled_filter_topk_dict = {}
+
+
+def cute_dsl_topk_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    return_val=True,
+    load_balance=False,
+    num_copy_bits=256,
+):
+    torch_dtype = input_values.dtype
+    torch_dtype_to_cutlass_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+    num_rows, num_cols = input_values.shape
+
+    large_occupancy = num_rows > 148
+    print(f"large_occupancy: {large_occupancy}, return_val: {return_val}")
+
+    # Note: don't forget num_cols, which means the maximum columns.
+    key = (
+        dtype,
+        num_cols,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        load_balance,
+        large_occupancy,
+    )
+    if key not in compiled_filter_topk_dict:
+        # Create fake tensors for compilation
+        n = cute.sym_int()
+        n_div_32 = cute.sym_int(divisibility=32)
+        input_fake = cute.runtime.make_fake_compact_tensor(
+            dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+        )
+        # used for large num_cols
+        buffer_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+            stride_order=(2, 1, 0),
+            assumed_align=32,
+        )
+        seqlen_fake = cute.runtime.make_fake_compact_tensor(
+            cute.Int32,
+            (n,),
+            stride_order=(0,),
+        )
+        output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n, top_k),
+            stride_order=(1, 0),
+        )
+        if return_val:
+            output_values_fake = cute.runtime.make_fake_compact_tensor(
+                dtype,
+                (n, top_k),
+                stride_order=(1, 0),
+            )
+        else:
+            output_values_fake = None
+        fake_stream = cute.runtime.make_fake_stream()
+
+        filtered_topk_func = FilteredTopKKernelVarlenDecode(
+            dtype,
+            num_cols,
+            top_k,
+            next_n,
+            num_copy_bits=num_copy_bits,
+            return_val=return_val,
+            large_occupancy=large_occupancy,
+        )
+
+        # Compile the kernel
+        compiled_kernel = cute.compile(
+            filtered_topk_func,
+            input_fake,
+            None,  # indices_fake,
+            buffer_fake,
+            None,  # g_global_counter_fake,
+            seqlen_fake,
+            output_indices_fake,
+            output_values_fake,
+            stream=fake_stream,
+            enable_persistent_dymamic_scheduling=load_balance,
+            min_blocks_per_mp=1,  # TODO: do we need this one?
+        )
+        compiled_filter_topk_dict[key] = compiled_kernel
+    else:
+        compiled_kernel = compiled_filter_topk_dict[key]
+
+    output_indices_torch = torch.empty(num_rows, top_k, dtype=torch.int32, device="cuda")
+    if return_val:
+        output_values_torch = torch.empty(num_rows, top_k, dtype=torch_dtype, device="cuda")
+    else:
+        output_values_torch = None
+
+    if dtype == cutlass.Float32:
+        buffer_numbers = 2
+    else:
+        buffer_numbers = 1
+    # Note: zeros will trigger an elementwise_add kernel.
+    buffer_torch = torch.empty(num_rows, buffer_numbers, num_cols, dtype=torch.int32, device="cuda")
+    g_global_counter_torch = None
+
+    torch_stream = torch.cuda.current_stream()
+    current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    compiled_kernel(
+        input_values,
+        None,  # indices, used for merge blocks kernel of the multi-cta.
+        buffer_torch,
+        g_global_counter_torch,
+        seq_lens,
+        output_indices_torch,
+        output_values_torch,
+        current_stream,
+    )
+    return output_indices_torch, output_values_torch
+
+
+def cute_dsl_topk_multi_cta_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    return_val=True,
+    load_balance=False,
+    num_copy_bits=256,
+    chunk_size_per_cta=16384,
+):
+    torch_dtype = input_values.dtype
+    torch_dtype_to_cutlass_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }
+    dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+    num_rows, num_cols = input_values.shape
+
+    large_occupancy = num_rows > 148
+    print(f"large_occupancy: {large_occupancy}, return_val: {return_val}")
+
+    # Note: don't forget num_cols, which means the maximum columns.
+    enable_multi_cta = True
+    num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
+    print(f"num_ctas_per_row: {num_ctas_per_row}")
+    key = (
+        dtype,
+        num_cols,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        load_balance,
+        large_occupancy,
+        enable_multi_cta,
+        chunk_size_per_cta,
+    )
+    if key not in compiled_filter_topk_dict:
+        # Create fake tensors for compilation
+        n = cute.sym_int()
+        n_div_32 = cute.sym_int(divisibility=32)
+        input_fake = cute.runtime.make_fake_compact_tensor(
+            dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+        )
+        # used for large num_cols
+        buffer_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+            stride_order=(2, 1, 0),
+            assumed_align=32,
+        )
+        seqlen_fake = cute.runtime.make_fake_compact_tensor(
+            cute.Int32,
+            (n,),
+            stride_order=(0,),
+        )
+        # used for load-balance, now we don't support it.
+        # TODO: used for first kernel output.
+        first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n, n_div_32),
+            stride_order=(1, 0),
+        )
+        first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (n, n_div_32),
+            stride_order=(1, 0),
+            assumed_align=32,
+        )
+        fake_stream = cute.runtime.make_fake_stream()
+
+        filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
+            dtype,
+            chunk_size_per_cta,  # num_cols
+            top_k,
+            next_n,
+            num_copy_bits=num_copy_bits,
+            # for the first kernel, it must return values.
+            return_val=True,
+            large_occupancy=large_occupancy,
+            enable_multi_cta=True,
+            chunk_size_per_cta=chunk_size_per_cta,
+            num_ctas_per_row=num_ctas_per_row,
+            merge_blocks=False,
+        )
+        # Compile the kernel
+        compiled_kernel_first = cute.compile(
+            filtered_topk_func_first,
+            input_fake,
+            None,  # indices_fake,
+            buffer_fake,
+            None,  # g_global_counter_fake,
+            seqlen_fake,
+            # output_indices_fake,
+            # output_values_fake,
+            first_kernel_output_indices_fake,
+            first_kernel_output_values_fake,
+            stream=fake_stream,
+            enable_persistent_dymamic_scheduling=load_balance,
+            min_blocks_per_mp=1,
+        )
+
+        # TODO: 2nd kernel: use the output of the first kernel as the input.
+        indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n, n_div_32),
+            stride_order=(1, 0),
+        )
+        output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n, top_k),
+            stride_order=(1, 0),
+        )
+        output_values_fake = cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (n, top_k),
+            stride_order=(1, 0),
+        )
+        filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
+            dtype,
+            num_ctas_per_row * top_k,  # num_cols
+            top_k,
+            next_n,
+            num_copy_bits=num_copy_bits,
+            return_val=return_val,
+            large_occupancy=large_occupancy,
+            enable_multi_cta=False,
+            # chunk_size_per_cta=chunk_size_per_cta, # no use
+            # num_ctas_per_row=1, # no use
+            merge_blocks=True,
+        )
+        # Compile the kernel
+        compiled_kernel_second = cute.compile(
+            filtered_topk_func_second,
+            input_fake,
+            indices_fake,
+            buffer_fake,
+            None,  # g_global_counter_fake,
+            seqlen_fake,
+            output_indices_fake,
+            output_values_fake,
+            stream=fake_stream,
+            enable_persistent_dymamic_scheduling=load_balance,
+            min_blocks_per_mp=1,
+        )
+
+        compiled_filter_topk_dict[key] = (compiled_kernel_first, compiled_kernel_second)
+    else:
+        compiled_kernel_first, compiled_kernel_second = compiled_filter_topk_dict[key]
+
+    first_kernel_output_indices_torch = torch.empty(
+        num_rows, num_ctas_per_row * top_k, dtype=torch.int32, device="cuda"
+    )
+    first_kernel_output_values_torch = torch.empty(
+        num_rows, num_ctas_per_row * top_k, dtype=torch_dtype, device="cuda"
+    )
+    output_indices_torch = torch.empty(num_rows, top_k, dtype=torch.int32, device="cuda")
+    if return_val:
+        output_values_torch = torch.empty(num_rows, top_k, dtype=torch_dtype, device="cuda")
+    else:
+        output_values_torch = None
+
+    if dtype == cutlass.Float32:
+        buffer_numbers = 2
+    else:
+        buffer_numbers = 1
+    buffer_torch = torch.empty(
+        num_rows * num_ctas_per_row,
+        buffer_numbers,
+        max(chunk_size_per_cta, num_ctas_per_row * top_k),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    g_global_counter_torch = None
+
+    torch_stream = torch.cuda.current_stream()
+    current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    compiled_kernel_first(
+        input_values,
+        None,  # indices, used for merge blocks kernel of the multi-cta.
+        buffer_torch,
+        g_global_counter_torch,
+        seq_lens,
+        first_kernel_output_indices_torch,
+        first_kernel_output_values_torch,
+        current_stream,
+    )
+
+    compiled_kernel_second(
+        first_kernel_output_values_torch,
+        first_kernel_output_indices_torch,
+        buffer_torch,
+        g_global_counter_torch,
+        seq_lens,
+        output_indices_torch,
+        output_values_torch,
+        current_stream,
+    )
+    return output_indices_torch, output_values_torch
+
+
+def generate_seq_lens(batch_size, min_long_seq, num_tokens):
+    seq_lens = torch.zeros(batch_size, dtype=torch.int32, device="cuda")
+    is_long = torch.rand(batch_size, device="cuda") < 0.9
+    num_long = is_long.sum().item()
+    if num_long > 0:
+        seq_lens[is_long] = torch.randint(
+            min_long_seq, num_tokens, (num_long,), dtype=torch.int32, device="cuda"
+        )
+
+    num_short = (~is_long).sum().item()
+    if num_short > 0:
+        seq_lens[~is_long] = torch.randint(
+            1, min_long_seq, (num_short,), dtype=torch.int32, device="cuda"
+        )
+    return seq_lens
+
+
+def run_filtered_topk_decode(
+    dtype: Type[cutlass.Numeric],
+    batch_size,
+    max_num_cols,
+    top_k,
+    next_n,
+    load_balance: bool = False,
+    num_copy_bits=256,
+    return_val=True,
+    large_occupancy=False,
+    do_ref_check=True,
+    do_benchmark=False,
+    warmup_iterations=10,
+    iterations=100,
+    use_cold_l2=True,
+    print_verbose=True,
+):
+    """
+    Prepare input tensors, launch GPU kernel, and reference checking.
+    """
+    if print_verbose:
+        print("=" * 60)
+        print("Launching Blackwell Filtered TopK Test")
+        print("-" * 60)
+        print(f"Data Types & Precision: {dtype}")
+        print(f"    Input matrix: {dtype}")
+        print(f"    Output indices: {cutlass.Int32}")
+        print(f"    Output values: {dtype}")
+        print(
+            f"Input dimensions (batch_size, max_num_cols, top_k): {batch_size, max_num_cols, top_k}"
+        )
+        print(f"    batch_size: {batch_size}")
+        print(f"    next_n: {next_n}")
+        print(f"    max_num_cols: {max_num_cols}")
+        print(f"    top_k: {top_k}")
+        print(f"    load_balance: {load_balance}")
+        print(f"    num_copy_bits: {num_copy_bits}")
+        print(f"    return_val: {return_val}")
+        print(f"    large_occupancy: {large_occupancy}")
+        print(f"Do reference checking: {do_ref_check}")
+        print(f"Do benchmark: {do_benchmark}")
+        print(f"Warmup iterations: {warmup_iterations}")
+        print(f"Iterations: {iterations}")
+        print(f"Use cold L2: {use_cold_l2}")
+        print("=" * 60)
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    seed = 1111
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(1111)
+
+    torch_stream = torch.cuda.Stream()
+    current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    # Create fake tensors for compilation
+    n = cute.sym_int()
+    n_div_32 = cute.sym_int(divisibility=32)
+
+    # # We need to pad the input tensor so that each row can be aligned to vec_size and could use vectorized copy.
+    input_fake = cute.runtime.make_fake_compact_tensor(
+        dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+    )
+    # TODO
+    if dtype == cutlass.Float32:
+        buffer_numbers = 2
+    else:
+        buffer_numbers = 1
+    buffer_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (n, n, n_div_32),
+        stride_order=(2, 1, 0),
+        assumed_align=32,
+    )
+    g_global_counter_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (1,), stride_order=(0,)
+    )
+    seqlen_fake = cute.runtime.make_fake_compact_tensor(
+        cute.Int32,
+        (n,),
+        stride_order=(0,),
+    )
+    print("input_fake: ", input_fake)
+    print("seqlen_fake: ", seqlen_fake)
+    output_indices_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (n, top_k),
+        stride_order=(1, 0),
+    )
+    if return_val:
+        output_values_fake = cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (n, top_k),
+            stride_order=(1, 0),
+        )
+    else:
+        output_values_fake = None
+    fake_stream = cute.runtime.make_fake_stream()
+
+    filtered_topk_func = FilteredTopKKernelVarlenDecode(
+        dtype,
+        max_num_cols,
+        top_k,
+        next_n,
+        num_copy_bits=num_copy_bits,
+        return_val=return_val,
+        large_occupancy=large_occupancy,
+    )
+
+    # Compile the kernel
+    compiled_kernel = cute.compile(
+        filtered_topk_func,
+        input_fake,
+        None,  # indices, used for merge blocks kernel of the multi-cta.
+        buffer_fake,
+        g_global_counter_fake,
+        seqlen_fake,
+        output_indices_fake,
+        output_values_fake,
+        stream=fake_stream,
+        enable_persistent_dymamic_scheduling=load_balance,
+        # TODO: confirm this parameter.
+        min_blocks_per_mp=4 if large_occupancy else 1,
+    )
+
+    # Set input data
+    # num_gen_tokens is the number of rows in the input tensor
+    g_global_counter_torch = torch.zeros(1, dtype=torch.int32, device="cuda")
+    torch.cuda.synchronize()
+    print("g_global_counter_torch: ", g_global_counter_torch)
+    num_gen_tokens = batch_size * next_n  # Use the same variable name as dsa.py
+    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
+    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
+    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
+
+    # max_num_cols is the maximum col length in the input tensor
+    seq_lens = generate_seq_lens(batch_size, top_k, max_num_cols)
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+    row_ends = row_ends.to(torch.int32)
+    # print("row_ends: ", row_ends)
+    print("row_ends.dtype: ", row_ends.dtype)
+
+    input_torch = create_random_logits(
+        row_starts,
+        row_ends,
+        torch_dtype(dtype),
+        seed,
+    )
+    print("input_torch.shape: ", input_torch.shape)
+
+    output_indices_torch = torch.empty(num_gen_tokens, top_k, dtype=torch.int32, device="cuda")
+    if return_val:
+        output_values_torch = torch.empty(
+            num_gen_tokens, top_k, dtype=torch_dtype(dtype), device="cuda"
+        )
+    else:
+        output_values_torch = None
+    buffer_torch = torch.zeros(
+        num_gen_tokens,
+        buffer_numbers,
+        max_num_cols,
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    compiled_kernel(
+        input_torch,
+        None,  # indices, used for merge blocks kernel of the multi-cta.
+        buffer_torch,
+        g_global_counter_torch,
+        seq_lens,
+        output_indices_torch,
+        output_values_torch,
+        current_stream,
+    )
+
+    if do_ref_check and top_k <= max_num_cols and return_val:
+        torch.cuda.synchronize()
+
+        # Compare results
+        torch_indices = run_reference_top_k(input_torch, row_starts, row_ends, top_k)
+        assert compare_top_k_results(
+            input_torch,
+            output_indices_torch,
+            torch_indices,
+            row_starts,
+            row_ends,
+            top_k,
+        ), "CUDA top_k_per_row results don't match torch.topk"
+        if print_verbose:
+            print("PASSED")
+
+        if not load_balance:
+            wrapper_output_indices, wrapper_output_values = cute_dsl_topk_wrapper(
+                input_torch,
+                seq_lens,
+                top_k,
+                next_n,
+                return_val,
+                load_balance,
+                num_copy_bits,
+            )
+            wrapper_output_val_sorted = torch.sort(
+                wrapper_output_values.cpu(), dim=1, descending=True
+            ).values
+            output_val_ref_sorted = torch.sort(
+                output_values_torch.cpu(), dim=1, descending=True
+            ).values
+
+            assert torch.allclose(wrapper_output_val_sorted, output_val_ref_sorted, atol=1e-5), (
+                "CUDA top_k_per_row results don't match wrapper"
+            )
+            if print_verbose:
+                print("Wrapper: PASSED")
+
+            # test multi-cta version.
+            wrapper_output_indices_multi_cta, wrapper_output_values_multi_cta = (
+                cute_dsl_topk_multi_cta_wrapper(
+                    input_torch,
+                    seq_lens,
+                    top_k,
+                    next_n,
+                    return_val,
+                    load_balance,
+                    num_copy_bits,
+                    chunk_size_per_cta=8192,
+                )
+            )
+            wrapper_output_val_sorted_multi_cta = torch.sort(
+                wrapper_output_values_multi_cta.cpu(), dim=1, descending=True
+            ).values
+            output_val_ref_sorted = torch.sort(
+                output_values_torch.cpu(), dim=1, descending=True
+            ).values
+
+            for i in range(num_gen_tokens):
+                if not torch.allclose(
+                    wrapper_output_val_sorted_multi_cta[i, :],
+                    output_val_ref_sorted[i, :],
+                    atol=1e-5,
+                ):
+                    print(f"FAILED for row_id: {i}")
+                    print(
+                        f"wrapper_output_val_sorted_multi_cta: {wrapper_output_val_sorted_multi_cta[i]}"
+                    )
+                    print(f"output_values_torch: {output_val_ref_sorted[i]}")
+                    break
+            assert torch.allclose(
+                wrapper_output_val_sorted_multi_cta,
+                output_val_ref_sorted.cpu(),
+                atol=1e-5,
+            ), "CUDA top_k_per_row results don't match wrapper multi-cta"
+            if print_verbose:
+                print("Wrapper multi-cta: PASSED")
+
+    if do_benchmark:
+
+        def generate_inputs():
+            g_global_counter_torch = torch.zeros(1, dtype=torch.int32, device="cuda")
+            torch.cuda.synchronize()
+            input_tensor = create_random_logits(
+                row_starts,
+                row_ends,
+                torch_dtype(dtype),
+                seed,
+            )
+
+            output_indices_tensor = torch.empty(
+                num_gen_tokens, top_k, dtype=torch.int32, device="cuda"
+            )
+            if return_val:
+                output_values_tensor = torch.empty(
+                    num_gen_tokens, top_k, dtype=torch_dtype(dtype), device="cuda"
+                )
+            else:
+                output_values_tensor = None
+            return cute.testing.JitArguments(
+                input_tensor,
+                None,  # indices, used for merge blocks kernel of the multi-cta.
+                buffer_torch,
+                g_global_counter_torch,
+                seq_lens,
+                output_indices_tensor,
+                output_values_tensor,
+                current_stream,
+            )
+
+        workspace_count = 1
+        if use_cold_l2:
+            one_workspace_bytes = (
+                input_torch.numel() * input_torch.element_size()
+                + row_starts.numel() * row_starts.element_size()
+                + row_ends.numel() * row_ends.element_size()
+                + seq_lens.numel() * seq_lens.element_size()
+                + output_indices_torch.numel() * output_indices_torch.element_size()
+                + (
+                    output_values_torch.numel() * output_values_torch.element_size()
+                    if return_val
+                    else 0
+                )
+            )
+            workspace_count = cute.testing.get_workspace_count(
+                one_workspace_bytes, warmup_iterations, iterations
+            )
+            # Note: when load-balance is enabled, we need to memset g_global_counter_torch to 0 for each iteration.
+            # without this, the kernel will accumulate the global counter from previous iterations.
+            # Here, we war the memset by setting the workspace_count to the sum of warmup_iterations and iterations.
+            workspace_count = iterations + warmup_iterations
+            print("workspace_count: ", workspace_count)
+        time = cute.testing.benchmark(
+            compiled_kernel,
+            workspace_generator=generate_inputs,
+            workspace_count=workspace_count,
+            warmup_iterations=warmup_iterations,
+            iterations=iterations,
+            use_cuda_graphs=True,
+            stream=current_stream,
+        )
+        if print_verbose:
+            print(f"Time: {time} us")
+        print(f"{dtype}-{batch_size}-{max_num_cols}-{top_k} {time}")
+    torch.cuda.synchronize()
+
+
+def run_topk_decode(
+    dtype: Type[cutlass.Numeric],
+    batch_size: int,
+    max_num_cols: int,
+    top_k: int,
+    next_n: int,
+    load_balance: bool = False,
+    num_copy_bits: int = 256,
+    return_val: bool = True,
+    large_occupancy: bool = False,
+    do_ref_check: bool = True,
+    do_benchmark: bool = False,
+    warmup_iterations: int = 10,
+    iterations: int = 10,
+    use_cold_l2: bool = True,
+):
+    run_filtered_topk_decode(
+        dtype,
+        batch_size,
+        max_num_cols,
+        top_k,
+        next_n,
+        load_balance,
+        num_copy_bits,
+        return_val,
+        large_occupancy,
+        do_ref_check,
+        do_benchmark,
+        warmup_iterations,
+        iterations,
+        use_cold_l2,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Example of Sm100 Dense BlockScaled GEMM.")
+    parser.add_argument(
+        "--dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float32,
+        choices=[cutlass.Float32, cutlass.Float16, cutlass.BFloat16],
+        help="Data type of the input matrix",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="batch_size",
+    )
+    parser.add_argument("--max_num_cols", type=int, default=4096, help="max_num_cols")
+    parser.add_argument("--next_n", type=int, default=3, help="next_n")
+    parser.add_argument("--top_k", type=int, default=2048, help="top_k")
+    parser.add_argument(
+        "--load_balance",
+        action="store_true",
+        default=False,
+        help="Use load balance for varlen optimization",
+    )
+    parser.add_argument(
+        "--num_copy_bits",
+        type=int,
+        default=256,
+        help="num_copy_bits, used for vectorization",
+    )
+    parser.add_argument(
+        "--return_val",
+        action="store_true",
+        default=False,
+        help="Return values",
+    )
+    parser.add_argument(
+        "--large_occupancy",
+        action="store_true",
+        default=False,
+        help="Use large occupancy",
+    )
+    parser.add_argument(
+        "--do_ref_check",
+        action="store_true",
+        default=False,
+        help="Do reference checking",
+    )
+    parser.add_argument(
+        "--do_benchmark", action="store_true", default=False, help="Do benchmark test"
+    )
+    parser.add_argument("--warmup_iterations", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--iterations", type=int, default=100, help="Iterations")
+    parser.add_argument("--use_cold_l2", action="store_true", default=True, help="Use cold L2")
+
+    args = parser.parse_args()
+    if args.top_k % 2 != 0:
+        parser.error("top_k must be a multiple of 2 (got top_k={})".format(args.top_k))
+
+    run_topk_decode(
+        dtype=args.dtype,
+        batch_size=args.batch_size,
+        max_num_cols=args.max_num_cols,
+        top_k=args.top_k,
+        next_n=args.next_n,
+        load_balance=args.load_balance,
+        num_copy_bits=args.num_copy_bits,
+        return_val=args.return_val,
+        large_occupancy=args.large_occupancy,
+        do_ref_check=args.do_ref_check,
+        do_benchmark=args.do_benchmark,
+        warmup_iterations=args.warmup_iterations,
+        iterations=args.iterations,
+        use_cold_l2=args.use_cold_l2,
+    )

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -60,6 +60,102 @@ Constraints for this example:
 """
 
 
+class ComputeDynamicCTAOffsets:
+    """CuTE DSL kernel to compute row_cta_offsets and row_output_offsets.
+
+    Replaces ~20 small PyTorch tensor ops (arange, indexing, arithmetic,
+    cumsum, etc.) with a single GPU kernel launch.
+
+    Uses NUM_THREADS threads in two phases:
+      Phase 1 (parallel): Each thread computes per_row_ctas for its rows,
+              writes to shared memory.
+      Phase 2 (thread 0): Sequential prefix sum from shared memory,
+              writes to global memory.
+
+    Inputs:
+        seq_lens:  (batch_size,) int32
+    Outputs (pre-allocated by caller):
+        row_cta_offsets:    (num_rows + 1,) int32  — prefix sum of per-row CTAs
+        row_output_offsets: (num_rows + 1,) int32  — prefix sum of per-row output elems
+    """
+
+    NUM_THREADS = 128
+    # Max supported num_rows (batch_size * next_n). Covers batch_size up to
+    # ~340 with next_n=3 or 512 with next_n=2.
+    MAX_NUM_ROWS = 1024
+
+    def __init__(self, next_n: int, chunk_size_per_cta: int, top_k: int):
+        self.next_n = next_n
+        self.chunk_size_per_cta = chunk_size_per_cta
+        self.top_k = top_k
+
+    @cute.kernel
+    def compute_offsets_kernel(
+        self,
+        seq_lens: cute.Tensor,
+        row_cta_offsets: cute.Tensor,
+        row_output_offsets: cute.Tensor,
+    ):
+        smem = utils.SmemAllocator()
+        s_ctas = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout(
+                (self.MAX_NUM_ROWS,), order=(0,)),
+            byte_alignment=128,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        num_rows = seq_lens.shape[0] * self.next_n
+
+        # Phase 1: Parallel per-row CTA count computation
+        i = tidx
+        while i < num_rows:
+            batch_idx = i // self.next_n
+            next_n_off = i % self.next_n
+            eff_len = seq_lens[batch_idx] - self.next_n + next_n_off + 1
+            ctas = (eff_len + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
+            if ctas < 1:
+                ctas = 1
+            s_ctas[i] = ctas
+            i = i + self.NUM_THREADS
+
+        cute.arch.barrier()
+
+        # Phase 2: Thread 0 sequential prefix sum from shared memory
+        if tidx == 0:
+            cta_sum = 0
+            out_sum = 0
+            row_cta_offsets[0] = 0
+            row_output_offsets[0] = 0
+
+            j = 0
+            while j < num_rows:
+                c = s_ctas[j]
+                cta_sum = cta_sum + c
+                out_sum = out_sum + c * self.top_k
+                row_cta_offsets[j + 1] = cta_sum
+                row_output_offsets[j + 1] = out_sum
+                j = j + 1
+
+    @cute.jit
+    def __call__(
+        self,
+        seq_lens,
+        row_cta_offsets,
+        row_output_offsets,
+        stream: cuda.CUstream,
+    ):
+        self.compute_offsets_kernel(
+            seq_lens,
+            row_cta_offsets,
+            row_output_offsets,
+        ).launch(
+            grid=(1, 1, 1),
+            block=(self.NUM_THREADS, 1, 1),
+            stream=stream,
+        )
+
+
 class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
     def __init__(
         self,
@@ -75,6 +171,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         chunk_size_per_cta: int = 16384,
         num_ctas_per_row: int = 1,
         merge_blocks: bool = False,
+        enable_dynamic_multi_cta: bool = False,
+        varlen_merge_input: bool = False,
         debug: bool = False,
     ):
         super().__init__(
@@ -93,6 +191,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         self.chunk_size_per_cta = chunk_size_per_cta
         self.merge_blocks = merge_blocks
         self.num_ctas_per_row = num_ctas_per_row
+        self.enable_dynamic_multi_cta = enable_dynamic_multi_cta
+        self.varlen_merge_input = varlen_merge_input
 
         if cutlass.const_expr(large_occupancy):
             # tuned value, could be tuned further.
@@ -143,6 +243,19 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             print(
                 f"first_refine_shift: {self.first_refine_shift}, num_refine_rounds: {self.num_refine_rounds}"
             )
+
+    @cute.jit
+    def _binary_search_row(self, row_cta_offsets, task_id, num_rows):
+        """Binary search: find largest row_id where row_cta_offsets[row_id] <= task_id."""
+        lo = 0
+        hi = num_rows
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if row_cta_offsets[mid] <= task_id:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
 
     @cute.jit
     def run_kernel(
@@ -209,6 +322,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         seqlen: cute.Tensor,
         output_indices: cute.Tensor,
         output_values: cute.Tensor,
+        row_cta_offsets: cute.Tensor,
+        row_output_offsets: cute.Tensor,
         tiler_mn: cute.Shape,
         copy_atom: cute.CopyAtom,
         tiled_copy: cute.TiledCopy,
@@ -281,6 +396,19 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             # Thread and block indexing
             bidx, bidy, _ = cute.arch.block_idx()
 
+            if cutlass.const_expr(self.enable_dynamic_multi_cta):
+                # 1D grid: bidx = task_id. Binary search -> row_id, chunk_id.
+                # Grid is launched with upper-bound size to avoid DtoH sync;
+                # padding CTAs (task_id >= total_ctas) are skipped below.
+                task_id = bidx
+                num_rows_val = seqlen.shape[0] * self.next_n
+                bidx = self._binary_search_row(row_cta_offsets, task_id, num_rows_val)
+                bidy = task_id - row_cta_offsets[bidx]
+                # Clamp to valid range so all pointer arithmetic below is safe.
+                # Padding CTAs are skipped via the _should_run guard later.
+                bidx = min(bidx, num_rows_val - 1)
+                bidy = min(bidy, self.num_ctas_per_row - 1)
+
             row_start = 0
             row_end = 0
             length = 0
@@ -304,34 +432,49 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
                 ]
 
             if cutlass.const_expr(self.merge_blocks):
-                # Note, after 1st kernel, the output is fix-lenght.
-                # Note, for merge_block kernels, need to ensure max_num_cols is the same as bucketed_num_cols.
-                row_end = self.max_num_cols
-                length = self.max_num_cols
+                if cutlass.const_expr(self.varlen_merge_input):
+                    # Varlen merge: read per-row valid length from offset table.
+                    # Input is still 2D (num_rows, max_merge_cols); only the
+                    # first `merge_width` elements per row are valid.
+                    merge_width = row_output_offsets[bidx + 1] - row_output_offsets[bidx]
+                    row_end = merge_width
+                    length = merge_width
+                else:
+                    # Existing fixed-length path
+                    # Note, after 1st kernel, the output is fix-lenght.
+                    # Note, for merge_block kernels, need to ensure max_num_cols is the same as bucketed_num_cols.
+                    row_end = self.max_num_cols
+                    length = self.max_num_cols
 
-            self.filtered_topk_kernel_per_row(
-                input,
-                indices,
-                extra_buffer,
-                output_indices,
-                output_values,
-                tiler_mn,
-                copy_atom,
-                tiled_copy,
-                row_start,
-                length,
-                bidx,
-                s_histogram,
-                s_counter,
-                s_threshold_bin_id,
-                s_num_input,
-                g_num_input,
-                s_indices,
-                s_input_idx,
-                s_last_remain,
-                num_warps,
-                s_warp_sums,
-            )
+            # Skip padding CTAs launched beyond actual total_ctas.
+            _should_run = True
+            if cutlass.const_expr(self.enable_dynamic_multi_cta):
+                _should_run = task_id < row_cta_offsets[num_rows_val]
+
+            if _should_run:
+                self.filtered_topk_kernel_per_row(
+                    input,
+                    indices,
+                    extra_buffer,
+                    output_indices,
+                    output_values,
+                    tiler_mn,
+                    copy_atom,
+                    tiled_copy,
+                    row_start,
+                    length,
+                    bidx,
+                    s_histogram,
+                    s_counter,
+                    s_threshold_bin_id,
+                    s_num_input,
+                    g_num_input,
+                    s_indices,
+                    s_input_idx,
+                    s_last_remain,
+                    num_warps,
+                    s_warp_sums,
+                )
         else:
             num_rows = input.shape[0]
             tidx, _, _ = cute.arch.thread_idx()
@@ -406,6 +549,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         seqlen,
         output_indices,
         output_values,
+        row_cta_offsets,
+        row_output_offsets,
         stream: cuda.CUstream,
         enable_persistent_dynamic_scheduling: cutlass.Constexpr[bool] = False,
         min_blocks_per_mp: cutlass.Constexpr[int] = 1,
@@ -418,7 +563,10 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
 
         num_rows = input_values.shape[0]
         # each cta processes one row of input.
-        if cutlass.const_expr(not enable_persistent_dynamic_scheduling):
+        if cutlass.const_expr(self.enable_dynamic_multi_cta):
+            total_ctas = extra_buffer.shape[0]
+            blocks = (total_ctas, 1, 1)
+        elif cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             blocks = (num_rows, self.num_ctas_per_row, 1)
         else:
             blocks = (min(148 * min_blocks_per_mp, num_rows), self.num_ctas_per_row, 1)
@@ -436,6 +584,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             seqlen,
             output_indices,
             output_values,
+            row_cta_offsets,
+            row_output_offsets,
             tiler_mn,
             copy_atom,
             tiled_copy,
@@ -561,6 +711,8 @@ def cute_dsl_topk_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
+            None,  # row_cta_offsets
+            None,  # row_output_offsets
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,  # TODO: do we need this one?
@@ -593,6 +745,8 @@ def cute_dsl_topk_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
+        None,  # row_cta_offsets
+        None,  # row_output_offsets
     )
     return output_indices_torch, output_values_torch
 
@@ -693,6 +847,8 @@ def cute_dsl_topk_multi_cta_wrapper(
             # output_values_fake,
             first_kernel_output_indices_fake,
             first_kernel_output_values_fake,
+            None,  # row_cta_offsets
+            None,  # row_output_offsets
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -738,6 +894,8 @@ def cute_dsl_topk_multi_cta_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
+            None,  # row_cta_offsets
+            None,  # row_output_offsets
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -782,6 +940,8 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         first_kernel_output_indices_torch,
         first_kernel_output_values_torch,
+        None,  # row_cta_offsets
+        None,  # row_output_offsets
     )
 
     compiled_kernel_second(
@@ -792,6 +952,8 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
+        None,  # row_cta_offsets
+        None,  # row_output_offsets
     )
     return output_indices_torch, output_values_torch
 
@@ -929,6 +1091,8 @@ def run_filtered_topk_decode(
         seqlen_fake,
         output_indices_fake,
         output_values_fake,
+        None,  # row_cta_offsets
+        None,  # row_output_offsets
         stream=fake_stream,
         enable_persistent_dynamic_scheduling=load_balance,
         # TODO: confirm this parameter.
@@ -979,6 +1143,8 @@ def run_filtered_topk_decode(
         seq_lens,
         output_indices_torch,
         output_values_torch,
+        None,  # row_cta_offsets
+        None,  # row_output_offsets
     )
 
     if do_ref_check and top_k <= max_num_cols and return_val:
@@ -1089,6 +1255,8 @@ def run_filtered_topk_decode(
                 seq_lens,
                 output_indices_tensor,
                 output_values_tensor,
+                None,  # row_cta_offsets
+                None,  # row_output_offsets
             )
 
         workspace_count = 1

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -448,6 +448,24 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         return
 
 
+def _next_positive_power_of_2(x: int) -> int:
+    """Round up to the next power of 2 (returns x if already a power of 2)."""
+    if x <= 0:
+        return 1
+    return 1 << (x - 1).bit_length()
+
+
+def _bucket_num_cols(num_cols: int) -> int:
+    """Bucket num_cols to the next power of 2 for compilation caching.
+
+    This reduces recompilations when num_cols changes slightly (e.g.,
+    KV cache length growing each decode step). Safe because num_cols
+    only affects compile-time config; actual data access is bounded
+    by seq_lens.
+    """
+    return _next_positive_power_of_2(num_cols)
+
+
 # This function is used for integration of framework, e.g. trtllm.
 compiled_filter_topk_dict = {}
 
@@ -469,6 +487,7 @@ def cute_dsl_topk_wrapper(
     }
     dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
     num_rows, num_cols = input_values.shape
+    bucketed_num_cols = _bucket_num_cols(num_cols)
 
     large_occupancy = num_rows > 148
     assert not load_balance
@@ -476,7 +495,7 @@ def cute_dsl_topk_wrapper(
     # Note: don't forget num_cols, which means the maximum columns.
     key = (
         dtype,
-        num_cols,
+        bucketed_num_cols,
         top_k,
         next_n,
         return_val,
@@ -520,7 +539,7 @@ def cute_dsl_topk_wrapper(
 
         filtered_topk_func = FilteredTopKKernelVarlenDecode(
             dtype,
-            num_cols,
+            bucketed_num_cols,
             top_k,
             next_n,
             num_copy_bits=num_copy_bits,
@@ -594,6 +613,7 @@ def cute_dsl_topk_multi_cta_wrapper(
     }
     dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
     num_rows, num_cols = input_values.shape
+    bucketed_num_cols = _bucket_num_cols(num_cols)
 
     large_occupancy = num_rows > 148
     assert not load_balance
@@ -603,7 +623,7 @@ def cute_dsl_topk_multi_cta_wrapper(
     num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
     key = (
         dtype,
-        num_cols,
+        bucketed_num_cols,
         top_k,
         next_n,
         return_val,
@@ -612,6 +632,7 @@ def cute_dsl_topk_multi_cta_wrapper(
         large_occupancy,
         enable_multi_cta,
         chunk_size_per_cta,
+        num_ctas_per_row,
     )
     if key not in compiled_filter_topk_dict:
         # Create fake tensors for compilation

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,7 +94,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         self.merge_blocks = merge_blocks
         self.num_ctas_per_row = num_ctas_per_row
 
-        print(f"large_occupancy: {large_occupancy}")
         if cutlass.const_expr(large_occupancy):
             # reduce the smem usage and improve occupancy.
             if self.max_num_cols >= 262144:
@@ -119,14 +118,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
 
             # set the number of threads per cta to 512.
             self.num_threads_per_cta = 512
-
-            print(f"return_val: {return_val}")
-            print(f"limin: max_num_cols: {self.max_num_cols}")
-            print(f"limin: num_threads_per_cta: {self.num_threads_per_cta}")
-            print(
-                f"limin: filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}",
-            )
-            print(f"limin: enable_gmem_store: {self.enable_gmem_store}")
 
     @cute.jit
     def run_kernel(
@@ -455,7 +446,7 @@ def cute_dsl_topk_wrapper(
     num_rows, num_cols = input_values.shape
 
     large_occupancy = num_rows > 148
-    print(f"large_occupancy: {large_occupancy}, return_val: {return_val}")
+    assert not load_balance
 
     # Note: don't forget num_cols, which means the maximum columns.
     key = (
@@ -580,12 +571,11 @@ def cute_dsl_topk_multi_cta_wrapper(
     num_rows, num_cols = input_values.shape
 
     large_occupancy = num_rows > 148
-    print(f"large_occupancy: {large_occupancy}, return_val: {return_val}")
+    assert not load_balance
 
     # Note: don't forget num_cols, which means the maximum columns.
     enable_multi_cta = True
     num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
-    print(f"num_ctas_per_row: {num_ctas_per_row}")
     key = (
         dtype,
         num_cols,
@@ -831,7 +821,7 @@ def run_filtered_topk_decode(
 
     seed = 1111
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(1111)
+    torch.cuda.manual_seed(seed)
 
     torch_stream = torch.cuda.Stream()
     current_stream = cuda.CUstream(torch_stream.cuda_stream)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -237,19 +237,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             )
 
     @cute.jit
-    def _binary_search_row(self, row_cta_offsets, task_id, num_rows):
-        """Binary search: find largest row_id where row_cta_offsets[row_id] <= task_id."""
-        lo = 0
-        hi = num_rows
-        while lo < hi:
-            mid = (lo + hi + 1) // 2
-            if row_cta_offsets[mid] <= task_id:
-                lo = mid
-            else:
-                hi = mid - 1
-        return lo
-
-    @cute.jit
     def run_kernel(
         self,
         input,
@@ -382,74 +369,16 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             byte_alignment=128,
         )
 
-        # Shared memory for in-kernel dynamic CTA offset computation.
-        # All threads compute the prefix sum of per-row CTA counts via
-        # block_prefix_sum_kernel, then binary-search the result.
-        if cutlass.const_expr(self.enable_dynamic_multi_cta):
-            _DYNAMIC_MAX_NUM_ROWS = 512
-            s_row_cta_offsets = smem.allocate_tensor(
-                element_type=cutlass.Int32,
-                layout=cute.make_ordered_layout(
-                    (_DYNAMIC_MAX_NUM_ROWS + 1,), order=(0,)),
-                byte_alignment=128,
-            )
-            _num_warps_prefix = cutlass.const_expr(
-                self.num_threads_per_cta // 32)
-            s_prefix_warp_sums = smem.allocate_tensor(
-                element_type=cutlass.Int32,
-                layout=cute.make_ordered_layout(
-                    (_num_warps_prefix,), order=(0,)),
-                byte_alignment=128,
-            )
-
         if cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             # Thread and block indexing
             bidx, bidy, _ = cute.arch.block_idx()
 
             if cutlass.const_expr(self.enable_dynamic_multi_cta):
-                # 1D grid: bidx = task_id.  Each CTA computes
-                # row_cta_offsets in shared memory via parallel prefix
-                # sum, then binary-searches to find (row_id, chunk_id).
-                task_id = bidx
+                # 2D grid with early exit: bidx = row_id, bidy = chunk_id.
+                # Each CTA computes how many chunks its row actually needs
+                # from seqlen and exits early if bidy >= num_needed_ctas.
+                # This avoids prefix sum + binary search overhead entirely.
                 num_rows_val = seqlen.shape[0] * self.next_n
-                tidx, _, _ = cute.arch.thread_idx()
-
-                _num_passes = cutlass.const_expr(
-                    (_DYNAMIC_MAX_NUM_ROWS + self.num_threads_per_cta - 1)
-                    // self.num_threads_per_cta)
-                previous_sum = 0
-                for _pass in cutlass.range(_num_passes, unroll_full=True):
-                    row_idx = tidx + _pass * self.num_threads_per_cta
-                    ctas_val = 0
-                    if row_idx < num_rows_val:
-                        _batch = row_idx // self.next_n
-                        _off = row_idx % self.next_n
-                        _eff = seqlen[_batch] - self.next_n + _off + 1
-                        ctas_val = (_eff + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
-                        if ctas_val < 1:
-                            ctas_val = 1
-
-                    _psum, _tsum = block_prefix_sum_kernel(
-                        ctas_val, s_prefix_warp_sums, tidx,
-                        self.num_threads_per_cta, _num_warps_prefix,
-                        barrier_id=2, need_total_sum=True)
-
-                    if row_idx < num_rows_val:
-                        s_row_cta_offsets[row_idx + 1] = _psum + previous_sum
-                    previous_sum = previous_sum + _tsum
-
-                if tidx == 0:
-                    s_row_cta_offsets[0] = 0
-                cute.arch.barrier()
-
-                # Binary search from shared memory
-                bidx = self._binary_search_row(
-                    s_row_cta_offsets, task_id, num_rows_val)
-                bidy = task_id - s_row_cta_offsets[bidx]
-                # Clamp to valid range so all pointer arithmetic below is safe.
-                # Padding CTAs are skipped via the _should_run guard later.
-                bidx = min(bidx, num_rows_val - 1)
-                bidy = min(bidy, self.num_ctas_per_row - 1)
 
             row_start = 0
             row_end = 0
@@ -492,10 +421,16 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
                     row_end = self.max_num_cols
                     length = self.max_num_cols
 
-            # Skip padding CTAs launched beyond actual total_ctas.
+            # Skip CTAs that exceed this row's actual chunk count.
             _should_run = True
             if cutlass.const_expr(self.enable_dynamic_multi_cta):
-                _should_run = task_id < s_row_cta_offsets[num_rows_val]
+                _batch_check = bidx // self.next_n
+                _off_check = bidx % self.next_n
+                _eff_check = seqlen[_batch_check] - self.next_n + _off_check + 1
+                _needed_ctas = (_eff_check + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
+                if _needed_ctas < 1:
+                    _needed_ctas = 1
+                _should_run = (bidx < num_rows_val) and (bidy < _needed_ctas)
 
             if _should_run:
                 self.filtered_topk_kernel_per_row(
@@ -608,8 +543,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         num_rows = input_values.shape[0]
         # each cta processes one row of input.
         if cutlass.const_expr(self.enable_dynamic_multi_cta):
-            total_ctas = extra_buffer.shape[0]
-            blocks = (total_ctas, 1, 1)
+            blocks = (num_rows, self.num_ctas_per_row, 1)
         elif cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             blocks = (num_rows, self.num_ctas_per_row, 1)
         else:

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -95,6 +95,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         self.num_ctas_per_row = num_ctas_per_row
 
         if cutlass.const_expr(large_occupancy):
+            # tuned value, could be tuned further.
             # reduce the smem usage and improve occupancy.
             if self.max_num_cols >= 262144:
                 self.filtered_topk_smem_input_size = 4096

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import argparse
 import math
 from typing import Type
 
@@ -213,7 +212,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         tiler_mn: cute.Shape,
         copy_atom: cute.CopyAtom,
         tiled_copy: cute.TiledCopy,
-        enable_persistent_dymamic_scheduling: cutlass.Constexpr[bool] = False,
+        enable_persistent_dynamic_scheduling: cutlass.Constexpr[bool] = False,
         min_blocks_per_mp: cutlass.Constexpr[int] = 1,
     ):
         """CuTe DSL implementation of TopK kernel based on radix-based filter algorithm."""
@@ -278,7 +277,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             byte_alignment=128,
         )
 
-        if cutlass.const_expr(not enable_persistent_dymamic_scheduling):
+        if cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             # Thread and block indexing
             bidx, bidy, _ = cute.arch.block_idx()
 
@@ -407,18 +406,18 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         output_indices,
         output_values,
         stream: cuda.CUstream,
-        enable_persistent_dymamic_scheduling: cutlass.Constexpr[bool] = False,
+        enable_persistent_dynamic_scheduling: cutlass.Constexpr[bool] = False,
         min_blocks_per_mp: cutlass.Constexpr[int] = 1,
     ):
         """Host function for the filtered topk kernel"""
         # now we don't support it.
-        assert not (self.enable_multi_cta and enable_persistent_dymamic_scheduling), (
-            "enable_multi_cta and enable_persistent_dymamic_scheduling cannot both be True"
+        assert not (self.enable_multi_cta and enable_persistent_dynamic_scheduling), (
+            "enable_multi_cta and enable_persistent_dynamic_scheduling cannot both be True"
         )
 
         num_rows = input_values.shape[0]
         # each cta processes one row of input.
-        if cutlass.const_expr(not enable_persistent_dymamic_scheduling):
+        if cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             blocks = (num_rows, self.num_ctas_per_row, 1)
         else:
             blocks = (min(148 * min_blocks_per_mp, num_rows), self.num_ctas_per_row, 1)
@@ -439,7 +438,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             tiler_mn,
             copy_atom,
             tiled_copy,
-            enable_persistent_dymamic_scheduling,
+            enable_persistent_dynamic_scheduling,
             min_blocks_per_mp,
         ).launch(
             grid=blocks,
@@ -540,7 +539,7 @@ def cute_dsl_topk_wrapper(
             output_indices_fake,
             output_values_fake,
             stream=fake_stream,
-            enable_persistent_dymamic_scheduling=load_balance,
+            enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,  # TODO: do we need this one?
         )
         compiled_filter_topk_dict[key] = compiled_kernel
@@ -675,7 +674,7 @@ def cute_dsl_topk_multi_cta_wrapper(
             first_kernel_output_indices_fake,
             first_kernel_output_values_fake,
             stream=fake_stream,
-            enable_persistent_dymamic_scheduling=load_balance,
+            enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
         )
 
@@ -719,7 +718,7 @@ def cute_dsl_topk_multi_cta_wrapper(
             output_indices_fake,
             output_values_fake,
             stream=fake_stream,
-            enable_persistent_dymamic_scheduling=load_balance,
+            enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
         )
 
@@ -879,8 +878,6 @@ def run_filtered_topk_decode(
         (n,),
         stride_order=(0,),
     )
-    print("input_fake: ", input_fake)
-    print("seqlen_fake: ", seqlen_fake)
     output_indices_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
         (n, top_k),
@@ -917,7 +914,7 @@ def run_filtered_topk_decode(
         output_indices_fake,
         output_values_fake,
         stream=fake_stream,
-        enable_persistent_dymamic_scheduling=load_balance,
+        enable_persistent_dynamic_scheduling=load_balance,
         # TODO: confirm this parameter.
         min_blocks_per_mp=4 if large_occupancy else 1,
     )
@@ -926,7 +923,6 @@ def run_filtered_topk_decode(
     # num_gen_tokens is the number of rows in the input tensor
     g_global_counter_torch = torch.zeros(1, dtype=torch.int32, device="cuda")
     torch.cuda.synchronize()
-    print("g_global_counter_torch: ", g_global_counter_torch)
     num_gen_tokens = batch_size * next_n  # Use the same variable name as dsa.py
     row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
     row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
@@ -936,17 +932,12 @@ def run_filtered_topk_decode(
     seq_lens = generate_seq_lens(batch_size, top_k, max_num_cols)
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
     row_ends = row_ends.to(torch.int32)
-    # print("row_ends: ", row_ends)
-    print("row_ends.dtype: ", row_ends.dtype)
-
     input_torch = create_random_logits(
         row_starts,
         row_ends,
         torch_dtype(dtype),
         seed,
     )
-    print("input_torch.shape: ", input_torch.shape)
-
     output_indices_torch = torch.empty(num_gen_tokens, top_k, dtype=torch.int32, device="cuda")
     if return_val:
         output_values_torch = torch.empty(
@@ -1156,7 +1147,9 @@ def run_topk_decode(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Example of Sm100 Dense BlockScaled GEMM.")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Blackwell CuTE DSL filtered top-k decode benchmark.")
     parser.add_argument(
         "--dtype",
         type=cutlass.dtype,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -24,6 +24,7 @@ import torch
 from cutlass.torch import dtype as torch_dtype
 from cutlass.utils.distributed import atomicAdd
 
+from .block_scan import block_prefix_sum_kernel
 from .filtered_top_k_varlen_util import (
     FilteredTopKKernelVarlen,
     compare_top_k_results,
@@ -66,28 +67,26 @@ class ComputeDynamicCTAOffsets:
     Replaces ~20 small PyTorch tensor ops (arange, indexing, arithmetic,
     cumsum, etc.) with a single GPU kernel launch.
 
-    Uses NUM_THREADS threads in two phases:
-      Phase 1 (parallel): Each thread computes per_row_ctas for its rows,
-              writes to shared memory.
-      Phase 2 (thread 0): Sequential prefix sum from shared memory,
-              writes to global memory.
+    Uses 512 threads: each thread computes the CTA count for one row,
+    then a block-wide parallel prefix sum (via block_prefix_sum_kernel)
+    produces the exclusive scan in a single pass.
 
     Inputs:
         seq_lens:  (batch_size,) int32
     Outputs (pre-allocated by caller):
-        row_cta_offsets:    (num_rows + 1,) int32  — prefix sum of per-row CTAs
-        row_output_offsets: (num_rows + 1,) int32  — prefix sum of per-row output elems
+        row_cta_offsets:    (num_rows + 1,) int32  — exclusive prefix sum of per-row CTAs
+        row_output_offsets: (num_rows + 1,) int32  — exclusive prefix sum of per-row output elems
     """
 
-    NUM_THREADS = 128
-    # Max supported num_rows (batch_size * next_n). Covers batch_size up to
-    # ~340 with next_n=3 or 512 with next_n=2.
-    MAX_NUM_ROWS = 1024
+    # Max supported num_rows (batch_size * next_n). Must equal NUM_THREADS
+    # since each thread handles one row.
+    MAX_NUM_ROWS = 512
 
     def __init__(self, next_n: int, chunk_size_per_cta: int, top_k: int):
         self.next_n = next_n
         self.chunk_size_per_cta = chunk_size_per_cta
         self.top_k = top_k
+        self.NUM_THREADS = 512
 
     @cute.kernel
     def compute_offsets_kernel(
@@ -97,45 +96,38 @@ class ComputeDynamicCTAOffsets:
         row_output_offsets: cute.Tensor,
     ):
         smem = utils.SmemAllocator()
-        s_ctas = smem.allocate_tensor(
+        num_warps = cutlass.const_expr(self.NUM_THREADS // 32)
+        s_warp_sums = smem.allocate_tensor(
             element_type=cutlass.Int32,
-            layout=cute.make_ordered_layout(
-                (self.MAX_NUM_ROWS,), order=(0,)),
+            layout=cute.make_ordered_layout((num_warps,), order=(0,)),
             byte_alignment=128,
         )
 
         tidx, _, _ = cute.arch.thread_idx()
         num_rows = seq_lens.shape[0] * self.next_n
 
-        # Phase 1: Parallel per-row CTA count computation
-        i = tidx
-        while i < num_rows:
-            batch_idx = i // self.next_n
-            next_n_off = i % self.next_n
+        # Each thread computes CTA count for its row (0 if out of bounds)
+        ctas = 0
+        if tidx < num_rows:
+            batch_idx = tidx // self.next_n
+            next_n_off = tidx % self.next_n
             eff_len = seq_lens[batch_idx] - self.next_n + next_n_off + 1
             ctas = (eff_len + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
             if ctas < 1:
                 ctas = 1
-            s_ctas[i] = ctas
-            i = i + self.NUM_THREADS
 
-        cute.arch.barrier()
+        # Block-wide inclusive prefix sum
+        prefix_ctas, _ = block_prefix_sum_kernel(
+            ctas, s_warp_sums, tidx,
+            self.NUM_THREADS, num_warps, barrier_id=1)
 
-        # Phase 2: Thread 0 sequential prefix sum from shared memory
+        # Write exclusive prefix sum (shifted by 1)
         if tidx == 0:
-            cta_sum = 0
-            out_sum = 0
             row_cta_offsets[0] = 0
             row_output_offsets[0] = 0
-
-            j = 0
-            while j < num_rows:
-                c = s_ctas[j]
-                cta_sum = cta_sum + c
-                out_sum = out_sum + c * self.top_k
-                row_cta_offsets[j + 1] = cta_sum
-                row_output_offsets[j + 1] = out_sum
-                j = j + 1
+        if tidx < num_rows:
+            row_cta_offsets[tidx + 1] = prefix_ctas
+            row_output_offsets[tidx + 1] = prefix_ctas * self.top_k
 
     @cute.jit
     def __call__(
@@ -322,8 +314,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         seqlen: cute.Tensor,
         output_indices: cute.Tensor,
         output_values: cute.Tensor,
-        row_cta_offsets: cute.Tensor,
-        row_output_offsets: cute.Tensor,
         tiler_mn: cute.Shape,
         copy_atom: cute.CopyAtom,
         tiled_copy: cute.TiledCopy,
@@ -392,18 +382,70 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             byte_alignment=128,
         )
 
+        # Shared memory for in-kernel dynamic CTA offset computation.
+        # All threads compute the prefix sum of per-row CTA counts via
+        # block_prefix_sum_kernel, then binary-search the result.
+        if cutlass.const_expr(self.enable_dynamic_multi_cta):
+            _DYNAMIC_MAX_NUM_ROWS = 512
+            s_row_cta_offsets = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout(
+                    (_DYNAMIC_MAX_NUM_ROWS + 1,), order=(0,)),
+                byte_alignment=128,
+            )
+            _num_warps_prefix = cutlass.const_expr(
+                self.num_threads_per_cta // 32)
+            s_prefix_warp_sums = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout(
+                    (_num_warps_prefix,), order=(0,)),
+                byte_alignment=128,
+            )
+
         if cutlass.const_expr(not enable_persistent_dynamic_scheduling):
             # Thread and block indexing
             bidx, bidy, _ = cute.arch.block_idx()
 
             if cutlass.const_expr(self.enable_dynamic_multi_cta):
-                # 1D grid: bidx = task_id. Binary search -> row_id, chunk_id.
-                # Grid is launched with upper-bound size to avoid DtoH sync;
-                # padding CTAs (task_id >= total_ctas) are skipped below.
+                # 1D grid: bidx = task_id.  Each CTA computes
+                # row_cta_offsets in shared memory via parallel prefix
+                # sum, then binary-searches to find (row_id, chunk_id).
                 task_id = bidx
                 num_rows_val = seqlen.shape[0] * self.next_n
-                bidx = self._binary_search_row(row_cta_offsets, task_id, num_rows_val)
-                bidy = task_id - row_cta_offsets[bidx]
+                tidx, _, _ = cute.arch.thread_idx()
+
+                _num_passes = cutlass.const_expr(
+                    (_DYNAMIC_MAX_NUM_ROWS + self.num_threads_per_cta - 1)
+                    // self.num_threads_per_cta)
+                previous_sum = 0
+                for _pass in cutlass.range(_num_passes, unroll_full=True):
+                    row_idx = tidx + _pass * self.num_threads_per_cta
+                    ctas_val = 0
+                    if row_idx < num_rows_val:
+                        _batch = row_idx // self.next_n
+                        _off = row_idx % self.next_n
+                        _eff = seqlen[_batch] - self.next_n + _off + 1
+                        ctas_val = (_eff + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
+                        if ctas_val < 1:
+                            ctas_val = 1
+
+                    _psum, _tsum = block_prefix_sum_kernel(
+                        ctas_val, s_prefix_warp_sums, tidx,
+                        self.num_threads_per_cta, _num_warps_prefix,
+                        barrier_id=2, need_total_sum=True)
+
+                    if row_idx < num_rows_val:
+                        s_row_cta_offsets[row_idx + 1] = _psum + previous_sum
+                    previous_sum = previous_sum + _tsum
+
+                if tidx == 0:
+                    s_row_cta_offsets[0] = 0
+                cute.arch.barrier()
+
+                # Binary search from shared memory
+                bidx = self._binary_search_row(
+                    s_row_cta_offsets, task_id, num_rows_val)
+                bidy = task_id - s_row_cta_offsets[bidx]
                 # Clamp to valid range so all pointer arithmetic below is safe.
                 # Padding CTAs are skipped via the _should_run guard later.
                 bidx = min(bidx, num_rows_val - 1)
@@ -433,10 +475,14 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
 
             if cutlass.const_expr(self.merge_blocks):
                 if cutlass.const_expr(self.varlen_merge_input):
-                    # Varlen merge: read per-row valid length from offset table.
-                    # Input is still 2D (num_rows, max_merge_cols); only the
-                    # first `merge_width` elements per row are valid.
-                    merge_width = row_output_offsets[bidx + 1] - row_output_offsets[bidx]
+                    # Varlen merge: compute per-row valid length from seqlen.
+                    _batch = bidx // self.next_n
+                    _off = bidx % self.next_n
+                    _eff = seqlen[_batch] - self.next_n + _off + 1
+                    _num_ctas = (_eff + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
+                    if _num_ctas < 1:
+                        _num_ctas = 1
+                    merge_width = _num_ctas * self.top_k
                     row_end = merge_width
                     length = merge_width
                 else:
@@ -449,7 +495,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             # Skip padding CTAs launched beyond actual total_ctas.
             _should_run = True
             if cutlass.const_expr(self.enable_dynamic_multi_cta):
-                _should_run = task_id < row_cta_offsets[num_rows_val]
+                _should_run = task_id < s_row_cta_offsets[num_rows_val]
 
             if _should_run:
                 self.filtered_topk_kernel_per_row(
@@ -549,8 +595,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         seqlen,
         output_indices,
         output_values,
-        row_cta_offsets,
-        row_output_offsets,
         stream: cuda.CUstream,
         enable_persistent_dynamic_scheduling: cutlass.Constexpr[bool] = False,
         min_blocks_per_mp: cutlass.Constexpr[int] = 1,
@@ -584,8 +628,6 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             seqlen,
             output_indices,
             output_values,
-            row_cta_offsets,
-            row_output_offsets,
             tiler_mn,
             copy_atom,
             tiled_copy,
@@ -711,8 +753,7 @@ def cute_dsl_topk_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
-            None,  # row_cta_offsets
-            None,  # row_output_offsets
+
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,  # TODO: do we need this one?
@@ -745,8 +786,7 @@ def cute_dsl_topk_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        None,  # row_cta_offsets
-        None,  # row_output_offsets
+
     )
     return output_indices_torch, output_values_torch
 
@@ -847,8 +887,7 @@ def cute_dsl_topk_multi_cta_wrapper(
             # output_values_fake,
             first_kernel_output_indices_fake,
             first_kernel_output_values_fake,
-            None,  # row_cta_offsets
-            None,  # row_output_offsets
+
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -894,8 +933,7 @@ def cute_dsl_topk_multi_cta_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
-            None,  # row_cta_offsets
-            None,  # row_output_offsets
+
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -940,8 +978,7 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         first_kernel_output_indices_torch,
         first_kernel_output_values_torch,
-        None,  # row_cta_offsets
-        None,  # row_output_offsets
+
     )
 
     compiled_kernel_second(
@@ -952,8 +989,7 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        None,  # row_cta_offsets
-        None,  # row_output_offsets
+
     )
     return output_indices_torch, output_values_torch
 
@@ -1091,8 +1127,7 @@ def run_filtered_topk_decode(
         seqlen_fake,
         output_indices_fake,
         output_values_fake,
-        None,  # row_cta_offsets
-        None,  # row_output_offsets
+
         stream=fake_stream,
         enable_persistent_dynamic_scheduling=load_balance,
         # TODO: confirm this parameter.
@@ -1143,8 +1178,7 @@ def run_filtered_topk_decode(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        None,  # row_cta_offsets
-        None,  # row_output_offsets
+
     )
 
     if do_ref_check and top_k <= max_num_cols and return_val:
@@ -1255,8 +1289,6 @@ def run_filtered_topk_decode(
                 seq_lens,
                 output_indices_tensor,
                 output_values_tensor,
-                None,  # row_cta_offsets
-                None,  # row_output_offsets
             )
 
         workspace_count = 1

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -128,18 +128,22 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
                 # created by _fill_oob are counted in the radix histogram
                 # and may be selected as top-k candidates with invalid
                 # indices, causing incorrect results.
-                self.num_threads_per_cta = self.max_num_cols // self.vec_size
+                self.num_threads_per_cta = min(self.max_num_cols // self.vec_size, 512)
 
         # only used for debug info
         if cutlass.const_expr(debug):
             print(f"dtype: {self.dtype}, vec_size: {self.vec_size}")
-            print(f"max_num_cols: {self.max_num_cols}, num_threads_per_cta: {self.num_threads_per_cta}")
+            print(
+                f"max_num_cols: {self.max_num_cols}, num_threads_per_cta: {self.num_threads_per_cta}"
+            )
             print(f"filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
             print(f"enable_gmem_store: {self.enable_gmem_store}")
             print(f"return_val: {self.return_val}")
             print(f"large_occupancy: {large_occupancy}")
             print(f"filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
-            print(f"first_refine_shift: {self.first_refine_shift}, num_refine_rounds: {self.num_refine_rounds}")
+            print(
+                f"first_refine_shift: {self.first_refine_shift}, num_refine_rounds: {self.num_refine_rounds}"
+            )
 
     @cute.jit
     def run_kernel(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -305,6 +305,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
 
             if cutlass.const_expr(self.merge_blocks):
                 # Note, after 1st kernel, the output is fix-lenght.
+                # Note, for merge_block kernels, need to ensure max_num_cols is the same as bucketed_num_cols.
                 row_end = self.max_num_cols
                 length = self.max_num_cols
 
@@ -455,6 +456,13 @@ def _next_positive_power_of_2(x: int) -> int:
     return 1 << (x - 1).bit_length()
 
 
+_TORCH_TO_CUTLASS_DTYPE = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
 def _bucket_num_cols(num_cols: int) -> int:
     """Bucket num_cols to the next power of 2 for compilation caching.
 
@@ -480,12 +488,7 @@ def cute_dsl_topk_wrapper(
     num_copy_bits=256,
 ):
     torch_dtype = input_values.dtype
-    torch_dtype_to_cutlass_dtype = {
-        torch.float16: cutlass.Float16,
-        torch.bfloat16: cutlass.BFloat16,
-        torch.float32: cutlass.Float32,
-    }
-    dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+    dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
     num_rows, num_cols = input_values.shape
     bucketed_num_cols = _bucket_num_cols(num_cols)
 
@@ -505,10 +508,11 @@ def cute_dsl_topk_wrapper(
     )
     if key not in compiled_filter_topk_dict:
         # Create fake tensors for compilation
-        n = cute.sym_int()
-        n_div_32 = cute.sym_int(divisibility=32)
+        n_rows = cute.sym_int()
+        n_cols = cute.sym_int()
+        n_batch = cute.sym_int()
         input_fake = cute.runtime.make_fake_compact_tensor(
-            dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
         )
         # used for large num_cols
         buffer_fake = cute.runtime.make_fake_compact_tensor(
@@ -519,23 +523,23 @@ def cute_dsl_topk_wrapper(
         )
         seqlen_fake = cute.runtime.make_fake_compact_tensor(
             cute.Int32,
-            (n,),
+            (n_batch,),
             stride_order=(0,),
         )
         output_indices_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Int32,
-            (n, top_k),
+            (n_rows, top_k),
             stride_order=(1, 0),
         )
         if return_val:
             output_values_fake = cute.runtime.make_fake_compact_tensor(
                 dtype,
-                (n, top_k),
+                (n_rows, top_k),
                 stride_order=(1, 0),
             )
         else:
             output_values_fake = None
-        fake_stream = cute.runtime.make_fake_stream()
+        fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
         filtered_topk_func = FilteredTopKKernelVarlenDecode(
             dtype,
@@ -560,6 +564,7 @@ def cute_dsl_topk_wrapper(
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,  # TODO: do we need this one?
+            options="--enable-tvm-ffi",
         )
         compiled_filter_topk_dict[key] = compiled_kernel
     else:
@@ -579,9 +584,7 @@ def cute_dsl_topk_wrapper(
     buffer_torch = torch.empty(num_rows, buffer_numbers, num_cols, dtype=torch.int32, device="cuda")
     g_global_counter_torch = None
 
-    torch_stream = torch.cuda.current_stream()
-    current_stream = cuda.CUstream(torch_stream.cuda_stream)
-
+    # TVM FFI uses env stream automatically
     compiled_kernel(
         input_values,
         None,  # indices, used for merge blocks kernel of the multi-cta.
@@ -590,7 +593,6 @@ def cute_dsl_topk_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        current_stream,
     )
     return output_indices_torch, output_values_torch
 
@@ -606,12 +608,7 @@ def cute_dsl_topk_multi_cta_wrapper(
     chunk_size_per_cta=16384,
 ):
     torch_dtype = input_values.dtype
-    torch_dtype_to_cutlass_dtype = {
-        torch.float16: cutlass.Float16,
-        torch.bfloat16: cutlass.BFloat16,
-        torch.float32: cutlass.Float32,
-    }
-    dtype = torch_dtype_to_cutlass_dtype[torch_dtype]
+    dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
     num_rows, num_cols = input_values.shape
     bucketed_num_cols = _bucket_num_cols(num_cols)
 
@@ -636,10 +633,11 @@ def cute_dsl_topk_multi_cta_wrapper(
     )
     if key not in compiled_filter_topk_dict:
         # Create fake tensors for compilation
-        n = cute.sym_int()
-        n_div_32 = cute.sym_int(divisibility=32)
+        n_rows = cute.sym_int()
+        n_cols = cute.sym_int()
+        n_batch = cute.sym_int()
         input_fake = cute.runtime.make_fake_compact_tensor(
-            dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
         )
         # used for large num_cols
         buffer_fake = cute.runtime.make_fake_compact_tensor(
@@ -650,23 +648,24 @@ def cute_dsl_topk_multi_cta_wrapper(
         )
         seqlen_fake = cute.runtime.make_fake_compact_tensor(
             cute.Int32,
-            (n,),
+            (n_batch,),
             stride_order=(0,),
         )
         # used for load-balance, now we don't support it.
         # TODO: used for first kernel output.
+        n_first_output_cols = cute.sym_int()
         first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Int32,
-            (n, n_div_32),
+            (n_rows, n_first_output_cols),
             stride_order=(1, 0),
         )
         first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
             dtype,
-            (n, n_div_32),
+            (n_rows, n_first_output_cols),
             stride_order=(1, 0),
             assumed_align=32,
         )
-        fake_stream = cute.runtime.make_fake_stream()
+        fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
         filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
             dtype,
@@ -697,22 +696,23 @@ def cute_dsl_topk_multi_cta_wrapper(
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
+            options="--enable-tvm-ffi",
         )
 
         # TODO: 2nd kernel: use the output of the first kernel as the input.
         indices_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Int32,
-            (n, n_div_32),
+            (n_rows, n_first_output_cols),
             stride_order=(1, 0),
         )
         output_indices_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Int32,
-            (n, top_k),
+            (n_rows, top_k),
             stride_order=(1, 0),
         )
         output_values_fake = cute.runtime.make_fake_compact_tensor(
             dtype,
-            (n, top_k),
+            (n_rows, top_k),
             stride_order=(1, 0),
         )
         filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
@@ -741,6 +741,7 @@ def cute_dsl_topk_multi_cta_wrapper(
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
+            options="--enable-tvm-ffi",
         )
 
         compiled_filter_topk_dict[key] = (compiled_kernel_first, compiled_kernel_second)
@@ -772,9 +773,7 @@ def cute_dsl_topk_multi_cta_wrapper(
     )
     g_global_counter_torch = None
 
-    torch_stream = torch.cuda.current_stream()
-    current_stream = cuda.CUstream(torch_stream.cuda_stream)
-
+    # TVM FFI uses env stream automatically
     compiled_kernel_first(
         input_values,
         None,  # indices, used for merge blocks kernel of the multi-cta.
@@ -783,7 +782,6 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         first_kernel_output_indices_torch,
         first_kernel_output_values_torch,
-        current_stream,
     )
 
     compiled_kernel_second(
@@ -794,7 +792,6 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        current_stream,
     )
     return output_indices_torch, output_values_torch
 
@@ -869,16 +866,14 @@ def run_filtered_topk_decode(
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
 
-    torch_stream = torch.cuda.Stream()
-    current_stream = cuda.CUstream(torch_stream.cuda_stream)
-
     # Create fake tensors for compilation
-    n = cute.sym_int()
-    n_div_32 = cute.sym_int(divisibility=32)
+    n_rows = cute.sym_int()
+    n_cols = cute.sym_int()
+    n_batch = cute.sym_int()
 
     # # We need to pad the input tensor so that each row can be aligned to vec_size and could use vectorized copy.
     input_fake = cute.runtime.make_fake_compact_tensor(
-        dtype, (n, n_div_32), stride_order=(1, 0), assumed_align=32
+        dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
     )
     # TODO
     if dtype == cutlass.Float32:
@@ -887,7 +882,7 @@ def run_filtered_topk_decode(
         buffer_numbers = 1
     buffer_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (n, n, n_div_32),
+        (n_rows, cute.sym_int(), n_cols),
         stride_order=(2, 1, 0),
         assumed_align=32,
     )
@@ -896,23 +891,23 @@ def run_filtered_topk_decode(
     )
     seqlen_fake = cute.runtime.make_fake_compact_tensor(
         cute.Int32,
-        (n,),
+        (n_batch,),
         stride_order=(0,),
     )
     output_indices_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (n, top_k),
+        (n_rows, top_k),
         stride_order=(1, 0),
     )
     if return_val:
         output_values_fake = cute.runtime.make_fake_compact_tensor(
             dtype,
-            (n, top_k),
+            (n_rows, top_k),
             stride_order=(1, 0),
         )
     else:
         output_values_fake = None
-    fake_stream = cute.runtime.make_fake_stream()
+    fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     filtered_topk_func = FilteredTopKKernelVarlenDecode(
         dtype,
@@ -938,6 +933,7 @@ def run_filtered_topk_decode(
         enable_persistent_dynamic_scheduling=load_balance,
         # TODO: confirm this parameter.
         min_blocks_per_mp=4 if large_occupancy else 1,
+        options="--enable-tvm-ffi",
     )
 
     # Set input data
@@ -969,11 +965,12 @@ def run_filtered_topk_decode(
     buffer_torch = torch.zeros(
         num_gen_tokens,
         buffer_numbers,
-        max_num_cols,
+        input_torch.shape[1],
         dtype=torch.int32,
         device="cuda",
     )
 
+    # TVM FFI uses env stream automatically
     compiled_kernel(
         input_torch,
         None,  # indices, used for merge blocks kernel of the multi-cta.
@@ -982,7 +979,6 @@ def run_filtered_topk_decode(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-        current_stream,
     )
 
     if do_ref_check and top_k <= max_num_cols and return_val:
@@ -1093,7 +1089,6 @@ def run_filtered_topk_decode(
                 seq_lens,
                 output_indices_tensor,
                 output_values_tensor,
-                current_stream,
             )
 
         workspace_count = 1
@@ -1118,6 +1113,8 @@ def run_filtered_topk_decode(
             # Here, we war the memset by setting the workspace_count to the sum of warmup_iterations and iterations.
             workspace_count = iterations + warmup_iterations
             print("workspace_count: ", workspace_count)
+        torch_stream = torch.cuda.Stream()
+        benchmark_stream = cuda.CUstream(torch_stream.cuda_stream)
         time = cute.testing.benchmark(
             compiled_kernel,
             workspace_generator=generate_inputs,
@@ -1125,7 +1122,7 @@ def run_filtered_topk_decode(
             warmup_iterations=warmup_iterations,
             iterations=iterations,
             use_cuda_graphs=True,
-            stream=current_stream,
+            stream=benchmark_stream,
         )
         if print_verbose:
             print(f"Time: {time} us")
@@ -1170,7 +1167,9 @@ def run_topk_decode(
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Blackwell CuTE DSL filtered top-k decode benchmark.")
+    parser = argparse.ArgumentParser(
+        description="Blackwell CuTE DSL filtered top-k decode benchmark."
+    )
     parser.add_argument(
         "--dtype",
         type=cutlass.dtype,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -76,6 +76,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
         chunk_size_per_cta: int = 16384,
         num_ctas_per_row: int = 1,
         merge_blocks: bool = False,
+        debug: bool = False,
     ):
         super().__init__(
             dtype,
@@ -118,7 +119,27 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
                 self.enable_gmem_store = False
 
             # set the number of threads per cta to 512.
-            self.num_threads_per_cta = 512
+            if cutlass.const_expr(not self.merge_blocks):
+                self.num_threads_per_cta = 512
+            else:
+                # For merge_blocks, cap num_threads_per_cta so that the tile
+                # width (num_threads_per_cta * vec_size) does not exceed
+                # max_num_cols. Otherwise, out-of-bounds padding elements
+                # created by _fill_oob are counted in the radix histogram
+                # and may be selected as top-k candidates with invalid
+                # indices, causing incorrect results.
+                self.num_threads_per_cta = self.max_num_cols // self.vec_size
+
+        # only used for debug info
+        if cutlass.const_expr(debug):
+            print(f"dtype: {self.dtype}, vec_size: {self.vec_size}")
+            print(f"max_num_cols: {self.max_num_cols}, num_threads_per_cta: {self.num_threads_per_cta}")
+            print(f"filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
+            print(f"enable_gmem_store: {self.enable_gmem_store}")
+            print(f"return_val: {self.return_val}")
+            print(f"large_occupancy: {large_occupancy}")
+            print(f"filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
+            print(f"first_refine_shift: {self.first_refine_shift}, num_refine_rounds: {self.num_refine_rounds}")
 
     @cute.jit
     def run_kernel(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_decode_varlen.py
@@ -118,8 +118,8 @@ class ComputeDynamicCTAOffsets:
 
         # Block-wide inclusive prefix sum
         prefix_ctas, _ = block_prefix_sum_kernel(
-            ctas, s_warp_sums, tidx,
-            self.NUM_THREADS, num_warps, barrier_id=1)
+            ctas, s_warp_sums, tidx, self.NUM_THREADS, num_warps, barrier_id=1
+        )
 
         # Write exclusive prefix sum (shifted by 1)
         if tidx == 0:
@@ -517,7 +517,9 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             work_remaining = task_id < num_rows
             while work_remaining:
                 if tidx == 0:
-                    s_row_id[0] = atomicAdd(g_global_counter.iterator, cutlass.Int32(1)) + grid_size_x
+                    s_row_id[0] = (
+                        atomicAdd(g_global_counter.iterator, cutlass.Int32(1)) + grid_size_x
+                    )
                 cute.arch.barrier()
 
                 row_id = s_row_id[0]
@@ -722,7 +724,6 @@ def cute_dsl_topk_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
-
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,  # TODO: do we need this one?
@@ -755,7 +756,6 @@ def cute_dsl_topk_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-
     )
     return output_indices_torch, output_values_torch
 
@@ -856,7 +856,6 @@ def cute_dsl_topk_multi_cta_wrapper(
             # output_values_fake,
             first_kernel_output_indices_fake,
             first_kernel_output_values_fake,
-
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -902,7 +901,6 @@ def cute_dsl_topk_multi_cta_wrapper(
             seqlen_fake,
             output_indices_fake,
             output_values_fake,
-
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
@@ -947,7 +945,6 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         first_kernel_output_indices_torch,
         first_kernel_output_values_torch,
-
     )
 
     compiled_kernel_second(
@@ -958,7 +955,6 @@ def cute_dsl_topk_multi_cta_wrapper(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-
     )
     return output_indices_torch, output_values_torch
 
@@ -1096,7 +1092,6 @@ def run_filtered_topk_decode(
         seqlen_fake,
         output_indices_fake,
         output_values_fake,
-
         stream=fake_stream,
         enable_persistent_dynamic_scheduling=load_balance,
         # TODO: confirm this parameter.
@@ -1147,7 +1142,6 @@ def run_filtered_topk_decode(
         seq_lens,
         output_indices_torch,
         output_values_torch,
-
     )
 
     if do_ref_check and top_k <= max_num_cols and return_val:

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ from cutlass.utils.distributed import atomicAdd
 from .block_scan import block_prefix_sum_kernel, fence_acq_rel_cta
 
 """
-top-k varlen utils. reused by prefill and decode.
+top-k varlen utils. could be used by prefill and decode phase.
 """
 
 
@@ -88,9 +88,6 @@ class FilteredTopKKernelVarlen:
             self.enable_gmem_store = True
         else:
             self.enable_gmem_store = False
-        print(f"self.filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
-        print(f"self.max_num_cols: {self.max_num_cols}")
-        print(f"enable_gmem_store: {self.enable_gmem_store}")
 
         self.return_val = return_val
 
@@ -1021,14 +1018,10 @@ class FilteredTopKKernelVarlen:
         val_layout = cute.make_layout((1, self.vec_size))
         tiled_copy = cute.make_tiled_copy_tv(copy_atom, thr_layout, val_layout)
 
-        print(f"max_num_cols: {self.max_num_cols}")
-        print(f"tiler_mn: {tiler_mn}")
         return (
             copy_atom,
             tiled_copy,
             tiler_mn,
-            # aligned_size,
-            # left_size,
         )
 
     @cute.jit
@@ -1087,7 +1080,7 @@ def create_random_logits(
         Tensor of shape (num_rows, max_row_length) with random values and -inf padding
     """
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(1111)
+    torch.cuda.manual_seed(seed)
     num_rows = row_starts.shape[0]
     max_len = int(row_ends.max().item())
     if pad_to_vec_size:

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
@@ -472,6 +472,8 @@ class FilteredTopKKernelVarlen:
                 if i < length:
                     if cutlass.const_expr(self.enable_multi_cta):
                         dst[i] = i + row_start
+                    elif cutlass.const_expr(self.merge_blocks):
+                        dst[i] = indices[i]
                     else:
                         dst[i] = i
                     if cutlass.const_expr(self.return_val):

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
@@ -54,6 +54,7 @@ class FilteredTopKKernelVarlen:
         self.top_k = top_k
         self.num_copy_bits = num_copy_bits
 
+        # Note: now we only support top_k <= 2048, we could change the code here to support larger top_k.
         self.filtered_topk_max_k = 2048
         # 8 bits for radix-based filter.
         self.radix = 256

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
@@ -1,0 +1,1221 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass._mlir.dialects import llvm
+from cutlass.utils.distributed import atomicAdd
+
+from .block_scan import block_prefix_sum_kernel, fence_acq_rel_cta
+
+"""
+top-k varlen utils. reused by prefill and decode.
+"""
+
+
+def half_as_ushort(half_val):
+    """Interpret FP16 value as uint16 bit pattern"""
+    return llvm.bitcast(cutlass.Uint16.mlir_type, half_val.ir_value())
+
+
+def float_as_uint32(float_val):
+    """Interpret FP32 value as uint32 bit pattern"""
+    return llvm.bitcast(cutlass.Uint32.mlir_type, float_val.ir_value())
+
+
+class FilteredTopKKernelVarlen:
+    def __init__(
+        self,
+        dtype: cutlass.Numeric,
+        max_num_cols: int,
+        top_k: int,
+        num_copy_bits: int = 256,
+        return_val: bool = True,
+        enable_multi_cta: bool = False,
+        chunk_size_per_cta: int = 16384,
+        num_ctas_per_row: int = 1,
+        merge_blocks: bool = False,
+    ):
+        self.dtype = dtype
+        self.max_num_cols = max_num_cols
+        self.top_k = top_k
+        self.num_copy_bits = num_copy_bits
+
+        self.filtered_topk_max_k = 2048
+        # 8 bits for radix-based filter.
+        self.radix = 256
+
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            self.num_buffer_smem_input_idx = 2
+        else:
+            self.num_buffer_smem_input_idx = 1
+
+        # 65536 is the max index value for uint16.
+        if cutlass.const_expr(enable_multi_cta):
+            self.per_row_max_num_cols = chunk_size_per_cta * num_ctas_per_row
+        else:
+            self.per_row_max_num_cols = self.max_num_cols
+
+        if cutlass.const_expr(self.per_row_max_num_cols <= 65536):
+            self.index_type = cutlass.Uint16
+            if cutlass.const_expr(self.num_buffer_smem_input_idx == 2):
+                self.max_smem_input_size = 32 * 1024
+            else:
+                self.max_smem_input_size = 64 * 1024
+        else:
+            self.index_type = cutlass.Uint32
+            if cutlass.const_expr(self.num_buffer_smem_input_idx == 2):
+                self.max_smem_input_size = 16 * 1024
+            else:
+                self.max_smem_input_size = 32 * 1024
+
+        self.filtered_topk_smem_input_size = min(self.max_smem_input_size, self.max_num_cols)
+
+        if cutlass.const_expr(self.max_num_cols > self.filtered_topk_smem_input_size):
+            self.enable_gmem_store = True
+        else:
+            self.enable_gmem_store = False
+        print(f"self.filtered_topk_smem_input_size: {self.filtered_topk_smem_input_size}")
+        print(f"self.max_num_cols: {self.max_num_cols}")
+        print(f"enable_gmem_store: {self.enable_gmem_store}")
+
+        self.return_val = return_val
+
+        self.vec_size = num_copy_bits // dtype.width
+        if cutlass.const_expr(dtype not in [cutlass.Float32, cute.BFloat16, cutlass.Float16]):
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        if cutlass.const_expr(dtype == cutlass.Float32):
+            if self.max_num_cols >= self.vec_size * 1024:
+                self.num_threads_per_cta = 1024
+            else:
+                if cutlass.const_expr(self.max_num_cols > 2048 and self.max_num_cols < 8192):
+                    self.num_threads_per_cta = 512
+                else:
+                    self.num_threads_per_cta = 256
+        else:
+            if self.max_num_cols >= 43008:
+                self.num_threads_per_cta = 1024
+            else:
+                if cutlass.const_expr(self.max_num_cols > 4096 and self.max_num_cols < 43008):
+                    self.num_threads_per_cta = 512
+                else:
+                    self.num_threads_per_cta = 256
+
+        # radix-based filter parameters.
+        if cutlass.const_expr(dtype == cutlass.Float32):
+            self.ordered_type = cute.Uint32
+            self.first_refine_shift = 24
+            self.num_refine_rounds = 4
+        elif cutlass.const_expr(dtype in [cutlass.Float16, cute.BFloat16]):
+            self.ordered_type = cute.Uint16
+            self.first_refine_shift = 0
+            self.num_refine_rounds = 1
+
+    @cute.jit
+    def to_coarse_key(self, x):
+        """Convert to coarse 8-bit key for histogram"""
+
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            # Convert to FP16 and extract high 8 bits
+            h = x.to(cutlass.Float16)
+            bits = half_as_ushort(h)
+
+            key = cutlass.Uint16(0)
+
+            # extract the sign bit
+            # key = (bits & 0x8000) ? bits : ~bits & 0x7fff;
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(0x7FFF)
+
+            # high 8 bits
+            return cute.Uint8((key >> 8) & 0xFF)
+        else:
+            # For half/bfloat16, extract high 8 bits directly
+            if cutlass.const_expr(self.dtype == cutlass.Float16):
+                bits = half_as_ushort(x)
+            else:  # BFloat16
+                bits = half_as_ushort(x)
+
+            key = cute.Uint16(0)
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(0x7FFF)
+            # high 8 bits
+            return cute.Uint8((key >> 8) & 0xFF)
+
+    @cute.jit
+    def to_ordered(self, x):
+        """Convert to ordered integer for comparison"""
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            bits = float_as_uint32(x)
+
+            key = cutlass.Uint32(0)
+            if bits & 0x80000000:
+                key = cutlass.Uint32(bits)
+            else:
+                key = (bits ^ cutlass.Uint32(0xFFFFFFFF)) & cutlass.Uint32(0x7FFFFFFF)
+            return cute.Uint32(key)
+        else:
+            if cutlass.const_expr(self.dtype == cutlass.Float16):
+                bits = half_as_ushort(x)
+            else:  # BFloat16
+                bits = half_as_ushort(x)
+
+            key = cute.Uint16(0)
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cute.Uint16(0xFFFF)) & cute.Uint16(0x7FFF)
+            return cute.Uint16(key)
+
+    @cute.jit
+    def prefix_sum_and_find_threshold_coarse(
+        self,
+        tidx,
+        s_histogram,
+        s_warp_sums,
+        num_warps,
+        s_threshold_bin_id,
+        s_num_input,
+        s_counter,
+        s_last_remain,
+        topk_remaining,
+        g_num_input,
+        s_num_input_idx=0,
+    ):
+        if cutlass.const_expr(self.radix <= self.num_threads_per_cta):
+            previous = 0
+            if tidx < cutlass.Int32(self.radix):
+                val = s_histogram[tidx]
+                val, total_sum = block_prefix_sum_kernel(
+                    val, s_warp_sums, tidx, self.radix, num_warps, barrier_id=1
+                )
+                s_histogram[tidx] = val
+                # sync among self.radix threads
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.radix)
+
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                    s_threshold_bin_id[0] = tidx
+                    s_num_input[s_num_input_idx] = 0
+                    if cutlass.const_expr(self.enable_gmem_store):
+                        g_num_input[s_num_input_idx] = 0
+                    # TODO: the difference between 1 and 2.
+                    s_counter[0] = 0
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+        else:
+            assert self.radix % self.num_threads_per_cta == 0
+            previous_sum = 0
+            val = 0
+            total_sum = 0
+            for i in range(tidx, self.radix, self.num_threads_per_cta):
+                val = s_histogram[i]
+                val, total_sum = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    self.num_threads_per_cta,
+                    num_warps,
+                    barrier_id=2,
+                    need_total_sum=True,
+                )
+                s_histogram[i] = val + previous_sum
+                previous_sum = previous_sum + total_sum
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+            previous = 0
+            run_loop = True
+            if tidx > 0:
+                previous = s_histogram[tidx - 1]
+            if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                s_threshold_bin_id[0] = tidx
+                s_num_input[s_num_input_idx] = 0
+                if cutlass.const_expr(self.enable_gmem_store):
+                    g_num_input[s_num_input_idx] = 0
+                # the difference between coarse and fine-grained.
+                s_counter[0] = 0
+                run_loop = False
+
+            if run_loop:
+                run_next_loop = True
+                for i in range(
+                    tidx + self.num_threads_per_cta,
+                    self.radix,
+                    self.num_threads_per_cta,
+                ):
+                    if run_next_loop:
+                        previous = s_histogram[i - 1]
+                        if previous <= topk_remaining and s_histogram[i] > topk_remaining:
+                            s_threshold_bin_id[0] = i
+                            s_num_input[s_num_input_idx] = 0
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                g_num_input[s_num_input_idx] = 0
+                            # the difference between coarse and fine-grained.
+                            s_counter[0] = 0
+                            run_next_loop = False
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+    @cute.jit
+    def prefix_sum_and_find_threshold_fine_grained(
+        self,
+        tidx,
+        s_histogram,
+        s_warp_sums,
+        num_warps,
+        s_threshold_bin_id,
+        s_num_input,
+        s_counter,
+        s_last_remain,
+        topk_remaining,
+        g_num_input,
+        s_num_input_idx=0,
+    ):
+        if cutlass.const_expr(self.radix <= self.num_threads_per_cta):
+            previous = 0
+            if tidx < cutlass.Int32(self.radix):
+                val = s_histogram[tidx]
+                val, total_sum = block_prefix_sum_kernel(
+                    val, s_warp_sums, tidx, self.radix, num_warps, barrier_id=1
+                )
+                s_histogram[tidx] = val
+                # sync
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.radix)
+
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                    s_threshold_bin_id[0] = tidx
+                    s_num_input[s_num_input_idx] = 0
+                    if cutlass.const_expr(self.enable_gmem_store):
+                        g_num_input[s_num_input_idx] = 0
+                    # the first difference between coarse and fine-grained.
+                    s_last_remain[0] = topk_remaining - previous
+            cute.arch.barrier()
+        else:
+            assert self.radix % self.num_threads_per_cta == 0
+            previous_sum = 0
+            val = 0
+            total_sum = 0
+            for i in range(tidx, self.radix, self.num_threads_per_cta):
+                val = s_histogram[i]
+                val, total_sum = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    self.num_threads_per_cta,
+                    num_warps,
+                    barrier_id=2,
+                    need_total_sum=True,
+                )
+                s_histogram[i] = val + previous_sum
+                previous_sum = previous_sum + total_sum
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+            previous = 0
+            run_loop = True
+            if tidx > 0:
+                previous = s_histogram[tidx - 1]
+            if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                s_threshold_bin_id[0] = tidx
+                s_num_input[s_num_input_idx] = 0
+                if cutlass.const_expr(self.enable_gmem_store):
+                    g_num_input[s_num_input_idx] = 0
+                # the difference between coarse and fine-grained.
+                s_last_remain[0] = topk_remaining - previous
+                run_loop = False
+            if run_loop:
+                run_next_loop = True
+                for i in range(
+                    tidx + self.num_threads_per_cta,
+                    self.radix,
+                    self.num_threads_per_cta,
+                ):
+                    if run_next_loop:
+                        previous = s_histogram[i - 1]
+                        if previous <= topk_remaining and s_histogram[i] > topk_remaining:
+                            s_threshold_bin_id[0] = i
+                            s_num_input[s_num_input_idx] = 0
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                g_num_input[s_num_input_idx] = 0
+                            # the difference between coarse and fine-grained.
+                            s_last_remain[0] = topk_remaining - previous
+                            run_next_loop = False
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+    @cute.jit
+    def filtered_topk_kernel_per_row(
+        self,
+        input: cute.Tensor,
+        # gmem, used for the merge blocks kernel.
+        input_indices: cute.Tensor,
+        extra_buffer: cute.Tensor,
+        output_indices: cute.Tensor,
+        output_values: cute.Tensor,
+        tiler_mn: cute.Shape,
+        copy_atom: cute.CopyAtom,
+        tiled_copy: cute.TiledCopy,
+        row_start: int,
+        length: int,
+        bidx: int,
+        s_histogram,
+        s_counter,
+        s_threshold_bin_id,
+        s_num_input,
+        g_num_input,
+        s_indices,
+        s_input_idx,
+        s_last_remain,
+        num_warps,
+        s_warp_sums,
+    ):
+        """CuTe DSL implementation of TopK kernel based on radix-based filter algorithm."""
+        # # Thread and block indexing
+        tidx, _, _ = cute.arch.thread_idx()
+
+        score = input[bidx, None]
+        if cutlass.const_expr(self.merge_blocks):
+            indices = input_indices[bidx, None]
+        if cutlass.const_expr(self.enable_multi_cta):
+            dst = output_indices
+            if cutlass.const_expr(self.return_val):
+                dst_values = output_values
+        else:
+            dst = output_indices[bidx, None]
+            if cutlass.const_expr(self.return_val):
+                dst_values = output_values[bidx, None]
+        # Note, for multi-cta version, each ctas must have its own extra_buffer.
+        if cutlass.const_expr(self.enable_gmem_store):
+            if cutlass.const_expr(self.enable_multi_cta):
+                grid_dim_x, grid_dim_y, _ = cute.arch.grid_dim()
+                bidx_val, bidy_val, _ = cute.arch.block_idx()
+                buffer_row_id = bidx_val * grid_dim_y + bidy_val
+                buffer = extra_buffer[buffer_row_id, None, None]
+            else:
+                buffer = extra_buffer[bidx, None, None]
+
+        # for initial scalar load part.
+        row_ptr = score.iterator + row_start
+        row_addr_u64 = row_ptr.toint()
+
+        # 256/8 = 32bytes
+        align_bytes = self.num_copy_bits // 8
+        # fp32: 4bytes
+        elem_bytes = self.dtype.width // 8
+
+        misalign = row_addr_u64 % align_bytes
+        fix_bytes = cutlass.Int64(0)
+        if misalign != 0:
+            fix_bytes = align_bytes - misalign
+
+        prologue_elems = cutlass.Int32(fix_bytes // elem_bytes)
+
+        remaining = length - prologue_elems
+        aligned_size = (remaining // self.vec_size) * self.vec_size
+        left_size = remaining - aligned_size
+
+        vec_start = row_start + prologue_elems
+        left_start = vec_start + aligned_size
+
+        shape = input.shape
+
+        idX = cute.make_identity_tensor((shape[0], aligned_size))
+        input_ptr = input.iterator + vec_start
+        input_addr_u64 = input_ptr.toint()
+        input_ptr_aligned = cute.make_ptr(self.dtype, input_addr_u64, assumed_align=align_bytes)
+
+        input_tensor = cute.make_tensor(
+            input_ptr_aligned,
+            cute.make_layout((shape[0], aligned_size), stride=input.stride),
+        )
+
+        # slice for CTAs
+        gX, cX = [cute.local_tile(mT, tiler_mn, (bidx, None)) for mT in (input_tensor, idX)]
+        # Note, we use gX_aligned here to avoid the alignment issue when the input is not aligned.
+        gX_aligned_ptr = cute.make_ptr(self.dtype, gX.iterator.toint(), assumed_align=align_bytes)
+        gX_aligned = cute.make_tensor(gX_aligned_ptr, cute.make_layout(gX.shape, stride=gX.stride))
+
+        self.num_sub_tiles = gX.shape[2]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+
+        tXgX = thr_copy.partition_S(gX_aligned)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None, None]
+        tXrX = cute.make_fragment_like(tXgX[None, None, None, 0])
+
+        tXcX_tile = thr_copy.partition_S(cX)
+
+        # Trivial case: length <= top_k
+        if length <= self.top_k:
+            for i in range(tidx, self.top_k, self.num_threads_per_cta):
+                # TODO: add multi-cta version support here.
+                if i < length:
+                    if cutlass.const_expr(self.enable_multi_cta):
+                        dst[i] = i + row_start
+                    else:
+                        dst[i] = i
+                    if cutlass.const_expr(self.return_val):
+                        if cutlass.const_expr(self.enable_multi_cta):
+                            dst_values[i] = score[i + row_start]
+                        else:
+                            dst_values[i] = score[i]
+                else:
+                    dst[i] = -1
+                    if cutlass.const_expr(self.return_val):
+                        dst_values[i] = dst_values.element_type(
+                            dst_values.element_type.inf * dst_values.element_type(-1.0)
+                        )
+        else:
+            topk_remaining = self.top_k
+
+            val_one = cutlass.Int32(1)
+            val_one_negative = cutlass.Int32(-1)
+
+            # Stage 1: Coarse histogram.
+            if tidx < self.radix + 1:
+                s_histogram[tidx] = 0
+            cute.arch.barrier()
+
+            # 1.1 Build histogram with vectorized loads
+            vec_size = self.vec_size
+
+            for tile_idx in range(self.num_sub_tiles):
+                tXpX_tile = self.predicate_tile(
+                    tXcX_tile[None, None, None, tile_idx],
+                    cutlass.Int32(aligned_size),
+                )
+                cute.copy(
+                    copy_atom,
+                    tXgX[None, None, None, tile_idx],
+                    tXrX,
+                    pred=tXpX_tile[None, None, None],
+                )
+                self._fill_oob(
+                    tXrX,
+                    tXpX_tile[None, None, None],
+                    -tXrX.element_type.inf,
+                )
+
+                for i in cutlass.range(cute.size(tXrX), unroll_full=True):
+                    bin_val = self.to_coarse_key(tXrX[i])
+                    atomicAdd(
+                        s_histogram.iterator + cutlass.Int32(bin_val),
+                        val_one,
+                    )
+
+            # for initial scalar load part.
+            for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+                col_idx = cutlass.Int32(row_start + j)
+                raw = score[col_idx]
+                bin_val = self.to_coarse_key(raw)
+                atomicAdd(
+                    s_histogram.iterator + cutlass.Int32(bin_val),
+                    val_one,
+                )
+
+            # for left part (left_size)
+            for j in range(tidx, left_size, self.num_threads_per_cta):
+                col_idx = cutlass.Int32(left_start + j)
+                raw = score[col_idx]
+                bin_val = self.to_coarse_key(raw)
+                atomicAdd(
+                    s_histogram.iterator + cutlass.Int32(bin_val),
+                    val_one,
+                )
+
+            cute.arch.barrier()
+
+            # 1.2 and 1.3  Suffix sum to find threshold and find threshold bin
+            self.prefix_sum_and_find_threshold_coarse(
+                tidx,
+                s_histogram,
+                s_warp_sums,
+                num_warps,
+                s_threshold_bin_id,
+                s_num_input,
+                s_counter,
+                s_last_remain,
+                topk_remaining,
+                g_num_input,
+                s_num_input_idx=0,
+            )
+
+            threshold_bin = s_threshold_bin_id[0]
+            if threshold_bin > 0:
+                topk_remaining -= s_histogram[threshold_bin - 1]
+
+            # 1.4 Collect indices
+            if topk_remaining == 0:
+                # Collect indices where bin > threshold
+                for tile_idx in range(self.num_sub_tiles):
+                    tXpX_tile = self.predicate_tile(
+                        tXcX_tile[None, None, None, tile_idx],
+                        cutlass.Int32(aligned_size),
+                    )
+                    cute.copy(
+                        copy_atom,
+                        tXgX[None, None, None, tile_idx],
+                        tXrX,
+                        pred=tXpX_tile[None, None, None],
+                    )
+                    self._fill_oob(
+                        tXrX,
+                        tXpX_tile[None, None, None],
+                        -tXrX.element_type.inf,
+                    )
+                    for i in cutlass.range(cute.size(tXrX), unroll_full=True):
+                        cur_tXcX = tXcX[None, None, None, tile_idx]
+                        bin_val = self.to_coarse_key(tXrX[i])
+                        if bin_val < threshold_bin:
+                            pos = atomicAdd(s_counter.iterator, val_one)
+                            idx = self.index_type(
+                                cur_tXcX[i // vec_size][1] + i % vec_size + vec_start
+                            )
+                            s_indices[pos] = idx
+
+                # for initial scalar load part.
+                for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(row_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    if bin_val < threshold_bin:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        idx = self.index_type(col_idx)
+                        s_indices[pos] = idx
+
+                # for left part (left_size)
+                for j in range(tidx, left_size, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(left_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    if bin_val < threshold_bin:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        idx = self.index_type(col_idx)
+                        s_indices[pos] = idx
+
+                cute.arch.barrier()
+
+            else:
+                # Reset histogram for refinement
+                cute.arch.barrier()
+                if tidx < self.radix + 1:
+                    s_histogram[tidx] = 0
+                cute.arch.barrier()
+
+                # Filter and build refinement histogram
+                for tile_idx in range(self.num_sub_tiles):
+                    tXpX_tile = self.predicate_tile(
+                        tXcX_tile[None, None, None, tile_idx],
+                        cutlass.Int32(aligned_size),
+                    )
+                    cute.copy(
+                        copy_atom,
+                        tXgX[None, None, None, tile_idx],
+                        tXrX,
+                        pred=tXpX_tile[None, None, None],
+                    )
+                    self._fill_oob(
+                        tXrX,
+                        tXpX_tile[None, None, None],
+                        -tXrX.element_type.inf,
+                    )
+
+                    for i in cutlass.range(cute.size(tXrX), unroll_full=True):
+                        raw_input = tXrX[i]
+                        bin_val = self.to_coarse_key(raw_input)
+                        cur_tXcX = tXcX[None, None, None, tile_idx]
+                        idx = self.index_type(cur_tXcX[i // vec_size][1] + i % vec_size + vec_start)
+                        if bin_val < threshold_bin:
+                            pos = atomicAdd(s_counter.iterator, val_one)
+                            s_indices[pos] = idx
+                        elif bin_val == threshold_bin:
+                            # pos = atomicAdd(s_num_input[0], 1)
+                            pos = atomicAdd(s_num_input.iterator, val_one)
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                if pos < self.filtered_topk_smem_input_size:
+                                    s_input_idx[0, pos] = idx
+                                else:
+                                    buffer_pos = atomicAdd(
+                                        g_num_input.iterator,
+                                        val_one,
+                                    )
+                                    buffer[0, buffer_pos] = cutlass.Int32(cutlass.Uint32(idx))
+                                ordered = self.to_ordered(raw_input)
+                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                # atomicAdd(s_histogram[sub_bin], 1)
+                                atomicAdd(
+                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                    val_one,
+                                )
+                            else:
+                                if pos < self.filtered_topk_smem_input_size:
+                                    s_input_idx[0, pos] = idx
+                                ordered = self.to_ordered(raw_input)
+                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                # atomicAdd(s_histogram[sub_bin], 1)
+                                atomicAdd(
+                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                    val_one,
+                                )
+
+                # for initial scalar load part.
+                for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(row_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    if bin_val < threshold_bin:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        idx = self.index_type(col_idx)
+                        s_indices[pos] = idx
+                    elif bin_val == threshold_bin:
+                        pos = atomicAdd(
+                            s_num_input.iterator,
+                            val_one,
+                        )
+                        # TODO: add gmem buffer here.
+                        if cutlass.const_expr(self.enable_gmem_store):
+                            if pos < self.filtered_topk_smem_input_size:
+                                s_input_idx[0, pos] = self.index_type(col_idx)
+                            else:
+                                buffer_pos = atomicAdd(
+                                    g_num_input.iterator,
+                                    val_one,
+                                )
+                                buffer[0, buffer_pos] = cutlass.Int32(col_idx)
+                            ordered = self.to_ordered(raw)
+                            sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                            atomicAdd(
+                                s_histogram.iterator + cutlass.Int32(sub_bin),
+                                val_one,
+                            )
+                        else:
+                            # TODO: how to handle the type of sub_bin and ordered?
+                            if cutlass.const_expr(self.dtype == cutlass.Float32):
+                                ordered = cutlass.Uint32(0)
+                                sub_bin = cutlass.Uint32(0)
+                            else:
+                                ordered = cutlass.Uint16(0)
+                                sub_bin = cutlass.Int32(0)
+                            if pos < self.filtered_topk_smem_input_size:
+                                s_input_idx[0, pos] = self.index_type(col_idx)
+                                ordered = self.to_ordered(raw)
+                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                atomicAdd(
+                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                    val_one,
+                                )
+
+                # for left part
+                for j in range(tidx, left_size, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(left_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    if bin_val < threshold_bin:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        idx = self.index_type(col_idx)
+                        s_indices[pos] = idx
+                    elif bin_val == threshold_bin:
+                        pos = atomicAdd(
+                            s_num_input.iterator,
+                            val_one,
+                        )
+                        # TODO: add gmem buffer here.
+                        if cutlass.const_expr(self.enable_gmem_store):
+                            if pos < self.filtered_topk_smem_input_size:
+                                s_input_idx[0, pos] = self.index_type(col_idx)
+                            else:
+                                buffer_pos = atomicAdd(
+                                    g_num_input.iterator,
+                                    val_one,
+                                )
+                                buffer[0, buffer_pos] = cutlass.Int32(col_idx)
+                            ordered = self.to_ordered(raw)
+                            sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                            atomicAdd(
+                                s_histogram.iterator + cutlass.Int32(sub_bin),
+                                val_one,
+                            )
+                        else:
+                            # TODO: how to handle the type of sub_bin and ordered?
+                            if cutlass.const_expr(self.dtype == cutlass.Float32):
+                                ordered = cutlass.Uint32(0)
+                                sub_bin = cutlass.Uint32(0)
+                            else:
+                                ordered = cutlass.Uint16(0)
+                                sub_bin = cutlass.Int32(0)
+                            if pos < self.filtered_topk_smem_input_size:
+                                s_input_idx[0, pos] = self.index_type(col_idx)
+                                ordered = self.to_ordered(raw)
+                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                atomicAdd(
+                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                    val_one,
+                                )
+                fence_acq_rel_cta()
+                cute.arch.barrier()
+
+                # Phase 2: Refinement rounds
+                run_next_round = True
+                for round in range(self.num_refine_rounds):
+                    if run_next_round:
+                        r_idx = round % 2
+
+                        self.prefix_sum_and_find_threshold_fine_grained(
+                            tidx,
+                            s_histogram,
+                            s_warp_sums,
+                            num_warps,
+                            s_threshold_bin_id,
+                            s_num_input,
+                            s_counter,
+                            s_last_remain,
+                            topk_remaining,
+                            g_num_input,
+                            s_num_input_idx=r_idx ^ 1,
+                        )
+                        num_input = min(s_num_input[r_idx], self.filtered_topk_smem_input_size)
+                        if cutlass.const_expr(self.enable_gmem_store):
+                            cur_g_num_input = g_num_input[r_idx]
+
+                        threshold = s_threshold_bin_id[0]
+                        if threshold > 0:
+                            topk_remaining -= s_histogram[threshold - 1]
+                        offset = self.first_refine_shift - round * 8
+                        is_last_round = round == self.num_refine_rounds - 1
+
+                        if topk_remaining == 0:
+                            for i in range(tidx, num_input, self.num_threads_per_cta):
+                                idx = s_input_idx[r_idx, i]
+                                idx = cutlass.Int32(cutlass.Uint32(idx))
+                                bin_val = (self.to_ordered(score[idx]) >> offset) & 0xFF
+                                if bin_val < threshold:
+                                    pos = atomicAdd(s_counter.iterator, val_one)
+                                    s_indices[pos] = self.index_type(idx)
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                for i in range(
+                                    tidx,
+                                    cur_g_num_input,
+                                    self.num_threads_per_cta,
+                                ):
+                                    idx = buffer[r_idx, i]
+                                    bin_val = (self.to_ordered(score[idx]) >> offset) & 0xFF
+                                    if bin_val < threshold:
+                                        pos = atomicAdd(s_counter.iterator, val_one)
+                                        s_indices[pos] = self.index_type(idx)
+                            cute.arch.barrier()
+                            # break
+                            run_next_round = False
+                        else:
+                            # Reset histogram
+                            cute.arch.barrier()
+                            if tidx < self.radix + 1:
+                                s_histogram[tidx] = 0
+                            cute.arch.barrier()
+
+                            for i in range(tidx, num_input, self.num_threads_per_cta):
+                                idx = s_input_idx[r_idx, i]
+                                idx_int32 = cutlass.Int32(cutlass.Uint32(idx))
+                                raw_input = score[idx_int32]
+                                idx = self.index_type(idx_int32)
+                                bin_val = (self.to_ordered(raw_input) >> offset) & 0xFF
+                                if bin_val < threshold:
+                                    pos = atomicAdd(s_counter.iterator, val_one)
+                                    s_indices[pos] = idx
+                                elif bin_val == threshold:
+                                    if is_last_round:
+                                        cur_pos = atomicAdd(
+                                            s_last_remain.iterator,
+                                            val_one_negative,
+                                        )
+                                        if cur_pos > 0:
+                                            s_indices[self.top_k - cur_pos] = idx
+                                    else:
+                                        # pos = atomicAdd(s_num_input[r_idx ^ 1], 1)
+                                        cur_pos = atomicAdd(
+                                            s_num_input.iterator + (r_idx ^ 1),
+                                            val_one,
+                                        )
+                                        # TODO: remove this if logic for gmem store?
+                                        # num_input < filter_topk_smem_input_size
+                                        if cutlass.const_expr(self.enable_gmem_store):
+                                            if cur_pos < self.filtered_topk_smem_input_size:
+                                                s_input_idx[r_idx ^ 1, cur_pos] = idx
+                                            else:
+                                                buffer_pos = atomicAdd(
+                                                    g_num_input.iterator + (r_idx ^ 1),
+                                                    val_one,
+                                                )
+                                                buffer[r_idx ^ 1, buffer_pos] = idx_int32
+                                            bin32 = self.to_ordered(raw_input)
+                                            sub_bin = (bin32 >> (offset - 8)) & 0xFF
+                                            # atomicAdd(s_histogram[sub_bin], 1)
+                                            atomicAdd(
+                                                s_histogram.iterator + cutlass.Int32(sub_bin),
+                                                val_one,
+                                            )
+                                        else:
+                                            # TODO: how to handle the type of sub_bin and bin32?
+                                            if cutlass.const_expr(self.dtype == cutlass.Float32):
+                                                bin32 = cutlass.Uint32(0)
+                                                sub_bin = cutlass.Uint32(0)
+                                            else:
+                                                bin32 = cutlass.Uint16(0)
+                                                sub_bin = cutlass.Int32(0)
+                                            if cur_pos < self.filtered_topk_smem_input_size:
+                                                s_input_idx[r_idx ^ 1, cur_pos] = idx
+                                                bin32 = self.to_ordered(raw_input)
+                                                sub_bin = (bin32 >> (offset - 8)) & 0xFF
+                                                # atomicAdd(s_histogram[sub_bin], 1)
+                                                atomicAdd(
+                                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                                    val_one,
+                                                )
+
+                            cute.arch.barrier()
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                for i in range(
+                                    tidx,
+                                    cur_g_num_input,
+                                    self.num_threads_per_cta,
+                                ):
+                                    # int32
+                                    idx = buffer[r_idx, i]
+                                    raw_input = score[idx]
+                                    bin_val = (self.to_ordered(raw_input) >> offset) & 0xFF
+                                    if bin_val < threshold:
+                                        pos = atomicAdd(
+                                            s_counter.iterator,
+                                            val_one,
+                                        )
+                                        s_indices[pos] = self.index_type(idx)
+                                    elif bin_val == threshold:
+                                        if is_last_round:
+                                            cur_pos = atomicAdd(
+                                                s_last_remain.iterator,
+                                                val_one_negative,
+                                            )
+                                            if cur_pos > 0:
+                                                s_indices[self.top_k - cur_pos] = self.index_type(
+                                                    idx
+                                                )
+                                        else:
+                                            # pos = atomicAdd(s_num_input[r_idx ^ 1], 1)
+                                            cur_pos = atomicAdd(
+                                                s_num_input.iterator + (r_idx ^ 1),
+                                                val_one,
+                                            )
+                                            if cutlass.const_expr(self.enable_gmem_store):
+                                                if cur_pos < self.filtered_topk_smem_input_size:
+                                                    s_input_idx[r_idx ^ 1, cur_pos] = (
+                                                        self.index_type(idx)
+                                                    )
+                                                else:
+                                                    buffer_pos = atomicAdd(
+                                                        g_num_input.iterator + (r_idx ^ 1),
+                                                        val_one,
+                                                    )
+                                                    buffer[r_idx ^ 1, buffer_pos] = idx
+                                                bin32 = self.to_ordered(raw_input)
+                                                sub_bin = (bin32 >> (offset - 8)) & 0xFF
+                                                # atomicAdd(s_histogram[sub_bin], 1)
+                                                atomicAdd(
+                                                    s_histogram.iterator + cutlass.Int32(sub_bin),
+                                                    val_one,
+                                                )
+                                            else:
+                                                if cur_pos < self.filtered_topk_smem_input_size:
+                                                    s_input_idx[r_idx ^ 1, cur_pos] = idx
+                                                    bin32 = self.to_ordered(raw_input)
+                                                    sub_bin = (bin32 >> (offset - 8)) & 0xFF
+                                                    # atomicAdd(s_histogram[sub_bin], 1)
+                                                    atomicAdd(
+                                                        s_histogram.iterator
+                                                        + cutlass.Int32(sub_bin),
+                                                        val_one,
+                                                    )
+                            fence_acq_rel_cta()
+                            cute.arch.barrier()
+
+            # Phase 3: Output phase
+            vecsize_out = cutlass.const_expr(
+                min(
+                    self.top_k,
+                    cute.ceil_div(self.top_k, self.num_threads_per_cta),
+                    self.num_copy_bits // self.dtype.width,
+                    # TODO: only tested for float32. need to check for other dtypes.
+                    2,
+                )
+            )
+            assert self.top_k % vecsize_out == 0
+
+            nvec_per_thread = cutlass.const_expr(
+                cute.ceil_div(self.top_k, vecsize_out * self.num_threads_per_cta)
+            )
+            topk_vals = cute.make_fragment((vecsize_out, nvec_per_thread), self.dtype)
+            topk_indices = cute.make_fragment((vecsize_out, nvec_per_thread), cutlass.Int32)
+
+            stride = self.num_threads_per_cta * vecsize_out
+            for i in cutlass.range(nvec_per_thread, unroll_full=True):
+                idx = i * stride + tidx % self.num_threads_per_cta * vecsize_out
+                if idx < self.top_k:
+                    for v in cutlass.range(vecsize_out, unroll_full=True):
+                        index_raw = s_indices[idx + v]
+                        index = cutlass.Int32(cutlass.Uint32(index_raw))
+                        if cutlass.const_expr(self.return_val):
+                            topk_vals[v, i] = score[index]
+                        if cutlass.const_expr(self.merge_blocks):
+                            topk_indices[v, i] = indices[index]
+                        else:
+                            topk_indices[v, i] = index
+            # [atom, rest_vec]
+            mIndices_store = cute.tiled_divide(dst, (vecsize_out,))
+            if cutlass.const_expr(self.return_val):
+                mValues_store = cute.tiled_divide(dst_values, (vecsize_out,))
+            # i represents the index of the vector in the output.
+            for i in cutlass.range(cute.size(topk_vals.shape, [1]), unroll_full=True):
+                col = i * self.num_threads_per_cta + tidx % self.num_threads_per_cta
+                if col < self.top_k // vecsize_out:
+                    cute.autovec_copy(topk_indices[None, i], mIndices_store[None, col])
+                    if cutlass.const_expr(self.return_val):
+                        cute.autovec_copy(topk_vals[None, i], mValues_store[None, col])
+
+    def _get_tiled_copy(self):
+        threads_per_row = self.num_threads_per_cta
+        tiler_mn = (
+            1,
+            self.vec_size * threads_per_row,
+        )
+
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=self.num_copy_bits,
+        )
+
+        thr_layout = cute.make_ordered_layout(
+            (1, threads_per_row),
+            order=(1, 0),
+        )
+        val_layout = cute.make_layout((1, self.vec_size))
+        tiled_copy = cute.make_tiled_copy_tv(copy_atom, thr_layout, val_layout)
+
+        print(f"max_num_cols: {self.max_num_cols}")
+        print(f"tiler_mn: {tiler_mn}")
+        return (
+            copy_atom,
+            tiled_copy,
+            tiler_mn,
+            # aligned_size,
+            # left_size,
+        )
+
+    @cute.jit
+    def predicate_tile(self, tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+        tApA = cute.make_fragment(
+            cute.make_layout(
+                (
+                    cute.size(tAcA, mode=[0, 1]),
+                    cute.size(tAcA, mode=[1]),
+                    cute.size(tAcA, mode=[2]),
+                ),
+                stride=(cute.size(tAcA, mode=[2]), 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in range(tApA.shape[0]):
+            for rest_k in range(tApA.shape[2]):
+                tApA[rest_v, 0, rest_k] = cute.elem_less(tAcA[(0, rest_v), 0, rest_k][1], limit)
+        return tApA
+
+    @cute.jit
+    def _fill_oob(self, tXrX: cute.Tensor, tXpX: cute.Tensor, fill_value: cute.Numeric) -> None:
+        """Fill out-of-bounds values in register tensor.
+
+        Args:
+            tXrX: Register tensor to fill
+            tXpX: Predicate tensor indicating valid elements
+            fill_value: Value to fill OOB locations with
+        """
+        tXrX_fill = cute.make_fragment_like(tXrX[(None, 0), None, 0])
+        tXrX_fill.fill(fill_value)
+        for rest_v in range(tXrX.shape[0][1]):
+            for rest_k in range(tXrX.shape[2]):
+                if cutlass.const_expr(tXpX is not None):
+                    if not tXpX[0, rest_v, rest_k]:
+                        cute.autovec_copy(tXrX_fill, tXrX[(None, rest_v), None, rest_k])
+
+
+def create_random_logits(
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    dtype: torch.dtype,
+    seed: int,
+    pad_to_vec_size: bool = False,
+    vec_size: int = 8,
+) -> torch.Tensor:
+    """Create random logits tensor for testing.
+
+    Args:
+        row_starts: Tensor of shape (num_rows,) indicating the start position of each row
+        row_ends: Tensor of shape (num_rows,) indicating the end position (exclusive) of each row
+        dtype: Data type for the logits tensor
+        seed: Random seed for reproducibility
+
+    Returns:
+        Tensor of shape (num_rows, max_row_length) with random values and -inf padding
+    """
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(1111)
+    num_rows = row_starts.shape[0]
+    max_len = int(row_ends.max().item())
+    if pad_to_vec_size:
+        max_len = (max_len + vec_size - 1) // vec_size * vec_size
+
+    # Generate random logits
+    logits = torch.randn(num_rows, max_len, dtype=dtype, device="cuda")
+
+    # Vectorized masking: set positions outside [row_start, row_end) to -inf
+    col_indices = torch.arange(max_len, device="cuda").unsqueeze(0)  # (1, max_len)
+    mask_lo = col_indices < row_starts.unsqueeze(1)  # positions before row_start
+    mask_hi = col_indices >= row_ends.unsqueeze(1)  # positions at or after row_end
+    mask = mask_lo | mask_hi  # positions outside valid range
+    logits[mask] = float("-inf")
+
+    return logits
+
+
+def run_reference_top_k(logits, row_starts, row_ends, index_topk):
+    # Run reference implementation
+    torch_indices = logits.topk(min(index_topk, max(row_ends)), dim=-1)[1]
+    mask_lo = torch_indices >= 0
+    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
+    mask = mask_lo & mask_hi
+    torch_indices = torch_indices.masked_fill(~mask, -1)
+
+    return torch_indices
+
+
+def compare_top_k_results(
+    logits: torch.Tensor,
+    cuda_indices: torch.Tensor,
+    torch_indices: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    top_k: int,
+    tolerance: float = 1e-5,
+) -> bool:
+    """
+    Compare results from CUDA top_k_per_row with torch.topk.
+    Handles different shapes and -1 placeholders in cuda_indices.
+
+    Args:
+        logits: Input logits tensor [num_rows, vocab_size]
+        cuda_indices: CUDA implementation output [num_rows, cuda_k], may contain -1
+        torch_indices: PyTorch reference output [num_rows, torch_k], may contain -1
+        row_starts: Start positions for each row [num_rows]
+        row_ends: End positions for each row [num_rows]
+        top_k: Target top-k value
+        tolerance: Tolerance for floating point comparison
+
+    Returns:
+        True if results match within tolerance, False otherwise
+    """
+    num_rows = cuda_indices.shape[0]
+
+    # Handle potentially different k values
+    cuda_indices.shape[1]
+    torch_indices.shape[1]
+
+    # Calculate valid lengths for each row (vectorized)
+    row_lengths = row_ends - row_starts
+
+    # For each row, compare only the valid indices (non -1)
+    for row_idx in range(num_rows):
+        row_len = row_lengths[row_idx].item()
+        expected_valid = min(row_len, top_k)
+
+        # Get valid indices from both implementations (filter out -1)
+        cuda_row = cuda_indices[row_idx]
+        torch_row = torch_indices[row_idx]
+
+        # Filter out -1 (invalid) indices
+        cuda_valid_mask = cuda_row != -1
+        torch_valid_mask = torch_row != -1
+
+        cuda_valid = cuda_row[cuda_valid_mask]
+        torch_valid = torch_row[torch_valid_mask]
+
+        # Check if the number of valid indices matches
+        if cuda_valid.shape[0] != torch_valid.shape[0]:
+            print(
+                f"Row {row_idx}: Different number of valid indices - "
+                f"Row {row_idx}: CUDA: {cuda_valid.shape[0]}, PyTorch: {torch_valid.shape[0]}"
+            )
+            return False
+
+        if cuda_valid.shape[0] != expected_valid:
+            print(
+                f"Row {row_idx}: Expected {expected_valid} valid indices, got {cuda_valid.shape[0]}"
+            )
+            return False
+
+        # If no valid indices, continue
+        if cuda_valid.shape[0] == 0:
+            continue
+
+        # Gather the corresponding logit values
+        row_start = row_starts[row_idx].item()
+        logits_row = logits[row_idx]
+
+        # Adjust indices to absolute positions (add row_start offset)
+        cuda_abs_indices = cuda_valid + row_start
+        torch_abs_indices = torch_valid + row_start
+
+        # Get logit values for the selected indices
+        cuda_values = logits_row[cuda_abs_indices]
+        torch_values = logits_row[torch_abs_indices]
+
+        # Sort both value arrays in descending order
+        cuda_values_sorted, _ = torch.sort(cuda_values, descending=True)
+        torch_values_sorted, _ = torch.sort(torch_values, descending=True)
+
+        # Compare sorted values
+        if not torch.allclose(
+            cuda_values_sorted, torch_values_sorted, rtol=tolerance, atol=tolerance
+        ):
+            # Additional debug: check if sets are identical
+            cuda_set = set(cuda_valid.cpu().tolist())
+            torch_set = set(torch_valid.cpu().tolist())
+            print(f"row_idx: {row_idx}, row_len: {row_len}, expected_valid: {expected_valid}")
+            print(f"cuda_values_sorted: {cuda_values_sorted}")
+            print(f"torch_values_sorted: {torch_values_sorted}")
+            if cuda_set != torch_set:
+                print("  Different indices selected:")
+                print(f"    Only in CUDA: {cuda_set - torch_set}")
+                print(f"    Only in Torch: {torch_set - cuda_set}")
+
+            return False
+
+    return True

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/filtered_top_k_varlen_util.py
@@ -53,6 +53,10 @@ class FilteredTopKKernelVarlen:
         self.max_num_cols = max_num_cols
         self.top_k = top_k
         self.num_copy_bits = num_copy_bits
+        self.enable_multi_cta = enable_multi_cta
+        self.chunk_size_per_cta = chunk_size_per_cta
+        self.num_ctas_per_row = num_ctas_per_row
+        self.merge_blocks = merge_blocks
 
         # Note: now we only support top_k <= 2048, we could change the code here to support larger top_k.
         self.filtered_topk_max_k = 2048
@@ -1140,10 +1144,6 @@ def compare_top_k_results(
     """
     num_rows = cuda_indices.shape[0]
 
-    # Handle potentially different k values
-    cuda_indices.shape[1]
-    torch_indices.shape[1]
-
     # Calculate valid lengths for each row (vectorized)
     row_lengths = row_ends - row_starts
 
@@ -1167,7 +1167,7 @@ def compare_top_k_results(
         if cuda_valid.shape[0] != torch_valid.shape[0]:
             print(
                 f"Row {row_idx}: Different number of valid indices - "
-                f"Row {row_idx}: CUDA: {cuda_valid.shape[0]}, PyTorch: {torch_valid.shape[0]}"
+                f"CUDA: {cuda_valid.shape[0]}, PyTorch: {torch_valid.shape[0]}"
             )
             return False
 

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -91,10 +91,6 @@ def compare_top_k_results(
     """
     num_rows = cuda_indices.shape[0]
 
-    # Handle potentially different k values
-    cuda_indices.shape[1]
-    torch_indices.shape[1]
-
     # Calculate valid lengths for each row (vectorized)
     row_lengths = row_ends - row_starts
 

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -335,8 +335,10 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
 @pytest.mark.parametrize("num_tokens", [32768, 65536])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("chunk_size_per_cta", [16384])
+@pytest.mark.parametrize("dynamic", [False, True])
 def test_cute_dsl_topk_decode_multi_cta(
-    batch_size, next_n, index_topk, num_tokens, dtype, chunk_size_per_cta
+    batch_size, next_n, index_topk, num_tokens, dtype, chunk_size_per_cta,
+    dynamic
 ):
     _run_cute_dsl_topk_test(
         batch_size,
@@ -351,6 +353,7 @@ def test_cute_dsl_topk_decode_multi_cta(
             next_n=next_n,
             num_copy_bits=256,
             chunk_size_per_cta=chunk_size_per_cta,
+            dynamic=dynamic,
         ),
     )
 

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -348,6 +348,71 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
     ), "CuTE DSL top-k results don't match torch.topk"
 
 
+# TODO: failed on one of the fp16 test. 
+@pytest.mark.parametrize("batch_size", [1, 4, 64])
+@pytest.mark.parametrize("next_n", [1, 3])
+@pytest.mark.parametrize("index_topk", [2048])
+@pytest.mark.parametrize("num_tokens", [32768, 65536])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("chunk_size_per_cta", [16384])
+# @pytest.mark.parametrize("batch_size", [64])
+# @pytest.mark.parametrize("next_n", [3])
+# @pytest.mark.parametrize("index_topk", [2048])
+# @pytest.mark.parametrize("num_tokens", [32768])
+# @pytest.mark.parametrize("dtype", [torch.float16])
+# @pytest.mark.parametrize("chunk_size_per_cta", [16384])
+def test_cute_dsl_topk_decode_multi_cta(batch_size, next_n, index_topk,
+                                        num_tokens, dtype,
+                                        chunk_size_per_cta):
+    skip_if_no_cute_dsl()
+    skip_if_not_blackwell()
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    # Set input data (same structure as test_indexer_topk_decode)
+    num_gen_tokens = batch_size * next_n
+    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
+    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
+    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
+
+    seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+
+    # Create logits with the specified dtype
+    logits = create_random_logits(row_starts, row_ends, dtype, 42)
+
+    # Run CuTE DSL multi-CTA implementation
+    result = torch.ops.trtllm.cute_dsl_topk_decode_multi_cta_blackwell(
+        input_values=logits,
+        seq_lens=seq_lens,
+        top_k=index_topk,
+        next_n=next_n,
+        num_copy_bits=256,
+        chunk_size_per_cta=chunk_size_per_cta,
+    )
+    cute_indices = result
+
+    torch.cuda.synchronize()
+
+    # Run reference implementation
+    max_row_len = row_ends.max().item()
+    torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
+    mask_lo = torch_indices >= 0
+    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
+    mask = mask_lo & mask_hi
+    torch_indices = torch_indices.masked_fill(~mask, -1)
+
+    # Convert cute_indices to int32 for comparison
+    cute_indices_int32 = cute_indices.to(torch.int32)
+
+    # Compare results
+    assert compare_top_k_results(
+        logits, cute_indices_int32, torch_indices, row_starts, row_ends,
+        index_topk
+    ), "CuTE DSL multi-CTA top-k results don't match torch.topk"
+
+
 def index_topk_decode_benchmark(
     batch_size=64,
     next_n=1,
@@ -431,11 +496,11 @@ def index_topk_decode_benchmark(
     end_event.record()
     torch.cuda.synchronize()
 
-    time_standard_ms = start_event.elapsed_time(end_event) / num_iterations
+    time_standard_us = start_event.elapsed_time(end_event) / num_iterations * 1000
 
-    print(f"  Average time: {time_standard_ms:.4f} ms")
+    print(f"  Average time: {time_standard_us:.4f} us")
     print(
-        f"  Throughput: {num_gen_tokens * num_tokens / time_standard_ms / 1e6:.2f} G elements/s\n"
+        f"  Throughput: {num_gen_tokens * num_tokens / time_standard_us / 1e6:.2f} M elements/s\n"
     )
 
     # ========================================================================
@@ -467,20 +532,20 @@ def index_topk_decode_benchmark(
     end_event.record()
     torch.cuda.synchronize()
 
-    time_cute_ms = start_event.elapsed_time(end_event) / num_iterations
+    time_cute_us = start_event.elapsed_time(end_event) / num_iterations * 1000
 
-    print(f"  Average time: {time_cute_ms:.4f} ms")
-    print(f"  Throughput: {num_gen_tokens * num_tokens / time_cute_ms / 1e6:.2f} G elements/s\n")
+    print(f"  Average time: {time_cute_us:.4f} us")
+    print(f"  Throughput: {num_gen_tokens * num_tokens / time_cute_us / 1e6:.2f} M elements/s\n")
 
     # ========================================================================
     # Results Summary
     # ========================================================================
-    speedup = time_standard_ms / time_cute_ms
+    speedup = time_standard_us / time_cute_us
     print(f"{'=' * 80}")
     print("Results Summary:")
     print(f"{'=' * 80}")
-    print(f"  Standard implementation: {time_standard_ms:.4f} ms")
-    print(f"  CuTE DSL implementation: {time_cute_ms:.4f} ms")
+    print(f"  Standard implementation: {time_standard_us:.4f} us")
+    print(f"  CuTE DSL implementation: {time_cute_us:.4f} us")
     print(
         f"  Speedup: {speedup:.2f}x {'(CuTE DSL faster)' if speedup > 1 else '(Standard faster)'}"
     )
@@ -512,8 +577,8 @@ def index_topk_decode_benchmark(
             "num_tokens": num_tokens,
             "dtype": str(dtype),
         },
-        "standard_ms": time_standard_ms,
-        "cute_dsl_ms": time_cute_ms,
+        "standard_us": time_standard_us,
+        "cute_dsl_us": time_cute_us,
         "speedup": speedup,
         "correct": correct,
     }
@@ -523,7 +588,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Top-K Performance Benchmark")
-    parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
+    parser.add_argument("--batch_size", type=int, default=1, help="Batch size")
     parser.add_argument("--next_n", type=int, default=1, help="Number of candidates per sequence")
     parser.add_argument("--index_topk", type=int, default=2048, help="Top-k value")
     parser.add_argument("--num_tokens", type=int, default=8192, help="Vocabulary size")
@@ -606,7 +671,7 @@ if __name__ == "__main__":
         for r in results:
             config_str = f"B={r['config']['batch_size']}, K={r['config']['index_topk']}, V={r['config']['num_tokens']}"
             print(
-                f"{config_str:<40} {r['standard_ms']:>14.4f} {r['cute_dsl_ms']:>14.4f} {r['speedup']:>9.2f}x"
+                f"{config_str:<40} {r['standard_us']:>14.4f} {r['cute_dsl_us']:>14.4f} {r['speedup']:>9.2f}x"
             )
         print("=" * 80 + "\n")
 

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -346,3 +346,278 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
     assert compare_top_k_results(
         logits, cute_indices_int32, torch_indices, row_starts, row_ends, index_topk
     ), "CuTE DSL top-k results don't match torch.topk"
+
+
+def index_topk_decode_benchmark(
+    batch_size=64,
+    next_n=1,
+    index_topk=2048,
+    num_tokens=8192,
+    dtype=torch.float16,
+    num_warmup=10,
+    num_iterations=100,
+):
+    """Benchmark comparison between CuTE DSL and standard top-k implementations.
+
+    Args:
+        batch_size: Number of sequences
+        next_n: Number of candidates per sequence (for speculative decoding)
+        index_topk: Number of top elements to select
+        num_tokens: Vocabulary size
+        dtype: Data type for logits
+        num_warmup: Number of warmup iterations
+        num_iterations: Number of timed iterations
+
+    Returns:
+        dict: Performance metrics for both implementations
+    """
+
+    # Check if CuTE DSL is available
+    if not IS_CUTLASS_DSL_AVAILABLE:
+        print("CuTE DSL not available, skipping benchmark")
+        return None
+
+    # Check if Blackwell architecture
+    sm = getSMVersion()
+    if sm < 100:
+        print(f"CuTE DSL top-k requires Blackwell (SM100+), got SM{sm}")
+        return None
+
+    print(f"\n{'=' * 80}")
+    print("Top-K Performance Benchmark")
+    print(f"{'=' * 80}")
+    print("Configuration:")
+    print(f"  batch_size: {batch_size}")
+    print(f"  next_n: {next_n}")
+    print(f"  index_topk: {index_topk}")
+    print(f"  num_tokens: {num_tokens}")
+    print(f"  dtype: {dtype}")
+    print(f"  num_warmup: {num_warmup}")
+    print(f"  num_iterations: {num_iterations}")
+    print(f"{'=' * 80}\n")
+
+    # Set up input data
+    num_gen_tokens = batch_size * next_n
+    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
+    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
+    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
+
+    seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+
+    # Create logits
+    logits = create_random_logits(row_starts, row_ends, dtype, 42)
+
+    # Create output tensors for standard implementation
+    indices_standard = torch.empty((num_gen_tokens, index_topk), dtype=torch.int32, device="cuda")
+
+    # ========================================================================
+    # Benchmark 1: Standard indexer_topk_decode
+    # ========================================================================
+    print("Benchmarking: torch.ops.trtllm.indexer_topk_decode")
+
+    # Warmup
+    for _ in range(num_warmup):
+        torch.ops.trtllm.indexer_topk_decode(logits, seq_lens, indices_standard, next_n, index_topk)
+    torch.cuda.synchronize()
+
+    # Timed runs
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start_event.record()
+    for _ in range(num_iterations):
+        torch.ops.trtllm.indexer_topk_decode(logits, seq_lens, indices_standard, next_n, index_topk)
+    end_event.record()
+    torch.cuda.synchronize()
+
+    time_standard_ms = start_event.elapsed_time(end_event) / num_iterations
+
+    print(f"  Average time: {time_standard_ms:.4f} ms")
+    print(
+        f"  Throughput: {num_gen_tokens * num_tokens / time_standard_ms / 1e6:.2f} G elements/s\n"
+    )
+
+    # ========================================================================
+    # Benchmark 2: CuTE DSL top-k
+    # ========================================================================
+    print("Benchmarking: torch.ops.trtllm.cute_dsl_topk_decode_blackwell")
+
+    # Warmup
+    for _ in range(num_warmup):
+        indices_cute = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
+            input_values=logits,
+            seq_lens=seq_lens,
+            top_k=index_topk,
+            next_n=next_n,
+            num_copy_bits=256,
+        )
+    torch.cuda.synchronize()
+
+    # Timed runs
+    start_event.record()
+    for _ in range(num_iterations):
+        indices_cute = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
+            input_values=logits,
+            seq_lens=seq_lens,
+            top_k=index_topk,
+            next_n=next_n,
+            num_copy_bits=256,
+        )
+    end_event.record()
+    torch.cuda.synchronize()
+
+    time_cute_ms = start_event.elapsed_time(end_event) / num_iterations
+
+    print(f"  Average time: {time_cute_ms:.4f} ms")
+    print(f"  Throughput: {num_gen_tokens * num_tokens / time_cute_ms / 1e6:.2f} G elements/s\n")
+
+    # ========================================================================
+    # Results Summary
+    # ========================================================================
+    speedup = time_standard_ms / time_cute_ms
+    print(f"{'=' * 80}")
+    print("Results Summary:")
+    print(f"{'=' * 80}")
+    print(f"  Standard implementation: {time_standard_ms:.4f} ms")
+    print(f"  CuTE DSL implementation: {time_cute_ms:.4f} ms")
+    print(
+        f"  Speedup: {speedup:.2f}x {'(CuTE DSL faster)' if speedup > 1 else '(Standard faster)'}"
+    )
+    print(f"{'=' * 80}\n")
+
+    # Verify correctness
+    print("Verifying correctness...")
+    max_row_len = row_ends.max().item()
+    torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
+    mask_lo = torch_indices >= 0
+    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
+    mask = mask_lo & mask_hi
+    torch_indices = torch_indices.masked_fill(~mask, -1)
+
+    # Convert cute_indices to int32 for comparison
+    cute_indices_int32 = indices_cute.to(torch.int32)
+
+    # Compare results
+    correct = compare_top_k_results(
+        logits, cute_indices_int32, torch_indices, row_starts, row_ends, index_topk
+    )
+    print(f"Correctness check: {'PASSED' if correct else 'FAILED'}\n")
+
+    return {
+        "config": {
+            "batch_size": batch_size,
+            "next_n": next_n,
+            "index_topk": index_topk,
+            "num_tokens": num_tokens,
+            "dtype": str(dtype),
+        },
+        "standard_ms": time_standard_ms,
+        "cute_dsl_ms": time_cute_ms,
+        "speedup": speedup,
+        "correct": correct,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Top-K Performance Benchmark")
+    parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
+    parser.add_argument("--next_n", type=int, default=1, help="Number of candidates per sequence")
+    parser.add_argument("--index_topk", type=int, default=2048, help="Top-k value")
+    parser.add_argument("--num_tokens", type=int, default=8192, help="Vocabulary size")
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="float32",
+        choices=["float16", "bfloat16", "float32"],
+        help="Data type",
+    )
+    parser.add_argument("--num_warmup", type=int, default=10, help="Number of warmup iterations")
+    parser.add_argument(
+        "--num_iterations", type=int, default=100, help="Number of timed iterations"
+    )
+    parser.add_argument("--sweep", action="store_true", help="Run parameter sweep")
+
+    args = parser.parse_args()
+
+    dtype_map = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }
+
+    if args.sweep:
+        print("\n" + "=" * 80)
+        print("Running Parameter Sweep")
+        print("=" * 80 + "\n")
+
+        results = []
+
+        # Sweep configurations
+        configs = [
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
+            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
+            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
+            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
+            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
+        ]
+
+        for config in configs:
+            result = index_topk_decode_benchmark(
+                dtype=dtype_map[args.dtype],
+                num_warmup=args.num_warmup,
+                num_iterations=args.num_iterations,
+                **config,
+            )
+            if result:
+                results.append(result)
+
+        # Print summary table
+        print("\n" + "=" * 80)
+        print("Summary Table")
+        print("=" * 80)
+        print(f"{'Config':<40} {'Standard (ms)':<15} {'CuTE DSL (ms)':<15} {'Speedup':<10}")
+        print("-" * 80)
+        for r in results:
+            config_str = f"B={r['config']['batch_size']}, K={r['config']['index_topk']}, V={r['config']['num_tokens']}"
+            print(
+                f"{config_str:<40} {r['standard_ms']:>14.4f} {r['cute_dsl_ms']:>14.4f} {r['speedup']:>9.2f}x"
+            )
+        print("=" * 80 + "\n")
+
+    else:
+        # Single run
+        index_topk_decode_benchmark(
+            batch_size=args.batch_size,
+            next_n=args.next_n,
+            index_topk=args.index_topk,
+            num_tokens=args.num_tokens,
+            dtype=dtype_map[args.dtype],
+            num_warmup=args.num_warmup,
+            num_iterations=args.num_iterations,
+        )

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from utils.util import getSMVersion, skip_pre_hopper, skip_pre_blackwell
+from utils.util import getSMVersion, skip_pre_blackwell, skip_pre_hopper
 
 # Import tensorrt_llm to load custom CUDA operators (indexer_topk_decode, indexer_topk_prefill)
 import tensorrt_llm  # noqa: F401
@@ -265,6 +265,7 @@ def test_indexer_topk_prefill(batch_size, index_topk, num_tokens):
 # CuTE DSL Top-K Tests
 # ============================================================================
 
+
 def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, run_fn):
     """Common test logic for CuTE DSL top-k kernels.
 
@@ -311,8 +312,7 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, r
 @pytest.mark.parametrize("num_tokens", [4096, 8192])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("load_balance", [False, True])
-def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype,
-                              load_balance):
+def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype, load_balance):
     _run_cute_dsl_topk_test(
         batch_size,
         next_n,
@@ -340,8 +340,7 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype,
 @pytest.mark.parametrize("chunk_size_per_cta", [16384])
 @pytest.mark.parametrize("dynamic", [False, True])
 def test_cute_dsl_topk_decode_multi_cta(
-    batch_size, next_n, index_topk, num_tokens, dtype, chunk_size_per_cta,
-    dynamic
+    batch_size, next_n, index_topk, num_tokens, dtype, chunk_size_per_cta, dynamic
 ):
     _run_cute_dsl_topk_test(
         batch_size,

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -283,8 +283,7 @@ def skip_if_not_blackwell():
         pytest.skip("CuTE DSL top-k kernel requires Blackwell (SM100+)")
 
 
-def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype,
-                            run_fn):
+def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, run_fn):
     """Common test logic for CuTE DSL top-k kernels.
 
     Args:
@@ -316,13 +315,11 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype,
 
     max_row_len = row_ends.max().item()
     torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
-    mask = (torch_indices >= 0) & (
-        (torch_indices - (row_ends - row_starts)[:, None]) < 0)
+    mask = (torch_indices >= 0) & ((torch_indices - (row_ends - row_starts)[:, None]) < 0)
     torch_indices = torch_indices.masked_fill(~mask, -1)
 
     assert compare_top_k_results(
-        logits, cute_indices.to(torch.int32), torch_indices, row_starts,
-        row_ends, index_topk
+        logits, cute_indices.to(torch.int32), torch_indices, row_starts, row_ends, index_topk
     ), "CuTE DSL top-k results don't match torch.topk"
 
 
@@ -331,14 +328,21 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype,
 @pytest.mark.parametrize("index_topk", [2048])
 @pytest.mark.parametrize("num_tokens", [4096, 8192])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens,
-                              dtype):
+def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype):
     _run_cute_dsl_topk_test(
-        batch_size, next_n, index_topk, num_tokens, dtype,
-        lambda logits, seq_lens: torch.ops.trtllm.
-        cute_dsl_topk_decode_blackwell(
-            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
-            next_n=next_n, num_copy_bits=256))
+        batch_size,
+        next_n,
+        index_topk,
+        num_tokens,
+        dtype,
+        lambda logits, seq_lens: torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
+            input_values=logits,
+            seq_lens=seq_lens,
+            top_k=index_topk,
+            next_n=next_n,
+            num_copy_bits=256,
+        ),
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 64])
@@ -347,27 +351,42 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens,
 @pytest.mark.parametrize("num_tokens", [32768, 65536])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("chunk_size_per_cta", [16384])
-def test_cute_dsl_topk_decode_multi_cta(batch_size, next_n, index_topk,
-                                        num_tokens, dtype,
-                                        chunk_size_per_cta):
+def test_cute_dsl_topk_decode_multi_cta(
+    batch_size, next_n, index_topk, num_tokens, dtype, chunk_size_per_cta
+):
     _run_cute_dsl_topk_test(
-        batch_size, next_n, index_topk, num_tokens, dtype,
-        lambda logits, seq_lens: torch.ops.trtllm.
-        cute_dsl_topk_decode_multi_cta_blackwell(
-            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
-            next_n=next_n, num_copy_bits=256,
-            chunk_size_per_cta=chunk_size_per_cta))
+        batch_size,
+        next_n,
+        index_topk,
+        num_tokens,
+        dtype,
+        lambda logits, seq_lens: torch.ops.trtllm.cute_dsl_topk_decode_multi_cta_blackwell(
+            input_values=logits,
+            seq_lens=seq_lens,
+            top_k=index_topk,
+            next_n=next_n,
+            num_copy_bits=256,
+            chunk_size_per_cta=chunk_size_per_cta,
+        ),
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 64, 128])
 @pytest.mark.parametrize("next_n", [1, 2])
 @pytest.mark.parametrize("index_topk", [2048])
 @pytest.mark.parametrize("num_tokens", [4096, 8192, 65536, 131072])
-def test_cute_dsl_indexer_topk_decode(batch_size, next_n, index_topk,
-                                      num_tokens):
+def test_cute_dsl_indexer_topk_decode(batch_size, next_n, index_topk, num_tokens):
     _run_cute_dsl_topk_test(
-        batch_size, next_n, index_topk, num_tokens, torch.float32,
-        lambda logits, seq_lens: torch.ops.trtllm.
-        cute_dsl_indexer_topk_decode(
-            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
-            next_n=next_n, num_copy_bits=256))
+        batch_size,
+        next_n,
+        index_topk,
+        num_tokens,
+        torch.float32,
+        lambda logits, seq_lens: torch.ops.trtllm.cute_dsl_indexer_topk_decode(
+            input_values=logits,
+            seq_lens=seq_lens,
+            top_k=index_topk,
+            next_n=next_n,
+            num_copy_bits=256,
+        ),
+    )

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -5,6 +5,9 @@ from utils.util import getSMVersion, skip_pre_hopper
 # Import tensorrt_llm to load custom CUDA operators (indexer_topk_decode, indexer_topk_prefill)
 import tensorrt_llm  # noqa: F401
 
+# Import CuTE DSL utils
+from tensorrt_llm._torch.cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
+
 if not torch.cuda.is_available():
     pytest.skip("CUDA is required for indexer_topk tests", allow_module_level=True)
 
@@ -260,3 +263,86 @@ def test_indexer_topk_prefill(batch_size, index_topk, num_tokens):
     assert compare_top_k_results(
         logits, indices, torch_indices, row_starts, row_ends, index_topk
     ), "CUDA top_k_per_row results don't match torch.topk"
+
+
+# ============================================================================
+# CuTE DSL Top-K Tests
+# ============================================================================
+
+
+def skip_if_no_cute_dsl():
+    """Skip test if CuTE DSL is not available."""
+    if not IS_CUTLASS_DSL_AVAILABLE:
+        pytest.skip("CuTE DSL not available")
+
+
+def skip_if_not_blackwell():
+    """Skip test if not running on Blackwell architecture."""
+    sm = getSMVersion()
+    if sm < 100:
+        pytest.skip("CuTE DSL top-k kernel requires Blackwell (SM100+)")
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 64])
+@pytest.mark.parametrize("next_n", [1, 3])
+@pytest.mark.parametrize("index_topk", [2048])
+@pytest.mark.parametrize("num_tokens", [4096, 8192])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype):
+    skip_if_no_cute_dsl()
+    skip_if_not_blackwell()
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    # Set input data (same structure as test_indexer_topk_decode)
+    num_gen_tokens = batch_size * next_n
+    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
+    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
+    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
+
+    seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+
+    # Create logits with the specified dtype
+    logits = create_random_logits(row_starts, row_ends, dtype, 42)
+
+    # Run CuTE DSL implementation
+    # result = cute_dsl_topk_wrapper(
+    #     input_values=logits,
+    #     seq_lens=seq_lens,
+    #     top_k=index_topk,
+    #     next_n=next_n,
+    #     return_val=return_val,
+    #     load_balance=False,
+    #     num_copy_bits=256,
+    # )
+    # # Extract indices from result
+    # # The wrapper returns (indices, values) if return_val=True
+    # if isinstance(result, tuple):
+    #     cute_indices, _ = result
+    # else:
+    #     cute_indices = result
+
+    result = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
+        input_values=logits, seq_lens=seq_lens, top_k=index_topk, next_n=next_n, num_copy_bits=256
+    )
+    cute_indices = result
+
+    torch.cuda.synchronize()
+
+    # Run reference implementation
+    max_row_len = row_ends.max().item()
+    torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
+    mask_lo = torch_indices >= 0
+    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
+    mask = mask_lo & mask_hi
+    torch_indices = torch_indices.masked_fill(~mask, -1)
+
+    # Convert cute_indices to int32 for comparison
+    cute_indices_int32 = cute_indices.to(torch.int32)
+
+    # Compare results
+    assert compare_top_k_results(
+        logits, cute_indices_int32, torch_indices, row_starts, row_ends, index_topk
+    ), "CuTE DSL top-k results don't match torch.topk"

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from utils.util import getSMVersion, skip_pre_hopper
+from utils.util import getSMVersion, skip_pre_hopper, skip_pre_blackwell
 
 # Import tensorrt_llm to load custom CUDA operators (indexer_topk_decode, indexer_topk_prefill)
 import tensorrt_llm  # noqa: F401
@@ -265,20 +265,6 @@ def test_indexer_topk_prefill(batch_size, index_topk, num_tokens):
 # CuTE DSL Top-K Tests
 # ============================================================================
 
-
-def skip_if_no_cute_dsl():
-    """Skip test if CuTE DSL is not available."""
-    if not IS_CUTLASS_DSL_AVAILABLE:
-        pytest.skip("CuTE DSL not available")
-
-
-def skip_if_not_blackwell():
-    """Skip test if not running on Blackwell architecture."""
-    sm = getSMVersion()
-    if sm < 100:
-        pytest.skip("CuTE DSL top-k kernel requires Blackwell (SM100+)")
-
-
 def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, run_fn):
     """Common test logic for CuTE DSL top-k kernels.
 
@@ -290,8 +276,6 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, r
         dtype: Data type for the logits tensor.
         run_fn: Callable(logits, seq_lens) -> indices tensor.
     """
-    skip_if_no_cute_dsl()
-    skip_if_not_blackwell()
 
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
@@ -319,6 +303,8 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, r
     ), "CuTE DSL top-k results don't match torch.topk"
 
 
+@pytest.mark.skipif(not IS_CUTLASS_DSL_AVAILABLE, reason="CuTE DSL not available")
+@skip_pre_blackwell
 @pytest.mark.parametrize("batch_size", [1, 4, 64])
 @pytest.mark.parametrize("next_n", [1, 3])
 @pytest.mark.parametrize("index_topk", [2048])
@@ -341,6 +327,8 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
     )
 
 
+@pytest.mark.skipif(not IS_CUTLASS_DSL_AVAILABLE, reason="CuTE DSL not available")
+@skip_pre_blackwell
 @pytest.mark.parametrize("batch_size", [1, 4, 64])
 @pytest.mark.parametrize("next_n", [1, 3])
 @pytest.mark.parametrize("index_topk", [2048])
@@ -367,6 +355,8 @@ def test_cute_dsl_topk_decode_multi_cta(
     )
 
 
+@pytest.mark.skipif(not IS_CUTLASS_DSL_AVAILABLE, reason="CuTE DSL not available")
+@skip_pre_blackwell
 @pytest.mark.parametrize("batch_size", [1, 4, 64, 128])
 @pytest.mark.parametrize("next_n", [1, 2])
 @pytest.mark.parametrize("index_topk", [2048])

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -310,7 +310,9 @@ def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype, r
 @pytest.mark.parametrize("index_topk", [2048])
 @pytest.mark.parametrize("num_tokens", [4096, 8192])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype):
+@pytest.mark.parametrize("load_balance", [False, True])
+def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype,
+                              load_balance):
     _run_cute_dsl_topk_test(
         batch_size,
         next_n,
@@ -323,6 +325,7 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
             top_k=index_topk,
             next_n=next_n,
             num_copy_bits=256,
+            load_balance=load_balance,
         ),
     )
 

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -283,19 +283,24 @@ def skip_if_not_blackwell():
         pytest.skip("CuTE DSL top-k kernel requires Blackwell (SM100+)")
 
 
-@pytest.mark.parametrize("batch_size", [1, 4, 64])
-@pytest.mark.parametrize("next_n", [1, 3])
-@pytest.mark.parametrize("index_topk", [2048])
-@pytest.mark.parametrize("num_tokens", [4096, 8192])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype):
+def _run_cute_dsl_topk_test(batch_size, next_n, index_topk, num_tokens, dtype,
+                            run_fn):
+    """Common test logic for CuTE DSL top-k kernels.
+
+    Args:
+        batch_size: Number of sequences in the batch.
+        next_n: Number of next tokens per sequence.
+        index_topk: Number of top-k indices to select.
+        num_tokens: Maximum sequence length for generating seq_lens.
+        dtype: Data type for the logits tensor.
+        run_fn: Callable(logits, seq_lens) -> indices tensor.
+    """
     skip_if_no_cute_dsl()
     skip_if_not_blackwell()
 
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
 
-    # Set input data (same structure as test_indexer_topk_decode)
     num_gen_tokens = batch_size * next_n
     row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
     row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
@@ -304,385 +309,65 @@ def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens, dtype)
     seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
 
-    # Create logits with the specified dtype
     logits = create_random_logits(row_starts, row_ends, dtype, 42)
 
-    # Run CuTE DSL implementation
-    # result = cute_dsl_topk_wrapper(
-    #     input_values=logits,
-    #     seq_lens=seq_lens,
-    #     top_k=index_topk,
-    #     next_n=next_n,
-    #     return_val=return_val,
-    #     load_balance=False,
-    #     num_copy_bits=256,
-    # )
-    # # Extract indices from result
-    # # The wrapper returns (indices, values) if return_val=True
-    # if isinstance(result, tuple):
-    #     cute_indices, _ = result
-    # else:
-    #     cute_indices = result
-
-    result = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
-        input_values=logits, seq_lens=seq_lens, top_k=index_topk, next_n=next_n, num_copy_bits=256
-    )
-    cute_indices = result
-
+    cute_indices = run_fn(logits, seq_lens)
     torch.cuda.synchronize()
 
-    # Run reference implementation
     max_row_len = row_ends.max().item()
     torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
-    mask_lo = torch_indices >= 0
-    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
-    mask = mask_lo & mask_hi
+    mask = (torch_indices >= 0) & (
+        (torch_indices - (row_ends - row_starts)[:, None]) < 0)
     torch_indices = torch_indices.masked_fill(~mask, -1)
 
-    # Convert cute_indices to int32 for comparison
-    cute_indices_int32 = cute_indices.to(torch.int32)
-
-    # Compare results
     assert compare_top_k_results(
-        logits, cute_indices_int32, torch_indices, row_starts, row_ends, index_topk
+        logits, cute_indices.to(torch.int32), torch_indices, row_starts,
+        row_ends, index_topk
     ), "CuTE DSL top-k results don't match torch.topk"
 
 
-# TODO: failed on one of the fp16 test. 
+@pytest.mark.parametrize("batch_size", [1, 4, 64])
+@pytest.mark.parametrize("next_n", [1, 3])
+@pytest.mark.parametrize("index_topk", [2048])
+@pytest.mark.parametrize("num_tokens", [4096, 8192])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cute_dsl_topk_decode(batch_size, next_n, index_topk, num_tokens,
+                              dtype):
+    _run_cute_dsl_topk_test(
+        batch_size, next_n, index_topk, num_tokens, dtype,
+        lambda logits, seq_lens: torch.ops.trtllm.
+        cute_dsl_topk_decode_blackwell(
+            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
+            next_n=next_n, num_copy_bits=256))
+
+
 @pytest.mark.parametrize("batch_size", [1, 4, 64])
 @pytest.mark.parametrize("next_n", [1, 3])
 @pytest.mark.parametrize("index_topk", [2048])
 @pytest.mark.parametrize("num_tokens", [32768, 65536])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("chunk_size_per_cta", [16384])
-# @pytest.mark.parametrize("batch_size", [64])
-# @pytest.mark.parametrize("next_n", [3])
-# @pytest.mark.parametrize("index_topk", [2048])
-# @pytest.mark.parametrize("num_tokens", [32768])
-# @pytest.mark.parametrize("dtype", [torch.float16])
-# @pytest.mark.parametrize("chunk_size_per_cta", [16384])
 def test_cute_dsl_topk_decode_multi_cta(batch_size, next_n, index_topk,
                                         num_tokens, dtype,
                                         chunk_size_per_cta):
-    skip_if_no_cute_dsl()
-    skip_if_not_blackwell()
-
-    torch.manual_seed(42)
-    torch.cuda.manual_seed(42)
-
-    # Set input data (same structure as test_indexer_topk_decode)
-    num_gen_tokens = batch_size * next_n
-    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
-    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
-    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
-
-    seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
-    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
-
-    # Create logits with the specified dtype
-    logits = create_random_logits(row_starts, row_ends, dtype, 42)
-
-    # Run CuTE DSL multi-CTA implementation
-    result = torch.ops.trtllm.cute_dsl_topk_decode_multi_cta_blackwell(
-        input_values=logits,
-        seq_lens=seq_lens,
-        top_k=index_topk,
-        next_n=next_n,
-        num_copy_bits=256,
-        chunk_size_per_cta=chunk_size_per_cta,
-    )
-    cute_indices = result
-
-    torch.cuda.synchronize()
-
-    # Run reference implementation
-    max_row_len = row_ends.max().item()
-    torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
-    mask_lo = torch_indices >= 0
-    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
-    mask = mask_lo & mask_hi
-    torch_indices = torch_indices.masked_fill(~mask, -1)
-
-    # Convert cute_indices to int32 for comparison
-    cute_indices_int32 = cute_indices.to(torch.int32)
-
-    # Compare results
-    assert compare_top_k_results(
-        logits, cute_indices_int32, torch_indices, row_starts, row_ends,
-        index_topk
-    ), "CuTE DSL multi-CTA top-k results don't match torch.topk"
+    _run_cute_dsl_topk_test(
+        batch_size, next_n, index_topk, num_tokens, dtype,
+        lambda logits, seq_lens: torch.ops.trtllm.
+        cute_dsl_topk_decode_multi_cta_blackwell(
+            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
+            next_n=next_n, num_copy_bits=256,
+            chunk_size_per_cta=chunk_size_per_cta))
 
 
-def index_topk_decode_benchmark(
-    batch_size=64,
-    next_n=1,
-    index_topk=2048,
-    num_tokens=8192,
-    dtype=torch.float16,
-    num_warmup=10,
-    num_iterations=100,
-):
-    """Benchmark comparison between CuTE DSL and standard top-k implementations.
-
-    Args:
-        batch_size: Number of sequences
-        next_n: Number of candidates per sequence (for speculative decoding)
-        index_topk: Number of top elements to select
-        num_tokens: Vocabulary size
-        dtype: Data type for logits
-        num_warmup: Number of warmup iterations
-        num_iterations: Number of timed iterations
-
-    Returns:
-        dict: Performance metrics for both implementations
-    """
-
-    # Check if CuTE DSL is available
-    if not IS_CUTLASS_DSL_AVAILABLE:
-        print("CuTE DSL not available, skipping benchmark")
-        return None
-
-    # Check if Blackwell architecture
-    sm = getSMVersion()
-    if sm < 100:
-        print(f"CuTE DSL top-k requires Blackwell (SM100+), got SM{sm}")
-        return None
-
-    print(f"\n{'=' * 80}")
-    print("Top-K Performance Benchmark")
-    print(f"{'=' * 80}")
-    print("Configuration:")
-    print(f"  batch_size: {batch_size}")
-    print(f"  next_n: {next_n}")
-    print(f"  index_topk: {index_topk}")
-    print(f"  num_tokens: {num_tokens}")
-    print(f"  dtype: {dtype}")
-    print(f"  num_warmup: {num_warmup}")
-    print(f"  num_iterations: {num_iterations}")
-    print(f"{'=' * 80}\n")
-
-    # Set up input data
-    num_gen_tokens = batch_size * next_n
-    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
-    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
-    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
-
-    seq_lens = generate_seq_lens(batch_size, index_topk, num_tokens)
-    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
-
-    # Create logits
-    logits = create_random_logits(row_starts, row_ends, dtype, 42)
-
-    # Create output tensors for standard implementation
-    indices_standard = torch.empty((num_gen_tokens, index_topk), dtype=torch.int32, device="cuda")
-
-    # ========================================================================
-    # Benchmark 1: Standard indexer_topk_decode
-    # ========================================================================
-    print("Benchmarking: torch.ops.trtllm.indexer_topk_decode")
-
-    # Warmup
-    for _ in range(num_warmup):
-        torch.ops.trtllm.indexer_topk_decode(logits, seq_lens, indices_standard, next_n, index_topk)
-    torch.cuda.synchronize()
-
-    # Timed runs
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-
-    start_event.record()
-    for _ in range(num_iterations):
-        torch.ops.trtllm.indexer_topk_decode(logits, seq_lens, indices_standard, next_n, index_topk)
-    end_event.record()
-    torch.cuda.synchronize()
-
-    time_standard_us = start_event.elapsed_time(end_event) / num_iterations * 1000
-
-    print(f"  Average time: {time_standard_us:.4f} us")
-    print(
-        f"  Throughput: {num_gen_tokens * num_tokens / time_standard_us / 1e6:.2f} M elements/s\n"
-    )
-
-    # ========================================================================
-    # Benchmark 2: CuTE DSL top-k
-    # ========================================================================
-    print("Benchmarking: torch.ops.trtllm.cute_dsl_topk_decode_blackwell")
-
-    # Warmup
-    for _ in range(num_warmup):
-        indices_cute = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
-            input_values=logits,
-            seq_lens=seq_lens,
-            top_k=index_topk,
-            next_n=next_n,
-            num_copy_bits=256,
-        )
-    torch.cuda.synchronize()
-
-    # Timed runs
-    start_event.record()
-    for _ in range(num_iterations):
-        indices_cute = torch.ops.trtllm.cute_dsl_topk_decode_blackwell(
-            input_values=logits,
-            seq_lens=seq_lens,
-            top_k=index_topk,
-            next_n=next_n,
-            num_copy_bits=256,
-        )
-    end_event.record()
-    torch.cuda.synchronize()
-
-    time_cute_us = start_event.elapsed_time(end_event) / num_iterations * 1000
-
-    print(f"  Average time: {time_cute_us:.4f} us")
-    print(f"  Throughput: {num_gen_tokens * num_tokens / time_cute_us / 1e6:.2f} M elements/s\n")
-
-    # ========================================================================
-    # Results Summary
-    # ========================================================================
-    speedup = time_standard_us / time_cute_us
-    print(f"{'=' * 80}")
-    print("Results Summary:")
-    print(f"{'=' * 80}")
-    print(f"  Standard implementation: {time_standard_us:.4f} us")
-    print(f"  CuTE DSL implementation: {time_cute_us:.4f} us")
-    print(
-        f"  Speedup: {speedup:.2f}x {'(CuTE DSL faster)' if speedup > 1 else '(Standard faster)'}"
-    )
-    print(f"{'=' * 80}\n")
-
-    # Verify correctness
-    print("Verifying correctness...")
-    max_row_len = row_ends.max().item()
-    torch_indices = logits.topk(min(index_topk, max_row_len), dim=-1)[1]
-    mask_lo = torch_indices >= 0
-    mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
-    mask = mask_lo & mask_hi
-    torch_indices = torch_indices.masked_fill(~mask, -1)
-
-    # Convert cute_indices to int32 for comparison
-    cute_indices_int32 = indices_cute.to(torch.int32)
-
-    # Compare results
-    correct = compare_top_k_results(
-        logits, cute_indices_int32, torch_indices, row_starts, row_ends, index_topk
-    )
-    print(f"Correctness check: {'PASSED' if correct else 'FAILED'}\n")
-
-    return {
-        "config": {
-            "batch_size": batch_size,
-            "next_n": next_n,
-            "index_topk": index_topk,
-            "num_tokens": num_tokens,
-            "dtype": str(dtype),
-        },
-        "standard_us": time_standard_us,
-        "cute_dsl_us": time_cute_us,
-        "speedup": speedup,
-        "correct": correct,
-    }
-
-
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Top-K Performance Benchmark")
-    parser.add_argument("--batch_size", type=int, default=1, help="Batch size")
-    parser.add_argument("--next_n", type=int, default=1, help="Number of candidates per sequence")
-    parser.add_argument("--index_topk", type=int, default=2048, help="Top-k value")
-    parser.add_argument("--num_tokens", type=int, default=8192, help="Vocabulary size")
-    parser.add_argument(
-        "--dtype",
-        type=str,
-        default="float32",
-        choices=["float16", "bfloat16", "float32"],
-        help="Data type",
-    )
-    parser.add_argument("--num_warmup", type=int, default=10, help="Number of warmup iterations")
-    parser.add_argument(
-        "--num_iterations", type=int, default=100, help="Number of timed iterations"
-    )
-    parser.add_argument("--sweep", action="store_true", help="Run parameter sweep")
-
-    args = parser.parse_args()
-
-    dtype_map = {
-        "float16": torch.float16,
-        "bfloat16": torch.bfloat16,
-        "float32": torch.float32,
-    }
-
-    if args.sweep:
-        print("\n" + "=" * 80)
-        print("Running Parameter Sweep")
-        print("=" * 80 + "\n")
-
-        results = []
-
-        # Sweep configurations
-        configs = [
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
-            {"batch_size": 1, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
-            {"batch_size": 16, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
-            {"batch_size": 64, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 4096},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 8192},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 16384},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 32768},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 65536},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 131072},
-            {"batch_size": 128, "next_n": 1, "index_topk": 2048, "num_tokens": 262144},
-        ]
-
-        for config in configs:
-            result = index_topk_decode_benchmark(
-                dtype=dtype_map[args.dtype],
-                num_warmup=args.num_warmup,
-                num_iterations=args.num_iterations,
-                **config,
-            )
-            if result:
-                results.append(result)
-
-        # Print summary table
-        print("\n" + "=" * 80)
-        print("Summary Table")
-        print("=" * 80)
-        print(f"{'Config':<40} {'Standard (ms)':<15} {'CuTE DSL (ms)':<15} {'Speedup':<10}")
-        print("-" * 80)
-        for r in results:
-            config_str = f"B={r['config']['batch_size']}, K={r['config']['index_topk']}, V={r['config']['num_tokens']}"
-            print(
-                f"{config_str:<40} {r['standard_us']:>14.4f} {r['cute_dsl_us']:>14.4f} {r['speedup']:>9.2f}x"
-            )
-        print("=" * 80 + "\n")
-
-    else:
-        # Single run
-        index_topk_decode_benchmark(
-            batch_size=args.batch_size,
-            next_n=args.next_n,
-            index_topk=args.index_topk,
-            num_tokens=args.num_tokens,
-            dtype=dtype_map[args.dtype],
-            num_warmup=args.num_warmup,
-            num_iterations=args.num_iterations,
-        )
+@pytest.mark.parametrize("batch_size", [1, 4, 64, 128])
+@pytest.mark.parametrize("next_n", [1, 2])
+@pytest.mark.parametrize("index_topk", [2048])
+@pytest.mark.parametrize("num_tokens", [4096, 8192, 65536, 131072])
+def test_cute_dsl_indexer_topk_decode(batch_size, next_n, index_topk,
+                                      num_tokens):
+    _run_cute_dsl_topk_test(
+        batch_size, next_n, index_topk, num_tokens, torch.float32,
+        lambda logits, seq_lens: torch.ops.trtllm.
+        cute_dsl_indexer_topk_decode(
+            input_values=logits, seq_lens=seq_lens, top_k=index_topk,
+            next_n=next_n, num_copy_bits=256))


### PR DESCRIPTION
## Description

Add CuTE DSL implementation of filtered top-k kernel optimized for Blackwell (SM100) architecture. The kernel uses radix-based filtering algorithm for efficient top-k selection.

### Changes:
- Add CuTE DSL kernel implementation in blackwell/top_k/:
  - filtered_top_k_decode_varlen.py: Main decode kernel
  - filtered_top_k_varlen_util.py: Base classes and utilities
  - block_scan.py: Block-level prefix sum operations
  - __init__.py: Module exports
- Add torch custom op wrapper in cute_dsl_custom_ops.py:
  - CuteDSLTopKDecodeSingleCTARunner class with compilation caching
  - torch.library.custom_op registration for trtllm::cute_dsl_topk_decode_blackwell
- Add unit tests in test_indexer_topk.py:
  - test_cute_dsl_topk_decode with parameterized configurations
  - Test coverage for multiple batch sizes, dtypes, and sequence lengths

### Op UT:

```
pytest -s -o log_cli=true tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k "test_cute_dsl_topk_decode"

pytest -s -o log_cli=true tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k "test_cute_dsl_topk_decode_multi_cta"

pytest -s -o log_cli=true tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k "cute_dsl"
```


### TODO:
(1) check the model accuracy and perf by using this new integrated op

### Op Performance：

  Benchmark: cute_dsl_indexer_topk_decode vs indexer_topk_decode

  Setup: Blackwell GPU, top_k=2048, num_copy_bits=256
  Seed: 42

  | batch | next_n | max_num_tokens | indexer (us) | cute_dsl (us) | speedup |
  |------:|-------:|-----------:|-------------:|--------------:|--------:|
  | 1 | 1 | 4096 | 5.78 | 6.98 | 0.83x |
  | 1 | 1 | 8192 | 6.16 | 7.45 | 0.83x |
  | 1 | 1 | 16384 | 17.98 | 10.93 | **1.64x** |
  | 1 | 1 | 32768 | 6.16 | 7.46 | 0.83x |
  | 1 | 1 | 65536 | 19.66 | 13.41 | **1.47x** |
  | 1 | 1 | 131072 | 30.71 | 22.34 | **1.37x** |
  | 1 | 1 | 262144 | 35.68 | 24.28 | **1.47x** |
  | 16 | 1 | 4096 | 5.96 | 7.55 | 0.79x |
  | 16 | 1 | 8192 | 7.67 | 9.25 | 0.83x |
  | 16 | 1 | 16384 | 19.07 | 11.99 | **1.59x** |
  | 16 | 1 | 32768 | 26.43 | 17.99 | **1.47x** |
  | 16 | 1 | 65536 | 38.49 | 26.37 | **1.46x** |
  | 16 | 1 | 131072 | 60.80 | 42.06 | **1.45x** |
  | 16 | 1 | 262144 | 60.87 | 61.93 | 0.98x |
  | 64 | 1 | 4096 | 6.41 | 7.65 | 0.84x |
  | 64 | 1 | 8192 | 7.96 | 9.84 | 0.81x |
  | 64 | 1 | 16384 | 19.65 | 12.35 | **1.59x** |
  | 64 | 1 | 32768 | 27.04 | 18.72 | **1.44x** |
  | 64 | 1 | 65536 | 38.79 | 26.55 | **1.46x** |
  | 64 | 1 | 131072 | 61.02 | 42.52 | **1.44x** |
  | 64 | 1 | 262144 | 93.92 | 77.04 | **1.22x** |
  | 128 | 1 | 4096 | 6.55 | 7.72 | 0.85x |
  | 128 | 1 | 8192 | 8.04 | 10.70 | 0.75x |
  | 128 | 1 | 16384 | 19.64 | 12.34 | **1.59x** |
  | 128 | 1 | 32768 | 26.96 | 19.09 | **1.41x** |
  | 128 | 1 | 65536 | 39.66 | 27.48 | **1.44x** |
  | 128 | 1 | 131072 | 61.11 | 42.71 | **1.43x** |
  | 128 | 1 | 262144 | 133.19 | 76.98 | **1.73x** |
  | 256 | 1 | 4096 | 7.45 | 9.32 | 0.80x |
  | 256 | 1 | 8192 | 9.45 | 13.62 | 0.69x |
  | 256 | 1 | 16384 | 27.95 | 21.11 | **1.32x** |
  | 256 | 1 | 32768 | 37.00 | 31.86 | **1.16x** |
  | 256 | 1 | 65536 | 51.76 | 48.59 | **1.07x** |
  | 256 | 1 | 131072 | 77.74 | 75.53 | **1.03x** |
  | 256 | 1 | 262144 | 246.59 | 156.99 | **1.57x** |
  | 1 | 2 | 4096 | 6.23 | 7.59 | 0.82x |
  | 1 | 2 | 8192 | 6.34 | 8.85 | 0.72x |
  | 1 | 2 | 16384 | 18.15 | 11.16 | **1.63x** |
  | 1 | 2 | 32768 | 6.36 | 8.85 | 0.72x |
  | 1 | 2 | 65536 | 20.21 | 14.57 | **1.39x** |
  | 1 | 2 | 131072 | 31.41 | 22.97 | **1.37x** |
  | 1 | 2 | 262144 | 36.46 | 25.22 | **1.45x** |
  | 16 | 2 | 4096 | 6.02 | 7.51 | 0.80x |
  | 16 | 2 | 8192 | 7.61 | 9.56 | 0.80x |
  | 16 | 2 | 16384 | 19.49 | 12.37 | **1.58x** |
  | 16 | 2 | 32768 | 26.73 | 18.66 | **1.43x** |
  | 16 | 2 | 65536 | 38.86 | 27.38 | **1.42x** |
  | 16 | 2 | 131072 | 61.41 | 41.89 | **1.47x** |
  | 16 | 2 | 262144 | 72.87 | 73.35 | 0.99x |
  | 64 | 2 | 4096 | 6.46 | 8.34 | 0.77x |
  | 64 | 2 | 8192 | 7.97 | 10.27 | 0.78x |
  | 64 | 2 | 16384 | 19.75 | 12.59 | **1.57x** |
  | 64 | 2 | 32768 | 27.17 | 18.96 | **1.43x** |
  | 64 | 2 | 65536 | 38.94 | 27.58 | **1.41x** |
  | 64 | 2 | 131072 | 61.60 | 42.96 | **1.43x** |
  | 64 | 2 | 262144 | 138.45 | 76.61 | **1.81x** |
  | 128 | 2 | 4096 | 7.41 | 9.81 | 0.75x |
  | 128 | 2 | 8192 | 9.29 | 13.43 | 0.69x |
  | 128 | 2 | 16384 | 28.73 | 21.90 | **1.31x** |
  | 128 | 2 | 32768 | 36.65 | 32.54 | **1.13x** |
  | 128 | 2 | 65536 | 51.95 | 48.30 | **1.08x** |
  | 128 | 2 | 131072 | 76.17 | 76.88 | 0.99x |
  | 128 | 2 | 262144 | 247.86 | 158.26 | **1.57x** |
  | 256 | 2 | 4096 | 11.39 | 12.44 | 0.92x |
  | 256 | 2 | 8192 | 13.99 | 19.71 | 0.71x |
  | 256 | 2 | 16384 | 38.49 | 30.81 | **1.25x** |
  | 256 | 2 | 32768 | 47.10 | 46.80 | **1.01x** |
  | 256 | 2 | 65536 | 69.30 | 78.08 | 0.89x |
  | 256 | 2 | 131072 | 118.75 | 122.54 | 0.97x |
  | 256 | 2 | 262144 | 473.88 | 196.94 | **2.41x** |
  | 1 | 3 | 4096 | 6.22 | 7.43 | 0.84x |
  | 1 | 3 | 8192 | 6.35 | 8.16 | 0.78x |
  | 1 | 3 | 16384 | 18.18 | 11.39 | **1.60x** |
  | 1 | 3 | 32768 | 6.36 | 8.15 | 0.78x |
  | 1 | 3 | 65536 | 20.23 | 14.64 | **1.38x** |
  | 1 | 3 | 131072 | 31.38 | 23.40 | **1.34x** |
  | 1 | 3 | 262144 | 36.43 | 25.21 | **1.45x** |
  | 16 | 3 | 4096 | 6.03 | 7.53 | 0.80x |
  | 16 | 3 | 8192 | 7.63 | 9.57 | 0.80x |
  | 16 | 3 | 16384 | 19.38 | 12.64 | **1.53x** |
  | 16 | 3 | 32768 | 26.95 | 18.44 | **1.46x** |
  | 16 | 3 | 65536 | 39.02 | 27.41 | **1.42x** |
  | 16 | 3 | 131072 | 61.82 | 43.01 | **1.44x** |
  | 16 | 3 | 262144 | 74.92 | 72.50 | **1.03x** |
  | 64 | 3 | 4096 | 7.31 | 9.25 | 0.79x |
  | 64 | 3 | 8192 | 9.55 | 13.56 | 0.70x |
  | 64 | 3 | 16384 | 27.74 | 20.86 | **1.33x** |
  | 64 | 3 | 32768 | 34.99 | 31.11 | **1.12x** |
  | 64 | 3 | 65536 | 45.43 | 42.29 | **1.07x** |
  | 64 | 3 | 131072 | 75.40 | 72.91 | **1.03x** |
  | 64 | 3 | 262144 | 205.09 | 139.77 | **1.47x** |
  | 128 | 3 | 4096 | 8.74 | 10.69 | 0.82x |
  | 128 | 3 | 8192 | 11.40 | 15.84 | 0.72x |
  | 128 | 3 | 16384 | 37.67 | 26.91 | **1.40x** |
  | 128 | 3 | 32768 | 46.39 | 37.78 | **1.23x** |
  | 128 | 3 | 65536 | 67.95 | 58.28 | **1.17x** |
  | 128 | 3 | 131072 | 102.43 | 97.57 | **1.05x** |
  | 128 | 3 | 262144 | 361.91 | 207.40 | **1.74x** |
  | 256 | 3 | 4096 | 14.49 | 16.86 | 0.86x |
  | 256 | 3 | 8192 | 18.31 | 23.52 | 0.78x |
  | 256 | 3 | 16384 | 58.63 | 37.07 | **1.58x** |
  | 256 | 3 | 32768 | 72.57 | 55.51 | **1.31x** |
  | 256 | 3 | 65536 | 107.42 | 86.44 | **1.24x** |
  | 256 | 3 | 131072 | 170.55 | 147.69 | **1.15x** |
  | 256 | 3 | 262144 | 700.79 | 264.53 | **2.65x** |

  #### Summary

  | Regime | Speedup | Notes |
  |--------|---------|-------|
  | Small vocab (`num_tokens <= 8192`) | 0.69x – 0.92x | it's because cute dsl kernel don't have sort shortcut, may run multi rounds. trtllm only runs one round + insert_sort on candicates. |
  | Medium vocab (`16K – 64K`) | **1.07x – 1.64x** | Single-CTA CuTE DSL path consistently wins |
  | Large vocab (`131K – 262K`) | **1.03x – 2.65x** | Multi-CTA path dominates; peak **2.65x** at `batch=256, next_n=3, 262K` |

  - **CuTE DSL wins in 73/105 configs** (70%), all with `num_tokens >= 16384`
  - Regressions are confined to small `num_tokens` where absolute latency is already low (< 20 us)
  - Largest gains at high `batch × next_n × num_tokens` where multi-CTA parallelism is fully utilized
  


<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->



<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
