### PR TITLE
[#11432][feat] AutoDeploy: Enable fp8 quantization fusion part 1

### DIFF
--- a/examples/auto_deploy/model_registry/configs/dashboard_default.yaml
+++ b/examples/auto_deploy/model_registry/configs/dashboard_default.yaml
@@ -7,3 +7,9 @@ compile_backend: torch-cudagraph
 model_factory: AutoModelForCausalLM
 skip_loading_weights: false
 max_seq_len: 512
+transforms:
+  fuse_trtllm_attn_quant_fp8:
+    enabled: true
+  fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: true

--- a/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
+++ b/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
@@ -1,0 +1,17 @@
+compile_backend: torch-cudagraph
+enable_chunked_prefill: true
+model_factory: AutoModelForCausalLM
+runtime: trtllm
+kv_cache_config:
+  dtype: fp8
+  free_gpu_memory_fraction: 0.9
+attn_backend: trtllm
+max_batch_size: 256
+max_seq_len: 16384
+transforms:
+  fuse_trtllm_attn_quant_fp8:
+    enabled: true
+  fuse_fp8_gemms:
+    enabled: true
+  fuse_rmsnorm_quant_fp8:
+    enabled: true

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -92,7 +92,7 @@ models:
 - name: meta-llama/Llama-2-7b-chat-hf
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
 - name: nvidia/Llama-3.1-8B-Instruct-FP8
-  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'llama3_1_8b.yaml']
 - name: nvidia/Llama-3.1-Minitron-4B-Depth-Base
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
 - name: nvidia/Llama-3.1-Minitron-4B-Width-Base

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -84,6 +84,9 @@ transforms:
     stage: pattern_matcher
   quantize_nvfp4_from_graph:
     stage: pattern_matcher
+  fuse_trtllm_attn_quant_fp8:
+    stage: pattern_matcher
+    enabled: false
   # SwiGLU pattern matching must run AFTER quantization transforms. For pre-quantized
   # checkpoints (e.g., NVFP4), quantization converts torch_linear_simple ops to quantized
   # ops first, and then match_nvfp4_swiglu_pattern captures the NVFP4 SwiGLU pattern.
@@ -155,6 +158,7 @@ transforms:
   fuse_fp8_linear:
     stage: post_load_fusion
     backend: trtllm
+    requires_shape_prop: true
   fuse_nvfp4_linear:
     stage: post_load_fusion
     backend: trtllm
@@ -205,6 +209,9 @@ transforms:
   fuse_add_rms_norm:
     stage: post_load_fusion
     enabled: true
+  fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: false
   gather_logits_before_lm_head:
     stage: post_load_fusion
     # TODO: fix https://github.com/NVIDIA/TensorRT-LLM/issues/9878 to enable by default

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -84,9 +84,6 @@ transforms:
     stage: pattern_matcher
   quantize_nvfp4_from_graph:
     stage: pattern_matcher
-  fuse_trtllm_attn_quant_fp8:
-    stage: pattern_matcher
-    enabled: false
   # SwiGLU pattern matching must run AFTER quantization transforms. For pre-quantized
   # checkpoints (e.g., NVFP4), quantization converts torch_linear_simple ops to quantized
   # ops first, and then match_nvfp4_swiglu_pattern captures the NVFP4 SwiGLU pattern.
@@ -159,6 +156,9 @@ transforms:
     stage: post_load_fusion
     backend: trtllm
     requires_shape_prop: true
+  fuse_trtllm_attn_quant_fp8:
+    stage: post_load_fusion
+    enabled: false
   fuse_nvfp4_linear:
     stage: post_load_fusion
     backend: trtllm

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -317,6 +317,7 @@ def trtllm_mha_with_cache(
     sliding_window: Optional[int] = None,
     kv_scale_orig_quant: float = 1.0,
     kv_scale_quant_orig: float = 1.0,
+    out_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """TRT-LLM attention with paged KV cache for Auto-Deploy.
 
@@ -369,8 +370,11 @@ def trtllm_mha_with_cache(
 
     # Prepare output (pre-allocate at full padded size so padding positions are clean zeros)
     total_padded_tokens = q_shape_og[0] * q_shape_og[1]
-    output = torch.zeros(total_padded_tokens, num_heads * head_dim, dtype=q.dtype, device=q.device)
-
+    # If out_scale is set, attention quantizes output to FP8.
+    out_dtype = torch.float8_e4m3fn if out_scale is not None else q.dtype
+    output = torch.zeros(
+        total_padded_tokens, num_heads * head_dim, dtype=out_dtype, device=q.device
+    )
     # Map SequenceInfo fields to thop.attention args
     sequence_length = seq_len_with_cache[:num_seq]  # device
     context_lengths = seq_len[:num_seq]  # device
@@ -415,7 +419,7 @@ def trtllm_mha_with_cache(
         None,  # cache_indirection (beam search)
         kv_scale_oq,  # kv_scale_orig_quant
         kv_scale_qo,  # kv_scale_quant_orig
-        None,  # out_scale
+        out_scale,  # out_scale
         None,  # rotary_inv_freq
         None,  # rotary_cos_sin
         None,  # latent_cache (MLA)
@@ -500,9 +504,11 @@ def trtllm_mha_with_cache_fake(
     sliding_window: Optional[int] = None,
     kv_scale_orig_quant: float = 1.0,
     kv_scale_quant_orig: float = 1.0,
+    out_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.compile tracing."""
-    return torch.empty_like(q.contiguous())
+    out_dtype = torch.float8_e4m3fn if out_scale is not None else q.dtype
+    return torch.empty_like(q.contiguous(), dtype=out_dtype)
 
 
 # =============================================================================
@@ -582,7 +588,8 @@ class TrtllmAttention(AttentionDescriptor):
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         """Extract constants from the source attention node.
 
-        Returns scale, sliding_window, kv_scale_orig_quant, and kv_scale_quant_orig.
+        Returns scale, sliding_window, kv_scale_orig_quant, kv_scale_quant_orig,
+        and optional output quant scale for FP8 linear consumers.
         Everything else (num_heads, head_dim, max_context_length, etc.) is inferred
         from tensor shapes or SequenceInfo metadata at runtime.
         """
@@ -618,9 +625,13 @@ class TrtllmAttention(AttentionDescriptor):
         # Get sliding_window from source attention node
         sliding_window = extract_op_args(source_attn_node, "sliding_window")[0]
 
+        # Optional out_scale is injected by cache-init stage when available.
+        out_scale = None
+
         return [
             scale,
             sliding_window,
             1.0,  # kv_scale_orig_quant (hard-coded, same as FlashInfer)
             1.0,  # kv_scale_quant_orig (hard-coded, same as FlashInfer)
+            out_scale,
         ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -30,7 +30,7 @@ from typing import List, Optional, Tuple
 import torch
 from torch._ops import OpOverloadPacket
 from torch._subclasses import FakeTensor
-from torch.fx import Node
+from torch.fx import GraphModule, Node
 
 from tensorrt_llm._utils import get_sm_version, prefer_pinned
 from tensorrt_llm.bindings.internal import thop
@@ -207,6 +207,21 @@ class _TrtllmPlanner:
 
 
 _GlobalTrtllmPlanner = _TrtllmPlanner()
+_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY = "trtllm_attention_input_scale"
+_TRTLLM_ATTN_OUT_SCALE_KEY = "trtllm_attention_out_scale"
+
+
+def set_trtllm_attention_fp8_input_scale(attn_node: Node, input_scale: Node) -> None:
+    attn_node.meta[_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY] = input_scale
+
+
+def get_trtllm_attention_fp8_input_scale(attn_node: Node) -> Optional[Node]:
+    scale = attn_node.meta.get(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY)
+    return scale if isinstance(scale, Node) else None
+
+
+def clear_trtllm_attention_fp8_input_scale(attn_node: Node) -> None:
+    attn_node.meta.pop(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY, None)
 
 
 # =============================================================================
@@ -585,6 +600,24 @@ class TrtllmAttention(AttentionDescriptor):
         return prepare_trtllm_metadata_host
 
     @classmethod
+    def prepare_node_for_cache_insertion(cls, gm: GraphModule, attn_node: Node) -> None:
+        """Materialize optional out_scale node for FP8 output path if contract exists."""
+        input_scale = get_trtllm_attention_fp8_input_scale(attn_node)
+        if input_scale is None:
+            attn_node.meta.pop(_TRTLLM_ATTN_OUT_SCALE_KEY, None)
+            return
+
+        existing_out_scale = attn_node.meta.get(_TRTLLM_ATTN_OUT_SCALE_KEY)
+        if isinstance(existing_out_scale, Node):
+            return
+
+        with gm.graph.inserting_before(attn_node):
+            out_scale = gm.graph.call_function(
+                torch.ops.aten.reciprocal.default, args=(input_scale,)
+            )
+        attn_node.meta[_TRTLLM_ATTN_OUT_SCALE_KEY] = out_scale
+
+    @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         """Extract constants from the source attention node.
 
@@ -625,8 +658,10 @@ class TrtllmAttention(AttentionDescriptor):
         # Get sliding_window from source attention node
         sliding_window = extract_op_args(source_attn_node, "sliding_window")[0]
 
-        # Optional out_scale is injected by cache-init stage when available.
-        out_scale = None
+        # Optional out_scale is injected by prepare_node_for_cache_insertion when available.
+        out_scale = source_attn_node.meta.get(_TRTLLM_ATTN_OUT_SCALE_KEY)
+        if not isinstance(out_scale, Node):
+            out_scale = None
 
         return [
             scale,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -41,6 +41,22 @@ from ..utils.logger import ad_logger
 
 Constant = Union[int, float, str, None]
 
+_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY = "trtllm_attention_input_scale"
+
+
+def set_trtllm_attention_fp8_input_scale(attn_node: Node, input_scale: Node) -> None:
+    attn_node.meta[_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY] = input_scale
+
+
+def get_trtllm_attention_fp8_input_scale(attn_node: Node) -> Optional[Node]:
+    scale = attn_node.meta.get(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY)
+    return scale if isinstance(scale, Node) else None
+
+
+def clear_trtllm_attention_fp8_input_scale(attn_node: Node) -> None:
+    attn_node.meta.pop(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY, None)
+
+
 # Torch dtype → numpy dtype for fast list-to-tensor conversion.
 # numpy's list→array conversion is ~2-3x faster than torch.tensor(list) for large lists.
 _TORCH_TO_NUMPY_DTYPE: Dict[torch.dtype, np.dtype] = {

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -31,7 +31,7 @@ from typing import Dict, List, Literal, Optional, Protocol, Sequence, Set, Tuple
 import numpy as np
 import torch
 from torch._ops import OpOverloadPacket
-from torch.fx import Node
+from torch.fx import GraphModule, Node
 from torch.types import Number
 
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
@@ -40,22 +40,6 @@ from ...._utils import nvtx_range, prefer_pinned, str_dtype_to_torch
 from ..utils.logger import ad_logger
 
 Constant = Union[int, float, str, None]
-
-_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY = "trtllm_attention_input_scale"
-
-
-def set_trtllm_attention_fp8_input_scale(attn_node: Node, input_scale: Node) -> None:
-    attn_node.meta[_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY] = input_scale
-
-
-def get_trtllm_attention_fp8_input_scale(attn_node: Node) -> Optional[Node]:
-    scale = attn_node.meta.get(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY)
-    return scale if isinstance(scale, Node) else None
-
-
-def clear_trtllm_attention_fp8_input_scale(attn_node: Node) -> None:
-    attn_node.meta.pop(_TRTLLM_ATTN_FP8_INPUT_SCALE_KEY, None)
-
 
 # Torch dtype → numpy dtype for fast list-to-tensor conversion.
 # numpy's list→array conversion is ~2-3x faster than torch.tensor(list) for large lists.
@@ -1582,6 +1566,15 @@ class AttentionDescriptor(ABC):
         This method is responsible for preparing the attention op for the forward pass.
         This function is not expected to be graph capturable or compatible with cuda graphs. It can
         use any argument from the SequenceInfo interface as input argument to its function.
+        """
+        return None
+
+    @classmethod
+    def prepare_node_for_cache_insertion(cls, gm: GraphModule, attn_node: Node) -> None:
+        """Perform optional backend-specific graph prep before cached attention insertion.
+
+        Default implementation is a no-op. Backends can override this hook to materialize
+        backend-specific graph nodes or metadata needed by ``get_constants``.
         """
         return None
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
@@ -18,6 +18,7 @@
 This module provides various normalization implementations:
 - rms_norm: RMSNorm implementations (FlashInfer, Triton, reference)
 - triton_rms_norm: Low-level Triton RMSNorm kernel
+- triton_fused_add_rms_norm_quant_fp8: Fused Add + RMSNorm + FP8 quantization
 - l2norm: L2 normalization operations
 - flashinfer_fused_add_rms_norm: Fused add + RMSNorm operation
 """
@@ -25,6 +26,7 @@ This module provides various normalization implementations:
 __all__ = [
     "rms_norm",
     "triton_rms_norm",
+    "triton_fused_add_rms_norm_quant_fp8",
     "l2norm",
     "flashinfer_fused_add_rms_norm",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/triton_fused_add_rms_norm_quant_fp8.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/triton_fused_add_rms_norm_quant_fp8.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton RMSNorm + FP8 quantization custom ops."""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+_FP8_MIN = float(torch.finfo(torch.float8_e4m3fn).min)
+_FP8_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+
+
+@triton.jit
+def rms_norm_quant_fp8_kernel(
+    input_ptr,
+    weight_ptr,
+    output_bf16_ptr,
+    output_fp8_ptr,
+    scale_ptr,
+    row_stride: tl.constexpr,
+    eps: tl.constexpr,
+    FP8_MIN: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    N_COLS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    prog_id = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_N)
+    mask = offsets < N_COLS
+
+    w = tl.load(weight_ptr + offsets, mask=mask)
+    x_ptr = input_ptr + prog_id * row_stride
+    x = tl.load(x_ptr + offsets, mask=mask)
+    xf = x.to(tl.float32)
+
+    var = tl.sum(xf * xf, 0) * float(1.0 / N_COLS)
+    normed = xf / tl.sqrt(var + eps)
+    out_f32 = w.to(tl.float32) * normed
+
+    out_bf16_row = output_bf16_ptr + prog_id * row_stride
+    tl.store(out_bf16_row + offsets, out_f32.to(x.dtype), mask=mask)
+
+    scale = tl.load(scale_ptr)
+    out_scaled = out_f32 / scale
+    out_clamped = tl.maximum(tl.minimum(out_scaled, FP8_MAX), FP8_MIN)
+    out_fp8 = out_clamped.to(tl.float8e4nv)
+
+    out_fp8_row = output_fp8_ptr + prog_id * N_COLS
+    tl.store(out_fp8_row + offsets, out_fp8, mask=mask)
+
+
+def rms_norm_quant_fp8(
+    hidden_states: Tensor, weight: Tensor, eps: float, scale: Tensor
+) -> Tuple[Tensor, Tensor]:
+    assert hidden_states.shape[-1] == weight.numel(), "hidden size must match weight size"
+
+    orig_shape = hidden_states.shape
+    feat_size = weight.shape[0]
+    hidden_states_flat = hidden_states.reshape(-1, feat_size)
+    seq_len = hidden_states_flat.shape[0]
+    input_stride = hidden_states_flat.stride(-2)
+
+    BLOCK_N = triton.next_power_of_2(feat_size)
+    out_bf16 = torch.empty_like(hidden_states_flat)
+    out_fp8 = torch.empty(
+        hidden_states_flat.shape,
+        dtype=torch.float8_e4m3fn,
+        device=hidden_states.device,
+    )
+
+    grid = (seq_len,)
+    rms_norm_quant_fp8_kernel[grid](
+        hidden_states_flat,
+        weight,
+        out_bf16,
+        out_fp8,
+        scale,
+        row_stride=input_stride,
+        eps=eps,
+        FP8_MIN=_FP8_MIN,
+        FP8_MAX=_FP8_MAX,
+        N_COLS=feat_size,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    return out_bf16.reshape(orig_shape), out_fp8.reshape(orig_shape)
+
+
+@torch.library.custom_op("auto_deploy::triton_rms_norm_quant_fp8", mutates_args=())
+def triton_rms_norm_quant_fp8(
+    input: torch.Tensor, weight: torch.Tensor, eps: float, scale: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return rms_norm_quant_fp8(input, weight, eps, scale)
+
+
+@triton_rms_norm_quant_fp8.register_fake
+def _rms_norm_quant_fp8_fake(
+    input: torch.Tensor, weight: torch.Tensor, eps: float, scale: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    bf16_out = torch.empty_like(input)
+    fp8_out = torch.empty(input.shape, dtype=torch.float8_e4m3fn, device=input.device)
+    return bf16_out, fp8_out
+
+
+@triton.jit
+def fused_add_rms_norm_quant_fp8_kernel(
+    x_ptr,
+    residual_ptr,
+    weight_ptr,
+    output_bf16_ptr,
+    output_fp8_ptr,
+    output_add_ptr,
+    scale_ptr,
+    row_stride_x: tl.constexpr,
+    row_stride_residual: tl.constexpr,
+    row_stride_out: tl.constexpr,
+    eps: tl.constexpr,
+    FP8_MIN: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    N_COLS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    prog_id = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_N)
+    mask = offsets < N_COLS
+
+    w = tl.load(weight_ptr + offsets, mask=mask)
+    x_row = x_ptr + prog_id * row_stride_x
+    residual_row = residual_ptr + prog_id * row_stride_residual
+    x = tl.load(x_row + offsets, mask=mask)
+    residual = tl.load(residual_row + offsets, mask=mask)
+
+    add_out = x + residual
+    add_out_f32 = add_out.to(tl.float32)
+
+    var = tl.sum(add_out_f32 * add_out_f32, 0) * float(1.0 / N_COLS)
+    normed = add_out_f32 / tl.sqrt(var + eps)
+    norm_out_f32 = w.to(tl.float32) * normed
+
+    out_bf16_row = output_bf16_ptr + prog_id * row_stride_out
+    tl.store(out_bf16_row + offsets, norm_out_f32.to(x.dtype), mask=mask)
+
+    scale = tl.load(scale_ptr)
+    out_scaled = norm_out_f32 / scale
+    out_clamped = tl.maximum(tl.minimum(out_scaled, FP8_MAX), FP8_MIN)
+    out_fp8 = out_clamped.to(tl.float8e4nv)
+
+    out_fp8_row = output_fp8_ptr + prog_id * N_COLS
+    tl.store(out_fp8_row + offsets, out_fp8, mask=mask)
+
+    out_add_row = output_add_ptr + prog_id * row_stride_out
+    tl.store(out_add_row + offsets, add_out, mask=mask)
+
+
+def fused_add_rms_norm_quant_fp8(
+    x: Tensor, residual: Tensor, weight: Tensor, eps: float, scale: Tensor
+) -> Tuple[Tensor, Tensor, Tensor]:
+    assert x.shape == residual.shape, "x and residual must have identical shape"
+    assert x.shape[-1] == weight.numel(), "x hidden size must match weight size"
+
+    orig_shape = x.shape
+    feat_size = weight.shape[0]
+    x_flat = x.reshape(-1, feat_size)
+    residual_flat = residual.reshape(-1, feat_size)
+    seq_len = x_flat.shape[0]
+
+    BLOCK_N = triton.next_power_of_2(feat_size)
+    out_bf16 = torch.empty_like(x_flat)
+    out_fp8 = torch.empty(x_flat.shape, dtype=torch.float8_e4m3fn, device=x.device)
+    out_add = torch.empty_like(x_flat)
+
+    grid = (seq_len,)
+    fused_add_rms_norm_quant_fp8_kernel[grid](
+        x_flat,
+        residual_flat,
+        weight,
+        out_bf16,
+        out_fp8,
+        out_add,
+        scale,
+        row_stride_x=x_flat.stride(-2),
+        row_stride_residual=residual_flat.stride(-2),
+        row_stride_out=out_bf16.stride(-2),
+        eps=eps,
+        FP8_MIN=_FP8_MIN,
+        FP8_MAX=_FP8_MAX,
+        N_COLS=feat_size,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    return out_bf16.reshape(orig_shape), out_fp8.reshape(orig_shape), out_add.reshape(orig_shape)
+
+
+@torch.library.custom_op("auto_deploy::triton_fused_add_rms_norm_quant_fp8", mutates_args=())
+def triton_fused_add_rms_norm_quant_fp8(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    scale: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return fused_add_rms_norm_quant_fp8(x, residual, weight, eps, scale)
+
+
+@triton_fused_add_rms_norm_quant_fp8.register_fake
+def _fused_add_rms_norm_quant_fp8_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    scale: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    bf16_out = torch.empty_like(x)
+    fp8_out = torch.empty(x.shape, dtype=torch.float8_e4m3fn, device=x.device)
+    add_out = torch.empty_like(x)
+    return bf16_out, fp8_out, add_out

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
@@ -62,8 +62,77 @@ FP4_MAX = 6.0
 FP4_GLOBAL_SCALE_MAX = FP8_MAX * FP4_MAX
 
 
+def _resolve_out_dtype_or_raise(out_dtype: str) -> torch.dtype:
+    try:
+        dtype = getattr(torch, out_dtype)
+    except AttributeError as e:
+        raise RuntimeError(
+            f"Unsupported out_dtype={out_dtype!r}; expected a valid torch dtype name."
+        ) from e
+    if dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise RuntimeError(
+            f"Unsupported out_dtype={out_dtype!r}; expected one of float16/bfloat16/float32."
+        )
+    return dtype
+
+
 def _to_fp8(x, scale):
     return (x / scale).clamp(FP8_MIN, FP8_MAX).to(torch.float8_e4m3fn)
+
+
+def _trtllm_fp8_prequant_linear_core(
+    input_fp8: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    input_scale: Optional[torch.Tensor],
+    weight_scale: Optional[torch.Tensor],
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    input_shape = input_fp8.shape
+    n = weight_fp8.shape[0]
+    k = weight_fp8.shape[1]
+    assert input_shape[-1] == k, f"Input last dim {input_shape[-1]} must match weight last dim {k}"
+
+    x = input_fp8.reshape(-1, k)
+    k_pad = (16 - k % 16) % 16
+    n_pad = (16 - n % 16) % 16
+
+    if k_pad != 0:
+        x = torch.nn.functional.pad(x, (0, k_pad), mode="constant", value=0).contiguous()
+        weight_fp8 = torch.nn.functional.pad(
+            weight_fp8, (0, k_pad), mode="constant", value=0
+        ).contiguous()
+    if n_pad != 0:
+        weight_fp8 = torch.nn.functional.pad(
+            weight_fp8, (0, 0, 0, n_pad), mode="constant", value=0
+        ).contiguous()
+
+    enable_cuda_core = False
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability(0)
+        enable_cuda_core = capability == (8, 9) or capability == (12, 0)
+
+    if x.shape[0] <= 8 and enable_cuda_core:
+        output = torch.ops.trtllm.cuda_scaled_mm(
+            x,
+            weight_fp8.t(),
+            scale_a=input_scale,
+            scale_b=weight_scale,
+            bias=None,
+            out_dtype=out_dtype,
+        )
+    else:
+        output = torch.ops.trtllm.cublas_scaled_mm(
+            x,
+            weight_fp8.t(),
+            scale_a=input_scale,
+            scale_b=weight_scale,
+            bias=None,
+            out_dtype=out_dtype,
+        )
+
+    if n_pad != 0:
+        output = output[..., :n]
+    return output.reshape(*input_shape[:-1], n)
 
 
 @torch.library.custom_op("auto_deploy::trtllm_quant_fp8_linear", mutates_args=())
@@ -73,6 +142,7 @@ def trtllm_quant_fp8_linear(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
+    out_dtype: Optional[str] = None,
 ) -> torch.Tensor:
     """FP8 linear op similar to torch.nn.linear using TensorRT-LLM FP8 operations.
 
@@ -85,75 +155,34 @@ def trtllm_quant_fp8_linear(
     Returns:
         The linear output with the original dtype as the input.
     """
-    input_shape = input.shape
-    input_dtype = input.dtype
-
-    n = weight_fp8.shape[0]  # out_features
-    k = weight_fp8.shape[1]  # in_features
-
-    # Verify dimensions match
-    assert input_shape[-1] == k, f"Input last dim {input_shape[-1]} must match weight last dim {k}"
-
-    input = input.reshape(-1, k)
-
-    # Calculate padding needed to reach next multiple of 16
-    k_pad = (16 - k % 16) % 16  # Amount to pad K dimension
-    n_pad = (16 - n % 16) % 16  # Amount to pad N dimension
-
-    if k_pad != 0:
-        # Pad input on the last dimension (K dimension)
-        input = torch.nn.functional.pad(input, (0, k_pad), mode="constant", value=0).contiguous()
-        # Pad weight on the last dimension (K dimension)
-        weight_fp8 = torch.nn.functional.pad(
-            weight_fp8, (0, k_pad), mode="constant", value=0
-        ).contiguous()
-
-    if n_pad != 0:
-        # Pad weight on the first dimension (N dimension)
-        weight_fp8 = torch.nn.functional.pad(
-            weight_fp8, (0, 0, 0, n_pad), mode="constant", value=0
-        ).contiguous()
-
-    # Use TensorRT-LLM FP8 per-tensor quantization
-    assert input_scale is not None
-    input_fp8, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(input, input_scale)
-
-    enable_cuda_core = False
-    if torch.cuda.is_available():
-        capability = torch.cuda.get_device_capability(0)
-        enable_cuda_core = capability == (8, 9) or capability == (12, 0)
-    # Use TensorRT-LLM FP8 scaled matrix multiply
-    # Choose between CUDA core (for small M) and cuBLAS (for large M) implementations
-    if (
-        input_fp8.shape[0] <= 8 and enable_cuda_core
-    ):  # NOTE: this kernel work with n % 2 == 0 as well??
-        # Use CUDA core for small M dimension (better for small batch sizes)
-        output = torch.ops.trtllm.cuda_scaled_mm(
-            input_fp8,
-            weight_fp8.t(),
-            scale_a=input_scale,
-            scale_b=weight_scale,
-            bias=None,
-            out_dtype=input_dtype,
-        )
+    # If input is already FP8 (e.g. fused attention output quantization), output
+    # dtype must be explicit (out_dtype) or inferable from bias dtype.
+    if input.dtype == torch.float8_e4m3fn:
+        if out_dtype is not None:
+            input_dtype = _resolve_out_dtype_or_raise(out_dtype)
+        elif bias is not None and bias.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            input_dtype = bias.dtype
+        else:
+            raise RuntimeError(
+                "trtllm_quant_fp8_linear with FP8 input requires either out_dtype or bias "
+                "to determine output dtype."
+            )
     else:
-        # Use cuBLAS for large M dimension
-        output = torch.ops.trtllm.cublas_scaled_mm(
-            input_fp8,
-            weight_fp8.t(),
-            scale_a=input_scale,
-            scale_b=weight_scale,
-            bias=None,
-            out_dtype=input_dtype,
-        )
+        input_dtype = input.dtype
 
-    # Remove padding from output if needed
-    if n_pad != 0:
-        output = output[..., :n]
+    # Use TensorRT-LLM FP8 per-tensor quantization unless input is already FP8.
+    assert input_scale is not None
+    if input.dtype == torch.float8_e4m3fn:
+        input_fp8 = input
+    else:
+        input_fp8, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(input, input_scale)
+    output = _trtllm_fp8_prequant_linear_core(
+        input_fp8, weight_fp8, input_scale, weight_scale, input_dtype
+    )
 
     if bias is not None:
         output = output + bias
-    return output.reshape(*input_shape[:-1], n)
+    return output
 
 
 @trtllm_quant_fp8_linear.register_fake
@@ -163,8 +192,62 @@ def trtllm_quant_fp8_linear_fake(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
+    out_dtype: Optional[str] = None,
 ) -> torch.Tensor:
-    return torch.ops.aten.linear(input, weight_fp8.to(input.dtype), bias)
+    # Match real op behavior: FP8 input requires explicit output dtype.
+    if input.dtype == torch.float8_e4m3fn:
+        if out_dtype is not None:
+            linear_out_dtype = _resolve_out_dtype_or_raise(out_dtype)
+        elif bias is not None and bias.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            linear_out_dtype = bias.dtype
+        else:
+            raise RuntimeError(
+                "trtllm_quant_fp8_linear_fake with FP8 input requires either out_dtype or bias "
+                "to determine output dtype."
+            )
+    else:
+        linear_out_dtype = input.dtype
+    return torch.ops.aten.linear(input.to(linear_out_dtype), weight_fp8.to(linear_out_dtype), bias)
+
+
+@torch.library.custom_op("auto_deploy::trtllm_fp8_prequant_linear", mutates_args=())
+def trtllm_fp8_prequant_linear(
+    input_fp8: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    input_scale: Optional[torch.Tensor] = None,
+    weight_scale: Optional[torch.Tensor] = None,
+    out_dtype: str = "bfloat16",
+) -> torch.Tensor:
+    """FP8 linear op for already-quantized activations."""
+    assert input_fp8.dtype == torch.float8_e4m3fn
+    assert input_scale is not None
+
+    output_dtype = _resolve_out_dtype_or_raise(out_dtype)
+    output = _trtllm_fp8_prequant_linear_core(
+        input_fp8, weight_fp8, input_scale, weight_scale, output_dtype
+    )
+    if bias is not None:
+        output = output + bias
+    return output
+
+
+@trtllm_fp8_prequant_linear.register_fake
+def trtllm_fp8_prequant_linear_fake(
+    input_fp8: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    input_scale: Optional[torch.Tensor] = None,
+    weight_scale: Optional[torch.Tensor] = None,
+    out_dtype: str = "bfloat16",
+) -> torch.Tensor:
+    assert input_scale is not None
+    output_dtype = _resolve_out_dtype_or_raise(out_dtype)
+    if bias is not None:
+        output_dtype = torch.promote_types(output_dtype, bias.dtype)
+    n = weight_fp8.shape[0]
+    out_shape = (*input_fp8.shape[:-1], n)
+    return torch.empty(out_shape, dtype=output_dtype, device=input_fp8.device)
 
 
 @torch.library.custom_op("auto_deploy::torch_quant_fp8_linear", mutates_args=())

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_quant_fp8.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_quant_fp8.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformation for fusing RMSNorm + FP8 quantization."""
+
+import operator
+from typing import List, Optional, Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...custom_ops.normalization.flashinfer_fused_add_rms_norm import flashinfer_fused_add_rms_norm
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import eliminate_dead_code
+from ...utils.node_utils import (
+    collect_terminal_users_through_passthrough,
+    extract_op_args,
+    extract_output_tuple,
+    is_op,
+    is_trivial_passthrough_user,
+)
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _is_supported_fp8_linear(node: Node) -> bool:
+    return is_op(node, torch.ops.auto_deploy.trtllm_quant_fp8_linear) or is_op(
+        node, torch.ops.auto_deploy.torch_quant_fp8_linear
+    )
+
+
+def _extract_fp8_linear_args(node: Node):
+    return extract_op_args(node, "input", "weight_fp8", "bias", "input_scale", "weight_scale")
+
+
+def _same_scale_node(lhs: Node, rhs: Node) -> bool:
+    if lhs is rhs:
+        return True
+    return lhs.op == "get_attr" and rhs.op == "get_attr" and lhs.target == rhs.target
+
+
+def _collect_grouped_fp8_linear_users(
+    source_node: Node,
+    seed_user: Node,
+    seed_scale: Node,
+    processed_users: set[int],
+) -> List[Node]:
+    terminal_users, traversal_ok = collect_terminal_users_through_passthrough(source_node)
+    if not traversal_ok:
+        return []
+
+    grouped_users: List[Node] = []
+    for user in terminal_users:
+        if not _is_supported_fp8_linear(user) or id(user) in processed_users:
+            continue
+
+        input_arg, _, _, input_scale, _ = _extract_fp8_linear_args(user)
+        if not isinstance(input_arg, Node) or not isinstance(input_scale, Node):
+            continue
+
+        user_source, _ = _unwrap_post_norm_nodes(input_arg)
+        if user_source is not source_node:
+            continue
+        if not _same_scale_node(seed_scale, input_scale):
+            continue
+
+        grouped_users.append(user)
+
+    if seed_user not in grouped_users:
+        grouped_users.append(seed_user)
+
+    return grouped_users
+
+
+def _is_view_like(node: Node) -> bool:
+    return is_op(node, torch.ops.aten.view.default) or is_op(node, torch.ops.aten.reshape.default)
+
+
+def _unwrap_post_norm_nodes(node: Node) -> Tuple[Node, list[Node]]:
+    current = node
+    post_nodes: list[Node] = []
+    while isinstance(current, Node) and _is_view_like(current):
+        post_nodes.append(current)
+        current = current.args[0]
+    return current, post_nodes
+
+
+def _reapply_post_norm_nodes(graph, current: Node, post_nodes: list[Node]) -> Node:
+    for post_node in reversed(post_nodes):
+        current = graph.call_function(
+            post_node.target,
+            args=(current, *post_node.args[1:]),
+            kwargs=post_node.kwargs,
+        )
+        current.meta.update(post_node.meta)
+    return current
+
+
+def _extract_dtype_from_meta(node: Node) -> Optional[torch.dtype]:
+    val = node.meta.get("val")
+    if hasattr(val, "dtype"):
+        return val.dtype
+
+    tensor_meta = node.meta.get("tensor_meta")
+    if hasattr(tensor_meta, "dtype"):
+        return tensor_meta.dtype
+
+    return None
+
+
+def _get_out_dtype_str(norm_node: Node) -> Optional[str]:
+    dtype = _extract_dtype_from_meta(norm_node)
+    if dtype is None:
+        return None
+    if dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(
+            f"{norm_node.format_node()} has unsupported dtype {dtype}; "
+            "expected float16/bfloat16/float32."
+        )
+    return str(dtype).replace("torch.", "")
+
+
+def _get_norm_source_info(
+    node: Node,
+) -> Tuple[bool, str, Tuple, Optional[Node], Optional[Node], Optional[Node], Optional[Node]]:
+    if is_op(node, torch.ops.auto_deploy.flashinfer_rms_norm):
+        return True, "direct", node.args, None, None, None, None
+
+    if is_op(node, torch.ops.auto_deploy.torch_rmsnorm):
+        norm_input = node.args[0]
+        pre_norm_node = norm_input if isinstance(norm_input, Node) else None
+        if isinstance(norm_input, Node) and is_op(norm_input, torch.ops.aten.to.dtype):
+            norm_input = norm_input.args[0]
+
+        if isinstance(norm_input, Node) and is_op(norm_input, torch.ops.aten.add.Tensor):
+            add_lhs, add_rhs = norm_input.args
+            return (
+                True,
+                "raw_add",
+                (add_lhs, add_rhs, node.args[1], node.args[2]),
+                None,
+                norm_input,
+                pre_norm_node,
+                None,
+            )
+
+        return (
+            True,
+            "direct",
+            (node.args[0], node.args[1], node.args[2]),
+            None,
+            None,
+            pre_norm_node,
+            None,
+        )
+
+    if node.op == "call_function" and node.target == operator.getitem:
+        source_node = node.args[0]
+        idx = node.args[1]
+        if idx == 0 and isinstance(source_node, Node):
+            if (
+                source_node.op == "call_function"
+                and source_node.target is flashinfer_fused_add_rms_norm
+            ):
+                add_rhs, add_lhs, weight, eps = source_node.args
+                _, add_out_node = extract_output_tuple(source_node, count=2)
+                return (
+                    True,
+                    "fused",
+                    (add_lhs, add_rhs, weight, eps),
+                    source_node,
+                    add_out_node,
+                    None,
+                    None,
+                )
+
+    return False, "", (), None, None, None, None
+
+
+@TransformRegistry.register("fuse_rmsnorm_quant_fp8")
+class FuseRMSNormQuantFP8(BaseTransform):
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        cnt = 0
+        processed_fused_nodes = set()
+        processed_fp8_users: set[int] = set()
+        original_nodes = list(graph.nodes)
+        node_order = {n: i for i, n in enumerate(original_nodes)}
+
+        for node in original_nodes:
+            if not _is_supported_fp8_linear(node) or id(node) in processed_fp8_users:
+                continue
+
+            input_arg, _, _, input_scale, _ = _extract_fp8_linear_args(node)
+            if not isinstance(input_arg, Node) or not isinstance(input_scale, Node):
+                continue
+
+            norm_node, _ = _unwrap_post_norm_nodes(input_arg)
+            (
+                is_norm,
+                source_type,
+                norm_info,
+                fused_node,
+                add_out_node,
+                pre_norm_node,
+                _unused_norm_source,
+            ) = _get_norm_source_info(norm_node)
+            if not is_norm:
+                continue
+            if fused_node is not None and id(fused_node) in processed_fused_nodes:
+                continue
+
+            fp8_linear_users = _collect_grouped_fp8_linear_users(
+                norm_node, node, input_scale, processed_fp8_users
+            )
+            if not fp8_linear_users:
+                continue
+
+            out_dtype_str = _get_out_dtype_str(norm_node)
+            if out_dtype_str is None:
+                continue
+            earliest_fp8_user = min(fp8_linear_users, key=lambda n: node_order.get(n, float("inf")))
+            earliest_fp8_user_idx = node_order.get(earliest_fp8_user)
+            if earliest_fp8_user_idx is None:
+                continue
+            _, _, _, earliest_scale, _ = _extract_fp8_linear_args(earliest_fp8_user)
+
+            fp8_user_set = set(fp8_linear_users)
+            has_other_consumer_before_fp8 = any(
+                u not in fp8_user_set
+                and not is_trivial_passthrough_user(u)
+                and node_order.get(u, float("inf")) < earliest_fp8_user_idx
+                for u in norm_node.users
+            )
+            if has_other_consumer_before_fp8:
+                continue
+
+            if source_type == "direct":
+                norm_args = norm_info
+                with graph.inserting_before(earliest_fp8_user):
+                    fused_quant_node = graph.call_function(
+                        torch.ops.auto_deploy.triton_rms_norm_quant_fp8.default,
+                        args=(*norm_args, earliest_scale),
+                    )
+                    bf16_node = graph.call_function(operator.getitem, args=(fused_quant_node, 0))
+                    fp8_node = graph.call_function(operator.getitem, args=(fused_quant_node, 1))
+
+                remaining_users = list(norm_node.users.keys())
+                users_to_rewire = [
+                    u
+                    for u in remaining_users
+                    if node_order.get(u, float("inf")) >= earliest_fp8_user_idx
+                ]
+                for user in users_to_rewire:
+                    user.replace_input_with(norm_node, bf16_node)
+                if len(norm_node.users) == 0:
+                    graph.erase_node(norm_node)
+            else:
+                add_lhs, add_rhs, weight, eps = norm_info
+                if fused_node is not None:
+                    processed_fused_nodes.add(id(fused_node))
+
+                with graph.inserting_before(earliest_fp8_user):
+                    fused_all_node = graph.call_function(
+                        torch.ops.auto_deploy.triton_fused_add_rms_norm_quant_fp8.default,
+                        args=(add_rhs, add_lhs, weight, eps, earliest_scale),
+                    )
+                    bf16_node = graph.call_function(operator.getitem, args=(fused_all_node, 0))
+                    fp8_node = graph.call_function(operator.getitem, args=(fused_all_node, 1))
+                    add_node = graph.call_function(operator.getitem, args=(fused_all_node, 2))
+
+                remaining_users = list(norm_node.users.keys())
+                users_to_rewire = [
+                    u
+                    for u in remaining_users
+                    if node_order.get(u, float("inf")) >= earliest_fp8_user_idx
+                ]
+                for user in users_to_rewire:
+                    user.replace_input_with(norm_node, bf16_node)
+
+                if add_out_node is not None:
+                    add_out_users = list(add_out_node.users.keys())
+                    add_users_to_rewire = [
+                        u
+                        for u in add_out_users
+                        if node_order.get(u, float("inf")) >= earliest_fp8_user_idx
+                    ]
+                    for user in add_users_to_rewire:
+                        user.replace_input_with(add_out_node, add_node)
+
+                if len(norm_node.users) == 0:
+                    graph.erase_node(norm_node)
+                if add_out_node is not None and len(add_out_node.users) == 0:
+                    graph.erase_node(add_out_node)
+                if fused_node is not None and len(fused_node.users) == 0:
+                    graph.erase_node(fused_node)
+
+            if (
+                pre_norm_node is not None
+                and pre_norm_node is not add_out_node
+                and len(pre_norm_node.users) == 0
+            ):
+                graph.erase_node(pre_norm_node)
+
+            for fp8_user in fp8_linear_users:
+                input_arg, weight_arg, bias_arg, in_scale, w_scale = _extract_fp8_linear_args(
+                    fp8_user
+                )
+                with graph.inserting_before(fp8_user):
+                    fp8_input = fp8_node
+                    if isinstance(input_arg, Node):
+                        source_arg, post_nodes = _unwrap_post_norm_nodes(input_arg)
+                        if source_arg is norm_node:
+                            fp8_input = _reapply_post_norm_nodes(graph, fp8_node, post_nodes)
+                    gemm_node = graph.call_function(
+                        torch.ops.auto_deploy.trtllm_fp8_prequant_linear.default,
+                        args=(fp8_input, weight_arg, bias_arg),
+                        kwargs={
+                            "input_scale": in_scale,
+                            "weight_scale": w_scale,
+                            "out_dtype": out_dtype_str,
+                        },
+                    )
+                    fp8_user.replace_all_uses_with(gemm_node)
+                graph.erase_node(fp8_user)
+                processed_fp8_users.add(id(fp8_user))
+                cnt += 1
+
+        if cnt > 0:
+            eliminate_dead_code(gm)
+        gm.recompile()
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_quant_fp8.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_quant_fp8.py
@@ -245,6 +245,15 @@ class FuseRMSNormQuantFP8(BaseTransform):
             )
             if not fp8_linear_users:
                 continue
+            # Safety: only fuse when all terminal consumers on the norm data path
+            # are FP8 linears in this group. Mixed-consumer patterns can otherwise
+            # split one logical norm into mismatched producer paths.
+            terminal_users, traversal_ok = collect_terminal_users_through_passthrough(norm_node)
+            if not traversal_ok:
+                continue
+            fp8_user_set = set(fp8_linear_users)
+            if any(user not in fp8_user_set for user in terminal_users):
+                continue
 
             out_dtype_str = _get_out_dtype_str(norm_node)
             if out_dtype_str is None:
@@ -255,7 +264,6 @@ class FuseRMSNormQuantFP8(BaseTransform):
                 continue
             _, _, _, earliest_scale, _ = _extract_fp8_linear_args(earliest_fp8_user)
 
-            fp8_user_set = set(fp8_linear_users)
             has_other_consumer_before_fp8 = any(
                 u not in fp8_user_set
                 and not is_trivial_passthrough_user(u)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_trtllm_attention_quant_fp8.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_trtllm_attention_quant_fp8.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare TRTLLM attention output FP8 quantization for downstream FP8 linears.
+
+This transform runs in the pattern_matcher stage and precomputes graph wiring required by
+the TRTLLM attention backend when all terminal consumers are FP8 linear ops that share
+the same input scale.
+"""
+
+from typing import Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...custom_ops.attention_interface import (
+    clear_trtllm_attention_fp8_input_scale,
+    set_trtllm_attention_fp8_input_scale,
+)
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import (
+    collect_terminal_users_through_passthrough,
+    get_shared_input_scale_for_fp8_linears,
+    is_op,
+    set_op_args,
+)
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _get_out_dtype_str(attn_node: Node) -> str:
+    val = attn_node.meta.get("val")
+    if val is None:
+        raise ValueError(
+            f"{attn_node.format_node()} missing meta['val']; cannot determine out_dtype."
+        )
+    if not hasattr(val, "dtype"):
+        raise ValueError(
+            f"{attn_node.format_node()} meta['val'] has no dtype; cannot determine out_dtype."
+        )
+    if val.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(
+            f"{attn_node.format_node()} has unsupported dtype {val.dtype}; "
+            "expected float16/bfloat16/float32."
+        )
+    return str(val.dtype).replace("torch.", "")
+
+
+@TransformRegistry.register("fuse_trtllm_attn_quant_fp8")
+class FuseTrtllmAttentionQuantFP8(BaseTransform):
+    """Prepare attention->FP8 linear path so TRTLLM attention can emit FP8 directly."""
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        cnt = 0
+
+        for attn_node in list(gm.graph.nodes):
+            if not is_op(attn_node, torch.ops.auto_deploy.torch_attention.default):
+                continue
+
+            terminal_users, traversal_ok = collect_terminal_users_through_passthrough(
+                attn_node, max_traversal_nodes=256
+            )
+            fp8_users, first_scale = get_shared_input_scale_for_fp8_linears(terminal_users)
+            if not (traversal_ok and fp8_users and len(fp8_users) == len(terminal_users)):
+                clear_trtllm_attention_fp8_input_scale(attn_node)
+                continue
+
+            out_dtype_str = _get_out_dtype_str(attn_node)
+            for user in fp8_users:
+                set_op_args(user, out_dtype=out_dtype_str)
+
+            if first_scale is not None:
+                if first_scale.op == "get_attr":
+                    attn_node.prepend(first_scale)
+                set_trtllm_attention_fp8_input_scale(attn_node, first_scale)
+                cnt += 1
+
+        if cnt > 0:
+            gm.recompile()
+
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_trtllm_attention_quant_fp8.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_trtllm_attention_quant_fp8.py
@@ -25,7 +25,7 @@ from typing import Tuple, Type
 import torch
 from torch.fx import GraphModule, Node
 
-from ...custom_ops.attention_interface import (
+from ...custom_ops.attention.trtllm_attention import (
     clear_trtllm_attention_fp8_input_scale,
     set_trtllm_attention_fp8_input_scale,
 )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_add_rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_add_rms_norm.py
@@ -111,6 +111,9 @@ class FuseAddRMSNorm(BaseTransform):
                 )
                 norm_out = graph.call_function(operator.getitem, args=(fused_node, 0))
                 add_out = graph.call_function(operator.getitem, args=(fused_node, 1))
+                # Preserve metadata needed by downstream transforms.
+                norm_out.meta.update(norm_node.meta)
+                add_out.meta.update(add_node.meta)
 
             # Rewire all consumers of the original norm → norm_out
             norm_node.replace_all_uses_with(norm_out)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -30,6 +30,7 @@ from ...custom_ops.attention_interface import (
     AttentionRegistry,
     Constant,
     PrepareMetadataCallable,
+    get_trtllm_attention_fp8_input_scale,
 )
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
@@ -205,7 +206,17 @@ class _InsertCachedOperator(BaseTransform):
                 cache_in_nodes.append(self._process_cache_node(gm, k_indexed))
 
             # retrieve constants for attention_op
+            out_scale = None
+            if self.config.backend == "trtllm":
+                input_scale = get_trtllm_attention_fp8_input_scale(attn_node)
+                if input_scale is not None:
+                    with gm.graph.inserting_before(attn_node):
+                        out_scale = gm.graph.call_function(
+                            torch.ops.aten.reciprocal.default, args=(input_scale,)
+                        )
             constants = attn_descriptor.get_constants(attn_node)
+            if self.config.backend == "trtllm":
+                constants[-1] = out_scale
 
             # insert cached attention replacement op
             self._insert_cached_attn_node(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -30,7 +30,6 @@ from ...custom_ops.attention_interface import (
     AttentionRegistry,
     Constant,
     PrepareMetadataCallable,
-    get_trtllm_attention_fp8_input_scale,
 )
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
@@ -205,18 +204,11 @@ class _InsertCachedOperator(BaseTransform):
                 cm.add_resource(k_indexed, resource_handler)
                 cache_in_nodes.append(self._process_cache_node(gm, k_indexed))
 
+            # allow backend-specific prep before constants are extracted
+            attn_descriptor.prepare_node_for_cache_insertion(gm, attn_node)
+
             # retrieve constants for attention_op
-            out_scale = None
-            if self.config.backend == "trtllm":
-                input_scale = get_trtllm_attention_fp8_input_scale(attn_node)
-                if input_scale is not None:
-                    with gm.graph.inserting_before(attn_node):
-                        out_scale = gm.graph.call_function(
-                            torch.ops.aten.reciprocal.default, args=(input_scale,)
-                        )
             constants = attn_descriptor.get_constants(attn_node)
-            if self.config.backend == "trtllm":
-                constants[-1] = out_scale
 
             # insert cached attention replacement op
             self._insert_cached_attn_node(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
@@ -364,6 +364,8 @@ class FuseRMSNorm(BaseTransform):
                         args=node.args,
                         kwargs=node.kwargs,
                     )
+                    # Preserve metadata (including val/tensor_meta) for downstream transforms.
+                    new_node.meta.update(node.meta)
                     node.replace_all_uses_with(new_node)
                     graph.erase_node(node)
                     cnt += 1
@@ -378,6 +380,7 @@ class FuseRMSNorm(BaseTransform):
                         args=node.args,
                         kwargs=node.kwargs,
                     )
+                    new_node.meta.update(node.meta)
                     node.replace_all_uses_with(new_node)
                     graph.erase_node(node)
                     cnt += 1

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -472,6 +472,106 @@ def is_op(node: Node, ops: Union[OperatorLike, Iterable[OperatorLike]]) -> bool:
     return is_match
 
 
+def is_trivial_passthrough_user(node: Node) -> bool:
+    """Check whether a node is a trivial layout/index passthrough op."""
+    if node.op == "call_method":
+        return node.target in {
+            "view",
+            "reshape",
+            "transpose",
+            "permute",
+            "contiguous",
+            "__getitem__",
+        }
+    if node.op == "call_function":
+        if node.target is operator.getitem:
+            return True
+        return (
+            is_op(node, torch.ops.aten.view)
+            or is_op(node, torch.ops.aten.reshape)
+            or is_op(node, torch.ops.aten.transpose)
+            or is_op(node, torch.ops.aten.permute)
+            or is_op(node, torch.ops.aten.contiguous)
+        )
+    return False
+
+
+def collect_terminal_users_through_passthrough(
+    source_node: Node,
+    *,
+    max_traversal_nodes: int = 256,
+) -> Tuple[List[Node], bool]:
+    """Collect terminal users while traversing trivial passthrough users.
+
+    Only follows passthrough nodes whose primary data argument (args[0])
+    comes from the source data path.  This prevents the traversal from
+    leaking into unrelated graph regions when the source node is referenced
+    as a non-data argument (e.g. shape) of a passthrough op.
+
+    Returns:
+        (terminal_users, traversal_ok)
+    """
+    terminal_users: List[Node] = []
+    data_nodes = {source_node}
+    stack = list(source_node.users)
+    seen = set()
+    while stack:
+        user = stack.pop()
+        if user in seen:
+            continue
+        seen.add(user)
+        if len(seen) > max_traversal_nodes:
+            return [], False
+        if is_trivial_passthrough_user(user):
+            if user.args and isinstance(user.args[0], Node) and user.args[0] in data_nodes:
+                data_nodes.add(user)
+                stack.extend(list(user.users))
+                continue
+        terminal_users.append(user)
+    return terminal_users, True
+
+
+def get_shared_input_scale_for_fp8_linears(
+    nodes: Iterable[Node],
+) -> Tuple[List[Node], Optional[Node]]:
+    """Return FP8 linear nodes and their shared input_scale if one exists."""
+    supported_fp8_linear_ops = (
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear,
+        torch.ops.auto_deploy.torch_quant_fp8_linear,
+    )
+    fp8_linear_nodes: List[Node] = [
+        node for node in nodes if any(is_op(node, op) for op in supported_fp8_linear_ops)
+    ]
+    if not fp8_linear_nodes:
+        return [], None
+
+    first_scale = extract_op_args(
+        fp8_linear_nodes[0], "input", "weight_fp8", "bias", "input_scale", "weight_scale"
+    )[3]
+    if not isinstance(first_scale, Node):
+        return [], None
+
+    for node in fp8_linear_nodes[1:]:
+        scale = extract_op_args(node, "input", "weight_fp8", "bias", "input_scale", "weight_scale")[
+            3
+        ]
+        if not isinstance(scale, Node):
+            return [], None
+        if scale is first_scale:
+            continue
+
+        # Allow equivalent scale nodes only when both are stable get_attr reads
+        # of the same module attribute.
+        if not (
+            first_scale.op == "get_attr"
+            and scale.op == "get_attr"
+            and scale.target == first_scale.target
+        ):
+            return [], None
+
+    return fp8_linear_nodes, first_scale
+
+
 def filtered_nodes(
     nodes: Iterable[Node],
     target: Union[Callable[[Node], bool], Union[OperatorLike, Iterable[OperatorLike]]] = None,

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -620,6 +620,38 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
+class TestLlama3_1_8BInstructFP8HFCheckpoint(LlmapiAccuracyTestHarness):
+    """Accuracy regression test for the direct HF FP8 Llama 3.1 checkpoint via AutoDeploy."""
+
+    MODEL_NAME = "nvidia/Llama-3.1-8B-Instruct-FP8"
+    CONFIG_YAML = str(_AD_CONFIGS_DIR / "llama3_1_8b.yaml")
+
+    def get_default_sampling_params(self):
+        eos_id = -1
+        beam_width = 1
+        return SamplingParams(end_id=eos_id,
+                              pad_id=eos_id,
+                              n=beam_width,
+                              use_beam_search=beam_width > 1)
+
+    @pytest.mark.skip_less_device_memory(32000)
+    @pytest.mark.parametrize("attn_backend", ["flashinfer", "trtllm"])
+    def test_accuracy(self, attn_backend):
+        with AutoDeployLLM(model=self.MODEL_NAME,
+                           tokenizer=self.MODEL_NAME,
+                           yaml_extra=[self.CONFIG_YAML],
+                           trust_remote_code=True,
+                           attn_backend=attn_backend) as llm:
+            llm.args.quant_config.quant_algo = QuantAlgo.FP8
+            llm.args.quant_config.kv_cache_quant_algo = QuantAlgo.FP8
+
+            sampling_params = self.get_default_sampling_params()
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm, sampling_params=sampling_params)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+
 class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
     """Accuracy regression tests for Qwen3.5-397B-A17B via AutoDeploy.
 

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -620,38 +620,6 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
-class TestLlama3_1_8BInstructFP8HFCheckpoint(LlmapiAccuracyTestHarness):
-    """Accuracy regression test for the direct HF FP8 Llama 3.1 checkpoint via AutoDeploy."""
-
-    MODEL_NAME = "nvidia/Llama-3.1-8B-Instruct-FP8"
-    CONFIG_YAML = str(_AD_CONFIGS_DIR / "llama3_1_8b.yaml")
-
-    def get_default_sampling_params(self):
-        eos_id = -1
-        beam_width = 1
-        return SamplingParams(end_id=eos_id,
-                              pad_id=eos_id,
-                              n=beam_width,
-                              use_beam_search=beam_width > 1)
-
-    @pytest.mark.skip_less_device_memory(32000)
-    @pytest.mark.parametrize("attn_backend", ["flashinfer", "trtllm"])
-    def test_accuracy(self, attn_backend):
-        with AutoDeployLLM(model=self.MODEL_NAME,
-                           tokenizer=self.MODEL_NAME,
-                           yaml_extra=[self.CONFIG_YAML],
-                           trust_remote_code=True,
-                           attn_backend=attn_backend) as llm:
-            llm.args.quant_config.quant_algo = QuantAlgo.FP8
-            llm.args.quant_config.kv_cache_quant_algo = QuantAlgo.FP8
-
-            sampling_params = self.get_default_sampling_params()
-            task = MMLU(self.MODEL_NAME)
-            task.evaluate(llm, sampling_params=sampling_params)
-            task = GSM8K(self.MODEL_NAME)
-            task.evaluate(llm)
-
-
 class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
     """Accuracy regression tests for Qwen3.5-397B-A17B via AutoDeploy.
 

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_rmsnorm.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_rmsnorm.py
@@ -107,3 +107,30 @@ def test_rmsnorm_fusion_nemotron_h():
     # Only the triton backend supports the nemotron h rmsnorm
     model = TestModel(eps=1e-6, use_nemotron_h=True)
     _run_test(model, torch.ops.auto_deploy.triton_rms_norm, variant="triton")
+
+
+def test_fuse_rmsnorm_preserves_node_metadata():
+    model = TestModel(eps=1e-6)
+    x = torch.randn(2, 1024, device="cuda", dtype=torch.float16)
+    dynamic_shapes = {0: Dim.DYNAMIC}
+    gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
+
+    gm_transformed = InferenceOptimizer(
+        None,
+        {
+            "match_rmsnorm_pattern": {
+                "stage": "pattern_matcher",
+            },
+            "fuse_rmsnorm": {
+                "stage": "post_load_fusion",
+                "gated_rmsnorm_backend": "triton",
+                "rmsnorm_backend": "flashinfer",
+            },
+        },
+    )(None, gm)
+
+    rms_nodes = [
+        n for n in gm_transformed.graph.nodes if is_op(n, torch.ops.auto_deploy.flashinfer_rms_norm)
+    ]
+    assert len(rms_nodes) >= 1
+    assert all("val" in n.meta and hasattr(n.meta["val"], "dtype") for n in rms_nodes)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
@@ -1,0 +1,315 @@
+import pytest
+import torch
+import torch.nn as nn
+from _torch_test_utils import fp8_compatible
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+    get_trtllm_attention_fp8_input_scale,
+)
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+
+def _build_fp8_linear_args(hidden_size: int, out_features: int, device: torch.device):
+    weight_fp8 = torch.randn(out_features, hidden_size, device=device, dtype=torch.float16).to(
+        torch.float8_e4m3fn
+    )
+    weight_scale = torch.tensor(1.0, device=device, dtype=torch.float32)
+    return weight_fp8, weight_scale
+
+
+class AttentionMixedConsumers(nn.Module):
+    def __init__(self, hidden_size: int = 16, num_heads: int = 2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.out_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+        device = torch.device("cuda")
+        w_fp8, w_scale = _build_fp8_linear_args(hidden_size, hidden_size, device)
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale", w_scale)
+        self.register_buffer("input_scale", torch.tensor(2.0, device=device, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor):
+        b, s, _ = x.shape
+        q = self.q_proj(x).view(b, s, self.num_heads, self.head_dim)
+        k = self.k_proj(x).view(b, s, self.num_heads, self.head_dim)
+        v = self.v_proj(x).view(b, s, self.num_heads, self.head_dim)
+        attn = torch.ops.auto_deploy.torch_attention.default(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=None,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        attn_flat = attn.reshape(b, s, self.hidden_size)
+        fp8_out = torch.ops.auto_deploy.trtllm_quant_fp8_linear.default(
+            attn_flat, self.weight_fp8, None, self.input_scale, self.weight_scale
+        )
+        non_fp8 = self.out_proj(attn_flat)
+        return fp8_out + non_fp8
+
+
+class AttentionDifferentScales(nn.Module):
+    def __init__(self, hidden_size: int = 16, num_heads: int = 2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+        device = torch.device("cuda")
+        w1_fp8, w1_scale = _build_fp8_linear_args(hidden_size, hidden_size, device)
+        w2_fp8, w2_scale = _build_fp8_linear_args(hidden_size, hidden_size, device)
+        self.register_buffer("weight1_fp8", w1_fp8)
+        self.register_buffer("weight1_scale", w1_scale)
+        self.register_buffer("weight2_fp8", w2_fp8)
+        self.register_buffer("weight2_scale", w2_scale)
+        self.register_buffer("input_scale_a", torch.tensor(2.0, device=device, dtype=torch.float32))
+        self.register_buffer("input_scale_b", torch.tensor(3.0, device=device, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor):
+        b, s, _ = x.shape
+        q = self.q_proj(x).view(b, s, self.num_heads, self.head_dim)
+        k = self.k_proj(x).view(b, s, self.num_heads, self.head_dim)
+        v = self.v_proj(x).view(b, s, self.num_heads, self.head_dim)
+        attn = torch.ops.auto_deploy.torch_attention.default(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=None,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        attn_flat = attn.reshape(b, s, self.hidden_size)
+        out_a = torch.ops.auto_deploy.trtllm_quant_fp8_linear.default(
+            attn_flat, self.weight1_fp8, None, self.input_scale_a, self.weight1_scale
+        )
+        out_b = torch.ops.auto_deploy.trtllm_quant_fp8_linear.default(
+            attn_flat, self.weight2_fp8, None, self.input_scale_b, self.weight2_scale
+        )
+        return out_a + out_b
+
+
+class AttentionSharedScales(nn.Module):
+    def __init__(self, hidden_size: int = 16, num_heads: int = 2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+        device = torch.device("cuda")
+        w1_fp8, w1_scale = _build_fp8_linear_args(hidden_size, hidden_size, device)
+        w2_fp8, w2_scale = _build_fp8_linear_args(hidden_size, hidden_size, device)
+        self.register_buffer("weight1_fp8", w1_fp8)
+        self.register_buffer("weight1_scale", w1_scale)
+        self.register_buffer("weight2_fp8", w2_fp8)
+        self.register_buffer("weight2_scale", w2_scale)
+        self.register_buffer("input_scale", torch.tensor(2.0, device=device, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor):
+        b, s, _ = x.shape
+        q = self.q_proj(x).view(b, s, self.num_heads, self.head_dim)
+        k = self.k_proj(x).view(b, s, self.num_heads, self.head_dim)
+        v = self.v_proj(x).view(b, s, self.num_heads, self.head_dim)
+        attn = torch.ops.auto_deploy.torch_attention.default(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=None,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        attn_flat = attn.reshape(b, s, self.hidden_size)
+        out_a = torch.ops.auto_deploy.trtllm_quant_fp8_linear.default(
+            attn_flat, self.weight1_fp8, None, self.input_scale, self.weight1_scale
+        )
+        out_b = torch.ops.auto_deploy.trtllm_quant_fp8_linear.default(
+            attn_flat, self.weight2_fp8, None, self.input_scale, self.weight2_scale
+        )
+        return out_a + out_b
+
+
+def _find_nodes(gm, op):
+    return [node for node in gm.graph.nodes if is_op(node, op)]
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+@pytest.mark.parametrize(
+    "model_cls",
+    [AttentionMixedConsumers, AttentionDifferentScales],
+    ids=["mixed_consumers", "different_scales"],
+)
+def test_fuse_trtllm_attention_quant_fp8_negative_no_contract_no_out_dtype(model_cls):
+    model = model_cls().to("cuda").eval()
+    x = torch.randn(2, 4, model.hidden_size, device="cuda", dtype=torch.float16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    gm = InferenceOptimizer(
+        None,
+        {
+            "fuse_trtllm_attn_quant_fp8": {
+                "stage": "pattern_matcher",
+                "enabled": True,
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = _find_nodes(gm, torch.ops.auto_deploy.torch_attention.default)
+    assert len(attn_nodes) == 1
+    assert get_trtllm_attention_fp8_input_scale(attn_nodes[0]) is None
+
+    fp8_linear_nodes = _find_nodes(gm, torch.ops.auto_deploy.trtllm_quant_fp8_linear.default)
+    assert len(fp8_linear_nodes) >= 1
+    assert all(node.kwargs.get("out_dtype", None) is None for node in fp8_linear_nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+def test_fuse_trtllm_attention_quant_fp8_sets_input_scale_contract_only():
+    model = AttentionSharedScales().to("cuda").eval()
+    x = torch.randn(2, 4, model.hidden_size, device="cuda", dtype=torch.float16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    # Start from graph where attention has FP8 input-scale contract.
+    gm = InferenceOptimizer(
+        None,
+        {
+            "fuse_trtllm_attn_quant_fp8": {
+                "stage": "pattern_matcher",
+                "enabled": True,
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = _find_nodes(gm, torch.ops.auto_deploy.torch_attention.default)
+    assert len(attn_nodes) == 1
+    input_scale_contract = get_trtllm_attention_fp8_input_scale(attn_nodes[0])
+    assert input_scale_contract is not None
+    assert len(_find_nodes(gm, torch.ops.aten.reciprocal.default)) == 0
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+def test_insert_cached_attention_trtllm_materializes_out_scale_reciprocal():
+    model = AttentionSharedScales().to("cuda").eval()
+    x = torch.randn(2, 4, model.hidden_size, device="cuda", dtype=torch.float16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    gm = InferenceOptimizer(
+        None,
+        {
+            "fuse_trtllm_attn_quant_fp8": {
+                "stage": "pattern_matcher",
+                "enabled": True,
+            },
+        },
+    )(None, gm)
+    attn_nodes = _find_nodes(gm, torch.ops.auto_deploy.torch_attention.default)
+    assert len(attn_nodes) == 1
+
+    reciprocal_nodes_before = _find_nodes(gm, torch.ops.aten.reciprocal.default)
+    assert len(reciprocal_nodes_before) == 0
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=32,
+        max_tokens=128,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=64,
+        max_batch_size=4,
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    gm = InferenceOptimizer(
+        None,
+        {
+            "insert_cached_attention": {
+                "stage": "cache_init",
+                "backend": "trtllm",
+            },
+        },
+    )(cm, gm)
+
+    reciprocal_nodes = _find_nodes(gm, torch.ops.aten.reciprocal.default)
+    assert len(reciprocal_nodes) == 1
+
+    cached_nodes = _find_nodes(gm, torch.ops.auto_deploy.trtllm_attention_mha_with_cache.default)
+    assert len(cached_nodes) == 1
+
+    out_scale_arg = cached_nodes[0].args[-1]
+    assert isinstance(out_scale_arg, torch.fx.Node)
+    assert is_op(out_scale_arg, torch.ops.aten.reciprocal.default)
+    assert out_scale_arg is reciprocal_nodes[0]
+    graph_nodes = list(gm.graph.nodes)
+    assert graph_nodes.index(reciprocal_nodes[0]) < graph_nodes.index(cached_nodes[0])
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support")
+def test_insert_cached_attention_trtllm_fallback_without_fp8_contract():
+    model = AttentionSharedScales().to("cuda").eval()
+    x = torch.randn(2, 4, model.hidden_size, device="cuda", dtype=torch.float16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    # No fusion transform run: input-scale contract is absent and cache-init should keep
+    # origin/main behavior (no out_scale contract, no reciprocal insertion).
+    attn_nodes = _find_nodes(gm, torch.ops.auto_deploy.torch_attention.default)
+    assert len(attn_nodes) == 1
+    assert get_trtllm_attention_fp8_input_scale(attn_nodes[0]) is None
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=32,
+        max_tokens=128,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=64,
+        max_batch_size=4,
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    gm = InferenceOptimizer(
+        None,
+        {
+            "insert_cached_attention": {
+                "stage": "cache_init",
+                "backend": "trtllm",
+            },
+        },
+    )(cm, gm)
+
+    assert len(_find_nodes(gm, torch.ops.aten.reciprocal.default)) == 0
+    cached_nodes = _find_nodes(gm, torch.ops.auto_deploy.trtllm_attention_mha_with_cache.default)
+    assert len(cached_nodes) == 1
+    assert cached_nodes[0].args[-1] is None

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
@@ -179,7 +179,7 @@ def test_fuse_trtllm_attention_quant_fp8_negative_no_contract_no_out_dtype(model
         None,
         {
             "fuse_trtllm_attn_quant_fp8": {
-                "stage": "pattern_matcher",
+                "stage": "post_load_fusion",
                 "enabled": True,
             },
         },
@@ -205,7 +205,7 @@ def test_fuse_trtllm_attention_quant_fp8_sets_input_scale_contract_only():
         None,
         {
             "fuse_trtllm_attn_quant_fp8": {
-                "stage": "pattern_matcher",
+                "stage": "post_load_fusion",
                 "enabled": True,
             },
         },
@@ -228,7 +228,7 @@ def test_insert_cached_attention_trtllm_materializes_out_scale_reciprocal():
         None,
         {
             "fuse_trtllm_attn_quant_fp8": {
-                "stage": "pattern_matcher",
+                "stage": "post_load_fusion",
                 "enabled": True,
             },
         },

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
-from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.trtllm_attention import (
     get_trtllm_attention_fp8_input_scale,
 )
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fused_add_rms_norm.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fused_add_rms_norm.py
@@ -295,3 +295,43 @@ def test_fuse_add_rms_norm_chained():
     y_ref = model(embed.clone(), attn_out.clone(), mlp_out.clone())
     torch.testing.assert_close(y_fused[0], y_ref[0], atol=1e-2, rtol=1e-2)
     torch.testing.assert_close(y_fused[1], y_ref[1], atol=1e-2, rtol=1e-2)
+
+
+def test_fuse_add_rms_norm_preserves_output_metadata():
+    """The fused getitem outputs must preserve add/norm metadata for downstream fusions."""
+    model = AddNormModel()
+    bsz, seq_len, hidden = 2, 8, 128
+    x = torch.randn(bsz, seq_len, hidden, device="cuda", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+
+    gm = _export_model(model, x, residual)
+
+    add_node = next(n for n in gm.graph.nodes if is_op(n, torch.ops.aten.add.Tensor))
+    norm_node = next(
+        n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.flashinfer_rms_norm)
+    )
+    add_meta = add_node.meta["val"]
+    norm_meta = norm_node.meta["val"]
+
+    gm_t, info = _apply_transform_direct(gm)
+
+    assert info.num_matches == 1
+    fused_getitems = [
+        n
+        for n in gm_t.graph.nodes
+        if n.op == "call_function"
+        and n.target is operator.getitem
+        and isinstance(n.args[0], torch.fx.Node)
+        and n.args[0].target is flashinfer_fused_add_rms_norm
+    ]
+    assert len(fused_getitems) == 2
+
+    norm_out = next(n for n in fused_getitems if n.args[1] == 0)
+    add_out = next(n for n in fused_getitems if n.args[1] == 1)
+
+    assert "val" in norm_out.meta
+    assert "val" in add_out.meta
+    assert norm_out.meta["val"].dtype == norm_meta.dtype
+    assert add_out.meta["val"].dtype == add_meta.dtype
+    assert tuple(norm_out.meta["val"].shape) == tuple(norm_meta.shape)
+    assert tuple(add_out.meta["val"].shape) == tuple(add_meta.shape)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quant_fusion.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quant_fusion.py
@@ -1,3 +1,5 @@
+import operator
+
 # test_quant_fusion.py
 import pytest
 import torch
@@ -6,7 +8,15 @@ from _graph_test_helpers import run_test_transformed_gm
 from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.normalization.flashinfer_fused_add_rms_norm import (  # noqa: F401
+    flashinfer_fused_add_rms_norm,
+)
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.interface import TransformConfig
+from tensorrt_llm._torch.auto_deploy.transform.library.fuse_rmsnorm_quant_fp8 import (
+    FuseRMSNormQuantFP8,
+    _get_out_dtype_str,
+)
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale, fp8_scale
@@ -289,3 +299,430 @@ def test_fuse_quant_rewrites_finegrained_fp8_linear(use_bias):
         None,  # dynamic_shapes
         True,  # skip_output_assert - skip numerical comparison for now
     )
+
+
+class TinyRMSNormQuantFP8(nn.Module):
+    """Minimal graph containing flashinfer_rms_norm -> trtllm_quant_fp8_linear."""
+
+    def __init__(self, hidden_size=128):
+        super().__init__()
+        self.eps = 1e-5
+        self.norm_weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=torch.bfloat16, device="cuda")
+        )
+        self.input_scale = nn.Buffer(torch.tensor(1.0, dtype=torch.float32, device="cuda"))
+
+        with torch.no_grad():
+            w_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+            w_bf16 = torch.randn(hidden_size, hidden_size, dtype=torch.bfloat16, device="cuda")
+            w_fp8 = (w_bf16 / w_scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale", w_scale)
+
+    def forward(self, x):
+        norm_out = torch.ops.auto_deploy.flashinfer_rms_norm(x, self.norm_weight, self.eps)
+        return torch.ops.auto_deploy.trtllm_quant_fp8_linear(
+            norm_out,
+            self.weight_fp8,
+            None,
+            input_scale=self.input_scale,
+            weight_scale=self.weight_scale,
+        )
+
+
+class TinyFusedAddRMSNormQuantFP8(nn.Module):
+    """Graph containing flashinfer_fused_add_rms_norm -> getitem[0] -> FP8 linear."""
+
+    def __init__(self, hidden_size=128):
+        super().__init__()
+        self.eps = 1e-5
+        self.norm_weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=torch.bfloat16, device="cuda")
+        )
+        self.input_scale = nn.Buffer(torch.tensor(1.0, dtype=torch.float32, device="cuda"))
+
+        with torch.no_grad():
+            w_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+            w_bf16 = torch.randn(hidden_size, hidden_size, dtype=torch.bfloat16, device="cuda")
+            w_fp8 = (w_bf16 / w_scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale", w_scale)
+
+    def forward(self, x, residual):
+        norm_out, add_out = flashinfer_fused_add_rms_norm(
+            x,
+            residual,
+            self.norm_weight,
+            self.eps,
+        )
+        gemm_out = torch.ops.auto_deploy.trtllm_quant_fp8_linear(
+            norm_out,
+            self.weight_fp8,
+            None,
+            input_scale=self.input_scale,
+            weight_scale=self.weight_scale,
+        )
+        return gemm_out, add_out
+
+
+class ExportedRMSNormQuantFP8MultiConsumer(nn.Module):
+    """Exported graph path with reshape and two FP8 consumers."""
+
+    def __init__(self, hidden_size=128):
+        super().__init__()
+        self.eps = 1e-5
+        self.norm_weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=torch.bfloat16, device="cuda")
+        )
+        self.input_scale = nn.Buffer(torch.tensor(1.0, dtype=torch.float32, device="cuda"))
+
+        with torch.no_grad():
+            w_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+            w_bf16 = torch.randn(hidden_size, hidden_size, dtype=torch.bfloat16, device="cuda")
+            w_fp8 = (w_bf16 / w_scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale", w_scale)
+
+    def forward(self, x):
+        norm_out = torch.ops.auto_deploy.flashinfer_rms_norm(x, self.norm_weight, self.eps)
+        reshaped = torch.ops.aten.reshape.default(norm_out, list(norm_out.shape))
+        out_trtllm = torch.ops.auto_deploy.trtllm_quant_fp8_linear(
+            reshaped,
+            self.weight_fp8,
+            None,
+            input_scale=self.input_scale,
+            weight_scale=self.weight_scale,
+        )
+        out_torch = torch.ops.auto_deploy.torch_quant_fp8_linear(
+            reshaped,
+            self.weight_fp8,
+            None,
+            self.input_scale,
+            self.weight_scale,
+        )
+        return out_trtllm, out_torch
+
+
+class ExportedRMSNormQuantFP8MixedConsumers(nn.Module):
+    """Exported graph path with a non-quant consumer before the FP8 consumer."""
+
+    def __init__(self, hidden_size=128):
+        super().__init__()
+        self.eps = 1e-5
+        self.norm_weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=torch.bfloat16, device="cuda")
+        )
+        self.input_scale = nn.Buffer(torch.tensor(1.0, dtype=torch.float32, device="cuda"))
+
+        with torch.no_grad():
+            w_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+            w_bf16 = torch.randn(hidden_size, hidden_size, dtype=torch.bfloat16, device="cuda")
+            w_fp8 = (w_bf16 / w_scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        self.register_buffer("weight_fp8", w_fp8)
+        self.register_buffer("weight_scale", w_scale)
+
+    def forward(self, x):
+        norm_out = torch.ops.auto_deploy.flashinfer_rms_norm(x, self.norm_weight, self.eps)
+        skipped_consumer = norm_out + 1
+        gemm_out = torch.ops.auto_deploy.trtllm_quant_fp8_linear(
+            norm_out,
+            self.weight_fp8,
+            None,
+            input_scale=self.input_scale,
+            weight_scale=self.weight_scale,
+        )
+        return skipped_consumer, gemm_out
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_graph():
+    model = TinyRMSNormQuantFP8().cuda()
+    gm = torch.fx.symbolic_trace(model)
+    for node in gm.graph.nodes:
+        if is_op(node, torch.ops.auto_deploy.flashinfer_rms_norm):
+            node.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    assert any(is_op(n, torch.ops.auto_deploy.flashinfer_rms_norm) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_exported_graph_rewrites_multi_consumer_path():
+    model = ExportedRMSNormQuantFP8MultiConsumer().cuda()
+    x = torch.randn(2, 128, device="cuda", dtype=torch.bfloat16)
+
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 2
+    assert (
+        sum(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes) == 1
+    )
+    assert any(is_op(n, torch.ops.aten.reshape.default) for n in gm.graph.nodes)
+    assert (
+        sum(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes) == 2
+    )
+    assert not any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_exported_graph_skips_when_non_quant_consumer_precedes_fp8():
+    model = ExportedRMSNormQuantFP8MixedConsumers().cuda()
+    x = torch.randn(2, 128, device="cuda", dtype=torch.bfloat16)
+
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 0
+    assert any(is_op(n, torch.ops.auto_deploy.flashinfer_rms_norm) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+    assert not any(
+        is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes
+    )
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_torch_quant_linear_graph():
+    model = TinyRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    norm_out = graph.call_function(
+        torch.ops.auto_deploy.flashinfer_rms_norm.default,
+        args=(x, norm_weight, model.eps),
+    )
+    gemm_out = graph.call_function(
+        torch.ops.auto_deploy.torch_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output(gemm_out)
+
+    norm_out.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_torch_rmsnorm_graph():
+    model = TinyRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    norm_out = graph.call_function(
+        torch.ops.auto_deploy.torch_rmsnorm.default,
+        args=(x, norm_weight, model.eps),
+    )
+    gemm_out = graph.call_function(
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output(gemm_out)
+
+    norm_out.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_rmsnorm) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_fused_add_rmsnorm_graph():
+    model = TinyFusedAddRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    residual = graph.placeholder("residual")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    fused = graph.call_function(
+        flashinfer_fused_add_rms_norm, args=(x, residual, norm_weight, model.eps)
+    )
+    norm_out = graph.call_function(operator.getitem, args=(fused, 0))
+    add_out = graph.call_function(operator.getitem, args=(fused, 1))
+    gemm_out = graph.call_function(
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output((gemm_out, add_out))
+    norm_out.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+
+    assert any(
+        n.op == "call_function" and n.target is flashinfer_fused_add_rms_norm
+        for n in gm.graph.nodes
+    )
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(
+        is_op(n, torch.ops.auto_deploy.triton_fused_add_rms_norm_quant_fp8) for n in gm.graph.nodes
+    )
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_torch_rmsnorm_add_graph():
+    model = TinyFusedAddRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    residual = graph.placeholder("residual")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    added = graph.call_function(torch.ops.aten.add.Tensor, args=(x, residual))
+    casted = graph.call_function(
+        torch.ops.aten.to.dtype,
+        args=(added, torch.bfloat16),
+        kwargs={"non_blocking": False, "copy": False, "memory_format": None},
+    )
+    norm_out = graph.call_function(
+        torch.ops.auto_deploy.torch_rmsnorm.default,
+        args=(casted, norm_weight, model.eps),
+    )
+    gemm_out = graph.call_function(
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output(gemm_out)
+
+    norm_out.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(
+        is_op(n, torch.ops.auto_deploy.triton_fused_add_rms_norm_quant_fp8) for n in gm.graph.nodes
+    )
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_rmsnorm) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_shares_fused_quant_across_multiple_linears():
+    model = TinyRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    norm_out = graph.call_function(
+        torch.ops.auto_deploy.flashinfer_rms_norm.default,
+        args=(x, norm_weight, model.eps),
+    )
+    gemm_out_1 = graph.call_function(
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    gemm_out_2 = graph.call_function(
+        torch.ops.auto_deploy.torch_quant_fp8_linear.default,
+        args=(norm_out, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output((gemm_out_1, gemm_out_2))
+
+    norm_out.meta["val"] = torch.empty((1, 1), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 2
+    assert (
+        sum(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes) == 1
+    )
+    assert (
+        sum(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes) == 2
+    )
+    assert not any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fuse_rmsnorm_quant_fp8_rewrites_through_post_norm_reshape():
+    model = TinyRMSNormQuantFP8().cuda()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    norm_weight = graph.get_attr("norm_weight")
+    weight_fp8 = graph.get_attr("weight_fp8")
+    input_scale = graph.get_attr("input_scale")
+    weight_scale = graph.get_attr("weight_scale")
+
+    norm_out = graph.call_function(
+        torch.ops.auto_deploy.flashinfer_rms_norm.default,
+        args=(x, norm_weight, model.eps),
+    )
+    reshaped = graph.call_function(torch.ops.aten.reshape.default, args=(norm_out, [2, 128]))
+    gemm_out = graph.call_function(
+        torch.ops.auto_deploy.trtllm_quant_fp8_linear.default,
+        args=(reshaped, weight_fp8, None, input_scale, weight_scale),
+    )
+    graph.output(gemm_out)
+
+    norm_out.meta["val"] = torch.empty((2, 128), dtype=torch.bfloat16)
+    reshaped.meta["val"] = torch.empty((2, 128), dtype=torch.bfloat16)
+
+    gm = torch.fx.GraphModule(model, graph)
+    transform = FuseRMSNormQuantFP8(TransformConfig(stage="post_load_fusion"))
+    gm, info = transform._apply(gm, None, None, None)
+
+    assert info.num_matches == 1
+    assert any(is_op(n, torch.ops.auto_deploy.triton_rms_norm_quant_fp8) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.aten.reshape.default) for n in gm.graph.nodes)
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_fp8_prequant_linear) for n in gm.graph.nodes)
+    assert not any(is_op(n, torch.ops.auto_deploy.trtllm_quant_fp8_linear) for n in gm.graph.nodes)
+
+
+def test_get_out_dtype_str_returns_none_when_norm_meta_missing():
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    w = graph.placeholder("w")
+    norm = graph.call_function(torch.ops.auto_deploy.flashinfer_rms_norm, args=(x, w, 1e-5))
+    graph.output(norm)
+
+    # Missing output metadata should skip fusion rather than guessing dtype.
+    norm.meta.pop("val", None)
+
+    assert _get_out_dtype_str(norm) is None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 quantization fusion for RMSNorm operations to improve model efficiency.
  * Enabled support for Llama-3.1-8B-Instruct-FP8 model with optimized FP8 configurations.
  * Enhanced FP8 output quantization throughout attention and linear operations.

* **Chores**
  * Updated model registry configurations with FP8 optimization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Enable fp8 quantization as part of attention output, when the trtllm attention backend is used
- Add a new transformation to enable rmsnorm + fp8 quantization fusion. The fused kernel is implemented with triton. The transformation is disabled by default.
- Add a new utility function to detect final consumer and skip trivial passthrough ops (copy-ops), allowing passing quantized outputs directly to consumers, even if separated by transpose/reshape/etc.
- Enable the new transformation in dashboard default config to assess perf on a variety of models.
- Add a config for llama3.1 8b to the model registry, enabling both fuse_fp8_gemms and the new fuse_rmsnorm_quant_fp8 transformation
- Re-enable testing nvidia/Llama-3.1-8B-Instruct-FP8 in dashboard

Future work (to be addressed in a follow-up PR):
- Enabling fuse_rmsnorm_quant_fp8 by default is pending perf dashboard results
- Enabling fuse_fp8_gemms  by default is pending fixing high memory usage during the transformation (will OOM with large models, but is safe for Llama3.1-8b) #4674 
- Enabling quant fusion with silu+mul will be addressed following #11094 
 
<img width="2964" height="1764" alt="llama3-1-fp8" src="https://github.com/user-attachments/assets/78c84808-821a-4645-ad9e-13320859de61" />

## Test Coverage

- pytest tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_fusion.py
    -k fuse_rmsnorm_quant_fp8_rewrites_graph
- Autodeploy performance dashboard 

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
