### PR TITLE
[None][feat] Export EdgeLLM ONNX precision NVFP4

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
@@ -59,6 +59,7 @@ transforms:
     stage: pattern_matcher
   quantize_nvfp4_linear_from_config:
     stage: pattern_matcher
+    load_for_onnx_export: true
   quantize_fp8_bmm_from_config:
     stage: pattern_matcher
   quantize_fp8_from_graph:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
@@ -29,7 +29,9 @@ import torch
 @torch.library.custom_op("auto_deploy::torch_onnx_attention_plugin", mutates_args=())
 def attention_plugin(
     # Inputs
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -39,6 +41,8 @@ def attention_plugin(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fused attention operation with integrated RoPE (Rotary Position Embedding).
 
@@ -48,10 +52,11 @@ def attention_plugin(
 
     Note:
         This is a placeholder implementation for ONNX export. The actual computation
-        is performed by the backend runtime (e.g., TensorRT, EdgeLLM
+        is performed by the backend runtime (e.g., TensorRT, EdgeLLM).
     Args:
-        qkv: Concatenated query, key, value tensor of shape
-            [batch_size, seq_len, (num_q_heads + 2 * num_kv_heads) * head_size].
+        q: Query tensor of shape [batch_size, seq_len, num_q_heads * head_size].
+        k: Key tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
+        v: Value tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
         past_key_values: KV-cache tensor of shape
             [batch_size, 2, num_kv_heads, past_seq_len, head_size].
         context_lengths: Sequence lengths for each batch element, shape [batch_size].
@@ -63,6 +68,8 @@ def attention_plugin(
         head_size: Dimension of each attention head.
         num_kv_heads: Number of key-value heads (for grouped-query attention).
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: Whether to use FP8 KV cache (0 or 1). Default 0.
+        sliding_window_size: Sliding window size for attention (-1 = no window). Default -1.
 
     Returns:
         A tuple containing:
@@ -71,12 +78,14 @@ def attention_plugin(
             - present_key_values: Updated KV-cache tensor of shape
               [batch_size, 2, num_kv_heads, present_seq_len, head_size].
     """
-    return qkv.new_empty(0), past_key_values.new_empty(0)
+    return q.new_empty(0), past_key_values.new_empty(0)
 
 
 @attention_plugin.register_fake
 def attention_plugin_fake(
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -85,6 +94,8 @@ def attention_plugin_fake(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fake implementation of attention_plugin for torch.compile shape inference.
 
@@ -92,7 +103,9 @@ def attention_plugin_fake(
     enabling torch.compile to trace through the custom operation.
 
     Args:
-        qkv: Concatenated QKV tensor.
+        q: Query tensor.
+        k: Key tensor.
+        v: Value tensor.
         past_key_values: Previous KV-cache tensor.
         context_lengths: Sequence lengths per batch.
         rope_rotary_cos_sin: RoPE embedding values.
@@ -101,18 +114,20 @@ def attention_plugin_fake(
         head_size: Attention head dimension.
         num_kv_heads: Number of KV heads.
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: FP8 KV cache flag (unused in shape).
+        sliding_window_size: Sliding window size (unused in shape).
 
     Returns:
         Tuple of empty tensors with correct shapes for attention output and
         present KV-cache.
     """
-    batch_size = qkv.size(0)
-    seq_len = qkv.size(1)
+    batch_size = q.size(0)
+    seq_len = q.size(1)
     past_len = past_key_values.size(3)
     present_kv_len = seq_len + past_len
     attn_shape = (batch_size, seq_len, num_q_heads, head_size)
     present_kv_shape = (batch_size, 2, num_kv_heads, present_kv_len, head_size)
-    return torch.empty(attn_shape, device=qkv.device, dtype=qkv.dtype), torch.empty(
+    return torch.empty(attn_shape, device=q.device, dtype=q.dtype), torch.empty(
         present_kv_shape, device=past_key_values.device, dtype=past_key_values.dtype
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/graph_module_visualizer.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/graph_module_visualizer.py
@@ -534,6 +534,12 @@ def to_dot(
     try:
         dot.render(save_path, cleanup=True)
         ad_logger.info(f"Diagram saved: {save_path}.{format}")
+
+        # Also save .dot source file if format is not already dot
+        if format != "dot":
+            dot.save(save_path + ".dot")
+            ad_logger.info(f"DOT source saved: {save_path}.dot")
+
         with open(save_path + ".txt", "w") as f:
             f.write(str(graph_module.graph))
     except Exception as e:
@@ -599,7 +605,7 @@ def _get_node_label(graph_module: GraphModule, node: fx.Node) -> str:
     elif node.op == "get_attr":
         attr_name = str(node.target).split(".")[-1] if "." in str(node.target) else str(node.target)
         label = attr_name
-        # Try to get actual dtype from state_dict/parameters
+        # Try to get actual dtype and value/shape from state_dict/parameters
         try:
             # Traverse the attribute path to get the actual tensor
             target_path = str(node.target)
@@ -608,7 +614,15 @@ def _get_node_label(graph_module: GraphModule, node: fx.Node) -> str:
                 obj = getattr(obj, attr)
             if isinstance(obj, torch.Tensor):
                 dtype_str = str(obj.dtype).replace("torch.", "")
-                label = f"{attr_name}\n({dtype_str})"
+                # Distinguish between scalar and tensor
+                if obj.numel() == 1:
+                    # Scalar: type=<dtype>\n<value>
+                    value = obj.item()
+                    label = f"{attr_name}\n{dtype_str}\n{value}"
+                else:
+                    # Tensor: type=<dtype>(shape)
+                    shape_dims = ", ".join(str(d) for d in obj.shape)
+                    label = f"{attr_name}\n{dtype_str}[{shape_dims}]"
         except (AttributeError, RuntimeError):
             pass  # Keep original label if attribute not found
     elif node.op == "placeholder":

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
@@ -85,8 +85,18 @@ _attention_plugin_schema = defs.OpSchema(
     doc="Fused RoPE + Attention operation for efficient inference.",
     inputs=[
         defs.OpSchema.FormalParameter(
-            name="qkv",
-            description="Concatenated Q, K, V tensors in shape [batch, seq_len, qkv_hidden_size]",
+            name="q",
+            description="Query tensor in shape [batch, seq_len, num_q_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="k",
+            description="Key tensor in shape [batch, seq_len, num_kv_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="v",
+            description="Value tensor in shape [batch, seq_len, num_kv_heads * head_size]",
             type_str="T",
         ),
         defs.OpSchema.FormalParameter(
@@ -158,6 +168,18 @@ _attention_plugin_schema = defs.OpSchema(
             type=defs.OpSchema.AttrType.INT,
             description="Number of query heads.",
             required=True,
+        ),
+        defs.OpSchema.Attribute(
+            name="enable_fp8_kv_cache",
+            type=defs.OpSchema.AttrType.INT,
+            description="Whether to use FP8 KV cache (0 or 1). Default 0.",
+            required=False,
+        ),
+        defs.OpSchema.Attribute(
+            name="sliding_window_size",
+            type=defs.OpSchema.AttrType.INT,
+            description="Sliding window size for attention (-1 = no window). Default -1.",
+            required=False,
         ),
     ],
 )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
@@ -273,8 +273,74 @@ _torch_attention_schema = defs.OpSchema(
 )
 
 
+# ONNX Custom Op Registration for TRT FP4 Dynamic Quantize (EdgeLLM)
+_trt_fp4_dynamic_quantize_schema = defs.OpSchema(
+    name="TRT_FP4DynamicQuantize",
+    domain=_TRT_DOMAIN_NAME,
+    since_version=1,
+    doc="Dynamic FP4 quantization: input + scale -> (packed_fp4, per_block_scale).",
+    inputs=[
+        defs.OpSchema.FormalParameter(
+            name="x",
+            description="Input tensor",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="scale",
+            description="Per-tensor scale",
+            type_str="T",
+        ),
+    ],
+    outputs=[
+        defs.OpSchema.FormalParameter(
+            name="packed",
+            description="Packed FP4 data (uint8)",
+            type_str="T1",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="per_block_scale",
+            description="Per-block scale for dequant",
+            type_str="T",
+        ),
+    ],
+    type_constraints=[
+        (
+            "T",
+            ["tensor(float)", "tensor(float16)", "tensor(bfloat16)"],
+            "Input and scale.",
+        ),
+        (
+            "T1",
+            ["tensor(uint8)"],
+            "Packed output.",
+        ),
+    ],
+    attributes=[
+        defs.OpSchema.Attribute(
+            name="axis",
+            type=defs.OpSchema.AttrType.INT,
+            description="Axis for block layout.",
+            required=False,
+        ),
+        defs.OpSchema.Attribute(
+            name="block_size",
+            type=defs.OpSchema.AttrType.INT,
+            description="Block size for FP4 (e.g. 16).",
+            required=False,
+        ),
+        defs.OpSchema.Attribute(
+            name="scale_type",
+            type=defs.OpSchema.AttrType.INT,
+            description="Scale type (opaque to this module).",
+            required=False,
+        ),
+    ],
+)
+
+
 def register_onnx_schemas():
     """Register ONNX custom ops."""
     defs.register_schema(_torch_rope_with_explicit_cos_sin_schema)
     defs.register_schema(_torch_attention_schema)
     defs.register_schema(_attention_plugin_schema)
+    defs.register_schema(_trt_fp4_dynamic_quantize_schema)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/adapt_to_edgellm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/adapt_to_edgellm.py
@@ -157,10 +157,16 @@ class AdaptToEdgeLLM(BaseTransform):
         num_converted = 0
         dtypes = [torch.float32, torch.float64, torch.bfloat16]
         for _name, param in gm.named_parameters():
+            # If it is the alpha or input_scale, we don't want to convert to float16
+            if param.dtype is torch.float32 and ("alpha" in _name or "input_scale" in _name):
+                continue
             if param.dtype in dtypes:
                 param.data = param.data.to(torch.float16)
                 num_converted += 1
         for _name, buffer in gm.named_buffers():
+            # If it is the alpha or input_scale, we don't want to convert to float16
+            if buffer.dtype is torch.float32 and ("alpha" in _name or "input_scale" in _name):
+                continue
             if buffer.dtype in dtypes:
                 buffer.data = buffer.data.to(torch.float16)
                 num_converted += 1

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
@@ -81,7 +81,9 @@ def _translate_gather_nd_op(data: ir.Tensor, indices: ir.Tensor, batch_dims: int
 
 
 def _translate_rope_attention_op(
-    qkv: ir.Tensor,
+    q: ir.Tensor,
+    k: ir.Tensor,
+    v: ir.Tensor,
     past_key_values: ir.Tensor,
     context_lengths: ir.Tensor,
     rope_rotary_cos_sin: ir.Tensor,
@@ -90,6 +92,8 @@ def _translate_rope_attention_op(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ):
     """
     ONNX custom op translation function for AttentionPlugin.
@@ -103,7 +107,9 @@ def _translate_rope_attention_op(
     """
     # Call the custom op from the trt domain
     return _onnx_schemas.trt_opset.AttentionPlugin(
-        qkv,
+        q,
+        k,
+        v,
         past_key_values,
         context_lengths,
         rope_rotary_cos_sin,
@@ -112,6 +118,8 @@ def _translate_rope_attention_op(
         head_size=head_size,
         num_kv_heads=num_kv_heads,
         num_q_heads=num_q_heads,
+        enable_fp8_kv_cache=enable_fp8_kv_cache,
+        sliding_window_size=sliding_window_size,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
@@ -17,9 +17,10 @@ import os
 from pathlib import Path
 from typing import Optional, Sequence, Tuple, Type
 
+import onnx
 import torch
 from onnx import TensorProto, helper
-from onnxscript import ir, opset20
+from onnxscript import ir, opset21
 from pydantic import Field
 from torch.export import Dim
 from torch.fx import GraphModule
@@ -39,6 +40,46 @@ from ..interface import (
 from . import _onnx_schemas
 from ._chat_template import process_chat_template
 from ._config_export import export_llm_config
+
+
+def _convert_nvfp4_weight_initializers_to_float4e2m1(model_proto) -> int:
+    """Convert packed uint8 FP4 weight initializers to float4e2m1 [N, K] in-place.
+
+    Finds initializers that are used as the 'data' input of DequantizeLinear with
+    block_size=16 (NVFP4 path). Converts them from uint8 [N, K_packed] to
+    float4e2m1 [N, K] (same raw bytes; ONNX stores 2 FP4 values per byte).
+    Returns the number of initializers converted.
+    """
+    graph = model_proto.graph
+    data_inputs_to_convert = set()
+    for node in graph.node:
+        if node.op_type != "DequantizeLinear":
+            continue
+        block_size = None
+        for attr in node.attribute:
+            if attr.name == "block_size":
+                block_size = attr.i
+                break
+        if block_size != 16:
+            continue
+        if len(node.input) >= 1:
+            data_inputs_to_convert.add(node.input[0])
+
+    converted = 0
+    for init in graph.initializer:
+        if init.name not in data_inputs_to_convert:
+            continue
+        if init.data_type != TensorProto.UINT8:
+            continue
+        if len(init.dims) < 2:
+            continue
+        k_packed = init.dims[-1]
+        init.data_type = TensorProto.FLOAT4E2M1
+        new_dims = list(init.dims)[:-1] + [k_packed * 2]
+        del init.dims[:]
+        init.dims.extend(new_dims)
+        converted += 1
+    return converted
 
 
 class ExportToONNXConfig(TransformConfig):
@@ -69,15 +110,15 @@ def _translate_rope_op(
 
 def _translate_simple_linear_op(input: ir.Tensor, weight: ir.Tensor, bias: Optional[ir.Tensor]):
     """Translate linear operation to ONNX MatMul + optional Add."""
-    weight = opset20.Transpose(weight, perm=[1, 0])
+    weight = opset21.Transpose(weight, perm=[1, 0])
     if bias is None:
-        return opset20.MatMul(input, weight)
-    return opset20.Add(opset20.MatMul(input, weight), bias)
+        return opset21.MatMul(input, weight)
+    return opset21.Add(opset21.MatMul(input, weight), bias)
 
 
 def _translate_gather_nd_op(data: ir.Tensor, indices: ir.Tensor, batch_dims: int):
     """Translate GatherND operation to ONNX GatherND op."""
-    return opset20.GatherND(data, indices, batch_dims=batch_dims)
+    return opset21.GatherND(data, indices, batch_dims=batch_dims)
 
 
 def _translate_rope_attention_op(
@@ -185,7 +226,7 @@ def _get_fp8e4m3fn_zero_point(zp: Sequence[ir.Tensor]) -> ir.Tensor:
         dims=[1],
         vals=[0.0],
     )
-    return opset20.Constant(value=fp8_const_proto)
+    return opset21.Constant(value=fp8_const_proto)
 
 
 def _translate_fake_quant_fp8_linear_op(
@@ -220,25 +261,86 @@ def _translate_fake_quant_fp8_linear_op(
         )
     s_in = input_scale[0]
     s_w = weight_scale[0]
+    s_in = opset21.Cast(s_in, to=TensorProto.FLOAT)
 
     # Get zero points (creates FP8 zero constant if empty)
     input_zp = _get_fp8e4m3fn_zero_point(input_zp)
     weight_zp = _get_fp8e4m3fn_zero_point(weight_zp)
 
     # Input fake quantization: quantize to FP8, then dequantize back
-    input_q = opset20.QuantizeLinear(input, s_in, y_zero_point=input_zp)
-    input_dq = opset20.DequantizeLinear(input_q, s_in, x_zero_point=input_zp)
+    input_q = opset21.QuantizeLinear(input, s_in, y_zero_point=input_zp)
+    input_dq = opset21.DequantizeLinear(input_q, s_in, x_zero_point=input_zp)
+    input_dq = opset21.Cast(input_dq, to=TensorProto.FLOAT16)
 
     # Weight dequantization (weight is already FP8)
-    weight_dq = opset20.DequantizeLinear(weight_quantized, s_w, x_zero_point=weight_zp)
+    weight_dq = opset21.DequantizeLinear(weight_quantized, s_w, x_zero_point=weight_zp)
+    weight_dq = opset21.Cast(weight_dq, to=TensorProto.FLOAT16)
 
     # Linear: Transpose weight [N, K] -> [K, N], then MatMul
-    weight_t = opset20.Transpose(weight_dq, perm=[1, 0])
-    out = opset20.MatMul(input_dq, weight_t)
+    weight_t = opset21.Transpose(weight_dq, perm=[1, 0])
+    out = opset21.MatMul(input_dq, weight_t)
 
     if bias is not None:
-        out = opset20.Add(out, bias)
+        out = opset21.Add(out, bias)
 
+    return out
+
+
+def _translate_fake_quant_nvfp4_linear_op(
+    input: ir.Tensor,
+    weight_quantized: ir.Tensor,
+    bias: Optional[ir.Tensor],
+    input_scale: Sequence[ir.Tensor],
+    weight_scale: Sequence[ir.Tensor],
+    input_zp: Sequence[ir.Tensor],
+    weight_zp: Sequence[ir.Tensor],
+):
+    """
+    ONNX translation for NVFP4 fake quantized linear operation.
+
+    Expands torch_fake_quant_nvfp4_linear to the target ONNX subgraph:
+    - Activation path: Reciprocal(x_scale) -> TRT_FP4DynamicQuantize -> two-stage
+      DequantizeLinear (first dequant scale, second dequant data) -> Cast to float16.
+    - Weight path: Div(w_alpha, ixscale) -> DequantizeLinear(w_scale, wscale_2) ->
+      DequantizeLinear(w, combined_scale, axis=-1, block_size=16) -> Cast -> Transpose.
+    - Linear: MatMul(cx, weight_t) + optional Add(bias).
+
+    Scale semantics: FP4 uses per-block scale (scale itself may be quantized); see
+    .ai/knowledge/fp4-two-stage-dequant-scale-compression.md. Arguments are lists:
+    input_scale[0]=x_scale, weight_scale[0]=w_scale, weight_scale[1]=w_alpha.
+    """
+    if len(input_scale) != 1 or len(weight_scale) != 2:
+        raise ValueError(
+            f"NVFP4 fake quantized linear requires input_scale length 1 and weight_scale length 2, "
+            f"got input_scale={len(input_scale)}, weight_scale={len(weight_scale)}"
+        )
+    x_scale = input_scale[0]
+    w_scale = weight_scale[0]
+    w_alpha = weight_scale[1]
+
+    # Activation path: ixscale = 1 / x_scale
+    ixscale = opset21.Reciprocal(x_scale)
+
+    # TRT_FP4DynamicQuantize(x, ixscale) -> (packed, per_block_scale)
+    fp4dq_packed, fp4dq_block_scale = _onnx_schemas.trt_opset.TRT_FP4DynamicQuantize(
+        input, ixscale, axis=-1, block_size=16, scale_type=TensorProto.FLOAT8E4M3FN
+    )
+
+    # Two-stage dequant (activation): xdq1 then xdq2 per user graph
+    xdq1 = opset21.DequantizeLinear(fp4dq_block_scale, ixscale)
+    xdq2 = opset21.DequantizeLinear(fp4dq_packed, xdq1, axis=-1, block_size=16)
+    cx = opset21.Cast(xdq2, to=TensorProto.FLOAT16)
+
+    # Weight path: wscale_2 = w_alpha / ixscale, then two-stage dequant
+    wscale_2 = opset21.Div(w_alpha, ixscale)
+    wdq1 = opset21.DequantizeLinear(w_scale, wscale_2)
+    wdq2 = opset21.DequantizeLinear(weight_quantized, wdq1, axis=-1, block_size=16)
+    cw = opset21.Cast(wdq2, to=TensorProto.FLOAT16)
+    weight_t = opset21.Transpose(cw, perm=[1, 0])
+
+    out = opset21.MatMul(cx, weight_t)
+    if bias is not None:
+        out = opset21.Add(out, bias)
     return out
 
 
@@ -254,7 +356,7 @@ class ExportToONNX(BaseTransform):
 
     The exported ONNX model includes custom ops from the auto_deploy. These custom ops include:
     - torch_onnx_attention_plugin: Fused RoPE + Attention for efficient inference(exported as EdgeLLM's custom op)
-    - torch_onnx_gather_nd: N-dimensional gather operation (exported as onnxscript.opset20.GatherND)
+    - torch_onnx_gather_nd: N-dimensional gather operation (exported as onnxscript.opset21.GatherND)
 
     Note:
         This transform does NOT modify the input graph. It only exports the graph
@@ -384,6 +486,8 @@ class ExportToONNX(BaseTransform):
             torch.ops.auto_deploy.torch_onnx_gather_nd.default: _translate_gather_nd_op,
             # FP8 quantized linear
             torch.ops.auto_deploy.torch_fake_quant_fp8_linear.default: _translate_fake_quant_fp8_linear_op,
+            # NVFP4 quantized linear (single-op expansion to ONNX subgraph)
+            torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear.default: _translate_fake_quant_nvfp4_linear_op,
         }
 
         # Prepare output names
@@ -397,13 +501,13 @@ class ExportToONNX(BaseTransform):
         # Register ONNX custom ops
         _onnx_schemas.register_onnx_schemas()
 
-        # Export the graph module to ONNX using dynamo (more advanced tracer)
+        # Export to ONNX IR in memory (f=None returns ONNXProgram), then optionally
         ad_logger.info(f"Exporting GraphModule to ONNX with dynamo: {output_path}")
-        torch.onnx.export(
+        onnx_program = torch.onnx.export(
             gm,
             tuple(args),
-            output_path,
-            opset_version=20,
+            None,  # f=None: get ONNXProgram instead of writing file
+            opset_version=21,
             kwargs=kwargs,
             dynamo=True,
             dynamic_shapes=dynamic_shapes,
@@ -412,6 +516,27 @@ class ExportToONNX(BaseTransform):
             custom_translation_table=custom_translation_table,
         )
 
+        # Keep a single reference to model_proto: ONNXProgram.model_proto may return a new
+        # copy on each access, so mutating the passed object would not be reflected in save().
+        # We mutate this reference and save it explicitly with onnx.save_model.
+        model_proto = onnx_program.model_proto
+
+        # convert NVFP4 weight initializers to float4e2m1, and save.
+        n_converted = _convert_nvfp4_weight_initializers_to_float4e2m1(model_proto)
+        if n_converted:
+            ad_logger.info(f"Converted {n_converted} NVFP4 weight initializers to float4e2m1")
+
+        # location must be relative to the model file; when None, onnx uses uuid.uuid1().data.
+        # Use "<model_basename>.data" so external file is e.g. model.onnx.data next to model.onnx.
+        external_location = output_path.name + ".data"
+        onnx.save_model(
+            model_proto,
+            str(output_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=external_location,
+            size_threshold=1024,
+        )
         ad_logger.info(f"Successfully exported ONNX model to {output_path}")
         return True
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -215,7 +215,7 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
     alpha = torch.tensor(1.2345, device="meta", dtype=torch.float32)
 
     cutlass_len = N * (K_eff // 16)  # 32 * (64/16) = 128
-    cutlass_vec = torch.randint(0, 255, (cutlass_len,), device="meta", dtype=torch.uint8)
+    cutlass_vec = torch.randint(0, 255, (cutlass_len,), device="meta", dtype=torch.float8_e4m3fn)
 
     # no-bias variant
     dummy_args_fp4_1 = [

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
@@ -345,11 +345,10 @@ class FuseRopeAttention(BaseTransform):
         For each matched pattern, this method:
             1. Creates a past_key_values input placeholder for KV-cache
             2. Reshape Q, K, V to (batch_size, seq_len, -1)
-            3. Concatenates reshaped Q, K, V tensors into a single QKV tensor
-            4. Inserts the fused AttentionPlugin operation
-            5. Creates getitem nodes to extract attention output and present KV-cache
-            6. Replaces the original attention node with the fused output
-            7. Adds present_key_values to graph outputs
+            3. Cast Q, K, V to float16 and insert the fused AttentionPlugin (q, k, v separate)
+            4. Creates getitem nodes to extract attention output and present KV-cache
+            5. Replaces the original attention node with the fused output
+            6. Adds present_key_values to graph outputs
 
         Args:
             gm: The GraphModule being transformed.
@@ -410,28 +409,22 @@ class FuseRopeAttention(BaseTransform):
                 f"Reshaped Q, K, V to (batch_size, seq_len, -1): {q_node.name}, {k_node.name}, {v_node.name}"
             )
 
-            # 3. Concatenate reshaped Q, K, V to (batch_size, seq_len, -1)
-            with graph.inserting_before(match.attn_node):
-                qkv_node = graph.call_function(
-                    torch.ops.aten.cat.default, args=([q_node, k_node, v_node], -1)
-                )
-
-            ad_logger.debug(f"Created qkv concat node: {qkv_node.name}")
-
-            # 4. Create AttentionPlugin node
+            # 3. Cast Q, K, V to float16 and create AttentionPlugin node (q, k, v as separate inputs)
             enable_tree_attention = 0
             head_dim = match.head_dim
             num_kv_heads = match.num_kv_heads
             num_q_heads = match.num_q_heads
 
             with graph.inserting_before(match.attn_node):
-                cast_node = graph.call_function(
-                    torch.ops.aten.to.dtype, args=(qkv_node, torch.float16)
-                )
+                cast_q = graph.call_function(torch.ops.aten.to.dtype, args=(q_node, torch.float16))
+                cast_k = graph.call_function(torch.ops.aten.to.dtype, args=(k_node, torch.float16))
+                cast_v = graph.call_function(torch.ops.aten.to.dtype, args=(v_node, torch.float16))
                 rope_attn_node = graph.call_function(
                     torch.ops.auto_deploy.torch_onnx_attention_plugin.default,
                     args=(
-                        cast_node,
+                        cast_q,
+                        cast_k,
+                        cast_v,
                         past_key_values_node,
                         context_lengths_node,
                         rope_rotary_cos_sin_node,
@@ -441,6 +434,7 @@ class FuseRopeAttention(BaseTransform):
                         num_kv_heads,
                         num_q_heads,
                     ),
+                    kwargs={"enable_fp8_kv_cache": 0, "sliding_window_size": -1},
                 )
 
             ad_logger.debug(f"Created AttentionPlugin node: {rope_attn_node.name}")

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -1,9 +1,10 @@
 import math
 from functools import partial
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Type
 
 import torch
 import torch.nn as nn
+from pydantic import Field
 from torch.fx import GraphModule, Node
 
 from ...custom_ops.quantization.quant import (
@@ -36,7 +37,13 @@ from ...utils.quantization_utils import (
     should_skip_mixed_precision_quantization,
     should_skip_quantization,
 )
-from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
 
 try:
     from .....quantization.utils.fp4_utils import float4_sf_dtype
@@ -351,9 +358,27 @@ class FP8LinearQuantizationFromConfig(Quantization):
         return super()._apply(gm, cm, factory, shared_config)
 
 
+class NVFP4QuantizationConfig(TransformConfig):
+    """Configuration for NVFP4 quantization from unified checkpoint."""
+
+    load_for_onnx_export: bool = Field(
+        default=False,
+        description=(
+            "Whether to load the weight scale for ONNX export. If True, the "
+            "weight scale will be loaded as float8_e4m3fn during weight loading. "
+            "And swizzle will not be applied."
+        ),
+    )
+
+
 @TransformRegistry.register("quantize_nvfp4_linear_from_config")
 class NVFP4LinearQuantizationFromConfig(Quantization):
     algo_name = "NVFP4"
+    config: NVFP4QuantizationConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return NVFP4QuantizationConfig
 
     def target_op(self):
         return torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear.default
@@ -383,7 +408,11 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         # alpha: 1 / (input_scale * weight_scale_2)
         return {
             "input_scale": torch.tensor(1.0 / 6.0),
-            "weight_scale": torch.empty((padded_m, padded_n), dtype=torch.uint8),
+            "weight_scale": torch.empty(
+                (padded_m, padded_n),
+                # If we are loading for ONNX export, we want to load the weight scale as float8_e4m3fn
+                dtype=torch.uint8 if not self.config.load_for_onnx_export else torch.float8_e4m3fn,
+            ),
             # "weight_scale": torch.empty((m, n), dtype=torch.uint8),
             # "weight_scale": torch.empty(padded_m * padded_n, dtype=torch.float8_e4m3fn),
             # "weight_scale": torch.empty(padded_m * padded_n, dtype=torch.uint8),
@@ -433,6 +462,15 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                     state_dict[alpha_name] = alpha
                     input_scale = torch.clamp(state_dict[input_scale_name], min=1e-30)
                     state_dict[input_scale_name] = 1 / input_scale
+
+                    # If we are loading for ONNX export, we don't want to swizzle the weight scale
+                    if self.config.load_for_onnx_export:
+                        state_dict[weight_name + "_scale"] = state_dict[
+                            weight_name + "_scale"
+                        ].view(torch.float8_e4m3fn)
+                        return
+
+                    # swizzle weight scale
                     weight_scale = state_dict[weight_name + "_scale"].view(float4_sf_dtype)
                     # Round the weight block scale factors to 128x4 and then swizzle.
                     weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_nvfp4_export.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_nvfp4_export.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NVFP4 linear ONNX export.
+
+Tests the _translate_fake_quant_nvfp4_linear_op path used during export_to_onnx:
+torch_fake_quant_nvfp4_linear is expanded to ONNX subgraph (TRT_FP4DynamicQuantize,
+two-stage DequantizeLinear, MatMul, optional Add). Includes the same
+_convert_nvfp4_weight_initializers_to_float4e2m1 step as production.
+"""
+
+import tempfile
+from pathlib import Path
+
+import onnx
+import pytest
+import torch
+import torch.nn as nn
+from _torch_test_utils import fp4_compatible, trtllm_ops_available
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.transform.library import _onnx_schemas
+from tensorrt_llm._torch.auto_deploy.transform.library.export_to_onnx import (
+    _convert_nvfp4_weight_initializers_to_float4e2m1,
+    _translate_fake_quant_nvfp4_linear_op,
+)
+from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
+
+# Register ONNX custom ops once so parametrized tests do not re-register.
+_onnx_schemas.register_onnx_schemas()
+
+torch.manual_seed(0)
+
+
+class TinyFP4Ref(nn.Module):
+    """Minimal module that uses torch_fake_quant_nvfp4_linear (same as test_quant_fusion.TinyFP4Ref)."""
+
+    def __init__(self, in_features=64, out_features=32, use_bias=True):
+        super().__init__()
+        assert in_features % 16 == 0
+        device = torch.device("cuda")
+
+        self.use_bias = use_bias
+        self.weight = nn.Parameter(
+            torch.rand(out_features, in_features, dtype=torch.half, device=device)
+        )
+        if use_bias:
+            self.bias = nn.Parameter(torch.rand(out_features, dtype=torch.half, device=device))
+        else:
+            self.register_parameter("bias", None)
+
+        with torch.no_grad():
+            s_in2 = fp4_global_scale(torch.rand(1, in_features, dtype=torch.half, device=device))
+            s_w2 = fp4_global_scale(self.weight)
+            w_fp4, cutlass_vec = torch.ops.trtllm.fp4_quantize(self.weight, s_w2, 16, False)
+            alpha = (1.0 / (s_in2 * s_w2)).to(torch.float32)
+
+        self.register_buffer("weight_fp4", w_fp4)
+        self.register_buffer("input_scale_2", s_in2.to(torch.float32))
+        self.register_buffer("weight_scale_cutlass", cutlass_vec)
+        self.register_buffer("alpha", alpha.to(torch.float32))
+
+    def forward(self, x):
+        bias = self.bias if self.use_bias else None
+        return torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
+            x,
+            self.weight_fp4,
+            bias,
+            [self.input_scale_2],
+            [self.weight_scale_cutlass, self.alpha],
+            [],
+            [],
+        )
+
+
+def _export_nvfp4_to_onnx_and_verify_structure(
+    model: nn.Module,
+    x: torch.Tensor,
+    use_bias: bool,
+) -> None:
+    """Export model to ONNX (with converter), then verify graph structure."""
+    model.eval()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_path = Path(tmp_dir) / "model.onnx"
+        external_location = "model.onnx.data"
+
+        custom_translation_table = {
+            torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear.default: _translate_fake_quant_nvfp4_linear_op,
+        }
+
+        onnx_program = torch.onnx.export(
+            model,
+            (x,),
+            None,
+            opset_version=21,
+            dynamo=True,
+            custom_translation_table=custom_translation_table,
+        )
+        model_proto = onnx_program.model_proto
+        _convert_nvfp4_weight_initializers_to_float4e2m1(model_proto)
+
+        onnx.save_model(
+            model_proto,
+            str(output_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=external_location,
+            size_threshold=1024,
+        )
+
+        assert output_path.exists(), f"ONNX file should exist at {output_path}"
+        onnx_model = onnx.load(str(output_path))
+
+        op_types = [node.op_type for node in onnx_model.graph.node]
+
+        assert "TRT_FP4DynamicQuantize" in op_types, (
+            f"TRT_FP4DynamicQuantize should be in graph, got ops: {op_types}"
+        )
+        assert "DequantizeLinear" in op_types, (
+            f"DequantizeLinear should be in graph, got ops: {op_types}"
+        )
+        assert "MatMul" in op_types, (
+            f"MatMul should be in graph for linear computation, got ops: {op_types}"
+        )
+        if use_bias:
+            assert "Add" in op_types, (
+                f"Add should be in graph for bias addition, got ops: {op_types}"
+            )
+
+
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.skipif(
+    not (fp4_compatible() and trtllm_ops_available()),
+    reason="Requires NVFP4 and TRT-LLM ops",
+)
+@torch.inference_mode()
+def test_nvfp4_linear_export_to_onnx_structure(use_bias):
+    """NVFP4 linear ONNX export expands to TRT_FP4DynamicQuantize, DequantizeLinear, MatMul, optional Add."""
+    model = TinyFP4Ref(in_features=64, out_features=32, use_bias=use_bias).to("cuda")
+    x = torch.rand(3, 64, dtype=torch.float16, device="cuda")
+
+    _export_nvfp4_to_onnx_and_verify_structure(model, x, use_bias)


### PR DESCRIPTION
## Description

Add NVFP4 (4-bit) export path for EdgeLLM ONNX so that AutoDeploy can export FP4-quantized models to ONNX with custom ops that EdgeLLM expects.

- **ONNX export**: `torch_fake_quant_nvfp4_linear` is translated during export (custom_translation_table) to `TRT_FP4DynamicQuantize`, two-stage `DequantizeLinear`, `MatMul`, optional `Add`; weight initializers are converted to `float4e2m1`.
- **Config/adapt**: `export_edgellm_onnx` config, `adapt_to_edgellm` leaves weight scales in fp32 where needed, constant-node shape/value handling, **ONNX opset 21** for `block_size`.
- **Test**: `test_nvfp4_export.py` rewritten to assert ONNX structure after export (no longer uses deprecated.

## Test Coverage

- `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_nvfp4_export.py::test_nvfp4_linear_export_to_onnx_structure` (parametrized `use_bias` `True`/`False`)

## PR Checklist

- [x] PR description clearly explains what and why
- [x] Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md)
- [x] Test cases provided for new code paths
- [x] New dependencies scanned for license and vulnerabilities
- [x] [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- [x] Documentation updated as needed
- [x] Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- [x] Reviewers assigned appropriately
- [x] Please check this after reviewing the above items as appropriate for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ONNX export support for NVFP4-quantized models with configurable behavior.
  * Enhanced graph visualization with improved node labeling and automatic DOT file saving.

* **Improvements**
  * Updated ONNX opset from 20 to 21 for better compatibility.
  * Improved precision handling for specific tensor components during float16 conversion.
  * Enhanced weight initializer conversion for FP4 export workflows.

* **Tests**
  * Added comprehensive unit tests for NVFP4 ONNX export validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->