### PR TITLE
[https://nvbugs/6115560][fix] catch OSError in config_file_lock for NFS compatibility

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -86,8 +86,10 @@ def config_file_lock(timeout: int = 10):
     try:
         with lock:
             yield
-    except (PermissionError, filelock.Timeout):
-        # Fallback to tempdir
+    except (PermissionError, OSError, filelock.Timeout):
+        # Fallback to tempdir when primary lock path is unusable (e.g.,
+        # NFS locking failures like ENOLCK/ESTALE, permission issues,
+        # or lock acquisition timeouts)
         tmp_dir = Path(tempfile.gettempdir())
         tmp_dir.mkdir(parents=True, exist_ok=True)
         tmp_lock_path = tmp_dir / "_remote_code.lock"
@@ -101,7 +103,7 @@ def config_file_lock(timeout: int = 10):
             )
             # proceed without lock
             yield
-        except (PermissionError) as e:
+        except (PermissionError, OSError) as e:
             logger.warning(
                 f"tempdir config lock unavailable due to OS/permission issue: {e}, proceeding without lock"
             )

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import json
 import os
 import tempfile
@@ -86,10 +87,14 @@ def config_file_lock(timeout: int = 10):
     try:
         with lock:
             yield
-    except (PermissionError, OSError, filelock.Timeout):
+    except (PermissionError, OSError, filelock.Timeout) as e:
         # Fallback to tempdir when primary lock path is unusable (e.g.,
         # NFS locking failures like ENOLCK/ESTALE, permission issues,
         # or lock acquisition timeouts)
+        if isinstance(e,
+                      OSError) and e.errno not in (errno.EACCES, errno.EPERM,
+                                                   errno.ENOLCK, errno.ESTALE):
+            raise
         tmp_dir = Path(tempfile.gettempdir())
         tmp_dir.mkdir(parents=True, exist_ok=True)
         tmp_lock_path = tmp_dir / "_remote_code.lock"
@@ -104,6 +109,10 @@ def config_file_lock(timeout: int = 10):
             # proceed without lock
             yield
         except (PermissionError, OSError) as e:
+            if isinstance(
+                    e, OSError) and e.errno not in (errno.EACCES, errno.EPERM,
+                                                    errno.ENOLCK, errno.ESTALE):
+                raise
             logger.warning(
                 f"tempdir config lock unavailable due to OS/permission issue: {e}, proceeding without lock"
             )


### PR DESCRIPTION
## Summary

`config_file_lock()` in `tensorrt_llm/_torch/model_config.py` crashes when `HF_MODULES_CACHE` resides on an NFS-mounted filesystem. On NFS, `filelock` operations can raise `OSError` with errno `ENOLCK` (No locks available) or `ESTALE` (Stale file handle) instead of `PermissionError`. Since the current exception handler only catches `PermissionError` and `filelock.Timeout`, these NFS-specific errors bypass the existing tempdir fallback and crash the process.

This is particularly impactful in multi-node GPU clusters where a shared NFS cache is standard practice — every pod that tries to load a model config concurrently hits this crash.

## Changes

Add `OSError` to both exception handlers in `config_file_lock()`:

1. **Primary lock attempt** (line 51): `except (PermissionError, filelock.Timeout)` → `except (PermissionError, OSError, filelock.Timeout)` — triggers the tempdir fallback for NFS errors
2. **Tempdir fallback** (line 66): `except (PermissionError)` → `except (PermissionError, OSError)` — handles the unlikely case where tempdir also fails

Since `PermissionError` is a subclass of `OSError`, catching `OSError` technically covers both, but keeping `PermissionError` explicit preserves the original intent and readability.

## Root Cause

NFSv3 uses the Network Lock Manager (NLM) protocol for file locking, which is unreliable for cross-node `flock()`/`fcntl()` operations. When `filelock.FileLock` attempts to acquire a lock on an NFS path:

- Lock acquisition can fail with `OSError: [Errno 37] No locks available` (ENOLCK)
- Lock release can fail with `OSError: [Errno 116] Stale file handle` (ESTALE)

The existing fallback to `/tmp` (local ephemeral storage) is the correct behavior for this case — it just wasn't being triggered.

## Reproduction

```python
# On any NFS-mounted path, run from multiple nodes concurrently:
import filelock
lock = filelock.FileLock("/nfs-mount/test.lock")
with lock:  # Raises OSError: [Errno 37] No locks available
    pass
```

## Workaround (for users on affected versions)

Set `HF_MODULES_CACHE=/tmp/hf_modules` as an environment variable to redirect the lock file to local storage.

Fixes #11958

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file locking behavior to catch additional OS and permission-related errors. Added temporary directory-based fallback locking with timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->