### PR TITLE
[None][fix] Reduce host memory usage during EPLB config model loading.

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -501,6 +501,8 @@ class FusedMoEMethodBase(ABC):
             # Finalize shared weights eagerly so each layer's CPU tensors are freed
             # before the next layer is loaded. This prevents accumulation of all
             # layers' shared weight tensors in host memory simultaneously.
+            # For partial loading (e.g. RLHF), finalization is deferred to the
+            # caller's explicit finalization phase (see rlhf_utils.py).
             self._finalize_shared_weights(module)
 
     def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -501,8 +501,8 @@ class FusedMoEMethodBase(ABC):
             # Finalize shared weights eagerly so each layer's CPU tensors are freed
             # before the next layer is loaded. This prevents accumulation of all
             # layers' shared weight tensors in host memory simultaneously.
-            # For partial loading (e.g. RLHF), finalization is deferred to the
-            # caller's explicit finalization phase (see rlhf_utils.py).
+            # Partial-loading callers (e.g. RLHF reload) instead rely on
+            # ``post_load_weights`` to finalize once the loading sequence ends.
             self._finalize_shared_weights(module)
 
     def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):
@@ -525,8 +525,16 @@ class FusedMoEMethodBase(ABC):
         from accumulating in host memory simultaneously.  With fewer GPUs per
         node each rank is responsible for more experts, so the accumulated
         private tensors can easily exceed available host memory.
+
+        This method is idempotent: if the per-layer ``local_shared_*`` tensors
+        have already been finalized (and deleted), it is a no-op.  This lets
+        ``post_load_weights`` invoke it as a safety net for callers that pass
+        ``allow_partial_loading=True`` (e.g. the RLHF reload path), without
+        double-finalizing in the eager path.
         """
         if not self.need_load_shared_weights(module):
+            return
+        if not hasattr(module, 'local_shared_w3_w1_tensors'):
             return
         self._prepare_shared_weights_for_finalization(module)
         weight_fns = {
@@ -548,6 +556,11 @@ class FusedMoEMethodBase(ABC):
         module.layer_load_balancer.host_tensor_sharer.finalize_layer_weights()
 
     def post_load_weights(self, module: torch.nn.Module):
+        # Safety net for deferred-finalization callers (e.g. RLHF reload, which
+        # passes allow_partial_loading=True and so skips the eager per-layer
+        # finalization in load_weights).  Idempotent when finalization already
+        # ran eagerly.
+        self._finalize_shared_weights(module)
         if hasattr(module,
                    "layer_load_balancer") and module.layer_load_balancer:
             module.layer_load_balancer.set_initial_weight_assignments(

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -498,26 +498,54 @@ class FusedMoEMethodBase(ABC):
         if not allow_partial_loading:
             self.process_weights_after_loading(module)
 
+            # Finalize shared weights eagerly so each layer's CPU tensors are freed
+            # before the next layer is loaded. This prevents accumulation of all
+            # layers' shared weight tensors in host memory simultaneously.
+            self._finalize_shared_weights(module)
+
+    def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):
+        """Hook for subclasses to transform shared weight tensors before
+        they are copied into shared memory and freed.
+
+        Called by ``_finalize_shared_weights`` just before the tensors stored
+        as ``local_shared_*`` module attributes are registered with the load
+        balancer and written into POSIX shared-memory segments.  Subclasses
+        may override this to apply weight transformations (e.g. resmoothing)
+        while the tensors are still in private process memory.
+        """
+
+    def _finalize_shared_weights(self, module: torch.nn.Module):
+        """Register shared weights with the load balancer and copy them into
+        shared memory, then delete the private CPU tensor copies.
+
+        Calling this at the end of each layer's ``load_weights`` (rather than
+        deferring to ``post_load_weights``) prevents all layers' CPU tensors
+        from accumulating in host memory simultaneously.  With fewer GPUs per
+        node each rank is responsible for more experts, so the accumulated
+        private tensors can easily exceed available host memory.
+        """
+        if not self.need_load_shared_weights(module):
+            return
+        self._prepare_shared_weights_for_finalization(module)
+        weight_fns = {
+            'w3_w1_weight': getattr(module, 'local_shared_w3_w1_tensors'),
+            'w2_weight': getattr(module, 'local_shared_w2_tensors')
+        }
+        delattr(module, 'local_shared_w3_w1_tensors')
+        delattr(module, 'local_shared_w2_tensors')
+        if module.bias:
+            weight_fns.update({
+                'w3_w1_bias':
+                getattr(module, 'local_shared_w3_w1_bias_tensors'),
+                'w2_bias':
+                getattr(module, 'local_shared_w2_bias_tensors')
+            })
+            delattr(module, 'local_shared_w3_w1_bias_tensors')
+            delattr(module, 'local_shared_w2_bias_tensors')
+        module.register_all_parameter_slot_and_to_fix_weight_fns(weight_fns)
+        module.layer_load_balancer.host_tensor_sharer.finalize_layer_weights()
+
     def post_load_weights(self, module: torch.nn.Module):
-        if self.need_load_shared_weights(module):
-            weight_fns = {
-                'w3_w1_weight': getattr(module, 'local_shared_w3_w1_tensors'),
-                'w2_weight': getattr(module, 'local_shared_w2_tensors')
-            }
-            delattr(module, 'local_shared_w3_w1_tensors')
-            delattr(module, 'local_shared_w2_tensors')
-            if module.bias:
-                weight_fns.update({
-                    'w3_w1_bias':
-                    getattr(module, 'local_shared_w3_w1_bias_tensors'),
-                    'w2_bias':
-                    getattr(module, 'local_shared_w2_bias_tensors')
-                })
-                delattr(module, 'local_shared_w3_w1_bias_tensors')
-                delattr(module, 'local_shared_w2_bias_tensors')
-            module.register_all_parameter_slot_and_to_fix_weight_fns(weight_fns)
-            module.layer_load_balancer.host_tensor_sharer.finalize_layer_weights(
-            )
         if hasattr(module,
                    "layer_load_balancer") and module.layer_load_balancer:
             module.layer_load_balancer.set_initial_weight_assignments(
@@ -1065,21 +1093,18 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
                 local_shared_w2_scale_tensors,
                 device=torch.device("cpu"))
 
-    def post_load_weights(self, module: torch.nn.Module):
-        if self.need_load_shared_weights(module):
-            weight_fns = {}
-            if hasattr(module, 'local_shared_w3_w1_scale_tensors'):
-                weight_fns['w3_w1_weight_scaling_factor'] = getattr(
-                    module, 'local_shared_w3_w1_scale_tensors')
-                delattr(module, 'local_shared_w3_w1_scale_tensors')
-            if hasattr(module, 'local_shared_w2_scale_tensors'):
-                weight_fns['w2_weight_scaling_factor'] = getattr(
-                    module, 'local_shared_w2_scale_tensors')
-                delattr(module, 'local_shared_w2_scale_tensors')
-            if weight_fns:
-                module.register_all_parameter_slot_and_to_fix_weight_fns(
-                    weight_fns)
-        super().post_load_weights(module)
+    def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):
+        weight_fns = {}
+        if hasattr(module, 'local_shared_w3_w1_scale_tensors'):
+            weight_fns['w3_w1_weight_scaling_factor'] = getattr(
+                module, 'local_shared_w3_w1_scale_tensors')
+            delattr(module, 'local_shared_w3_w1_scale_tensors')
+        if hasattr(module, 'local_shared_w2_scale_tensors'):
+            weight_fns['w2_weight_scaling_factor'] = getattr(
+                module, 'local_shared_w2_scale_tensors')
+            delattr(module, 'local_shared_w2_scale_tensors')
+        if weight_fns:
+            module.register_all_parameter_slot_and_to_fix_weight_fns(weight_fns)
 
 
 def resmooth_and_transform_fp8_scale(
@@ -1105,7 +1130,7 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
     def _needs_e8m0_resmooth(self):
         return is_sm_100f() or get_sm_version() == 120
 
-    def post_load_weights(self, module: torch.nn.Module):
+    def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):
         if self._needs_e8m0_resmooth():
             # Resmooth shared experts before registering shared weights
             if self.need_load_shared_weights(module):
@@ -1140,8 +1165,9 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                             resmoothed_shared_w2_weight.cpu())
                     setattr(module, 'local_shared_w2_scale_tensors',
                             transformed_shared_w2_scale.cpu())
+        super()._prepare_shared_weights_for_finalization(module)
 
-        # Call super() after resmooth shared experts (local_shared tensors will be deleted in super().post_load_weights())
+    def post_load_weights(self, module: torch.nn.Module):
         super().post_load_weights(module)
 
         if self._needs_e8m0_resmooth():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimization**
  * Improved memory efficiency during quantized weight loading through eager finalization and timely cleanup of shared weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes host OOM during EPLB startup on multi-node wide EP configs (e.g. DeepSeek-R1, 4 nodes × 4 GPUs).                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                    
Each rank loads expert_count / gpus_per_node experts into private CPU tensors per MoE layer. Previously all 61 layers' tensors accumulated in memory before any were copied to shared memory. With 4 GPUs/node each rank holds 64 experts/layer, totaling ~171GB/rank before anything is freed.                                                                                                   
                  
This PR moves shared memory finalization from post_load_weights() into load_weights(), so each layer's CPU tensors are freed immediately. 

This results in a reduction in peak memory consumption by ~40%.

<img width="1260" height="540" alt="baseline" src="https://github.com/user-attachments/assets/369b95fd-1b87-4b72-b101-550a268f0257" />
Memory consumption on main branch. Peak at ~230GB per rank.

<img width="1260" height="540" alt="fixed" src="https://github.com/user-attachments/assets/fcf898b3-2e1f-4b1d-9108-794864d67783" />
Memory consumption on this branch. Peak at ~135GB.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
