### PR TITLE
feat: support KV reuse in llava raw embedding case

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -15,7 +15,10 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
 from tensorrt_llm._torch.models.checkpoints.hf.llava_next_weight_mapper import \
     LlavaNextHfWeightMapper
-from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.inputs.multimodal import (MultimodalInput, MultimodalParams,
+                                            default_hasher,
+                                            find_mm_token_positions,
+                                            hexdigest_to_int32)
 
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
                        BaseMultimodalInputProcessor, ExtraProcessedInputs,
@@ -253,13 +256,19 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         This method skips vision processing and works with externally provided embeddings.
         It replaces/expands image placeholders in the text with appropriate tokens and prepares
         the embeddings for model forward pass.
+
+        Also computes multimodal hashing metadata (multimodal_input) so that
+        KV cache block reuse can properly coordinate with find_input_mm_embeds
+        to slice embeddings when cached blocks cover the multimodal token span.
+
         Args:
             inputs: Text prompt containing image placeholders
             multimodal_embedding: Dictionary containing pre-processed image embedding data
         Returns:
             Tuple of (token_ids, extra_processed_inputs) where:
             - token_ids: List of processed token IDs with image placeholders
-            - extra_processed_inputs: Optional dictionary containing multimodal embeddings
+            - extra_processed_inputs: Dictionary containing multimodal embeddings and
+              multimodal_input for KV cache reuse support
         """
         text_prompt = inputs.get("prompt")
         if not text_prompt:
@@ -276,11 +285,46 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         input_ids = self.tokenizer(text_prompt,
                                    return_tensors="pt").input_ids[0]
         mm_features = multimodal_embedding['image']
+
+        # Capture per-image token counts before _postprocess flattens the list
+        num_mm_tokens_per_image = []
+        for f in mm_features:
+            if f.dim() == 2:
+                num_mm_tokens_per_image.append(f.shape[0])
+            elif f.dim() == 3:
+                num_mm_tokens_per_image.append(f.shape[0] * f.shape[1])
+            else:
+                raise ValueError(f"Unexpected embedding dimension: {f.dim()}")
+
         fused_input_ids, mm_features = self._postprocess(input_ids, mm_features)
+        fused_token_ids = fused_input_ids.to(torch.int32).tolist()
+
+        # Compute multimodal hashes from embedding content for KV cache block matching
+        mm_hashes_int32 = []
+        for f in multimodal_embedding['image']:
+            raw = f.cpu().contiguous()
+            if raw.dtype == torch.bfloat16:
+                raw = raw.float()
+            h = default_hasher(raw.numpy().tobytes()).hexdigest()
+            mm_hashes_int32.append(hexdigest_to_int32(h))
+
+        start_positions, _ = find_mm_token_positions(
+            input_ids=fused_token_ids,
+            num_mm_tokens=num_mm_tokens_per_image,
+            vocab_size=self.vocab_size,
+        )
+
+        multimodal_input = MultimodalInput.from_components(
+            mm_hashes=mm_hashes_int32,
+            mm_positions=start_positions,
+            mm_lengths=num_mm_tokens_per_image,
+        )
+
         multimodal_data = {}
         multimodal_data["multimodal_embedding"] = mm_features
-        return fused_input_ids.to(torch.int32).tolist(), {
-            "multimodal_data": multimodal_data
+        return fused_token_ids, {
+            "multimodal_data": multimodal_data,
+            "multimodal_input": multimodal_input,
         }
 
     @torch.inference_mode()


### PR DESCRIPTION
## Why

When LLaVA-Next receives pre-computed (raw) embeddings from an external encoder, the `_process_raw_embedding` path does not produce `multimodal_input` metadata. Without it, the KV cache block-reuse mechanism cannot identify which token spans correspond to multimodal content, so cached KV blocks are never matched — defeating prefix caching for the disaggregated encode → prefill → decode pipeline.

## What Changed

- In `_process_raw_embedding`, compute per-image token counts, content-based hashes (`default_hasher` / `hexdigest_to_int32`), and start positions (`find_mm_token_positions`), then build a `MultimodalInput` and return it alongside the embeddings so the KV cache reuse path has the same metadata as the vision-processing path.

## Test Plan

- E2E test with disaggregated encoder + prefill/decode pipeline (existing `e_pd_embedding_e2e_test.sh`)
- Verify KV cache hit rate increases when the same image is sent repeatedly

```
curl -s localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "llava-hf/llava-v1.6-mistral-7b-hf",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "image_url",
          "image_url": {
            "url": "https://vllm-public-assets.s3.us-west-2.amazonaws.com/multimodal_asset/duck.jpg"
          }
        },
        {
          "type": "text",
          "text": "What is in this image?"
        }
      ]
    }
  ],
  "max_tokens": 300
}'
```

Prior to this PR, I will get the below error with the 2nd identical request (because of KV cache hit)

```
"/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_torch/models/modeling_multimodal_utils.py", line 354, in fuse_input_embeds
    raise ValueError(
ValueError: Multimodal token count mismatch: found 0 image tokens in input_ids but received 2046 image embeddings. This is likely due to KV cache reuse, chunk prefill, or other optimizations that cause token count mismatches within the inference batch.
```

After this PR, multiple identical requests will yield successfully with identical response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multimodal input handling with improved token positioning and hash computation for image embeddings.
  * Added KV cache reuse optimization for multimodal scenarios, improving memory efficiency and inference performance in multi-image processing.
  * Implemented comprehensive metadata management for multimodal inputs to support advanced image handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->