### PR TITLE
[TRTLLM-11257][fix] release GPU memory and FDs in MnnvlMemory on pidfd failure to prevent leak

### DIFF
--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -215,21 +215,21 @@ class MnnvlMemory:
                 allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
             )
         )
-        if (
-            allocation_prop.requestedHandleTypes
-            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        ):
-            all_handles_data = comm.allgather(exported_fabric_handle.data)
-        else:
-            all_handles_data = comm.allgather(exported_fabric_handle)
-            all_pids = comm.allgather(os.getpid())
-            libc = ctypes.CDLL(None, use_errno=True)
-            syscall = libc.syscall
-            SYS_pidfd_open = 434
-            SYS_pidfd_getfd = 438
-            pidfds = []
-            remote_fds = []
-            try:
+        pidfds = []
+        remote_fds = []
+        try:
+            if (
+                allocation_prop.requestedHandleTypes
+                == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+            ):
+                all_handles_data = comm.allgather(exported_fabric_handle.data)
+            else:
+                all_handles_data = comm.allgather(exported_fabric_handle)
+                all_pids = comm.allgather(os.getpid())
+                libc = ctypes.CDLL(None, use_errno=True)
+                syscall = libc.syscall
+                SYS_pidfd_open = 434
+                SYS_pidfd_getfd = 438
                 for i, pid in enumerate(all_pids):
                     pidfd = syscall(SYS_pidfd_open, pid, 0)
                     if pidfd < 0:
@@ -253,36 +253,36 @@ class MnnvlMemory:
                             error_msg += " This may be due to kernel version (requires Linux 5.6+)."
                         raise RuntimeError(error_msg)
                     remote_fds.append(remote_fd)
-            except Exception:
-                # Release resources on failure path to avoid leaks; then re-raise.
-                if isinstance(exported_fabric_handle, int):
-                    try:
-                        os.close(exported_fabric_handle)
-                    except OSError as e:
-                        logger.warning(
-                            "Failed to close exported shareable handle on error: %s",
-                            e,
-                        )
+
+                all_handles_data = remote_fds
+        except Exception:
+            # Release resources on failure path to avoid leaks; then re-raise.
+            if isinstance(exported_fabric_handle, int):
                 try:
-                    _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
-                except RuntimeError as e:
+                    os.close(exported_fabric_handle)
+                except OSError as e:
                     logger.warning(
-                        "cuMemRelease failed during error cleanup (original error will be raised): %s",
+                        "Failed to close exported shareable handle on error: %s",
                         e,
                     )
-                for _pidfd in pidfds:
-                    try:
-                        os.close(_pidfd)
-                    except OSError:
-                        pass
-                for _rfd in remote_fds:
-                    try:
-                        os.close(_rfd)
-                    except OSError:
-                        pass
-                raise
-
-            all_handles_data = remote_fds
+            try:
+                _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
+            except RuntimeError as e:
+                logger.warning(
+                    "cuMemRelease failed during error cleanup (original error will be raised): %s",
+                    e,
+                )
+            for _pidfd in pidfds:
+                try:
+                    os.close(_pidfd)
+                except OSError:
+                    pass
+            for _rfd in remote_fds:
+                try:
+                    os.close(_rfd)
+                except OSError:
+                    pass
+            raise
         # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
         # can use buf = memoryview(data) to import if using plain buffer for data.
 

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -261,7 +261,7 @@ class MnnvlMemory:
                             )
                     try:
                         _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
-                    except Exception as e:
+                    except RuntimeError as e:
                         logger.warning(
                             "cuMemRelease failed during error cleanup (original error will be raised): %s",
                             e,

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -228,56 +228,59 @@ class MnnvlMemory:
             SYS_pidfd_open = 434
             SYS_pidfd_getfd = 438
             pidfds = []
-            for i, pid in enumerate(all_pids):
-                pidfd = syscall(SYS_pidfd_open, pid, 0)
-                if pidfd < 0:
-                    err = ctypes.get_errno()
-                    raise RuntimeError(
-                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                    )
-                pidfds.append(pidfd)
-
             remote_fds = []
-            for i, (pidfd, fd) in enumerate(zip(pidfds, all_handles_data)):
-                remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                if remote_fd < 0:
-                    err = ctypes.get_errno()
-                    error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
-                    if err == 1:  # EPERM
-                        error_msg += (
-                            " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
-                            "to your docker run command."
+            try:
+                for i, pid in enumerate(all_pids):
+                    pidfd = syscall(SYS_pidfd_open, pid, 0)
+                    if pidfd < 0:
+                        err = ctypes.get_errno()
+                        raise RuntimeError(
+                            f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
                         )
-                    else:
-                        error_msg += " This may be due to kernel version (requires Linux 5.6+)."
-                    # Release resources on failure path to avoid leaks; then re-raise.
-                    if isinstance(exported_fabric_handle, int):
-                        try:
-                            os.close(exported_fabric_handle)
-                        except OSError as e:
-                            logger.warning(
-                                "Failed to close exported shareable handle on pidfd_getfd failure: %s",
-                                e,
+                    pidfds.append(pidfd)
+
+                for i, (pidfd, fd) in enumerate(zip(pidfds, all_handles_data)):
+                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
+                    if remote_fd < 0:
+                        err = ctypes.get_errno()
+                        error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
+                        if err == 1:  # EPERM
+                            error_msg += (
+                                " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
+                                "to your docker run command."
                             )
+                        else:
+                            error_msg += " This may be due to kernel version (requires Linux 5.6+)."
+                        raise RuntimeError(error_msg)
+                    remote_fds.append(remote_fd)
+            except Exception:
+                # Release resources on failure path to avoid leaks; then re-raise.
+                if isinstance(exported_fabric_handle, int):
                     try:
-                        _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
-                    except RuntimeError as e:
+                        os.close(exported_fabric_handle)
+                    except OSError as e:
                         logger.warning(
-                            "cuMemRelease failed during error cleanup (original error will be raised): %s",
+                            "Failed to close exported shareable handle on error: %s",
                             e,
                         )
-                    for _pidfd in pidfds:
-                        try:
-                            os.close(_pidfd)
-                        except OSError:
-                            pass
-                    for _rfd in remote_fds:
-                        try:
-                            os.close(_rfd)
-                        except OSError:
-                            pass
-                    raise RuntimeError(error_msg)
-                remote_fds.append(remote_fd)
+                try:
+                    _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
+                except RuntimeError as e:
+                    logger.warning(
+                        "cuMemRelease failed during error cleanup (original error will be raised): %s",
+                        e,
+                    )
+                for _pidfd in pidfds:
+                    try:
+                        os.close(_pidfd)
+                    except OSError:
+                        pass
+                for _rfd in remote_fds:
+                    try:
+                        os.close(_rfd)
+                    except OSError:
+                        pass
+                raise
 
             all_handles_data = remote_fds
         # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -250,6 +250,32 @@ class MnnvlMemory:
                         )
                     else:
                         error_msg += " This may be due to kernel version (requires Linux 5.6+)."
+                    # Release resources on failure path to avoid leaks; then re-raise.
+                    if isinstance(exported_fabric_handle, int):
+                        try:
+                            os.close(exported_fabric_handle)
+                        except OSError as e:
+                            logger.warning(
+                                "Failed to close exported shareable handle on pidfd_getfd failure: %s",
+                                e,
+                            )
+                    try:
+                        _check_cu_result(cuda.cuMemRelease(allocated_mem_handle))
+                    except Exception as e:
+                        logger.warning(
+                            "cuMemRelease failed during error cleanup (original error will be raised): %s",
+                            e,
+                        )
+                    for _pidfd in pidfds:
+                        try:
+                            os.close(_pidfd)
+                        except OSError:
+                            pass
+                    for _rfd in remote_fds:
+                        try:
+                            os.close(_rfd)
+                        except OSError:
+                            pass
                     raise RuntimeError(error_msg)
                 remote_fds.append(remote_fd)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during memory operations to ensure proper resource cleanup when failures occur, preventing potential resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description


When NVLink one-sided communication is used for MoE, workspace allocation in nvlink_one_sided.py calls MnnvlMemory(mapping, workspace_size_per_rank), which allocates via cuMemCreate + cuMemExportToShareableHandle and shares across processes using pidfd_open / pidfd_getfd. If pidfd_open or pidfd_getfd fails (e.g., EPERM in containers without SYS_PTRACE), the code previously raised without releasing resources created in the current attempt, including the CUDA allocation handle, exported shareable handle (FD for POSIX handle type), and any already-opened pidfds / duplicated remote FDs. Because self._WORKSPACE remains None, later retries could repeat this path, causing cumulative GPU memory and FD leaks._

This PR fixes the failure path in the POSIX (non-FABRIC) branch of open_mnnvl_memory in tensorrt_llm/_mnnvl_utils.py by ensuring proper cleanup before re-raising: it closes the exported shareable FD when applicable, calls cuMemRelease on the cuMemCreate allocation handle, and closes any pidfds and duplicated remote FDs opened during the attempt. Cleanup errors are logged as warnings and do not mask the original exception.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
