### PR TITLE
[https://nvbugs/5708901][perf] reduce logprobs=0 overhead in TorchSampler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -234,6 +234,8 @@ class LogProbStorage:
             if cum_log_probs is not None:
                 self.cum_log_probs[beam_idx] = cum_log_probs[beam_idx]
             else:
+                # FIXME: This relies on the ordering of LogProb's in the dictionary. TorchSampler ensures
+                #        that the sampled logprob is in the first position.
                 self.cum_log_probs[beam_idx] += sum(
                     next(iter(prob.values())).logprob for prob in probs)
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2395,15 +2395,13 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         else:
             token_log_probs = [[] for _ in range(beam_width)]
             for step_idx in range(count):
-                topk_token = token_list[step_idx]
-                topk_logprob = logprobs_list[step_idx]
-                topk_token = topk_token[:num_topk_logprobs]
-                topk_logprob = topk_logprob[:num_topk_logprobs]
-                min_rank = len(topk_token) + 1
+                topk_tokens = token_list[step_idx][:num_topk_logprobs]
+                topk_logprobs = logprobs_list[step_idx][:num_topk_logprobs]
+                min_rank = len(topk_tokens) + 1
 
                 topk_logprob_dict = {
                     token: Logprob(logprob=logprob, rank=rank + 1)
-                    for rank, (token, logprob) in enumerate(zip(topk_token, topk_logprob))
+                    for rank, (token, logprob) in enumerate(zip(topk_tokens, topk_logprobs))
                 }
 
                 for beam_idx in range(beam_width):

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -24,7 +24,6 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeAlias
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 
 from tensorrt_llm._torch.pyexecutor.make_decoding_batch_input_output import (
     MakeDecodingBatchInputOutput,
@@ -78,6 +77,7 @@ from .sampling_utils import (
     Strategy,
     StrategyMetadata,
     UtilsSamplingParams,
+    _Fusions,
     get_rejected_indices,
     resolve_sampling_strategy,
     sample,
@@ -416,8 +416,8 @@ def _request_sampling_params_cachable(params: UtilsSamplingParams) -> bool:
 def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
     # We try to cache the resolved strategy on the request object, as it's not cheap enough to
     # resolve it on every iteration.
-    if hasattr(request, "py_sampling_strategy"):
-        return request.py_sampling_strategy
+    if (cached_sampling_strategy := getattr(request, "py_sampling_strategy", None)) is not None:
+        return cast(Strategy, cached_sampling_strategy)
 
     params = _request_get_sampling_params(request)
     sampling_strategy = resolve_sampling_strategy(params, vocab_size=vocab_size)
@@ -2189,7 +2189,6 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         """
         Check if we can use the fast argmax path for greedy sampling.
         """
-
         # Check if all requests use greedy sampling and don't require features
         # that the fast path skips
         for req in requests:
@@ -2379,28 +2378,47 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         sampled_log_probs_vals_list = logprobs_state_list.sampled_vals[req_seq_slot]
         sampled_log_probs_rank_list = logprobs_state_list.sampled_rank[req_seq_slot]
 
-        token_log_probs: list[list[dict[int, Logprob]]] = []
-        for beam_idx in range(beam_width):
-            beam_token_log_probs: list[dict[int, Logprob]] = []
-            for step_idx, (topk_token, topk_logprob) in enumerate(
-                zip(token_list[:count], logprobs_list[:count])
-            ):
-                logprobs = {
-                    token: Logprob(logprob=logprob, rank=rank + 1)
-                    for rank, (token, logprob) in enumerate(
-                        zip(topk_token[:num_topk_logprobs], topk_logprob[:num_topk_logprobs])
-                    )
-                }
-                if sampled_log_probs_indices_list[beam_idx][step_idx] not in logprobs:
-                    logprobs[sampled_log_probs_indices_list[beam_idx][step_idx]] = Logprob(
-                        logprob=sampled_log_probs_vals_list[beam_idx][step_idx],
-                        rank=max(
-                            len(token_list[step_idx]) + 1,
+        token_log_probs: list[list[dict[int, Logprob]]]
+        if num_topk_logprobs == 0:
+            token_log_probs = [
+                [
+                    {
+                        sampled_log_probs_indices_list[beam_idx][step_idx]: Logprob(
+                            sampled_log_probs_vals_list[beam_idx][step_idx],
                             sampled_log_probs_rank_list[beam_idx][step_idx] + 1,
+                        )
+                    }
+                    for step_idx in range(count)
+                ]
+                for beam_idx in range(beam_width)
+            ]
+        else:
+            token_log_probs = [[] for _ in range(beam_width)]
+            for step_idx in range(count):
+                topk_token = token_list[step_idx]
+                topk_logprob = logprobs_list[step_idx]
+                topk_token = topk_token[:num_topk_logprobs]
+                topk_logprob = topk_logprob[:num_topk_logprobs]
+                min_rank = len(topk_token) + 1
+
+                topk_logprob_dict = {
+                    token: Logprob(logprob=logprob, rank=rank + 1)
+                    for rank, (token, logprob) in enumerate(zip(topk_token, topk_logprob))
+                }
+
+                for beam_idx in range(beam_width):
+                    # NB: Keeps sampled token in the first position (cf. https://stackoverflow.com/a/67786863)
+                    logprobs = {
+                        sampled_log_probs_indices_list[beam_idx][step_idx]: Logprob(
+                            logprob=sampled_log_probs_vals_list[beam_idx][step_idx],
+                            rank=max(
+                                min_rank,
+                                sampled_log_probs_rank_list[beam_idx][step_idx] + 1,
+                            ),
                         ),
-                    )
-                beam_token_log_probs.append(logprobs)
-            token_log_probs.append(beam_token_log_probs)
+                        **topk_logprob_dict,
+                    }
+                    token_log_probs[beam_idx].append(logprobs)
 
         return token_log_probs
 
@@ -2821,7 +2839,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 request,
                 vocab_size=2**31,  # vocab_size does not affect greediness
             )
-        return get_draft_token_length(request) > 0 and strategy != GREEDY
+        return strategy != GREEDY and get_draft_token_length(request) > 0
 
     def process_draft_tokens(
         self,
@@ -3269,9 +3287,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                     finish_reasons=finish_reasons,
                     resource_manager=resource_manager,
                 )
-                if get_draft_token_length(req) > 0:
+                if (actual_draft_len := get_draft_token_length(req)) > 0:
                     req.py_num_accepted_draft_tokens = num_accepted
-                    actual_draft_len = get_draft_token_length(req)
                     req.py_rewind_len = actual_draft_len - num_accepted
                 else:
                     req.py_num_accepted_draft_tokens = 0
@@ -3717,11 +3734,15 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 assert logit_indices_for_processed_logprobs_cuda is not None
                 assert group_softmax_cuda is not None
                 assert batch_logits_for_logprobs_cuda is not None
+                # NB: The logits copy could be avoided by instead counting (and storing):
+                #        -  the number of unmasked tokens 'nu'
+                #        -  r := log(max(probs)) - max(logits)
+                #   Later, processed logprobs can be reconstructed from raw logits _after_ applying
+                #   top-k: Add 'r' and mask smallest entries so that only min(k, nu) tokens remain.
                 current_logits_cuda = group_logits_cuda[
                     group_logits_indices_for_processed_logprobs_cuda
                 ]
                 current_softmax_cuda = group_softmax_cuda[logit_indices_for_processed_logprobs_cuda]
-
                 # processed_logits_cuda is an alias to current_logits_cuda after this operation
                 processed_logits_cuda = current_logits_cuda.masked_fill_(
                     current_softmax_cuda == 0, float("-inf")
@@ -3742,10 +3763,21 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 assert group_logits_indices_for_raw_logprobs_cuda is not None
                 assert logit_indices_for_raw_logprobs_cuda is not None
                 assert batch_logits_for_logprobs_cuda is not None
-                raw_logits_cuda = group_logits_cuda[group_logits_indices_for_raw_logprobs_cuda]
+                if (
+                    group_logits_indices_for_raw_logprobs_cuda
+                    is logit_indices_for_raw_logprobs_cuda
+                ):
+                    group_logits_indices_for_raw_logprobs_cuda = (
+                        group_logits_indices_for_raw_logprobs_cuda.clone()
+                    )
                 logit_indices_for_raw_logprobs_cuda += batch_next_tokens_offset_start
-                batch_logits_for_logprobs_cuda[logit_indices_for_raw_logprobs_cuda] = (
-                    raw_logits_cuda
+                # NB: Copy could be avoided by storing logit indices (and temperature) instead (cf. comment on
+                #     processed logprobs above).
+                _Fusions.gather_scatter(
+                    batch_logits_for_logprobs_cuda,
+                    logit_indices_for_raw_logprobs_cuda,
+                    group_logits_cuda,
+                    group_logits_indices_for_raw_logprobs_cuda,
                 )
 
             # Set LlmRequest.py_target_probs
@@ -4061,9 +4093,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             )
 
             # (batch_size, vocab_size)
-            group_logprobs_cuda = F.log_softmax(
-                batched_sampling_result.batch_logits_for_logprobs_cuda[group_logits_indices_cuda],
-                dim=-1,
+            group_logprobs_cuda = _Fusions.gather_log_softmax(
+                batched_sampling_result.batch_logits_for_logprobs_cuda, group_logits_indices_cuda
             )
 
             # Process the topk logprobs
@@ -4102,10 +4133,13 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             # Get the sampled logprobs indices
             sampled_indices_cuda = group_next_tokens_cuda.squeeze(1)
 
-            # NB: group_logprobs_cuda is not needed anymore and the storage can be safely reused.
             # sampled_rank_cuda contains the 0-based rank, it will be corrected to 1-based in handle_logprobs
-            group_logprobs_cuda.greater_(sampled_vals_cuda)
-            sampled_rank_cuda = group_logprobs_cuda.sum(dim=-1).to(torch.int32)
+            # NB: Computation of sampled rank could be lowered into GroupedStrategySampler, s.t., e.g., for
+            #     greedy sampling, logits management and log_softmax could be completely skipped (sampled rank
+            #     computation is trivial in this case).
+            sampled_rank_cuda = _Fusions.determine_sampled_rank(
+                group_logprobs_cuda, sampled_vals_cuda
+            )
 
             sampled_vals_cuda = sampled_vals_cuda.squeeze(1)
 

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -699,3 +699,74 @@ def torch_multi_arange(
     seq = seq.repeat_interleave(seq_repeats, output_size=output_length_arg)
     seq = seq.cumsum(0, dtype=ends.dtype)
     return seq
+
+
+class _Fusions:
+    @staticmethod
+    @torch.compile(dynamic=None, fullgraph=True)
+    def _gather_scatter_impl(
+        dst_cuda: torch.Tensor,
+        dst_index_cuda: torch.Tensor,
+        src_cuda: torch.Tensor,
+        src_index_cuda: torch.Tensor,
+    ) -> None:
+        # NB: helper function for TorchSampler._sample_batched_by_strategy, torch.compile is expected to avoid a copy
+        dst_cuda[dst_index_cuda] = src_cuda[src_index_cuda]
+
+    @staticmethod
+    def gather_scatter(
+        dst_cuda: torch.Tensor,
+        dst_index_cuda: torch.Tensor,
+        src_cuda: torch.Tensor,
+        src_index_cuda: torch.Tensor,
+    ) -> None:
+        torch._dynamo.mark_dynamic(dst_cuda, 0)
+        torch._dynamo.mark_dynamic(dst_index_cuda, 0)
+        torch._dynamo.mark_dynamic(src_cuda, 0)
+        torch._dynamo.mark_dynamic(src_index_cuda, 0)
+        _Fusions._gather_scatter_impl(dst_cuda, dst_index_cuda, src_cuda, src_index_cuda)
+
+    @staticmethod
+    @torch.compile(dynamic=None, fullgraph=True)
+    def _determine_sampled_rank_impl(
+        group_logprobs_cuda: torch.Tensor, sampled_logprobs_cuda: torch.Tensor
+    ) -> torch.Tensor:
+        sampled_rank_cuda = (
+            group_logprobs_cuda.greater(sampled_logprobs_cuda).count_nonzero(dim=-1).to(torch.int32)
+        )
+        return sampled_rank_cuda
+
+    @staticmethod
+    def determine_sampled_rank(
+        group_logprobs_cuda: torch.Tensor, sampled_logprobs_cuda: torch.Tensor
+    ) -> torch.Tensor:
+        # NB: helper function for TorchSampler._process_logprobs, torch.compile is expected to avoid
+        #     memory passes
+        torch._dynamo.mark_dynamic(group_logprobs_cuda, 0)
+        torch._dynamo.mark_dynamic(sampled_logprobs_cuda, 0)
+        return _Fusions._determine_sampled_rank_impl(group_logprobs_cuda, sampled_logprobs_cuda)
+
+    @staticmethod
+    @torch.compile(
+        dynamic=None,
+        fullgraph=True,
+        options=dict(
+            online_softmax=True,
+            split_reductions=False,  # https://github.com/pytorch/pytorch/issues/153241
+        ),
+    )
+    def _gather_log_softmax_impl(
+        inputs_cuda: torch.Tensor, indices_cuda: torch.Tensor
+    ) -> torch.Tensor:
+        # NB: helper function for TorchSampler._process_logprobs, torch.compile is expected to avoid
+        #     materializing the index select
+        return torch.nn.functional.log_softmax(
+            inputs_cuda[indices_cuda],
+            dim=-1,
+        )
+
+    @staticmethod
+    def gather_log_softmax(inputs_cuda: torch.Tensor, indices_cuda: torch.Tensor) -> torch.Tensor:
+        torch._dynamo.mark_dynamic(inputs_cuda, 0)
+        torch._dynamo.mark_dynamic(indices_cuda, 0)
+        return _Fusions._gather_log_softmax_impl(inputs_cuda, indices_cuda)

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -252,7 +252,7 @@ def test_sampled_token_always_in_logprobs(logprobs_k: int, logprobs_mode: str, s
                 assert len(token_logprobs) >= max(logprobs_k, 1)
 
             sorted_tokens_by_prob = sorted(
-                token_logprobs.items(), key=lambda x: x[1].logprob, reverse=True
+                token_logprobs.items(), key=lambda x: (x[1].logprob, -x[1].rank), reverse=True
             )
 
             if logprobs_k > 0:
@@ -331,7 +331,7 @@ def test_sampled_token_always_in_prompt_logprobs(logprobs_k: int, simple_llm: LL
                 assert len(token_logprobs) >= 1
 
             sorted_tokens_by_prob = sorted(
-                token_logprobs.items(), key=lambda x: x[1].logprob, reverse=True
+                token_logprobs.items(), key=lambda x: (x[1].logprob, -x[1].rank), reverse=True
             )
 
             if logprobs_k > 0:
@@ -399,16 +399,21 @@ def test_logprobs_against_logits(
                 processed_ranks_and_logprobs[logprob_obj.rank] = logprob_obj.logprob
 
                 # Check if the logprob matches the top-rank logprob from the logits
-                assert (
-                    logprob_obj.logprob == sorted_expected_logprobs_per_token[logprob_obj.rank - 1]
-                ), (
-                    f"Returned {case_str} logprob {logprob_obj.logprob} does not match expected logprob \
-                        {sorted_expected_logprobs_per_token[logprob_obj.rank - 1]} at rank {logprob_obj.rank}"
+                torch.testing.assert_close(
+                    torch.tensor(logprob_obj.logprob, dtype=torch.float32),
+                    torch.tensor(
+                        sorted_expected_logprobs_per_token[logprob_obj.rank - 1],
+                        dtype=torch.float32,
+                    ),
+                    msg=f"Returned {case_str} logprob {logprob_obj.logprob} does not match expected logprob \
+                        {sorted_expected_logprobs_per_token[logprob_obj.rank - 1]} at rank {logprob_obj.rank}",
                 )
                 # Check if the logprob matches the token-id logprob from the logits
-                assert logprob_obj.logprob == expected_logprobs_per_token[token_id], (
-                    f"Returned {case_str} logprob {logprob_obj.logprob} does not match expected logprob \
-                        {expected_logprobs_per_token[token_id]} for token {token_id}"
+                torch.testing.assert_close(
+                    torch.tensor(logprob_obj.logprob, dtype=torch.float32),
+                    torch.tensor(expected_logprobs_per_token[token_id], dtype=torch.float32),
+                    msg=f"Returned {case_str} logprob {logprob_obj.logprob} does not match expected logprob \
+                        {expected_logprobs_per_token[token_id]} for token {token_id}",
                 )
 
     for output in simple_llm.generate(["The future of AI is"], sampling_params=sampling_params):
@@ -509,11 +514,15 @@ def test_logprobs_with_grouped_samplings_strategies(logprobs_k: int, simple_llm:
             expected_logprobs = torch.nn.functional.log_softmax(logits_for_token, dim=-1).to(
                 device="cpu"
             )
-            expected_logprob = expected_logprobs[sampled_token_id].item()
+            expected_logprob = expected_logprobs[sampled_token_id]
             print(
-                f"Req {req_idx}, Token {token_idx}: returned={returned_logprob:.6f}, expected={expected_logprob:.6f}"
+                f"Req {req_idx}, Token {token_idx}: returned={returned_logprob:.6f}, "
+                f"expected={expected_logprob.item():.6f}"
             )
-            torch.testing.assert_close(returned_logprob, expected_logprob)
+            torch.testing.assert_close(
+                torch.tensor(returned_logprob, dtype=torch.float32),
+                expected_logprob,
+            )
 
 
 @pytest.mark.parametrize("logprobs_k", [-5], ids=["invalid_negative_value"])
@@ -645,13 +654,16 @@ def test_processed_logprobs_e2e(logprobs_k: int, simple_llm: LLM):
                 adjusted_logits_for_token, dim=-1
             ).to(device="cpu")
             for logprob_token, logprob_values in token_logprobs_dict.items():
-                expected_logprob = expected_logprobs[logprob_token].item()
+                expected_logprob = expected_logprobs[logprob_token]
                 returned_logprob = logprob_values.logprob
                 print(
                     f"Req {req_idx}, Token {token_idx}: "
-                    f"returned={returned_logprob:.6f}, expected={expected_logprob:.6f}"
+                    f"returned={returned_logprob:.6f}, expected={expected_logprob.item():.6f}"
                 )
-                torch.testing.assert_close(returned_logprob, expected_logprob)
+                torch.testing.assert_close(
+                    torch.tensor(returned_logprob, dtype=torch.float32),
+                    expected_logprob,
+                )
 
 
 @force_ampere


### PR DESCRIPTION
## Description

On L40S, for Llama-3.2-1B-Instruct with `logprobs=0` and batch size 1000, this reduces sampling related GPU time from 2.4 ms to 1.0 ms (half of `TRTLLMSampler`) and sampling related host overhead from 13.8 ms to 11.3 ms (TRTLLMSampler: 5.9 ms).

## Test Coverage

n/a

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal tensor operations for improved sampling performance
  * Enhanced robustness in probability calculation and edge case handling
  * Improved internal caching mechanisms for better efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->