### PR TITLE
[TRTLLM-11290][feat] Enable trtllm-serve E2E tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -79,6 +79,8 @@ l0_a10:
   - test_e2e.py::test_openai_chat_example[pytorch] TIMEOUT (90)
   - test_e2e.py::test_trtllm_bench_request_rate_and_concurrency[enable_concurrency-]
   - test_e2e.py::test_trtllm_bench_invalid_token_pytorch[TinyLlama-1.1B-Chat-v1.0-TinyLlama-1.1B-Chat-v1.0]
+  # visual_gen
+  - unittest/_torch/visual_gen/test_media_storage.py
   # llmapi
   - unittest/llmapi/test_llm_utils.py
   - unittest/llmapi/test_gc_utils.py

--- a/tests/unittest/_torch/visual_gen/test_media_storage.py
+++ b/tests/unittest/_torch/visual_gen/test_media_storage.py
@@ -24,40 +24,6 @@ def _make_dummy_video_tensor(
     return torch.randint(0, 256, (num_frames, height, width, 3), dtype=torch.uint8)
 
 
-class TestMediaStoragePNGFallback:
-    """Test PNG fallback path handling when video encoding fails."""
-
-    def test_png_fallback_with_avi_extension(self, tmp_path):
-        """Test that PNG fallback uses correct path after .avi extension change."""
-        video = _make_dummy_video_tensor()
-        output_path = str(tmp_path / "test.avi")
-
-        # Mock encoder to return None (no encoder available)
-        with patch("tensorrt_llm.serve.media_storage.get_video_encoder", return_value=None):
-            result = MediaStorage._save_encoded_video(video, None, output_path, 24.0)
-
-        # Should create PNG file with correct name
-        assert result.endswith(".png")
-        assert os.path.exists(result)
-        expected_path = str(tmp_path / "test.png")
-        assert result == expected_path
-
-    def test_png_fallback_with_mp4_extension(self, tmp_path):
-        """Test that PNG fallback uses correct path after .mp4 extension."""
-        video = _make_dummy_video_tensor()
-        output_path = str(tmp_path / "test.mp4")
-
-        # Mock encoder to return None (no encoder available)
-        with patch("tensorrt_llm.serve.media_storage.get_video_encoder", return_value=None):
-            result = MediaStorage._save_encoded_video(video, None, output_path, 24.0)
-
-        # Should create PNG file with correct name
-        assert result.endswith(".png")
-        assert os.path.exists(result)
-        expected_path = str(tmp_path / "test.png")
-        assert result == expected_path
-
-
 class TestMediaStorageMP4Encoding:
     """Test MP4 encoding with and without ffmpeg."""
 

--- a/tests/unittest/_torch/visual_gen/test_trtllm_serve_e2e.py
+++ b/tests/unittest/_torch/visual_gen/test_trtllm_serve_e2e.py
@@ -20,6 +20,7 @@ Usage::
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -174,14 +175,9 @@ def _model_available(path: Path) -> bool:
     return path.is_dir()
 
 
-def _av_available() -> bool:
-    """Check if PyAV is installed (required for video encoding in E2E tests)."""
-    try:
-        import av  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+def _ffmpeg_available() -> bool:
+    """Check if ffmpeg CLI is available (required for MP4 encoding)."""
+    return shutil.which("ffmpeg") is not None
 
 
 def _make_visual_gen_options(**extra) -> dict:
@@ -202,9 +198,6 @@ def _make_visual_gen_options(**extra) -> dict:
 @pytest.mark.skipif(
     not _model_available(_WAN_T2V_PATH), reason=f"Wan2.1-T2V model not found at {_WAN_T2V_PATH}"
 )
-@pytest.mark.skipif(
-    not _av_available(), reason="PyAV (av) not installed — required for video encoding in E2E tests"
-)
 class TestWanTextToVideo:
     """Test Wan2.1-T2V-1.3B-Diffusers text-to-video generation via serve API."""
 
@@ -222,7 +215,19 @@ class TestWanTextToVideo:
         resp = requests.get(server.url_for("health"))
         assert resp.status_code == 200
 
-    def test_t2v_sync(self, server):
+    @pytest.mark.parametrize(
+        "output_format,expected_content_type",
+        [
+            pytest.param("avi", "video/x-msvideo", id="avi"),
+            pytest.param(
+                "mp4",
+                "video/mp4",
+                id="mp4",
+                marks=pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not installed"),
+            ),
+        ],
+    )
+    def test_t2v_sync(self, server, output_format, expected_content_type):
         """Synchronous text-to-video via POST /v1/videos/generations."""
         resp = requests.post(
             server.url_for("v1", "videos", "generations"),
@@ -233,13 +238,26 @@ class TestWanTextToVideo:
                 "fps": 8,
                 "num_inference_steps": 4,
                 "seed": 42,
+                "output_format": output_format,
             },
         )
         assert resp.status_code == 200, resp.text
-        assert resp.headers["content-type"] == "video/mp4"
+        assert resp.headers["content-type"] == expected_content_type
         assert len(resp.content) > 1000, "Video file too small"
 
-    def test_t2v_async_lifecycle(self, server):
+    @pytest.mark.parametrize(
+        "output_format,expected_content_type",
+        [
+            pytest.param("avi", "video/x-msvideo", id="avi"),
+            pytest.param(
+                "mp4",
+                "video/mp4",
+                id="mp4",
+                marks=pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not installed"),
+            ),
+        ],
+    )
+    def test_t2v_async_lifecycle(self, server, output_format, expected_content_type):
         """Async video generation: create job → poll → download → delete."""
         base = server.url_for("v1", "videos")
 
@@ -253,6 +271,7 @@ class TestWanTextToVideo:
                 "fps": 8,
                 "num_inference_steps": 4,
                 "seed": 42,
+                "output_format": output_format,
             },
         )
         assert create_resp.status_code == 202, create_resp.text
@@ -275,7 +294,7 @@ class TestWanTextToVideo:
         # 3. Download video content
         content_resp = requests.get(f"{base}/{video_id}/content")
         assert content_resp.status_code == 200
-        assert "video/mp4" in content_resp.headers.get("content-type", "")
+        assert expected_content_type in content_resp.headers.get("content-type", "")
         assert len(content_resp.content) > 1000
 
         # 4. Verify it appears in list
@@ -305,9 +324,6 @@ class TestWanTextToVideo:
 @pytest.mark.skipif(
     not _REF_IMAGE_PATH.is_file(), reason=f"Reference image not found at {_REF_IMAGE_PATH}"
 )
-@pytest.mark.skipif(
-    not _av_available(), reason="PyAV (av) not installed — required for video encoding in E2E tests"
-)
 class TestWanImageToVideo:
     """Test Wan2.2-I2V-A14B-Diffusers image-to-video generation via serve API."""
 
@@ -325,7 +341,19 @@ class TestWanImageToVideo:
         resp = requests.get(server.url_for("health"))
         assert resp.status_code == 200
 
-    def test_ti2v_sync(self, server):
+    @pytest.mark.parametrize(
+        "output_format,expected_content_type",
+        [
+            pytest.param("avi", "video/x-msvideo", id="avi"),
+            pytest.param(
+                "mp4",
+                "video/mp4",
+                id="mp4",
+                marks=pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not installed"),
+            ),
+        ],
+    )
+    def test_ti2v_sync(self, server, output_format, expected_content_type):
         """Synchronous image-to-video via multipart POST /v1/videos/generations."""
         with open(_REF_IMAGE_PATH, "rb") as f:
             resp = requests.post(
@@ -337,16 +365,29 @@ class TestWanImageToVideo:
                     "fps": "8",
                     "num_inference_steps": "4",
                     "seed": "42",
+                    "output_format": output_format,
                 },
                 files={
                     "input_reference": ("cat_piano.png", f, "image/png"),
                 },
             )
         assert resp.status_code == 200, resp.text
-        assert resp.headers["content-type"] == "video/mp4"
+        assert resp.headers["content-type"] == expected_content_type
         assert len(resp.content) > 1000, "Video file too small"
 
-    def test_ti2v_async_lifecycle(self, server):
+    @pytest.mark.parametrize(
+        "output_format,expected_content_type",
+        [
+            pytest.param("avi", "video/x-msvideo", id="avi"),
+            pytest.param(
+                "mp4",
+                "video/mp4",
+                id="mp4",
+                marks=pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not installed"),
+            ),
+        ],
+    )
+    def test_ti2v_async_lifecycle(self, server, output_format, expected_content_type):
         """Async i2v: create job with image → poll → download → delete."""
         base = server.url_for("v1", "videos")
 
@@ -361,6 +402,7 @@ class TestWanImageToVideo:
                     "fps": "8",
                     "num_inference_steps": "4",
                     "seed": "42",
+                    "output_format": output_format,
                 },
                 files={
                     "input_reference": ("cat_piano.png", f, "image/png"),
@@ -385,7 +427,7 @@ class TestWanImageToVideo:
         # 3. Download
         content_resp = requests.get(f"{base}/{video_id}/content")
         assert content_resp.status_code == 200
-        assert "video/mp4" in content_resp.headers.get("content-type", "")
+        assert expected_content_type in content_resp.headers.get("content-type", "")
         assert len(content_resp.content) > 1000
 
         # 4. Delete


### PR DESCRIPTION
- Replace legacy PyAV (av) skip with FFmpeg CLI check
- Remove _av_available(); add _ffmpeg_available() using shutil.which
- Parametrize video tests for both AVI and MP4 (mp4 skipped if ffmpeg missing)
- Assert expected content-type per format (video/x-msvideo for AVI, video/mp4 for MP4)
- Tests: test_t2v_sync, test_t2v_async_lifecycle, test_ti2v_sync, test_ti2v_async_lifecycle


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to validate both AVI and MP4 output formats for video generation capabilities.
  * Updated test infrastructure: migrated from PyAV to ffmpeg-based validation for MP4 format testing.
  * Removed deprecated PNG fallback test suite from media storage tests.
  * Enhanced test parametrization for improved output format validation across async and sync operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
