### PR TITLE
[None][infra] Reduce Docker image layer count in release stage

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -120,35 +120,41 @@ WORKDIR /app/tensorrt_llm
 RUN --mount=type=cache,target=/root/.cache/pip --mount=type=bind,from=wheel,source=/src/tensorrt_llm/build,target=/tmp/wheel \
     pip install /tmp/wheel/tensorrt_llm*.whl
 
-COPY README.md ./
-COPY --from=wheel /src/tensorrt_llm/build/tensorrt_llm*.whl ./
-COPY docs docs
-COPY cpp/include include
-
-RUN ln -sv $(python3 -c 'import site; print(f"{site.getsitepackages()[0]}/tensorrt_llm/bin")') bin && \
-    test -f bin/executorWorker && \
-    ln -sv $(python3 -c 'import site; print(f"{site.getsitepackages()[0]}/tensorrt_llm/libs")') lib && \
-    test -f lib/libnvinfer_plugin_tensorrt_llm.so && \
-    echo "/app/tensorrt_llm/lib" > /etc/ld.so.conf.d/tensorrt_llm.conf && \
-    ldconfig && \
-    ! ( ldd -v bin/executorWorker | grep tensorrt_llm | grep -q "not found" )
-
-ARG SRC_DIR=/src/tensorrt_llm
-COPY --from=wheel ${SRC_DIR}/benchmarks benchmarks
-ARG CPP_BUILD_DIR=${SRC_DIR}/cpp/build
-COPY --from=wheel \
-     ${CPP_BUILD_DIR}/benchmarks/bertBenchmark \
-     ${CPP_BUILD_DIR}/benchmarks/gptManagerBenchmark \
-     ${CPP_BUILD_DIR}/benchmarks/disaggServerBenchmark \
-     benchmarks/cpp/
-
-COPY examples examples
-RUN chmod -R a+w examples && \
+RUN --mount=type=bind,source=README.md,target=/mnt/ctx/README.md \
+    --mount=type=bind,source=docs,target=/mnt/ctx/docs \
+    --mount=type=bind,source=cpp/include,target=/mnt/ctx/include \
+    --mount=type=bind,source=examples,target=/mnt/ctx/examples \
+    --mount=type=bind,from=wheel,source=/src/tensorrt_llm/build,target=/mnt/wheel \
+    --mount=type=bind,from=wheel,source=/src/tensorrt_llm/benchmarks,target=/mnt/benchmarks \
+    --mount=type=bind,from=wheel,source=/src/tensorrt_llm/cpp/build/benchmarks,target=/mnt/cpp_benchmarks \
+    # Copy build context files
+    cp /mnt/ctx/README.md ./ && \
+    cp -r /mnt/ctx/docs ./docs && \
+    cp -r /mnt/ctx/include ./include && \
+    cp -r /mnt/ctx/examples ./examples && \
+    chmod -R a+w examples && \
+    # Copy wheel stage outputs
+    cp /mnt/wheel/tensorrt_llm*.whl ./ && \
+    cp -r /mnt/benchmarks ./benchmarks && \
+    mkdir -p benchmarks/cpp && \
+    cp /mnt/cpp_benchmarks/bertBenchmark \
+       /mnt/cpp_benchmarks/gptManagerBenchmark \
+       /mnt/cpp_benchmarks/disaggServerBenchmark \
+       benchmarks/cpp/ && \
     rm -v \
       benchmarks/cpp/bertBenchmark.cpp \
       benchmarks/cpp/gptManagerBenchmark.cpp \
       benchmarks/cpp/disaggServerBenchmark.cpp \
       benchmarks/cpp/CMakeLists.txt && \
+    # Create symlinks to installed package binaries and libraries
+    ln -sv $(python3 -c 'import site; print(f"{site.getsitepackages()[0]}/tensorrt_llm/bin")') bin && \
+    test -f bin/executorWorker && \
+    ln -sv $(python3 -c 'import site; print(f"{site.getsitepackages()[0]}/tensorrt_llm/libs")') lib && \
+    test -f lib/libnvinfer_plugin_tensorrt_llm.so && \
+    echo "/app/tensorrt_llm/lib" > /etc/ld.so.conf.d/tensorrt_llm.conf && \
+    ldconfig && \
+    ! ( ldd -v bin/executorWorker | grep tensorrt_llm | grep -q "not found" ) && \
+    # Clean up caches and CVE workarounds
     rm -rf /root/.cache/uv/archive-v0 && \
     # WAR against https://github.com/advisories/GHSA-58pv-8j8x-9vj2
     rm -rf /usr/local/lib/python3.12/dist-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info && \
@@ -162,8 +168,8 @@ ENV TRT_LLM_GIT_COMMIT=${GIT_COMMIT} \
     TRT_LLM_VERSION=${TRT_LLM_VER}
 
 # Generate OSS attribution file for release image
-COPY scripts/generate_container_oss_attribution.sh /tmp/generate_container_oss_attribution.sh
-RUN bash /tmp/generate_container_oss_attribution.sh "release" "${TRT_LLM_VER}" "${TARGETARCH}" && rm /tmp/generate_container_oss_attribution.sh
+RUN --mount=type=bind,source=scripts/generate_container_oss_attribution.sh,target=/mnt/gen_attribution.sh \
+    bash /mnt/gen_attribution.sh "release" "${TRT_LLM_VER}" "${TARGETARCH}"
 
 FROM wheel AS tritonbuild
 


### PR DESCRIPTION
## Summary

Follow-up to #11720 which already consolidated the devel stage layers using bind mounts.

This PR applies the same pattern to the **release stage**:

- Replace 7 `COPY` layers + 2 `RUN` layers with a single `RUN` using `--mount=type=bind` and `cp`, consolidating all file copies, symlink creation, and cleanup into one layer
- Replace the OSS attribution `COPY` + `RUN` + `rm` with a single `RUN` using a bind mount

Reduces the release stage from ~13 layers to 3 (`pip install`, copy+setup+cleanup, OSS attribution), saving ~10 layers in the published image and leaving more headroom under Docker's 128-layer overlay2 limit for downstream consumers.

## Test plan

- [x] Build release image and verify layer count reduction (`docker history`)
- [x] Verify `trtllm-serve` starts correctly from built image
- [x] Verify symlinks to bin/lib are created correctly
- [x] Verify OSS attribution file is generated in release image