### PR TITLE
[None][refactor] AutoDeploy: PyTorch-native format for NVFP4

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
@@ -373,9 +373,9 @@ def _pad_nvfp4_weight(
     weight_fp4 and weight_scale are padded independently because they have
     different alignment requirements:
       - weight_fp4 has shape [n, k/2] (packed uint8) — padded along both dims.
-      - weight_scale is 1D in cutlass format (swizzled/padded). It is converted
-        to modelopt row-major [n, k/16] for correct padding, then converted
-        back. The cutlass conversion handles 128x4 alignment internally.
+      - weight_scale is in modelopt row-major FP8 format with shape [n, k/16]
+        (or already padded to [padded_n, padded_k/16]). Padded directly along
+        both dims.
       - alpha has shape [n] or is a scalar — padded along dim 0 when 1-D.
 
     Returns (weight_fp4, weight_scale, alpha, n_padded, k_padded).
@@ -392,20 +392,13 @@ def _pad_nvfp4_weight(
     if alpha.ndim >= 1 and pad_n > 0:
         alpha = torch.nn.functional.pad(alpha, (0, pad_n))
 
-    # weight_scale is in cutlass format (swizzled/padded). Convert to
-    # modelopt row-major [n, k/16] so the reshape/pad operates on the correct
-    # logical layout, then convert back. modelopt_fp4_scale_to_cutlass_fp4_scale
-    # handles the 128x4 alignment internally.
-    from ...utils.quantization_utils import (
-        cutlass_fp4_scale_to_modelopt_fp4_scale,
-        modelopt_fp4_scale_to_cutlass_fp4_scale,
-    )
-
+    # weight_scale is in modelopt FP8 row-major format. Pad directly.
+    # The caller is responsible for CUTLASS conversion after padding.
     bsv = TRTLLM_NVFP4_SCALING_VECTOR_SIZE
     blocks_per_row_padded = k_padded // bsv
-    ws = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale, (n, k))
+    ws = weight_scale.reshape(n, -1)
     ws = torch.nn.functional.pad(ws, (0, blocks_per_row_padded - ws.shape[1], 0, pad_n))
-    weight_scale = modelopt_fp4_scale_to_cutlass_fp4_scale(ws)
+    weight_scale = ws
 
     return weight_fp4, weight_scale, alpha, n_padded, k_padded
 
@@ -426,9 +419,8 @@ def nvfp4_linear(
         input: unquantized input tensor
         weight_fp4: pre-quantized weight tensor, with dtype torch.uint8 (1 uint8 == 2 elements)
         input_scale: a scalar tensor defined as per_tensor_amax / (FP8 max value (448.0) * FP4 max value (6.0)).
-        weight_scale: a 1D tensor with shape (out_dim * in_dim / 16) padded to be multiple of (128 * 4).
-            with value: per_block_amax / per_tensor_amax * FP8 max value (448.0)
-        weight_scale_2: a scalar tensor defined as per_tensor_amax / (FP8 max value (448.0) * FP4 max value (6.0)).
+        weight_scale: per-block scale in torch FP8 (float8_e4m3fn), shape (out_dim, in_dim/16) or padded.
+        alpha: 1 / (input_scale * weight_scale_2).
 
     Returns:
         The linear output with the original dtype as the input.
@@ -442,9 +434,6 @@ def nvfp4_linear(
     k = input_shape[-1]
     assert k % 16 == 0
     assert weight_shape[-1] % 8 == 0
-    assert weight_scale.numel() % (128 * 4) == 0
-
-    input = input.reshape(-1, k)
 
     # FP4 compatibility
     assert input_scale is not None
@@ -462,12 +451,22 @@ def nvfp4_linear(
         if k_padded != k:
             input = torch.nn.functional.pad(input, (0, k_padded - k))
 
+    # Convert torch-compatible FP8 per-block scale to CUTLASS (padded, swizzled) for the kernel.
+    from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
+        modelopt_fp4_scale_to_cutlass_fp4_scale,
+    )
+
+    weight_scale_cutlass = modelopt_fp4_scale_to_cutlass_fp4_scale(weight_scale)
+    assert weight_scale_cutlass.numel() % (128 * 4) == 0
+
+    input = input.reshape(-1, input.shape[-1])
+
     x_fp4, x_sf_block = torch.ops.trtllm.fp4_quantize(
         input, input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False
     )
 
     output = torch.ops.trtllm.nvfp4_gemm(
-        x_fp4, weight_fp4, x_sf_block, weight_scale, alpha, input.dtype
+        x_fp4, weight_fp4, x_sf_block, weight_scale_cutlass, alpha, input.dtype
     )
 
     if need_pad and n % 32 != 0:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
@@ -411,16 +411,16 @@ def nvfp4_linear(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
-    alpha: Optional[torch.Tensor] = None,
+    weight_scale_2: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """FP4 linear op similar to torch.nn.linear.
 
     Args:
         input: unquantized input tensor
         weight_fp4: pre-quantized weight tensor, with dtype torch.uint8 (1 uint8 == 2 elements)
-        input_scale: a scalar tensor defined as per_tensor_amax / (FP8 max value (448.0) * FP4 max value (6.0)).
+        input_scale: per-tensor input scale_2 = input_amax / FP4_GLOBAL_SCALE_MAX.
         weight_scale: per-block scale in torch FP8 (float8_e4m3fn), shape (out_dim, in_dim/16) or padded.
-        alpha: 1 / (input_scale * weight_scale_2).
+        weight_scale_2: per-tensor weight scale_2 = weight_amax / FP4_GLOBAL_SCALE_MAX.
 
     Returns:
         The linear output with the original dtype as the input.
@@ -435,18 +435,17 @@ def nvfp4_linear(
     assert k % 16 == 0
     assert weight_shape[-1] % 8 == 0
 
-    # FP4 compatibility
     assert input_scale is not None
     assert weight_scale is not None
-    assert alpha is not None
+    assert weight_scale_2 is not None
 
     # nvfp4_gemm requires both n and k to be divisible by 32. TP sharding can
     # misalign either: column-sharding affects n (e.g. Mamba2 in_proj 10304/8=1288),
     # row-sharding affects k (e.g. shared experts down_proj 3712/8=464).
     need_pad = n % 32 != 0 or k % 32 != 0
     if need_pad:
-        weight_fp4, weight_scale, alpha, n_padded, k_padded = _pad_nvfp4_weight(
-            weight_fp4, weight_scale, alpha, n, k, align_to=32
+        weight_fp4, weight_scale, weight_scale_2, n_padded, k_padded = _pad_nvfp4_weight(
+            weight_fp4, weight_scale, weight_scale_2, n, k, align_to=32
         )
         if k_padded != k:
             input = torch.nn.functional.pad(input, (0, k_padded - k))
@@ -459,14 +458,18 @@ def nvfp4_linear(
     weight_scale_cutlass = modelopt_fp4_scale_to_cutlass_fp4_scale(weight_scale)
     assert weight_scale_cutlass.numel() % (128 * 4) == 0
 
+    # Derive kernel values from raw per-tensor scales
+    fp4_input_scale = 1.0 / torch.clamp(input_scale, min=1e-30)
+    kernel_alpha = torch.clamp(input_scale * weight_scale_2, min=1e-30)
+
     input = input.reshape(-1, input.shape[-1])
 
     x_fp4, x_sf_block = torch.ops.trtllm.fp4_quantize(
-        input, input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False
+        input, fp4_input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False
     )
 
     output = torch.ops.trtllm.nvfp4_gemm(
-        x_fp4, weight_fp4, x_sf_block, weight_scale_cutlass, alpha, input.dtype
+        x_fp4, weight_fp4, x_sf_block, weight_scale_cutlass, kernel_alpha, input.dtype
     )
 
     if need_pad and n % 32 != 0:
@@ -485,7 +488,7 @@ def fp4_linear_fake(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
-    alpha: Optional[torch.Tensor] = None,
+    weight_scale_2: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.ops.aten.linear(input, weight_fp4.repeat(1, 2).to(input.dtype), bias)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
@@ -373,9 +373,9 @@ def _pad_nvfp4_weight(
     weight_fp4 and weight_scale are padded independently because they have
     different alignment requirements:
       - weight_fp4 has shape [n, k/2] (packed uint8) — padded along both dims.
-      - weight_scale is in modelopt row-major FP8 format with shape [n, k/16]
-        (or already padded to [padded_n, padded_k/16]). Padded directly along
-        both dims.
+      - weight_scale is 1D in cutlass format (swizzled/padded). It is converted
+        to modelopt row-major [n, k/16] for correct padding, then converted
+        back. The cutlass conversion handles 128x4 alignment internally.
       - alpha has shape [n] or is a scalar — padded along dim 0 when 1-D.
 
     Returns (weight_fp4, weight_scale, alpha, n_padded, k_padded).
@@ -392,13 +392,20 @@ def _pad_nvfp4_weight(
     if alpha.ndim >= 1 and pad_n > 0:
         alpha = torch.nn.functional.pad(alpha, (0, pad_n))
 
-    # weight_scale is in modelopt FP8 row-major format. Pad directly.
-    # The caller is responsible for CUTLASS conversion after padding.
+    # weight_scale is in cutlass format (swizzled/padded). Convert to
+    # modelopt row-major [n, k/16] so the reshape/pad operates on the correct
+    # logical layout, then convert back. modelopt_fp4_scale_to_cutlass_fp4_scale
+    # handles the 128x4 alignment internally.
+    from ...utils.quantization_utils import (
+        cutlass_fp4_scale_to_modelopt_fp4_scale,
+        modelopt_fp4_scale_to_cutlass_fp4_scale,
+    )
+
     bsv = TRTLLM_NVFP4_SCALING_VECTOR_SIZE
     blocks_per_row_padded = k_padded // bsv
-    ws = weight_scale.reshape(n, -1)
+    ws = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale, (n, k))
     ws = torch.nn.functional.pad(ws, (0, blocks_per_row_padded - ws.shape[1], 0, pad_n))
-    weight_scale = ws
+    weight_scale = modelopt_fp4_scale_to_cutlass_fp4_scale(ws)
 
     return weight_fp4, weight_scale, alpha, n_padded, k_padded
 
@@ -411,16 +418,20 @@ def nvfp4_linear(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
-    weight_scale_2: Optional[torch.Tensor] = None,
+    alpha: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """FP4 linear op similar to torch.nn.linear.
+
+    All scale arguments are expected to be pre-processed at load time by the fuse transform's
+    load hook (see FuseNVFP4Linear in fuse_quant.py).
 
     Args:
         input: unquantized input tensor
         weight_fp4: pre-quantized weight tensor, with dtype torch.uint8 (1 uint8 == 2 elements)
-        input_scale: per-tensor input scale_2 = input_amax / FP4_GLOBAL_SCALE_MAX.
-        weight_scale: per-block scale in torch FP8 (float8_e4m3fn), shape (out_dim, in_dim/16) or padded.
-        weight_scale_2: per-tensor weight scale_2 = weight_amax / FP4_GLOBAL_SCALE_MAX.
+        input_scale: inverted per-tensor input scale = FP4_GLOBAL_SCALE_MAX / input_amax.
+        weight_scale: flat uint8 tensor of CUTLASS-swizzled per-block weight scales,
+            ready to pass directly to nvfp4_gemm.
+        alpha: pre-computed product of raw per-tensor scales (input_s2 * weight_s2).
 
     Returns:
         The linear output with the original dtype as the input.
@@ -437,39 +448,29 @@ def nvfp4_linear(
 
     assert input_scale is not None
     assert weight_scale is not None
-    assert weight_scale_2 is not None
+    assert alpha is not None
 
     # nvfp4_gemm requires both n and k to be divisible by 32. TP sharding can
     # misalign either: column-sharding affects n (e.g. Mamba2 in_proj 10304/8=1288),
     # row-sharding affects k (e.g. shared experts down_proj 3712/8=464).
     need_pad = n % 32 != 0 or k % 32 != 0
     if need_pad:
-        weight_fp4, weight_scale, weight_scale_2, n_padded, k_padded = _pad_nvfp4_weight(
-            weight_fp4, weight_scale, weight_scale_2, n, k, align_to=32
+        weight_fp4, weight_scale, alpha, n_padded, k_padded = _pad_nvfp4_weight(
+            weight_fp4, weight_scale, alpha, n, k, align_to=32
         )
         if k_padded != k:
             input = torch.nn.functional.pad(input, (0, k_padded - k))
 
-    # Convert torch-compatible FP8 per-block scale to CUTLASS (padded, swizzled) for the kernel.
-    from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
-        modelopt_fp4_scale_to_cutlass_fp4_scale,
-    )
-
-    weight_scale_cutlass = modelopt_fp4_scale_to_cutlass_fp4_scale(weight_scale)
-    assert weight_scale_cutlass.numel() % (128 * 4) == 0
-
-    # Derive kernel values from raw per-tensor scales
-    fp4_input_scale = 1.0 / torch.clamp(input_scale, min=1e-30)
-    kernel_alpha = torch.clamp(input_scale * weight_scale_2, min=1e-30)
+    assert weight_scale.numel() % (128 * 4) == 0
 
     input = input.reshape(-1, input.shape[-1])
 
     x_fp4, x_sf_block = torch.ops.trtllm.fp4_quantize(
-        input, fp4_input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False
+        input, input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False
     )
 
     output = torch.ops.trtllm.nvfp4_gemm(
-        x_fp4, weight_fp4, x_sf_block, weight_scale_cutlass, kernel_alpha, input.dtype
+        x_fp4, weight_fp4, x_sf_block, weight_scale, alpha, input.dtype
     )
 
     if need_pad and n % 32 != 0:
@@ -488,7 +489,7 @@ def fp4_linear_fake(
     bias: Optional[torch.Tensor] = None,
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
-    weight_scale_2: Optional[torch.Tensor] = None,
+    alpha: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.ops.aten.linear(input, weight_fp4.repeat(1, 2).to(input.dtype), bias)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/quant.py
@@ -463,7 +463,7 @@ def nvfp4_linear(
 
     assert weight_scale.numel() % (128 * 4) == 0
 
-    input = input.reshape(-1, input.shape[-1])
+    input = input.reshape(-1, k)
 
     x_fp4, x_sf_block = torch.ops.trtllm.fp4_quantize(
         input, input_scale, TRTLLM_NVFP4_SCALING_VECTOR_SIZE, False

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -232,29 +232,24 @@ def torch_fake_quant_nvfp4_linear(
     """
     Reference (eager) implementation for NVFP4 fake-quant linear.
     Expects torch-compatible FP8 per-block weight scale (no kernel-specific swizzling).
-      - input_scale[0]  = s_in2   (scalar, (448*6)/amax for input)
+      - input_scale[0]  = per-tensor input scale_2 (amax / FP4_GLOBAL_SCALE_MAX)
       - weight_scale[0] = per-block scale in FP8 (torch.float8_e4m3fn), shape >= N*(K/16)
-      - weight_scale[1] = alpha = 1/(s_in2 * s_w2) (inverse combined per-tensor scale)
+      - weight_scale[1] = per-tensor weight scale_2 (amax / FP4_GLOBAL_SCALE_MAX)
     """
     if weight_quantized.dtype != torch.uint8:
         raise TypeError("NVFP4 path requires packed uint8 weights (2x FP4 per byte).")
 
-    inv_x = _expect_single_scale(input_scale, "input_scale")
+    s2_x = _expect_single_scale(input_scale, "input_scale")
     if len(weight_scale) < 2 or weight_scale[0] is None or weight_scale[1] is None:
         raise ValueError(
-            "NVFP4 needs weight_scale[0] (per-block FP8 scale) and weight_scale[1] (alpha)."
+            "NVFP4 needs weight_scale[0] (per-block FP8 scale) and weight_scale[1] (weight scale_2)."
         )
     per_block_scale = weight_scale[0]
-    alpha = weight_scale[1]
+    s2_w = weight_scale[1]
 
     if per_block_scale.dtype != torch.float8_e4m3fn:
         raise TypeError("NVFP4 expects weight_scale[0] in torch-compatible FP8 (float8_e4m3fn).")
 
-    inv_w = 1 / (inv_x * alpha)
-    s2_x = 1.0 / inv_x
-    s2_w = 1.0 / inv_w
-
-    # Shapes
     in_dtype = input.dtype
     input_shape = input.shape
     N, K_packed = weight_quantized.shape[-2], weight_quantized.shape[-1]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -20,10 +20,7 @@ import torch
 import triton
 import triton.language as tl
 
-from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
-    cutlass_fp4_scale_to_modelopt_fp4_scale,
-    unpack_uint8_to_int4_weight_2d,
-)
+from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import unpack_uint8_to_int4_weight_2d
 
 # FP4 tables (E2M1)
 e2m1_bounds = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5])
@@ -233,11 +230,11 @@ def torch_fake_quant_nvfp4_linear(
     weight_zp: List[torch.Tensor],
 ) -> torch.Tensor:
     """
-    Reference (eager) implementation for multiple quant formats via `format_type`.
-    For FP4:
-      - input_scale[0]  = s_in2   (scalar, amax/(448*6))
-      - weight_scale[0] = q_per_block_scale_w  (len >= N*K/16; may be padded)
-      - weight_scale[1] = alpha = s_in2 * s_w2 (combined per-tensor scales)
+    Reference (eager) implementation for NVFP4 fake-quant linear.
+    Expects torch-compatible FP8 per-block weight scale (no kernel-specific swizzling).
+      - input_scale[0]  = s_in2   (scalar, (448*6)/amax for input)
+      - weight_scale[0] = per-block scale in FP8 (torch.float8_e4m3fn), shape >= N*(K/16)
+      - weight_scale[1] = alpha = 1/(s_in2 * s_w2) (inverse combined per-tensor scale)
     """
     if weight_quantized.dtype != torch.uint8:
         raise TypeError("NVFP4 path requires packed uint8 weights (2x FP4 per byte).")
@@ -245,13 +242,13 @@ def torch_fake_quant_nvfp4_linear(
     inv_x = _expect_single_scale(input_scale, "input_scale")
     if len(weight_scale) < 2 or weight_scale[0] is None or weight_scale[1] is None:
         raise ValueError(
-            "NVFP4 needs weight_scale[0] (per-block vector) and weight_scale[1] (alpha)."
+            "NVFP4 needs weight_scale[0] (per-block FP8 scale) and weight_scale[1] (alpha)."
         )
-    cutlass_qscale = weight_scale[0]
+    per_block_scale = weight_scale[0]
     alpha = weight_scale[1]
 
-    if cutlass_qscale.dtype != torch.uint8:
-        raise TypeError("NVFP4 expects CUTLASS per-block scale vector in uint8 (same as fused op).")
+    if per_block_scale.dtype != torch.float8_e4m3fn:
+        raise TypeError("NVFP4 expects weight_scale[0] in torch-compatible FP8 (float8_e4m3fn).")
 
     inv_w = 1 / (inv_x * alpha)
     s2_x = 1.0 / inv_x
@@ -265,9 +262,7 @@ def torch_fake_quant_nvfp4_linear(
     assert K % 16 == 0, "NVFP4 requires K to be a multiple of 16"
     num_blocks_w = N * (K // 16)
 
-    q_scale_w_slice = cutlass_fp4_scale_to_modelopt_fp4_scale(cutlass_qscale, (N, K))
-    # (1) Dequantize weights with scale_1 = q_scale_w (sliced), scale_2 = s_w2
-    q_scale_w_slice = q_scale_w_slice.reshape(-1)[:num_blocks_w]
+    q_scale_w_slice = per_block_scale.reshape(-1)[:num_blocks_w]
     W_deq = _dequantize_nvfp4(weight_quantized, q_scale_w_slice, s2_w, (N, K), in_dtype)  # [N, K]
 
     # (2) Quantize+dequantize inputs with _quantize_nvfp4/_dequantize_nvfp4

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -232,9 +232,11 @@ def torch_fake_quant_nvfp4_linear(
     """
     Reference (eager) implementation for NVFP4 fake-quant linear.
     Expects torch-compatible FP8 per-block weight scale (no kernel-specific swizzling).
-      - input_scale[0]  = per-tensor input scale_2 (amax / FP4_GLOBAL_SCALE_MAX)
-      - weight_scale[0] = per-block scale in FP8 (torch.float8_e4m3fn), shape >= N*(K/16)
-      - weight_scale[1] = per-tensor weight scale_2 (amax / FP4_GLOBAL_SCALE_MAX)
+
+    Scale tensors must be in raw (checkpoint / pre-fusion) form:
+      - input_scale[0]: per-tensor activation scale, (raw amax / FP4_GLOBAL_SCALE_MAX).
+      - weight_scale[0]: per-block scale in FP8 (torch.float8_e4m3fn), shape >= N*(K/16)
+      - weight_scale[1]: per-tensor weight scale (raw amax / FP4_GLOBAL_SCALE_MAX)
     """
     if weight_quantized.dtype != torch.uint8:
         raise TypeError("NVFP4 path requires packed uint8 weights (2x FP4 per byte).")

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -209,22 +209,22 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
     K_packed = 32  # weight is packed by 2 FP4 per byte
     K_eff = 2 * K_packed
 
-    # FP4 dummy tensors
+    # FP4 dummy tensors (new IR format: weight_scale is FP8 per-block 2D)
     x_fp4 = torch.randn(3, K_eff, device="meta", dtype=torch.float16)
     w_fp4 = torch.randint(0, 255, (N, K_packed), device="meta", dtype=torch.uint8)
 
     s_in2 = torch.tensor(0.01, device="meta", dtype=torch.float32)
     ws2 = torch.tensor(1.2345, device="meta", dtype=torch.float32)
 
-    cutlass_len = N * (K_eff // 16)  # 32 * (64/16) = 128
-    cutlass_vec = torch.randint(0, 255, (cutlass_len,), device="meta", dtype=torch.uint8)
+    # Per-block FP8 weight scale: 2D [N, K_eff//16] (new IR format)
+    weight_scale_fp8 = torch.empty((N, K_eff // 16), device="meta", dtype=torch.float8_e4m3fn)
 
     # no-bias variant
     dummy_args_fp4_1 = [
         x_fp4,
         w_fp4,
         s_in2,
-        cutlass_vec,
+        weight_scale_fp8,
         ws2,
     ]
     register_ad_pattern(
@@ -240,7 +240,7 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
         w_fp4,
         torch.randn(N, device="meta", dtype=torch.float16),  # bias
         s_in2,
-        cutlass_vec,
+        weight_scale_fp8,
         ws2,
     ]
     register_ad_pattern(
@@ -299,6 +299,34 @@ class FuseFP8Linear(BaseTransform):
         return gm, info
 
 
+def _swizzle_nvfp4_scale(
+    raw_ws: torch.Tensor, float4_sf_dtype, flatten: bool = True
+) -> torch.Tensor:
+    """Swizzle a 2D FP8 per-block weight scale into CUTLASS-ready uint8.
+
+    Args:
+        raw_ws: Per-block weight scale tensor, dtype=float8_e4m3fn, shape (M, N/16).
+        float4_sf_dtype: The float4 scale factor dtype (from fp4_utils).
+        flatten: If True (default), return flat 1D uint8. If False, return 2D uint8
+            [padded_M, padded_N] suitable for MoE stacking into 3D.
+
+    Returns:
+        uint8 tensor in CUTLASS-swizzled layout, on the same device as raw_ws.
+        Shape is flat 1D if flatten=True, else 2D [padded_M, padded_N].
+    """
+    device = raw_ws.device
+    weight_scale = raw_ws.view(float4_sf_dtype)
+    weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
+        weight_scale.view(torch.uint8).cpu().contiguous()
+    ).view(float4_sf_dtype)
+    m, n = weight_scale.shape
+    padded_m = math.ceil(m / 128) * 128
+    padded_n = math.ceil(n / 4) * 4
+    swizzled_shape = (padded_m, padded_n)
+    result = weight_scale_swizzled.reshape(swizzled_shape).view(torch.uint8).to(device)
+    return result.reshape(-1) if flatten else result
+
+
 def _collect_nvfp4_scale_keys(gm: GraphModule):
     """Collect (input_scale, weight_scale, weight_scale_2) buffer keys from fused nvfp4 nodes."""
     scale_keys = []
@@ -310,11 +338,12 @@ def _collect_nvfp4_scale_keys(gm: GraphModule):
             if inp.op != "get_attr":
                 continue
             t = inp.target
-            if t.endswith(".weight_scale_2"):
+            attr = t.rsplit(".", 1)[-1]
+            if attr == "weight_scale_2":
                 scale_map["ws2"] = t
-            elif t.endswith(".weight_scale"):
+            elif attr == "weight_scale":
                 scale_map["ws"] = t
-            elif t.endswith(".input_scale"):
+            elif attr == "input_scale":
                 scale_map["is"] = t
         if len(scale_map) == 3:
             scale_keys.append((scale_map["is"], scale_map["ws"], scale_map["ws2"]))
@@ -349,25 +378,12 @@ def _process_nvfp4_scales_inplace(gm: GraphModule, scale_keys):
         raw_is = getattr(is_submod, is_attr)
         raw_ws = getattr(ws_submod, ws_attr)
         raw_ws2 = getattr(ws2_submod, ws2_attr)
-        device = raw_ws.device
 
         alpha = torch.clamp(raw_ws2 * raw_is, min=1e-30)
 
         inv_input_scale = 1 / torch.clamp(raw_is, min=1e-30)
 
-        weight_scale = raw_ws.view(float4_sf_dtype)
-        weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
-            weight_scale.view(torch.uint8).cpu().contiguous()
-        ).view(float4_sf_dtype)
-
-        m, n = weight_scale.shape
-        padded_m = math.ceil(m / 128) * 128
-        padded_n = math.ceil(n / 4) * 4
-        swizzled_shape = (padded_m, padded_n)
-
-        new_ws = (
-            weight_scale_swizzled.reshape(swizzled_shape).view(torch.uint8).reshape(-1).to(device)
-        )
+        new_ws = _swizzle_nvfp4_scale(raw_ws, float4_sf_dtype)
 
         is_submod.register_buffer(is_attr, inv_input_scale)
         ws_submod.register_buffer(ws_attr, new_ws)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -1,3 +1,4 @@
+import math
 from typing import Tuple, Type
 
 import torch
@@ -6,6 +7,7 @@ from torch.fx import GraphModule
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ..interface import (
     BaseTransform,
@@ -85,7 +87,7 @@ def _fp4_ref_repl_1(
         bias=None,
         input_scale=input_scale,
         weight_scale=weight_scale,
-        weight_scale_2=weight_scale_2,
+        alpha=weight_scale_2,
     )
 
 
@@ -123,7 +125,7 @@ def _fp4_ref_repl_2(
         bias=bias,
         input_scale=input_scale,
         weight_scale=weight_scale,
-        weight_scale_2=weight_scale_2,
+        alpha=weight_scale_2,
     )
 
 
@@ -297,6 +299,81 @@ class FuseFP8Linear(BaseTransform):
         return gm, info
 
 
+def _collect_nvfp4_scale_keys(gm: GraphModule):
+    """Collect (input_scale, weight_scale, weight_scale_2) buffer keys from fused nvfp4 nodes."""
+    scale_keys = []
+    for node in gm.graph.nodes:
+        if not is_op(node, torch.ops.auto_deploy.torch_quant_nvfp4_linear):
+            continue
+        scale_map = {}
+        for inp in node.all_input_nodes:
+            if inp.op != "get_attr":
+                continue
+            t = inp.target
+            if t.endswith(".weight_scale_2"):
+                scale_map["ws2"] = t
+            elif t.endswith(".weight_scale"):
+                scale_map["ws"] = t
+            elif t.endswith(".input_scale"):
+                scale_map["is"] = t
+        if len(scale_map) == 3:
+            scale_keys.append((scale_map["is"], scale_map["ws"], scale_map["ws2"]))
+    return scale_keys
+
+
+def _process_nvfp4_scales_inplace(gm: GraphModule, scale_keys):
+    """Pre-process raw NVFP4 scale buffers in-place into the format expected by the kernel.
+
+    Converts:
+      - weight_scale_2 * input_scale -> alpha (clamped)
+      - input_scale -> 1 / input_scale (clamped then inverted)
+      - weight_scale -> CUTLASS-swizzled flat uint8 via block_scale_interleave
+    """
+    try:
+        from .....quantization.utils.fp4_utils import float4_sf_dtype
+    except ImportError:
+        float4_sf_dtype = None
+
+    if not float4_sf_dtype:
+        return
+
+    for is_key, ws_key, ws2_key in scale_keys:
+        is_mod_path, _, is_attr = is_key.rpartition(".")
+        ws_mod_path, _, ws_attr = ws_key.rpartition(".")
+        ws2_mod_path, _, ws2_attr = ws2_key.rpartition(".")
+
+        is_submod = gm.get_submodule(is_mod_path)
+        ws_submod = gm.get_submodule(ws_mod_path)
+        ws2_submod = gm.get_submodule(ws2_mod_path)
+
+        raw_is = getattr(is_submod, is_attr)
+        raw_ws = getattr(ws_submod, ws_attr)
+        raw_ws2 = getattr(ws2_submod, ws2_attr)
+        device = raw_ws.device
+
+        alpha = torch.clamp(raw_ws2 * raw_is, min=1e-30)
+
+        inv_input_scale = 1 / torch.clamp(raw_is, min=1e-30)
+
+        weight_scale = raw_ws.view(float4_sf_dtype)
+        weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
+            weight_scale.view(torch.uint8).cpu().contiguous()
+        ).view(float4_sf_dtype)
+
+        m, n = weight_scale.shape
+        padded_m = math.ceil(m / 128) * 128
+        padded_n = math.ceil(n / 4) * 4
+        swizzled_shape = (padded_m, padded_n)
+
+        new_ws = (
+            weight_scale_swizzled.reshape(swizzled_shape).view(torch.uint8).reshape(-1).to(device)
+        )
+
+        is_submod.register_buffer(is_attr, inv_input_scale)
+        ws_submod.register_buffer(ws_attr, new_ws)
+        ws2_submod.register_buffer(ws2_attr, alpha)
+
+
 class FuseNVFP4LinearConfig(TransformConfig):
     """Configuration for NVFP4 linear fusion transform."""
 
@@ -329,6 +406,11 @@ class FuseNVFP4Linear(BaseTransform):
         patterns = ADPatternMatcherPass()
         _register_quant_fp4_linear_patterns(patterns)
         cnt = patterns.apply(gm.graph)
+
+        if cnt > 0:
+            scale_keys = _collect_nvfp4_scale_keys(gm)
+            if scale_keys:
+                _process_nvfp4_scales_inplace(gm, scale_keys)
 
         info = TransformInfo(
             skipped=(cnt == 0),

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -7,6 +7,7 @@ from torch.fx import GraphModule
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+from ...utils.logger import ad_logger
 from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ..interface import (
@@ -209,14 +210,14 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
     K_packed = 32  # weight is packed by 2 FP4 per byte
     K_eff = 2 * K_packed
 
-    # FP4 dummy tensors (new IR format: weight_scale is FP8 per-block 2D)
+    # FP4 dummy tensors (weight_scale is FP8 per-block 2D)
     x_fp4 = torch.randn(3, K_eff, device="meta", dtype=torch.float16)
     w_fp4 = torch.randint(0, 255, (N, K_packed), device="meta", dtype=torch.uint8)
 
     s_in2 = torch.tensor(0.01, device="meta", dtype=torch.float32)
     ws2 = torch.tensor(1.2345, device="meta", dtype=torch.float32)
 
-    # Per-block FP8 weight scale: 2D [N, K_eff//16] (new IR format)
+    # Per-block FP8 weight scale: 2D [N, K_eff//16]
     weight_scale_fp8 = torch.empty((N, K_eff // 16), device="meta", dtype=torch.float8_e4m3fn)
 
     # no-bias variant
@@ -328,8 +329,13 @@ def _swizzle_nvfp4_scale(
 
 
 def _collect_nvfp4_scale_keys(gm: GraphModule):
-    """Collect (input_scale, weight_scale, weight_scale_2) buffer keys from fused nvfp4 nodes."""
+    """Collect unique (input_scale, weight_scale, weight_scale_2) buffer keys from fused nvfp4 nodes.
+
+    Deduplicates by target path so the same quantized module referenced from multiple nodes
+    is only processed once by _process_nvfp4_scales_inplace (which mutates buffers).
+    """
     scale_keys = []
+    seen = set()
     for node in gm.graph.nodes:
         if not is_op(node, torch.ops.auto_deploy.torch_quant_nvfp4_linear):
             continue
@@ -346,7 +352,10 @@ def _collect_nvfp4_scale_keys(gm: GraphModule):
             elif attr == "input_scale":
                 scale_map["is"] = t
         if len(scale_map) == 3:
-            scale_keys.append((scale_map["is"], scale_map["ws"], scale_map["ws2"]))
+            key = (scale_map["is"], scale_map["ws"], scale_map["ws2"])
+            if key not in seen:
+                seen.add(key)
+                scale_keys.append(key)
     return scale_keys
 
 
@@ -361,9 +370,9 @@ def _process_nvfp4_scales_inplace(gm: GraphModule, scale_keys):
     try:
         from .....quantization.utils.fp4_utils import float4_sf_dtype
     except ImportError:
-        float4_sf_dtype = None
-
-    if not float4_sf_dtype:
+        ad_logger.warning(
+            "Could not import float4_sf_dtype from fp4_utils; skipping NVFP4 scale pre-processing."
+        )
         return
 
     for is_key, ws_key, ws2_key in scale_keys:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_quant.py
@@ -59,14 +59,14 @@ def _fp4_ref_pattern_1(
     w_fp4: torch.Tensor,
     input_scale: torch.Tensor,
     weight_scale: torch.Tensor,
-    alpha: torch.Tensor,
+    weight_scale_2: torch.Tensor,
 ):
     return torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
         x,
         w_fp4,
         None,
         input_scale=[input_scale],
-        weight_scale=[weight_scale, alpha],
+        weight_scale=[weight_scale, weight_scale_2],
         input_zp=[],
         weight_zp=[],
     )
@@ -77,7 +77,7 @@ def _fp4_ref_repl_1(
     w_fp4: torch.Tensor,
     input_scale: torch.Tensor,
     weight_scale: torch.Tensor,
-    alpha: torch.Tensor,
+    weight_scale_2: torch.Tensor,
 ):
     return torch.ops.auto_deploy.torch_quant_nvfp4_linear(
         x,
@@ -85,7 +85,7 @@ def _fp4_ref_repl_1(
         bias=None,
         input_scale=input_scale,
         weight_scale=weight_scale,
-        alpha=alpha,
+        weight_scale_2=weight_scale_2,
     )
 
 
@@ -96,14 +96,14 @@ def _fp4_ref_pattern_2(
     bias: torch.Tensor,
     input_scale: torch.Tensor,
     weight_scale: torch.Tensor,
-    alpha: torch.Tensor,
+    weight_scale_2: torch.Tensor,
 ):
     return torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
         x,
         w_fp4,
         bias,
         input_scale=[input_scale],
-        weight_scale=[weight_scale, alpha],
+        weight_scale=[weight_scale, weight_scale_2],
         input_zp=[],
         weight_zp=[],
     )
@@ -115,7 +115,7 @@ def _fp4_ref_repl_2(
     bias: torch.Tensor | None,
     input_scale: torch.Tensor,
     weight_scale: torch.Tensor,
-    alpha: torch.Tensor,
+    weight_scale_2: torch.Tensor,
 ):
     return torch.ops.auto_deploy.torch_quant_nvfp4_linear(
         x,
@@ -123,7 +123,7 @@ def _fp4_ref_repl_2(
         bias=bias,
         input_scale=input_scale,
         weight_scale=weight_scale,
-        alpha=alpha,
+        weight_scale_2=weight_scale_2,
     )
 
 
@@ -212,7 +212,7 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
     w_fp4 = torch.randint(0, 255, (N, K_packed), device="meta", dtype=torch.uint8)
 
     s_in2 = torch.tensor(0.01, device="meta", dtype=torch.float32)
-    alpha = torch.tensor(1.2345, device="meta", dtype=torch.float32)
+    ws2 = torch.tensor(1.2345, device="meta", dtype=torch.float32)
 
     cutlass_len = N * (K_eff // 16)  # 32 * (64/16) = 128
     cutlass_vec = torch.randint(0, 255, (cutlass_len,), device="meta", dtype=torch.uint8)
@@ -223,7 +223,7 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
         w_fp4,
         s_in2,
         cutlass_vec,
-        alpha,
+        ws2,
     ]
     register_ad_pattern(
         search_fn=_fp4_ref_pattern_1,
@@ -239,7 +239,7 @@ def _register_quant_fp4_linear_patterns(patterns: ADPatternMatcherPass) -> None:
         torch.randn(N, device="meta", dtype=torch.float16),  # bias
         s_in2,
         cutlass_vec,
-        alpha,
+        ws2,
     ]
     register_ad_pattern(
         search_fn=_fp4_ref_pattern_2,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
@@ -43,6 +43,7 @@ from ...utils._graph import (
     eliminate_dead_code,
     get_attr_by_name,
 )
+from ...utils.logger import ad_logger
 from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ..interface import (
@@ -522,6 +523,13 @@ class FuseNVFP4SwiGLU(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
+        if _float4_sf_dtype is None:
+            ad_logger.warning(
+                "Could not import float4_sf_dtype from fp4_utils; "
+                "skipping NVFP4 SwiGLU fusion transform."
+            )
+            return gm, TransformInfo(skipped=True)
+
         graph = gm.graph
         cnt = 0
         fused_weight_idx = 0
@@ -561,17 +569,45 @@ class FuseNVFP4SwiGLU(BaseTransform):
             up_weight_scale = get_attr_by_name(gm, up_weight_scale_node.target)
             gate_up_weight_scale_fp8 = torch.cat([gate_weight_scale, up_weight_scale], dim=0)
 
-            # Get raw scale values for processing:
+            # Get raw scale values for processing.
+            # Gate and up must share the same per-tensor scales (raw_is, raw_ws2);
+            # this invariant is validated below before proceeding with fusion.
             #   gate_input_scale_node  -> input_scale buffer = 1/s_in2 (raw)
             #   gate_alpha_node        -> weight_scale_2 buffer = 1/s_w2 (raw)
+            #   up_input_scale_node    -> same semantics as gate (must match)
+            #   up_alpha_node          -> same semantics as gate (must match)
             #   down_input_scale_node  -> down input_scale buffer = 1/s_in2_down (raw)
             #   down_weight_scale_node -> down FP8 weight scale (raw)
             #   down_alpha_node        -> down weight_scale_2 buffer = 1/s_w2_down (raw)
             raw_gate_is = get_attr_by_name(gm, gate_input_scale_node.target)
             raw_gate_ws2 = get_attr_by_name(gm, gate_alpha_node.target)
+            raw_up_is = get_attr_by_name(gm, up_input_scale_node.target)
+            raw_up_ws2 = get_attr_by_name(gm, up_alpha_node.target)
             raw_down_is = get_attr_by_name(gm, down_input_scale_node.target)
             raw_down_ws = get_attr_by_name(gm, down_weight_scale_node.target)
             raw_down_ws2 = get_attr_by_name(gm, down_alpha_node.target)
+
+            # Guard: the fused gate+up GEMM uses a single inv_input_scale and alpha
+            # for both halves of the concatenated weight. This is only valid when gate
+            # and up share identical per-tensor scales. Skip fusion on mismatch so the
+            # unfused path (which handles each projection independently) stays correct.
+            # TODO: a future enhancement could renormalize the per-block FP8 scales to
+            # a common s2_w instead of skipping.
+            if not (
+                torch.allclose(raw_gate_is, raw_up_is, rtol=1e-4)
+                and torch.allclose(raw_gate_ws2, raw_up_ws2, rtol=1e-4)
+            ):
+                ad_logger.warning(
+                    "Skipping NVFP4 SwiGLU gate+up fusion for layer %d: "
+                    "gate and up projections have mismatched per-tensor scales "
+                    "(gate_is=%s vs up_is=%s, gate_ws2=%s vs up_ws2=%s).",
+                    fused_weight_idx,
+                    raw_gate_is.item(),
+                    raw_up_is.item(),
+                    raw_gate_ws2.item(),
+                    raw_up_ws2.item(),
+                )
+                continue
 
             # Process gate+up scales into kernel-ready format (same logic as
             # _process_nvfp4_scales_inplace in fuse_quant.py):
@@ -580,21 +616,12 @@ class FuseNVFP4SwiGLU(BaseTransform):
             #   weight_scale    = swizzled uint8
             prefix = f"fused_nvfp4_swiglu_{fused_weight_idx}"
 
-            if _float4_sf_dtype is not None:
-                gate_up_ws_uint8 = _swizzle_nvfp4_scale(gate_up_weight_scale_fp8, _float4_sf_dtype)
-                gate_up_inv_is = 1.0 / torch.clamp(raw_gate_is, min=1e-30)
-                gate_up_alpha_val = torch.clamp(raw_gate_ws2 * raw_gate_is, min=1e-30)
-                down_ws_uint8 = _swizzle_nvfp4_scale(raw_down_ws, _float4_sf_dtype)
-                down_inv_is = 1.0 / torch.clamp(raw_down_is, min=1e-30)
-                down_alpha_val = torch.clamp(raw_down_ws2 * raw_down_is, min=1e-30)
-            else:
-                # float4_sf_dtype not available: keep raw values (swizzling deferred)
-                gate_up_ws_uint8 = gate_up_weight_scale_fp8
-                gate_up_inv_is = raw_gate_is
-                gate_up_alpha_val = raw_gate_ws2
-                down_ws_uint8 = raw_down_ws
-                down_inv_is = raw_down_is
-                down_alpha_val = raw_down_ws2
+            gate_up_ws_uint8 = _swizzle_nvfp4_scale(gate_up_weight_scale_fp8, _float4_sf_dtype)
+            gate_up_inv_is = 1.0 / torch.clamp(raw_gate_is, min=1e-30)
+            gate_up_alpha_val = torch.clamp(raw_gate_ws2 * raw_gate_is, min=1e-30)
+            down_ws_uint8 = _swizzle_nvfp4_scale(raw_down_ws, _float4_sf_dtype)
+            down_inv_is = 1.0 / torch.clamp(raw_down_is, min=1e-30)
+            down_alpha_val = torch.clamp(raw_down_ws2 * raw_down_is, min=1e-30)
 
             # Register fused buffers (processed)
             gm.register_buffer(f"{prefix}_gate_up_weight", gate_up_weight)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
@@ -25,6 +25,11 @@ The SwiGLU pattern is: silu(x @ gate.T) * (x @ up.T) @ down.T
 from typing import Tuple, Type
 
 import torch
+
+try:
+    from .....quantization.utils.fp4_utils import float4_sf_dtype as _float4_sf_dtype
+except ImportError:
+    _float4_sf_dtype = None
 from pydantic import Field
 from torch.fx import GraphModule, Node
 
@@ -311,6 +316,7 @@ class FuseSwiGLU(BaseTransform):
 # ── NVFP4 quantized SwiGLU pattern matching and fusion ──────────────────────
 
 from ...custom_ops.linear.swiglu import torch_nvfp4_swiglu_mlp  # noqa: E402
+from .fuse_quant import _swizzle_nvfp4_scale  # noqa: E402
 
 
 def _nvfp4_swiglu_pattern_no_bias(
@@ -432,28 +438,24 @@ class MatchNVFP4SwiGLUPattern(BaseTransform):
         N_down = K_eff  # hidden_size (output of down proj)
         K_down_packed = N // 2  # intermediate_size / 2 (down proj input)
 
-        # Weight scale sizes (per-block scale: N * K / 16)
-        gate_cutlass_len = N * (K_eff // 16)
-        down_cutlass_len = N_down * (N // 16)
-
         x = torch.randn(2, K_eff, device="meta", dtype=torch.float16)
 
-        # Gate args
+        # Gate args — weight_scale is FP8 per-block 2D (new IR format)
         gate_w = torch.randint(0, 255, (N, K_packed), device="meta", dtype=torch.uint8)
         gate_is = torch.tensor(0.01, device="meta", dtype=torch.float32)
-        gate_ws = torch.randint(0, 255, (gate_cutlass_len,), device="meta", dtype=torch.uint8)
+        gate_ws = torch.empty((N, K_eff // 16), device="meta", dtype=torch.float8_e4m3fn)
         gate_a = torch.tensor(1.2345, device="meta", dtype=torch.float32)
 
         # Up args (same shapes as gate)
         up_w = torch.randint(0, 255, (N, K_packed), device="meta", dtype=torch.uint8)
         up_is = torch.tensor(0.02, device="meta", dtype=torch.float32)
-        up_ws = torch.randint(0, 255, (gate_cutlass_len,), device="meta", dtype=torch.uint8)
+        up_ws = torch.empty((N, K_eff // 16), device="meta", dtype=torch.float8_e4m3fn)
         up_a = torch.tensor(2.3456, device="meta", dtype=torch.float32)
 
         # Down args
         down_w = torch.randint(0, 255, (N_down, K_down_packed), device="meta", dtype=torch.uint8)
         down_is = torch.tensor(0.03, device="meta", dtype=torch.float32)
-        down_ws = torch.randint(0, 255, (down_cutlass_len,), device="meta", dtype=torch.uint8)
+        down_ws = torch.empty((N_down, N // 16), device="meta", dtype=torch.float8_e4m3fn)
         down_a = torch.tensor(3.4567, device="meta", dtype=torch.float32)
 
         dummy_args = [
@@ -554,23 +556,66 @@ class FuseNVFP4SwiGLU(BaseTransform):
             # Concatenate gate and up FP4 packed weights along dim=0
             gate_up_weight = torch.cat([gate_weight, up_weight], dim=0)
 
-            # Get and concatenate weight scales
+            # Get and concatenate FP8 per-block weight scales (new IR format: 2D float8_e4m3fn)
             gate_weight_scale = get_attr_by_name(gm, gate_weight_scale_node.target)
             up_weight_scale = get_attr_by_name(gm, up_weight_scale_node.target)
-            gate_up_weight_scale = torch.cat([gate_weight_scale, up_weight_scale], dim=0)
+            gate_up_weight_scale_fp8 = torch.cat([gate_weight_scale, up_weight_scale], dim=0)
 
-            # Register fused buffers
+            # Get raw scale values for processing:
+            #   gate_input_scale_node  -> input_scale buffer = 1/s_in2 (raw)
+            #   gate_alpha_node        -> weight_scale_2 buffer = 1/s_w2 (raw)
+            #   down_input_scale_node  -> down input_scale buffer = 1/s_in2_down (raw)
+            #   down_weight_scale_node -> down FP8 weight scale (raw)
+            #   down_alpha_node        -> down weight_scale_2 buffer = 1/s_w2_down (raw)
+            raw_gate_is = get_attr_by_name(gm, gate_input_scale_node.target)
+            raw_gate_ws2 = get_attr_by_name(gm, gate_alpha_node.target)
+            raw_down_is = get_attr_by_name(gm, down_input_scale_node.target)
+            raw_down_ws = get_attr_by_name(gm, down_weight_scale_node.target)
+            raw_down_ws2 = get_attr_by_name(gm, down_alpha_node.target)
+
+            # Process gate+up scales into kernel-ready format (same logic as
+            # _process_nvfp4_scales_inplace in fuse_quant.py):
+            #   inv_input_scale = 1 / raw_is  = s_in2
+            #   alpha           = raw_ws2 * raw_is  = 1/(s_in2*s_w2)
+            #   weight_scale    = swizzled uint8
             prefix = f"fused_nvfp4_swiglu_{fused_weight_idx}"
-            gm.register_buffer(f"{prefix}_gate_up_weight", gate_up_weight)
-            gm.register_buffer(f"{prefix}_gate_up_weight_scale", gate_up_weight_scale)
 
-            # Create get_attr nodes for fused weights/scales
+            if _float4_sf_dtype is not None:
+                gate_up_ws_uint8 = _swizzle_nvfp4_scale(gate_up_weight_scale_fp8, _float4_sf_dtype)
+                gate_up_inv_is = 1.0 / torch.clamp(raw_gate_is, min=1e-30)
+                gate_up_alpha_val = torch.clamp(raw_gate_ws2 * raw_gate_is, min=1e-30)
+                down_ws_uint8 = _swizzle_nvfp4_scale(raw_down_ws, _float4_sf_dtype)
+                down_inv_is = 1.0 / torch.clamp(raw_down_is, min=1e-30)
+                down_alpha_val = torch.clamp(raw_down_ws2 * raw_down_is, min=1e-30)
+            else:
+                # float4_sf_dtype not available: keep raw values (swizzling deferred)
+                gate_up_ws_uint8 = gate_up_weight_scale_fp8
+                gate_up_inv_is = raw_gate_is
+                gate_up_alpha_val = raw_gate_ws2
+                down_ws_uint8 = raw_down_ws
+                down_inv_is = raw_down_is
+                down_alpha_val = raw_down_ws2
+
+            # Register fused buffers (processed)
+            gm.register_buffer(f"{prefix}_gate_up_weight", gate_up_weight)
+            gm.register_buffer(f"{prefix}_gate_up_weight_scale", gate_up_ws_uint8)
+            gm.register_buffer(f"{prefix}_gate_up_inv_input_scale", gate_up_inv_is)
+            gm.register_buffer(f"{prefix}_gate_up_alpha", gate_up_alpha_val)
+            gm.register_buffer(f"{prefix}_down_weight_scale", down_ws_uint8)
+            gm.register_buffer(f"{prefix}_down_inv_input_scale", down_inv_is)
+            gm.register_buffer(f"{prefix}_down_alpha", down_alpha_val)
+
+            # Create get_attr nodes for all processed buffers
             with graph.inserting_before(node):
                 fused_gate_up_weight_node = graph.get_attr(f"{prefix}_gate_up_weight")
                 fused_gate_up_weight_scale_node = graph.get_attr(f"{prefix}_gate_up_weight_scale")
+                gate_up_inv_is_node = graph.get_attr(f"{prefix}_gate_up_inv_input_scale")
+                gate_up_alpha_node = graph.get_attr(f"{prefix}_gate_up_alpha")
+                down_ws_node = graph.get_attr(f"{prefix}_down_weight_scale")
+                down_inv_is_node = graph.get_attr(f"{prefix}_down_inv_input_scale")
+                down_alpha_node_new = graph.get_attr(f"{prefix}_down_alpha")
 
-            # Create the fused_nvfp4_swiglu_mlp node
-            # Use gate's input_scale and alpha (same as up's since they share input)
+            # Create the fused_nvfp4_swiglu_mlp node with kernel-ready processed scales
             with graph.inserting_after(node):
                 fused_node: Node = graph.call_function(
                     torch.ops.auto_deploy.fused_nvfp4_swiglu_mlp.default,
@@ -578,12 +623,12 @@ class FuseNVFP4SwiGLU(BaseTransform):
                         input_node,
                         fused_gate_up_weight_node,
                         down_weight_node,
-                        gate_input_scale_node,  # shared input_scale for gate+up
+                        gate_up_inv_is_node,
                         fused_gate_up_weight_scale_node,
-                        gate_alpha_node,  # shared alpha for gate+up
-                        down_input_scale_node,
-                        down_weight_scale_node,
-                        down_alpha_node,
+                        gate_up_alpha_node,
+                        down_inv_is_node,
+                        down_ws_node,
+                        down_alpha_node_new,
                     ),
                 )
 
@@ -600,6 +645,12 @@ class FuseNVFP4SwiGLU(BaseTransform):
             _try_free_attr_node(gm, graph, up_weight_scale_node)
             _try_free_attr_node(gm, graph, up_input_scale_node)
             _try_free_attr_node(gm, graph, up_alpha_node)
+            # Free raw scale nodes replaced by processed buffers
+            _try_free_attr_node(gm, graph, gate_input_scale_node)
+            _try_free_attr_node(gm, graph, gate_alpha_node)
+            _try_free_attr_node(gm, graph, down_input_scale_node)
+            _try_free_attr_node(gm, graph, down_weight_scale_node)
+            _try_free_attr_node(gm, graph, down_alpha_node)
 
             fused_weight_idx += 1
             cnt += 1

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -364,7 +364,7 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         return torch.empty((m, n // 2), dtype=torch.uint8, device=w.device)
 
     def scale_names(self) -> List[str]:
-        return ["input_scale", "weight_scale", "alpha"]
+        return ["input_scale", "weight_scale", "weight_scale_2"]
 
     def _pad_m_n(self, m: int, n: int) -> Tuple[int, int]:
         """Pad m and n to be divisible by 128 and 4 respectively.
@@ -378,19 +378,14 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         m, n = original_weight_shape
         n = n // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
         padded_m, padded_n = self._pad_m_n(m, n)
-        # definition of scales
-        # input_scale: FP4_GLOBAL_SCALE_MAX / input_amax
-        # weight_scale_2: FP4_GLOBAL_SCALE_MAX / weight_amax
-        # alpha: 1 / (input_scale * weight_scale_2)
         return {
             "input_scale": torch.tensor(1.0 / 6.0),
             "weight_scale": torch.empty((padded_m, padded_n), dtype=torch.float8_e4m3fn),
-            "alpha": torch.tensor(1.0 / 6.0),
+            "weight_scale_2": torch.tensor(1.0 / 6.0),
         }
 
     def build_custom_args_for_linear(self, scales: Dict[str, Node]) -> Tuple:
-        # weight_scale list is (per-block FP8 scale, alpha)
-        return ([scales["input_scale"]], [scales["weight_scale"], scales["alpha"]], [], [])
+        return ([scales["input_scale"]], [scales["weight_scale"], scales["weight_scale_2"]], [], [])
 
     def _scale_buffer_key(self, weight_name: str, prefix: str = "") -> str:
         """Key for the weight_scale buffer (get_scale_name('weight_scale') = attrname + '_weight_scale')."""
@@ -402,21 +397,20 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         if weight_name in state_dict:
             modname = weight_name.rsplit(".", 1)[0]
             input_scale_name = modname + ".input_scale"
-            alpha_name = modname + ".alpha"
+            ws2_name = modname + ".weight_scale_2"
             scale_buffer_key = self._scale_buffer_key(weight_name, prefix)
             weight = state_dict[weight_name]
             # ModelOpt quantized graph path
             if weight.dtype != torch.uint8:
                 assert input_scale_name in state_dict
-                # Unquantized weight
                 amax_name = weight_name + "_quantizer._amax"
                 if amax_name in state_dict:
-                    weight_scale_2 = FP4_GLOBAL_SCALE_MAX / state_dict[amax_name].to(torch.float)
+                    ws2_global = FP4_GLOBAL_SCALE_MAX / state_dict[amax_name].to(torch.float)
                 else:
-                    weight_scale_2 = fp4_global_scale(weight)
+                    ws2_global = fp4_global_scale(weight)
                 weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
                     weight.to("cuda"),
-                    weight_scale_2.to("cuda"),
+                    ws2_global.to("cuda"),
                     TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
                     False,
                 )
@@ -425,25 +419,10 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                 state_dict[scale_buffer_key] = cutlass_fp4_scale_to_modelopt_fp4_scale(
                     weight_scale_cutlass, (m, k)
                 )
-                state_dict[weight_name + "_scale_2"] = weight_scale_2
-                state_dict[alpha_name] = 1 / torch.clamp(
-                    weight_scale_2 * state_dict[input_scale_name], min=1e-30
+                state_dict[input_scale_name] = 1 / torch.clamp(
+                    state_dict[input_scale_name], min=1e-30
                 )
-            # Unified HF ckpt path
-            else:
-                if (
-                    weight_name + "_scale_2" in state_dict
-                    and weight_name + "_scale" in state_dict
-                    and input_scale_name in state_dict
-                    and float4_sf_dtype
-                ):
-                    alpha = state_dict[weight_name + "_scale_2"] * state_dict[input_scale_name]
-                    alpha = torch.clamp(alpha, min=1e-30)
-                    state_dict[alpha_name] = alpha
-                    input_scale = torch.clamp(state_dict[input_scale_name], min=1e-30)
-                    state_dict[input_scale_name] = 1 / input_scale
-                    weight_scale = state_dict[weight_name + "_scale"].view(float4_sf_dtype)
-                    state_dict[scale_buffer_key] = weight_scale
+                state_dict[ws2_name] = 1 / torch.clamp(ws2_global, min=1e-30)
 
     def convert_amax_hook(self, state_dict, prefix, *args, scale_name: str, amax_name: str):
         """Convert amax from modelopt quantized graph to scales."""

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -25,6 +25,7 @@ from ...utils.node_utils import (
     is_linear_op,
 )
 from ...utils.quantization_utils import (
+    cutlass_fp4_scale_to_modelopt_fp4_scale,
     fp4_global_scale,
     fp8_scale,
     get_quantization_from_linear_node,
@@ -383,21 +384,26 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         # alpha: 1 / (input_scale * weight_scale_2)
         return {
             "input_scale": torch.tensor(1.0 / 6.0),
-            "weight_scale": torch.empty((padded_m, padded_n), dtype=torch.uint8),
-            # "weight_scale": torch.empty((m, n), dtype=torch.uint8),
-            # "weight_scale": torch.empty(padded_m * padded_n, dtype=torch.float8_e4m3fn),
-            # "weight_scale": torch.empty(padded_m * padded_n, dtype=torch.uint8),
+            "weight_scale": torch.empty((padded_m, padded_n), dtype=torch.float8_e4m3fn),
             "alpha": torch.tensor(1.0 / 6.0),
         }
 
     def build_custom_args_for_linear(self, scales: Dict[str, Node]) -> Tuple:
-        # weight_scale list is (cutlass_vec, alpha)
+        # weight_scale list is (per-block FP8 scale, alpha)
         return ([scales["input_scale"]], [scales["weight_scale"], scales["alpha"]], [], [])
+
+    def _scale_buffer_key(self, weight_name: str, prefix: str = "") -> str:
+        """Key for the weight_scale buffer (get_scale_name('weight_scale') = attrname + '_weight_scale')."""
+        modname, _, attrname = weight_name.rpartition(".")
+        scale_buffer_name = attrname + "_weight_scale"
+        return prefix + modname + "." + scale_buffer_name
 
     def load_hook(self, state_dict, prefix, *args, weight_name):
         if weight_name in state_dict:
-            input_scale_name = weight_name.rsplit(".", 1)[0] + ".input_scale"
-            alpha_name = weight_name.rsplit(".", 1)[0] + ".alpha"
+            modname = weight_name.rsplit(".", 1)[0]
+            input_scale_name = modname + ".input_scale"
+            alpha_name = modname + ".alpha"
+            scale_buffer_key = self._scale_buffer_key(weight_name, prefix)
             weight = state_dict[weight_name]
             # ModelOpt quantized graph path
             if weight.dtype != torch.uint8:
@@ -408,14 +414,17 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                     weight_scale_2 = FP4_GLOBAL_SCALE_MAX / state_dict[amax_name].to(torch.float)
                 else:
                     weight_scale_2 = fp4_global_scale(weight)
-                weight_fp4, weight_scale = torch.ops.trtllm.fp4_quantize(
+                weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
                     weight.to("cuda"),
                     weight_scale_2.to("cuda"),
                     TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
                     False,
                 )
                 state_dict[weight_name] = weight_fp4
-                state_dict[weight_name + "_scale"] = weight_scale
+                m, k = weight.shape
+                state_dict[scale_buffer_key] = cutlass_fp4_scale_to_modelopt_fp4_scale(
+                    weight_scale_cutlass, (m, k)
+                )
                 state_dict[weight_name + "_scale_2"] = weight_scale_2
                 state_dict[alpha_name] = 1 / torch.clamp(
                     weight_scale_2 * state_dict[input_scale_name], min=1e-30
@@ -434,20 +443,7 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                     input_scale = torch.clamp(state_dict[input_scale_name], min=1e-30)
                     state_dict[input_scale_name] = 1 / input_scale
                     weight_scale = state_dict[weight_name + "_scale"].view(float4_sf_dtype)
-                    # Round the weight block scale factors to 128x4 and then swizzle.
-                    weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
-                        weight_scale.view(torch.uint8).cpu().contiguous()
-                    ).view(float4_sf_dtype)
-
-                    m, n = weight_scale.shape
-                    # scaling factors m is padded along 128 and n is padded along 4.
-                    # check cpp/tensorrt_llm/plugins/fp4GemmPlugin/fp4GemmPlugin.cpp for more details.
-                    padded_m, padded_n = self._pad_m_n(m, n)
-                    swizzled_shape = (padded_m, padded_n)
-
-                    state_dict[weight_name + "_scale"] = weight_scale_swizzled.reshape(
-                        swizzled_shape
-                    )
+                    state_dict[scale_buffer_key] = weight_scale
 
     def convert_amax_hook(self, state_dict, prefix, *args, scale_name: str, amax_name: str):
         """Convert amax from modelopt quantized graph to scales."""

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -376,11 +376,10 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
 
     def default_scales(self, original_weight_shape: Tuple) -> Dict[str, torch.Tensor]:
         m, n = original_weight_shape
-        n = n // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
-        padded_m, padded_n = self._pad_m_n(m, n)
+        n_blocks = n // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
         return {
             "input_scale": torch.tensor(1.0 / 6.0),
-            "weight_scale": torch.empty((padded_m, padded_n), dtype=torch.float8_e4m3fn),
+            "weight_scale": torch.empty((m, n_blocks), dtype=torch.float8_e4m3fn),
             "weight_scale_2": torch.tensor(1.0 / 6.0),
         }
 
@@ -388,10 +387,9 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         return ([scales["input_scale"]], [scales["weight_scale"], scales["weight_scale_2"]], [], [])
 
     def _scale_buffer_key(self, weight_name: str, prefix: str = "") -> str:
-        """Key for the weight_scale buffer (get_scale_name('weight_scale') = attrname + '_weight_scale')."""
-        modname, _, attrname = weight_name.rpartition(".")
-        scale_buffer_name = attrname + "_weight_scale"
-        return prefix + modname + "." + scale_buffer_name
+        """Key for the weight_scale buffer registered as 'weight_scale' on the linear module."""
+        modname = weight_name.rsplit(".", 1)[0]
+        return prefix + modname + ".weight_scale"
 
     def load_hook(self, state_dict, prefix, *args, weight_name):
         if weight_name in state_dict:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,8 @@ from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils.node_utils import is_op
 from ...utils.quantization_utils import (
+    cutlass_fp4_scale_to_modelopt_fp4_scale,
+    fp4_global_scale,
     is_mixed_precision_config,
     mixed_precision_has_algo,
     should_skip_mixed_precision_quantization,
@@ -37,6 +39,17 @@ from .quantization import (
     NVFP4LinearQuantizationFromConfig,
     Quantization,
 )
+
+try:
+    from .....quantization.utils.fp4_utils import float4_sf_dtype as _float4_sf_dtype
+    from ...custom_ops.quantization.quant import (
+        FP4_GLOBAL_SCALE_MAX,
+        TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
+    )
+except ImportError:
+    FP4_GLOBAL_SCALE_MAX = None
+    TRTLLM_NVFP4_SCALING_VECTOR_SIZE = None
+    _float4_sf_dtype = None
 
 
 def _quantize_moe_node(
@@ -246,10 +259,177 @@ class QuantizeNVFP4MOE(NVFP4LinearQuantizationFromConfig):
     """
     Traverse gm, find every torch.ops.auto_deploy.torch_moe, and replace it with the
     quantized version using the quant_algo from quant_config.
+
+    Unlike the linear NVFP4 path (which defers scale processing to FuseNVFP4Linear),
+    the MoE path has no post-load fusion pass, so quantize_weight computes the full
+    kernel-ready scales during the transform (weight_scale swizzled uint8, alpha, inv_input_scale).
+    The load_hook handles reloading from float or pre-quantized checkpoints.
     """
 
     def target_op(self):
         return torch.ops.auto_deploy.torch_quant_nvfp4_moe
+
+    def _post_init(self):
+        self._pending_scales = None
+
+    def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
+        """Quantize weight to FP4 and pre-compute kernel-ready scales.
+
+        On success, stores scales in self._pending_scales for default_scales() to consume.
+        Falls back to placeholder (empty uint8) if required ops are unavailable.
+        """
+        if (
+            FP4_GLOBAL_SCALE_MAX is None
+            or TRTLLM_NVFP4_SCALING_VECTOR_SIZE is None
+            or _float4_sf_dtype is None
+        ):
+            return super().quantize_weight(w)
+
+        try:
+            from .fuse_quant import _swizzle_nvfp4_scale
+
+            ws2_global = fp4_global_scale(w)
+            weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
+                w.to("cuda"),
+                ws2_global.to("cuda"),
+                TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
+                False,
+            )
+            m, k = w.shape
+            raw_ws = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, (m, k))
+            # Default input_scale = 1/6; kernel needs inv_input_scale = 6
+            raw_is = torch.tensor(1.0 / 6.0)
+            raw_ws2 = 1.0 / torch.clamp(ws2_global, min=1e-30)
+            swizzled_ws = _swizzle_nvfp4_scale(raw_ws, _float4_sf_dtype, flatten=False)
+            inv_is = 1.0 / torch.clamp(raw_is, min=1e-30)
+            alpha = torch.clamp(raw_ws2 * raw_is, min=1e-30)
+            self._pending_scales = {
+                "input_scale": inv_is,
+                "weight_scale": swizzled_ws,
+                "weight_scale_2": alpha,
+            }
+            return weight_fp4
+        except Exception:
+            self._pending_scales = None
+            return super().quantize_weight(w)
+
+    def default_scales(self, original_weight_shape):
+        if self._pending_scales is not None:
+            scales = self._pending_scales
+            self._pending_scales = None
+            return scales
+        if TRTLLM_NVFP4_SCALING_VECTOR_SIZE is None:
+            return super().default_scales(original_weight_shape)
+        # Fallback: flat uint8 placeholder matching kernel-ready (swizzled) format.
+        # Shape must match what _swizzle_nvfp4_scale produces and what the checkpoint stores.
+        m, n = original_weight_shape
+        n_blocks = n // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+        padded_m = math.ceil(m / 128) * 128
+        padded_n = math.ceil(n_blocks / 4) * 4
+        return {
+            "input_scale": torch.tensor(1.0 / 6.0),
+            "weight_scale": torch.zeros(padded_m, padded_n, dtype=torch.uint8),
+            "weight_scale_2": torch.tensor(1.0 / 6.0),
+        }
+
+    def load_hook(self, state_dict, prefix, *args, weight_name):
+        """Full-processing load hook for NVFP4 MoE experts.
+
+        Handles two cases:
+        1. Non-quantized checkpoint (weight dtype != uint8): quantize weight and compute
+           raw FP8 scales, then process into kernel-ready format.
+        2. Pre-quantized checkpoint (weight dtype == uint8): process raw FP8 scales
+           (if present) into kernel-ready format.
+
+        MoE experts register scales with names "input_scale", "weight_scale",
+        "weight_scale_2" directly on the expert submodule (not using the attrname
+        prefix from _scale_buffer_key), so this override uses the correct key names.
+        """
+        if weight_name not in state_dict:
+            return
+
+        modname = weight_name.rsplit(".", 1)[0]
+        input_scale_key = modname + ".input_scale"
+        weight_scale_key = modname + ".weight_scale"
+        ws2_key = modname + ".weight_scale_2"
+
+        weight = state_dict[weight_name]
+
+        # Case 1: non-quantized checkpoint — quantize weight and store raw scales
+        if weight.dtype != torch.uint8:
+            if FP4_GLOBAL_SCALE_MAX is None or TRTLLM_NVFP4_SCALING_VECTOR_SIZE is None:
+                return
+            amax_key = weight_name + "_quantizer._amax"
+            if amax_key in state_dict:
+                ws2_global = FP4_GLOBAL_SCALE_MAX / state_dict[amax_key].to(torch.float)
+            else:
+                ws2_global = fp4_global_scale(weight)
+            weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
+                weight.to("cuda"),
+                ws2_global.to("cuda"),
+                TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
+                False,
+            )
+            state_dict[weight_name] = weight_fp4
+            m, k = weight.shape
+            # Store raw FP8 per-block weight scale (2D, float8_e4m3fn)
+            state_dict[weight_scale_key] = cutlass_fp4_scale_to_modelopt_fp4_scale(
+                weight_scale_cutlass, (m, k)
+            )
+            # input_scale from checkpoint (may be amax or s_in2 after convert_amax_hook)
+            if input_scale_key in state_dict:
+                state_dict[input_scale_key] = 1 / torch.clamp(
+                    state_dict[input_scale_key], min=1e-30
+                )
+            # Store raw weight_scale_2 = 1/ws2_global
+            state_dict[ws2_key] = 1 / torch.clamp(ws2_global, min=1e-30)
+
+        # Case 1 & 2: process weight_scale into kernel-ready uint8 2D format.
+        # fuse_nvfp4_moe expects per-expert weight_scale as uint8 2D [padded_M, padded_N]
+        # so it can stack them into 3D [num_experts, padded_M, padded_N].
+        if weight_scale_key not in state_dict:
+            return
+        raw_ws = state_dict[weight_scale_key]
+
+        if raw_ws.dtype == torch.uint8:
+            # Already in uint8 kernel-ready format.
+            if raw_ws.ndim == 2:
+                # Already 2D — correct format, nothing to do.
+                return
+            # Flat 1D uint8 from checkpoint: reshape to 2D [padded_M, padded_N].
+            m_w, k_half = weight.shape  # weight is uint8 FP4-packed, shape (M, K//2)
+            k_blocks = (k_half * 2) // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+            padded_m = math.ceil(m_w / 128) * 128
+            padded_n = math.ceil(k_blocks / 4) * 4
+            state_dict[weight_scale_key] = raw_ws.reshape(padded_m, padded_n)
+            return
+
+        # FP8 weight_scale: swizzle to uint8 2D for fuse_nvfp4_moe compatibility.
+        if raw_ws.dtype != torch.float8_e4m3fn:
+            return
+        if _float4_sf_dtype is None:
+            return
+
+        from .fuse_quant import _swizzle_nvfp4_scale
+
+        # Use default 1/6 if input_scale not in source state_dict (e.g. fresh float checkpoint)
+        raw_is = state_dict.get(input_scale_key, torch.tensor(1.0 / 6.0)).float()
+        if ws2_key not in state_dict:
+            return
+        raw_ws2 = state_dict[ws2_key].float()
+
+        # Handle flat 1D FP8: reshape to 2D (M, K_blocks) before swizzling
+        if raw_ws.ndim == 1:
+            m_w, k_half = weight.shape  # weight is uint8-packed, shape (M, K//2)
+            k_blocks = (k_half * 2) // TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+            raw_ws = raw_ws.reshape(m_w, k_blocks).view(torch.float8_e4m3fn)
+
+        # Swizzle weight_scale: FP8 2D → uint8 2D [padded_M, padded_N] (NOT flattened)
+        state_dict[weight_scale_key] = _swizzle_nvfp4_scale(raw_ws, _float4_sf_dtype, flatten=False)
+        # Compute alpha = raw_ws2 * raw_is
+        state_dict[ws2_key] = torch.clamp(raw_ws2 * raw_is, min=1e-30)
+        # Invert input_scale
+        state_dict[input_scale_key] = 1.0 / torch.clamp(raw_is, min=1e-30)
 
     def _apply(
         self,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
@@ -269,55 +269,7 @@ class QuantizeNVFP4MOE(NVFP4LinearQuantizationFromConfig):
     def target_op(self):
         return torch.ops.auto_deploy.torch_quant_nvfp4_moe
 
-    def _post_init(self):
-        self._pending_scales = None
-
-    def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
-        """Quantize weight to FP4 and pre-compute kernel-ready scales.
-
-        On success, stores scales in self._pending_scales for default_scales() to consume.
-        Falls back to placeholder (empty uint8) if required ops are unavailable.
-        """
-        if (
-            FP4_GLOBAL_SCALE_MAX is None
-            or TRTLLM_NVFP4_SCALING_VECTOR_SIZE is None
-            or _float4_sf_dtype is None
-        ):
-            return super().quantize_weight(w)
-
-        try:
-            from .fuse_quant import _swizzle_nvfp4_scale
-
-            ws2_global = fp4_global_scale(w)
-            weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
-                w.to("cuda"),
-                ws2_global.to("cuda"),
-                TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
-                False,
-            )
-            m, k = w.shape
-            raw_ws = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, (m, k))
-            # Default input_scale = 1/6; kernel needs inv_input_scale = 6
-            raw_is = torch.tensor(1.0 / 6.0)
-            raw_ws2 = 1.0 / torch.clamp(ws2_global, min=1e-30)
-            swizzled_ws = _swizzle_nvfp4_scale(raw_ws, _float4_sf_dtype, flatten=False)
-            inv_is = 1.0 / torch.clamp(raw_is, min=1e-30)
-            alpha = torch.clamp(raw_ws2 * raw_is, min=1e-30)
-            self._pending_scales = {
-                "input_scale": inv_is,
-                "weight_scale": swizzled_ws,
-                "weight_scale_2": alpha,
-            }
-            return weight_fp4
-        except Exception:
-            self._pending_scales = None
-            return super().quantize_weight(w)
-
     def default_scales(self, original_weight_shape):
-        if self._pending_scales is not None:
-            scales = self._pending_scales
-            self._pending_scales = None
-            return scales
         if TRTLLM_NVFP4_SCALING_VECTOR_SIZE is None:
             return super().default_scales(original_weight_shape)
         # Fallback: flat uint8 placeholder matching kernel-ready (swizzled) format.
@@ -376,11 +328,6 @@ class QuantizeNVFP4MOE(NVFP4LinearQuantizationFromConfig):
             state_dict[weight_scale_key] = cutlass_fp4_scale_to_modelopt_fp4_scale(
                 weight_scale_cutlass, (m, k)
             )
-            # input_scale from checkpoint (may be amax or s_in2 after convert_amax_hook)
-            if input_scale_key in state_dict:
-                state_dict[input_scale_key] = 1 / torch.clamp(
-                    state_dict[input_scale_key], min=1e-30
-                )
             # Store raw weight_scale_2 = 1/ws2_global
             state_dict[ws2_key] = 1 / torch.clamp(ws2_global, min=1e-30)
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 from torch.fx import GraphModule, Node
 
-from ..custom_ops.quantization.quant import FP4_GLOBAL_SCALE_MAX, FP8_MAX
 from .logger import ad_logger
 from .node_utils import (
     extract_weight_name,
@@ -21,6 +20,12 @@ try:
     from ....quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
+
+# tmp: Local constants to avoid circular import with quant (which uses these same values).
+_FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+_FP4_MAX = 6.0
+FP4_GLOBAL_SCALE_MAX = _FP8_MAX * _FP4_MAX
+FP8_MAX = _FP8_MAX
 
 
 def modelopt_fp4_scale_to_cutlass_fp4_scale(modelopt_scale: torch.Tensor) -> torch.Tensor:

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.fx import GraphModule, Node
 
+from ..custom_ops.quantization.quant import FP4_GLOBAL_SCALE_MAX, FP8_MAX
 from .logger import ad_logger
 from .node_utils import (
     extract_weight_name,
@@ -21,11 +22,11 @@ try:
 except ImportError:
     float4_sf_dtype = None
 
-# tmp: Local constants to avoid circular import with quant (which uses these same values).
-_FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
-_FP4_MAX = 6.0
-FP4_GLOBAL_SCALE_MAX = _FP8_MAX * _FP4_MAX
-FP8_MAX = _FP8_MAX
+# # tmp: Local constants to avoid circular import with quant (which uses these same values).
+# _FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+# _FP4_MAX = 6.0
+# FP4_GLOBAL_SCALE_MAX = _FP8_MAX * _FP4_MAX
+# FP8_MAX = _FP8_MAX
 
 
 def modelopt_fp4_scale_to_cutlass_fp4_scale(modelopt_scale: torch.Tensor) -> torch.Tensor:

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
@@ -60,20 +60,21 @@ def test_fp4_linear():
     input = torch.rand(1, 3, 64, dtype=torch.half, device="cuda")
     weight = torch.rand(128, 64, dtype=torch.half, device="cuda")
 
-    input_scale = fp4_global_scale(input)
-    weight_scale_2 = fp4_global_scale(weight)
+    input_gs = fp4_global_scale(input)
+    weight_gs = fp4_global_scale(weight)
 
-    weight_fp4, weight_scale = torch.ops.trtllm.fp4_quantize(
-        weight, weight_scale_2, SCALING_VECTOR_SIZE, False
+    weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
+        weight, weight_gs, SCALING_VECTOR_SIZE, False
     )
+    weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, weight.shape)
 
     output_fp4_gemm = torch.ops.auto_deploy.torch_quant_nvfp4_linear(
         input,
         weight_fp4,
         bias=None,
-        input_scale=input_scale,
-        weight_scale=weight_scale,
-        alpha=1 / (input_scale * weight_scale_2),
+        input_scale=1.0 / input_gs,
+        weight_scale=weight_scale_fp8,
+        weight_scale_2=1.0 / weight_gs,
     )
     output_fp16_gemm = torch.ops.aten.linear.default(input, weight, bias=None)
 
@@ -172,18 +173,21 @@ def test_quant_linear_nvfp4_matches_fused_op(bias):
     N, K = W.shape
     assert K % SCALING_VECTOR_SIZE == 0
 
-    # Per-tensor scale-2 (amax / (448 * 6))
-    s_in2 = fp4_global_scale(x).to(torch.float32)  # input per-tensor scale
-    s_w2 = fp4_global_scale(W).to(torch.float32)  # weight per-tensor scale
+    s_in_gs = fp4_global_scale(x).to(torch.float32)
+    s_w_gs = fp4_global_scale(W).to(torch.float32)
 
     weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
-        W, s_w2, SCALING_VECTOR_SIZE, False
+        W, s_w_gs, SCALING_VECTOR_SIZE, False
     )
     assert weight_fp4.dtype == torch.uint8
     assert weight_scale_cutlass.dtype == torch.uint8
 
-    # Fused op (expects CUTLASS uint8 scale + kernel alpha = 1/(s_in2*s_w2))
-    alpha_fused = (1.0 / (s_in2 * s_w2)).to(torch.float32)
+    weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, (N, K))
+
+    # Raw per-tensor scale_2 values (amax / FP4_GLOBAL_SCALE_MAX = 1/global_scale)
+    input_s2 = (1.0 / s_in_gs).to(torch.float32)
+    weight_s2 = (1.0 / s_w_gs).to(torch.float32)
+
     if bias is not None and bias.dtype != x.dtype:
         bias = bias.to(x.dtype)
 
@@ -191,23 +195,21 @@ def test_quant_linear_nvfp4_matches_fused_op(bias):
         x,
         weight_fp4,
         bias=bias,
-        input_scale=s_in2,
-        weight_scale=weight_scale_cutlass,
-        alpha=alpha_fused,
+        input_scale=input_s2,
+        weight_scale=weight_scale_fp8,
+        weight_scale_2=weight_s2,
     )
-
-    weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, (N, K))
     out_unified = torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
         x,
         weight_fp4,
         bias,
-        [s_in2],  # input_scale list
+        [input_s2],
         [
             weight_scale_fp8,
-            alpha_fused,
-        ],  # weight_scale list: [per-block FP8 scale, alpha]
-        [],  # input_zp
-        [],  # weight_zp
+            weight_s2,
+        ],
+        [],
+        [],
     )
 
     assert out_unified.shape == out_fused.shape

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
@@ -5,6 +5,7 @@ from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_availab
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
+    cutlass_fp4_scale_to_modelopt_fp4_scale,
     fp4_global_scale,
     pack_int4_in_uint8,
     unpack_uint8_to_int4_weight_2d,
@@ -195,15 +196,16 @@ def test_quant_linear_nvfp4_matches_fused_op(bias):
         alpha=alpha_fused,
     )
 
+    weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, (N, K))
     out_unified = torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
         x,
         weight_fp4,
         bias,
         [s_in2],  # input_scale list
         [
-            weight_scale_cutlass,
+            weight_scale_fp8,
             alpha_fused,
-        ],  # weight_scale list: [per-block vector, combined alpha]
+        ],  # weight_scale list: [per-block FP8 scale, alpha]
         [],  # input_zp
         [],  # weight_zp
     )

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/quantization/test_quant.py
@@ -66,15 +66,18 @@ def test_fp4_linear():
     weight_fp4, weight_scale_cutlass = torch.ops.trtllm.fp4_quantize(
         weight, weight_gs, SCALING_VECTOR_SIZE, False
     )
-    weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(weight_scale_cutlass, weight.shape)
+
+    raw_input_s2 = 1.0 / input_gs
+    raw_weight_s2 = 1.0 / weight_gs
+    alpha = torch.clamp(raw_input_s2 * raw_weight_s2, min=1e-30)
 
     output_fp4_gemm = torch.ops.auto_deploy.torch_quant_nvfp4_linear(
         input,
         weight_fp4,
         bias=None,
-        input_scale=1.0 / input_gs,
-        weight_scale=weight_scale_fp8,
-        weight_scale_2=1.0 / weight_gs,
+        input_scale=input_gs,
+        weight_scale=weight_scale_cutlass,
+        alpha=alpha,
     )
     output_fp16_gemm = torch.ops.aten.linear.default(input, weight, bias=None)
 
@@ -188,6 +191,8 @@ def test_quant_linear_nvfp4_matches_fused_op(bias):
     input_s2 = (1.0 / s_in_gs).to(torch.float32)
     weight_s2 = (1.0 / s_w_gs).to(torch.float32)
 
+    alpha = torch.clamp(input_s2 * weight_s2, min=1e-30)
+
     if bias is not None and bias.dtype != x.dtype:
         bias = bias.to(x.dtype)
 
@@ -195,9 +200,9 @@ def test_quant_linear_nvfp4_matches_fused_op(bias):
         x,
         weight_fp4,
         bias=bias,
-        input_scale=input_s2,
-        weight_scale=weight_scale_fp8,
-        weight_scale_2=weight_s2,
+        input_scale=s_in_gs,
+        weight_scale=weight_scale_cutlass,
+        alpha=alpha,
     )
     out_unified = torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear(
         x,

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quant_fusion.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quant_fusion.py
@@ -19,7 +19,11 @@ from tensorrt_llm._torch.auto_deploy.transform.library.fuse_rmsnorm_quant_fp8 im
 )
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale, fp8_scale
+from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
+    cutlass_fp4_scale_to_modelopt_fp4_scale,
+    fp4_global_scale,
+    fp8_scale,
+)
 
 
 def _has_fused_linear_fp8(gm):
@@ -96,7 +100,13 @@ class TinyFP8Ref(nn.Module):
 class TinyFP4Ref(nn.Module):
     """A tiny module whose forward uses the reference NVFP4 op.
 
-    Uses: torch_fake_quant_nvfp4_linear(x, w_fp4, bias, [s_in2], [cutlass_vec, alpha], [], [])
+    Uses: torch_fake_quant_nvfp4_linear(x, w_fp4, bias, [input_scale_2], [weight_scale_fp8, weight_scale_2], [], [])
+
+    Scales are stored in raw (un-processed) format — kernel-specific processing
+    (swizzling, alpha computation, input_scale inversion) is deferred to the fusion pass.
+      - input_scale_2:   raw amax / FP4_GLOBAL_SCALE_MAX  (= 1 / fp4_global_scale)
+      - weight_scale_fp8: per-block FP8 scale (float8_e4m3fn, 2D [N, K//16])
+      - weight_scale_2:  raw amax / FP4_GLOBAL_SCALE_MAX  (= 1 / fp4_global_scale)
     """
 
     def __init__(self, in_features=64, out_features=32, use_bias=True):
@@ -117,12 +127,18 @@ class TinyFP4Ref(nn.Module):
             s_in2 = fp4_global_scale(torch.rand(1, in_features, dtype=torch.half, device=device))
             s_w2 = fp4_global_scale(self.weight)
             w_fp4, cutlass_vec = torch.ops.trtllm.fp4_quantize(self.weight, s_w2, 16, False)
-            alpha = (1.0 / (s_in2 * s_w2)).to(torch.float32)
+            # Convert CUTLASS uint8 vec → FP8 per-block 2D scale (new IR format)
+            weight_scale_fp8 = cutlass_fp4_scale_to_modelopt_fp4_scale(
+                cutlass_vec, (out_features, in_features)
+            )
+            # Store raw "amax / FP4_GLOBAL_SCALE_MAX" = 1/s_in2 and 1/s_w2
+            input_s2_raw = (1.0 / s_in2).to(torch.float32)
+            weight_s2_raw = (1.0 / s_w2).to(torch.float32)
 
         self.register_buffer("weight_fp4", w_fp4)  # uint8 packed
-        self.register_buffer("input_scale_2", s_in2.to(torch.float32))
-        self.register_buffer("weight_scale_cutlass", cutlass_vec)  # uint8 vec
-        self.register_buffer("alpha", alpha.to(torch.float32))
+        self.register_buffer("weight_scale", weight_scale_fp8)  # float8_e4m3fn 2D
+        self.register_buffer("weight_scale_2", weight_s2_raw)  # raw scalar
+        self.register_buffer("input_scale", input_s2_raw)  # raw scalar
 
     def forward(self, x):
         bias = self.bias if self.use_bias else None
@@ -130,8 +146,8 @@ class TinyFP4Ref(nn.Module):
             x,
             self.weight_fp4,
             bias,
-            [self.input_scale_2],
-            [self.weight_scale_cutlass, self.alpha],
+            [self.input_scale],
+            [self.weight_scale, self.weight_scale_2],
             [],
             [],
         )


### PR DESCRIPTION

- [X] update `quantize_nvfp4_linear_from_config`, move weight_scale, weight_scale_2, input_scale processing into the custom op
- [X] update `fuse_nvfp4_linear` for param change, pre-process weight scales and input_scales in-place
- TODO: modularize unified checkpoint weight handling
- [X] update swiglu fusion
- [X] update load_hook logic for quantize moe to preserve functionality.
- [X] update doc: custom op description
- 
TODO: check `quantize_nvfp4_from_graph` on the side branch
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved NVFP4 quantization scale preprocessing and validation to ensure proper handling during model loading and inference.

* **Tests**
  * Updated quantization tests to reflect refined scale tensor representations and computation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

Tested e2e with `nvidia/Llama-3.1-8B-Instruct-NVFP4`, `DeepInfra/GLM-4.7-Flash-NVFP4` and Super V3 NVFP4

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
