### PR TITLE
[None][feat] Skip softmax via sparsity ratio

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -10,6 +10,7 @@ from torch import nn
 import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
 from tensorrt_llm._utils import (get_sm_version, is_sm_100f, nvtx_range,
                                  nvtx_range_debug)
+from tensorrt_llm.llmapi.llm_args import SkipSoftmaxAttentionConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -525,9 +526,26 @@ class Attention(nn.Module):
 
         self.quant_config = config.get_quant_config()
         self.attn_backend = config.attn_backend
-        attn_cls = get_attention_backend(
-            self.attn_backend,
-            sparse_attn_config=config.sparse_attention_config)
+
+        # Resolve target_sparsity → threshold_scale_factor if needed
+        sparse_attn_cfg = config.sparse_attention_config
+        if (isinstance(sparse_attn_cfg, SkipSoftmaxAttentionConfig)
+                and sparse_attn_cfg.target_sparsity is not None):
+            hf_sparse = getattr(config.pretrained_config,
+                                'sparse_attention_config', None)
+            if not isinstance(hf_sparse, dict):
+                raise ValueError(
+                    "sparse_attention_config with target_sparsity requires formula "
+                    "coefficients in the model's config.json "
+                    "(sparse_attention_config.threshold_scale_factor.{prefill,decode}.{a,b}), "
+                    "but sparse_attention_config was not found or was not dict type in config.json."
+                )
+            formula = hf_sparse.get('threshold_scale_factor', {})
+            sparse_attn_cfg = sparse_attn_cfg.resolve_for_target_sparsity(
+                formula)
+
+        attn_cls = get_attention_backend(self.attn_backend,
+                                         sparse_attn_config=sparse_attn_cfg)
 
         # These two modules are mutually exclusive - either splitted_qkv_lora or fused_qkv_lora will be used,
         # but never both at the same time. splitted_qkv_lora handles Q,K,V separately while fused_qkv_lora
@@ -593,7 +611,7 @@ class Attention(nn.Module):
             skip_create_weights_in_init=config.skip_create_weights_in_init,
             q_scaling=self.q_scaling,
             attention_chunk_size=self.attention_chunk_size,
-            sparse_attention_config=config.sparse_attention_config,
+            sparse_attention_config=sparse_attn_cfg,
         )
 
         self.support_fused_qkv = self.attn.support_fused_qkv()

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -357,6 +357,11 @@ class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
     threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = Field(
         default=None,
         description="The threshold scale factor for skip softmax attention.")
+    target_sparsity: Optional[Union[float, Dict[str, float]]] = Field(
+        default=None,
+        description="Target sparsity for prefill and/or decode phases. "
+        "Requires formula coefficients in the model's config.json. "
+        "Ignored if threshold_scale_factor is also set.")
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -372,6 +377,56 @@ class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
         if isinstance(self.threshold_scale_factor, dict):
             return self.threshold_scale_factor.get('decode', None)
         return self.threshold_scale_factor
+
+    @property
+    def target_sparsity_prefill(self) -> Optional[float]:
+        if isinstance(self.target_sparsity, dict):
+            return self.target_sparsity.get('prefill', None)
+        return self.target_sparsity
+
+    @property
+    def target_sparsity_decode(self) -> Optional[float]:
+        if isinstance(self.target_sparsity, dict):
+            return self.target_sparsity.get('decode', None)
+        return self.target_sparsity
+
+    def resolve_for_target_sparsity(
+            self, formula: dict) -> 'SkipSoftmaxAttentionConfig':
+        """
+        Given formula coefficients from HF config.json (dict with 'prefill' and
+        'decode' keys, each containing 'a' and 'b'), compute threshold_scale_factor
+        and return a new SkipSoftmaxAttentionConfig with it set.
+
+        formula example:
+          {"prefill": {"a": 7e-5, "b": 7.929109},
+           "decode":  {"a": 7e-5, "b": 16.9025}}
+
+        If threshold_scale_factor is already set, it takes precedence and
+        this method returns self unchanged.
+        """
+        if self.threshold_scale_factor is not None:
+            return self
+
+        import math
+
+        def _compute(phase: str, sparsity: Optional[float]) -> Optional[float]:
+            if sparsity is None:
+                return None
+            coeffs = formula.get(phase)
+            if not coeffs or 'a' not in coeffs or 'b' not in coeffs:
+                raise ValueError(
+                    f"SkipSoftmaxAttentionConfig: config.json is missing formula "
+                    f"coefficients for phase '{phase}' needed to compute "
+                    f"threshold_scale_factor from target_sparsity.")
+            return coeffs['a'] * math.exp(coeffs['b'] * sparsity)
+
+        return SkipSoftmaxAttentionConfig(
+            algorithm=self.algorithm,
+            target_sparsity=self.target_sparsity,
+            threshold_scale_factor={
+                'prefill': _compute('prefill', self.target_sparsity_prefill),
+                'decode': _compute('decode', self.target_sparsity_decode),
+            })
 
 
 class MoeLoadBalancerConfig(StrictBaseModel):

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1536,3 +1536,78 @@ class TestPydanticBestPractices:
                 + "\n".join(violations) +
                 "\n\nThese should be replaced with alternatives like validators, model_post_init, or classmethods. See this test's docstring for more details."
             )
+
+
+class TestSkipSoftmaxAttentionConfig:
+
+    def test_resolve_computes_thresholds(self):
+        import math
+
+        from tensorrt_llm.llmapi.llm_args import SkipSoftmaxAttentionConfig
+
+        formula = {
+            'prefill': {
+                'a': 7e-5,
+                'b': 7.929109
+            },
+            'decode': {
+                'a': 7e-5,
+                'b': 16.9025
+            },
+        }
+        cfg = SkipSoftmaxAttentionConfig(target_sparsity={
+            'prefill': 0.5,
+            'decode': 0.5
+        })
+        resolved = cfg.resolve_for_target_sparsity(formula)
+
+        expected_prefill = 7e-5 * math.exp(7.929109 * 0.5)
+        expected_decode = 7e-5 * math.exp(16.9025 * 0.5)
+        assert resolved.threshold_scale_factor_prefill == pytest.approx(
+            expected_prefill)
+        assert resolved.threshold_scale_factor_decode == pytest.approx(
+            expected_decode)
+
+    def test_resolve_scalar_target_sparsity(self):
+        import math
+
+        from tensorrt_llm.llmapi.llm_args import SkipSoftmaxAttentionConfig
+
+        formula = {
+            'prefill': {
+                'a': 7e-5,
+                'b': 7.929109
+            },
+            'decode': {
+                'a': 7e-5,
+                'b': 16.9025
+            },
+        }
+        cfg = SkipSoftmaxAttentionConfig(target_sparsity=0.3)
+        resolved = cfg.resolve_for_target_sparsity(formula)
+
+        assert resolved.threshold_scale_factor_prefill == pytest.approx(
+            7e-5 * math.exp(7.929109 * 0.3))
+        assert resolved.threshold_scale_factor_decode == pytest.approx(
+            7e-5 * math.exp(16.9025 * 0.3))
+
+    def test_resolve_missing_coefficients_raises(self):
+        from tensorrt_llm.llmapi.llm_args import SkipSoftmaxAttentionConfig
+
+        cfg = SkipSoftmaxAttentionConfig(target_sparsity={
+            'prefill': 0.5,
+            'decode': 0.5
+        })
+        with pytest.raises(ValueError, match="missing formula coefficients"):
+            cfg.resolve_for_target_sparsity({})
+
+    def test_threshold_scale_factor_unaffected(self):
+        from tensorrt_llm.llmapi.llm_args import SkipSoftmaxAttentionConfig
+
+        cfg = SkipSoftmaxAttentionConfig(threshold_scale_factor={
+            'prefill': 0.001,
+            'decode': 0.002
+        })
+        assert cfg.target_sparsity is None
+        assert cfg.threshold_scale_factor_prefill == pytest.approx(0.001)
+        assert cfg.threshold_scale_factor_decode == pytest.approx(0.002)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic sparse attention threshold computation from model checkpoints.
  * Enabled configuration of sparse attention using target sparsity ratio parameter.
  * Implemented precedence handling when multiple sparse attention configuration options are provided.

* **Tests**
  * Added comprehensive test coverage for sparse attention configuration workflows and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Description                                                                                                                                                       
                  
  Skip-softmax sparse attention previously required users to manually supply raw `threshold_scale_factor` values (separate prefill and decode scalars) in `extra_llm_api_options.yaml.` Determining these values is non-intuitive and requires offline experimentation.                                                       

  This PR adds a higher-level interface for model checkpoints exported from ModelOpt using its skip-softmax calibration method. ModelOpt embeds per-phase exponential calibration parameters (a, b) in the checkpoint's config.json under `sparse_attention_config.threshold_scale_factor.prefill `and `.decode`. Users can then specify a `target_sparsity_ratio` in `extra_llm_api_options.yaml`, and TRT-LLM will automatically compute the threshold scale factors using:

  `threshold = a * exp(b * target_sparsity_ratio)`

  If `threshold_scale_factor` is provided directly in the YAML, it takes precedence and target_sparsity_ratio is ignored, preserving full backward compatibility.

  Test Coverage

  Unit tests added in `tests/unittest/llmapi/test_llm_args.py` (TestSkipSoftmaxSparseAttentionConfig):
  - Direct `threshold_scale_factor `passthrough (no checkpoint needed)
  - `threshold_scale_factor `takes precedence over `target_sparsity_ratio `when both are present
  - Threshold computation from checkpoint calibration params matches the exponential formula
  - End-to-end resolution via `update_llm_args_with_extra_dict` for both code paths
  - Error cases: missing model path, missing checkpoint structure

  `pytest tests/unittest/llmapi/test_llm_args.py -k "TestSkipSoftmaxSparseAttentionConfig"`

  PR Checklist

  - Please check this after reviewing the above items as appropriate for this PR.

