### PR TITLE
[None][feat] Enable non-gated activation to the new MoE test

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -2149,7 +2149,8 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                 self.load_expert_w2_weight_scale_nvfp4(
                     module, w2_weight_scale, dst_w2_weight_scale[expert_idx])
                 module._add_raw_shared_weights_for_unmap([
-                    w for w in [w1_weight_scale, w3_weight_scale, w2_weight_scale]
+                    w for w in
+                    [w1_weight_scale, w3_weight_scale, w2_weight_scale]
                     if w is not None
                 ])
 
@@ -3136,7 +3137,9 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
                                                 device=device)
 
         # Check if w3 is empty (for non-gated activations like ReLU2 in Nemotron H)
-        w3_size = w3_weight_scale.shape[0] if w3_weight_scale is not None and w3_weight_scale.numel() > 0 else 0
+        w3_size = w3_weight_scale.shape[
+            0] if w3_weight_scale is not None and w3_weight_scale.numel(
+            ) > 0 else 0
         # Keep weights in device buffer
         if module.is_gated_activation:
             # Gated activation: buffer contains both w3 and w1 scales

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -554,8 +554,7 @@ class FusedMoEMethodBase(ABC):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight.device
         if not allow_partial_loading:
-            assert w1_weight is not None
-            assert w3_weight is not None or not module.is_gated_activation
+            assert w1_weight is not None and w3_weight is not None
         w1_weight_shard = load_weight_shard(
             w1_weight,
             module.tp_size,
@@ -2056,11 +2055,9 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
     def load_expert_fc31_input_scale_nvfp4(self, w1_input_scale, w3_input_scale,
                                            dst_fc31_input_scale: torch.Tensor):
         w1_input_scale = w1_input_scale[...].reshape([])
-        if w3_input_scale is not None:
-            w3_input_scale = w3_input_scale[...].reshape([])
-            assert torch.allclose(
-                w1_input_scale,
-                w3_input_scale), "w1_input_scale != w3_input_scale"
+        w3_input_scale = w3_input_scale[...].reshape([])
+        assert torch.allclose(
+            w1_input_scale, w3_input_scale), "w1_input_scale != w3_input_scale"
         dst_fc31_input_scale.copy_(w1_input_scale)
 
     def load_expert_fc2_input_scale_nvfp4(self, w2_input_scale,
@@ -2071,11 +2068,10 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                                      final_fc31_input_scale: torch.Tensor,
                                      dst_fc31_alpha: torch.Tensor):
         w1_weight_scale_2 = w1_weight_scale_2[...].reshape([])
-        if w3_weight_scale_2 is not None:
-            w3_weight_scale_2 = w3_weight_scale_2[...].reshape([])
-            assert torch.allclose(
-                w1_weight_scale_2,
-                w3_weight_scale_2), "w1_weight_scale_2 != w3_weight_scale_2"
+        w3_weight_scale_2 = w3_weight_scale_2[...].reshape([])
+        assert torch.allclose(
+            w1_weight_scale_2,
+            w3_weight_scale_2), "w1_weight_scale_2 != w3_weight_scale_2"
 
         w3_w1_weight_scale_2 = 1.0 / w1_weight_scale_2
         dst_fc31_alpha.copy_(1.0 /
@@ -2107,12 +2103,10 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
             if module.weight_loading_mode == MoEWeightLoadingMode.VANILLA:
                 if not ignore_weight_scale:
                     w1_weight_scale = weights[f"{expert_id}.w1.weight_scale"]
-                    w3_weight_scale = weights[
-                        f"{expert_id}.w3.weight_scale"] if module.is_gated_activation else None
+                    w3_weight_scale = weights[f"{expert_id}.w3.weight_scale"]
                     w2_weight_scale = weights[f"{expert_id}.w2.weight_scale"]
                 w1_weight_scale_2 = weights[f"{expert_id}.w1.weight_scale_2"]
-                w3_weight_scale_2 = weights[
-                    f"{expert_id}.w3.weight_scale_2"] if module.is_gated_activation else None
+                w3_weight_scale_2 = weights[f"{expert_id}.w3.weight_scale_2"]
                 w2_weight_scale_2 = weights[f"{expert_id}.w2.weight_scale_2"]
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 if not ignore_weight_scale:
@@ -2123,8 +2117,7 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                     w2_weight_scale = weights["down_proj_weight_scale"][
                         expert_id].transpose(0, 1).contiguous()
                 w1_weight_scale_2 = weights["gate_up_proj_weight_scale_2"]
-                w3_weight_scale_2 = weights[
-                    "gate_up_proj_weight_scale_2"] if module.is_gated_activation else None
+                w3_weight_scale_2 = weights["gate_up_proj_weight_scale_2"]
                 w2_weight_scale_2 = weights["down_proj_weight_scale_2"]
             else:
                 raise NotImplementedError(
@@ -2133,8 +2126,7 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
 
             expert_idx = local_slot_id
 
-            if w3_weight_scale_2 is not None and not torch.allclose(
-                    w1_weight_scale_2, w3_weight_scale_2):
+            if not torch.allclose(w1_weight_scale_2, w3_weight_scale_2):
                 logger.warning(
                     f"w1_weight_scale_2 != w3_weight_scale_2 ({w1_weight_scale_2} != {w3_weight_scale_2}), selecting the larger value. Accuracy may be affected."
                 )
@@ -2148,11 +2140,8 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                     dst_w3_w1_weight_scale[expert_idx])
                 self.load_expert_w2_weight_scale_nvfp4(
                     module, w2_weight_scale, dst_w2_weight_scale[expert_idx])
-                module._add_raw_shared_weights_for_unmap([
-                    w for w in
-                    [w1_weight_scale, w3_weight_scale, w2_weight_scale]
-                    if w is not None
-                ])
+                module._add_raw_shared_weights_for_unmap(
+                    [w1_weight_scale, w3_weight_scale, w2_weight_scale])
 
             self.load_expert_fc31_alpha_nvfp4(w1_weight_scale_2,
                                               w3_weight_scale_2,
@@ -2190,13 +2179,11 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
         for expert_id in range(module.num_experts):
             if module.weight_loading_mode == MoEWeightLoadingMode.VANILLA:
                 w1_input_scale = weights[f"{expert_id}.w1.input_scale"]
-                w3_input_scale = weights[
-                    f"{expert_id}.w3.input_scale"] if module.is_gated_activation else None
+                w3_input_scale = weights[f"{expert_id}.w3.input_scale"]
                 w2_input_scale = weights[f"{expert_id}.w2.input_scale"]
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w1_input_scale = weights["gate_up_proj_input_scale"]
-                w3_input_scale = weights[
-                    "gate_up_proj_input_scale"] if module.is_gated_activation else None
+                w3_input_scale = weights["gate_up_proj_input_scale"]
                 w2_input_scale = weights["down_proj_input_scale"]
             else:
                 raise NotImplementedError(
@@ -2217,9 +2204,6 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
 
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         if has_pre_quant_scale:
-            assert module.is_gated_activation, (
-                "pre_quant_scale (NVFP4_AWQ) is not supported with non-gated activations"
-            )
             from ..linear import TensorParallelMode, load_weight_shard
 
             device = module.fc31_act_scale.device
@@ -2403,9 +2387,6 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
             dst_w3_w1_weight_scale: torch.Tensor):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight_scale.device
-        assert w3_weight_scale is not None, (
-            "NVFP4CutlassFusedMoEMethod currently does not support non-gated activations"
-        )
         w1_weight_scale = load_weight_shard(w1_weight_scale,
                                             module.tp_size,
                                             module.tp_rank,
@@ -2722,19 +2703,14 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN,
                                             device=device)
-        w3_weight_scale = load_weight_shard(
-            w3_weight_scale,
-            module.tp_size,
-            module.tp_rank,
-            TensorParallelMode.COLUMN,
-            device=device
-        ) if w3_weight_scale is not None and w3_weight_scale.numel(
-        ) > 0 else None
+        w3_weight_scale = load_weight_shard(w3_weight_scale,
+                                            module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.COLUMN,
+                                            device=device)
 
         # Check if w3 is empty (for non-gated activations like ReLU2 in Nemotron H)
-        w3_size = w3_weight_scale.shape[
-            0] if w3_weight_scale is not None and w3_weight_scale.numel(
-            ) > 0 else 0
+        w3_size = w3_weight_scale.shape[0] if w3_weight_scale.numel() > 0 else 0
 
         # Keep weights in device buffer
         if module.is_gated_activation:
@@ -3129,7 +3105,7 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
             w1_weight_scale,
             self.input_hidden_alignment // module.scaling_vector_size,
             alignment)
-        if w3_weight_scale is not None:
+        if module.is_gated_activation:
             w3_weight_scale = maybe_pad_for_mxfp4(
                 w3_weight_scale,
                 self.input_hidden_alignment // module.scaling_vector_size,
@@ -3140,7 +3116,7 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN,
                                             device=device)
-        if w3_weight_scale is not None:
+        if module.is_gated_activation:
             w3_weight_scale = load_weight_shard(w3_weight_scale,
                                                 module.tp_size,
                                                 module.tp_rank,
@@ -3148,9 +3124,7 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
                                                 device=device)
 
         # Check if w3 is empty (for non-gated activations like ReLU2 in Nemotron H)
-        w3_size = w3_weight_scale.shape[
-            0] if w3_weight_scale is not None and w3_weight_scale.numel(
-            ) > 0 else 0
+        w3_size = w3_weight_scale.shape[0] if w3_weight_scale.numel() > 0 else 0
         # Keep weights in device buffer
         if module.is_gated_activation:
             # Gated activation: buffer contains both w3 and w1 scales

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -554,7 +554,8 @@ class FusedMoEMethodBase(ABC):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight.device
         if not allow_partial_loading:
-            assert w1_weight is not None and w3_weight is not None
+            assert w1_weight is not None
+            assert w3_weight is not None or not module.is_gated_activation
         w1_weight_shard = load_weight_shard(
             w1_weight,
             module.tp_size,
@@ -2055,9 +2056,11 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
     def load_expert_fc31_input_scale_nvfp4(self, w1_input_scale, w3_input_scale,
                                            dst_fc31_input_scale: torch.Tensor):
         w1_input_scale = w1_input_scale[...].reshape([])
-        w3_input_scale = w3_input_scale[...].reshape([])
-        assert torch.allclose(
-            w1_input_scale, w3_input_scale), "w1_input_scale != w3_input_scale"
+        if w3_input_scale is not None:
+            w3_input_scale = w3_input_scale[...].reshape([])
+            assert torch.allclose(
+                w1_input_scale,
+                w3_input_scale), "w1_input_scale != w3_input_scale"
         dst_fc31_input_scale.copy_(w1_input_scale)
 
     def load_expert_fc2_input_scale_nvfp4(self, w2_input_scale,
@@ -2068,10 +2071,11 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                                      final_fc31_input_scale: torch.Tensor,
                                      dst_fc31_alpha: torch.Tensor):
         w1_weight_scale_2 = w1_weight_scale_2[...].reshape([])
-        w3_weight_scale_2 = w3_weight_scale_2[...].reshape([])
-        assert torch.allclose(
-            w1_weight_scale_2,
-            w3_weight_scale_2), "w1_weight_scale_2 != w3_weight_scale_2"
+        if w3_weight_scale_2 is not None:
+            w3_weight_scale_2 = w3_weight_scale_2[...].reshape([])
+            assert torch.allclose(
+                w1_weight_scale_2,
+                w3_weight_scale_2), "w1_weight_scale_2 != w3_weight_scale_2"
 
         w3_w1_weight_scale_2 = 1.0 / w1_weight_scale_2
         dst_fc31_alpha.copy_(1.0 /
@@ -2103,10 +2107,12 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
             if module.weight_loading_mode == MoEWeightLoadingMode.VANILLA:
                 if not ignore_weight_scale:
                     w1_weight_scale = weights[f"{expert_id}.w1.weight_scale"]
-                    w3_weight_scale = weights[f"{expert_id}.w3.weight_scale"]
+                    w3_weight_scale = weights[
+                        f"{expert_id}.w3.weight_scale"] if module.is_gated_activation else None
                     w2_weight_scale = weights[f"{expert_id}.w2.weight_scale"]
                 w1_weight_scale_2 = weights[f"{expert_id}.w1.weight_scale_2"]
-                w3_weight_scale_2 = weights[f"{expert_id}.w3.weight_scale_2"]
+                w3_weight_scale_2 = weights[
+                    f"{expert_id}.w3.weight_scale_2"] if module.is_gated_activation else None
                 w2_weight_scale_2 = weights[f"{expert_id}.w2.weight_scale_2"]
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 if not ignore_weight_scale:
@@ -2117,7 +2123,8 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                     w2_weight_scale = weights["down_proj_weight_scale"][
                         expert_id].transpose(0, 1).contiguous()
                 w1_weight_scale_2 = weights["gate_up_proj_weight_scale_2"]
-                w3_weight_scale_2 = weights["gate_up_proj_weight_scale_2"]
+                w3_weight_scale_2 = weights[
+                    "gate_up_proj_weight_scale_2"] if module.is_gated_activation else None
                 w2_weight_scale_2 = weights["down_proj_weight_scale_2"]
             else:
                 raise NotImplementedError(
@@ -2126,7 +2133,8 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
 
             expert_idx = local_slot_id
 
-            if not torch.allclose(w1_weight_scale_2, w3_weight_scale_2):
+            if w3_weight_scale_2 is not None and not torch.allclose(
+                    w1_weight_scale_2, w3_weight_scale_2):
                 logger.warning(
                     f"w1_weight_scale_2 != w3_weight_scale_2 ({w1_weight_scale_2} != {w3_weight_scale_2}), selecting the larger value. Accuracy may be affected."
                 )
@@ -2140,8 +2148,10 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                     dst_w3_w1_weight_scale[expert_idx])
                 self.load_expert_w2_weight_scale_nvfp4(
                     module, w2_weight_scale, dst_w2_weight_scale[expert_idx])
-                module._add_raw_shared_weights_for_unmap(
-                    [w1_weight_scale, w3_weight_scale, w2_weight_scale])
+                module._add_raw_shared_weights_for_unmap([
+                    w for w in [w1_weight_scale, w3_weight_scale, w2_weight_scale]
+                    if w is not None
+                ])
 
             self.load_expert_fc31_alpha_nvfp4(w1_weight_scale_2,
                                               w3_weight_scale_2,
@@ -2179,11 +2189,13 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
         for expert_id in range(module.num_experts):
             if module.weight_loading_mode == MoEWeightLoadingMode.VANILLA:
                 w1_input_scale = weights[f"{expert_id}.w1.input_scale"]
-                w3_input_scale = weights[f"{expert_id}.w3.input_scale"]
+                w3_input_scale = weights[
+                    f"{expert_id}.w3.input_scale"] if module.is_gated_activation else None
                 w2_input_scale = weights[f"{expert_id}.w2.input_scale"]
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w1_input_scale = weights["gate_up_proj_input_scale"]
-                w3_input_scale = weights["gate_up_proj_input_scale"]
+                w3_input_scale = weights[
+                    "gate_up_proj_input_scale"] if module.is_gated_activation else None
                 w2_input_scale = weights["down_proj_input_scale"]
             else:
                 raise NotImplementedError(
@@ -3105,24 +3117,26 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
             w1_weight_scale,
             self.input_hidden_alignment // module.scaling_vector_size,
             alignment)
-        w3_weight_scale = maybe_pad_for_mxfp4(
-            w3_weight_scale,
-            self.input_hidden_alignment // module.scaling_vector_size,
-            alignment)
+        if w3_weight_scale is not None:
+            w3_weight_scale = maybe_pad_for_mxfp4(
+                w3_weight_scale,
+                self.input_hidden_alignment // module.scaling_vector_size,
+                alignment)
 
         w1_weight_scale = load_weight_shard(w1_weight_scale,
                                             module.tp_size,
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN,
                                             device=device)
-        w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
-                                            device=device)
+        if w3_weight_scale is not None:
+            w3_weight_scale = load_weight_shard(w3_weight_scale,
+                                                module.tp_size,
+                                                module.tp_rank,
+                                                TensorParallelMode.COLUMN,
+                                                device=device)
 
         # Check if w3 is empty (for non-gated activations like ReLU2 in Nemotron H)
-        w3_size = w3_weight_scale.shape[0] if w3_weight_scale.numel() > 0 else 0
+        w3_size = w3_weight_scale.shape[0] if w3_weight_scale is not None and w3_weight_scale.numel() > 0 else 0
         # Keep weights in device buffer
         if module.is_gated_activation:
             # Gated activation: buffer contains both w3 and w1 scales

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -2204,6 +2204,9 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
 
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         if has_pre_quant_scale:
+            assert module.is_gated_activation, (
+                "pre_quant_scale (NVFP4_AWQ) is not supported with non-gated activations"
+            )
             from ..linear import TensorParallelMode, load_weight_shard
 
             device = module.fc31_act_scale.device

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -2217,6 +2217,9 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
 
         # Load pre_quant_scale if it exists (for NVFP4_AWQ)
         if has_pre_quant_scale:
+            assert module.is_gated_activation, (
+                "pre_quant_scale (NVFP4_AWQ) is not supported with non-gated activations"
+            )
             from ..linear import TensorParallelMode, load_weight_shard
 
             device = module.fc31_act_scale.device
@@ -2400,6 +2403,9 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
             dst_w3_w1_weight_scale: torch.Tensor):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight_scale.device
+        assert w3_weight_scale is not None, (
+            "NVFP4CutlassFusedMoEMethod currently does not support non-gated activations"
+        )
         w1_weight_scale = load_weight_shard(w1_weight_scale,
                                             module.tp_size,
                                             module.tp_rank,
@@ -2716,14 +2722,19 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN,
                                             device=device)
-        w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
-                                            device=device)
+        w3_weight_scale = load_weight_shard(
+            w3_weight_scale,
+            module.tp_size,
+            module.tp_rank,
+            TensorParallelMode.COLUMN,
+            device=device
+        ) if w3_weight_scale is not None and w3_weight_scale.numel(
+        ) > 0 else None
 
         # Check if w3 is empty (for non-gated activations like ReLU2 in Nemotron H)
-        w3_size = w3_weight_scale.shape[0] if w3_weight_scale.numel() > 0 else 0
+        w3_size = w3_weight_scale.shape[
+            0] if w3_weight_scale is not None and w3_weight_scale.numel(
+            ) > 0 else 0
 
         # Keep weights in device buffer
         if module.is_gated_activation:

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -52,8 +52,11 @@ class ActivationType(IntEnum):
 # Keep this in sync with the ActType enum in
 # cpp/tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/KernelRunner.h
 class ActType_TrtllmGen(IntEnum):
+    # act = x0 * x1 * sigmoid(x1)
     SwiGlu = 0
+    # act = relu(x0) ^ 2
     Relu2 = 1
+    # act = x0 * sigmoid(x0)
     Silu = 2
 
 

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -46,7 +46,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
 )
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE
-from tensorrt_llm._torch.utils import ActivationType
+from tensorrt_llm._torch.utils import ActivationType, is_gated_activation
 from tensorrt_llm.models.modeling_utils import QuantAlgo
 
 G_LOGGER = logging.getLogger(__name__)
@@ -945,8 +945,8 @@ def should_skip_to_accelerate_ci(
     if model_config is None:
         return None
 
-    # --- Rule 0: Skip unquantized (quant=None) ---
-    if quant_algo is None and activation_type == ActivationType.Swiglu:
+    # --- Rule 0: Skip gated and unquantized (quant=None) ---
+    if quant_algo is None and is_gated_activation(activation_type):
         return "[CI accel] Skip unquantized (quant=None) in CI"
 
     is_large_model = model_config.num_experts >= 256 and model_config.hidden_size >= 7168

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -46,6 +46,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
 )
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE
+from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm.models.modeling_utils import QuantAlgo
 
 G_LOGGER = logging.getLogger(__name__)
@@ -909,6 +910,7 @@ def should_skip_to_accelerate_ci(
     seq_len: Optional[int] = None,
     swiglu_gptoss_style: bool = False,
     parallel_mode: Optional[str] = None,
+    activation_type: Optional[ActivationType] = ActivationType.Swiglu,
 ) -> Optional[str]:
     """
     Skip low-information-density test combinations to accelerate CI.
@@ -944,7 +946,7 @@ def should_skip_to_accelerate_ci(
         return None
 
     # --- Rule 0: Skip unquantized (quant=None) ---
-    if quant_algo is None:
+    if quant_algo is None and activation_type == ActivationType.Swiglu:
         return "[CI accel] Skip unquantized (quant=None) in CI"
 
     is_large_model = model_config.num_experts >= 256 and model_config.hidden_size >= 7168

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -568,13 +568,13 @@ class FP8QuantizeUtil(BaseQuantizeUtil):
         return super().create_ref_module(routing_method, ref_cls)
 
 
-class NVFP4RefGatedMLPFusedMoE(RefMLPFusedMoE):
+class NVFP4RefMLPFusedMoE(RefMLPFusedMoE):
     """Reference implementation of NVFP4 quantization for correctness testing."""
 
     scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
     expected_quant_algo = QuantAlgo.NVFP4
 
-    def __init__(self, *args, swiglu_gptoss_style: bool = False, **kwargs):
+    def __init__(self, *args, swiglu_gptoss_style: Optional[bool] = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.swiglu_gptoss_style = swiglu_gptoss_style
 
@@ -587,19 +587,6 @@ class NVFP4RefGatedMLPFusedMoE(RefMLPFusedMoE):
             # error accumulation with certain routing methods (e.g. Llama4Renormalize).
             # Max observed mismatch in non-skipped cases is ~2.7% < 3%.
             check_accuracy(output, ref_output, rtol=1e-2, atol=0.15, percent=0.97)
-
-
-class NVFP4RefMLPFusedMoE(RefMLPFusedMoE):
-    """Reference implementation of NVFP4 quantization for correctness testing."""
-
-    scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
-    expected_quant_algo = QuantAlgo.NVFP4
-
-    def check_accuracy(self, output, ref_output):
-        # Relaxed percent from 0.98 to 0.97 to account for NVFP4 quantization
-        # error accumulation with certain routing methods (e.g. Llama4Renormalize).
-        # Max observed mismatch in non-skipped cases is ~2.7% < 3%.
-        check_accuracy(output, ref_output, rtol=1e-2, atol=0.15, percent=0.97)
 
 
 class NVFP4QuantizeUtil(BaseQuantizeUtil):
@@ -715,14 +702,10 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
                 )
         return weights
 
-    def create_ref_module(self, routing_method, ref_cls=None) -> torch.nn.Module:
+    def create_ref_module(self, routing_method, ref_cls=NVFP4RefMLPFusedMoE) -> torch.nn.Module:
         """
         Create a reference module for correctness testing.
-        Uses NVFP4RefGatedMLPFusedMoE for gated activations and
-        NVFP4RefMLPFusedMoE for element-wise activations.
         """
-        if ref_cls is None:
-            ref_cls = NVFP4RefGatedMLPFusedMoE if self._is_gated else NVFP4RefMLPFusedMoE
         kwargs = dict(
             num_experts=self.num_experts,
             routing_method=routing_method,
@@ -736,8 +719,7 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
         )
-        if ref_cls == NVFP4RefGatedMLPFusedMoE:
-            # NVFP4RefGatedMLPFusedMoE accepts swiglu_gptoss_style for tolerance tuning
+        if self._is_gated:
             kwargs["swiglu_gptoss_style"] = self.swiglu_gptoss_style
         return ref_cls(**kwargs)
 

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -220,6 +220,7 @@ class RefMLPFusedMoE(nn.Module):
         if model_config is None:
             model_config = ModelConfig()
         self.quant_config = model_config.quant_config
+        self.activation_type = activation_type
         self._is_gated = is_gated_activation(activation_type)
 
         skip_if_insufficient_gpu_memory(
@@ -459,6 +460,8 @@ class BaseQuantizeUtil(ABC):
                 weights[f"{expert_id}.w3.weight"] = torch.randn(
                     (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
                 )
+            else:
+                weights[f"{expert_id}.w3.weight"] = torch.empty(0, dtype=self.dtype, device="cuda")
         return weights
 
     def create_ref_module(self, routing_method, ref_cls=RefMLPFusedMoE) -> torch.nn.Module:
@@ -626,7 +629,7 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
                 )
                 w3_sf_global = (448 * 6) / w3_weight.abs().max().float()
             else:
-                w3_weight = None
+                w3_weight = torch.empty(0, dtype=self.dtype, device="cuda")
                 w3_sf_global = None
 
             assert "x_sf_global" in quant_kwargs, "x_sf_global is required for NVFP4 quant"
@@ -638,8 +641,7 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             w2_sf_global = (448 * 6) / w2_weight.abs().max().float()
 
             w3_w1_global = w1_sf_global
-            if self._is_gated:
-                # w3 global and w1 global must be the same
+            if w3_sf_global is not None:
                 w3_w1_global = min(w1_sf_global, w3_sf_global)
 
             # start to quantize
@@ -653,39 +655,37 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             )
             w2_sf_block_unswizzled = w2_sf_block_unswizzled.view(self.hidden_size, -1)
 
-            w3_weight_nvfp4, w3_sf_block_unswizzled = (
-                torch.ops.trtllm.fp4_quantize(
+            if self._is_gated:
+                w3_weight_nvfp4, w3_sf_block_unswizzled = torch.ops.trtllm.fp4_quantize(
                     w3_weight, w3_w1_global, scaling_vector_size, False, False
                 )
-                if self._is_gated
-                else (None, None)
-            )
-            w3_sf_block_unswizzled = (
-                w3_sf_block_unswizzled.view(self.intermediate_size, -1) if self._is_gated else None
-            )
+                w3_sf_block_unswizzled = w3_sf_block_unswizzled.view(self.intermediate_size, -1)
+            else:
+                w3_weight_nvfp4 = torch.empty(0, dtype=torch.uint8, device="cuda")
+                w3_sf_block_unswizzled = torch.empty(0, dtype=torch.float8_e4m3fn, device="cuda")
+
+            w1_input_scale = x_sf_global.cuda()
+            w2_input_scale = x_sf_global.cuda()
+            w3_input_scale = x_sf_global.cuda()
 
             weights[f"{expert_id}.w1.weight"] = w1_weight_nvfp4
             weights[f"{expert_id}.w2.weight"] = w2_weight_nvfp4
-            weights[f"{expert_id}.w3.weight"] = w3_weight_nvfp4 if self._is_gated else None
+            weights[f"{expert_id}.w3.weight"] = w3_weight_nvfp4
             weights[f"{expert_id}.w1.weight_scale"] = w1_sf_block_unswizzled.view(
                 torch.float8_e4m3fn
             ).cuda()
             weights[f"{expert_id}.w2.weight_scale"] = w2_sf_block_unswizzled.view(
                 torch.float8_e4m3fn
             ).cuda()
-            weights[f"{expert_id}.w3.weight_scale"] = (
-                w3_sf_block_unswizzled.view(torch.float8_e4m3fn).cuda() if self._is_gated else None
-            )
-            weights[f"{expert_id}.w1.input_scale"] = 1.0 / x_sf_global.cuda()
-            weights[f"{expert_id}.w2.input_scale"] = 1.0 / x_sf_global.cuda()
-            weights[f"{expert_id}.w3.input_scale"] = (
-                1.0 / x_sf_global.cuda() if self._is_gated else None
-            )
+            weights[f"{expert_id}.w3.weight_scale"] = w3_sf_block_unswizzled.view(
+                torch.float8_e4m3fn
+            ).cuda()
+            weights[f"{expert_id}.w1.input_scale"] = 1.0 / w1_input_scale
+            weights[f"{expert_id}.w2.input_scale"] = 1.0 / w2_input_scale
+            weights[f"{expert_id}.w3.input_scale"] = 1.0 / w3_input_scale
             weights[f"{expert_id}.w1.weight_scale_2"] = 1.0 / w3_w1_global
             weights[f"{expert_id}.w2.weight_scale_2"] = 1.0 / w2_sf_global
-            weights[f"{expert_id}.w3.weight_scale_2"] = (
-                1.0 / w3_w1_global if self._is_gated else None
-            )
+            weights[f"{expert_id}.w3.weight_scale_2"] = 1.0 / w3_w1_global
 
             # Note: NVFP4 bias uses torch.float dtype
             if self.bias:
@@ -695,11 +695,14 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
                 weights[f"{expert_id}.w2.bias"] = torch.randn(
                     self.hidden_size, device="cuda", dtype=torch.float
                 )
-                weights[f"{expert_id}.w3.bias"] = (
-                    torch.randn(self.intermediate_size, device="cuda", dtype=torch.float)
-                    if self._is_gated
-                    else None
-                )
+                if self._is_gated:
+                    weights[f"{expert_id}.w3.bias"] = torch.randn(
+                        self.intermediate_size, device="cuda", dtype=torch.float
+                    )
+                else:
+                    weights[f"{expert_id}.w3.bias"] = torch.empty(
+                        0, device="cuda", dtype=torch.float
+                    )
         return weights
 
     def create_ref_module(self, routing_method, ref_cls=NVFP4RefMLPFusedMoE) -> torch.nn.Module:
@@ -714,13 +717,12 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             dtype=self.dtype,
             model_config=ModelConfig(quant_config=self.quant_config),
             bias=self.bias,
-            activation_type=self.activation_type,
+            swiglu_gptoss_style=self.swiglu_gptoss_style,
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
+            activation_type=self.activation_type,
         )
-        if self._is_gated:
-            kwargs["swiglu_gptoss_style"] = self.swiglu_gptoss_style
         return ref_cls(**kwargs)
 
 

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -577,7 +577,7 @@ class NVFP4RefMLPFusedMoE(RefMLPFusedMoE):
     scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
     expected_quant_algo = QuantAlgo.NVFP4
 
-    def __init__(self, *args, swiglu_gptoss_style: Optional[bool] = False, **kwargs):
+    def __init__(self, *args, swiglu_gptoss_style: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.swiglu_gptoss_style = swiglu_gptoss_style
 

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -256,7 +256,12 @@ class RefMLPFusedMoE(nn.Module):
                 ]
             )
         else:
-            element_wise_activation = relu2 if activation_type == ActivationType.Relu2 else F.silu
+            if activation_type == ActivationType.Relu2:
+                element_wise_activation = relu2
+            elif activation_type == ActivationType.Silu:
+                element_wise_activation = F.silu
+            else:
+                raise ValueError(f"Unsupported non-gated activation type: {activation_type}")
             self.experts = nn.ModuleList(
                 [
                     MLP(

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -31,6 +31,8 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules.fused_moe import BaseMoeRoutingMethod
 from tensorrt_llm._torch.modules.fused_moe.interface import MoEWeightLoadingMode
 from tensorrt_llm._torch.modules.gated_mlp import GatedMLP
+from tensorrt_llm._torch.modules.mlp import MLP
+from tensorrt_llm._torch.utils import ActivationType, is_gated_activation, relu2
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 
@@ -177,9 +179,9 @@ def get_test_quant_params(quant_algo, x, backend_type=None):
     return quantize_util_cls, quant_config, quant_kwargs
 
 
-class RefGatedMLPFusedMoE(nn.Module):
+class RefMLPFusedMoE(nn.Module):
     """
-    RefGatedMLPFusedMoE serves as a reference implementation with Gated MLPs designed for correctness testing.
+    RefMLPFusedMoE serves as a reference implementation with Gated MLPs designed for correctness testing.
     It utilizes derived classes to provide extensible support for various quantization algorithms.
 
     Subclasses can override `scale_keys` to specify which scale fields to load:
@@ -203,6 +205,7 @@ class RefGatedMLPFusedMoE(nn.Module):
         model_config: Optional[ModelConfig] = None,
         bias=False,
         use_cute_dsl_blockscaling_mm=False,
+        activation_type: ActivationType = ActivationType.Swiglu,
         swiglu_alpha: Optional[float] = None,
         swiglu_beta: Optional[float] = None,
         swiglu_limit: Optional[float] = None,
@@ -217,39 +220,56 @@ class RefGatedMLPFusedMoE(nn.Module):
         if model_config is None:
             model_config = ModelConfig()
         self.quant_config = model_config.quant_config
+        self._is_gated = is_gated_activation(activation_type)
 
         skip_if_insufficient_gpu_memory(
             num_experts, hidden_size, intermediate_size, dtype or torch.float32
         )
 
-        # Custom swiglu activation for swiglu_gptoss_style
-        def custom_swiglu(x):
-            gate, value = x.chunk(2, dim=-1)
-            if swiglu_limit is not None and swiglu_limit != float("inf"):
-                gate = gate.clamp(max=swiglu_limit)
-                value = value.clamp(min=-swiglu_limit, max=swiglu_limit)
+        if self._is_gated:
+            # Custom swiglu activation for swiglu_gptoss_style
+            def custom_swiglu(x):
+                gate, value = x.chunk(2, dim=-1)
+                if swiglu_limit is not None and swiglu_limit != float("inf"):
+                    gate = gate.clamp(max=swiglu_limit)
+                    value = value.clamp(min=-swiglu_limit, max=swiglu_limit)
 
-            alpha = swiglu_alpha if swiglu_alpha is not None else 1.0
-            gate_act = gate * torch.sigmoid(gate * alpha)
+                alpha = swiglu_alpha if swiglu_alpha is not None else 1.0
+                gate_act = gate * torch.sigmoid(gate * alpha)
 
-            beta = swiglu_beta if swiglu_beta is not None else 0.0
+                beta = swiglu_beta if swiglu_beta is not None else 0.0
 
-            return gate_act * (value + beta)
+                return gate_act * (value + beta)
 
-        self.experts = nn.ModuleList(
-            [
-                GatedMLP(
-                    hidden_size=self.hidden_size,
-                    intermediate_size=self.intermediate_size,
-                    bias=bias,
-                    dtype=self.dtype,
-                    config=model_config,
-                    use_cute_dsl_blockscaling_mm=use_cute_dsl_blockscaling_mm,
-                    activation=custom_swiglu if swiglu_alpha is not None else F.silu,
-                )
-                for _ in range(self.num_experts)
-            ]
-        )
+            self.experts = nn.ModuleList(
+                [
+                    GatedMLP(
+                        hidden_size=self.hidden_size,
+                        intermediate_size=self.intermediate_size,
+                        bias=bias,
+                        dtype=self.dtype,
+                        config=model_config,
+                        use_cute_dsl_blockscaling_mm=use_cute_dsl_blockscaling_mm,
+                        activation=custom_swiglu if swiglu_alpha is not None else F.silu,
+                    )
+                    for _ in range(self.num_experts)
+                ]
+            )
+        else:
+            element_wise_activation = relu2 if activation_type == ActivationType.Relu2 else F.silu
+            self.experts = nn.ModuleList(
+                [
+                    MLP(
+                        hidden_size=self.hidden_size,
+                        intermediate_size=self.intermediate_size,
+                        bias=bias,
+                        activation=element_wise_activation,
+                        dtype=self.dtype,
+                        config=model_config,
+                    )
+                    for _ in range(self.num_experts)
+                ]
+            )
 
     def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         assert hidden_states.shape[-1] == self.hidden_size
@@ -279,27 +299,38 @@ class RefGatedMLPFusedMoE(nn.Module):
 
     def _load_expert_weights_with_scales(self, weights: Dict, expert: int):
         """Load weights for a single expert with configured scale keys."""
-        gate_up_proj_weights = [{}, {}]
+        up_proj_weights = [{}, {}] if self._is_gated else [{}]
         down_proj_weights = [{}]
-
-        # Load base weights
-        gate_up_proj_weights[0]["weight"] = weights[f"{expert}.w1.weight"]
-        gate_up_proj_weights[1]["weight"] = weights[f"{expert}.w3.weight"]
+        # Load down_proj weights
         down_proj_weights[0]["weight"] = weights[f"{expert}.w2.weight"]
 
         # Load bias if enabled
         if self.bias:
-            gate_up_proj_weights[0]["bias"] = weights[f"{expert}.w1.bias"]
-            gate_up_proj_weights[1]["bias"] = weights[f"{expert}.w3.bias"]
             down_proj_weights[0]["bias"] = weights[f"{expert}.w2.bias"]
 
         # Load scale keys defined by subclass
         for scale_key in self.scale_keys:
-            gate_up_proj_weights[0][scale_key] = weights[f"{expert}.w1.{scale_key}"]
-            gate_up_proj_weights[1][scale_key] = weights[f"{expert}.w3.{scale_key}"]
             down_proj_weights[0][scale_key] = weights[f"{expert}.w2.{scale_key}"]
 
-        self.experts[expert].gate_up_proj.load_weights(gate_up_proj_weights)
+        # Load up_proj weights
+        if self._is_gated:
+            up_proj_weights[0]["weight"] = weights[f"{expert}.w1.weight"]
+            up_proj_weights[1]["weight"] = weights[f"{expert}.w3.weight"]
+            if self.bias:
+                up_proj_weights[0]["bias"] = weights[f"{expert}.w1.bias"]
+                up_proj_weights[1]["bias"] = weights[f"{expert}.w3.bias"]
+            for scale_key in self.scale_keys:
+                up_proj_weights[0][scale_key] = weights[f"{expert}.w1.{scale_key}"]
+                up_proj_weights[1][scale_key] = weights[f"{expert}.w3.{scale_key}"]
+            self.experts[expert].gate_up_proj.load_weights(up_proj_weights)
+        else:
+            up_proj_weights[0]["weight"] = weights[f"{expert}.w1.weight"]
+            if self.bias:
+                up_proj_weights[0]["bias"] = weights[f"{expert}.w1.bias"]
+            for scale_key in self.scale_keys:
+                up_proj_weights[0][scale_key] = weights[f"{expert}.w1.{scale_key}"]
+            self.experts[expert].up_proj.load_weights(up_proj_weights)
+
         self.experts[expert].down_proj.load_weights(down_proj_weights)
 
     def load_weights(self, weights_list: List[Dict]):
@@ -342,6 +373,7 @@ class BaseQuantizeUtil(ABC):
         swiglu_beta: Optional[float] = None,
         swiglu_limit: Optional[float] = None,
         num_local_experts: Optional[int] = None,
+        activation_type: ActivationType = ActivationType.Swiglu,
     ):
         self.num_experts = num_experts
         self.dtype = dtype
@@ -349,6 +381,8 @@ class BaseQuantizeUtil(ABC):
         self.hidden_size = hidden_size
         self.quant_config = quant_config
         self.bias = bias
+        self.activation_type = activation_type
+        self._is_gated = is_gated_activation(activation_type)
         self._swiglu_gptoss_style = swiglu_gptoss_style
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
@@ -410,22 +444,19 @@ class BaseQuantizeUtil(ABC):
         assert self.quant_config is None, "quant_config should be None for BaseQuantizeUtil"
         weights = {}
         for expert_id in range(self.num_experts):
-            w1_weight = torch.randn(
+            weights[f"{expert_id}.w1.weight"] = torch.randn(
                 (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
             )
-            w2_weight = torch.randn(
+            weights[f"{expert_id}.w2.weight"] = torch.randn(
                 (self.hidden_size, self.intermediate_size), dtype=self.dtype, device="cuda"
             )
-            w3_weight = torch.randn(
-                (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
-            )
-
-            weights[f"{expert_id}.w1.weight"] = w1_weight
-            weights[f"{expert_id}.w2.weight"] = w2_weight
-            weights[f"{expert_id}.w3.weight"] = w3_weight
+            if self._is_gated:
+                weights[f"{expert_id}.w3.weight"] = torch.randn(
+                    (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
+                )
         return weights
 
-    def create_ref_module(self, routing_method, ref_cls=RefGatedMLPFusedMoE) -> torch.nn.Module:
+    def create_ref_module(self, routing_method, ref_cls=RefMLPFusedMoE) -> torch.nn.Module:
         """
         Create a reference module for correctness testing.
         """
@@ -437,6 +468,7 @@ class BaseQuantizeUtil(ABC):
             dtype=self.dtype,
             model_config=ModelConfig(quant_config=self.quant_config),
             bias=self.bias,
+            activation_type=self.activation_type,
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
@@ -444,7 +476,7 @@ class BaseQuantizeUtil(ABC):
         return ref_fused_moe
 
 
-class FP8RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class FP8RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """Reference implementation of FP8 quantization for correctness testing."""
 
     scale_keys = ["weight_scale", "input_scale"]
@@ -531,7 +563,7 @@ class FP8QuantizeUtil(BaseQuantizeUtil):
         return super().create_ref_module(routing_method, ref_cls)
 
 
-class NVFP4RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class NVFP4RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """Reference implementation of NVFP4 quantization for correctness testing."""
 
     scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
@@ -552,10 +584,24 @@ class NVFP4RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
             check_accuracy(output, ref_output, rtol=1e-2, atol=0.15, percent=0.97)
 
 
+class NVFP4RefMLPFusedMoE(RefMLPFusedMoE):
+    """Reference implementation of NVFP4 quantization for correctness testing."""
+
+    scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
+    expected_quant_algo = QuantAlgo.NVFP4
+
+    def check_accuracy(self, output, ref_output):
+        # Relaxed percent from 0.98 to 0.97 to account for NVFP4 quantization
+        # error accumulation with certain routing methods (e.g. Llama4Renormalize).
+        # Max observed mismatch in non-skipped cases is ~2.7% < 3%.
+        check_accuracy(output, ref_output, rtol=1e-2, atol=0.15, percent=0.97)
+
+
 class NVFP4QuantizeUtil(BaseQuantizeUtil):
     """
     NVFP4QuantizeUtil inherits from BaseQuantizeUtil to support correctness testing for NVFP4 quantized MoE modules.
     Supports swiglu_gptoss_style with custom swiglu parameters (inherited from BaseQuantizeUtil).
+    Supports element-wise activations (Relu2, Silu) via activation_type.
     """
 
     def create_weights(self, **quant_kwargs) -> Dict[str, torch.Tensor]:
@@ -579,12 +625,17 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
                 )
                 * 0.05
             )
-            w3_weight = (
-                torch.randn(
-                    (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
+            if self._is_gated:
+                w3_weight = (
+                    torch.randn(
+                        (self.intermediate_size, self.hidden_size), dtype=self.dtype, device="cuda"
+                    )
+                    * 0.05
                 )
-                * 0.05
-            )
+                w3_sf_global = (448 * 6) / w3_weight.abs().max().float()
+            else:
+                w3_weight = None
+                w3_sf_global = None
 
             assert "x_sf_global" in quant_kwargs, "x_sf_global is required for NVFP4 quant"
 
@@ -593,11 +644,11 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
 
             w1_sf_global = (448 * 6) / w1_weight.abs().max().float()
             w2_sf_global = (448 * 6) / w2_weight.abs().max().float()
-            w3_sf_global = (448 * 6) / w3_weight.abs().max().float()
 
-            w3_w1_global = min(
-                w1_sf_global, w3_sf_global
-            )  # w3 global and w1 global must be the same
+            w3_w1_global = w1_sf_global
+            if self._is_gated:
+                # w3 global and w1 global must be the same
+                w3_w1_global = min(w1_sf_global, w3_sf_global)
 
             # start to quantize
             w1_weight_nvfp4, w1_sf_block_unswizzled = torch.ops.trtllm.fp4_quantize(
@@ -610,33 +661,39 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             )
             w2_sf_block_unswizzled = w2_sf_block_unswizzled.view(self.hidden_size, -1)
 
-            w3_weight_nvfp4, w3_sf_block_unswizzled = torch.ops.trtllm.fp4_quantize(
-                w3_weight, w3_w1_global, scaling_vector_size, False, False
+            w3_weight_nvfp4, w3_sf_block_unswizzled = (
+                torch.ops.trtllm.fp4_quantize(
+                    w3_weight, w3_w1_global, scaling_vector_size, False, False
+                )
+                if self._is_gated
+                else (None, None)
             )
-            w3_sf_block_unswizzled = w3_sf_block_unswizzled.view(self.intermediate_size, -1)
-
-            w1_input_scale = x_sf_global.cuda()
-            w2_input_scale = x_sf_global.cuda()
-            w3_input_scale = x_sf_global.cuda()
+            w3_sf_block_unswizzled = (
+                w3_sf_block_unswizzled.view(self.intermediate_size, -1) if self._is_gated else None
+            )
 
             weights[f"{expert_id}.w1.weight"] = w1_weight_nvfp4
             weights[f"{expert_id}.w2.weight"] = w2_weight_nvfp4
-            weights[f"{expert_id}.w3.weight"] = w3_weight_nvfp4
+            weights[f"{expert_id}.w3.weight"] = w3_weight_nvfp4 if self._is_gated else None
             weights[f"{expert_id}.w1.weight_scale"] = w1_sf_block_unswizzled.view(
                 torch.float8_e4m3fn
             ).cuda()
             weights[f"{expert_id}.w2.weight_scale"] = w2_sf_block_unswizzled.view(
                 torch.float8_e4m3fn
             ).cuda()
-            weights[f"{expert_id}.w3.weight_scale"] = w3_sf_block_unswizzled.view(
-                torch.float8_e4m3fn
-            ).cuda()
-            weights[f"{expert_id}.w1.input_scale"] = 1.0 / w1_input_scale
-            weights[f"{expert_id}.w2.input_scale"] = 1.0 / w2_input_scale
-            weights[f"{expert_id}.w3.input_scale"] = 1.0 / w3_input_scale
+            weights[f"{expert_id}.w3.weight_scale"] = (
+                w3_sf_block_unswizzled.view(torch.float8_e4m3fn).cuda() if self._is_gated else None
+            )
+            weights[f"{expert_id}.w1.input_scale"] = 1.0 / x_sf_global.cuda()
+            weights[f"{expert_id}.w2.input_scale"] = 1.0 / x_sf_global.cuda()
+            weights[f"{expert_id}.w3.input_scale"] = (
+                1.0 / x_sf_global.cuda() if self._is_gated else None
+            )
             weights[f"{expert_id}.w1.weight_scale_2"] = 1.0 / w3_w1_global
             weights[f"{expert_id}.w2.weight_scale_2"] = 1.0 / w2_sf_global
-            weights[f"{expert_id}.w3.weight_scale_2"] = 1.0 / w3_w1_global
+            weights[f"{expert_id}.w3.weight_scale_2"] = (
+                1.0 / w3_w1_global if self._is_gated else None
+            )
 
             # Note: NVFP4 bias uses torch.float dtype
             if self.bias:
@@ -646,18 +703,22 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
                 weights[f"{expert_id}.w2.bias"] = torch.randn(
                     self.hidden_size, device="cuda", dtype=torch.float
                 )
-                weights[f"{expert_id}.w3.bias"] = torch.randn(
-                    self.intermediate_size, device="cuda", dtype=torch.float
+                weights[f"{expert_id}.w3.bias"] = (
+                    torch.randn(self.intermediate_size, device="cuda", dtype=torch.float)
+                    if self._is_gated
+                    else None
                 )
         return weights
 
-    def create_ref_module(
-        self, routing_method, ref_cls=NVFP4RefGatedMLPFusedMoE
-    ) -> torch.nn.Module:
+    def create_ref_module(self, routing_method, ref_cls=None) -> torch.nn.Module:
         """
-        Create a reference module for correctness testing with swiglu_gptoss_style support.
+        Create a reference module for correctness testing.
+        Uses NVFP4RefGatedMLPFusedMoE for gated activations and
+        NVFP4RefMLPFusedMoE for element-wise activations.
         """
-        ref_fused_moe = ref_cls(
+        if ref_cls is None:
+            ref_cls = NVFP4RefGatedMLPFusedMoE if self._is_gated else NVFP4RefMLPFusedMoE
+        kwargs = dict(
             num_experts=self.num_experts,
             routing_method=routing_method,
             hidden_size=self.hidden_size,
@@ -665,15 +726,18 @@ class NVFP4QuantizeUtil(BaseQuantizeUtil):
             dtype=self.dtype,
             model_config=ModelConfig(quant_config=self.quant_config),
             bias=self.bias,
-            swiglu_gptoss_style=self.swiglu_gptoss_style,
+            activation_type=self.activation_type,
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
         )
-        return ref_fused_moe
+        if ref_cls == NVFP4RefGatedMLPFusedMoE:
+            # NVFP4RefGatedMLPFusedMoE accepts swiglu_gptoss_style for tolerance tuning
+            kwargs["swiglu_gptoss_style"] = self.swiglu_gptoss_style
+        return ref_cls(**kwargs)
 
 
-class FP8BlockScalesRefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class FP8BlockScalesRefGatedMLPFusedMoE(RefMLPFusedMoE):
     """Reference implementation of FP8 block-wise quantization for correctness testing."""
 
     scale_keys = ["weight_scale"]
@@ -1058,7 +1122,7 @@ class TRTLLMGenFP8BlockScalesRefModule(FP8BlockScalesRefGatedMLPFusedMoE):
         check_accuracy(output, ref_output, atol=0.1, rtol=0.85, percent=0.925)
 
 
-class W4A8NVFP4FP8RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class W4A8NVFP4FP8RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """Reference implementation of W4A8_NVFP4_FP8 quantization for correctness testing."""
 
     scale_keys = ["weight_scale", "input_scale", "weight_scale_2"]
@@ -1159,7 +1223,7 @@ class W4A8NVFP4FP8QuantizeUtil(BaseQuantizeUtil):
         return super().create_ref_module(routing_method, ref_cls)
 
 
-class MXFP4MXFP8RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class MXFP4MXFP8RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """
     Reference implementation of W4A8_MXFP4_MXFP8 quantization for correctness testing.
 
@@ -1510,9 +1574,9 @@ class MXFP4MXFP8QuantizeUtil(BaseQuantizeUtil):
         return ref_fused_moe
 
 
-class WFP4A16RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class WFP4A16RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """
-    A derived class of RefGatedMLPFusedMoE serves as a reference implementation of W4A16_MXFP4
+    A derived class of RefMLPFusedMoE serves as a reference implementation of W4A16_MXFP4
     quantization for correctness testing.
 
     Since GatedMLP doesn't support wfp4a16 quantization, we dequantize the weights
@@ -1528,10 +1592,14 @@ class WFP4A16RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
         dtype: Optional[torch.dtype] = None,
         model_config: Optional[ModelConfig] = None,
         bias=False,
+        activation_type: ActivationType = ActivationType.Swiglu,
         swiglu_alpha: Optional[float] = None,
         swiglu_beta: Optional[float] = None,
         swiglu_limit: Optional[float] = None,
     ):
+        assert activation_type == ActivationType.Swiglu, (
+            "Only Swiglu activation is supported for WFP4A16RefGatedMLPFusedMoE"
+        )
         # Store the original quant_config for assertion in load_weights
         self._original_quant_config = model_config.quant_config if model_config else None
         # Create experts without quantization config since we'll dequantize weights
@@ -1710,9 +1778,9 @@ class WFP4A16QuantizeUtil(BaseQuantizeUtil):
         return super().create_ref_module(routing_method, ref_cls)
 
 
-class W8A16RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
+class W8A16RefGatedMLPFusedMoE(RefMLPFusedMoE):
     """
-    A derived class of RefGatedMLPFusedMoE serves as a reference implementation of W8A16
+    A derived class of RefMLPFusedMoE serves as a reference implementation of W8A16
     quantization for correctness testing.
 
     Since GatedMLP doesn't support W8A16 quantization, we dequantize the weights
@@ -1728,10 +1796,14 @@ class W8A16RefGatedMLPFusedMoE(RefGatedMLPFusedMoE):
         dtype: Optional[torch.dtype] = None,
         model_config: Optional[ModelConfig] = None,
         bias=False,
+        activation_type: ActivationType = ActivationType.Swiglu,
         swiglu_alpha: Optional[torch.Tensor] = None,
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
     ):
+        assert activation_type == ActivationType.Swiglu, (
+            "Only Swiglu activation is supported for W8A16RefGatedMLPFusedMoE"
+        )
         # Store the original quant_config for assertion in load_weights
         self._original_quant_config = model_config.quant_config if model_config else None
         # Create experts without quantization config since we'll dequantize weights
@@ -1848,7 +1920,7 @@ class W4A8AWQRefGatedMLPFusedMoE(nn.Module):
     """
     A reference implementation of W4A8_AWQ quantization for MoE correctness testing.
 
-    IMPORTANT: This class does NOT inherit from RefGatedMLPFusedMoE because W4A8_AWQ
+    IMPORTANT: This class does NOT inherit from RefMLPFusedMoE because W4A8_AWQ
     cannot be correctly reproduced by simply dequantizing weights and using non-quantized
     GatedMLP forward. The reasons are:
 

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -52,7 +52,7 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules.fused_moe import RenormalizeMoeRoutingMethod
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
-from tensorrt_llm._torch.utils import ActivationType
+from tensorrt_llm._torch.utils import ActivationType, is_gated_activation
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo
@@ -318,6 +318,7 @@ def generate_test_params() -> List:
             seq_len,
             model_config,
             routing_method_cls,
+            ActivationType.Swiglu,
             swiglu_alpha,
             swiglu_beta,
             swiglu_limit,
@@ -329,6 +330,60 @@ def generate_test_params() -> List:
 
 # Pre-generate test parameters at module load time
 TEST_PARAMS = generate_test_params()
+
+
+# (activation_type, backend_type, quant_algo) — valid combinations only.
+_ELEMENT_WISE_BACKEND_COMBOS = [
+    (ActivationType.Relu2, MoeBackendType.CUTLASS, None),
+    (ActivationType.Relu2, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
+    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
+    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.W4A16_MXFP4),
+]
+
+
+def generate_element_wise_test_params() -> List:
+    params: List = []
+    for activation_type, backend_type, quant_algo in _ELEMENT_WISE_BACKEND_COMBOS:
+        for (
+            _,  # swiglu_alpha  (ignored)
+            _,  # swiglu_beta   (ignored)
+            _,  # swiglu_limit  (ignored)
+            model_config,
+            seq_len,
+            dtype,
+            _bt,  # overwritten by backend_type in loop
+            _qa,  # overwritten by quant_algo in loop
+            routing_method_cls,
+            skip_reason,
+            base_test_id,
+        ) in iter_base_test_configs(
+            [(1, 0, float("inf"))],  # swiglu parameters are irrelevant
+            MOE_MODEL_CONFIGS,
+            SEQ_LENS_TO_TEST,
+            DTYPES_TO_TEST,
+            [backend_type],
+            [quant_algo],
+        ):
+            if skip_reason:
+                continue
+            test_id = f"act={activation_type.name}-{base_test_id}"
+            param_values = (
+                dtype,
+                backend_type,
+                quant_algo,
+                seq_len,
+                model_config,
+                routing_method_cls,
+                activation_type,
+                None,
+                None,
+                None,
+            )
+            params.append(create_test_param(param_values, test_id))
+    return params
+
+
+TEST_PARAMS += generate_element_wise_test_params()
 
 
 # ============================================================================
@@ -349,13 +404,20 @@ TEST_PARAMS = generate_test_params()
 # Test Coverage Matrix
 # =============================================================================
 # 1. BACKENDS: CUTLASS, TRTLLM, CUTEDSL, DEEPGEMM
+#    - When using element wise activations (Relu2, Silu), only CUTLASS and TRTLLM
+#      are supported
 #
 # 2. QUANTIZATION ALGORITHMS:
-#    - Unquantized (None)
-#    - FP8, FP8_BLOCK_SCALES
-#    - NVFP4, W4A8_NVFP4_FP8
-#    - W4A16_MXFP4, W4A8_MXFP4_MXFP8
-#    - W8A16, W4A8_AWQ
+#    - When using Swiglu:
+#      - Unquantized (None)
+#      - FP8, FP8_BLOCK_SCALES
+#      - NVFP4, W4A8_NVFP4_FP8
+#      - W4A16_MXFP4, W4A8_MXFP4_MXFP8
+#      - W8A16, W4A8_AWQ
+#    - When using element-wise activations
+#      - CUTLASS + Unquantized (Relu2 only)
+#      - TRTLLM + NVFP4
+#      - TRTLLM + W4A16_MXFP4
 #
 # 3. ACTIVATION DTYPES: float16, bfloat16
 #
@@ -386,7 +448,7 @@ TEST_PARAMS = generate_test_params()
 # =============================================================================
 @pytest.mark.parametrize(
     "dtype_activation,backend_type,quant_algo,seq_len,model_config,"
-    "routing_method_cls,swiglu_alpha,swiglu_beta,swiglu_limit",
+    "routing_method_cls,activation_type,swiglu_alpha,swiglu_beta,swiglu_limit",
     TEST_PARAMS,
 )
 def test_moe_backend(
@@ -396,9 +458,10 @@ def test_moe_backend(
     seq_len: int,
     model_config: MoeModelConfig,
     routing_method_cls,
-    swiglu_alpha: float,
-    swiglu_beta: float,
-    swiglu_limit: float,
+    activation_type: ActivationType,
+    swiglu_alpha: Optional[float],
+    swiglu_beta: Optional[float],
+    swiglu_limit: Optional[float],
 ):
     """
     Test MoE backend with autotune to capture all tactics.
@@ -409,10 +472,13 @@ def test_moe_backend(
     3. Different sequence lengths use appropriate tactics
     4. swiglu_gptoss_style (SwiGlu with custom parameters) works correctly
     """
-    # Determine swiglu_gptoss_style based on swiglu parameters
-    # swiglu_gptoss_style is True when any swiglu parameter deviates from default
-    # Default values: alpha=1, beta=0, limit=inf
-    swiglu_gptoss_style = swiglu_alpha != 1 or swiglu_beta != 0 or swiglu_limit != float("inf")
+    is_gated = is_gated_activation(activation_type)
+    swiglu_gptoss_style = False
+    if is_gated:
+        # Determine swiglu_gptoss_style based on swiglu parameters
+        # swiglu_gptoss_style is True when any swiglu parameter deviates from default
+        # Default values: alpha=1, beta=0, limit=inf
+        swiglu_gptoss_style = swiglu_alpha != 1 or swiglu_beta != 0 or swiglu_limit != float("inf")
 
     ci_skip = should_skip_to_accelerate_ci(
         backend_type=backend_type,
@@ -422,6 +488,7 @@ def test_moe_backend(
         dtype=dtype_activation,
         seq_len=seq_len,
         swiglu_gptoss_style=swiglu_gptoss_style,
+        activation_type=activation_type,
     )
     if ci_skip:
         pytest.skip(ci_skip)
@@ -579,175 +646,3 @@ def test_moe_backend(
             with torch.inference_mode():
                 output = run_moe()
                 ref_fused_moe.check_accuracy(output, ref_output)
-
-
-# ============================================================================
-# Non-gated Activation Type Tests: Relu2, Silu
-# ============================================================================
-#
-# As an additional test, we want to verify that element-wise activations (Relu2, Silu)
-# are correctly applied by the MoE backend kernels that support them.
-#
-# =============================================================================
-# Purpose & Scope
-# =============================================================================
-#
-# Similar to the main test.
-#
-# =============================================================================
-# Test Coverage Matrix
-# =============================================================================
-#   Relu2  (element-wise) – CUTLASS + unquantized  (no gate projection)
-#   Relu2  (element-wise) – TRTLLM  + NVFP4        (quantized path)
-#   Silu   (element-wise) – TRTLLM  + NVFP4        (only backend that supports Silu)
-#
-# =============================================================================
-# Skip Logic
-# =============================================================================
-#
-# Similar to the main test.
-
-
-# (activation_type, backend_type, quant_algo) — valid combinations only.
-_ELEMENT_WISE_BACKEND_COMBOS = [
-    (ActivationType.Relu2, MoeBackendType.CUTLASS, None),
-    (ActivationType.Relu2, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
-    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
-]
-
-
-def _generate_element_wise_test_params() -> List:
-    params: List = []
-    for activation_type, backend_type, quant_algo in _ELEMENT_WISE_BACKEND_COMBOS:
-        for (
-            _,  # swiglu_alpha  (ignored)
-            _,  # swiglu_beta   (ignored)
-            _,  # swiglu_limit  (ignored)
-            model_config,
-            seq_len,
-            dtype,
-            _bt,
-            _qa,
-            _routing_method_cls,
-            skip_reason,
-            base_test_id,
-        ) in iter_base_test_configs(
-            [(1, 0, float("inf"))],  # swiglu parameters are irrelevant
-            MOE_MODEL_CONFIGS,
-            SEQ_LENS_TO_TEST,
-            DTYPES_TO_TEST,
-            [backend_type],
-            [quant_algo],
-        ):
-            if skip_reason:
-                continue
-            test_id = f"act={activation_type.name}-{base_test_id}"
-            param_values = (activation_type, backend_type, quant_algo, model_config, seq_len, dtype)
-            params.append(create_test_param(param_values, test_id))
-    return params
-
-
-ELEMENT_WISE_TEST_PARAMS = _generate_element_wise_test_params()
-
-
-@pytest.mark.parametrize(
-    "activation_type,backend_type,quant_algo,model_config,seq_len,dtype",
-    ELEMENT_WISE_TEST_PARAMS,
-)
-def test_moe_backend_element_wise(
-    activation_type: ActivationType,
-    backend_type: MoeBackendType,
-    quant_algo: Optional[QuantAlgo],
-    model_config: MoeModelConfig,
-    seq_len: int,
-    dtype: torch.dtype,
-):
-    """
-    Verify that element-wise activations (Relu2, Silu) are correctly applied by
-    the MoE backend kernels.
-
-    Each combo is tested against a float-precision reference (RefMLPFusedMoE with MLP experts).
-    A single small model config is used to keep runtime short.
-    """
-    num_experts = model_config.num_experts
-    top_k = model_config.top_k
-    hidden_size = model_config.hidden_size
-    intermediate_size = model_config.intermediate_size
-
-    skip_if_insufficient_gpu_memory(num_experts, hidden_size, intermediate_size, dtype)
-
-    mapping = Mapping()
-    mapping.rank = mpi_rank()
-
-    with torch.device(f"cuda:{mapping.rank}"):
-        torch.manual_seed(42)
-        torch.cuda.manual_seed(42)
-
-        AutoTuner.get().setup_distributed_state(mapping)
-
-        routing_method = RenormalizeMoeRoutingMethod(top_k=top_k)
-
-        x = torch.randn((seq_len, hidden_size), dtype=dtype, device="cuda")
-        router_logits = torch.randn((seq_len, num_experts), dtype=dtype, device="cuda")
-
-        quantize_util_cls, quant_config, quant_kwargs = get_test_quant_params(
-            quant_algo, x, backend_type
-        )
-
-        quantize_util = quantize_util_cls(
-            num_experts=num_experts,
-            dtype=dtype,
-            intermediate_size=intermediate_size,
-            hidden_size=hidden_size,
-            quant_config=quant_config,
-            activation_type=activation_type,
-        )
-
-        # Create backend with the specified activation type.
-        backend = create_test_backend(
-            backend_type=backend_type,
-            routing_method=routing_method,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            dtype=dtype,
-            quant_config=quant_config,
-            mapping=mapping,
-            activation_type=activation_type,
-        )
-
-        # Create weights.  For NVFP4 element-wise the reference uses pre-quantization
-        # float weights stored by the util; fall back to the quantized dict otherwise.
-        weights = quantize_util.create_weights(**quant_kwargs)
-        ref_weights = weights
-
-        backend.load_weights([weights])
-        backend.post_load_weights()
-        backend.cuda()
-
-        # Create and load reference module.
-        ref_fused_moe = quantize_util.create_ref_module(routing_method)
-        ref_fused_moe.load_weights([ref_weights])
-        ref_fused_moe.cuda()
-
-        # Reference output.
-        with torch.inference_mode():
-            ref_output = ref_fused_moe.forward(x, router_logits)
-
-        def run_moe():
-            token_selected_experts, token_final_scales = routing_method.apply(router_logits)
-            x_quantized, x_sf = backend.quantize_input(x, post_quant_comm=False)
-            return run_backend_moe(
-                backend,
-                backend_type,
-                x_quantized,
-                x_sf,
-                token_selected_experts,
-                token_final_scales,
-                dtype,
-                router_logits,
-            )
-
-        with torch.inference_mode():
-            output = run_moe()
-            ref_fused_moe.check_accuracy(output, ref_output)

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -332,18 +332,9 @@ def generate_test_params() -> List:
 TEST_PARAMS = generate_test_params()
 
 
-# (activation_type, backend_type, quant_algo) — valid combinations only.
-_ELEMENT_WISE_BACKEND_COMBOS = [
-    (ActivationType.Relu2, MoeBackendType.CUTLASS, None),
-    (ActivationType.Relu2, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
-    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
-    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.W4A16_MXFP4),
-]
-
-
 def generate_element_wise_test_params() -> List:
     params: List = []
-    for activation_type, backend_type, quant_algo in _ELEMENT_WISE_BACKEND_COMBOS:
+    for activation_type in [ActivationType.Silu, ActivationType.Relu2]:
         for (
             _,  # swiglu_alpha  (ignored)
             _,  # swiglu_beta   (ignored)
@@ -351,8 +342,8 @@ def generate_element_wise_test_params() -> List:
             model_config,
             seq_len,
             dtype,
-            _bt,  # overwritten by backend_type in loop
-            _qa,  # overwritten by quant_algo in loop
+            backend_type,
+            quant_algo,
             routing_method_cls,
             skip_reason,
             base_test_id,
@@ -361,10 +352,14 @@ def generate_element_wise_test_params() -> List:
             MOE_MODEL_CONFIGS,
             SEQ_LENS_TO_TEST,
             DTYPES_TO_TEST,
-            [backend_type],
-            [quant_algo],
+            [MoeBackendType.CUTLASS, MoeBackendType.TRTLLM],
+            [None, QuantAlgo.NVFP4],
         ):
             if skip_reason:
+                continue
+            if backend_type == MoeBackendType.CUTLASS and activation_type == ActivationType.Silu:
+                continue
+            if backend_type == MoeBackendType.TRTLLM and quant_algo is None:
                 continue
             test_id = f"act={activation_type.name}-{base_test_id}"
             param_values = (
@@ -415,9 +410,8 @@ TEST_PARAMS += generate_element_wise_test_params()
 #      - W4A16_MXFP4, W4A8_MXFP4_MXFP8
 #      - W8A16, W4A8_AWQ
 #    - When using element-wise activations
-#      - CUTLASS + Unquantized (Relu2 only)
-#      - TRTLLM + NVFP4
-#      - TRTLLM + W4A16_MXFP4
+#      - Unquantized (CUTLASS)
+#      - NVFP4 (TRTLLM, CUTLASS)
 #
 # 3. ACTIVATION DTYPES: float16, bfloat16
 #
@@ -537,6 +531,7 @@ def test_moe_backend(
             swiglu_alpha=swiglu_alpha if swiglu_gptoss_style else None,
             swiglu_beta=swiglu_beta if swiglu_gptoss_style else None,
             swiglu_limit=swiglu_limit if swiglu_gptoss_style else None,
+            activation_type=activation_type,
         )
 
         # Get swiglu tensors if swiglu_gptoss_style is enabled
@@ -562,6 +557,7 @@ def test_moe_backend(
             swiglu_beta=swiglu_tensors["swiglu_beta"] if swiglu_tensors else None,
             swiglu_limit=swiglu_tensors["swiglu_limit"] if swiglu_tensors else None,
             weight_loading_mode=weight_loading_mode,
+            activation_type=activation_type,
         )
 
         # W4A8_MXFP4_MXFP8 requires different weights for backend and reference

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -52,6 +52,7 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules.fused_moe import RenormalizeMoeRoutingMethod
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
+from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo
@@ -106,6 +107,7 @@ def create_test_backend(
     swiglu_beta: Optional[torch.Tensor] = None,
     swiglu_limit: Optional[torch.Tensor] = None,
     weight_loading_mode: MoEWeightLoadingMode = MoEWeightLoadingMode.VANILLA,
+    activation_type: ActivationType = ActivationType.Swiglu,
 ) -> MoE:
     """Create a MoE backend for testing."""
     backend_cls = get_backend_class(backend_type)
@@ -138,6 +140,7 @@ def create_test_backend(
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
         weight_loading_mode=weight_loading_mode,
+        activation_type=activation_type,
     )
 
 
@@ -576,3 +579,175 @@ def test_moe_backend(
             with torch.inference_mode():
                 output = run_moe()
                 ref_fused_moe.check_accuracy(output, ref_output)
+
+
+# ============================================================================
+# Non-gated Activation Type Tests: Relu2, Silu
+# ============================================================================
+#
+# As an additional test, we want to verify that element-wise activations (Relu2, Silu)
+# are correctly applied by the MoE backend kernels that support them.
+#
+# =============================================================================
+# Purpose & Scope
+# =============================================================================
+#
+# Similar to the main test.
+#
+# =============================================================================
+# Test Coverage Matrix
+# =============================================================================
+#   Relu2  (element-wise) – CUTLASS + unquantized  (no gate projection)
+#   Relu2  (element-wise) – TRTLLM  + NVFP4        (quantized path)
+#   Silu   (element-wise) – TRTLLM  + NVFP4        (only backend that supports Silu)
+#
+# =============================================================================
+# Skip Logic
+# =============================================================================
+#
+# Similar to the main test.
+
+
+# (activation_type, backend_type, quant_algo) — valid combinations only.
+_ELEMENT_WISE_BACKEND_COMBOS = [
+    (ActivationType.Relu2, MoeBackendType.CUTLASS, None),
+    (ActivationType.Relu2, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
+    (ActivationType.Silu, MoeBackendType.TRTLLM, QuantAlgo.NVFP4),
+]
+
+
+def _generate_element_wise_test_params() -> List:
+    params: List = []
+    for activation_type, backend_type, quant_algo in _ELEMENT_WISE_BACKEND_COMBOS:
+        for (
+            _,  # swiglu_alpha  (ignored)
+            _,  # swiglu_beta   (ignored)
+            _,  # swiglu_limit  (ignored)
+            model_config,
+            seq_len,
+            dtype,
+            _bt,
+            _qa,
+            _routing_method_cls,
+            skip_reason,
+            base_test_id,
+        ) in iter_base_test_configs(
+            [(1, 0, float("inf"))],  # swiglu parameters are irrelevant
+            MOE_MODEL_CONFIGS,
+            SEQ_LENS_TO_TEST,
+            DTYPES_TO_TEST,
+            [backend_type],
+            [quant_algo],
+        ):
+            if skip_reason:
+                continue
+            test_id = f"act={activation_type.name}-{base_test_id}"
+            param_values = (activation_type, backend_type, quant_algo, model_config, seq_len, dtype)
+            params.append(create_test_param(param_values, test_id))
+    return params
+
+
+ELEMENT_WISE_TEST_PARAMS = _generate_element_wise_test_params()
+
+
+@pytest.mark.parametrize(
+    "activation_type,backend_type,quant_algo,model_config,seq_len,dtype",
+    ELEMENT_WISE_TEST_PARAMS,
+)
+def test_moe_backend_element_wise(
+    activation_type: ActivationType,
+    backend_type: MoeBackendType,
+    quant_algo: Optional[QuantAlgo],
+    model_config: MoeModelConfig,
+    seq_len: int,
+    dtype: torch.dtype,
+):
+    """
+    Verify that element-wise activations (Relu2, Silu) are correctly applied by
+    the MoE backend kernels.
+
+    Each combo is tested against a float-precision reference (RefMLPFusedMoE with MLP experts).
+    A single small model config is used to keep runtime short.
+    """
+    num_experts = model_config.num_experts
+    top_k = model_config.top_k
+    hidden_size = model_config.hidden_size
+    intermediate_size = model_config.intermediate_size
+
+    skip_if_insufficient_gpu_memory(num_experts, hidden_size, intermediate_size, dtype)
+
+    mapping = Mapping()
+    mapping.rank = mpi_rank()
+
+    with torch.device(f"cuda:{mapping.rank}"):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+        AutoTuner.get().setup_distributed_state(mapping)
+
+        routing_method = RenormalizeMoeRoutingMethod(top_k=top_k)
+
+        x = torch.randn((seq_len, hidden_size), dtype=dtype, device="cuda")
+        router_logits = torch.randn((seq_len, num_experts), dtype=dtype, device="cuda")
+
+        quantize_util_cls, quant_config, quant_kwargs = get_test_quant_params(
+            quant_algo, x, backend_type
+        )
+
+        quantize_util = quantize_util_cls(
+            num_experts=num_experts,
+            dtype=dtype,
+            intermediate_size=intermediate_size,
+            hidden_size=hidden_size,
+            quant_config=quant_config,
+            activation_type=activation_type,
+        )
+
+        # Create backend with the specified activation type.
+        backend = create_test_backend(
+            backend_type=backend_type,
+            routing_method=routing_method,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            dtype=dtype,
+            quant_config=quant_config,
+            mapping=mapping,
+            activation_type=activation_type,
+        )
+
+        # Create weights.  For NVFP4 element-wise the reference uses pre-quantization
+        # float weights stored by the util; fall back to the quantized dict otherwise.
+        weights = quantize_util.create_weights(**quant_kwargs)
+        ref_weights = weights
+
+        backend.load_weights([weights])
+        backend.post_load_weights()
+        backend.cuda()
+
+        # Create and load reference module.
+        ref_fused_moe = quantize_util.create_ref_module(routing_method)
+        ref_fused_moe.load_weights([ref_weights])
+        ref_fused_moe.cuda()
+
+        # Reference output.
+        with torch.inference_mode():
+            ref_output = ref_fused_moe.forward(x, router_logits)
+
+        def run_moe():
+            token_selected_experts, token_final_scales = routing_method.apply(router_logits)
+            x_quantized, x_sf = backend.quantize_input(x, post_quant_comm=False)
+            return run_backend_moe(
+                backend,
+                backend_type,
+                x_quantized,
+                x_sf,
+                token_selected_experts,
+                token_final_scales,
+                dtype,
+                router_logits,
+            )
+
+        with torch.inference_mode():
+            output = run_moe()
+            ref_fused_moe.check_accuracy(output, ref_output)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for non-gated activation types (Relu2, Silu) in MoE modules alongside existing gated activations (Swiglu).
  * Introduced `activation_type` parameter to enable selection between gated and non-gated activation paths.

* **Tests**
  * Added comprehensive test coverage for non-gated element-wise activations across multiple quantization backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR aims to add the non-gated activation functions (Relu2, Silu) to the new MoE tests introduced by #11817. 

## Test Coverage

`pytest tests/unittest/_torch/modules/moe/test_moe_backend.py -k "Relu2 or Silu"`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
