### PR TITLE
[TRTLLM-11342][fix] Fix FLUX.1 TeaCache polynomial coefficients and default t…

### DIFF
--- a/examples/visual_gen/serve/configs/flux1.yml
+++ b/examples/visual_gen/serve/configs/flux1.yml
@@ -2,7 +2,7 @@ linear:
   type: default
 teacache:
    enable_teacache: true
-   teacache_thresh: 0.2
+   teacache_thresh: 0.6
 attention:
    backend: VANILLA
 parallel:

--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -116,8 +116,8 @@ def parse_args():
     parser.add_argument(
         "--teacache_thresh",
         type=float,
-        default=0.2,
-        help="TeaCache similarity threshold (rel_l1_thresh)",
+        default=None,
+        help="TeaCache similarity threshold (default: 0.6 for FLUX.1, 0.2 for FLUX.2)",
     )
     parser.add_argument(
         "--use_ret_steps",
@@ -217,7 +217,11 @@ def build_diffusion_config(args):
         },
         "teacache": {
             "enable_teacache": args.enable_teacache,
-            "teacache_thresh": args.teacache_thresh,
+            **(
+                {"teacache_thresh": args.teacache_thresh}
+                if args.teacache_thresh is not None
+                else {}
+            ),
             "use_ret_steps": args.use_ret_steps,
         },
         "parallel": {

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -22,10 +22,13 @@ from tensorrt_llm.logger import logger
 from .transformer_flux import FluxTransformer2DModel
 
 # TeaCache coefficients for FLUX.1 variants
+# Source: https://github.com/ali-vilab/TeaCache/blob/main/TeaCache4FLUX/teacache_flux.py
+# Official default threshold: 0.6 (~2x speedup), range: 0.25 (~1.5x) to 0.8 (~2.25x)
 FLUX_TEACACHE_COEFFICIENTS = {
     "dev": {
-        "ret_steps": [2.57151496e05, -3.54229917e04, 1.40286849e03, -1.35890334e01, 1.32517977e-01],
-        "standard": [2.57151496e05, -3.54229917e04, 1.40286849e03, -1.35890334e01, 1.32517977e-01],
+        "ret_steps": [4.98651651e02, -2.83781631e02, 5.58554382e01, -3.82021401e00, 2.64230861e-01],
+        "standard": [4.98651651e02, -2.83781631e02, 5.58554382e01, -3.82021401e00, 2.64230861e-01],
+        "default_thresh": 0.6,
     },
     "schnell": {
         "ret_steps": [1.0, 0.0],  # Schnell is already fast, minimal caching

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -172,6 +172,16 @@ class BasePipeline(nn.Module):
                         if mode in coeff_data:
                             teacache_cfg.coefficients = coeff_data[mode]
                             logger.info(f"TeaCache: Using {model_size} coefficients ({mode} mode)")
+                        # Apply model-specific default threshold if user didn't explicitly set one
+                        default_thresh = coeff_data.get("default_thresh")
+                        if (
+                            default_thresh is not None
+                            and "teacache_thresh" not in teacache_cfg.model_fields_set
+                        ):
+                            teacache_cfg.teacache_thresh = default_thresh
+                            logger.info(
+                                f"TeaCache: Using {model_size} default threshold {default_thresh}"
+                            )
                     else:
                         # Single coefficient list (no mode distinction)
                         teacache_cfg.coefficients = coeff_data


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated default caching threshold values for improved performance
  * Model-specific thresholds now automatically applied based on variant selection
  * Refined configuration handling for visual generation models
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fix FLUX.1 TeaCache polynomial coefficients that were incorrectly copied from WAN I2V 480P config, and update the default threshold to match the official TeaCache repository.

  - **Root cause**: FLUX.1 coefficients `[2.57e+05, ...]` were WAN I2V 480P values instead of the official FLUX values `[4.99e+02, ...]` (leading term 515x too large)
  - **Impact**: TeaCache hit rate was ~28% instead of ~64%, largely negating the caching speedup
  - **Fix**: Replace with official coefficients from [TeaCache4FLUX](https://github.com/ali-vilab/TeaCache/blob/main/TeaCache4FLUX/teacache_flux.py), update default threshold 0.2 → 0.6


## Test Coverage

### Validated on H200 — FLUX.1-dev, 10 prompts, 50 steps, seed 42

  | Threshold | Hit Rate | PSNR vs Baseline (dB) | Official Expected Speedup |
  |-----------|----------|----------------------|--------------------------|
  | 0.25 | 42.4% | 24.7 (min 14.1) | ~1.5x |
  | 0.40 | 55.1% | 20.6 (min 13.7) | ~1.8x |
  | **0.60** (default) | **63.6%** | **19.1 (min 13.1)** | **~2.0x** |
  | 0.80 | 68.9% | 18.1 (min 12.9) | ~2.25x |

  - All 10 prompts produce visually coherent images across all thresholds

  ### Visual comparison (Baseline → t=0.25 → t=0.4 → t=0.6 → t=0.8)

  <!-- Attach comparison_00.png through comparison_09.png -->

  - [x] Verify FLUX.1 TeaCache hit rate matches expected ~64% at default threshold
  - [x] Verify FLUX.2 is unaffected (no coefficient or threshold changes)
  - [x] Verify WAN pipelines are unaffected
  - [x] Verify user-specified `--teacache_thresh` still overrides the default

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
