### PR TITLE
[None][infra] Update AutoDeploy CODEOWNERS coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,9 @@
 ## TensorRT-LLM Pytorch backend - AutoDeploy flow
 /tensorrt_llm/_torch/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
 /examples/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
-/tests/unittest/_torch/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
+/docs/source/features/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs @NVIDIA/trt-llm-doc-owners
+/tests/unittest/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
+/tests/integration/defs/accuracy/test_llm_api_autodeploy.py @NVIDIA/trt-llm-torch-autodeploy-devs @NVIDIA/trt-llm-qa-function
 
 ## TensorRT-LLM Pytorch - Speculative Decoding
 /tensorrt_llm/_torch/speculative @NVIDIA/trt-llm-torch-spec-decoding

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 /tensorrt_llm/_torch/pyexecutor @NVIDIA/trt-llm-torch-runtime-devs
 ## TensorRT-LLM Pytorch backend - AutoDeploy flow
 /tensorrt_llm/_torch/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
-/examples/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs @NVIDIA/trt-llm-doc-owners
+/examples/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
 /tests/unittest/_torch/auto_deploy @NVIDIA/trt-llm-torch-autodeploy-devs
 
 ## TensorRT-LLM Pytorch - Speculative Decoding


### PR DESCRIPTION
## Summary
- Remove `@NVIDIA/trt-llm-doc-owners` from `examples/auto_deploy` — AutoDeploy examples should only require AutoDeploy dev review, consistent with other AutoDeploy paths
- Add `docs/source/features/auto_deploy` with `@NVIDIA/trt-llm-torch-autodeploy-devs` + `@NVIDIA/trt-llm-doc-owners`
- Add `tests/unittest/auto_deploy` (new test location, forgot to modify this during the AD test refactor) with `@NVIDIA/trt-llm-torch-autodeploy-devs`
- Add `tests/integration/defs/accuracy/test_llm_api_autodeploy.py` with `@NVIDIA/trt-llm-torch-autodeploy-devs` + `@NVIDIA/trt-llm-qa-function`
- Remove stale `tests/unittest/_torch/auto_deploy` entry (tests have been moved to `tests/unittest/auto_deploy`)

## Test plan
- No functional changes; CODEOWNERS file update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes**

This release includes internal administrative updates to code ownership and test path configurations. These changes do not impact functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->