### PR TITLE
[None][feat] executor: accept torch managed weights with optional GPU aliasing

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1542,7 +1542,8 @@ public:
         std::optional<PeftCacheConfig> const& peftCacheConfig = std::nullopt,
         std::optional<LogitsPostProcessorConfig> logitsPostProcessorConfig = std::nullopt,
         std::optional<DecodingConfig> decodingConfig = std::nullopt, bool useGpuDirectStorage = false,
-        float gpuWeightsPercent = 1, std::optional<SizeType32> maxQueueSize = std::nullopt,
+        float gpuWeightsPercent = 1, bool aliasManagedWeightsFromGpu = false,
+        std::optional<SizeType32> maxQueueSize = std::nullopt,
         ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig = ExtendedRuntimePerfKnobConfig(),
         std::optional<DebugConfig> debugConfig = std::nullopt, SizeType32 recvPollPeriodMs = 0,
         uint64_t maxSeqIdleMicroseconds = kDefaultMaxSeqIdleMicroseconds,
@@ -1552,6 +1553,22 @@ public:
         std::optional<CacheTransceiverConfig> cacheTransceiverConfig = std::nullopt,
         bool gatherGenerationLogits = false, bool promptTableOffloading = false, bool enableTrtOverlap = false,
         bool failFastOnAttentionWindowTooLarge = false);
+
+    // Compatibility constructor preserving the historical argument order.
+    ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedulerConfig, KvCacheConfig kvCacheConfig,
+        bool enableChunkedContext, bool normalizeLogProbs, SizeType32 iterStatsMaxIterations,
+        SizeType32 requestStatsMaxIterations, BatchingType batchingType, std::optional<SizeType32> maxBatchSize,
+        std::optional<SizeType32> maxNumTokens, std::optional<ParallelConfig> parallelConfig,
+        std::optional<PeftCacheConfig> const& peftCacheConfig,
+        std::optional<LogitsPostProcessorConfig> logitsPostProcessorConfig,
+        std::optional<DecodingConfig> decodingConfig, bool useGpuDirectStorage, float gpuWeightsPercent,
+        std::optional<SizeType32> maxQueueSize, ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig,
+        std::optional<DebugConfig> debugConfig, SizeType32 recvPollPeriodMs, uint64_t maxSeqIdleMicroseconds,
+        std::optional<SpeculativeDecodingConfig> specDecConfig,
+        std::optional<GuidedDecodingConfig> guidedDecodingConfig,
+        std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
+        std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
+        bool promptTableOffloading, bool enableTrtOverlap, bool failFastOnAttentionWindowTooLarge);
 
     [[nodiscard]] SizeType32 getMaxBeamWidth() const;
     [[nodiscard]] SchedulerConfig getSchedulerConfig() const;
@@ -1574,6 +1591,7 @@ public:
     [[nodiscard]] std::optional<DecodingConfig> getDecodingConfig() const;
     [[nodiscard]] bool getUseGpuDirectStorage() const;
     [[nodiscard]] float getGpuWeightsPercent() const;
+    [[nodiscard]] bool getAliasManagedWeightsFromGpu() const;
     [[nodiscard]] std::optional<SizeType32> getMaxQueueSize() const;
     [[nodiscard]] ExtendedRuntimePerfKnobConfig getExtendedRuntimePerfKnobConfig() const;
     [[nodiscard]] std::optional<DebugConfig> getDebugConfig() const;
@@ -1604,6 +1622,7 @@ public:
     void setDecodingConfig(DecodingConfig const& decodingConfig);
     void setUseGpuDirectStorage(bool const& useGpuDirectStorage);
     void setGpuWeightsPercent(float const& gpuWeightsPercent);
+    void setAliasManagedWeightsFromGpu(bool const& aliasManagedWeightsFromGpu);
     void setMaxQueueSize(std::optional<SizeType32> const& maxQueueSize);
     void setExtendedRuntimePerfKnobConfig(ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig);
     void setDebugConfig(DebugConfig const& debugConfig);
@@ -1666,6 +1685,9 @@ private:
 
     /// @brief GPU weights percent for weight streaming.
     float mGpuWeightsPercent;
+
+    /// @brief Alias managed GPU weights directly when loading from engine buffer instead of making a device copy.
+    bool mAliasManagedWeightsFromGpu;
 
     /// @brief The maximum number of requests allowed in queue before rejecting new requests.
     std::optional<SizeType32> mMaxQueueSize;

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
@@ -46,8 +46,8 @@ TrtEncoderModel::TrtEncoderModel(runtime::ModelConfig const& modelConfig, WorldC
     , mWorldConfig{worldConfig}
     , mDevice{runtime::utils::initDevice(worldConfig)}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}
-    , mRuntime{std::make_shared<TllmRuntime>(
-          rawEngine, mLogger.get(), executorConfig.getUseGpuDirectStorage(), executorConfig.getGpuWeightsPercent())}
+    , mRuntime{std::make_shared<TllmRuntime>(rawEngine, mLogger.get(), executorConfig.getUseGpuDirectStorage(),
+          executorConfig.getGpuWeightsPercent(), executorConfig.getAliasManagedWeightsFromGpu(), true)}
     , mNumMicroBatches{1}
     , mNumBuffers{mNumMicroBatches}
     , mCopyBufferManager{std::make_shared<CudaStream>()}

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -181,7 +181,8 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
                                                                        : std::nullopt}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}
     , mRuntime{std::make_unique<TllmRuntime>(rawEngine, mLogger.get(), executorConfig.getUseGpuDirectStorage(),
-          executorConfig.getGpuWeightsPercent(), modelConfig.useShapeInference())}
+          executorConfig.getGpuWeightsPercent(), executorConfig.getAliasManagedWeightsFromGpu(),
+          modelConfig.useShapeInference())}
     , mCopyBufferManager{std::make_shared<CudaStream>()}
     , mCtxGenFusion(ctxGenFusion)
     , mOperatingBeamWidth{getMaxBeamWidth()}

--- a/cpp/tensorrt_llm/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/executor/executorConfig.cpp
@@ -28,9 +28,9 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     std::optional<SizeType32> maxNumTokens, std::optional<ParallelConfig> parallelConfig,
     std::optional<PeftCacheConfig> const& peftCacheConfig,
     std::optional<LogitsPostProcessorConfig> logitsPostProcessorConfig, std::optional<DecodingConfig> decodingConfig,
-    bool useGpuDirectStorage, float gpuWeightPercent, std::optional<SizeType32> maxQueueSize,
-    ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig, std::optional<DebugConfig> debugConfig,
-    SizeType32 recvPollPeriodMs, uint64_t maxSeqIdleMicroseconds,
+    bool useGpuDirectStorage, float gpuWeightPercent, bool aliasManagedWeightsFromGpu,
+    std::optional<SizeType32> maxQueueSize, ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig,
+    std::optional<DebugConfig> debugConfig, SizeType32 recvPollPeriodMs, uint64_t maxSeqIdleMicroseconds,
     std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
     std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
     std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
@@ -51,6 +51,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     , mDecodingConfig(std::move(decodingConfig))
     , mUseGpuDirectStorage((useGpuDirectStorage))
     , mGpuWeightsPercent(gpuWeightPercent)
+    , mAliasManagedWeightsFromGpu(aliasManagedWeightsFromGpu)
     , mMaxQueueSize(maxQueueSize)
     , mExtendedRuntimePerfKnobConfig(extendedRuntimePerfKnobConfig)
     , mDebugConfig(std::move(debugConfig))
@@ -69,6 +70,29 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     TLLM_CHECK(requestStatsMaxIterations >= 0);
     TLLM_CHECK(mMaxBeamWidth > 0);
     TLLM_CHECK(maxSeqIdleMicroseconds > 0);
+}
+
+ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedulerConfig, KvCacheConfig kvCacheConfig,
+    bool enableChunkedContext, bool normalizeLogProbs, SizeType32 iterStatsMaxIterations,
+    SizeType32 requestStatsMaxIterations, BatchingType batchingType, std::optional<SizeType32> maxBatchSize,
+    std::optional<SizeType32> maxNumTokens, std::optional<ParallelConfig> parallelConfig,
+    std::optional<PeftCacheConfig> const& peftCacheConfig,
+    std::optional<LogitsPostProcessorConfig> logitsPostProcessorConfig, std::optional<DecodingConfig> decodingConfig,
+    bool useGpuDirectStorage, float gpuWeightPercent, std::optional<SizeType32> maxQueueSize,
+    ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig, std::optional<DebugConfig> debugConfig,
+    SizeType32 recvPollPeriodMs, uint64_t maxSeqIdleMicroseconds,
+    std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
+    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
+    std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
+    bool promptTableOffloading, bool enableTrtOverlap, bool failFastOnAttentionWindowTooLarge)
+    : ExecutorConfig(maxBeamWidth, std::move(schedulerConfig), std::move(kvCacheConfig), enableChunkedContext,
+        normalizeLogProbs, iterStatsMaxIterations, requestStatsMaxIterations, batchingType, maxBatchSize, maxNumTokens,
+        std::move(parallelConfig), peftCacheConfig, std::move(logitsPostProcessorConfig), std::move(decodingConfig),
+        useGpuDirectStorage, gpuWeightPercent, false, maxQueueSize, extendedRuntimePerfKnobConfig,
+        std::move(debugConfig), recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig,
+        std::move(guidedDecodingConfig), std::move(additionalModelOutputs), std::move(cacheTransceiverConfig),
+        gatherGenerationLogits, promptTableOffloading, enableTrtOverlap, failFastOnAttentionWindowTooLarge)
+{
 }
 
 // getters
@@ -161,6 +185,11 @@ bool ExecutorConfig::getUseGpuDirectStorage() const
 float ExecutorConfig::getGpuWeightsPercent() const
 {
     return mGpuWeightsPercent;
+}
+
+bool ExecutorConfig::getAliasManagedWeightsFromGpu() const
+{
+    return mAliasManagedWeightsFromGpu;
 }
 
 std::optional<SizeType32> ExecutorConfig::getMaxQueueSize() const
@@ -313,6 +342,11 @@ void ExecutorConfig::setUseGpuDirectStorage(bool const& useGpuDirectStorage)
 void ExecutorConfig::setGpuWeightsPercent(float const& gpuWeightsPercent)
 {
     mGpuWeightsPercent = gpuWeightsPercent;
+}
+
+void ExecutorConfig::setAliasManagedWeightsFromGpu(bool const& aliasManagedWeightsFromGpu)
+{
+    mAliasManagedWeightsFromGpu = aliasManagedWeightsFromGpu;
 }
 
 void ExecutorConfig::setMaxQueueSize(std::optional<SizeType32> const& maxQueueSize)

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -1153,6 +1153,8 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
     auto decodingConfig = su::deserializeWithGetterType<decltype(&ExecutorConfig::getDecodingConfig)>(is);
     auto useGpuDirectStorage = su::deserializeWithGetterType<decltype(&ExecutorConfig::getUseGpuDirectStorage)>(is);
     auto gpuWeightsPercent = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGpuWeightsPercent)>(is);
+    auto aliasManagedWeightsFromGpu
+        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getAliasManagedWeightsFromGpu)>(is);
     auto maxQueueSize = su::deserializeWithGetterType<decltype(&ExecutorConfig::getMaxQueueSize)>(is);
     auto extendedRuntimePerfKnobConfig
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getExtendedRuntimePerfKnobConfig)>(is);
@@ -1173,10 +1175,10 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
 
     return ExecutorConfig{maxBeamWidth, schedulerConfig, kvCacheConfig, enableChunkedContext, normalizeLogProbs,
         iterStatsMaxIterations, requestStatsMaxIterations, batchingType, maxBatchSize, maxNumTokens, parallelConfig,
-        peftCacheConfig, std::nullopt, decodingConfig, useGpuDirectStorage, gpuWeightsPercent, maxQueueSize,
-        extendedRuntimePerfKnobConfig, debugConfig, recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig,
-        guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig, gatherGenerationLogits,
-        promptTableOffloading, enableTrtOverlap};
+        peftCacheConfig, std::nullopt, decodingConfig, useGpuDirectStorage, gpuWeightsPercent,
+        aliasManagedWeightsFromGpu, maxQueueSize, extendedRuntimePerfKnobConfig, debugConfig, recvPollPeriodMs,
+        maxSeqIdleMicroseconds, specDecConfig, guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig,
+        gatherGenerationLogits, promptTableOffloading, enableTrtOverlap};
 }
 
 size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
@@ -1201,6 +1203,7 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getDecodingConfig());
     totalSize += su::serializedSize(executorConfig.getUseGpuDirectStorage());
     totalSize += su::serializedSize(executorConfig.getGpuWeightsPercent());
+    totalSize += su::serializedSize(executorConfig.getAliasManagedWeightsFromGpu());
     totalSize += su::serializedSize(executorConfig.getMaxQueueSize());
     totalSize += su::serializedSize(executorConfig.getExtendedRuntimePerfKnobConfig());
     totalSize += su::serializedSize(executorConfig.getDebugConfig());
@@ -1237,6 +1240,7 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getDecodingConfig(), os);
     su::serialize(executorConfig.getUseGpuDirectStorage(), os);
     su::serialize(executorConfig.getGpuWeightsPercent(), os);
+    su::serialize(executorConfig.getAliasManagedWeightsFromGpu(), os);
     su::serialize(executorConfig.getMaxQueueSize(), os);
     su::serialize(executorConfig.getExtendedRuntimePerfKnobConfig(), os);
     su::serialize(executorConfig.getDebugConfig(), os);

--- a/cpp/tensorrt_llm/nanobind/executor/executor.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.cpp
@@ -52,7 +52,7 @@ struct dtype_traits<half>
 
 namespace
 {
-tle::Tensor numpyToTensor(nb::object const& object)
+tle::Tensor arrayInterfaceToTensor(nb::object const& object)
 {
     std::string dtype_name = nb::cast<std::string>(object.attr("dtype").attr("name"));
     nb::object metadata = object.attr("dtype").attr("metadata");
@@ -108,6 +108,26 @@ tle::Tensor numpyToTensor(nb::object const& object)
     return tle::Tensor::of(dtype, data_ptr, shape);
 }
 
+tle::Tensor pythonObjectToTensor(nb::object const& object)
+{
+    try
+    {
+        // Use the custom caster path for torch.Tensor inputs (CPU or CUDA).
+        return nb::cast<tle::Tensor>(object);
+    }
+    catch (std::exception const&)
+    {
+        // Fallback to array interface path below.
+    }
+
+    if (nb::hasattr(object, "__array_interface__"))
+    {
+        return arrayInterfaceToTensor(object);
+    }
+
+    TLLM_THROW("Unsupported managed weight input. Expected torch.Tensor or an object with __array_interface__.");
+}
+
 } // namespace
 
 namespace tensorrt_llm::nanobind::executor
@@ -138,7 +158,7 @@ Executor::Executor(nb::bytes const& engineBuffer, std::string const& jsonConfigS
         {
             std::string name = nb::cast<std::string>(rawName);
             nb::object array_obj = nb::cast<nb::object>(rawArray);
-            managedWeightsMap->emplace(name, numpyToTensor(array_obj));
+            managedWeightsMap->emplace(name, pythonObjectToTensor(array_obj));
         }
     }
     mExecutor = std::make_unique<tle::Executor>(

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -492,8 +492,8 @@ void initConfigBindings(nb::module_& m)
             c.getEnableChunkedContext(), c.getNormalizeLogProbs(), c.getIterStatsMaxIterations(),
             c.getRequestStatsMaxIterations(), c.getBatchingType(), c.getMaxBatchSize(), c.getMaxNumTokens(),
             c.getParallelConfig(), c.getPeftCacheConfig(), c.getLogitsPostProcessorConfig(), c.getDecodingConfig(),
-            c.getUseGpuDirectStorage(), c.getGpuWeightsPercent(), c.getMaxQueueSize(),
-            c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
+            c.getUseGpuDirectStorage(), c.getGpuWeightsPercent(), c.getAliasManagedWeightsFromGpu(),
+            c.getMaxQueueSize(), c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
             c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
             c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
             c.getPromptTableOffloading(), c.getEnableTrtOverlap(), c.getFailFastOnAttentionWindowTooLarge());
@@ -509,10 +509,25 @@ void initConfigBindings(nb::module_& m)
         }
 
         auto cpp_states = nb::cast<nb::tuple>(state[0]);
-        if (cpp_states.size() != 29)
+        if (cpp_states.size() != 29 && cpp_states.size() != 30)
         {
             throw std::runtime_error("Invalid cpp_states!");
         }
+        auto const hasAliasManagedWeightsFromGpu = cpp_states.size() == 30;
+        auto const aliasManagedWeightsFromGpu = hasAliasManagedWeightsFromGpu ? nb::cast<bool>(cpp_states[16]) : false;
+        auto const maxQueueSizeIndex = hasAliasManagedWeightsFromGpu ? 17 : 16;
+        auto const extendedRuntimePerfKnobConfigIndex = hasAliasManagedWeightsFromGpu ? 18 : 17;
+        auto const debugConfigIndex = hasAliasManagedWeightsFromGpu ? 19 : 18;
+        auto const recvPollPeriodMsIndex = hasAliasManagedWeightsFromGpu ? 20 : 19;
+        auto const maxSeqIdleMicrosecondsIndex = hasAliasManagedWeightsFromGpu ? 21 : 20;
+        auto const specDecConfigIndex = hasAliasManagedWeightsFromGpu ? 22 : 21;
+        auto const guidedDecodingConfigIndex = hasAliasManagedWeightsFromGpu ? 23 : 22;
+        auto const additionalModelOutputsIndex = hasAliasManagedWeightsFromGpu ? 24 : 23;
+        auto const cacheTransceiverConfigIndex = hasAliasManagedWeightsFromGpu ? 25 : 24;
+        auto const gatherGenerationLogitsIndex = hasAliasManagedWeightsFromGpu ? 26 : 25;
+        auto const promptTableOffloadingIndex = hasAliasManagedWeightsFromGpu ? 27 : 26;
+        auto const enableTrtOverlapIndex = hasAliasManagedWeightsFromGpu ? 28 : 27;
+        auto const failFastOnAttentionWindowTooLargeIndex = hasAliasManagedWeightsFromGpu ? 29 : 28;
 
         // Restore C++ data
         tle::ExecutorConfig* cpp_self = nb::inst_ptr<tle::ExecutorConfig>(self);
@@ -533,19 +548,24 @@ void initConfigBindings(nb::module_& m)
             nb::cast<std::optional<tle::DecodingConfig>>(cpp_states[13]),            // DecodingConfig
             nb::cast<bool>(cpp_states[14]),                                          // UseGpuDirectStorage
             nb::cast<float>(cpp_states[15]),                                         // GpuWeightsPercent
-            nb::cast<std::optional<SizeType32>>(cpp_states[16]),                     // MaxQueueSize
-            nb::cast<tle::ExtendedRuntimePerfKnobConfig>(cpp_states[17]),            // ExtendedRuntimePerfKnobConfig
-            nb::cast<std::optional<tle::DebugConfig>>(cpp_states[18]),               // DebugConfig
-            nb::cast<SizeType32>(cpp_states[19]),                                    // RecvPollPeriodMs
-            nb::cast<uint64_t>(cpp_states[20]),                                      // MaxSeqIdleMicroseconds
-            nb::cast<std::optional<tle::SpeculativeDecodingConfig>>(cpp_states[21]), // SpecDecConfig
-            nb::cast<std::optional<tle::GuidedDecodingConfig>>(cpp_states[22]),      // GuidedDecodingConfig
-            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(cpp_states[23]), // AdditionalModelOutputs
-            nb::cast<std::optional<tle::CacheTransceiverConfig>>(cpp_states[24]),             // CacheTransceiverConfig
-            nb::cast<bool>(cpp_states[25]),                                                   // GatherGenerationLogits
-            nb::cast<bool>(cpp_states[26]),                                                   // PromptTableOffloading
-            nb::cast<bool>(cpp_states[27]),                                                   // EnableTrtOverlap
-            nb::cast<bool>(cpp_states[28]) // FailFastOnAttentionWindowTooLarge
+            aliasManagedWeightsFromGpu,                                              // AliasManagedWeightsFromGpu
+            nb::cast<std::optional<SizeType32>>(cpp_states[maxQueueSizeIndex]),      // MaxQueueSize
+            nb::cast<tle::ExtendedRuntimePerfKnobConfig>(
+                cpp_states[extendedRuntimePerfKnobConfigIndex]),                     // ExtendedRuntimePerfKnobConfig
+            nb::cast<std::optional<tle::DebugConfig>>(cpp_states[debugConfigIndex]), // DebugConfig
+            nb::cast<SizeType32>(cpp_states[recvPollPeriodMsIndex]),                 // RecvPollPeriodMs
+            nb::cast<uint64_t>(cpp_states[maxSeqIdleMicrosecondsIndex]),             // MaxSeqIdleMicroseconds
+            nb::cast<std::optional<tle::SpeculativeDecodingConfig>>(cpp_states[specDecConfigIndex]), // SpecDecConfig
+            nb::cast<std::optional<tle::GuidedDecodingConfig>>(
+                cpp_states[guidedDecodingConfigIndex]),                        // GuidedDecodingConfig
+            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(
+                cpp_states[additionalModelOutputsIndex]),                      // AdditionalModelOutputs
+            nb::cast<std::optional<tle::CacheTransceiverConfig>>(
+                cpp_states[cacheTransceiverConfigIndex]),                      // CacheTransceiverConfig
+            nb::cast<bool>(cpp_states[gatherGenerationLogitsIndex]),           // GatherGenerationLogits
+            nb::cast<bool>(cpp_states[promptTableOffloadingIndex]),            // PromptTableOffloading
+            nb::cast<bool>(cpp_states[enableTrtOverlapIndex]),                 // EnableTrtOverlap
+            nb::cast<bool>(cpp_states[failFastOnAttentionWindowTooLargeIndex]) // FailFastOnAttentionWindowTooLarge
         );
 
         // Restore Python data
@@ -573,6 +593,7 @@ void initConfigBindings(nb::module_& m)
                  std::optional<tle::DecodingConfig>,                     // DecodingConfig
                  bool,                                                   // UseGpuDirectStorage
                  float,                                                  // GpuWeightsPercent
+                 bool,                                                   // AliasManagedWeightsFromGpu
                  std::optional<SizeType32>,                              // MaxQueueSize
                  tle::ExtendedRuntimePerfKnobConfig const&,              // ExtendedRuntimePerfKnobConfig
                  std::optional<tle::DebugConfig>,                        // DebugConfig
@@ -596,7 +617,8 @@ void initConfigBindings(nb::module_& m)
             nb::arg("max_num_tokens") = nb::none(), nb::arg("parallel_config") = nb::none(),
             nb::arg("peft_cache_config") = tle::PeftCacheConfig(), nb::arg("logits_post_processor_config") = nb::none(),
             nb::arg("decoding_config") = nb::none(), nb::arg("use_gpu_direct_storage") = false,
-            nb::arg("gpu_weights_percent") = 1.0, nb::arg("max_queue_size") = nb::none(),
+            nb::arg("gpu_weights_percent") = 1.0, nb::arg("alias_managed_weights_from_gpu") = false,
+            nb::arg("max_queue_size") = nb::none(),
             nb::arg("extended_runtime_perf_knob_config") = tle::ExtendedRuntimePerfKnobConfig(),
             nb::arg("debug_config") = nb::none(), nb::arg("recv_poll_period_ms") = 0,
             nb::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
@@ -632,6 +654,8 @@ void initConfigBindings(nb::module_& m)
             &tle::ExecutorConfig::setUseGpuDirectStorage)
         .def_prop_rw("gpu_weights_percent", &tle::ExecutorConfig::getGpuWeightsPercent,
             &tle::ExecutorConfig::setGpuWeightsPercent)
+        .def_prop_rw("alias_managed_weights_from_gpu", &tle::ExecutorConfig::getAliasManagedWeightsFromGpu,
+            &tle::ExecutorConfig::setAliasManagedWeightsFromGpu)
         .def_prop_rw("max_queue_size", &tle::ExecutorConfig::getMaxQueueSize, &tle::ExecutorConfig::setMaxQueueSize)
         .def_prop_rw("extended_runtime_perf_knob_config", &tle::ExecutorConfig::getExtendedRuntimePerfKnobConfig,
             &tle::ExecutorConfig::setExtendedRuntimePerfKnobConfig)

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
@@ -185,12 +185,25 @@ void assessLikelihoodOfRuntimeAllocation(
 
 } // namespace
 
+TllmRuntime::TllmRuntime(
+    RawEngine const& rawEngine, nvinfer1::ILogger* logger, float gpuWeightsPercent, bool useShapeInference)
+    : TllmRuntime(rawEngine, logger, false, gpuWeightsPercent, false, useShapeInference)
+{
+}
+
 TllmRuntime::TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage,
     float gpuWeightsPercent, bool useShapeInference)
+    : TllmRuntime(rawEngine, logger, useGpuDirectStorage, gpuWeightsPercent, false, useShapeInference)
+{
+}
+
+TllmRuntime::TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage,
+    float gpuWeightsPercent, bool aliasManagedWeightsFromGpu, bool useShapeInference)
     : mStream(std::make_shared<CudaStream>())
     , mBufferManager{mStream, true} // Ensure to trim the memory pool on destruction.
     , mRuntime{nvinfer1::createInferRuntime(static_cast<bool>(logger) ? *logger : defaultLogger)}
     , mUseShapeInference{useShapeInference}
+    , mAliasManagedWeightsFromGpu{aliasManagedWeightsFromGpu}
     , mUserBufferEnabled{false}
 {
     auto const startTime = std::chrono::high_resolution_clock::now();
@@ -803,7 +816,15 @@ void TllmRuntime::loadManagedWeights(RawEngine const& rawEngine, int localRank)
         {
             TLLM_LOG_DEBUG("Loading managed weight: %s", name.c_str());
             auto iTensor = tensorrt_llm::executor::detail::toITensor(weight);
-            auto weightsDevice = std::shared_ptr<ITensor>{manager.copyFrom(*iTensor, MemoryType::kGPU)};
+            std::shared_ptr<ITensor> weightsDevice;
+            if (mAliasManagedWeightsFromGpu && iTensor->getMemoryType() == MemoryType::kGPU)
+            {
+                weightsDevice = iTensor;
+            }
+            else
+            {
+                weightsDevice = std::shared_ptr<ITensor>{manager.copyFrom(*iTensor, MemoryType::kGPU)};
+            }
             mManagedWeightsMap.insert(std::make_pair(name, weightsDevice));
         }
     }

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.h
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.h
@@ -37,8 +37,16 @@ class TllmRuntime
 public:
     using TensorMap = StringPtrMap<ITensor>;
 
-    explicit TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage = false,
-        float gpuWeightsPercent = 1.0f, bool useShapeInference = true);
+    explicit TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage,
+        float gpuWeightsPercent, bool aliasManagedWeightsFromGpu, bool useShapeInference);
+
+    // Compatibility constructor preserving historical argument order.
+    explicit TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage,
+        float gpuWeightsPercent, bool useShapeInference = true);
+
+    // Compatibility constructor preserving historical argument order.
+    explicit TllmRuntime(
+        RawEngine const& rawEngine, nvinfer1::ILogger* logger, float gpuWeightsPercent, bool useShapeInference = true);
 
     SizeType32 getNbContexts() const
     {
@@ -230,6 +238,7 @@ private:
     std::unique_ptr<nvinfer1::IEngineInspector> mEngineInspector;
     std::unique_ptr<LayerProfiler> mLayerProfiler;
     bool mUseShapeInference;
+    bool mAliasManagedWeightsFromGpu;
     TensorMap mManagedWeightsMap;
     // List of input tensor names.
     // Names of static tensors are removed from this list when setStaticInputTensors is called.

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -99,7 +99,60 @@ def test_executor_with_managed_weights(model_files, model_path):
                                trtllm.ModelType.DECODER_ONLY, executor_config,
                                managed_weights)
 
-    assert executor.can_enqueue_requests() == True
+    assert executor.can_enqueue_requests()
+
+
+def test_executor_with_torch_managed_weights(model_files, model_path):
+    """Test executor constructor with torch.Tensor managed weights."""
+
+    executor_config = trtllm.ExecutorConfig(
+        1, kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.5))
+    engine_buffer = open(model_path / "rank0.engine", mode="rb").read()
+    json_config_str = open(model_path / "config.json", 'r').read()
+
+    managed_weights = {
+        "weight_float32":
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "weight_int32":
+        torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+    }
+    if torch.cuda.is_available():
+        managed_weights["weight_fp16_cuda"] = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]], dtype=torch.float16, device="cuda")
+
+    executor = trtllm.Executor(engine_buffer, json_config_str,
+                               trtllm.ModelType.DECODER_ONLY, executor_config,
+                               managed_weights)
+
+    assert executor.can_enqueue_requests()
+
+
+def test_executor_with_torch_cuda_managed_weights_alias_enabled(
+        model_files, model_path):
+    """Test CUDA torch managed weights with alias_managed_weights_from_gpu enabled."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for managed weight alias test")
+
+    executor_config = trtllm.ExecutorConfig(
+        1,
+        kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.5),
+        alias_managed_weights_from_gpu=True)
+    engine_buffer = open(model_path / "rank0.engine", mode="rb").read()
+    json_config_str = open(model_path / "config.json", 'r').read()
+
+    managed_weights = {
+        "weight_fp16_cuda":
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]],
+                     dtype=torch.float16,
+                     device="cuda"),
+    }
+
+    executor = trtllm.Executor(engine_buffer, json_config_str,
+                               trtllm.ModelType.DECODER_ONLY, executor_config,
+                               managed_weights)
+
+    assert executor.can_enqueue_requests()
 
 
 def test_executor_invalid_ctor():
@@ -1748,6 +1801,7 @@ def test_executor_config():
     assert config.additional_model_outputs is None
     assert config.gather_generation_logits is False
     assert config.use_gpu_direct_storage is False
+    assert config.alias_managed_weights_from_gpu is False
     assert config.mm_embedding_offloading is False
     assert config.enable_trt_overlap is False
 
@@ -1800,6 +1854,8 @@ def test_executor_config():
         True,
         "use_gpu_direct_storage":
         True,
+        "alias_managed_weights_from_gpu":
+        True,
         "mm_embedding_offloading":
         True,
         "enable_trt_overlap":
@@ -1827,6 +1883,7 @@ def test_executor_config():
     assert config.additional_model_outputs[0].gather_context is False
     assert config.gather_generation_logits is True
     assert config.use_gpu_direct_storage is True
+    assert config.alias_managed_weights_from_gpu is True
     assert config.mm_embedding_offloading is True
     assert config.enable_trt_overlap is True
 
@@ -2632,6 +2689,8 @@ def test_executor_config_pickle():
         [trtllm.AdditionalModelOutput("topKLogits")],
         "gather_generation_logits":
         True,
+        "alias_managed_weights_from_gpu":
+        True,
         "mm_embedding_offloading":
         True,
         "enable_trt_overlap":
@@ -2665,6 +2724,7 @@ def test_executor_config_pickle():
     assert config.backend == config_copy.backend
     assert config.spec_dec_config.fast_logits == config_copy.spec_dec_config.fast_logits
     assert config.use_gpu_direct_storage == config_copy.use_gpu_direct_storage
+    assert config.alias_managed_weights_from_gpu == config_copy.alias_managed_weights_from_gpu
 
     assert config_copy.guided_decoding_config.backend == config.guided_decoding_config.backend
     assert config_copy.guided_decoding_config.encoded_vocab == config.guided_decoding_config.encoded_vocab


### PR DESCRIPTION
I was trying to write some code to load models from OCI images (in a kubernetes environment), load the bytes into GPU using [GDS cuFile API](https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html) and then use those pre-loaded things from `trtllm.ExecutorConfig` and ran into somethings i could not find a way around. Here's a patch that seems to work in this PR.

Larger context / proof of concept where i got code in this PR to work:
- https://github.com/dims/oci2gdsd/commit/685773cc1824936709c2116b3d8efcb15e5d5efb#diff-43ac7007c20def91facaac60d97ffb400b04a0676acbdb3cdbb435cad5d91c25R629-R637
- Repo itself - https://github.com/dims/oci2gdsd

Happy to iterate as i don't know the code base well and am using codex to help me.

## Description

- Support `torch.Tensor` inputs for `managed_weights` in Python executor bindings.
- Allow CUDA tensor managed weights via the existing tensor caster path.
- Add `alias_managed_weights_from_gpu` as an opt-in `ExecutorConfig` policy so GPU-resident managed weights can be aliased rather than copied.
- Preserve existing call sites by keeping compatibility constructors for `ExecutorConfig` and `TllmRuntime` positional argument order.

## Test Coverage

- Added CUDA managed-weights aliasing coverage in:
  - `tests/unittest/bindings/test_executor_bindings.py::test_executor_with_torch_cuda_managed_weights_alias_enabled`
- Extended/validated managed-weights binding behavior in:
  - `tests/unittest/bindings/test_executor_bindings.py::test_executor_with_torch_managed_weights`
  - `tests/unittest/bindings/test_executor_bindings.py::test_executor_config`
  - `tests/unittest/bindings/test_executor_bindings.py::test_executor_config_from_json`
  - `tests/unittest/bindings/test_executor_bindings.py::test_executor_config_copy`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to enable GPU weight aliasing in the executor. This allows managed weights to be referenced directly from GPU memory when available, potentially improving performance and memory efficiency.

* **Tests**
  * Added comprehensive test coverage for GPU-managed weight handling with both CPU and CUDA scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->