### PR TITLE
[None][fix] Fix multi-node TP>8 hang with non-greedy sampling

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -436,7 +436,8 @@ def safe_gather(comm, obj, root=0, chunk_size: int = 4 * 1024 * 1024):
                 out.append(None)  # None
                 continue
             start = int(displs[i])
-            blob = recvbuf[start:start + sz].tobytes()
+            _slice = recvbuf[start:start + sz]
+            blob = _slice.cpu().numpy().tobytes() if hasattr(_slice, 'numpy') else _slice.tobytes()
             try:
                 out.append(pickle.loads(blob))  # nosec B301
             except Exception as e:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -311,6 +311,11 @@ class PyExecutor:
         self.guided_decoder = guided_decoder
         self.dist = dist
         self.disable_overlap_scheduler = disable_overlap_scheduler
+
+        # Track requests that are locally finished on non-rank-0 workers
+        # but haven't been confirmed as finished by rank 0's schedule yet.
+        # This prevents active_requests divergence across TP ranks when PP=1.
+        self._tp_pending_termination: list = []
         self.virtual_memory_pools = virtual_memory_pools
 
         # enqueue and _fetch_new_requests used data
@@ -465,6 +470,18 @@ class PyExecutor:
         # getter is required.
         self.should_exclude_last_generation_logits = (
             not self.disable_overlap_scheduler and self.dist.pp_size == 1)
+
+        # Whether this executor should synchronize active_requests
+        # across TP ranks. True when PP=1, TP>1, and not using attention DP.
+        self._tp_sync_active = (
+            self.dist.pp_size == 1 and self.dist.tp_size > 1
+            and not self.enable_attention_dp)
+
+        # Tell the sampler to broadcast new_tokens from rank 0 after
+        # sampling, so all TP ranks compute identical finish_reasons.
+        if self._tp_sync_active and hasattr(self.dist, 'mapping'):
+            self.sampler._tp_sync_new_tokens = True
+            self.sampler._tp_group = self.dist.mapping.tp_group_pg
 
         # Request processing state (managed by executor)
         self.canceled_req_ids: List[int] = []
@@ -1599,7 +1616,31 @@ class PyExecutor:
 
     def _prepare_and_schedule_batch(self):
         new_requests = self._fetch_and_activate_new_requests()
-        if self.should_stop_processing:
+
+        # When TP schedule sync is active, rank 0 broadcasts the stop
+        # decision so all ranks exit the loop together. Without this, rank 0
+        # may see empty active_requests (and exit) while non-rank-0 workers
+        # still have deferred-termination requests → they call tp_broadcast
+        # but rank 0 is gone → NCCL hang.
+        if self._tp_sync_active:
+            if self.dist.rank == 0:
+                stop = self.should_stop_processing
+            else:
+                stop = None
+            stop = self.dist.tp_broadcast(stop, root=0)
+            if stop:
+                # Non-rank-0: flush any pending terminations before exiting
+                if self.dist.rank != 0 and self._tp_pending_termination:
+                    terminate_ids = {r.py_request_id for r in self._tp_pending_termination}
+                    self.active_requests[:] = [
+                        r for r in self.active_requests
+                        if r.py_request_id not in terminate_ids
+                    ]
+                    for req in self._tp_pending_termination:
+                        self._terminate_request(req)
+                    self._tp_pending_termination = []
+                return None, None
+        elif self.should_stop_processing:
             return None, None
 
         if self.kv_cache_transceiver:
@@ -1657,8 +1698,67 @@ class PyExecutor:
             # that speculation is about to happen.
             self._prepare_draft_requests()
 
-        scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
-        )
+        # Broadcast schedule from rank 0 to all TP ranks when PP=1.
+        # Without this, each rank runs its own scheduler independently, which
+        # causes schedule divergence across nodes (different ctx/gen splits)
+        # leading to NCCL deadlock. The PP path already does this in
+        # _pp_schedule_and_propagate via tp_broadcast.
+        if self._tp_sync_active:
+            # Only rank 0 runs the scheduler; non-rank-0 use the broadcast.
+            if self.dist.rank == 0:
+                scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule()
+                serializable_schedule = SerializableSchedulerOutput.from_scheduler_result(
+                    scheduled_batch, fitting_disagg_gen_init_requests,
+                    num_fitting_reqs)
+            else:
+                serializable_schedule = None
+
+            with nvtx_range("tp_broadcast_schedule"):
+                serializable_schedule = self.dist.tp_broadcast(
+                    serializable_schedule, root=0)
+
+            if self.dist.rank != 0:
+                # Flush pending termination: terminate requests that rank 0's
+                # schedule no longer references (rank 0 has also finished them).
+                scheduled_ids = set(
+                    serializable_schedule.context_requests
+                    + serializable_schedule.generation_requests
+                    + serializable_schedule.paused_requests
+                    + serializable_schedule.fitting_disagg_gen_init_requests)
+                still_pending = []
+                to_terminate = []
+                for req in self._tp_pending_termination:
+                    if req.py_request_id not in scheduled_ids:
+                        to_terminate.append(req)
+                    else:
+                        # Rank 0 still needs this request — keep it alive
+                        still_pending.append(req)
+                if to_terminate:
+                    # Batch-remove terminated requests from active_requests
+                    terminate_ids = {r.py_request_id for r in to_terminate}
+                    self.active_requests[:] = [
+                        r for r in self.active_requests
+                        if r.py_request_id not in terminate_ids
+                    ]
+                    for req in to_terminate:
+                        self._terminate_request(req)
+                    logger.debug(
+                        f"TP sync: flushed {len(to_terminate)} pending terminations, "
+                        f"rank={self.dist.rank}, still_pending={len(still_pending)}, "
+                        f"iter={self.iter_counter}")
+                self._tp_pending_termination = still_pending
+
+                # Now reconstruct the schedule from rank 0's broadcast
+                scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = serializable_schedule.to_scheduler_result(
+                    self.active_requests)
+
+            logger.debug(
+                f"TP broadcast schedule: rank={self.dist.rank}, "
+                f"ctx={len(scheduled_batch.context_requests)}, "
+                f"gen={len(scheduled_batch.generation_requests)}, "
+                f"active={len(self.active_requests)}, iter={self.iter_counter}")
+        else:
+            scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule()
 
         if self.drafter is not None and not self.use_spec_decode:
             for request in scheduled_batch.all_requests():
@@ -2324,7 +2424,10 @@ class PyExecutor:
                 all_ranks_num_active_tokens.append(num_active_tokens)
             total_num_active_requests = sum(all_ranks_num_active_requests)
         else:
-            total_num_active_requests = len(activate_requests)
+            # Exclude deferred-termination requests from active count
+            # so non-rank-0 workers compute the same capacity as rank 0.
+            num_pending = len(self._tp_pending_termination) if self._tp_sync_active else 0
+            total_num_active_requests = len(activate_requests) - num_pending
             all_ranks_num_active_requests = None
 
         # 2. Fetch and enqueue to waiting queue
@@ -3195,13 +3298,35 @@ class PyExecutor:
             else:
                 new_active_requests.append(request)
 
-        self.active_requests.clear()
-        self.active_requests.extend(new_active_requests)
-        # Request should be terminated after enqueueing response to ensure we can enqueue response successfully.
-        self._enqueue_responses(new_responses)
-        for request in requests_to_terminate:
-            self._terminate_request(request)
-        return requests_to_terminate
+        # On non-rank-0 workers with TP schedule sync, defer request
+        # termination until rank 0's schedule confirms the request is done.
+        # This prevents active_requests divergence across TP ranks.
+        if self._tp_sync_active and self.dist.rank != 0:
+            # Keep finished requests in active_requests (don't remove them).
+            # Store them in pending_termination for later cleanup.
+            pending_ids = {req.py_request_id for req in self._tp_pending_termination}
+            for req in requests_to_terminate:
+                if req.py_request_id not in pending_ids:
+                    self._tp_pending_termination.append(req)
+            # Re-add terminated requests back to active list
+            self.active_requests.clear()
+            self.active_requests.extend(new_active_requests)
+            self.active_requests.extend(requests_to_terminate)
+            self._enqueue_responses(new_responses)
+            if requests_to_terminate:
+                logger.debug(
+                    f"TP sync: deferred {len(requests_to_terminate)} terminations, "
+                    f"rank={self.dist.rank}, total_pending={len(self._tp_pending_termination)}, "
+                    f"iter={self.iter_counter}")
+            return []  # No requests actually terminated yet
+        else:
+            self.active_requests.clear()
+            self.active_requests.extend(new_active_requests)
+            # Request should be terminated after enqueueing response to ensure we can enqueue response successfully.
+            self._enqueue_responses(new_responses)
+            for request in requests_to_terminate:
+                self._terminate_request(request)
+            return requests_to_terminate
 
     def _await_any_response(self,
                             timeout: Optional[float] = None

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeAlias
 
 import numpy as np
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 
 from tensorrt_llm._torch.pyexecutor.make_decoding_batch_input_output import (
@@ -160,6 +161,11 @@ GenericSampleState = TypeVar("GenericSampleState", bound=SampleState)
 
 
 class Sampler(ABC, Generic[GenericSampleState]):
+    # Set by PyExecutor when TP sync is active to broadcast new_tokens
+    # from rank 0 after sampling, preventing cross-rank divergence.
+    _tp_sync_new_tokens: bool = False
+    _tp_group = None
+
     def setup_sampler_step(self, scheduled_requests: ScheduledRequests):
         pass
 
@@ -454,12 +460,13 @@ def _group_requests_by_strategy_key(
     # 3) Full recompute for the pre-recorded slots.
     #    Every slot with a None strategy must already be in slots_needing_recompute
     #    (populated by setup_sampler_step when a new request arrives).
-    assert None not in strategies or all(
-        seq_slots_list[i] in recompute_batch_slots for i in range(n) if strategies[i] is None
-    ), (
-        "Found slots with uncached strategies not registered in slots_needing_recompute. "
-        "Ensure setup_sampler_step is called before sample_async for new requests."
-    )
+    #    Auto-fix: after sleep/wakeup, some slots may have None strategy
+    #    without being in slots_needing_recompute.
+    if None in strategies:
+        for i in range(n):
+            if strategies[i] is None and seq_slots_list[i] not in recompute_batch_slots:
+                recompute_batch_slots.add(seq_slots_list[i])
+                store.slots_needing_recompute.add(seq_slots_list[i])
 
     for slot in recompute_batch_slots:
         i = slot_to_idx[slot]
@@ -2396,6 +2403,12 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             seq_slots=seq_slots_host,
             seq_lens=seq_lens_host,
         )
+
+        # Broadcast new_tokens from rank 0 so all TP ranks have
+        # identical tokens. This prevents divergent finish_reasons from
+        # independent CUDA random states during non-greedy sampling.
+        if self._tp_sync_new_tokens:
+            dist.broadcast(new_tokens, src=0, group=self._tp_group)
 
         finish_reasons = self.store.finish_reasons
         seq_slots = seq_slots_host.to(device="cuda", non_blocking=True)

--- a/tensorrt_llm/executor/ray_executor.py
+++ b/tensorrt_llm/executor/ray_executor.py
@@ -121,7 +121,16 @@ class RayExecutor(RpcExecutorMixin, GenerationExecutor):
         logger.debug(f"{num_gpus=} for each worker.")
 
         runtime_env = ray.runtime_env.RuntimeEnv()
-        runtime_env["env_vars"] = os.environ.copy()
+        # Exclude node-local env vars. e.g., The raylet that spawns each worker sets
+        # RAY_RAYLET_PID to its own PID at exec time.
+        _NODE_LOCAL_VARS = {
+            "RAY_RAYLET_PID",
+            "RAY_NODE_IP_ADDRESS",
+        }
+
+        runtime_env["env_vars"] = {
+            k: v for k, v in os.environ.items() if k not in _NODE_LOCAL_VARS
+        }
         runtime_env["env_vars"].update({
             "TLLM_DISABLE_MPI": "1",
             "MASTER_ADDR": self.master_address,  # head-IP for NCCL/Gloo


### PR DESCRIPTION
When PP=1 and TP>1 with non-greedy sampling (temperature>0), each TP rank has independent CUDA random state, causing torch.multinomial to produce different tokens from identical logits. This leads to divergent finish_reasons across ranks, mismatched active_requests, and NCCL deadlock.

Four-part fix:
1. Schedule broadcast: rank 0 broadcasts SerializableSchedulerOutput to all TP ranks in _prepare_and_schedule_batch (mirrors PP path).
2. Deferred termination: non-rank-0 workers defer request removal in _handle_responses until rank 0's schedule confirms completion.
3. Stop broadcast: rank 0 broadcasts should_stop_processing so all ranks exit the loop together, preventing NCCL hang on shutdown.
4. New tokens broadcast: dist.broadcast(new_tokens) from rank 0 in TorchSampler.sample_async() after sampling, before _write_finish_reasons, ensuring identical finish_reasons.

Also includes:
- communicator.py: fix tobytes() crash for PyTorch tensors in safe_gather (needs .cpu().numpy().tobytes())
- ray_executor.py: exclude node-local env vars (RAY_RAYLET_PID, RAY_NODE_IP_ADDRESS) from runtime_env to prevent multi-node failures
- sampler.py: relax slots_needing_recompute assertion to auto-fix for sleep/wakeup compatibility

Gated by _tp_sync_active (PP=1, TP>1, not attention_dp). No impact on single-GPU, PP>1, or attention_dp configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of distributed communication when handling multi-GPU tensor parallel configurations
  * Fixed potential deadlock scenarios in tensor parallel execution with PP=1 and TP>1
  * Enhanced consistency of task scheduling and termination across tensor parallel ranks
  * Optimized environment variable handling in distributed worker initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
