### PR TITLE
[None][fix] use tool parser for named tool choice responses

### DIFF
--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -216,49 +216,38 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
         delta_text, reasoning_delta_text = apply_reasoning_parser(
             args, i, delta_text, True)
 
-        if args.tool_choice and type(
-                args.tool_choice) is ChatCompletionNamedToolChoiceParam:
-            delta_message = DeltaMessage(tool_calls=[
-                DeltaToolCall(
-                    function=DeltaFunctionCall(
-                        name=args.tool_choice.function.name,
-                        arguments=delta_text),
-                    index=i,
-                ),
-            ], )
-        else:
-            delta_text, calls = apply_tool_parser(args, i, delta_text, True)
-            tool_calls = []
-            for call_item in calls:
-                # Tool call ID should be generated only once per tool call
-                if call_item.name:
-                    # First chunk: include ID and function name
-                    tool_call_id = make_tool_call_id(
-                        id_type=args.tool_call_id_type,
-                        func_name=call_item.name,
-                        idx=call_item.tool_index)
-                    function_name = call_item.name
-                else:
-                    # Subsequent chunks: null ID and name for argument deltas
-                    tool_call_id = None
-                    function_name = None
-
-                tool_calls.append(
-                    DeltaToolCall(
-                        id=tool_call_id,
-                        index=call_item.tool_index,
-                        function=DeltaFunctionCall(
-                            name=function_name,
-                            arguments=call_item.parameters,
-                        ),
-                    ))
-            if tool_calls or delta_text or reasoning_delta_text or output.finish_reason:
-                delta_message = DeltaMessage(
-                    content=delta_text,
-                    reasoning_content=reasoning_delta_text,
-                    tool_calls=tool_calls if tool_calls else None)
+        delta_text, calls = apply_tool_parser(args, i, delta_text, True)
+        tool_calls = []
+        for call_item in calls:
+            # Tool call ID should be generated only once per tool call
+            if call_item.name:
+                # First chunk: include ID and function name
+                tool_call_id = make_tool_call_id(
+                    id_type=args.tool_call_id_type,
+                    func_name=call_item.name,
+                    idx=call_item.tool_index)
+                function_name = call_item.name
             else:
-                continue
+                # Subsequent chunks: null ID and name for argument deltas
+                tool_call_id = None
+                function_name = None
+
+            tool_calls.append(
+                DeltaToolCall(
+                    id=tool_call_id,
+                    index=call_item.tool_index,
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=call_item.parameters,
+                    ),
+                ))
+        if tool_calls or delta_text or reasoning_delta_text or output.finish_reason:
+            delta_message = DeltaMessage(
+                content=delta_text,
+                reasoning_content=reasoning_delta_text,
+                tool_calls=tool_calls if tool_calls else None)
+        else:
+            continue
 
         choice = ChatCompletionResponseStreamChoice(
             index=i,
@@ -319,28 +308,18 @@ def chat_response_post_processor(
         text, reasoning_text = apply_reasoning_parser(args, output.index,
                                                       output.text, False)
 
-        if args.tool_choice and isinstance(args.tool_choice,
-                                           ChatCompletionNamedToolChoiceParam):
-            message = ChatMessage(
-                role=role,
-                content="",
-                tool_calls=[
-                    ToolCall(function=FunctionCall(
-                        name=args.tool_choice.function.name, arguments=text))
-                ])
-        else:
-            if text is None:
-                text = ""
-            text, calls = apply_tool_parser(args, output.index, text, False)
-            tool_calls = [
-                ToolCall(function=FunctionCall(name=call.name or "",
-                                               arguments=call.parameters))
-                for call in calls
-            ]
-            message = ChatMessage(role=role,
-                                  content=text,
-                                  reasoning_content=reasoning_text,
-                                  tool_calls=tool_calls)
+        if text is None:
+            text = ""
+        text, calls = apply_tool_parser(args, output.index, text, False)
+        tool_calls = [
+            ToolCall(function=FunctionCall(name=call.name or "",
+                                           arguments=call.parameters))
+            for call in calls
+        ]
+        message = ChatMessage(role=role,
+                              content=text,
+                              reasoning_content=reasoning_text,
+                              tool_calls=tool_calls)
         disaggregated_params = to_disaggregated_params(
             output.disaggregated_params)
         choice = ChatCompletionResponseChoice(


### PR DESCRIPTION
## Description
- remove named-tool-choice special handling in chat postprocessors
- always run tool output through `apply_tool_parser` for parity with auto tool choice

## Test coverage
- tests/unittest/llmapi/apps/_test_openai_tool_call.py 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool call handling is now unified and consistent between streaming and non-streaming response processing modes.
  * Tool calls are reliably parsed and integrated into messages regardless of the processing path.
  * Improved stability and consistency when handling tool calls across all post-processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->