### PR TITLE
[None][fix] Various fixes for agentic flow

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -659,7 +659,7 @@ class ChoiceWithAlias(click.Choice):
         "prototype"))
 @click.option(
     "--reasoning_parser",
-    type=click.Choice(ReasoningParserFactory.parsers.keys()),
+    type=click.Choice(ReasoningParserFactory.keys()),
     default=None,
     help=help_info_with_stability_tag(
         "Specify the parser for reasoning models.", "prototype"),

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -177,8 +177,23 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
                  *,
                  reasoning_at_start: bool = True,
                  chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        self._force_nonempty_content = False
         if isinstance(chat_template_kwargs, dict):
             reasoning_at_start = chat_template_kwargs.get(
                 "enable_thinking", reasoning_at_start)
+            self._force_nonempty_content = chat_template_kwargs.get(
+                "force_nonempty_content", False) is True
         super().__init__(reasoning_at_start=reasoning_at_start,
                          chat_template_kwargs=chat_template_kwargs)
+
+    def _maybe_swap_content(
+            self, result: ReasoningParserResult) -> ReasoningParserResult:
+        """When force_nonempty_content is set and content is empty, move
+        reasoning_content into content so the response always has content."""
+        if self._force_nonempty_content and not result.content and result.reasoning_content:
+            return ReasoningParserResult(content=result.reasoning_content,
+                                         reasoning_content="")
+        return result
+
+    def parse(self, text: str) -> ReasoningParserResult:
+        return self._maybe_swap_content(super().parse(text))

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -9,7 +9,57 @@ class ReasoningParserResult:
     reasoning_content: str = ""
 
 
+def register_reasoning_parser(*keys: str, **default_kwargs):
+    """Decorator that registers a BaseReasoningParser under one or more keys.
+
+    Any extra keyword arguments are stored as defaults and forwarded to
+    the parser constructor at creation time.
+
+    Usage::
+
+        @register_reasoning_parser("my-model", reasoning_at_start=True)
+        class MyParser(BaseReasoningParser):
+            ...
+    """
+
+    def decorator(parser_cls: Type["BaseReasoningParser"]):
+        for key in keys:
+            ReasoningParserFactory._parsers[key] = (parser_cls, default_kwargs)
+        return parser_cls
+
+    return decorator
+
+
+class ReasoningParserFactory:
+    _parsers: dict[str, tuple[Type["BaseReasoningParser"], dict[str, Any]]] = {}
+
+    @classmethod
+    def create_reasoning_parser(
+        cls,
+        reasoning_parser: str,
+        chat_template_kwargs: Optional[dict[str, Any]] = None,
+    ) -> "BaseReasoningParser":
+        key = reasoning_parser.lower()
+        try:
+            parser_cls, default_kwargs = cls._parsers[key]
+        except KeyError as e:
+            raise ValueError(
+                f"Invalid reasoning parser: {reasoning_parser}\n"
+                f"Supported parsers: {list(cls._parsers.keys())}") from e
+        return parser_cls(chat_template_kwargs=chat_template_kwargs,
+                          **default_kwargs)
+
+    @classmethod
+    def keys(cls):
+        return cls._parsers.keys()
+
+
 class BaseReasoningParser(ABC):
+
+    def __init__(self,
+                 *,
+                 chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        pass
 
     @abstractmethod
     def parse(self, text: str) -> ReasoningParserResult:
@@ -20,6 +70,8 @@ class BaseReasoningParser(ABC):
         raise NotImplementedError
 
 
+@register_reasoning_parser("deepseek-r1", reasoning_at_start=True)
+@register_reasoning_parser("qwen3")
 class DeepSeekR1Parser(BaseReasoningParser):
     """
     Reasoning parser for DeepSeek-R1. Reasoning format: <think>(.*)</think>.
@@ -28,7 +80,11 @@ class DeepSeekR1Parser(BaseReasoningParser):
     treat all the text before the </think> tag as `reasoning_content` and the text after as `content`.
     """
 
-    def __init__(self, reasoning_at_start: bool = False) -> None:
+    def __init__(self,
+                 *,
+                 reasoning_at_start: bool = False,
+                 chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(chat_template_kwargs=chat_template_kwargs)
         self.reasoning_start = "<think>"
         self.reasoning_end = "</think>"
         self.reasoning_at_start = reasoning_at_start
@@ -105,35 +161,24 @@ class DeepSeekR1Parser(BaseReasoningParser):
             "Unreachable code reached in `DeepSeekR1Parser.parse_delta`")
 
 
-class ReasoningParserFactory:
-    parsers: dict[str, Type[BaseReasoningParser]] = {
-        "deepseek-r1": DeepSeekR1Parser,
-        "qwen3": DeepSeekR1Parser,
-        "nano-v3": DeepSeekR1Parser,
-    }
+@register_reasoning_parser("nano-v3")
+class NemotronV3ReasoningParser(DeepSeekR1Parser):
+    """Reasoning parser for Nemotron Nano v3.
 
-    @staticmethod
-    def create_reasoning_parser(
-        reasoning_parser: str,
-        chat_template_kwargs: Optional[dict[str, Any]] = None
-    ) -> BaseReasoningParser:
-        try:
-            reasoning_parser_class = ReasoningParserFactory.parsers[
-                reasoning_parser.lower()]
-            if reasoning_parser == "deepseek-r1":
-                return reasoning_parser_class(reasoning_at_start=True)
-            elif reasoning_parser == "nano-v3":
-                # Note: If the model is with reasoning (default behavior), `reasoning_at_start` should be True, and the starting response should be parsed into `reasoning_content`.
-                # While the model is without reasoning, `reasoning_at_start` should be False to parse the response into `content` fields.
-                is_reasoning_model = True
-                if isinstance(chat_template_kwargs, dict):
-                    is_reasoning_model = chat_template_kwargs.get(
-                        "enable_thinking", True)
-                return reasoning_parser_class(
-                    reasoning_at_start=is_reasoning_model)
-            return reasoning_parser_class()
-        except KeyError as e:
-            raise ValueError(
-                f"Invalid reasoning parser: {reasoning_parser}\n"
-                f"Supported parsers: {list(ReasoningParserFactory.parsers.keys())}"
-            ) from e
+    If the model is with reasoning (default behavior), `reasoning_at_start` is `True` and the
+    starting response is parsed into `reasoning_content`.
+    When the model is without reasoning, `reasoning_at_start` is `False` so the response is parsed
+    into `content` fields.
+
+    The `enable_thinking` flag is read from `chat_template_kwargs`.
+    """
+
+    def __init__(self,
+                 *,
+                 reasoning_at_start: bool = True,
+                 chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        if isinstance(chat_template_kwargs, dict):
+            reasoning_at_start = chat_template_kwargs.get(
+                "enable_thinking", reasoning_at_start)
+        super().__init__(reasoning_at_start=reasoning_at_start,
+                         chat_template_kwargs=chat_template_kwargs)

--- a/tensorrt_llm/serve/chat_utils.py
+++ b/tensorrt_llm/serve/chat_utils.py
@@ -242,6 +242,13 @@ def parse_chat_message_content(
 # Adapted from: https://github.com/vllm-project/vllm/blob/4574d48bab9c4e38b7c0a830eeefc8f0980e8c58/vllm/entrypoints/chat_utils.py#L1406
 def _parse_assistant_message_content(message: Dict[str, Any]) -> Dict[str, Any]:
     result = {}
+    # Include reasoning if present for interleaved thinking.
+    reasoning_content = message.get("reasoning")
+    if reasoning_content is None:
+        reasoning_content = message.get("reasoning_content")
+    if reasoning_content is not None:
+        result["reasoning_content"] = reasoning_content
+
     tool_calls = message.get("tool_calls")
     if tool_calls is not None:
         # Materialize Pydantic v2 ValidatorIterator (single-use) to a list.

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -547,6 +547,9 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
 class ReasoningAssistantMessage(ChatCompletionAssistantMessageParam):
     """Assistant message that includes reasoning tokens."""
     reasoning: Optional[str]
+    # NOTE: some older benchmarks and chat templates assume the below, which has been deprecated
+    # in other inference frameworks in favor of the above `reasoning` field.
+    reasoning_content: Optional[str]
 
 
 ChatCompletionMessageParam = Union[OpenAIChatCompletionMessageParam,

--- a/tensorrt_llm/serve/tool_parser/base_tool_parser.py
+++ b/tensorrt_llm/serve/tool_parser/base_tool_parser.py
@@ -70,7 +70,10 @@ class BaseToolParser(ABC):
         results = []
         for act in action:
             name = act.get("name")
-            if name and name in tool_indices:
+            if name:
+                if name not in tool_indices:
+                    logger.warning(
+                        f"Model attempted to call undefined function: {name}")
                 results.append(
                     ToolCallItem(
                         tool_index=
@@ -81,9 +84,6 @@ class BaseToolParser(ABC):
                             ensure_ascii=False,
                         ),
                     ))
-            else:
-                logger.warning(
-                    f"Model attempted to call undefined function: {name}")
 
         return results
 
@@ -173,16 +173,6 @@ class BaseToolParser(ABC):
                 is_current_complete = is_complete_json(
                     current_text[start_idx:start_idx + end_idx])
 
-                # Validate tool name if present
-                if "name" in obj and obj["name"] not in self._tool_indices:
-                    # Invalid tool name - reset state
-                    self._buffer = ""
-                    self.current_tool_id = -1
-                    self.current_tool_name_sent = False
-                    if self.streamed_args_for_tool:
-                        self.streamed_args_for_tool.pop()
-                    return StreamingParseResult()
-
                 # Handle parameters/arguments consistency
                 # NOTE: we assume here that the obj is always partial of a single tool call
                 if "parameters" in obj:
@@ -203,7 +193,7 @@ class BaseToolParser(ABC):
             if not self.current_tool_name_sent:
                 function_name = current_tool_call.get("name")
 
-                if function_name and function_name in self._tool_indices:
+                if function_name:
                     # If this is a new tool (current_tool_id was -1), initialize it
                     if self.current_tool_id == -1:
                         self.current_tool_id = 0

--- a/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
@@ -106,7 +106,7 @@ class Qwen3CoderToolParser(BaseToolParser):
                     function_name = function_match.group(1).strip()
 
                     # Validate function name
-                    if function_name in self._tool_indices:
+                    if function_name:
                         self._current_function_name = function_name
                         self._function_name_sent = True
 
@@ -138,13 +138,6 @@ class Qwen3CoderToolParser(BaseToolParser):
                         # Remove the processed function declaration
                         self._buf = self._buf[function_match.end() :]
                         continue
-                    else:
-                        # Invalid function name, reset state
-                        logger.warning(f"Invalid function name: {function_name}")
-                        self._reset_streaming_state()
-                        normal += self._buf
-                        self._buf = ""
-                        break
                 else:
                     # Function name not complete yet, wait for more text
                     break
@@ -324,13 +317,13 @@ class Qwen3CoderToolParser(BaseToolParser):
                 # Convert parameter value to the correct type.
                 param_config = self._get_arguments_config(fname, tools)
                 params[pname] = self._convert_param_value(pval, pname, param_config, fname)
-            raw = {"name": fname, "arguments": params}
-            try:
-                # TODO: fix idx in function call, the index for a function
-                # call will always be -1 in parse_base_json
-                res.extend(self.parse_base_json(raw, tools))
-            except Exception:
-                logger.warning(f"invalid tool call for {fname} dropped")
+            res.append(
+                ToolCallItem(
+                    tool_index=-1,
+                    name=fname,
+                    parameters=json.dumps(params, ensure_ascii=False),
+                )
+            )
         return res
 
     def supports_structural_tag(self) -> bool:

--- a/tests/unittest/llmapi/apps/test_chat_utils.py
+++ b/tests/unittest/llmapi/apps/test_chat_utils.py
@@ -158,6 +158,56 @@ class TestParseAssistantMessages:
         }
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "message_extra_fields, expected_reasoning",
+        [
+            # reasoning field is used directly.
+            ({"reasoning": "Let me think step by step..."}, "Let me think step by step..."),
+            # reasoning field falls back to reasoning_content.
+            ({"reasoning_content": "Let me think step by step..."}, "Let me think step by step..."),
+            # reasoning takes priority over reasoning_content.
+            (
+                {"reasoning": "Primary reasoning.", "reasoning_content": "Fallback reasoning."},
+                "Primary reasoning.",
+            ),
+            # Neither field provided -> key absent.
+            ({}, None),
+        ],
+    )
+    def test_assistant_message_reasoning(
+        self, mock_mm_data_tracker, message_extra_fields, expected_reasoning
+    ):
+        """Test parsing assistant messages with various reasoning field combinations."""
+        message = {"role": "assistant", "content": "The answer is 42.", **message_extra_fields}
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        assert result["role"] == "assistant"
+        assert result["content"] == "The answer is 42."
+        assert result["media"] == []
+        assert result.get("reasoning_content", None) == expected_reasoning
+
+    def test_assistant_message_with_reasoning_and_tool_calls(self, mock_mm_data_tracker):
+        """Test parsing an assistant message with both reasoning and tool calls."""
+        message = {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "I need to check the weather.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'},
+                }
+            ],
+        }
+
+        result = parse_chat_message_content(message, mock_mm_data_tracker)
+
+        assert result["reasoning_content"] == "I need to check the weather."
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["arguments"] == {"city": "NYC"}
+
 
 class TestParseToolMessages:
     """Test suite for tool role messages."""

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -191,8 +191,11 @@ class TestBaseToolParser:
 
         results = parser.parse_base_json(action, sample_tools)
 
-        # Should return empty list and log warning
-        assert len(results) == 0
+        # Should return the tool call with tool_index=-1 and log warning.
+        assert len(results) == 1
+        assert results[0].name == "undefined_function"
+        assert results[0].tool_index == -1
+        assert json.loads(results[0].parameters) == {}
 
     def test_parse_base_json_missing_parameters(self, sample_tools):
         """Test parse_base_json handles missing parameters."""
@@ -299,14 +302,14 @@ class TestBaseToolParser:
         """Test streaming parser handles invalid tool name."""
         parser = ConcreteToolParser()
 
-        # Send invalid tool name
+        # Send invalid tool name - parser streams it through.
         result = parser.parse_streaming_increment(
             '[TOOL_CALLS] {"name":"invalid_tool"', sample_tools)
 
-        # Should reset state
-        assert len(result.calls) == 0
-        assert parser._buffer == ""
-        assert parser.current_tool_id == -1
+        # Should still return the tool call.
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "invalid_tool"
+        assert result.calls[0].tool_index == 0
 
     def test_supports_structural_tag(self):
         """Test supports_structural_tag returns True."""
@@ -470,8 +473,9 @@ class BaseToolParserTestClass:
 
         result = parser.detect_and_parse(text, sample_tools)
 
-        # Should not return any calls for undefined function
-        assert len(result.calls) == 0
+        # Should return the tool call with tool_index=-1.
+        assert len(result.calls) == 1
+        assert result.calls[0].tool_index == -1
 
 
 class TestKimiK2ToolParser(BaseToolParserTestClass):
@@ -603,6 +607,14 @@ class TestKimiK2ToolParser(BaseToolParserTestClass):
         assert "get_weather" in info1.begin
         assert "search_web" in info2.begin
         assert info1.end == info2.end == "<|tool_call_end|><|tool_calls_section_end|>"
+
+    def test_undefined_tool(self, sample_tools, parser, tool_parser_test_cases):
+        """KimiK2 has custom detect_and_parse that filters undefined tools."""
+        text = tool_parser_test_cases.undefined_tool
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 0
 
     def test_kimi_k2_format_compliance(self, sample_tools, parser):
         """Test that KimiK2ToolParser follows the documented format structure."""

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -94,6 +94,17 @@ def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
         (f"a b {R1_END}", f"a b {R1_END}", "", {
             "enable_thinking": False
         }),
+        # force_nonempty_content swaps reasoning into content when content is
+        # empty (reasoning_at_start stays True, so parsing is unchanged).
+        ("a b", "a b", "", {
+            "force_nonempty_content": True
+        }),
+        (f"a {R1_END} b", " b", "a ", {
+            "force_nonempty_content": True
+        }),
+        (f"a b {R1_END}", "a b ", "", {
+            "force_nonempty_content": True
+        }),
     ])
 def test_nano_v3_reasoning_parser(text: str, content: str,
                                   reasoning_context: str,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Assistant messages now support reasoning content
  - Added optional reasoning_content field to chat messages for improved transparency

* **Improvements**
  - Enhanced tool parsing to explicitly surface undefined or invalid tool references, providing better visibility into tool call behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This commit fixes a couple of bugs and adds appropriate unit tests for them:

- the `reasoning` / `reasoning_content` was not being forwarded to the chat template.
- tool call parsers would filter out tool calls generated by the model whose names did not match any of those in the request.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
