### PR TITLE
[None][fix] Fix ValueError and missing decoding statistics for MTP

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -45,25 +45,28 @@ class MTPHiddenStatesManager(BaseResourceManager):
         self.hidden_size = hidden_size
         self.max_num_requests = max_num_requests
         self.use_relaxed_acceptance_for_thinking = config.use_relaxed_acceptance_for_thinking
-        self.slot_manager = SlotManager(max_num_requests)
+        # Reserve one extra slot for the CUDA graph padding dummy request,
+        # which is kept alive permanently and must not consume a real slot.
+        slot_pool_size = max_num_requests + 1
+        self.slot_manager = SlotManager(slot_pool_size)
         # Optional SA manager for MTP+SA mode
         self.sa_manager = sa_manager
 
         # Since golden token's hidden state will always be generated after target model
         self.mtp_past_hidden_states_pool = torch.zeros(
-            (max_num_requests, self.num_nextn_predict_layers, self.hidden_size),
+            (slot_pool_size, self.num_nextn_predict_layers, self.hidden_size),
             device='cuda',
             dtype=self.dtype,
         )
         self.mtp_past_tokens_pool = torch.zeros(
-            (max_num_requests, self.num_nextn_predict_layers),
+            (slot_pool_size, self.num_nextn_predict_layers),
             device='cuda',
             dtype=torch.int,
         )
         if self.use_relaxed_acceptance_for_thinking:
             # The relaxed_delta for relaxed acceptance
             self.mtp_relaxed_delta_pool = torch.zeros(
-                (self.max_num_requests),
+                (slot_pool_size),
                 dtype=torch.float,
                 device='cuda',
             )

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -778,7 +778,9 @@ class ReportUtility:
             spec_config = self.kwargs["speculative_config"]
             # Handle both dict (from YAML) and object types
             if isinstance(spec_config, dict):
-                return spec_config.get("max_draft_len") or 0
+                draft_len = (spec_config.get("max_draft_len")
+                             or spec_config.get("num_nextn_predict_layers"))
+                return draft_len or 0
             return spec_config.max_draft_len or 0
 
         return 0


### PR DESCRIPTION
## Description
This PR addressed below two issues for MTP:
1. there's a `ValueError: No free slots` when enable `use_relaxed_acceptance_for_thinking` or `use_sa_spec` for MTP with a max_batch_size > 1.
2. the speculative decoding statistics is missing in the log for MTP.



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed draft length calculation logic in benchmarking reports to use fallback values when primary metrics are unavailable.

* **Refactor**
  * Optimized resource allocation for speculative decoding operations to improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->