### PR TITLE
[https://nvbugs/5948539][fix] Fix disagg gen-only benchmark

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1636,25 +1636,30 @@ class PyExecutor:
             self._check_disagg_gen_transfer_status()
             self._check_kv_transfer_timeout()
 
-        # In gen-only benchmark mode with disaggregated serving, keep fetching
-        # until all real requests have arrived before adding ADP dummies.
-        # This ensures the benchmark starts with the exact number of real
-        # requests specified, since dummies only get added after this loop.
+        # In benchmark disagg mode, fetch requests in batches to avoid
+        # blocking the CTX→GEN KV cache pipeline. With ADP, fetch tp_size
+        # requests per batch (one per rank) for even distribution; without
+        # ADP, fetch 1 request per batch.
         if not self.is_warmup and self.benchmark_req_queues_size > 0 \
                 and self.kv_cache_transceiver \
                 and self.num_fetch_requests < self.benchmark_req_queues_size:
+            batch_size = min(
+                self.dist.tp_size if self.enable_attention_dp else 1,
+                self.benchmark_req_queues_size)
+            fill_target = min(self.num_fetch_requests + batch_size,
+                              self.benchmark_req_queues_size)
             if self.dist.rank == 0:
                 logger.info(f"Starting benchmark fill loop, "
                             f"num_fetch_requests={self.num_fetch_requests}/"
-                            f"{self.benchmark_req_queues_size}, "
+                            f"{fill_target}, "
                             f"len(active_requests)={len(self.active_requests)}")
-            while self.num_fetch_requests < self.benchmark_req_queues_size:
+            while self.num_fetch_requests < fill_target:
                 iter_requests = self._fetch_and_activate_new_requests()
                 if self.should_stop_processing:
                     return None, None
                 new_requests += iter_requests
                 self.hang_detector.checkpoint()
-                if self.num_fetch_requests < self.benchmark_req_queues_size:
+                if self.num_fetch_requests < fill_target:
                     time.sleep(1)
 
         iter_stats = None


### PR DESCRIPTION
@coderabbitai summary

## Description

The benchmark fill loop in `py_executor.py` blocked the GEN server until all `benchmark_req_queues_size` requests were fetched before processing any of them. In disagg `gen_only` mode, the CTX server did not have enough KV cache to send all requests at once — it needed the GEN server to fetch and process requests to free KV cache. This created a deadlock.

**Changes:**
- Replace the full fill loop with a batched version that fetches `tp_size` requests per iteration (with ADP) or 1 request per iteration (without ADP), allowing the GEN server to process requests incrementally and free KV cache for the CTX server

## Test Coverage

- Reproduced the hang on Lyris with DeepSeek-R1 GEN-DEP32 config (TP32, ISL 8192/OSL 1024, concurrency 1024)
- Verified the fix resolves the hang — benchmark completed successfully in ~737 seconds
- Verified even request distribution across ranks (32 requests per rank)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.