### PR TITLE
[TRTLLM-11288][feat] Configurable warmup shapes for VisualGen

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -205,7 +205,11 @@ class TeaCacheConfig(StrictBaseModel):
 
 
 class TorchCompileConfig(StrictBaseModel):
-    """Configuration for torch.compile and autotuning."""
+    """Configuration for torch.compile and autotuning.
+
+    Warmup shapes for torch.compile specialization are configured via
+    CompilationConfig (resolutions + num_frames), not here.
+    """
 
     enable_torch_compile: bool = True
     enable_fullgraph: bool = False
@@ -213,13 +217,17 @@ class TorchCompileConfig(StrictBaseModel):
 
 
 class CudaGraphConfig(StrictBaseModel):
-    """Configuration for CUDA graph capture/replay."""
+    """Configuration for CUDA graph capture/replay.
+
+    Warmup shapes for CUDA graph pre-capture are configured via
+    CompilationConfig (resolutions + num_frames), not here.
+    """
 
     enable_cuda_graph: bool = False
 
 
-class WarmupConfig(StrictBaseModel):
-    """Configuration for pipeline warmup at startup.
+class CompilationConfig(StrictBaseModel):
+    """Configuration for torch.compile / CUDA graph warmup shapes.
 
     Warmup shapes are the Cartesian product of ``resolutions`` and ``num_frames``.
     For example, 2 resolutions x 2 frame counts = 4 warmup shapes.
@@ -227,6 +235,10 @@ class WarmupConfig(StrictBaseModel):
     More warmup shapes = slower startup, but lower risk of torch.compile
     recompilation delays on first requests. Fewer shapes = faster startup,
     but first request with an un-warmed shape triggers recompilation.
+
+    Note: torch.compile has a cache size limit (cache_size_limit). Adding too
+    many warmup shapes may fill the compile cache. See TorchCompileConfig for
+    torch.compile-specific settings and CudaGraphConfig for CUDA graph settings.
     """
 
     resolutions: Optional[List[Tuple[int, int]]] = PydanticField(
@@ -328,7 +340,7 @@ class VisualGenArgs(StrictBaseModel):
 
     # Sub-configs (dict input for quant_config is coerced to QuantConfig in model_validator)
     quant_config: QuantConfig = PydanticField(default_factory=QuantConfig)
-    warmup: WarmupConfig = PydanticField(default_factory=WarmupConfig)
+    compilation: CompilationConfig = PydanticField(default_factory=CompilationConfig)
     torch_compile: TorchCompileConfig = PydanticField(default_factory=TorchCompileConfig)
     cuda_graph: CudaGraphConfig = PydanticField(default_factory=CudaGraphConfig)
     pipeline: PipelineConfig = PydanticField(default_factory=PipelineConfig)
@@ -463,7 +475,7 @@ class DiffusionModelConfig(BaseModel):
     quant_config: QuantConfig = PydanticField(default_factory=QuantConfig)
     # Per-layer quant (from load_diffusion_quant_config layer_quant_config; None until mixed-precision parsing exists)
     quant_config_dict: Optional[Dict[str, QuantConfig]] = None
-    warmup: WarmupConfig = PydanticField(default_factory=WarmupConfig)
+    compilation: CompilationConfig = PydanticField(default_factory=CompilationConfig)
     torch_compile: TorchCompileConfig = PydanticField(default_factory=TorchCompileConfig)
     cuda_graph: CudaGraphConfig = PydanticField(default_factory=CudaGraphConfig)
     pipeline: PipelineConfig = PydanticField(default_factory=PipelineConfig)
@@ -691,13 +703,13 @@ class DiffusionModelConfig(BaseModel):
         Args:
             checkpoint_dir: Path to checkpoint
             args: VisualGenArgs containing user config
-                - (warmup, torch_compile, cuda_graph, pipeline, attention, parallel, teacache)
+                - (compilation, torch_compile, cuda_graph, pipeline, attention, parallel, teacache)
             **kwargs: Additional config options (e.g., mapping)
         """
         kwargs.pop("trust_remote_code", None)
 
         # Extract sub-configs from args or use defaults
-        warmup_cfg = args.warmup if args else WarmupConfig()
+        compilation_cfg = args.compilation if args else CompilationConfig()
         torch_compile_cfg = args.torch_compile if args else TorchCompileConfig()
         cuda_graph_cfg = args.cuda_graph if args else CudaGraphConfig()
         pipeline_cfg = args.pipeline if args else PipelineConfig()
@@ -805,7 +817,7 @@ class DiffusionModelConfig(BaseModel):
             dynamic_weight_quant=dynamic_weight_quant,
             force_dynamic_quantization=dynamic_activation_quant,
             # Sub-configs from VisualGenArgs
-            warmup=warmup_cfg,
+            compilation=compilation_cfg,
             torch_compile=torch_compile_cfg,
             cuda_graph=cuda_graph_cfg,
             pipeline=pipeline_cfg,

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -218,6 +218,36 @@ class CudaGraphConfig(StrictBaseModel):
     enable_cuda_graph: bool = False
 
 
+class WarmupConfig(StrictBaseModel):
+    """Configuration for pipeline warmup at startup.
+
+    Warmup shapes are the Cartesian product of ``resolutions`` and ``num_frames``.
+    For example, 2 resolutions x 2 frame counts = 4 warmup shapes.
+
+    More warmup shapes = slower startup, but lower risk of torch.compile
+    recompilation delays on first requests. Fewer shapes = faster startup,
+    but first request with an un-warmed shape triggers recompilation.
+    """
+
+    resolutions: Optional[List[Tuple[int, int]]] = PydanticField(
+        default=None,
+        description=(
+            "List of (height, width) resolutions to warmup at startup. "
+            "Combined with num_frames via Cartesian product. "
+            "If None, uses model-specific defaults."
+        ),
+    )
+    num_frames: Optional[List[int]] = PydanticField(
+        default=None,
+        description=(
+            "List of frame counts to warmup at startup. "
+            "Combined with resolutions via Cartesian product. "
+            "If None, uses model-specific defaults. "
+            "For image models, use [1]."
+        ),
+    )
+
+
 class PipelineConfig(StrictBaseModel):
     """Model-specific pipeline configuration."""
 
@@ -298,6 +328,7 @@ class VisualGenArgs(StrictBaseModel):
 
     # Sub-configs (dict input for quant_config is coerced to QuantConfig in model_validator)
     quant_config: QuantConfig = PydanticField(default_factory=QuantConfig)
+    warmup: WarmupConfig = PydanticField(default_factory=WarmupConfig)
     torch_compile: TorchCompileConfig = PydanticField(default_factory=TorchCompileConfig)
     cuda_graph: CudaGraphConfig = PydanticField(default_factory=CudaGraphConfig)
     pipeline: PipelineConfig = PydanticField(default_factory=PipelineConfig)
@@ -432,6 +463,7 @@ class DiffusionModelConfig(BaseModel):
     quant_config: QuantConfig = PydanticField(default_factory=QuantConfig)
     # Per-layer quant (from load_diffusion_quant_config layer_quant_config; None until mixed-precision parsing exists)
     quant_config_dict: Optional[Dict[str, QuantConfig]] = None
+    warmup: WarmupConfig = PydanticField(default_factory=WarmupConfig)
     torch_compile: TorchCompileConfig = PydanticField(default_factory=TorchCompileConfig)
     cuda_graph: CudaGraphConfig = PydanticField(default_factory=CudaGraphConfig)
     pipeline: PipelineConfig = PydanticField(default_factory=PipelineConfig)
@@ -659,12 +691,13 @@ class DiffusionModelConfig(BaseModel):
         Args:
             checkpoint_dir: Path to checkpoint
             args: VisualGenArgs containing user config
-                - (torch_compile, cuda_graph, pipeline, attention, parallel, teacache)
+                - (warmup, torch_compile, cuda_graph, pipeline, attention, parallel, teacache)
             **kwargs: Additional config options (e.g., mapping)
         """
         kwargs.pop("trust_remote_code", None)
 
         # Extract sub-configs from args or use defaults
+        warmup_cfg = args.warmup if args else WarmupConfig()
         torch_compile_cfg = args.torch_compile if args else TorchCompileConfig()
         cuda_graph_cfg = args.cuda_graph if args else CudaGraphConfig()
         pipeline_cfg = args.pipeline if args else PipelineConfig()
@@ -772,6 +805,7 @@ class DiffusionModelConfig(BaseModel):
             dynamic_weight_quant=dynamic_weight_quant,
             force_dynamic_quantization=dynamic_activation_quant,
             # Sub-configs from VisualGenArgs
+            warmup=warmup_cfg,
             torch_compile=torch_compile_cfg,
             cuda_graph=cuda_graph_cfg,
             pipeline=pipeline_cfg,

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -235,10 +235,6 @@ class CompilationConfig(StrictBaseModel):
     More warmup shapes = slower startup, but lower risk of torch.compile
     recompilation delays on first requests. Fewer shapes = faster startup,
     but first request with an un-warmed shape triggers recompilation.
-
-    Note: torch.compile has a cache size limit (cache_size_limit). Adding too
-    many warmup shapes may fill the compile cache. See TorchCompileConfig for
-    torch.compile-specific settings and CudaGraphConfig for CUDA graph settings.
     """
 
     resolutions: Optional[List[Tuple[int, int]]] = PydanticField(

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -184,19 +184,20 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
-        self.pipeline.validate_shape(req.height, req.width, req.num_frames)
-
-        if (
-            self.pipeline._warmed_up_shapes
-            and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
-        ):
-            logger.warning(
-                f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
-                f"was not warmed up. First request will be slower due to "
-                f"torch.compile recompilation. "
-                f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
-            )
         try:
+            self.pipeline.validate_shape(req.height, req.width, req.num_frames)
+
+            if (
+                self.pipeline._warmed_up_shapes
+                and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
+            ):
+                logger.warning(
+                    f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
+                    f"was not warmed up. First request will be slower due to "
+                    f"torch.compile recompilation. "
+                    f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
+                )
+
             output = self.pipeline.infer(req)
             if self.rank == 0:
                 self.response_queue.put(DiffusionResponse(request_id=req.request_id, output=output))

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -184,20 +184,17 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
+        if (
+            self.pipeline._warmed_up_shapes
+            and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
+        ):
+            logger.warning(
+                f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
+                f"was not warmed up. First request will be slower due to "
+                f"torch.compile recompilation. "
+                f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
+            )
         try:
-            self.pipeline.validate_shape(req.height, req.width, req.num_frames)
-
-            if (
-                self.pipeline._warmed_up_shapes
-                and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
-            ):
-                logger.warning(
-                    f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
-                    f"was not warmed up. First request will be slower due to "
-                    f"torch.compile recompilation. "
-                    f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
-                )
-
             output = self.pipeline.infer(req)
             if self.rank == 0:
                 self.response_queue.put(DiffusionResponse(request_id=req.request_id, output=output))

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -189,9 +189,10 @@ class DiffusionExecutor:
             and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
         ):
             logger.warning(
-                f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
-                f"was not warmed up. First request will be slower due to "
-                f"torch.compile recompilation. "
+                f"Requested shape (height={req.height}, width={req.width}, "
+                f"num_frames={req.num_frames}) "
+                f"was not warmed up. First request with this shape will be slower due to "
+                f"torch.compile recompilation or CUDA graph capture."
                 f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
             )
         try:

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -184,15 +184,17 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
+        self.pipeline.validate_shape(req.height, req.width, req.num_frames)
+
         if (
-            self.pipeline.common_warmup_shapes
-            and (req.height, req.width, req.num_frames) not in self.pipeline.common_warmup_shapes
+            self.pipeline._warmed_up_shapes
+            and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
         ):
             logger.warning(
-                f"Requested shape (height={req.height}, width={req.width}, num_frames={req.num_frames}) "
-                f"was not warmed up. First request with this shape will be slower due to "
-                "torch.compile recompilation or CUDA graph capture."
-                f"Warmed-up shapes: {self.pipeline.common_warmup_shapes}"
+                f"Requested shape ({req.height}x{req.width}, {req.num_frames} frames) "
+                f"was not warmed up. First request will be slower due to "
+                f"torch.compile recompilation. "
+                f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
             )
         try:
             output = self.pipeline.infer(req)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -106,9 +106,6 @@ class FluxPipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
-    def is_valid_frame_count(self, num_frames):
-        return num_frames == 1
-
     def _init_transformer(self) -> None:
         """Initialize FLUX transformer with quantization support."""
         logger.info("Creating FLUX transformer with quantization support...")

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -99,29 +99,32 @@ class FluxPipeline(BasePipeline):
         return torch.device("cuda:0")
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes (height, width, num_frames)."""
-        return [(1024, 1024, 1)]
+    def default_warmup_resolutions(self):
+        return [(1024, 1024)]
+
+    @property
+    def default_warmup_num_frames(self):
+        return [1]
+
+    def is_valid_frame_count(self, num_frames):
+        return num_frames == 1
 
     def _init_transformer(self) -> None:
         """Initialize FLUX transformer with quantization support."""
         logger.info("Creating FLUX transformer with quantization support...")
         self.transformer = FluxTransformer2DModel(model_config=self.model_config)
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Run warmup inference to trigger torch.compile and CUDA init."""
-        for height, width, _ in self.common_warmup_shapes:
-            logger.info(f"Warmup: FLUX.1 {height}x{width}, {warmup_steps} steps")
-            with torch.no_grad():
-                self.forward(
-                    prompt="warmup",
-                    height=height,
-                    width=width,
-                    num_inference_steps=warmup_steps,
-                    guidance_scale=3.5,
-                    seed=0,
-                    max_sequence_length=512,
-                )
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        with torch.no_grad():
+            self.forward(
+                prompt="warmup",
+                height=height,
+                width=width,
+                num_inference_steps=steps,
+                guidance_scale=3.5,
+                seed=0,
+                max_sequence_length=512,
+            )
 
     def load_standard_components(
         self,

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -119,7 +119,7 @@ class FluxPipeline(BasePipeline):
                 width=width,
                 num_inference_steps=steps,
                 guidance_scale=3.5,
-                seed=0,
+                seed=42,
                 max_sequence_length=512,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -187,7 +187,7 @@ class Flux2Pipeline(BasePipeline):
                 width=width,
                 num_inference_steps=steps,
                 guidance_scale=3.5,
-                seed=0,
+                seed=42,
                 max_sequence_length=512,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -167,29 +167,32 @@ class Flux2Pipeline(BasePipeline):
         return torch.device("cuda:0")
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes (height, width, num_frames)."""
-        return [(1024, 1024, 1)]
+    def default_warmup_resolutions(self):
+        return [(1024, 1024)]
+
+    @property
+    def default_warmup_num_frames(self):
+        return [1]
+
+    def is_valid_frame_count(self, num_frames):
+        return num_frames == 1
 
     def _init_transformer(self) -> None:
         """Initialize FLUX.2 transformer with quantization support."""
         logger.info("Creating FLUX.2 transformer with quantization support...")
         self.transformer = Flux2Transformer2DModel(model_config=self.model_config)
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Run warmup inference to trigger torch.compile and CUDA init."""
-        for height, width, _ in self.common_warmup_shapes:
-            logger.info(f"Warmup: FLUX.2 {height}x{width}, {warmup_steps} steps")
-            with torch.no_grad():
-                self.forward(
-                    prompt="warmup",
-                    height=height,
-                    width=width,
-                    num_inference_steps=warmup_steps,
-                    guidance_scale=3.5,
-                    seed=0,
-                    max_sequence_length=512,
-                )
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        with torch.no_grad():
+            self.forward(
+                prompt="warmup",
+                height=height,
+                width=width,
+                num_inference_steps=steps,
+                guidance_scale=3.5,
+                seed=0,
+                max_sequence_length=512,
+            )
 
     def _detect_text_encoder_type(self, checkpoint_dir: str) -> str:
         """Detect text encoder class from model_index.json."""

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -174,9 +174,6 @@ class Flux2Pipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
-    def is_valid_frame_count(self, num_frames):
-        return num_frames == 1
-
     def _init_transformer(self) -> None:
         """Initialize FLUX.2 transformer with quantization support."""
         logger.info("Creating FLUX.2 transformer with quantization support...")

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -297,7 +297,7 @@ class WanPipeline(BasePipeline):
                 num_frames=num_frames,
                 num_inference_steps=steps,
                 guidance_scale=5.0,
-                seed=0,
+                seed=42,
                 max_sequence_length=512,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -147,9 +147,6 @@ class WanPipeline(BasePipeline):
             self.vae_scale_factor_spatial * patch_size[2],
         )
 
-    def is_valid_frame_count(self, num_frames):
-        return (num_frames - 1) % self.vae_scale_factor_temporal == 0
-
     def _init_transformer(self) -> None:
         logger.info("Creating WAN transformer with quantization support...")
         self.transformer = WanTransformer3DModel(model_config=self.model_config)
@@ -338,6 +335,8 @@ class WanPipeline(BasePipeline):
     ):
         pipeline_start = time.time()
         generator = torch.Generator(device=self.device).manual_seed(seed)
+
+        self.validate_resolution(height, width, num_frames)
 
         # Use user-provided boundary_ratio if given, otherwise fall back to model config
         boundary_ratio = boundary_ratio if boundary_ratio is not None else self.boundary_ratio

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -124,9 +124,31 @@ class WanPipeline(BasePipeline):
         return ["transformer"]
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes for the pipeline."""
-        return [(480, 832, 33), (480, 832, 81), (720, 1280, 81)]
+    def default_warmup_resolutions(self):
+        return [(480, 832), (720, 1280)]
+
+    @property
+    def default_warmup_num_frames(self):
+        return [33, 81]
+
+    @property
+    def default_warmup_steps(self):
+        return 4 if self.is_wan22 else 2
+
+    @property
+    def resolution_multiple_of(self):
+        patch_size = (
+            self.transformer.config.patch_size
+            if self.transformer is not None
+            else self.transformer_2.config.patch_size
+        )
+        return (
+            self.vae_scale_factor_spatial * patch_size[1],
+            self.vae_scale_factor_spatial * patch_size[2],
+        )
+
+    def is_valid_frame_count(self, num_frames):
+        return (num_frames - 1) % self.vae_scale_factor_temporal == 0
 
     def _init_transformer(self) -> None:
         logger.info("Creating WAN transformer with quantization support...")
@@ -268,31 +290,19 @@ class WanPipeline(BasePipeline):
             if hasattr(self.transformer_2, "post_load_weights"):
                 self.transformer_2.post_load_weights()
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Run warmup inference to trigger torch.compile and CUDA init.
-
-        Runs warmup inference with common shapes for Wan models.
-        """
-
-        if self.is_wan22:
-            # Double warmup steps to also warmup the 2nd transformer
-            warmup_steps = warmup_steps * 2
-
-        for height, width, num_frames in self.common_warmup_shapes:
-            logger.info(f"Warmup: Wan {height}x{width}, {num_frames} frames {warmup_steps} steps")
-
-            with torch.no_grad():
-                self.forward(
-                    prompt="warmup",
-                    negative_prompt="",
-                    height=height,
-                    width=width,
-                    num_frames=num_frames,
-                    num_inference_steps=warmup_steps,
-                    guidance_scale=5.0,
-                    seed=0,
-                    max_sequence_length=512,  # should match DiffusionRequest.max_sequence_length
-                )
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        with torch.no_grad():
+            self.forward(
+                prompt="warmup",
+                negative_prompt="",
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=steps,
+                guidance_scale=5.0,
+                seed=0,
+                max_sequence_length=512,
+            )
 
     def infer(self, req):
         """Run inference with request parameters."""

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -167,9 +167,6 @@ class WanImageToVideoPipeline(BasePipeline):
             self.vae_scale_factor_spatial * patch_size[2],
         )
 
-    def is_valid_frame_count(self, num_frames):
-        return (num_frames - 1) % self.vae_scale_factor_temporal == 0
-
     def _init_transformer(self) -> None:
         logger.info("Creating WAN I2V transformer with quantization support...")
         self.transformer = WanTransformer3DModel(model_config=self.model_config)
@@ -447,7 +444,17 @@ class WanImageToVideoPipeline(BasePipeline):
             )
             guidance_scale_2 = None
 
-        self.validate_shape(height, width, num_frames)
+        self.validate_resolution(height, width, num_frames)
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            logger.warning(
+                f"`num_frames - 1` must be divisible by {self.vae_scale_factor_temporal}. "
+                f"Rounding {num_frames} to nearest valid value."
+            )
+            num_frames = (
+                num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+            )
+        num_frames = max(num_frames, 1)
 
         # Encode Prompt
         logger.info("Encoding prompts...")

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -144,9 +144,31 @@ class WanImageToVideoPipeline(BasePipeline):
         return ["transformer"]
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes for the pipeline."""
-        return [(480, 832, 33), (480, 832, 81), (720, 1280, 81)]
+    def default_warmup_resolutions(self):
+        return [(480, 832), (720, 1280)]
+
+    @property
+    def default_warmup_num_frames(self):
+        return [33, 81]
+
+    @property
+    def default_warmup_steps(self):
+        return 4 if self.is_wan22 else 2
+
+    @property
+    def resolution_multiple_of(self):
+        patch_size = (
+            self.transformer.config.patch_size
+            if self.transformer is not None
+            else self.transformer_2.config.patch_size
+        )
+        return (
+            self.vae_scale_factor_spatial * patch_size[1],
+            self.vae_scale_factor_spatial * patch_size[2],
+        )
+
+    def is_valid_frame_count(self, num_frames):
+        return (num_frames - 1) % self.vae_scale_factor_temporal == 0
 
     def _init_transformer(self) -> None:
         logger.info("Creating WAN I2V transformer with quantization support...")
@@ -328,36 +350,21 @@ class WanImageToVideoPipeline(BasePipeline):
             if hasattr(self.transformer_2, "post_load_weights"):
                 self.transformer_2.post_load_weights()
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Run warmup inference to trigger torch.compile and CUDA init.
-
-        Runs warmup inference with common shapes for Wan I2V models.
-        Creates a dummy black image for the image conditioning input.
-        """
-
-        if self.is_wan22:
-            warmup_steps = warmup_steps * 2
-
-        for height, width, num_frames in self.common_warmup_shapes:
-            logger.info(
-                f"Warmup: Wan I2V {height}x{width}, {num_frames} frames {warmup_steps} steps"
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        dummy_image = PIL.Image.new("RGB", (width, height))
+        with torch.no_grad():
+            self.forward(
+                image=dummy_image,
+                prompt="warmup",
+                negative_prompt="",
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=steps,
+                guidance_scale=5.0,
+                seed=0,
+                max_sequence_length=512,
             )
-
-            dummy_image = PIL.Image.new("RGB", (width, height))
-
-            with torch.no_grad():
-                self.forward(
-                    image=dummy_image,
-                    prompt="warmup",
-                    negative_prompt="",
-                    height=height,
-                    width=width,
-                    num_frames=num_frames,
-                    num_inference_steps=warmup_steps,
-                    guidance_scale=5.0,
-                    seed=0,
-                    max_sequence_length=512,
-                )
 
     def infer(self, req):
         """Run inference with request parameters."""
@@ -440,33 +447,7 @@ class WanImageToVideoPipeline(BasePipeline):
             )
             guidance_scale_2 = None
 
-        # Validate and adjust frame count for VAE compatibility
-        if num_frames % self.vae_scale_factor_temporal != 1:
-            logger.warning(
-                f"`num_frames - 1` must be divisible by {self.vae_scale_factor_temporal}. "
-                f"Rounding {num_frames} to nearest valid value."
-            )
-            num_frames = (
-                num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
-            )
-        num_frames = max(num_frames, 1)
-
-        # Validate and adjust resolution for transformer patchification
-        patch_size = (
-            self.transformer.config.patch_size
-            if self.transformer is not None
-            else self.transformer_2.config.patch_size
-        )
-        h_multiple_of = self.vae_scale_factor_spatial * patch_size[1]
-        w_multiple_of = self.vae_scale_factor_spatial * patch_size[2]
-        calc_height = height // h_multiple_of * h_multiple_of
-        calc_width = width // w_multiple_of * w_multiple_of
-        if height != calc_height or width != calc_width:
-            logger.warning(
-                f"Height and width must be multiples of ({h_multiple_of}, {w_multiple_of}) for patchification. "
-                f"Adjusting ({height}, {width}) -> ({calc_height}, {calc_width})."
-            )
-            height, width = calc_height, calc_width
+        self.validate_shape(height, width, num_frames)
 
         # Encode Prompt
         logger.info("Encoding prompts...")

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -359,7 +359,7 @@ class WanImageToVideoPipeline(BasePipeline):
                 num_frames=num_frames,
                 num_inference_steps=steps,
                 guidance_scale=5.0,
-                seed=0,
+                seed=42,
                 max_sequence_length=512,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -195,7 +195,7 @@ class BasePipeline(nn.Module):
         return valid_shapes, self.default_warmup_steps
 
     @property
-    def vae_adapter_class(self) -> Type[BaseParallelVAEAdapter] | None:
+    def vae_adapter_class(self) -> Type[ParallelVAEFactory] | None:
         """Return the VAE adapter class for the pipeline."""
         return None
 

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -135,6 +135,11 @@ class BasePipeline(nn.Module):
 
     def validate_shape(self, height: int, width: int, num_frames: int) -> None:
         """Validate shape against model constraints. Raises ValueError."""
+        if height <= 0 or width <= 0 or num_frames <= 0:
+            raise ValueError(
+                f"Dimensions must be positive: height={height}, width={width}, "
+                f"num_frames={num_frames} for {self.__class__.__name__}."
+            )
         h_mul, w_mul = self.resolution_multiple_of
         if h_mul > 1 or w_mul > 1:
             if height % h_mul != 0 or width % w_mul != 0:

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -1,6 +1,7 @@
+import itertools
 import os
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type
 
 import torch
 import torch.distributed as dist
@@ -24,8 +25,6 @@ class BasePipeline(nn.Module):
     Base class for diffusion pipelines.
     """
 
-    warmup_steps: int = 2
-
     def __init__(self, model_config: "DiffusionModelConfig"):
         super().__init__()
         self.model_config = model_config
@@ -33,6 +32,7 @@ class BasePipeline(nn.Module):
         self.mapping: Mapping = getattr(model_config, "mapping", None) or Mapping()
         self._cuda_graph_runners: Dict[str, CUDAGraphRunner] = {}
         self._parallel_vae_enabled: bool = False
+        self._warmed_up_shapes: Set[Tuple[int, int, int]] = set()
 
         # Components
         self.transformer: Optional[nn.Module] = None
@@ -102,12 +102,92 @@ class BasePipeline(nn.Module):
         return [PipelineComponent.TRANSFORMER] if self.transformer is not None else []
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes for the pipeline.
-        Should be in format of (height, width, num_frames)
-        Override this property and use in self._run_warmup() for model-specific warmup.
+    def default_warmup_resolutions(self) -> List[Tuple[int, int]]:
+        """Model-specific default warmup resolutions (height, width).
+
+        Subclasses should override. Combined with default_warmup_num_frames
+        via Cartesian product to produce warmup shapes.
         """
         return []
+
+    @property
+    def default_warmup_num_frames(self) -> List[int]:
+        """Model-specific default warmup frame counts.
+
+        Subclasses should override. Combined with default_warmup_resolutions
+        via Cartesian product to produce warmup shapes.
+        """
+        return []
+
+    @property
+    def default_warmup_steps(self) -> int:
+        """Model-specific default denoising steps for warmup. Subclass override."""
+        return 2
+
+    @property
+    def resolution_multiple_of(self) -> Tuple[int, int]:
+        """(h_multiple, w_multiple) resolution constraint. Subclass override."""
+        return (1, 1)
+
+    def is_valid_frame_count(self, num_frames: int) -> bool:
+        """Check if frame count is valid for this model. Subclass override."""
+        return True
+
+    def validate_shape(self, height: int, width: int, num_frames: int) -> None:
+        """Validate shape against model constraints. Raises ValueError."""
+        h_mul, w_mul = self.resolution_multiple_of
+        if h_mul > 1 or w_mul > 1:
+            if height % h_mul != 0 or width % w_mul != 0:
+                raise ValueError(
+                    f"Resolution ({height}x{width}) must be multiples of "
+                    f"({h_mul}x{w_mul}) for {self.__class__.__name__}."
+                )
+        if not self.is_valid_frame_count(num_frames):
+            raise ValueError(f"Invalid num_frames={num_frames} for {self.__class__.__name__}.")
+
+    def resolve_warmup_plan(self) -> Tuple[List[Tuple[int, int, int]], int]:
+        """Resolve warmup shapes and steps from config or model defaults.
+
+        Shapes are the Cartesian product of resolutions x num_frames.
+
+        Priority:
+            1. User-specified: model_config.warmup.resolutions / num_frames
+            2. Model defaults: default_warmup_resolutions / default_warmup_num_frames
+            3. Empty: skip warmup
+
+        Steps: always from model subclass (default_warmup_steps).
+
+        Returns:
+            (shapes, steps) tuple where shapes = list of (h, w, f)
+        """
+        warmup_cfg = self.model_config.warmup
+
+        if warmup_cfg.resolutions is not None or warmup_cfg.num_frames is not None:
+            resolutions = (
+                warmup_cfg.resolutions
+                if warmup_cfg.resolutions is not None
+                else self.default_warmup_resolutions
+            )
+            num_frames_list = (
+                warmup_cfg.num_frames
+                if warmup_cfg.num_frames is not None
+                else self.default_warmup_num_frames
+            )
+        else:
+            resolutions = self.default_warmup_resolutions
+            num_frames_list = self.default_warmup_num_frames
+
+        shapes = [(h, w, f) for (h, w), f in itertools.product(resolutions, num_frames_list)]
+
+        for h, w, f in shapes:
+            self.validate_shape(h, w, f)
+
+        return shapes, self.default_warmup_steps
+
+    @property
+    def vae_adapter_class(self) -> Type[BaseParallelVAEAdapter] | None:
+        """Return the VAE adapter class for the pipeline."""
+        return None
 
     def infer(self, req: Any):
         raise NotImplementedError
@@ -320,43 +400,48 @@ class BasePipeline(nn.Module):
     def warmup(self) -> None:
         """Run warmup inference to trigger torch.compile and CUDA initialization.
 
-        Runs a short denoising loop with dummy inputs. This:
+        Resolves warmup shapes from user config or model defaults, then runs
+        a short denoising loop with dummy inputs for each shape. This:
         1. Triggers torch.compile's lazy compilation (first forward trace + codegen)
-        2. Warms up CUDA kernels and allocators
-        3. Populates any lazy caches (e.g., RoPE frequencies)
+        2. Pre-captures CUDA graphs (if enabled)
+        3. Warms up CUDA kernels and allocators
+        4. Populates any lazy caches (e.g., RoPE frequencies)
 
         Called automatically by PipelineLoader after model loading and torch.compile.
+        OOM is not caught — if a warmup shape OOMs, the server fails fast at startup.
         """
-        warmup_steps = self.warmup_steps
-        if warmup_steps <= 0:
-            logger.info("Warmup disabled (warmup_steps=0)")
+        shapes, steps = self.resolve_warmup_plan()
+        if not shapes:
+            logger.info("Warmup disabled (no warmup shapes)")
             return
 
         logger.info(
-            f"Running warmup for {self.__class__.__name__} with {self.common_warmup_shapes} shapes "
-            f"and {warmup_steps} steps..."
+            f"Running warmup for {self.__class__.__name__} "
+            f"with {len(shapes)} shapes and {steps} steps..."
         )
         warmup_start = time.time()
 
-        self._run_warmup(warmup_steps)
+        for height, width, num_frames in shapes:
+            logger.info(f"Warmup: {height}x{width}, {num_frames} frames, {steps} steps")
+            self._run_warmup(height, width, num_frames, steps)
+            torch.cuda.synchronize()
 
-        torch.cuda.synchronize()
+        self._warmed_up_shapes = set(tuple(s) for s in shapes)
         elapsed = time.time() - warmup_start
         logger.info(f"Warmup completed in {elapsed:.2f}s")
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Execute warmup forward passes. Subclasses should override for model-specific warmup.
-
-        Default implementation runs the transformer forward with dummy tensors matching
-        typical input shapes. Subclasses can override to run the full pipeline with
-        reduced steps for more thorough warmup.
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        """Run warmup for a single shape. Subclasses must override.
 
         Args:
-            warmup_steps: Number of denoising steps to run
+            height: Video/image height in pixels
+            width: Video/image width in pixels
+            num_frames: Number of frames (1 for image models)
+            steps: Number of denoising steps
         """
         logger.warning(
             f"{self.__class__.__name__} does not implement _run_warmup(); "
-            "skipping warmup. Override _run_warmup() for model-specific warmup."
+            "skipping warmup for this shape."
         )
 
     def decode_latents(

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -156,7 +156,7 @@ class BasePipeline(nn.Module):
         Shapes are the Cartesian product of resolutions x num_frames.
 
         Priority:
-            1. User-specified: model_config.warmup.resolutions / num_frames
+            1. User-specified: model_config.compilation.resolutions / num_frames
             2. Model defaults: default_warmup_resolutions / default_warmup_num_frames
             3. Empty: skip warmup
 
@@ -165,7 +165,7 @@ class BasePipeline(nn.Module):
         Returns:
             (shapes, steps) tuple where shapes = list of (h, w, f)
         """
-        warmup_cfg = self.model_config.warmup
+        warmup_cfg = self.model_config.compilation
 
         if warmup_cfg.resolutions is not None or warmup_cfg.num_frames is not None:
             resolutions = (
@@ -182,12 +182,17 @@ class BasePipeline(nn.Module):
             resolutions = self.default_warmup_resolutions
             num_frames_list = self.default_warmup_num_frames
 
-        shapes = [(h, w, f) for (h, w), f in itertools.product(resolutions, num_frames_list)]
+        all_shapes = [(h, w, f) for (h, w), f in itertools.product(resolutions, num_frames_list)]
 
-        for h, w, f in shapes:
-            self.validate_shape(h, w, f)
+        valid_shapes = []
+        for h, w, f in all_shapes:
+            try:
+                self.validate_shape(h, w, f)
+                valid_shapes.append((h, w, f))
+            except ValueError as e:
+                logger.warning(f"Skipping invalid warmup shape ({h}x{w}, {f} frames): {e}")
 
-        return shapes, self.default_warmup_steps
+        return valid_shapes, self.default_warmup_steps
 
     @property
     def vae_adapter_class(self) -> Type[BaseParallelVAEAdapter] | None:

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -129,12 +129,14 @@ class BasePipeline(nn.Module):
         """(h_multiple, w_multiple) resolution constraint. Subclass override."""
         return (1, 1)
 
-    def is_valid_frame_count(self, num_frames: int) -> bool:
-        """Check if frame count is valid for this model. Subclass override."""
-        return True
+    def validate_resolution(self, height: int, width: int, num_frames: int) -> None:
+        """Validate resolution against model constraints. Raises ValueError.
 
-    def validate_shape(self, height: int, width: int, num_frames: int) -> None:
-        """Validate shape against model constraints. Raises ValueError."""
+        Only checks resolution constraints (must be positive and divisible by
+        model-specific multiples). Frame count is NOT validated here — following
+        HuggingFace diffusers convention, invalid frame counts are silently
+        rounded in forward() instead of rejected.
+        """
         if height <= 0 or width <= 0 or num_frames <= 0:
             raise ValueError(
                 f"Dimensions must be positive: height={height}, width={width}, "
@@ -147,8 +149,6 @@ class BasePipeline(nn.Module):
                     f"Resolution ({height}x{width}) must be multiples of "
                     f"({h_mul}x{w_mul}) for {self.__class__.__name__}."
                 )
-        if not self.is_valid_frame_count(num_frames):
-            raise ValueError(f"Invalid num_frames={num_frames} for {self.__class__.__name__}.")
 
     def resolve_warmup_plan(self) -> Tuple[List[Tuple[int, int, int]], int]:
         """Resolve warmup shapes and steps from config or model defaults.
@@ -187,7 +187,7 @@ class BasePipeline(nn.Module):
         valid_shapes = []
         for h, w, f in all_shapes:
             try:
-                self.validate_shape(h, w, f)
+                self.validate_resolution(h, w, f)
                 valid_shapes.append((h, w, f))
             except ValueError as e:
                 logger.warning(f"Skipping invalid warmup shape ({h}x{w}, {f} frames): {e}")

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -16,6 +16,7 @@ from tensorrt_llm._torch.visual_gen.config import (
     TeaCacheConfig,
     TorchCompileConfig,
     VisualGenArgs,
+    WarmupConfig,
 )
 
 
@@ -52,6 +53,10 @@ class TestVisualGenArgsStrictValidation:
     def test_nested_cuda_graph_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             CudaGraphConfig(enable_cuda_graph=False, extra=True)
+
+    def test_nested_warmup_unknown_field_rejected(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            WarmupConfig(resolutions=[(480, 832)], bad_field=True)
 
     def test_nested_pipeline_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -10,13 +10,13 @@ from pydantic import ValidationError
 
 from tensorrt_llm._torch.visual_gen.config import (
     AttentionConfig,
+    CompilationConfig,
     CudaGraphConfig,
     ParallelConfig,
     PipelineConfig,
     TeaCacheConfig,
     TorchCompileConfig,
     VisualGenArgs,
-    WarmupConfig,
 )
 
 
@@ -56,7 +56,7 @@ class TestVisualGenArgsStrictValidation:
 
     def test_nested_warmup_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-            WarmupConfig(resolutions=[(480, 832)], bad_field=True)
+            CompilationConfig(resolutions=[(480, 832)], bad_field=True)
 
     def test_nested_pipeline_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):

--- a/tests/unittest/_torch/visual_gen/test_warmup.py
+++ b/tests/unittest/_torch/visual_gen/test_warmup.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for VisualGen warmup configuration, plan resolution, and shape validation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from tensorrt_llm._torch.visual_gen.config import VisualGenArgs, WarmupConfig
+from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
+
+
+class TestWarmupConfig:
+    """WarmupConfig construction and validation."""
+
+    def test_default_values(self):
+        cfg = WarmupConfig()
+        assert cfg.resolutions is None
+        assert cfg.num_frames is None
+
+    def test_explicit_values(self):
+        cfg = WarmupConfig(
+            resolutions=[(480, 832), (720, 1280)],
+            num_frames=[33, 81],
+        )
+        assert len(cfg.resolutions) == 2
+        assert cfg.num_frames == [33, 81]
+
+    def test_empty_lists(self):
+        cfg = WarmupConfig(resolutions=[], num_frames=[])
+        assert cfg.resolutions == []
+        assert cfg.num_frames == []
+
+    def test_partial_resolutions_only(self):
+        cfg = WarmupConfig(resolutions=[(1920, 1080)])
+        assert cfg.resolutions == [(1920, 1080)]
+        assert cfg.num_frames is None
+
+    def test_partial_num_frames_only(self):
+        cfg = WarmupConfig(num_frames=[81])
+        assert cfg.resolutions is None
+        assert cfg.num_frames == [81]
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            WarmupConfig(resolutions=[(480, 832)], bad_field=True)
+
+
+class TestVisualGenArgsWarmup:
+    """WarmupConfig integration with VisualGenArgs."""
+
+    def test_default_warmup(self):
+        args = VisualGenArgs(checkpoint_path="/tmp/model")
+        assert isinstance(args.warmup, WarmupConfig)
+        assert args.warmup.resolutions is None
+        assert args.warmup.num_frames is None
+
+    def test_warmup_from_dict(self):
+        args = VisualGenArgs(
+            checkpoint_path="/tmp/model",
+            warmup={"resolutions": [(480, 832)], "num_frames": [33, 81]},
+        )
+        assert args.warmup.resolutions == [(480, 832)]
+        assert args.warmup.num_frames == [33, 81]
+
+    def test_warmup_from_yaml(self, tmp_path):
+        yaml_path = tmp_path / "config.yml"
+        yaml_path.write_text(
+            "checkpoint_path: /tmp/model\n"
+            "warmup:\n"
+            "  resolutions:\n"
+            "    - [480, 832]\n"
+            "    - [720, 1280]\n"
+            "  num_frames: [33, 81]\n"
+        )
+        args = VisualGenArgs.from_yaml(yaml_path)
+        assert len(args.warmup.resolutions) == 2
+        assert args.warmup.num_frames == [33, 81]
+
+    def test_warmup_pickle_roundtrip(self):
+        import pickle
+
+        args = VisualGenArgs(
+            checkpoint_path="/tmp/model",
+            warmup=WarmupConfig(resolutions=[(480, 832)], num_frames=[33]),
+        )
+        restored = pickle.loads(pickle.dumps(args))
+        assert restored.warmup.resolutions == [(480, 832)]
+        assert restored.warmup.num_frames == [33]
+
+
+# ---------------------------------------------------------------------------
+# Stub pipelines for testing resolve_warmup_plan() and validate_shape()
+# without loading a real model.
+# ---------------------------------------------------------------------------
+
+
+class _BaseStubPipeline(BasePipeline):
+    """Minimal stub that skips real __init__ (no DiffusionModelConfig needed)."""
+
+    def __init__(self, warmup_cfg):
+        self._warmed_up_shapes = set()
+        self.model_config = MagicMock()
+        self.model_config.warmup = warmup_cfg or WarmupConfig()
+
+    def forward(self, *args, **kwargs):
+        pass
+
+    def _init_transformer(self):
+        pass
+
+    def infer(self, req):
+        pass
+
+    def _run_warmup(self, height, width, num_frames, steps):
+        pass
+
+
+def _make_stub_pipeline(warmup_cfg=None):
+    """Wan-like stub: resolution must be multiple of 16, (num_frames-1) % 4 == 0."""
+
+    class WanStub(_BaseStubPipeline):
+        @property
+        def default_warmup_resolutions(self):
+            return [(480, 832), (720, 1280)]
+
+        @property
+        def default_warmup_num_frames(self):
+            return [33, 81]
+
+        @property
+        def resolution_multiple_of(self):
+            return (16, 16)
+
+        def is_valid_frame_count(self, num_frames):
+            return (num_frames - 1) % 4 == 0
+
+    return WanStub(warmup_cfg)
+
+
+def _make_flux_stub_pipeline(warmup_cfg=None):
+    """Flux-like stub: image only, num_frames must be 1."""
+
+    class FluxStub(_BaseStubPipeline):
+        @property
+        def default_warmup_resolutions(self):
+            return [(1024, 1024)]
+
+        @property
+        def default_warmup_num_frames(self):
+            return [1]
+
+        def is_valid_frame_count(self, num_frames):
+            return num_frames == 1
+
+    return FluxStub(warmup_cfg)
+
+
+class TestResolveWarmupPlan:
+    """resolve_warmup_plan() Cartesian product and priority logic."""
+
+    def test_default_no_user_config(self):
+        """No user config → model defaults → Cartesian product."""
+        pipe = _make_stub_pipeline()
+        shapes, steps = pipe.resolve_warmup_plan()
+        assert steps == 2
+        assert len(shapes) == 4  # 2 resolutions x 2 frame counts
+        assert (480, 832, 33) in shapes
+        assert (480, 832, 81) in shapes
+        assert (720, 1280, 33) in shapes
+        assert (720, 1280, 81) in shapes
+
+    def test_user_resolutions_only(self):
+        """User specifies resolutions, num_frames from model default."""
+        cfg = WarmupConfig(resolutions=[(1920, 1088)])
+        pipe = _make_stub_pipeline(cfg)
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert len(shapes) == 2  # 1 resolution x 2 default frame counts
+        assert (1920, 1088, 33) in shapes
+        assert (1920, 1088, 81) in shapes
+
+    def test_user_num_frames_only(self):
+        """User specifies num_frames, resolutions from model default."""
+        cfg = WarmupConfig(num_frames=[81])
+        pipe = _make_stub_pipeline(cfg)
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert len(shapes) == 2  # 2 default resolutions x 1 frame count
+        assert (480, 832, 81) in shapes
+        assert (720, 1280, 81) in shapes
+
+    def test_user_both(self):
+        """User specifies both → user values Cartesian product."""
+        cfg = WarmupConfig(
+            resolutions=[(256, 256)],
+            num_frames=[5],
+        )
+        pipe = _make_stub_pipeline(cfg)
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert shapes == [(256, 256, 5)]
+
+    def test_empty_resolutions_skips_warmup(self):
+        """Empty resolutions → no shapes → warmup skipped."""
+        cfg = WarmupConfig(resolutions=[], num_frames=[33])
+        pipe = _make_stub_pipeline(cfg)
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert shapes == []
+
+    def test_empty_num_frames_skips_warmup(self):
+        """Empty num_frames → no shapes → warmup skipped."""
+        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[])
+        pipe = _make_stub_pipeline(cfg)
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert shapes == []
+
+    def test_invalid_user_resolution_raises(self):
+        """User resolution not multiple of 16 → validate_shape raises."""
+        cfg = WarmupConfig(resolutions=[(481, 832)])
+        pipe = _make_stub_pipeline(cfg)
+        with pytest.raises(ValueError, match="must be multiples of"):
+            pipe.resolve_warmup_plan()
+
+    def test_invalid_user_num_frames_raises(self):
+        """User num_frames not valid → validate_shape raises."""
+        cfg = WarmupConfig(num_frames=[30])  # (30-1)%4 != 0
+        pipe = _make_stub_pipeline(cfg)
+        with pytest.raises(ValueError, match="Invalid num_frames"):
+            pipe.resolve_warmup_plan()
+
+    def test_flux_default(self):
+        """Flux default: 1 resolution x 1 frame = 1 shape."""
+        pipe = _make_flux_stub_pipeline()
+        shapes, steps = pipe.resolve_warmup_plan()
+        assert shapes == [(1024, 1024, 1)]
+        assert steps == 2
+
+    def test_flux_rejects_video_frames(self):
+        """Flux: num_frames != 1 → raises."""
+        cfg = WarmupConfig(num_frames=[81])
+        pipe = _make_flux_stub_pipeline(cfg)
+        with pytest.raises(ValueError, match="Invalid num_frames"):
+            pipe.resolve_warmup_plan()
+
+
+class TestValidateShape:
+    """validate_shape() model constraint checks."""
+
+    def test_valid_wan_shape(self):
+        pipe = _make_stub_pipeline()
+        pipe.validate_shape(480, 832, 33)
+        pipe.validate_shape(720, 1280, 81)
+
+    def test_invalid_resolution_height(self):
+        pipe = _make_stub_pipeline()
+        with pytest.raises(ValueError, match="must be multiples of"):
+            pipe.validate_shape(481, 832, 33)
+
+    def test_invalid_resolution_width(self):
+        pipe = _make_stub_pipeline()
+        with pytest.raises(ValueError, match="must be multiples of"):
+            pipe.validate_shape(480, 833, 33)
+
+    def test_invalid_frame_count(self):
+        pipe = _make_stub_pipeline()
+        with pytest.raises(ValueError, match="Invalid num_frames"):
+            pipe.validate_shape(480, 832, 30)
+
+    def test_valid_frame_count_edge_cases(self):
+        pipe = _make_stub_pipeline()
+        pipe.validate_shape(480, 832, 1)  # (1-1)%4 == 0
+        pipe.validate_shape(480, 832, 5)  # (5-1)%4 == 0
+        pipe.validate_shape(480, 832, 9)  # (9-1)%4 == 0
+
+    def test_flux_valid_single_frame(self):
+        pipe = _make_flux_stub_pipeline()
+        pipe.validate_shape(1024, 1024, 1)
+
+    def test_flux_rejects_multi_frame(self):
+        pipe = _make_flux_stub_pipeline()
+        with pytest.raises(ValueError, match="Invalid num_frames"):
+            pipe.validate_shape(1024, 1024, 2)
+
+
+class TestWarmupExecution:
+    """warmup() integration: shapes recorded in _warmed_up_shapes."""
+
+    def test_warmup_records_shapes(self):
+        pipe = _make_stub_pipeline()
+        pipe.warmup()
+        assert len(pipe._warmed_up_shapes) == 4
+        assert (480, 832, 33) in pipe._warmed_up_shapes
+        assert (720, 1280, 81) in pipe._warmed_up_shapes
+
+    def test_warmup_empty_shapes_skips(self):
+        cfg = WarmupConfig(resolutions=[], num_frames=[])
+        pipe = _make_stub_pipeline(cfg)
+        pipe.warmup()
+        assert pipe._warmed_up_shapes == set()
+
+    def test_warmup_user_shapes_recorded(self):
+        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[33])
+        pipe = _make_stub_pipeline(cfg)
+        pipe.warmup()
+        assert pipe._warmed_up_shapes == {(480, 832, 33)}
+
+
+class TestRequestValidation:
+    """Request-level validation: validate_shape() + _warmed_up_shapes check."""
+
+    def test_valid_warmed_shape_no_warning(self, caplog):
+        """Request with a warmed-up shape → no warning."""
+        pipe = _make_stub_pipeline()
+        pipe.warmup()
+
+        req = MagicMock()
+        req.height, req.width, req.num_frames = 480, 832, 33
+
+        pipe.validate_shape(req.height, req.width, req.num_frames)
+        shape = (req.height, req.width, req.num_frames)
+        assert shape in pipe._warmed_up_shapes
+
+    def test_valid_unwarmed_shape_warns(self):
+        """Request with valid but un-warmed shape → pipeline accepts but would warn."""
+        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[33])
+        pipe = _make_stub_pipeline(cfg)
+        pipe.warmup()
+
+        pipe.validate_shape(720, 1280, 81)
+        assert (720, 1280, 81) not in pipe._warmed_up_shapes
+
+    def test_invalid_shape_raises_before_warmup_check(self):
+        """Invalid shape → raises ValueError, never reaches warmup check."""
+        pipe = _make_stub_pipeline()
+        pipe.warmup()
+
+        with pytest.raises(ValueError, match="must be multiples of"):
+            pipe.validate_shape(481, 832, 33)

--- a/tests/unittest/_torch/visual_gen/test_warmup.py
+++ b/tests/unittest/_torch/visual_gen/test_warmup.py
@@ -92,7 +92,7 @@ class TestVisualGenArgsWarmup:
 
 
 # ---------------------------------------------------------------------------
-# Stub pipelines for testing resolve_warmup_plan() and validate_shape()
+# Stub pipelines for testing resolve_warmup_plan() and validate_resolution()
 # without loading a real model.
 # ---------------------------------------------------------------------------
 
@@ -134,9 +134,6 @@ def _make_stub_pipeline(warmup_cfg=None):
         def resolution_multiple_of(self):
             return (16, 16)
 
-        def is_valid_frame_count(self, num_frames):
-            return (num_frames - 1) % 4 == 0
-
     return WanStub(warmup_cfg)
 
 
@@ -151,9 +148,6 @@ def _make_flux_stub_pipeline(warmup_cfg=None):
         @property
         def default_warmup_num_frames(self):
             return [1]
-
-        def is_valid_frame_count(self, num_frames):
-            return num_frames == 1
 
     return FluxStub(warmup_cfg)
 
@@ -222,12 +216,12 @@ class TestResolveWarmupPlan:
         assert (481, 832, 33) not in shapes
         assert (481, 832, 81) not in shapes
 
-    def test_invalid_user_num_frames_skipped(self):
-        """User num_frames not valid → warning, shape skipped."""
-        cfg = CompilationConfig(num_frames=[30])  # (30-1)%4 != 0
+    def test_any_user_num_frames_accepted(self):
+        """Any num_frames accepted in warmup (rounded in forward)."""
+        cfg = CompilationConfig(num_frames=[30])
         pipe = _make_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
-        assert len(shapes) == 0
+        assert len(shapes) == 2  # 2 resolutions x 1 frame count
 
     def test_flux_default(self):
         """Flux default: 1 resolution x 1 frame = 1 shape."""
@@ -236,51 +230,38 @@ class TestResolveWarmupPlan:
         assert shapes == [(1024, 1024, 1)]
         assert steps == 2
 
-    def test_flux_skips_video_frames(self):
-        """Flux: num_frames != 1 → warning, shape skipped."""
+    def test_flux_any_num_frames_accepted(self):
+        """Flux: any num_frames accepted in warmup (no frame validation)."""
         cfg = CompilationConfig(num_frames=[81])
         pipe = _make_flux_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
-        assert len(shapes) == 0
+        assert len(shapes) == 1  # 1 resolution x 1 frame count
 
 
 class TestValidateShape:
-    """validate_shape() model constraint checks."""
+    """validate_resolution() model constraint checks."""
 
     def test_valid_wan_shape(self):
         pipe = _make_stub_pipeline()
-        pipe.validate_shape(480, 832, 33)
-        pipe.validate_shape(720, 1280, 81)
+        pipe.validate_resolution(480, 832, 33)
+        pipe.validate_resolution(720, 1280, 81)
 
     def test_invalid_resolution_height(self):
         pipe = _make_stub_pipeline()
         with pytest.raises(ValueError, match="must be multiples of"):
-            pipe.validate_shape(481, 832, 33)
+            pipe.validate_resolution(481, 832, 33)
 
     def test_invalid_resolution_width(self):
         pipe = _make_stub_pipeline()
         with pytest.raises(ValueError, match="must be multiples of"):
-            pipe.validate_shape(480, 833, 33)
+            pipe.validate_resolution(480, 833, 33)
 
-    def test_invalid_frame_count(self):
+    def test_any_frame_count_accepted(self):
+        """validate_resolution does not check frame counts (silently rounded in forward)."""
         pipe = _make_stub_pipeline()
-        with pytest.raises(ValueError, match="Invalid num_frames"):
-            pipe.validate_shape(480, 832, 30)
-
-    def test_valid_frame_count_edge_cases(self):
-        pipe = _make_stub_pipeline()
-        pipe.validate_shape(480, 832, 1)  # (1-1)%4 == 0
-        pipe.validate_shape(480, 832, 5)  # (5-1)%4 == 0
-        pipe.validate_shape(480, 832, 9)  # (9-1)%4 == 0
-
-    def test_flux_valid_single_frame(self):
-        pipe = _make_flux_stub_pipeline()
-        pipe.validate_shape(1024, 1024, 1)
-
-    def test_flux_rejects_multi_frame(self):
-        pipe = _make_flux_stub_pipeline()
-        with pytest.raises(ValueError, match="Invalid num_frames"):
-            pipe.validate_shape(1024, 1024, 2)
+        pipe.validate_resolution(480, 832, 30)
+        pipe.validate_resolution(480, 832, 1)
+        pipe.validate_resolution(480, 832, 8)
 
 
 class TestWarmupExecution:
@@ -307,7 +288,7 @@ class TestWarmupExecution:
 
 
 class TestRequestValidation:
-    """Request-level validation: validate_shape() + _warmed_up_shapes check."""
+    """Request-level validation: validate_resolution() + _warmed_up_shapes check."""
 
     def test_valid_warmed_shape_no_warning(self, caplog):
         """Request with a warmed-up shape → no warning."""
@@ -317,7 +298,7 @@ class TestRequestValidation:
         req = MagicMock()
         req.height, req.width, req.num_frames = 480, 832, 33
 
-        pipe.validate_shape(req.height, req.width, req.num_frames)
+        pipe.validate_resolution(req.height, req.width, req.num_frames)
         shape = (req.height, req.width, req.num_frames)
         assert shape in pipe._warmed_up_shapes
 
@@ -327,7 +308,7 @@ class TestRequestValidation:
         pipe = _make_stub_pipeline(cfg)
         pipe.warmup()
 
-        pipe.validate_shape(720, 1280, 81)
+        pipe.validate_resolution(720, 1280, 81)
         assert (720, 1280, 81) not in pipe._warmed_up_shapes
 
     def test_invalid_shape_raises_before_warmup_check(self):
@@ -336,4 +317,4 @@ class TestRequestValidation:
         pipe.warmup()
 
         with pytest.raises(ValueError, match="must be multiples of"):
-            pipe.validate_shape(481, 832, 33)
+            pipe.validate_resolution(481, 832, 33)

--- a/tests/unittest/_torch/visual_gen/test_warmup.py
+++ b/tests/unittest/_torch/visual_gen/test_warmup.py
@@ -8,20 +8,20 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
-from tensorrt_llm._torch.visual_gen.config import VisualGenArgs, WarmupConfig
+from tensorrt_llm._torch.visual_gen.config import CompilationConfig, VisualGenArgs
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
 
 
-class TestWarmupConfig:
-    """WarmupConfig construction and validation."""
+class TestCompilationConfig:
+    """CompilationConfig construction and validation."""
 
     def test_default_values(self):
-        cfg = WarmupConfig()
+        cfg = CompilationConfig()
         assert cfg.resolutions is None
         assert cfg.num_frames is None
 
     def test_explicit_values(self):
-        cfg = WarmupConfig(
+        cfg = CompilationConfig(
             resolutions=[(480, 832), (720, 1280)],
             num_frames=[33, 81],
         )
@@ -29,62 +29,62 @@ class TestWarmupConfig:
         assert cfg.num_frames == [33, 81]
 
     def test_empty_lists(self):
-        cfg = WarmupConfig(resolutions=[], num_frames=[])
+        cfg = CompilationConfig(resolutions=[], num_frames=[])
         assert cfg.resolutions == []
         assert cfg.num_frames == []
 
     def test_partial_resolutions_only(self):
-        cfg = WarmupConfig(resolutions=[(1920, 1080)])
+        cfg = CompilationConfig(resolutions=[(1920, 1080)])
         assert cfg.resolutions == [(1920, 1080)]
         assert cfg.num_frames is None
 
     def test_partial_num_frames_only(self):
-        cfg = WarmupConfig(num_frames=[81])
+        cfg = CompilationConfig(num_frames=[81])
         assert cfg.resolutions is None
         assert cfg.num_frames == [81]
 
     def test_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-            WarmupConfig(resolutions=[(480, 832)], bad_field=True)
+            CompilationConfig(resolutions=[(480, 832)], bad_field=True)
 
 
 class TestVisualGenArgsWarmup:
-    """WarmupConfig integration with VisualGenArgs."""
+    """CompilationConfig integration with VisualGenArgs."""
 
     def test_default_warmup(self):
         args = VisualGenArgs(checkpoint_path="/tmp/model")
-        assert isinstance(args.warmup, WarmupConfig)
-        assert args.warmup.resolutions is None
-        assert args.warmup.num_frames is None
+        assert isinstance(args.compilation, CompilationConfig)
+        assert args.compilation.resolutions is None
+        assert args.compilation.num_frames is None
 
     def test_warmup_from_dict(self):
         args = VisualGenArgs(
             checkpoint_path="/tmp/model",
-            warmup={"resolutions": [(480, 832)], "num_frames": [33, 81]},
+            compilation={"resolutions": [(480, 832)], "num_frames": [33, 81]},
         )
-        assert args.warmup.resolutions == [(480, 832)]
-        assert args.warmup.num_frames == [33, 81]
+        assert args.compilation.resolutions == [(480, 832)]
+        assert args.compilation.num_frames == [33, 81]
 
     def test_warmup_from_yaml(self, tmp_path):
         yaml_path = tmp_path / "config.yml"
         yaml_path.write_text(
             "checkpoint_path: /tmp/model\n"
-            "warmup:\n"
+            "compilation:\n"
             "  resolutions:\n"
             "    - [480, 832]\n"
             "    - [720, 1280]\n"
             "  num_frames: [33, 81]\n"
         )
         args = VisualGenArgs.from_yaml(yaml_path)
-        assert len(args.warmup.resolutions) == 2
-        assert args.warmup.num_frames == [33, 81]
+        assert len(args.compilation.resolutions) == 2
+        assert args.compilation.num_frames == [33, 81]
 
     def test_warmup_pickle_roundtrip(self):
         import pickle
 
         args = VisualGenArgs(
             checkpoint_path="/tmp/model",
-            warmup=WarmupConfig(resolutions=[(480, 832)], num_frames=[33]),
+            compilation=CompilationConfig(resolutions=[(480, 832)], num_frames=[33]),
         )
         restored = pickle.loads(pickle.dumps(args))
         assert restored.warmup.resolutions == [(480, 832)]
@@ -103,7 +103,7 @@ class _BaseStubPipeline(BasePipeline):
     def __init__(self, warmup_cfg):
         self._warmed_up_shapes = set()
         self.model_config = MagicMock()
-        self.model_config.warmup = warmup_cfg or WarmupConfig()
+        self.model_config.compilation = warmup_cfg or CompilationConfig()
 
     def forward(self, *args, **kwargs):
         pass
@@ -174,7 +174,7 @@ class TestResolveWarmupPlan:
 
     def test_user_resolutions_only(self):
         """User specifies resolutions, num_frames from model default."""
-        cfg = WarmupConfig(resolutions=[(1920, 1088)])
+        cfg = CompilationConfig(resolutions=[(1920, 1088)])
         pipe = _make_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
         assert len(shapes) == 2  # 1 resolution x 2 default frame counts
@@ -183,7 +183,7 @@ class TestResolveWarmupPlan:
 
     def test_user_num_frames_only(self):
         """User specifies num_frames, resolutions from model default."""
-        cfg = WarmupConfig(num_frames=[81])
+        cfg = CompilationConfig(num_frames=[81])
         pipe = _make_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
         assert len(shapes) == 2  # 2 default resolutions x 1 frame count
@@ -192,7 +192,7 @@ class TestResolveWarmupPlan:
 
     def test_user_both(self):
         """User specifies both → user values Cartesian product."""
-        cfg = WarmupConfig(
+        cfg = CompilationConfig(
             resolutions=[(256, 256)],
             num_frames=[5],
         )
@@ -202,31 +202,32 @@ class TestResolveWarmupPlan:
 
     def test_empty_resolutions_skips_warmup(self):
         """Empty resolutions → no shapes → warmup skipped."""
-        cfg = WarmupConfig(resolutions=[], num_frames=[33])
+        cfg = CompilationConfig(resolutions=[], num_frames=[33])
         pipe = _make_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
         assert shapes == []
 
     def test_empty_num_frames_skips_warmup(self):
         """Empty num_frames → no shapes → warmup skipped."""
-        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[])
+        cfg = CompilationConfig(resolutions=[(480, 832)], num_frames=[])
         pipe = _make_stub_pipeline(cfg)
         shapes, _ = pipe.resolve_warmup_plan()
         assert shapes == []
 
-    def test_invalid_user_resolution_raises(self):
-        """User resolution not multiple of 16 → validate_shape raises."""
-        cfg = WarmupConfig(resolutions=[(481, 832)])
+    def test_invalid_user_resolution_skipped(self):
+        """User resolution not multiple of 16 → warning, shape skipped."""
+        cfg = CompilationConfig(resolutions=[(481, 832)])
         pipe = _make_stub_pipeline(cfg)
-        with pytest.raises(ValueError, match="must be multiples of"):
-            pipe.resolve_warmup_plan()
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert (481, 832, 33) not in shapes
+        assert (481, 832, 81) not in shapes
 
-    def test_invalid_user_num_frames_raises(self):
-        """User num_frames not valid → validate_shape raises."""
-        cfg = WarmupConfig(num_frames=[30])  # (30-1)%4 != 0
+    def test_invalid_user_num_frames_skipped(self):
+        """User num_frames not valid → warning, shape skipped."""
+        cfg = CompilationConfig(num_frames=[30])  # (30-1)%4 != 0
         pipe = _make_stub_pipeline(cfg)
-        with pytest.raises(ValueError, match="Invalid num_frames"):
-            pipe.resolve_warmup_plan()
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert len(shapes) == 0
 
     def test_flux_default(self):
         """Flux default: 1 resolution x 1 frame = 1 shape."""
@@ -235,12 +236,12 @@ class TestResolveWarmupPlan:
         assert shapes == [(1024, 1024, 1)]
         assert steps == 2
 
-    def test_flux_rejects_video_frames(self):
-        """Flux: num_frames != 1 → raises."""
-        cfg = WarmupConfig(num_frames=[81])
+    def test_flux_skips_video_frames(self):
+        """Flux: num_frames != 1 → warning, shape skipped."""
+        cfg = CompilationConfig(num_frames=[81])
         pipe = _make_flux_stub_pipeline(cfg)
-        with pytest.raises(ValueError, match="Invalid num_frames"):
-            pipe.resolve_warmup_plan()
+        shapes, _ = pipe.resolve_warmup_plan()
+        assert len(shapes) == 0
 
 
 class TestValidateShape:
@@ -293,13 +294,13 @@ class TestWarmupExecution:
         assert (720, 1280, 81) in pipe._warmed_up_shapes
 
     def test_warmup_empty_shapes_skips(self):
-        cfg = WarmupConfig(resolutions=[], num_frames=[])
+        cfg = CompilationConfig(resolutions=[], num_frames=[])
         pipe = _make_stub_pipeline(cfg)
         pipe.warmup()
         assert pipe._warmed_up_shapes == set()
 
     def test_warmup_user_shapes_recorded(self):
-        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[33])
+        cfg = CompilationConfig(resolutions=[(480, 832)], num_frames=[33])
         pipe = _make_stub_pipeline(cfg)
         pipe.warmup()
         assert pipe._warmed_up_shapes == {(480, 832, 33)}
@@ -322,7 +323,7 @@ class TestRequestValidation:
 
     def test_valid_unwarmed_shape_warns(self):
         """Request with valid but un-warmed shape → pipeline accepts but would warn."""
-        cfg = WarmupConfig(resolutions=[(480, 832)], num_frames=[33])
+        cfg = CompilationConfig(resolutions=[(480, 832)], num_frames=[33])
         pipe = _make_stub_pipeline(cfg)
         pipe.warmup()
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Make VisualGen warmup shapes configurable via a new `CompilationConfig` sub-config, replacing hardcoded warmup shapes in model pipeline subclasses.

**Problem:** Warmup shapes (resolution + frame count) were hardcoded in each pipeline class (e.g., `[(480, 832, 33), (480, 832, 81), (720, 1280, 81)]` for Wan). Users could not configure which shapes to pre-compile at startup. Requesting an un-warmed shape triggers torch.compile recompilation with seconds of delay.

**Solution:**
- New `CompilationConfig` sub-config with `resolutions` and `num_frames` fields, combined via Cartesian product at warmup time
- `BasePipeline.resolve_warmup_plan()` to resolve user config vs model defaults (user > model-default > empty)
- `BasePipeline.validate_resolution()` for resolution constraint checking (divisibility by model-specific multiples)
- Frame count handling follows HuggingFace diffusers convention: warning + silent round to nearest valid value (not strict rejection)

**User-facing YAML config:**
```yaml
compilation:
  resolutions:
    - [480, 832]
    - [720, 1280]
  num_frames: [33, 81]
```

**Design decisions:**
- `CompilationConfig` as sub-config: follows the same pattern as existing 6 sub-configs (`torch_compile`, `cuda_graph`, etc.)
- Cartesian product: `resolutions × num_frames` — simpler to configure than explicit (h, w, f) triples
- Frame count: warning + silent round (following diffusers/vllm-omni convention), not strict rejection — API users specify `seconds × fps` and shouldn't need to know about VAE temporal scale factors
- Resolution: strict validation via `validate_resolution()` in forward()
- `warmup_steps` not exposed: stays as model-internal heuristic (`default_warmup_steps`)
- torch.compile cache: tested with 128 shapes — dynamo automatic dynamic shapes merges all shapes after ~3 recompilations, cache limit is not a practical concern

**Backward compatibility:**
- Default behavior unchanged when `compilation` is not configured in YAML

## Test Coverage

- `tests/unittest/_torch/visual_gen/test_warmup.py` — **30 new unit tests** (CPU only):
  - `TestCompilationConfig` (6): config construction, defaults, empty lists, strict validation
  - `TestVisualGenArgsWarmup` (4): dict/YAML construction, pickle serialization
  - `TestResolveWarmupPlan` (10): Cartesian product, priority chain, empty lists, invalid resolution skipped, any frame count accepted
  - `TestValidateShape` (4): resolution validation, non-positive dimension rejection
  - `TestWarmupExecution` (3): `_warmed_up_shapes` tracking, empty shapes skip
  - `TestRequestValidation` (3): warmed/un-warmed/invalid resolution behavior
- `tests/unittest/_torch/visual_gen/test_visual_gen_args.py` — 1 new test: `CompilationConfig` strict validation

Existing CI tests are not affected: all use `skip_warmup=True` and do not reference removed APIs.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
