### PR TITLE
[#12290][fix] Qwen 3.5 fix 3d position ID handling

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -10,7 +10,7 @@ kv_cache_config:
 model_kwargs:
   torch_dtype: bfloat16
 transforms:
-  initialize_qwen_mrope_delta_cache:
+  initialize_mrope_delta_cache:
     enabled: true
   export_to_gm:
     num_moe_experts_for_export: 2

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -7,7 +7,7 @@ max_batch_size: 512
 world_size: 4
 cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 enable_chunked_prefill: true
-model_factory: AutoModelForCausalLM
+model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
   enable_block_reuse: false
   free_gpu_memory_fraction: 0.8

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -1,12 +1,16 @@
-max_seq_len: 4096
+runtime: trtllm
+compile_backend: torch-cudagraph
+attn_backend: trtllm
+max_seq_len: 8192
 max_num_tokens: 4096
 max_batch_size: 512
+cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 enable_chunked_prefill: true
 model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.95
-  tokens_per_block: 64
+  free_gpu_memory_fraction: 0.8
+  tokens_per_block: 32
 model_kwargs:
   torch_dtype: bfloat16
 transforms:
@@ -14,6 +18,8 @@ transforms:
     enabled: true
   export_to_gm:
     num_moe_experts_for_export: 2
+  fuse_gemms_mixed_children:
+    enabled: true
   detect_sharding:
     allreduce_strategy: SYMM_MEM
     shard_all_unprocessed: true

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_35b.yaml
@@ -1,28 +1,41 @@
-runtime: trtllm
-compile_backend: torch-cudagraph
-attn_backend: trtllm
-max_seq_len: 8192
+max_seq_len: 4096
 max_num_tokens: 4096
 max_batch_size: 512
-world_size: 4
-cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 enable_chunked_prefill: true
 model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.8
-  tokens_per_block: 32
+  free_gpu_memory_fraction: 0.95
+  tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
 transforms:
+  initialize_qwen_mrope_delta_cache:
+    enabled: true
   export_to_gm:
     num_moe_experts_for_export: 2
-  fuse_gemms_mixed_children:
-    enabled: true
   detect_sharding:
     allreduce_strategy: SYMM_MEM
     shard_all_unprocessed: true
     simple_shard_filter: "lm_head"
+    sharding_dims: ['tp','ep', 'bmm']
+    # use only manual config for TP sharding
+    sharding_source: ['manual']
+    manual_config:
+      tp_plan:
+        # GDN layer
+        "in_proj_qkv": "delta"
+        # attention layer
+        "q_proj": "colwise"
+        "k_proj": "colwise"
+        "v_proj": "colwise"
+        "o_proj": "rowwise"
+        # replicating shared experts (keep them commented out)
+        # "shared_expert_gate_proj": "colwise"
+        # "shared_expert_up_proj": "colwise"
+        # "shared_expert_down_proj": "rowwise"
+        # gating layer should be replicated as well
+        # "gate": "gather"
   multi_stream_moe:
     stage: compile
     enabled: true

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -7,7 +7,7 @@ max_batch_size: 32
 cuda_graph_batch_sizes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 world_size: 8
 enable_chunked_prefill: true
-model_factory: AutoModelForCausalLM
+model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
   enable_block_reuse: true
   free_gpu_memory_fraction: 0.8

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -11,7 +11,7 @@ kv_cache_config:
 model_kwargs:
   torch_dtype: bfloat16
 transforms:
-  initialize_qwen_mrope_delta_cache:
+  initialize_mrope_delta_cache:
     enabled: true
   export_to_gm:
     num_moe_experts_for_export: 2

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -1,20 +1,18 @@
-runtime: trtllm
-compile_backend: torch-cudagraph
-attn_backend: trtllm
-max_seq_len: 262144
-max_num_tokens: 8192
-max_batch_size: 32
-cuda_graph_batch_sizes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
-world_size: 8
+max_seq_len: 2048
+max_num_tokens: 2048
+max_batch_size: 512
+cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 enable_chunked_prefill: true
 model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
-  enable_block_reuse: true
-  free_gpu_memory_fraction: 0.8
-  tokens_per_block: 32
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.95
+  tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
 transforms:
+  initialize_qwen_mrope_delta_cache:
+    enabled: true
   export_to_gm:
     num_moe_experts_for_export: 2
   fuse_gemms_mixed_children:
@@ -23,6 +21,24 @@ transforms:
     allreduce_strategy: SYMM_MEM
     shard_all_unprocessed: true
     simple_shard_filter: "lm_head"
+    sharding_dims: ['tp','ep', 'bmm']
+    # use only manual config for TP sharding
+    sharding_source: ['manual']
+    manual_config:
+      tp_plan:
+        # GDN layer
+        "in_proj_qkv": "delta"
+        # attention layer
+        "q_proj": "colwise"
+        "k_proj": "colwise"
+        "v_proj": "colwise"
+        "o_proj": "rowwise"
+        # replicating shared experts (keep them commented out)
+        # "shared_expert_gate_proj": "colwise"
+        # "shared_expert_up_proj": "colwise"
+        # "shared_expert_down_proj": "rowwise"
+        # gating layer should be replicated as well
+        # "gate": "gather"
   multi_stream_moe:
     stage: compile
     enabled: true

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -1,13 +1,16 @@
-max_seq_len: 2048
-max_num_tokens: 2048
-max_batch_size: 512
+runtime: trtllm
+compile_backend: torch-cudagraph
+attn_backend: trtllm
+max_seq_len: 262144
+max_num_tokens: 8192
+max_batch_size: 32
 cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 enable_chunked_prefill: true
 model_factory: Qwen3_5MoeForConditionalGeneration
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.95
-  tokens_per_block: 64
+  free_gpu_memory_fraction: 0.8
+  tokens_per_block: 32
 model_kwargs:
   torch_dtype: bfloat16
 transforms:

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -213,9 +213,9 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_4.yaml']
 # --- Qwen3.5 MoE (Feb 2026) ---
 - name: Qwen/Qwen3.5-35B-A3B
-  yaml_extra: ['qwen3.5_moe_35b.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'qwen3.5_moe_35b.yaml']
 - name: Qwen/Qwen3.5-397B-A17B
-  yaml_extra: ['qwen3.5_moe_400b.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'qwen3.5_moe_400b.yaml']
 # --- GLM-5 (Feb 2026) ---
 - name: zai-org/GLM-5
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml']

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -11,6 +11,7 @@ When piecewise_enabled=True, a DualModeCapturedGraph is returned that dispatches
 
 import copy  # noqa: I001
 import gc
+from collections import abc
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import torch
@@ -608,6 +609,14 @@ class DualModeCapturedGraph(nn.Module):
             result = self.piecewise(*args, num_tokens=bucket, **kwargs)
             ADPiecewiseRunner.set_current_num_tokens(None)
             if bucket > num_tokens:
+                # HF ModelOutput iterates over field names (e.g. "logits"), not
+                # tensor values. Normalize to the payload tuple before slicing.
+                if hasattr(result, "to_tuple"):
+                    result = result.to_tuple()
+                elif isinstance(result, abc.Mapping):
+                    result = tuple(result.values())
+                else:
+                    result = tuple(result)
                 result = tuple(r[:, :num_tokens] if r.ndim >= 2 else r for r in result)
             return result
 

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -249,7 +249,7 @@ transforms:
   insert_cached_residual_add:
     stage: cache_init
     backend: cached_residual_add
-  initialize_qwen_mrope_delta_cache:
+  initialize_mrope_delta_cache:
     stage: cache_init
     run_per_gm: false
     enabled: false

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -252,6 +252,7 @@ transforms:
   initialize_qwen_mrope_delta_cache:
     stage: cache_init
     run_per_gm: false
+    enabled: false
   initialize_cache:
     stage: cache_init
     expect_mem_change: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -249,6 +249,9 @@ transforms:
   insert_cached_residual_add:
     stage: cache_init
     backend: cached_residual_add
+  initialize_qwen_mrope_delta_cache:
+    stage: cache_init
+    run_per_gm: false
   initialize_cache:
     stage: cache_init
     expect_mem_change: true

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -69,6 +69,7 @@ class ADInputProcessor(DefaultInputProcessor):
         # for example, this might be the case when invoking AD via trtllm-serve
         elif "multi_modal_data" in inputs:
             images = inputs["multi_modal_data"]["image"]
+            do_rescale = True
             if images is not None and isinstance(images[0], torch.Tensor):
                 # The default multimodal input loader will normalize images to [0, 1] when the requested
                 # format is "pt" (pytorch tensors), but not for "pil" (PIL images).

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -127,7 +127,11 @@ class LLM(_TorchLLM):
         pass
 
     def _create_input_processor(self) -> ADInputProcessor:
-        return ADInputProcessor(self.tokenizer, self.factory.init_processor())
+        processor = self.factory.init_processor()
+        base = ADInputProcessor(self.tokenizer, processor)
+        if hasattr(self.factory, "init_input_processor"):
+            return self.factory.init_input_processor(base)
+        return base
 
     def _prefetch_model(self):
         """Prefetch the model for the LLM."""

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -2,6 +2,7 @@ import types
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
+from PIL import Image
 
 from ...executor.result import CompletionOutput
 from ...inputs.registry import DefaultInputProcessor, ExtraProcessedInputs
@@ -25,6 +26,83 @@ class ADInputProcessor(DefaultInputProcessor):
         super().__init__(model_path=None, config=None, tokenizer=tokenizer)
         # NOTE: HF's tokenizer/processor that has the apply_chat_template method
         self.processor = processor or getattr(tokenizer, "tokenizer", None)
+
+    @property
+    def get_num_multimodal_tokens(self):
+        """Delegate multimodal token counting to the wrapped HF processor."""
+        if hasattr(self.processor, "_get_num_multimodal_tokens"):
+            return self.processor._get_num_multimodal_tokens
+        raise NotImplementedError(
+            f"get_num_multimodal_tokens not implemented for {self.__class__.__name__}. "
+            "Please ensure the processor exposes _get_num_multimodal_tokens."
+        )
+
+    def get_num_tokens_per_image(self, *, image: Image.Image, **kwargs) -> int:
+        image_size = (image.height, image.width)
+        return self.get_num_multimodal_tokens([image_size], **kwargs)["num_image_tokens"][0]
+
+    def get_num_tokens_per_video(self, *, video: List[Image.Image], **kwargs) -> int:
+        video_size = (len(video), video[0].height, video[0].width)
+        num_video_tokens = self.get_num_multimodal_tokens(video_sizes=[video_size], **kwargs).get(
+            "num_video_tokens"
+        )
+        if num_video_tokens is None:
+            raise NotImplementedError("Underlying processor does not expose num_video_tokens.")
+        return num_video_tokens[0]
+
+    def get_vocab_size(self) -> Optional[int]:
+        """Return the tokenizer vocabulary size for multimodal hashing."""
+        if self.tokenizer is not None and hasattr(self.tokenizer, "vocab_size"):
+            return int(self.tokenizer.vocab_size)
+        wrapped_tokenizer = getattr(self.tokenizer, "tokenizer", None)
+        if wrapped_tokenizer is not None and hasattr(wrapped_tokenizer, "vocab_size"):
+            return int(wrapped_tokenizer.vocab_size)
+        processor_tokenizer = getattr(self.processor, "tokenizer", None)
+        if processor_tokenizer is not None and hasattr(processor_tokenizer, "vocab_size"):
+            return int(processor_tokenizer.vocab_size)
+        return None
+
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        if hasattr(self.processor, "mm_token_ids"):
+            return self.processor.mm_token_ids
+        sources = [
+            self.processor,
+            getattr(self.processor, "tokenizer", None),
+            self.tokenizer,
+            getattr(self.tokenizer, "tokenizer", None),
+        ]
+        token_ids = []
+        for source in sources:
+            if source is None:
+                continue
+            for attr in ("image_token_id", "video_token_id"):
+                value = getattr(source, attr, None)
+                if value is not None:
+                    token_ids.append(int(value))
+        if token_ids:
+            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
+        return None
+
+    def get_mm_special_token_ids(self) -> Optional[torch.Tensor]:
+        if hasattr(self.processor, "mm_special_token_ids"):
+            return self.processor.mm_special_token_ids
+        sources = [
+            self.processor,
+            getattr(self.processor, "tokenizer", None),
+            self.tokenizer,
+            getattr(self.tokenizer, "tokenizer", None),
+        ]
+        token_ids = []
+        for source in sources:
+            if source is None:
+                continue
+            for attr in ("vision_start_token_id", "vision_end_token_id"):
+                value = getattr(source, attr, None)
+                if value is not None:
+                    token_ids.append(int(value))
+        if token_ids:
+            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
+        return None
 
     def __call__(
         self, inputs: Dict[str, Any], sampling_params: SamplingParams

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -2,7 +2,6 @@ import types
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-from PIL import Image
 
 from ...executor.result import CompletionOutput
 from ...inputs.registry import DefaultInputProcessor, ExtraProcessedInputs
@@ -26,83 +25,6 @@ class ADInputProcessor(DefaultInputProcessor):
         super().__init__(model_path=None, config=None, tokenizer=tokenizer)
         # NOTE: HF's tokenizer/processor that has the apply_chat_template method
         self.processor = processor or getattr(tokenizer, "tokenizer", None)
-
-    @property
-    def get_num_multimodal_tokens(self):
-        """Delegate multimodal token counting to the wrapped HF processor."""
-        if hasattr(self.processor, "_get_num_multimodal_tokens"):
-            return self.processor._get_num_multimodal_tokens
-        raise NotImplementedError(
-            f"get_num_multimodal_tokens not implemented for {self.__class__.__name__}. "
-            "Please ensure the processor exposes _get_num_multimodal_tokens."
-        )
-
-    def get_num_tokens_per_image(self, *, image: Image.Image, **kwargs) -> int:
-        image_size = (image.height, image.width)
-        return self.get_num_multimodal_tokens([image_size], **kwargs)["num_image_tokens"][0]
-
-    def get_num_tokens_per_video(self, *, video: List[Image.Image], **kwargs) -> int:
-        video_size = (len(video), video[0].height, video[0].width)
-        num_video_tokens = self.get_num_multimodal_tokens(video_sizes=[video_size], **kwargs).get(
-            "num_video_tokens"
-        )
-        if num_video_tokens is None:
-            raise NotImplementedError("Underlying processor does not expose num_video_tokens.")
-        return num_video_tokens[0]
-
-    def get_vocab_size(self) -> Optional[int]:
-        """Return the tokenizer vocabulary size for multimodal hashing."""
-        if self.tokenizer is not None and hasattr(self.tokenizer, "vocab_size"):
-            return int(self.tokenizer.vocab_size)
-        wrapped_tokenizer = getattr(self.tokenizer, "tokenizer", None)
-        if wrapped_tokenizer is not None and hasattr(wrapped_tokenizer, "vocab_size"):
-            return int(wrapped_tokenizer.vocab_size)
-        processor_tokenizer = getattr(self.processor, "tokenizer", None)
-        if processor_tokenizer is not None and hasattr(processor_tokenizer, "vocab_size"):
-            return int(processor_tokenizer.vocab_size)
-        return None
-
-    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
-        if hasattr(self.processor, "mm_token_ids"):
-            return self.processor.mm_token_ids
-        sources = [
-            self.processor,
-            getattr(self.processor, "tokenizer", None),
-            self.tokenizer,
-            getattr(self.tokenizer, "tokenizer", None),
-        ]
-        token_ids = []
-        for source in sources:
-            if source is None:
-                continue
-            for attr in ("image_token_id", "video_token_id"):
-                value = getattr(source, attr, None)
-                if value is not None:
-                    token_ids.append(int(value))
-        if token_ids:
-            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
-        return None
-
-    def get_mm_special_token_ids(self) -> Optional[torch.Tensor]:
-        if hasattr(self.processor, "mm_special_token_ids"):
-            return self.processor.mm_special_token_ids
-        sources = [
-            self.processor,
-            getattr(self.processor, "tokenizer", None),
-            self.tokenizer,
-            getattr(self.tokenizer, "tokenizer", None),
-        ]
-        token_ids = []
-        for source in sources:
-            if source is None:
-                continue
-            for attr in ("vision_start_token_id", "vision_end_token_id"):
-                value = getattr(source, attr, None)
-                if value is not None:
-                    token_ids.append(int(value))
-        if token_ids:
-            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
-        return None
 
     def __call__(
         self, inputs: Dict[str, Any], sampling_params: SamplingParams

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -40,6 +40,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
@@ -1586,7 +1587,7 @@ def qwen3_mrope_delta(
     video_grid_thw: Optional[torch.Tensor],
     spatial_merge_size: int,
 ) -> torch.Tensor:
-    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_prefill, _, num_decode = BatchInfo(batch_info_host).get_absorbed_info()
     num_seq = num_prefill + num_decode
     device = mm_item_cu_seqlen.device
     out = torch.zeros((num_seq, 1), dtype=torch.int32, device=device)
@@ -1635,7 +1636,7 @@ def qwen3_mrope_delta_fake(
     video_grid_thw: Optional[torch.Tensor],
     spatial_merge_size: int,
 ) -> torch.Tensor:
-    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_prefill, _, num_decode = BatchInfo(batch_info_host).get_absorbed_info()
     num_seq = num_prefill + num_decode
     return torch.zeros((num_seq, 1), dtype=torch.int32, device=batch_info_host.device)
 
@@ -1656,7 +1657,7 @@ def qwen3_mrope_delta_with_cache(
     mrope_delta_cache: torch.Tensor,
     spatial_merge_size: int,
 ) -> torch.Tensor:
-    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_prefill, _, num_decode = BatchInfo(batch_info_host).get_absorbed_info()
     num_seq = num_prefill + num_decode
     out = torch.zeros((num_seq, 1), dtype=torch.int32, device=mrope_delta_cache.device)
     video_grid_norm = _normalize_video_grid_for_mrope(video_grid_thw)
@@ -1731,7 +1732,7 @@ def qwen3_mrope_delta_with_cache_fake(
     mrope_delta_cache: torch.Tensor,
     spatial_merge_size: int,
 ) -> torch.Tensor:
-    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_prefill, _, num_decode = BatchInfo(batch_info_host).get_absorbed_info()
     num_seq = num_prefill + num_decode
     return torch.zeros((num_seq, 1), dtype=torch.int32, device=slot_idx.device)
 
@@ -2060,6 +2061,11 @@ class Qwen3_5MoeModel(nn.Module):
         mm_special_offsets = kwargs.get("mm_special_offsets")
         slot_idx = kwargs.get("slot_idx")
         mrope_delta_cache = kwargs.get("mrope_delta_cache")
+        if mrope_delta_cache is None:
+            for key, value in kwargs.items():
+                if key.endswith("_mrope_delta_cache"):
+                    mrope_delta_cache = value
+                    break
         has_chunk_mm_layout = (
             mm_item_cu_seqlen is not None
             and mm_item_types is not None
@@ -2210,7 +2216,7 @@ class Qwen3_5MoeModel(nn.Module):
                 flat_position_ids = position_ids.reshape(-1)
                 token_delta = torch.zeros_like(flat_position_ids)
                 if (
-                    delta is not None
+                    torch.is_tensor(delta)
                     and cu_seqlen is not None
                     and delta.ndim == 2
                     and delta.shape[0] == cu_seqlen.numel() - 1
@@ -2237,6 +2243,9 @@ class Qwen3_5MoeModel(nn.Module):
             "mrope_delta_cache",
         ):
             kwargs.pop(key, None)
+        for key in list(kwargs.keys()):
+            if key.endswith("_mrope_delta_cache"):
+                kwargs.pop(key, None)
 
         return self.language_model(
             inputs_embeds=inputs_embeds,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1025,6 +1025,7 @@ class Qwen3_5MoeVisionAttention(nn.Module):
         self.head_dim = self.dim // self.num_heads
         self.qkv = nn.Linear(self.dim, self.dim * 3, bias=True)
         self.proj = nn.Linear(self.dim, self.dim)
+        self.scaling = self.head_dim**-0.5
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
+from PIL import Image
 from torch import nn
 from torch.export import Dim
 from transformers import AutoConfig
@@ -2313,6 +2314,83 @@ class Qwen3_5MoeADInputProcessor:
 
     def __getattr__(self, name: str):
         return getattr(self.base_processor, name)
+
+    @property
+    def get_num_multimodal_tokens(self):
+        """Delegate multimodal token counting to the wrapped Qwen HF processor."""
+        if hasattr(self.processor, "_get_num_multimodal_tokens"):
+            return self.processor._get_num_multimodal_tokens
+        raise NotImplementedError(
+            f"get_num_multimodal_tokens not implemented for {self.__class__.__name__}. "
+            "Please ensure the processor exposes _get_num_multimodal_tokens."
+        )
+
+    def get_num_tokens_per_image(self, *, image: Image.Image, **kwargs) -> int:
+        image_size = (image.height, image.width)
+        return self.get_num_multimodal_tokens([image_size], **kwargs)["num_image_tokens"][0]
+
+    def get_num_tokens_per_video(self, *, video: List[Image.Image], **kwargs) -> int:
+        video_size = (len(video), video[0].height, video[0].width)
+        num_video_tokens = self.get_num_multimodal_tokens(video_sizes=[video_size], **kwargs).get(
+            "num_video_tokens"
+        )
+        if num_video_tokens is None:
+            raise NotImplementedError("Underlying processor does not expose num_video_tokens.")
+        return num_video_tokens[0]
+
+    def get_vocab_size(self) -> Optional[int]:
+        """Return the tokenizer vocabulary size for Qwen multimodal hashing helpers."""
+        if self.tokenizer is not None and hasattr(self.tokenizer, "vocab_size"):
+            return int(self.tokenizer.vocab_size)
+        wrapped_tokenizer = getattr(self.tokenizer, "tokenizer", None)
+        if wrapped_tokenizer is not None and hasattr(wrapped_tokenizer, "vocab_size"):
+            return int(wrapped_tokenizer.vocab_size)
+        processor_tokenizer = getattr(self.processor, "tokenizer", None)
+        if processor_tokenizer is not None and hasattr(processor_tokenizer, "vocab_size"):
+            return int(processor_tokenizer.vocab_size)
+        return None
+
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        if hasattr(self.processor, "mm_token_ids"):
+            return self.processor.mm_token_ids
+        sources = [
+            self.processor,
+            getattr(self.processor, "tokenizer", None),
+            self.tokenizer,
+            getattr(self.tokenizer, "tokenizer", None),
+        ]
+        token_ids = []
+        for source in sources:
+            if source is None:
+                continue
+            for attr in ("image_token_id", "video_token_id"):
+                value = getattr(source, attr, None)
+                if value is not None:
+                    token_ids.append(int(value))
+        if token_ids:
+            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
+        return None
+
+    def get_mm_special_token_ids(self) -> Optional[torch.Tensor]:
+        if hasattr(self.processor, "mm_special_token_ids"):
+            return self.processor.mm_special_token_ids
+        sources = [
+            self.processor,
+            getattr(self.processor, "tokenizer", None),
+            self.tokenizer,
+            getattr(self.tokenizer, "tokenizer", None),
+        ]
+        token_ids = []
+        for source in sources:
+            if source is None:
+                continue
+            for attr in ("vision_start_token_id", "vision_end_token_id"):
+                value = getattr(source, attr, None)
+                if value is not None:
+                    token_ids.append(int(value))
+        if token_ids:
+            return torch.tensor(sorted(set(token_ids)), dtype=torch.int32)
+        return None
 
     def _build_multimodal_input(
         self,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -47,6 +47,7 @@ from tensorrt_llm._torch.auto_deploy.models.hf import (
     TextModelExportInfo,
 )
 from tensorrt_llm.inputs.multimodal import MultimodalInput, apply_mm_hashes, hexdigest_to_int32
+from tensorrt_llm.inputs.utils import VideoData
 
 # =============================================================================
 # Configuration
@@ -1469,6 +1470,58 @@ def _extract_mm_item_types_from_input_ids(
     return item_types
 
 
+def _is_qwen_video_frame(value: Any) -> bool:
+    return isinstance(value, (Image.Image, torch.Tensor))
+
+
+def _normalize_qwen_image_items(images: Any) -> list[Any]:
+    if images is None:
+        return []
+    if isinstance(images, list):
+        return images
+    return [images]
+
+
+def _normalize_qwen_video_items(videos: Any) -> list[Any]:
+    if videos is None:
+        return []
+    if isinstance(videos, VideoData):
+        return [videos]
+    if isinstance(videos, list):
+        if not videos:
+            return []
+        if all(_is_qwen_video_frame(frame) for frame in videos):
+            return [videos]
+        normalized_items = []
+        for item in videos:
+            if isinstance(item, VideoData):
+                normalized_items.append(item)
+            elif (
+                isinstance(item, list)
+                and item
+                and all(_is_qwen_video_frame(frame) for frame in item)
+            ):
+                normalized_items.append(item)
+            else:
+                normalized_items.append(item)
+        return normalized_items
+    return [videos]
+
+
+def _get_qwen_video_num_spans(video: Any) -> int:
+    if isinstance(video, VideoData):
+        return len(video.frames)
+    if isinstance(video, list):
+        if not video:
+            return 0
+        if all(_is_qwen_video_frame(frame) for frame in video):
+            return len(video)
+    shape = getattr(video, "shape", None)
+    if shape is not None and len(shape) >= 4:
+        return int(shape[0])
+    return 1
+
+
 def _compute_mm_item_special_counts(
     mm_token_lengths: torch.Tensor,
     mm_special_offsets_cu_seqlen: torch.Tensor,
@@ -1753,6 +1806,182 @@ class Qwen3_5MoeModel(nn.Module):
         )
         return special_image_mask, special_video_mask
 
+    def _select_request_chunk_multimodal_embeds(
+        self,
+        req_input_pos: int,
+        req_seq_len: int,
+        req_mm_item_types: Sequence[int],
+        req_mm_positions: Sequence[int],
+        req_mm_lengths: Sequence[int],
+        req_special_offsets: Sequence[int],
+        image_embeds_list: Optional[Sequence[torch.Tensor]],
+        video_embeds_list: Optional[Sequence[torch.Tensor]],
+    ) -> torch.Tensor:
+        chunk_end = req_input_pos + req_seq_len
+        mm_cumulative_offset = 0
+        img_idx = 0
+        vid_idx = 0
+        chunks: list[torch.Tensor] = []
+        hidden_size = self.config.text_config.hidden_size
+        special_offsets_set = set(int(x) for x in req_special_offsets)
+
+        for item_type, mm_start, mm_len in zip(req_mm_item_types, req_mm_positions, req_mm_lengths):
+            item_mm_offset = mm_cumulative_offset
+            item_mm_len = int(mm_len)
+            item_abs_start = int(mm_start)
+            item_abs_end = item_abs_start + item_mm_len
+            overlap_start = max(req_input_pos, item_abs_start)
+            overlap_end = min(chunk_end, item_abs_end)
+
+            if item_type == 0:
+                if image_embeds_list is None:
+                    raise ValueError("Missing image embeddings for image multimodal item")
+                item_embeds = image_embeds_list[img_idx]
+                img_idx += 1
+            elif item_type == 1:
+                if video_embeds_list is None:
+                    raise ValueError("Missing video embeddings for video multimodal item")
+                item_embeds = video_embeds_list[vid_idx]
+                vid_idx += 1
+            else:
+                raise ValueError(f"Unsupported multimodal item type: {item_type}")
+
+            local_to_feature_idx: list[Optional[int]] = []
+            feature_idx = 0
+            for rel in range(item_mm_len):
+                if item_mm_offset + rel in special_offsets_set:
+                    local_to_feature_idx.append(None)
+                else:
+                    local_to_feature_idx.append(feature_idx)
+                    feature_idx += 1
+
+            if feature_idx != item_embeds.shape[0]:
+                raise ValueError(
+                    "Multimodal embedding length mismatch for Qwen3.5 item: "
+                    f"type={item_type}, expected={feature_idx}, actual={item_embeds.shape[0]}, "
+                    f"mm_len={item_mm_len}, item_start={item_abs_start}, "
+                    f"special_offsets={sorted(special_offsets_set)}"
+                )
+
+            if overlap_start < overlap_end:
+                selected_indices = [
+                    local_to_feature_idx[rel]
+                    for rel in range(overlap_start - item_abs_start, overlap_end - item_abs_start)
+                    if local_to_feature_idx[rel] is not None
+                ]
+                if selected_indices:
+                    chunks.append(item_embeds[selected_indices])
+
+            mm_cumulative_offset += item_mm_len
+
+        if chunks:
+            return torch.cat(chunks, dim=0)
+
+        device = None
+        dtype = None
+        if image_embeds_list:
+            device = image_embeds_list[0].device
+            dtype = image_embeds_list[0].dtype
+        elif video_embeds_list:
+            device = video_embeds_list[0].device
+            dtype = video_embeds_list[0].dtype
+        if device is None or dtype is None:
+            raise ValueError(
+                "Cannot build empty multimodal chunk without image or video embeddings"
+            )
+        return torch.empty(0, hidden_size, device=device, dtype=dtype)
+
+    def _expand_video_embeds_by_span(
+        self,
+        video_embeds_list: Optional[Sequence[torch.Tensor]],
+        video_grid_thw: Optional[torch.Tensor],
+    ) -> Optional[List[torch.Tensor]]:
+        if video_embeds_list is None or video_grid_thw is None:
+            return None
+
+        merge = self.config.vision_config.spatial_merge_size
+        video_span_embeds: List[torch.Tensor] = []
+        for video_embeds, grid in zip(video_embeds_list, video_grid_thw):
+            t, h, w = [int(v) for v in grid.tolist()]
+            frame_tokens = (int(h) // merge) * (int(w) // merge)
+            expected = int(t) * frame_tokens
+            if video_embeds.shape[0] != expected:
+                raise ValueError(
+                    "Video embedding length mismatch in Qwen3.5 VLM forward: "
+                    f"expected={expected}, actual={video_embeds.shape[0]}, grid={tuple(grid.tolist())}"
+                )
+            video_span_embeds.extend(list(torch.split(video_embeds, frame_tokens, dim=0)))
+        return video_span_embeds
+
+    def _build_chunked_multimodal_embeds(
+        self,
+        input_ids: torch.LongTensor,
+        batch_info: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        input_pos: torch.Tensor,
+        seq_len: torch.Tensor,
+        image_embeds_list: Optional[Sequence[torch.Tensor]],
+        video_span_embeds_list: Optional[Sequence[torch.Tensor]],
+        mm_item_cu_seqlen: torch.Tensor,
+        mm_item_types: torch.Tensor,
+        mm_token_positions: torch.Tensor,
+        mm_token_lengths: torch.Tensor,
+        mm_special_offsets_cu_seqlen: Optional[torch.Tensor],
+        mm_special_offsets: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        num_prefill_seqs = int(batch_info[0].item())
+        img_idx = 0
+        vid_idx = 0
+        chunks: list[torch.Tensor] = []
+
+        for i in range(num_prefill_seqs):
+            item_start = int(mm_item_cu_seqlen[i].item())
+            item_end = int(mm_item_cu_seqlen[i + 1].item())
+            req_mm_item_types = mm_item_types[item_start:item_end].tolist()
+            req_mm_positions = mm_token_positions[item_start:item_end].tolist()
+            req_mm_lengths = mm_token_lengths[item_start:item_end].tolist()
+
+            req_special_offsets: list[int] = []
+            if mm_special_offsets_cu_seqlen is not None and mm_special_offsets is not None:
+                special_start = int(mm_special_offsets_cu_seqlen[i].item())
+                special_end = int(mm_special_offsets_cu_seqlen[i + 1].item())
+                req_special_offsets = mm_special_offsets[special_start:special_end].tolist()
+
+            num_images = sum(item_type == 0 for item_type in req_mm_item_types)
+            num_videos = sum(item_type == 1 for item_type in req_mm_item_types)
+            req_image_embeds = (
+                image_embeds_list[img_idx : img_idx + num_images]
+                if image_embeds_list is not None
+                else None
+            )
+            req_video_embeds = (
+                video_span_embeds_list[vid_idx : vid_idx + num_videos]
+                if video_span_embeds_list is not None
+                else None
+            )
+            img_idx += num_images
+            vid_idx += num_videos
+
+            req_chunk_embeds = self._select_request_chunk_multimodal_embeds(
+                req_input_pos=int(input_pos[i].item()),
+                req_seq_len=int(seq_len[i].item()),
+                req_mm_item_types=req_mm_item_types,
+                req_mm_positions=req_mm_positions,
+                req_mm_lengths=req_mm_lengths,
+                req_special_offsets=req_special_offsets,
+                image_embeds_list=req_image_embeds,
+                video_embeds_list=req_video_embeds,
+            )
+            chunks.append(req_chunk_embeds)
+
+        if chunks:
+            return torch.cat(chunks, dim=0)
+
+        hidden_size = self.config.text_config.hidden_size
+        return torch.empty(
+            0, hidden_size, device=input_ids.device, dtype=self.get_input_embeddings().weight.dtype
+        )
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -1787,59 +2016,22 @@ class Qwen3_5MoeModel(nn.Module):
         has_images = pixel_values is not None and image_grid_thw is not None
         has_videos = pixel_values_videos is not None and video_grid_thw is not None
 
+        image_embeds_list = None
         if has_images:
-            image_embeds = torch.cat(
-                self.get_image_features(pixel_values, image_grid_thw), dim=0
-            ).to(inputs_embeds.device, inputs_embeds.dtype)
-            image_mask = (
-                (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
-            )
-            # Chunked prefill: use only the slice of image_embeds for this chunk.
-            mm_chunk_flat_start = kwargs.pop("mm_chunk_flat_start", None)
-            mm_chunk_count = kwargs.pop("mm_chunk_count", None)
-            if (
-                mm_chunk_flat_start is not None
-                and mm_chunk_count is not None
-                and mm_chunk_flat_start.shape[0] > 0
-                and int(mm_chunk_count.sum().item()) > 0
-            ):
-                flat_start = mm_chunk_flat_start.to(image_embeds.device)
-                count = mm_chunk_count.to(image_embeds.device)
-                chunks = []
-                for i in range(flat_start.shape[0]):
-                    c = count[i].item()
-                    if c > 0:
-                        s = flat_start[i].item()
-                        chunks.append(image_embeds[s : s + c])
-                if chunks:
-                    chunk_image_embeds = torch.cat(chunks, dim=0)
-                else:
-                    chunk_image_embeds = torch.empty(
-                        0,
-                        image_embeds.shape[1],
-                        device=image_embeds.device,
-                        dtype=image_embeds.dtype,
-                    )
-                num_image_tokens = int((input_ids == self.config.image_token_id).sum().item())
-                if chunk_image_embeds.shape[0] != num_image_tokens:
-                    raise ValueError(
-                        "Chunk image embedding count mismatch in Qwen3.5 VLM forward: "
-                        f"selected={chunk_image_embeds.shape[0]}, placeholders={num_image_tokens}, "
-                        f"mm_chunk_flat_start={flat_start.tolist()}, mm_chunk_count={count.tolist()}, "
-                        f"input_shape={tuple(input_ids.shape)}, image_grid_shape={tuple(image_grid_thw.shape)}"
-                    )
-                inputs_embeds = inputs_embeds.masked_scatter(image_mask, chunk_image_embeds)
-            else:
-                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+            image_embeds_list = [
+                embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                for embeds in self.get_image_features(pixel_values, image_grid_thw)
+            ]
 
+        video_embeds_list = None
         if has_videos:
-            video_embeds = torch.cat(
-                self.get_video_features(pixel_values_videos, video_grid_thw), dim=0
-            ).to(inputs_embeds.device, inputs_embeds.dtype)
-            video_mask = (
-                (input_ids == self.config.video_token_id).unsqueeze(-1).expand_as(inputs_embeds)
-            )
-            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+            video_embeds_list = [
+                embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                for embeds in self.get_video_features(pixel_values_videos, video_grid_thw)
+            ]
+        video_span_embeds_list = self._expand_video_embeds_by_span(
+            video_embeds_list, video_grid_thw
+        )
 
         delta = mrope_position_deltas if mrope_position_deltas is not None else 0
 
@@ -1878,6 +2070,76 @@ class Qwen3_5MoeModel(nn.Module):
             and mm_token_positions.numel() > 0
             and mm_token_lengths.numel() > 0
         )
+
+        if has_images or has_videos:
+            multimodal_mask = (
+                (
+                    (input_ids == self.config.image_token_id)
+                    | (input_ids == self.config.video_token_id)
+                )
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+            )
+            num_multimodal_tokens = int(
+                (
+                    (input_ids == self.config.image_token_id)
+                    | (input_ids == self.config.video_token_id)
+                )
+                .sum()
+                .item()
+            )
+            if (
+                batch_info is not None
+                and cu_seqlen is not None
+                and input_pos is not None
+                and seq_len is not None
+                and has_chunk_mm_layout
+            ):
+                multimodal_embeds = self._build_chunked_multimodal_embeds(
+                    input_ids=input_ids,
+                    batch_info=batch_info,
+                    cu_seqlen=cu_seqlen,
+                    input_pos=input_pos,
+                    seq_len=seq_len,
+                    image_embeds_list=image_embeds_list,
+                    video_span_embeds_list=video_span_embeds_list,
+                    mm_item_cu_seqlen=mm_item_cu_seqlen,
+                    mm_item_types=mm_item_types,
+                    mm_token_positions=mm_token_positions,
+                    mm_token_lengths=mm_token_lengths,
+                    mm_special_offsets_cu_seqlen=mm_special_offsets_cu_seqlen,
+                    mm_special_offsets=mm_special_offsets,
+                )
+            else:
+                if image_embeds_list is not None:
+                    image_embeds = torch.cat(image_embeds_list, dim=0)
+                    image_mask = (
+                        (input_ids == self.config.image_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                    )
+                    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+                if video_embeds_list is not None:
+                    video_embeds = torch.cat(video_embeds_list, dim=0)
+                    video_mask = (
+                        (input_ids == self.config.video_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                    )
+                    inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+                multimodal_embeds = None
+
+            if (
+                multimodal_embeds is not None
+                and multimodal_embeds.shape[0] != num_multimodal_tokens
+            ):
+                raise ValueError(
+                    "Multimodal embedding count mismatch in Qwen3.5 VLM forward: "
+                    f"selected={multimodal_embeds.shape[0]}, placeholders={num_multimodal_tokens}, "
+                    f"input_shape={tuple(input_ids.shape)}"
+                )
+            if multimodal_embeds is not None:
+                inputs_embeds = inputs_embeds.masked_scatter(multimodal_mask, multimodal_embeds)
         if mrope_delta_cache is not None and batch_info_host is not None and slot_idx is not None:
             delta = torch.ops.auto_deploy.qwen3_mrope_delta_with_cache(
                 batch_info_host,
@@ -2015,6 +2277,7 @@ class Qwen3_5MoeModel(nn.Module):
         img_grid_idx = 0
         vid_grid_idx = 0
         prefill_3d_parts: list[torch.Tensor] = []
+        normalized_video_grid_thw = _normalize_video_grid_for_mrope(video_grid_thw)
 
         for i in range(num_prefill_seqs):
             start = cu_seqlen[i].item()
@@ -2035,7 +2298,7 @@ class Qwen3_5MoeModel(nn.Module):
                 req_special_offsets = mm_special_offsets[special_start:special_end].tolist()
 
             has_img = image_grid_thw is not None and len(req_mm_positions) > 0
-            has_vid = video_grid_thw is not None and len(req_mm_positions) > 0
+            has_vid = normalized_video_grid_thw is not None and len(req_mm_positions) > 0
 
             if has_img or has_vid:
                 req_img_grid = None
@@ -2046,7 +2309,9 @@ class Qwen3_5MoeModel(nn.Module):
                     req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + num_images]
                     img_grid_idx += num_images
                 if has_vid:
-                    req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + num_videos]
+                    req_vid_grid = normalized_video_grid_thw[
+                        vid_grid_idx : vid_grid_idx + num_videos
+                    ]
                     vid_grid_idx += num_videos
 
                 pos_3d = self._compute_request_chunk_mrope_positions(
@@ -2106,13 +2371,12 @@ class Qwen3_5MoeModel(nn.Module):
         """Compute chunk-local 3D mRoPE positions for one request in absolute coordinates."""
         chunk_end = req_input_pos + req_seq_len
         out = torch.empty((3, 1, req_seq_len), dtype=dtype, device=device)
-
+        special_offsets_set = set(int(x) for x in req_special_offsets)
         mm_cumulative_offset = 0
         abs_cursor = 0
         comp_cursor = 0
         img_idx = 0
         vid_idx = 0
-        special_offsets_set = set(int(x) for x in req_special_offsets)
 
         def fill_text(abs_start: int, abs_end: int, comp_start: int) -> None:
             ov_start = max(req_input_pos, abs_start)
@@ -2127,7 +2391,7 @@ class Qwen3_5MoeModel(nn.Module):
                 0
             ).expand(3, -1)
 
-        def fill_vision(abs_start: int, grid: torch.Tensor, comp_start: int) -> None:
+        def fill_vision(abs_start: int, grid: torch.Tensor, comp_start: int) -> Tuple[int, int]:
             t, h, w = [int(v) for v in grid.tolist()]
             llm_grid_t = int(t)
             llm_grid_h = int(h) // self.config.vision_config.spatial_merge_size
@@ -2483,19 +2747,21 @@ class Qwen3_5MoeADInputProcessor:
             mm_union_offset += j - i
             i = j
 
-        image_items = []
-        if "image" in mm_data:
-            images = mm_data["image"]
-            image_items = images if isinstance(images, list) else [images]
-        video_items = []
-        if "video" in mm_data:
-            videos = mm_data["video"]
-            video_items = videos if isinstance(videos, list) else [videos]
+        image_items = _normalize_qwen_image_items(mm_data.get("image"))
+        video_items = _normalize_qwen_video_items(mm_data.get("video"))
 
-        if len(starts) != len(image_items) + len(video_items):
+        num_video_spans = sum(item_type == 1 for item_type in item_types)
+        video_span_counts = [_get_qwen_video_num_spans(video) for video in video_items]
+        if num_video_spans != sum(video_span_counts):
+            raise ValueError(
+                "Mismatch between Qwen video prompt spans and video inputs: "
+                f"spans={num_video_spans}, expected_from_videos={sum(video_span_counts)}"
+            )
+
+        if len(starts) != len(image_items) + num_video_spans:
             raise ValueError(
                 "Mismatch between multimodal prompt spans and multimodal items: "
-                f"spans={len(starts)}, images={len(image_items)}, videos={len(video_items)}"
+                f"spans={len(starts)}, images={len(image_items)}, video_spans={num_video_spans}"
             )
 
         mm_uuids = inputs.get("multi_modal_uuids", None)
@@ -2512,6 +2778,7 @@ class Qwen3_5MoeADInputProcessor:
         video_uuids = list((mm_uuids or {}).get("video", [None] * len(video_items)))
         image_idx = 0
         video_idx = 0
+        remaining_video_spans = video_span_counts[0] if video_span_counts else 0
         mm_hashes_flat: List[List[int]] = []
         mm_uuid_list: List[Optional[str]] = []
         for item_type in item_types:
@@ -2520,9 +2787,16 @@ class Qwen3_5MoeADInputProcessor:
                 mm_uuid_list.append(image_uuids[image_idx])
                 image_idx += 1
             else:
+                if video_idx >= len(video_hashes):
+                    raise ValueError("Video span count exceeded available video items")
                 mm_hashes_flat.append(video_hashes[video_idx])
                 mm_uuid_list.append(video_uuids[video_idx])
-                video_idx += 1
+                remaining_video_spans -= 1
+                if remaining_video_spans == 0:
+                    video_idx += 1
+                    remaining_video_spans = (
+                        video_span_counts[video_idx] if video_idx < len(video_span_counts) else 0
+                    )
         return (
             MultimodalInput.from_components(
                 mm_hashes_flat,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 
 """Qwen3.5 MoE model for auto_deploy (text + vision).
 
@@ -1916,8 +1916,12 @@ class Qwen3_5MoeModel(nn.Module):
         else:
             if position_ids is None:
                 raise ValueError("position_ids is required for text-only or decode-only forward")
-            if position_ids.ndim == 1:
-                token_delta = torch.zeros_like(position_ids)
+            is_flattened_cached_layout = position_ids.ndim == 1 or (
+                position_ids.ndim == 2 and position_ids.shape[0] == 1
+            )
+            if is_flattened_cached_layout:
+                flat_position_ids = position_ids.reshape(-1)
+                token_delta = torch.zeros_like(flat_position_ids)
                 if (
                     delta is not None
                     and cu_seqlen is not None
@@ -1926,10 +1930,10 @@ class Qwen3_5MoeModel(nn.Module):
                 ):
                     seq_lens = (cu_seqlen[1:] - cu_seqlen[:-1]).to(torch.long)
                     token_delta = torch.repeat_interleave(
-                        delta.squeeze(-1).to(position_ids.device, position_ids.dtype),
-                        seq_lens.to(position_ids.device),
+                        delta.squeeze(-1).to(flat_position_ids.device, flat_position_ids.dtype),
+                        seq_lens.to(flat_position_ids.device),
                     )
-                position_ids_3d = (position_ids + token_delta).view(1, 1, -1).expand(3, 1, -1)
+                position_ids_3d = (flat_position_ids + token_delta).view(1, 1, -1).expand(3, 1, -1)
             else:
                 position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1736,6 +1736,7 @@ class Qwen3_5MoeModel(nn.Module):
         self,
         input_ids: Optional[torch.LongTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         pixel_values: Optional[torch.Tensor] = None,
         pixel_values_videos: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.LongTensor] = None,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -2510,8 +2510,10 @@ class Qwen3_5MoeADInputProcessor:
             extra_processed_inputs = {}
         extra_processed_inputs["multimodal_input"] = multimodal_input
         multimodal_data = extra_processed_inputs.get("multimodal_data", {})
-        multimodal_data["special_token_offsets"] = torch.tensor(special_offsets, dtype=torch.int32)
-        multimodal_data["item_types"] = torch.tensor(item_types, dtype=torch.int32)
+        multimodal_data["layout_metadata"] = {
+            "special_token_offsets": torch.tensor(special_offsets, dtype=torch.int32),
+            "item_types": torch.tensor(item_types, dtype=torch.int32),
+        }
         extra_processed_inputs["multimodal_data"] = multimodal_data
         return token_ids, extra_processed_inputs
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -25,7 +25,7 @@ dependency issues in the source, while remaining weight-compatible with HF check
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -45,6 +45,7 @@ from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForImageTextToTextFactory,
     TextModelExportInfo,
 )
+from tensorrt_llm.inputs.multimodal import MultimodalInput, apply_mm_hashes, hexdigest_to_int32
 
 # =============================================================================
 # Configuration
@@ -1444,8 +1445,6 @@ class Qwen3_5MoeModel(nn.Module):
     computes the correct mRoPE cos/sin.
     """
 
-    persistent_multimodal_keys = {"mrope_position_deltas"}
-
     def __init__(self, config: Qwen3_5MoeConfig):
         super().__init__()
         self.config = config
@@ -1547,7 +1546,43 @@ class Qwen3_5MoeModel(nn.Module):
             image_mask = (
                 (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
             )
-            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+            # Chunked prefill: use only the slice of image_embeds for this chunk.
+            mm_chunk_flat_start = kwargs.pop("mm_chunk_flat_start", None)
+            mm_chunk_count = kwargs.pop("mm_chunk_count", None)
+            if (
+                mm_chunk_flat_start is not None
+                and mm_chunk_count is not None
+                and mm_chunk_flat_start.shape[0] > 0
+                and int(mm_chunk_count.sum().item()) > 0
+            ):
+                flat_start = mm_chunk_flat_start.to(image_embeds.device)
+                count = mm_chunk_count.to(image_embeds.device)
+                chunks = []
+                for i in range(flat_start.shape[0]):
+                    c = count[i].item()
+                    if c > 0:
+                        s = flat_start[i].item()
+                        chunks.append(image_embeds[s : s + c])
+                if chunks:
+                    chunk_image_embeds = torch.cat(chunks, dim=0)
+                else:
+                    chunk_image_embeds = torch.empty(
+                        0,
+                        image_embeds.shape[1],
+                        device=image_embeds.device,
+                        dtype=image_embeds.dtype,
+                    )
+                num_image_tokens = int((input_ids == self.config.image_token_id).sum().item())
+                if chunk_image_embeds.shape[0] != num_image_tokens:
+                    raise ValueError(
+                        "Chunk image embedding count mismatch in Qwen3.5 VLM forward: "
+                        f"selected={chunk_image_embeds.shape[0]}, placeholders={num_image_tokens}, "
+                        f"mm_chunk_flat_start={flat_start.tolist()}, mm_chunk_count={count.tolist()}, "
+                        f"input_shape={tuple(input_ids.shape)}, image_grid_shape={tuple(image_grid_thw.shape)}"
+                    )
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, chunk_image_embeds)
+            else:
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
 
         if has_videos:
             video_embeds = torch.cat(
@@ -1561,9 +1596,61 @@ class Qwen3_5MoeModel(nn.Module):
         delta = mrope_position_deltas if mrope_position_deltas is not None else 0
 
         vision_grid = image_grid_thw if has_images else video_grid_thw if has_videos else None
+        if batch_info is None:
+            batch_info = kwargs.get("batch_info_host")
         cu_seqlen = kwargs.get("cu_seqlen")
+        if cu_seqlen is None:
+            cu_seqlen = kwargs.get("cu_seqlen_host")
+        seq_len = kwargs.get("seq_len")
+        if seq_len is None and cu_seqlen is not None:
+            seq_len = cu_seqlen[1:] - cu_seqlen[:-1]
+        input_pos = kwargs.get("input_pos")
+        if input_pos is None:
+            seq_len_with_cache = kwargs.get("seq_len_with_cache")
+            if seq_len_with_cache is None:
+                seq_len_with_cache = kwargs.get("seq_len_with_cache_host")
+            if seq_len_with_cache is not None and seq_len is not None:
+                input_pos = seq_len_with_cache.to(seq_len.device) - seq_len
+        mm_item_cu_seqlen = kwargs.get("mm_item_cu_seqlen")
+        mm_token_positions = kwargs.get("mm_token_positions")
+        mm_token_lengths = kwargs.get("mm_token_lengths")
+        mm_special_offsets_cu_seqlen = kwargs.get("mm_special_offsets_cu_seqlen")
+        mm_special_offsets = kwargs.get("mm_special_offsets")
+        has_chunk_mm_layout = (
+            mm_item_cu_seqlen is not None
+            and mm_token_positions is not None
+            and mm_token_lengths is not None
+            and mm_item_cu_seqlen.numel() > 0
+            and int(mm_item_cu_seqlen[-1].item()) > 0
+            and mm_token_positions.numel() > 0
+            and mm_token_lengths.numel() > 0
+        )
 
-        if vision_grid is not None and batch_info is not None and cu_seqlen is not None:
+        if (
+            vision_grid is not None
+            and batch_info is not None
+            and cu_seqlen is not None
+            and input_pos is not None
+            and seq_len is not None
+            and has_chunk_mm_layout
+        ):
+            position_ids_3d = self._build_chunked_multimodal_positions(
+                input_ids,
+                position_ids,
+                delta,
+                batch_info,
+                cu_seqlen,
+                input_pos,
+                seq_len,
+                image_grid_thw if has_images else None,
+                video_grid_thw if has_videos else None,
+                mm_item_cu_seqlen,
+                mm_token_positions,
+                mm_token_lengths,
+                mm_special_offsets_cu_seqlen,
+                mm_special_offsets,
+            )
+        elif vision_grid is not None and batch_info is not None and cu_seqlen is not None:
             position_ids_3d = self._build_mixed_positions(
                 input_ids,
                 position_ids,
@@ -1588,11 +1675,228 @@ class Qwen3_5MoeModel(nn.Module):
                 raise ValueError("position_ids is required for text-only or decode-only forward")
             position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
 
+        for key in (
+            "input_pos",
+            "seq_len",
+            "mm_chunk_flat_start",
+            "mm_chunk_count",
+            "mm_item_cu_seqlen",
+            "mm_token_positions",
+            "mm_token_lengths",
+            "mm_special_offsets_cu_seqlen",
+            "mm_special_offsets",
+        ):
+            kwargs.pop(key, None)
+
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids_3d,
             **kwargs,
         )
+
+    def _build_chunked_multimodal_positions(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: Optional[torch.LongTensor],
+        delta,
+        batch_info: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        input_pos: torch.Tensor,
+        seq_len: torch.Tensor,
+        image_grid_thw: Optional[torch.LongTensor],
+        video_grid_thw: Optional[torch.LongTensor],
+        mm_item_cu_seqlen: torch.Tensor,
+        mm_token_positions: torch.Tensor,
+        mm_token_lengths: torch.Tensor,
+        mm_special_offsets_cu_seqlen: Optional[torch.Tensor],
+        mm_special_offsets: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build 3D positions using chunk runtime metadata from the executor.
+
+        This path is for chunked multimodal prefill where ``input_ids`` only contains the current
+        chunk but full multimodal tensors are still available. It reconstructs the chunk's 3D
+        mRoPE positions in absolute request coordinates from:
+        - per-request chunk start/end (`input_pos`, `seq_len`)
+        - per-request multimodal item layout (`mm_token_positions`, `mm_token_lengths`)
+        - full multimodal grids (`image_grid_thw` / `video_grid_thw`)
+        """
+        num_prefill_seqs = batch_info[0].item()
+        num_prefill_tokens = batch_info[1].item()
+
+        img_grid_idx = 0
+        vid_grid_idx = 0
+        prefill_3d_parts: list[torch.Tensor] = []
+
+        for i in range(num_prefill_seqs):
+            start = cu_seqlen[i].item()
+            end = cu_seqlen[i + 1].item()
+            req_input_pos = int(input_pos[i].item())
+            req_seq_len = int(seq_len[i].item())
+
+            item_start = int(mm_item_cu_seqlen[i].item())
+            item_end = int(mm_item_cu_seqlen[i + 1].item())
+            req_mm_positions = mm_token_positions[item_start:item_end].tolist()
+            req_mm_lengths = mm_token_lengths[item_start:item_end].tolist()
+
+            req_special_offsets: list[int] = []
+            if mm_special_offsets_cu_seqlen is not None and mm_special_offsets is not None:
+                special_start = int(mm_special_offsets_cu_seqlen[i].item())
+                special_end = int(mm_special_offsets_cu_seqlen[i + 1].item())
+                req_special_offsets = mm_special_offsets[special_start:special_end].tolist()
+
+            has_img = image_grid_thw is not None and len(req_mm_positions) > 0
+            has_vid = video_grid_thw is not None and len(req_mm_positions) > 0
+
+            if has_img or has_vid:
+                req_img_grid = None
+                req_vid_grid = None
+                num_items = len(req_mm_positions)
+                if has_img:
+                    req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + num_items]
+                    img_grid_idx += num_items
+                if has_vid:
+                    req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + num_items]
+                    vid_grid_idx += num_items
+
+                pos_3d = self._compute_request_chunk_mrope_positions(
+                    req_input_pos=req_input_pos,
+                    req_seq_len=req_seq_len,
+                    req_mm_positions=req_mm_positions,
+                    req_mm_lengths=req_mm_lengths,
+                    req_special_offsets=req_special_offsets,
+                    image_grid_thw=req_img_grid,
+                    video_grid_thw=req_vid_grid,
+                    dtype=input_ids.dtype,
+                    device=input_ids.device,
+                )
+                prefill_3d_parts.append(pos_3d)
+            else:
+                if position_ids is not None:
+                    req_pos = position_ids[..., start:end]
+                else:
+                    req_pos = torch.arange(
+                        req_input_pos,
+                        req_input_pos + req_seq_len,
+                        device=input_ids.device,
+                        dtype=input_ids.dtype,
+                    ).unsqueeze(0)
+                prefill_3d_parts.append(req_pos[None].expand(3, -1, -1))
+
+        prefill_pos = torch.cat(prefill_3d_parts, dim=-1)
+
+        if num_prefill_tokens < input_ids.shape[-1]:
+            if position_ids is None:
+                raise ValueError("position_ids is required when decode tokens are present")
+            decode_pos_2d = position_ids[..., num_prefill_tokens:]
+            if isinstance(delta, torch.Tensor):
+                gen_deltas = delta[num_prefill_seqs:]
+                decode_adjusted = decode_pos_2d + gen_deltas.T
+            else:
+                decode_adjusted = decode_pos_2d + delta
+            decode_pos_3d = decode_adjusted[None].expand(3, -1, -1)
+            return torch.cat([prefill_pos, decode_pos_3d], dim=-1)
+
+        return prefill_pos
+
+    def _compute_request_chunk_mrope_positions(
+        self,
+        req_input_pos: int,
+        req_seq_len: int,
+        req_mm_positions: Sequence[int],
+        req_mm_lengths: Sequence[int],
+        req_special_offsets: Sequence[int],
+        image_grid_thw: Optional[torch.Tensor],
+        video_grid_thw: Optional[torch.Tensor],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Compute chunk-local 3D mRoPE positions for one request in absolute coordinates."""
+        chunk_end = req_input_pos + req_seq_len
+        out = torch.empty((3, 1, req_seq_len), dtype=dtype, device=device)
+
+        mm_cumulative_offset = 0
+        abs_cursor = 0
+        comp_cursor = 0
+        img_idx = 0
+        vid_idx = 0
+        special_offsets_set = set(int(x) for x in req_special_offsets)
+
+        def fill_text(abs_start: int, abs_end: int, comp_start: int) -> None:
+            ov_start = max(req_input_pos, abs_start)
+            ov_end = min(chunk_end, abs_end)
+            if ov_start >= ov_end:
+                return
+            start_pos = comp_start + (ov_start - abs_start)
+            text_pos = torch.arange(
+                start_pos, start_pos + (ov_end - ov_start), device=device, dtype=dtype
+            )
+            out[:, 0, ov_start - req_input_pos : ov_end - req_input_pos] = text_pos.unsqueeze(
+                0
+            ).expand(3, -1)
+
+        def fill_vision(abs_start: int, grid: torch.Tensor, comp_start: int) -> None:
+            t, h, w = [int(v) for v in grid.tolist()]
+            llm_grid_t = int(t)
+            llm_grid_h = int(h) // self.config.vision_config.spatial_merge_size
+            llm_grid_w = int(w) // self.config.vision_config.spatial_merge_size
+            vision_len = llm_grid_t * llm_grid_h * llm_grid_w
+
+            ov_start = max(req_input_pos, abs_start)
+            ov_end = min(chunk_end, abs_start + vision_len)
+            if ov_start < ov_end:
+                t_index = (
+                    torch.arange(llm_grid_t, device=device, dtype=dtype)
+                    .view(-1, 1)
+                    .expand(-1, llm_grid_h * llm_grid_w)
+                    .flatten()
+                )
+                h_index = (
+                    torch.arange(llm_grid_h, device=device, dtype=dtype)
+                    .view(1, -1, 1)
+                    .expand(llm_grid_t, -1, llm_grid_w)
+                    .flatten()
+                )
+                w_index = (
+                    torch.arange(llm_grid_w, device=device, dtype=dtype)
+                    .view(1, 1, -1)
+                    .expand(llm_grid_t, llm_grid_h, -1)
+                    .flatten()
+                )
+                positions = torch.stack([t_index, h_index, w_index]) + comp_start
+                local_start = ov_start - abs_start
+                local_end = ov_end - abs_start
+                out[:, 0, ov_start - req_input_pos : ov_end - req_input_pos] = positions[
+                    :, local_start:local_end
+                ]
+
+            return vision_len, comp_start + max(llm_grid_t, llm_grid_h, llm_grid_w)
+
+        for item_idx, (mm_start, mm_len) in enumerate(zip(req_mm_positions, req_mm_lengths)):
+            item_mm_offset = mm_cumulative_offset
+            leading_specials = 0
+            while item_mm_offset + leading_specials in special_offsets_set:
+                leading_specials += 1
+
+            vision_abs_start = int(mm_start) + leading_specials
+            fill_text(abs_cursor, vision_abs_start, comp_cursor)
+            comp_cursor += vision_abs_start - abs_cursor
+
+            if image_grid_thw is not None:
+                grid = image_grid_thw[img_idx]
+                img_idx += 1
+            elif video_grid_thw is not None:
+                grid = video_grid_thw[vid_idx]
+                vid_idx += 1
+            else:
+                raise ValueError("Expected image or video grids for multimodal request")
+
+            _, next_comp_cursor = fill_vision(vision_abs_start, grid, comp_cursor)
+            comp_cursor = next_comp_cursor
+            abs_cursor = int(mm_start) + int(mm_len)
+            mm_cumulative_offset += int(mm_len)
+
+        fill_text(abs_cursor, chunk_end, comp_cursor)
+        return out
 
     def _build_mixed_positions(
         self,
@@ -1735,46 +2039,85 @@ class Qwen3_5MoeTextExportInfo(TextModelExportInfo):
         return base
 
 
-class Qwen3_5MoeInputProcessor:
-    """Input processor that wraps an ``ADInputProcessor`` and adds mRoPE delta computation.
+class Qwen3_5MoeADInputProcessor:
+    """Qwen-specific AD input processor that emits exact multimodal spans from tokenized input."""
 
-    Uses composition (not inheritance) to avoid a circular import with
-    ``auto_deploy.llm``.  After the base tokenization/multimodal processing,
-    this runs the mRoPE position computation on the full token sequence to
-    produce ``mrope_position_deltas``.  The VLM wrapper later uses this delta
-    to adjust the executor's sequential 2D ``position_ids`` so that text
-    tokens after vision tokens get correct mRoPE positions.
-    """
+    def __init__(self, base_processor):
+        self.base_processor = base_processor
+        # Bypass the generic hashing wrapper. We produce multimodal_input directly.
+        self.multimodal_hashing_supported = False
 
-    def __init__(self, base_processor, config: Qwen3_5MoeConfig):
-        self._base = base_processor
-        self._mrope_config = config
+    def __getattr__(self, name: str):
+        return getattr(self.base_processor, name)
 
-    def __getattr__(self, name):
-        return getattr(self._base, name)
+    def _build_multimodal_input(
+        self,
+        token_ids: List[int],
+        inputs: Dict[str, Any],
+    ) -> Optional[Tuple[MultimodalInput, List[int]]]:
+        mm_data = inputs.get("multi_modal_data")
+        if not mm_data or "image" not in mm_data:
+            return None
+
+        image_token_id = int(self.processor.image_token_id)
+        vision_start_token_id = int(self.processor.vision_start_token_id)
+        ids = token_ids
+
+        starts: List[int] = []
+        lengths: List[int] = []
+        special_offsets: List[int] = []
+        mm_union_offset = 0
+        i = 0
+        while i < len(ids):
+            if ids[i] != vision_start_token_id:
+                i += 1
+                continue
+
+            j = i + 1
+            while j < len(ids) and ids[j] == image_token_id:
+                j += 1
+            if j == i + 1:
+                i += 1
+                continue
+
+            starts.append(i)
+            lengths.append(j - i)
+            special_offsets.append(mm_union_offset)
+            mm_union_offset += j - i
+            i = j
+
+        images = mm_data["image"]
+        image_items = images if isinstance(images, list) else [images]
+        if len(starts) != len(image_items):
+            raise ValueError(
+                f"Expected {len(image_items)} image multimodal spans, found {len(starts)} in tokenized prompt"
+            )
+
+        mm_uuids = inputs.get("multi_modal_uuids", None)
+        mm_hashes, mm_uuid_list = apply_mm_hashes({"image": image_items}, mm_uuids)
+        mm_hashes_flat = [hexdigest_to_int32(h) for h in mm_hashes["image"]]
+        return (
+            MultimodalInput.from_components(mm_hashes_flat, starts, lengths, mm_uuid_list),
+            special_offsets,
+        )
 
     def __call__(self, inputs, sampling_params):
-        token_ids, extra = self._base(inputs, sampling_params)
+        token_ids, extra_processed_inputs = self.base_processor(inputs, sampling_params)
+        if "multi_modal_data" not in inputs:
+            return token_ids, extra_processed_inputs
 
-        if extra is not None and "multimodal_data" in extra:
-            mm_data = extra["multimodal_data"]
-            image_grid_thw = mm_data.get("image_grid_thw")
-            video_grid_thw = mm_data.get("video_grid_thw")
+        built = self._build_multimodal_input(token_ids, inputs)
+        if built is None:
+            return token_ids, extra_processed_inputs
 
-            if image_grid_thw is not None or video_grid_thw is not None:
-                input_ids_t = torch.tensor([token_ids], dtype=torch.long)
-                _, deltas = compute_mrope_positions(
-                    input_ids=input_ids_t,
-                    image_grid_thw=image_grid_thw,
-                    video_grid_thw=video_grid_thw,
-                    image_token_id=self._mrope_config.image_token_id,
-                    video_token_id=self._mrope_config.video_token_id,
-                    vision_start_token_id=self._mrope_config.vision_start_token_id,
-                    spatial_merge_size=self._mrope_config.vision_config.spatial_merge_size,
-                )
-                mm_data["mrope_position_deltas"] = deltas
-
-        return token_ids, extra
+        multimodal_input, special_offsets = built
+        if extra_processed_inputs is None:
+            extra_processed_inputs = {}
+        extra_processed_inputs["multimodal_input"] = multimodal_input
+        multimodal_data = extra_processed_inputs.get("multimodal_data", {})
+        multimodal_data["special_token_offsets"] = torch.tensor(special_offsets, dtype=torch.int32)
+        extra_processed_inputs["multimodal_data"] = multimodal_data
+        return token_ids, extra_processed_inputs
 
 
 @ModelFactoryRegistry.register("Qwen3_5MoeForConditionalGeneration")
@@ -1784,13 +2127,8 @@ class Qwen3_5MoeFactory(AutoModelForImageTextToTextFactory):
     def get_export_infos(self, model: nn.Module):
         return [Qwen3_5MoeTextExportInfo.from_autoinferred(model)]
 
-    def init_input_processor(self, base_input_processor):
-        """Wrap the base input processor with mRoPE delta pre-computation."""
-        if not hasattr(self, "_cached_model_config"):
-            self._cached_model_config = AutoConfig.from_pretrained(
-                self.model, trust_remote_code=True
-            )
-        return Qwen3_5MoeInputProcessor(base_input_processor, self._cached_model_config)
+    def init_input_processor(self, base):
+        return Qwen3_5MoeADInputProcessor(base)
 
 
 # =============================================================================

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1023,7 +1023,6 @@ class Qwen3_5MoeVisionAttention(nn.Module):
         self.head_dim = self.dim // self.num_heads
         self.qkv = nn.Linear(self.dim, self.dim * 3, bias=True)
         self.proj = nn.Linear(self.dim, self.dim)
-        self.scaling = self.head_dim**-0.5
 
     def forward(
         self,
@@ -1042,7 +1041,6 @@ class Qwen3_5MoeVisionAttention(nn.Module):
         cos, sin = position_embeddings
         query_states, key_states = apply_rotary_pos_emb_vision(query_states, key_states, cos, sin)
 
-        # Eager path: process each variable-length sequence separately
         # Layout: (1, num_heads, seq_len, head_dim) per chunk
         query_states = query_states.transpose(0, 1).unsqueeze(0)  # (1, H, S, D)
         key_states = key_states.transpose(0, 1).unsqueeze(0)
@@ -1055,9 +1053,7 @@ class Qwen3_5MoeVisionAttention(nn.Module):
 
         attn_outputs = []
         for q, k, v in zip(q_splits, k_splits, v_splits):
-            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
-            attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
-            attn_outputs.append(torch.matmul(attn_weights, v))
+            attn_outputs.append(F.scaled_dot_product_attention(q, k, v, is_causal=False))
 
         attn_output = torch.cat(attn_outputs, dim=2)  # (1, H, total_S, D)
         attn_output = attn_output.squeeze(0).transpose(0, 1)  # (S, H, D)
@@ -1448,14 +1444,13 @@ class Qwen3_5MoeModel(nn.Module):
     computes the correct mRoPE cos/sin.
     """
 
+    persistent_multimodal_keys = {"mrope_position_deltas"}
+
     def __init__(self, config: Qwen3_5MoeConfig):
         super().__init__()
         self.config = config
         self.visual = Qwen3_5MoeVisionModel(config.vision_config)
         self.language_model = Qwen3_5MoeTextModel(config.text_config)
-
-        # Cache rope_deltas for decode steps
-        self.rope_deltas: Optional[torch.Tensor] = None
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
@@ -1521,74 +1516,157 @@ class Qwen3_5MoeModel(nn.Module):
         image_grid_thw: Optional[torch.LongTensor] = None,
         video_grid_thw: Optional[torch.LongTensor] = None,
         mrope_position_deltas: Optional[torch.Tensor] = None,
+        batch_info: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Qwen3_5MoeOutput:
         """Multimodal forward: vision encoding + embedding merge + mRoPE + text model.
 
-        Three position-handling branches:
+        3D mRoPE positions are computed per request at forward time using
+        ``cu_seqlen`` to identify request boundaries and ``image_grid_thw``
+        to derive spatial positions for multimodal requests.
 
-        A. **Text-only (no images ever)**: ``pixel_values`` is ``None`` and
-           ``rope_deltas`` has never been set.  Expand the executor's 2D
-           ``position_ids`` to 3D (all dims identical).
+        Position assembly cases:
 
-        B. **Image chunk**: ``pixel_values`` is present.  Run the vision tower,
-           merge embeddings, and recompute full 3D mRoPE ``position_ids`` via
-           ``get_rope_index``.  Cache ``rope_deltas`` for subsequent decode.
-
-        C. **Text-only after image (decode steps)**: ``pixel_values`` is
-           ``None`` but ``rope_deltas`` was cached from a prior image forward.
-           Adjust the executor's 2D ``position_ids`` by ``rope_deltas`` to
-           account for mRoPE position compression, then expand to 3D.
+        1. Images present + ``batch_info`` (mixed or prefill-only with images):
+           iterate prefill requests via ``cu_seqlen``, call
+           ``compute_mrope_positions`` for multimodal requests and expand 2D
+           positions to 3D for text-only requests.  Decode tokens get
+           delta-adjusted 3D expansion.
+        2. Otherwise (decode-only or text-only prefill without images): expand
+           ``position_ids + delta`` to 3D where delta defaults to 0.
         """
         inputs_embeds = self.get_input_embeddings()(input_ids)
 
         has_images = pixel_values is not None and image_grid_thw is not None
         has_videos = pixel_values_videos is not None and video_grid_thw is not None
 
-        # Image embedding merge
         if has_images:
-            image_embeds_list = self.get_image_features(pixel_values, image_grid_thw)
-            image_embeds = torch.cat(image_embeds_list, dim=0).to(
-                inputs_embeds.device, inputs_embeds.dtype
-            )
-            image_mask, _ = self.get_placeholder_mask(
-                input_ids, inputs_embeds, image_features=image_embeds
+            image_embeds = torch.cat(
+                self.get_image_features(pixel_values, image_grid_thw), dim=0
+            ).to(inputs_embeds.device, inputs_embeds.dtype)
+            image_mask = (
+                (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
             )
             inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
 
-        # Video embedding merge
         if has_videos:
-            video_embeds_list = self.get_video_features(pixel_values_videos, video_grid_thw)
-            video_embeds = torch.cat(video_embeds_list, dim=0).to(
-                inputs_embeds.device, inputs_embeds.dtype
-            )
-            _, video_mask = self.get_placeholder_mask(
-                input_ids, inputs_embeds, video_features=video_embeds
+            video_embeds = torch.cat(
+                self.get_video_features(pixel_values_videos, video_grid_thw), dim=0
+            ).to(inputs_embeds.device, inputs_embeds.dtype)
+            video_mask = (
+                (input_ids == self.config.video_token_id).unsqueeze(-1).expand_as(inputs_embeds)
             )
             inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
-        # Build 3D mRoPE position IDs
-        if has_images or has_videos:
-            # Branch B: multimodal -- recompute full 3D positions
-            position_ids_3d, self.rope_deltas = self.get_rope_index(
+        delta = mrope_position_deltas if mrope_position_deltas is not None else 0
+
+        vision_grid = image_grid_thw if has_images else video_grid_thw if has_videos else None
+        cu_seqlen = kwargs.get("cu_seqlen")
+
+        if vision_grid is not None and batch_info is not None and cu_seqlen is not None:
+            position_ids_3d = self._build_mixed_positions(
                 input_ids,
-                image_grid_thw,
-                video_grid_thw,
-                attention_mask=attention_mask,
+                position_ids,
+                delta,
+                batch_info,
+                cu_seqlen,
+                image_grid_thw if has_images else None,
+                video_grid_thw if has_videos else None,
             )
-        elif self.rope_deltas is not None:
-            # Branch C: text-only after image -- adjust for mRoPE compression
-            delta = mrope_position_deltas if mrope_position_deltas is not None else self.rope_deltas
-            position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
+        elif vision_grid is not None:
+            position_ids_3d, _ = compute_mrope_positions(
+                input_ids=input_ids,
+                image_grid_thw=image_grid_thw if has_images else None,
+                video_grid_thw=video_grid_thw if has_videos else None,
+                image_token_id=self.config.image_token_id,
+                video_token_id=self.config.video_token_id,
+                vision_start_token_id=self.config.vision_start_token_id,
+                spatial_merge_size=self.config.vision_config.spatial_merge_size,
+            )
         else:
-            # Branch A: text-only (no images ever) -- straight 2D -> 3D expansion
-            position_ids_3d = position_ids[None].expand(3, -1, -1)
+            if position_ids is None:
+                raise ValueError("position_ids is required for text-only or decode-only forward")
+            position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
 
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids_3d,
             **kwargs,
         )
+
+    def _build_mixed_positions(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: torch.LongTensor,
+        delta,
+        batch_info: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        image_grid_thw: Optional[torch.LongTensor],
+        video_grid_thw: Optional[torch.LongTensor],
+    ) -> torch.Tensor:
+        """Build 3D mRoPE positions for a batch with per-request granularity.
+
+        Iterates over prefill requests using ``cu_seqlen`` boundaries.  For
+        each request that contains vision tokens, calls
+        ``compute_mrope_positions`` with the matching ``image_grid_thw`` rows.
+        Text-only prefill requests get trivial 3D expansion.  Decode tokens
+        are delta-adjusted uniformly.
+        """
+        num_prefill_seqs = batch_info[0].item()
+        num_prefill_tokens = batch_info[1].item()
+
+        img_grid_idx = 0
+        vid_grid_idx = 0
+        prefill_3d_parts: list = []
+
+        for i in range(num_prefill_seqs):
+            start = cu_seqlen[i].item()
+            end = cu_seqlen[i + 1].item()
+            req_ids = input_ids[..., start:end]
+
+            has_img = image_grid_thw is not None and (req_ids == self.config.image_token_id).any()
+            has_vid = video_grid_thw is not None and (req_ids == self.config.video_token_id).any()
+
+            if has_img or has_vid:
+                req_img_grid = None
+                req_vid_grid = None
+                if has_img:
+                    n_img = (req_ids[0] == self.config.vision_start_token_id).sum().item()
+                    req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + n_img]
+                    img_grid_idx += n_img
+                if has_vid:
+                    n_vid = (req_ids[0] == self.config.vision_start_token_id).sum().item()
+                    req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + n_vid]
+                    vid_grid_idx += n_vid
+
+                pos_3d, _ = compute_mrope_positions(
+                    input_ids=req_ids,
+                    image_grid_thw=req_img_grid,
+                    video_grid_thw=req_vid_grid,
+                    image_token_id=self.config.image_token_id,
+                    video_token_id=self.config.video_token_id,
+                    vision_start_token_id=self.config.vision_start_token_id,
+                    spatial_merge_size=self.config.vision_config.spatial_merge_size,
+                )
+                prefill_3d_parts.append(pos_3d)
+            else:
+                req_pos = position_ids[..., start:end]
+                prefill_3d_parts.append((req_pos + 0)[None].expand(3, -1, -1))
+
+        prefill_pos = torch.cat(prefill_3d_parts, dim=-1)
+
+        if num_prefill_tokens < input_ids.shape[-1]:
+            decode_pos_2d = position_ids[..., num_prefill_tokens:]
+            if isinstance(delta, torch.Tensor):
+                num_prefill_seqs_t = batch_info[0].item()
+                gen_deltas = delta[num_prefill_seqs_t:]
+                decode_adjusted = decode_pos_2d + gen_deltas.T
+            else:
+                decode_adjusted = decode_pos_2d + delta
+            decode_pos_3d = decode_adjusted[None].expand(3, -1, -1)
+            return torch.cat([prefill_pos, decode_pos_3d], dim=-1)
+
+        return prefill_pos
 
 
 class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel):
@@ -1671,6 +1749,9 @@ class Qwen3_5MoeInputProcessor:
     def __init__(self, base_processor, config: Qwen3_5MoeConfig):
         self._base = base_processor
         self._mrope_config = config
+
+    def __getattr__(self, name):
+        return getattr(self._base, name)
 
     def __call__(self, inputs, sampling_params):
         token_ids, extra = self._base(inputs, sampling_params)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1941,7 +1941,6 @@ class Qwen3_5MoeModel(nn.Module):
 
         for key in (
             "input_pos",
-            "seq_len",
             "mm_chunk_flat_start",
             "mm_chunk_count",
             "mm_item_cu_seqlen",

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1449,6 +1449,26 @@ def _normalize_video_grid_for_mrope(
     return video_grid_thw
 
 
+def _extract_mm_item_types_from_input_ids(
+    input_ids: torch.Tensor,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+) -> List[int]:
+    """Return multimodal item types in prompt order for a single request."""
+    flat_ids = input_ids.reshape(-1).tolist()
+    item_types: List[int] = []
+    for idx in range(len(flat_ids) - 1):
+        if flat_ids[idx] != vision_start_token_id:
+            continue
+        next_token = flat_ids[idx + 1]
+        if next_token == image_token_id:
+            item_types.append(0)
+        elif next_token == video_token_id:
+            item_types.append(1)
+    return item_types
+
+
 def _compute_mm_item_special_counts(
     mm_token_lengths: torch.Tensor,
     mm_special_offsets_cu_seqlen: torch.Tensor,
@@ -1850,6 +1870,7 @@ class Qwen3_5MoeModel(nn.Module):
         mrope_delta_cache = kwargs.get("mrope_delta_cache")
         has_chunk_mm_layout = (
             mm_item_cu_seqlen is not None
+            and mm_item_types is not None
             and mm_token_positions is not None
             and mm_token_lengths is not None
             and mm_item_cu_seqlen.numel() > 0
@@ -1891,6 +1912,7 @@ class Qwen3_5MoeModel(nn.Module):
                 image_grid_thw if has_images else None,
                 video_grid_thw if has_videos else None,
                 mm_item_cu_seqlen,
+                mm_item_types,
                 mm_token_positions,
                 mm_token_lengths,
                 mm_special_offsets_cu_seqlen,
@@ -1972,6 +1994,7 @@ class Qwen3_5MoeModel(nn.Module):
         image_grid_thw: Optional[torch.LongTensor],
         video_grid_thw: Optional[torch.LongTensor],
         mm_item_cu_seqlen: torch.Tensor,
+        mm_item_types: torch.Tensor,
         mm_token_positions: torch.Tensor,
         mm_token_lengths: torch.Tensor,
         mm_special_offsets_cu_seqlen: Optional[torch.Tensor],
@@ -2001,6 +2024,7 @@ class Qwen3_5MoeModel(nn.Module):
 
             item_start = int(mm_item_cu_seqlen[i].item())
             item_end = int(mm_item_cu_seqlen[i + 1].item())
+            req_mm_item_types = mm_item_types[item_start:item_end].tolist()
             req_mm_positions = mm_token_positions[item_start:item_end].tolist()
             req_mm_lengths = mm_token_lengths[item_start:item_end].tolist()
 
@@ -2016,17 +2040,19 @@ class Qwen3_5MoeModel(nn.Module):
             if has_img or has_vid:
                 req_img_grid = None
                 req_vid_grid = None
-                num_items = len(req_mm_positions)
+                num_images = sum(item_type == 0 for item_type in req_mm_item_types)
+                num_videos = sum(item_type == 1 for item_type in req_mm_item_types)
                 if has_img:
-                    req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + num_items]
-                    img_grid_idx += num_items
+                    req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + num_images]
+                    img_grid_idx += num_images
                 if has_vid:
-                    req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + num_items]
-                    vid_grid_idx += num_items
+                    req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + num_videos]
+                    vid_grid_idx += num_videos
 
                 pos_3d = self._compute_request_chunk_mrope_positions(
                     req_input_pos=req_input_pos,
                     req_seq_len=req_seq_len,
+                    req_mm_item_types=req_mm_item_types,
                     req_mm_positions=req_mm_positions,
                     req_mm_lengths=req_mm_lengths,
                     req_special_offsets=req_special_offsets,
@@ -2068,6 +2094,7 @@ class Qwen3_5MoeModel(nn.Module):
         self,
         req_input_pos: int,
         req_seq_len: int,
+        req_mm_item_types: Sequence[int],
         req_mm_positions: Sequence[int],
         req_mm_lengths: Sequence[int],
         req_special_offsets: Sequence[int],
@@ -2137,7 +2164,7 @@ class Qwen3_5MoeModel(nn.Module):
 
             return vision_len, comp_start + max(llm_grid_t, llm_grid_h, llm_grid_w)
 
-        for item_idx, (mm_start, mm_len) in enumerate(zip(req_mm_positions, req_mm_lengths)):
+        for item_type, mm_start, mm_len in zip(req_mm_item_types, req_mm_positions, req_mm_lengths):
             item_mm_offset = mm_cumulative_offset
             leading_specials = 0
             while item_mm_offset + leading_specials in special_offsets_set:
@@ -2147,14 +2174,18 @@ class Qwen3_5MoeModel(nn.Module):
             fill_text(abs_cursor, vision_abs_start, comp_cursor)
             comp_cursor += vision_abs_start - abs_cursor
 
-            if image_grid_thw is not None:
+            if item_type == 0:
+                if image_grid_thw is None:
+                    raise ValueError("Missing image_grid_thw for image multimodal item")
                 grid = image_grid_thw[img_idx]
                 img_idx += 1
-            elif video_grid_thw is not None:
+            elif item_type == 1:
+                if video_grid_thw is None:
+                    raise ValueError("Missing video_grid_thw for video multimodal item")
                 grid = video_grid_thw[vid_idx]
                 vid_idx += 1
             else:
-                raise ValueError("Expected image or video grids for multimodal request")
+                raise ValueError(f"Unsupported multimodal item type: {item_type}")
 
             _, next_comp_cursor = fill_vision(vision_abs_start, grid, comp_cursor)
             comp_cursor = next_comp_cursor
@@ -2200,12 +2231,18 @@ class Qwen3_5MoeModel(nn.Module):
             if has_img or has_vid:
                 req_img_grid = None
                 req_vid_grid = None
+                req_item_types = _extract_mm_item_types_from_input_ids(
+                    req_ids,
+                    image_token_id=self.config.image_token_id,
+                    video_token_id=self.config.video_token_id,
+                    vision_start_token_id=self.config.vision_start_token_id,
+                )
                 if has_img:
-                    n_img = (req_ids[0] == self.config.vision_start_token_id).sum().item()
+                    n_img = sum(item_type == 0 for item_type in req_item_types)
                     req_img_grid = image_grid_thw[img_grid_idx : img_grid_idx + n_img]
                     img_grid_idx += n_img
                 if has_vid:
-                    n_vid = (req_ids[0] == self.config.vision_start_token_id).sum().item()
+                    n_vid = sum(item_type == 1 for item_type in req_item_types)
                     req_vid_grid = video_grid_thw[vid_grid_idx : vid_grid_idx + n_vid]
                     vid_grid_idx += n_vid
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1288,6 +1288,157 @@ class Qwen3_5MoeConditionalOutput(ModelOutput):
     logits: Optional[torch.FloatTensor] = None
 
 
+def compute_mrope_positions(
+    input_ids: torch.LongTensor,
+    image_grid_thw: Optional[torch.LongTensor],
+    video_grid_thw: Optional[torch.LongTensor],
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    spatial_merge_size: int,
+    attention_mask: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute 3D mRoPE position IDs for multimodal sequences.
+
+    Standalone function usable by both the model forward and the input processor.
+    For each sample in the batch, scans for vision placeholder tokens and assigns
+    spatial (T, H, W) positions to vision tokens while text tokens get sequential
+    positions.
+
+    Args:
+        input_ids: Token IDs, shape ``(B, S)``.
+        image_grid_thw: Grid dimensions ``(N_images, 3)`` with ``(T, H, W)`` per image.
+        video_grid_thw: Grid dimensions ``(N_videos, 3)`` with ``(T, H, W)`` per video.
+        image_token_id: Token ID for image placeholders.
+        video_token_id: Token ID for video placeholders.
+        vision_start_token_id: Token ID marking the start of a vision segment.
+        spatial_merge_size: Factor by which the vision patch merger reduces spatial dims.
+        attention_mask: Optional mask, shape ``(B, S)``.
+
+    Returns:
+        ``(position_ids, mrope_position_deltas)`` where ``position_ids`` has
+        shape ``(3, B, S)`` and ``mrope_position_deltas`` has shape ``(B, 1)``.
+    """
+    if video_grid_thw is not None:
+        video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+        video_grid_thw[:, 0] = 1
+
+    mrope_position_deltas = []
+
+    if input_ids is not None and (image_grid_thw is not None or video_grid_thw is not None):
+        total_input_ids = input_ids
+        if attention_mask is None:
+            attention_mask = torch.ones_like(total_input_ids)
+        position_ids = torch.ones(
+            3,
+            input_ids.shape[0],
+            input_ids.shape[1],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        image_index, video_index = 0, 0
+        attention_mask = attention_mask.to(total_input_ids.device)
+
+        for i, ids in enumerate(total_input_ids):
+            ids = ids[attention_mask[i] == 1]
+            vision_start_indices = torch.argwhere(ids == vision_start_token_id).squeeze(1)
+            vision_tokens = ids[vision_start_indices + 1]
+            image_nums = int((vision_tokens == image_token_id).sum().item())
+            video_nums = int((vision_tokens == video_token_id).sum().item())
+            input_tokens = ids.tolist()
+            llm_pos_ids_list: list = []
+            st = 0
+            remain_images, remain_videos = image_nums, video_nums
+
+            for _ in range(image_nums + video_nums):
+                ed_image = (
+                    input_tokens.index(image_token_id, st)
+                    if image_token_id in input_tokens and remain_images > 0
+                    else len(input_tokens) + 1
+                )
+                ed_video = (
+                    input_tokens.index(video_token_id, st)
+                    if video_token_id in input_tokens and remain_videos > 0
+                    else len(input_tokens) + 1
+                )
+
+                if ed_image < ed_video:
+                    t, h, w = image_grid_thw[image_index].tolist()
+                    image_index += 1
+                    remain_images -= 1
+                    ed = ed_image
+                else:
+                    t, h, w = video_grid_thw[video_index].tolist()
+                    video_index += 1
+                    remain_videos -= 1
+                    ed = ed_video
+
+                llm_grid_t = int(t)
+                llm_grid_h = int(h) // spatial_merge_size
+                llm_grid_w = int(w) // spatial_merge_size
+                text_len = ed - st
+
+                st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
+                llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+
+                t_index = (
+                    torch.arange(llm_grid_t)
+                    .view(-1, 1)
+                    .expand(-1, llm_grid_h * llm_grid_w)
+                    .flatten()
+                )
+                h_index = (
+                    torch.arange(llm_grid_h)
+                    .view(1, -1, 1)
+                    .expand(llm_grid_t, -1, llm_grid_w)
+                    .flatten()
+                )
+                w_index = (
+                    torch.arange(llm_grid_w)
+                    .view(1, 1, -1)
+                    .expand(llm_grid_t, llm_grid_h, -1)
+                    .flatten()
+                )
+                llm_pos_ids_list.append(
+                    torch.stack([t_index, h_index, w_index]) + text_len + st_idx
+                )
+                st = ed + llm_grid_t * llm_grid_h * llm_grid_w
+
+            if st < len(input_tokens):
+                st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
+                text_len = len(input_tokens) - st
+                llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+
+            llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+            position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(
+                device=position_ids.device, dtype=position_ids.dtype
+            )
+            mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
+
+        mrope_position_deltas = torch.tensor(
+            mrope_position_deltas, device=input_ids.device
+        ).unsqueeze(1)
+        return position_ids, mrope_position_deltas
+    else:
+        if attention_mask is not None:
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+            max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
+            mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+        else:
+            position_ids = (
+                torch.arange(input_ids.shape[1], device=input_ids.device)
+                .view(1, 1, -1)
+                .expand(3, input_ids.shape[0], -1)
+            )
+            mrope_position_deltas = torch.zeros(
+                [input_ids.shape[0], 1], device=input_ids.device, dtype=input_ids.dtype
+            )
+
+        return position_ids, mrope_position_deltas
+
+
 class Qwen3_5MoeModel(nn.Module):
     """Multimodal wrapper: vision tower + embedding merge + mRoPE + language model.
 
@@ -1316,144 +1467,17 @@ class Qwen3_5MoeModel(nn.Module):
         video_grid_thw: Optional[torch.LongTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Compute 3D mRoPE position IDs for multimodal sequences.
-
-        For each sample in the batch, scans for vision placeholder tokens and
-        assigns spatial (T, H, W) positions to vision tokens while text tokens
-        get sequential positions.
-
-        Returns:
-            ``(position_ids, mrope_position_deltas)`` where ``position_ids`` has
-            shape ``(3, B, S)`` and ``mrope_position_deltas`` has shape ``(B, 1)``.
-        """
-        # Split multi-frame videos into per-frame entries
-        if video_grid_thw is not None:
-            video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
-            video_grid_thw[:, 0] = 1
-
-        spatial_merge_size = self.config.vision_config.spatial_merge_size
-        image_token_id = self.config.image_token_id
-        video_token_id = self.config.video_token_id
-        vision_start_token_id = self.config.vision_start_token_id
-        mrope_position_deltas = []
-
-        if input_ids is not None and (image_grid_thw is not None or video_grid_thw is not None):
-            total_input_ids = input_ids
-            if attention_mask is None:
-                attention_mask = torch.ones_like(total_input_ids)
-            position_ids = torch.ones(
-                3,
-                input_ids.shape[0],
-                input_ids.shape[1],
-                dtype=input_ids.dtype,
-                device=input_ids.device,
-            )
-            image_index, video_index = 0, 0
-            attention_mask = attention_mask.to(total_input_ids.device)
-
-            for i, ids in enumerate(total_input_ids):
-                ids = ids[attention_mask[i] == 1]
-                vision_start_indices = torch.argwhere(ids == vision_start_token_id).squeeze(1)
-                vision_tokens = ids[vision_start_indices + 1]
-                image_nums = int((vision_tokens == image_token_id).sum().item())
-                video_nums = int((vision_tokens == video_token_id).sum().item())
-                input_tokens = ids.tolist()
-                llm_pos_ids_list: list = []
-                st = 0
-                remain_images, remain_videos = image_nums, video_nums
-
-                for _ in range(image_nums + video_nums):
-                    ed_image = (
-                        input_tokens.index(image_token_id, st)
-                        if image_token_id in input_tokens and remain_images > 0
-                        else len(input_tokens) + 1
-                    )
-                    ed_video = (
-                        input_tokens.index(video_token_id, st)
-                        if video_token_id in input_tokens and remain_videos > 0
-                        else len(input_tokens) + 1
-                    )
-
-                    if ed_image < ed_video:
-                        t, h, w = image_grid_thw[image_index].tolist()
-                        image_index += 1
-                        remain_images -= 1
-                        ed = ed_image
-                    else:
-                        t, h, w = video_grid_thw[video_index].tolist()
-                        video_index += 1
-                        remain_videos -= 1
-                        ed = ed_video
-
-                    llm_grid_t = int(t)
-                    llm_grid_h = int(h) // spatial_merge_size
-                    llm_grid_w = int(w) // spatial_merge_size
-                    text_len = ed - st
-
-                    st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
-                    llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
-                    )
-
-                    # Vision token spatial positions
-                    t_index = (
-                        torch.arange(llm_grid_t)
-                        .view(-1, 1)
-                        .expand(-1, llm_grid_h * llm_grid_w)
-                        .flatten()
-                    )
-                    h_index = (
-                        torch.arange(llm_grid_h)
-                        .view(1, -1, 1)
-                        .expand(llm_grid_t, -1, llm_grid_w)
-                        .flatten()
-                    )
-                    w_index = (
-                        torch.arange(llm_grid_w)
-                        .view(1, 1, -1)
-                        .expand(llm_grid_t, llm_grid_h, -1)
-                        .flatten()
-                    )
-                    llm_pos_ids_list.append(
-                        torch.stack([t_index, h_index, w_index]) + text_len + st_idx
-                    )
-                    st = ed + llm_grid_t * llm_grid_h * llm_grid_w
-
-                # Trailing text
-                if st < len(input_tokens):
-                    st_idx = llm_pos_ids_list[-1].max() + 1 if llm_pos_ids_list else 0
-                    text_len = len(input_tokens) - st
-                    llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
-                    )
-
-                llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
-                position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(position_ids.device)
-                mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
-
-            mrope_position_deltas = torch.tensor(
-                mrope_position_deltas, device=input_ids.device
-            ).unsqueeze(1)
-            return position_ids, mrope_position_deltas
-        else:
-            # Text-only path
-            if attention_mask is not None:
-                position_ids = attention_mask.long().cumsum(-1) - 1
-                position_ids.masked_fill_(attention_mask == 0, 1)
-                position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
-                max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
-                mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
-            else:
-                position_ids = (
-                    torch.arange(input_ids.shape[1], device=input_ids.device)
-                    .view(1, 1, -1)
-                    .expand(3, input_ids.shape[0], -1)
-                )
-                mrope_position_deltas = torch.zeros(
-                    [input_ids.shape[0], 1], device=input_ids.device, dtype=input_ids.dtype
-                )
-
-            return position_ids, mrope_position_deltas
+        """Compute 3D mRoPE position IDs. Delegates to ``compute_mrope_positions``."""
+        return compute_mrope_positions(
+            input_ids=input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            image_token_id=self.config.image_token_id,
+            video_token_id=self.config.video_token_id,
+            vision_start_token_id=self.config.vision_start_token_id,
+            spatial_merge_size=self.config.vision_config.spatial_merge_size,
+            attention_mask=attention_mask,
+        )
 
     def get_image_features(
         self, pixel_values: torch.Tensor, image_grid_thw: torch.LongTensor
@@ -1496,24 +1520,33 @@ class Qwen3_5MoeModel(nn.Module):
         pixel_values_videos: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.LongTensor] = None,
         video_grid_thw: Optional[torch.LongTensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
+        mrope_position_deltas: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Qwen3_5MoeOutput:
         """Multimodal forward: vision encoding + embedding merge + mRoPE + text model.
 
-        Steps:
-            1. Embed input_ids -> inputs_embeds
-            2. (Multimodal) Run vision tower on pixel_values -> masked_scatter into embeds
-            3. Build 3D mRoPE position_ids ``(3, B, S)``:
-               - Text-only: expand executor-provided 2D ``position_ids`` to 3D.
-               - Multimodal: compute spatial positions via ``get_rope_index``.
-            4. Call language_model with ``(inputs_embeds, position_ids)``; the text
-               model's internal ``rotary_emb`` computes cos/sin from the 3D positions.
+        Three position-handling branches:
+
+        A. **Text-only (no images ever)**: ``pixel_values`` is ``None`` and
+           ``rope_deltas`` has never been set.  Expand the executor's 2D
+           ``position_ids`` to 3D (all dims identical).
+
+        B. **Image chunk**: ``pixel_values`` is present.  Run the vision tower,
+           merge embeddings, and recompute full 3D mRoPE ``position_ids`` via
+           ``get_rope_index``.  Cache ``rope_deltas`` for subsequent decode.
+
+        C. **Text-only after image (decode steps)**: ``pixel_values`` is
+           ``None`` but ``rope_deltas`` was cached from a prior image forward.
+           Adjust the executor's 2D ``position_ids`` by ``rope_deltas`` to
+           account for mRoPE position compression, then expand to 3D.
         """
         inputs_embeds = self.get_input_embeddings()(input_ids)
 
+        has_images = pixel_values is not None and image_grid_thw is not None
+        has_videos = pixel_values_videos is not None and video_grid_thw is not None
+
         # Image embedding merge
-        if pixel_values is not None and image_grid_thw is not None:
+        if has_images:
             image_embeds_list = self.get_image_features(pixel_values, image_grid_thw)
             image_embeds = torch.cat(image_embeds_list, dim=0).to(
                 inputs_embeds.device, inputs_embeds.dtype
@@ -1524,7 +1557,7 @@ class Qwen3_5MoeModel(nn.Module):
             inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
 
         # Video embedding merge
-        if pixel_values_videos is not None and video_grid_thw is not None:
+        if has_videos:
             video_embeds_list = self.get_video_features(pixel_values_videos, video_grid_thw)
             video_embeds = torch.cat(video_embeds_list, dim=0).to(
                 inputs_embeds.device, inputs_embeds.dtype
@@ -1535,17 +1568,21 @@ class Qwen3_5MoeModel(nn.Module):
             inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
         # Build 3D mRoPE position IDs
-        if pixel_values is None and pixel_values_videos is None:
-            # Text-only: replicate executor-provided 2D positions across all 3 mRoPE dims
-            position_ids_3d = position_ids[None].expand(3, -1, -1)
-        else:
-            # Multimodal: compute spatial (T, H, W) positions for vision tokens
+        if has_images or has_videos:
+            # Branch B: multimodal -- recompute full 3D positions
             position_ids_3d, self.rope_deltas = self.get_rope_index(
                 input_ids,
                 image_grid_thw,
                 video_grid_thw,
                 attention_mask=attention_mask,
             )
+        elif self.rope_deltas is not None:
+            # Branch C: text-only after image -- adjust for mRoPE compression
+            delta = mrope_position_deltas if mrope_position_deltas is not None else self.rope_deltas
+            position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
+        else:
+            # Branch A: text-only (no images ever) -- straight 2D -> 3D expansion
+            position_ids_3d = position_ids[None].expand(3, -1, -1)
 
         return self.language_model(
             inputs_embeds=inputs_embeds,
@@ -1620,12 +1657,59 @@ class Qwen3_5MoeTextExportInfo(TextModelExportInfo):
         return base
 
 
+class Qwen3_5MoeInputProcessor:
+    """Input processor that wraps an ``ADInputProcessor`` and adds mRoPE delta computation.
+
+    Uses composition (not inheritance) to avoid a circular import with
+    ``auto_deploy.llm``.  After the base tokenization/multimodal processing,
+    this runs the mRoPE position computation on the full token sequence to
+    produce ``mrope_position_deltas``.  The VLM wrapper later uses this delta
+    to adjust the executor's sequential 2D ``position_ids`` so that text
+    tokens after vision tokens get correct mRoPE positions.
+    """
+
+    def __init__(self, base_processor, config: Qwen3_5MoeConfig):
+        self._base = base_processor
+        self._mrope_config = config
+
+    def __call__(self, inputs, sampling_params):
+        token_ids, extra = self._base(inputs, sampling_params)
+
+        if extra is not None and "multimodal_data" in extra:
+            mm_data = extra["multimodal_data"]
+            image_grid_thw = mm_data.get("image_grid_thw")
+            video_grid_thw = mm_data.get("video_grid_thw")
+
+            if image_grid_thw is not None or video_grid_thw is not None:
+                input_ids_t = torch.tensor([token_ids], dtype=torch.long)
+                _, deltas = compute_mrope_positions(
+                    input_ids=input_ids_t,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=video_grid_thw,
+                    image_token_id=self._mrope_config.image_token_id,
+                    video_token_id=self._mrope_config.video_token_id,
+                    vision_start_token_id=self._mrope_config.vision_start_token_id,
+                    spatial_merge_size=self._mrope_config.vision_config.spatial_merge_size,
+                )
+                mm_data["mrope_position_deltas"] = deltas
+
+        return token_ids, extra
+
+
 @ModelFactoryRegistry.register("Qwen3_5MoeForConditionalGeneration")
 class Qwen3_5MoeFactory(AutoModelForImageTextToTextFactory):
     """Factory for Qwen3.5 MoE that uses 3D mRoPE position_ids export info."""
 
     def get_export_infos(self, model: nn.Module):
         return [Qwen3_5MoeTextExportInfo.from_autoinferred(model)]
+
+    def init_input_processor(self, base_input_processor):
+        """Wrap the base input processor with mRoPE delta pre-computation."""
+        if not hasattr(self, "_cached_model_config"):
+            self._cached_model_config = AutoConfig.from_pretrained(
+                self.model, trust_remote_code=True
+            )
+        return Qwen3_5MoeInputProcessor(base_input_processor, self._cached_model_config)
 
 
 # =============================================================================

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -15,9 +15,10 @@ This implementation differs from the HuggingFace original in the following ways:
     (tensorrt_llm/_torch/auto_deploy/models/patches/qwen3_next.py).
   * The MoE implementation uses expert lists (individual nn.Linear layers per expert)
     that directly match the checkpoint structure, dispatched via torch_moe op.
-  * mRoPE cos/sin can be computed outside the export boundary (Option 3) and
-    passed in as ``position_embeddings`` to allow 3D spatial position IDs for
-    multimodal inputs without requiring the export graph to handle mRoPE internally.
+  * The VLM wrapper passes 3D ``position_ids (3, B, S)`` to the text model,
+    which computes mRoPE cos/sin internally via its own ``rotary_emb``.
+    For text-only inputs the wrapper expands the executor's 2D positions to 3D;
+    for multimodal inputs it computes spatial (T, H, W) positions via ``get_rope_index``.
 
 This allows us to have a "pytorch" native reference implementation decoupled from bugs and
 dependency issues in the source, while remaining weight-compatible with HF checkpoints.
@@ -29,6 +30,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch.export import Dim
 from transformers import AutoConfig
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
@@ -37,7 +39,12 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
+from tensorrt_llm._torch.auto_deploy.models.hf import (
+    AutoModelForCausalLMFactory,
+    AutoModelForImageTextToTextFactory,
+    TextModelExportInfo,
+)
 
 # =============================================================================
 # Configuration
@@ -1285,8 +1292,9 @@ class Qwen3_5MoeModel(nn.Module):
     """Multimodal wrapper: vision tower + embedding merge + mRoPE + language model.
 
     This module is NOT exported. It orchestrates the vision pipeline in plain
-    PyTorch and calls the (potentially exported) language model with pre-computed
-    ``(cos, sin)`` position embeddings (Option 3 for mRoPE).
+    PyTorch and calls the (potentially exported) language model with 3D
+    ``position_ids (3, B, S)`` so that the text model's internal ``rotary_emb``
+    computes the correct mRoPE cos/sin.
     """
 
     def __init__(self, config: Qwen3_5MoeConfig):
@@ -1294,9 +1302,6 @@ class Qwen3_5MoeModel(nn.Module):
         self.config = config
         self.visual = Qwen3_5MoeVisionModel(config.vision_config)
         self.language_model = Qwen3_5MoeTextModel(config.text_config)
-
-        # mRoPE embedding -- computed in this wrapper, passed to language model
-        self.rotary_emb = Qwen3_5MoeTextRotaryEmbedding(config.text_config)
 
         # Cache rope_deltas for decode steps
         self.rope_deltas: Optional[torch.Tensor] = None
@@ -1498,10 +1503,12 @@ class Qwen3_5MoeModel(nn.Module):
 
         Steps:
             1. Embed input_ids -> inputs_embeds
-            2. Run vision tower on pixel_values -> masked_scatter into embeds
-            3. Compute mRoPE position_ids via get_rope_index (or use external ones)
-            4. Compute (cos, sin) from rotary_emb
-            5. Call language_model (TextModel) with (inputs_embeds, position_embeddings)
+            2. (Multimodal) Run vision tower on pixel_values -> masked_scatter into embeds
+            3. Build 3D mRoPE position_ids ``(3, B, S)``:
+               - Text-only: expand executor-provided 2D ``position_ids`` to 3D.
+               - Multimodal: compute spatial positions via ``get_rope_index``.
+            4. Call language_model with ``(inputs_embeds, position_ids)``; the text
+               model's internal ``rotary_emb`` computes cos/sin from the 3D positions.
         """
         inputs_embeds = self.get_input_embeddings()(input_ids)
 
@@ -1527,29 +1534,23 @@ class Qwen3_5MoeModel(nn.Module):
             )
             inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
-        # TODO: Multi-modal case isn't handled here yet. Remove this once we have a proper way to handle multimodal
-        # position_ids. ADExecutor always provides a text-only position_ids.
-        if position_ids is not None:
-            # External position_ids (from AD runtime / nest_sequences) — pass
-            # directly to the language model which handles mRoPE expansion.
-            return self.language_model(
-                inputs_embeds=inputs_embeds,
-                position_ids=position_ids,
+        # Build 3D mRoPE position IDs
+        if pixel_values is None and pixel_values_videos is None:
+            # Text-only: replicate executor-provided 2D positions across all 3 mRoPE dims
+            position_ids_3d = position_ids[None].expand(3, -1, -1)
+        else:
+            # Multimodal: compute spatial (T, H, W) positions for vision tokens
+            position_ids_3d, self.rope_deltas = self.get_rope_index(
+                input_ids,
+                image_grid_thw,
+                video_grid_thw,
+                attention_mask=attention_mask,
             )
 
-        # Compute 3D position IDs and mRoPE cos/sin
-        position_ids, self.rope_deltas = self.get_rope_index(
-            input_ids,
-            image_grid_thw,
-            video_grid_thw,
-            attention_mask=attention_mask,
-        )
-        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
-
-        # Call language model with pre-computed position embeddings
         return self.language_model(
             inputs_embeds=inputs_embeds,
-            position_embeddings=position_embeddings,
+            position_ids=position_ids_3d,
+            **kwargs,
         )
 
 
@@ -1576,6 +1577,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         pixel_values: Optional[torch.Tensor] = None,
         pixel_values_videos: Optional[torch.Tensor] = None,
@@ -1585,6 +1587,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel):
     ) -> Qwen3_5MoeConditionalOutput:
         outputs = self.model(
             input_ids=input_ids,
+            position_ids=position_ids,
             attention_mask=attention_mask,
             pixel_values=pixel_values,
             pixel_values_videos=pixel_values_videos,
@@ -1598,6 +1601,34 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel):
 
 
 # =============================================================================
+# Custom Export Info and Factory
+# =============================================================================
+
+
+class Qwen3_5MoeTextExportInfo(TextModelExportInfo):
+    """Export info for mRoPE models that receive 3D position_ids ``(3, B, S)``.
+
+    Dim 0 is always 3 (temporal, height, width) and is static; dims 1 and 2
+    (batch, sequence) are dynamic.
+    """
+
+    def _init_dynamic_shape_lookup(self):
+        base = super()._init_dynamic_shape_lookup()
+        batch_size_dyn = Dim.DYNAMIC
+        seq_len_dyn = Dim.DYNAMIC
+        base["position_ids"] = {1: batch_size_dyn, 2: seq_len_dyn}
+        return base
+
+
+@ModelFactoryRegistry.register("Qwen3_5MoeForConditionalGeneration")
+class Qwen3_5MoeFactory(AutoModelForImageTextToTextFactory):
+    """Factory for Qwen3.5 MoE that uses 3D mRoPE position_ids export info."""
+
+    def get_export_infos(self, model: nn.Module):
+        return [Qwen3_5MoeTextExportInfo.from_autoinferred(model)]
+
+
+# =============================================================================
 # Registration
 # =============================================================================
 
@@ -1605,6 +1636,4 @@ AutoConfig.register("qwen3_5_moe", Qwen3_5MoeConfig)
 AutoConfig.register("qwen3_5_moe_text", Qwen3_5MoeTextConfig)
 
 AutoModelForCausalLMFactory.register_custom_model_cls("Qwen3_5MoeTextConfig", Qwen3_5MoeForCausalLM)
-AutoModelForCausalLMFactory.register_custom_model_cls(
-    "Qwen3_5MoeConfig", Qwen3_5MoeForConditionalGeneration
-)
+Qwen3_5MoeFactory.register_custom_model_cls("Qwen3_5MoeConfig", Qwen3_5MoeForConditionalGeneration)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -1436,6 +1436,231 @@ def compute_mrope_positions(
         return position_ids, mrope_position_deltas
 
 
+def _normalize_video_grid_for_mrope(
+    video_grid_thw: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    if video_grid_thw is None:
+        return None
+    video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+    video_grid_thw = video_grid_thw.clone()
+    video_grid_thw[:, 0] = 1
+    return video_grid_thw
+
+
+def _compute_mm_item_special_counts(
+    mm_token_lengths: torch.Tensor,
+    mm_special_offsets_cu_seqlen: torch.Tensor,
+    mm_special_offsets: torch.Tensor,
+    req_idx: int,
+) -> List[int]:
+    item_lengths = mm_token_lengths.tolist()
+    special_start = int(mm_special_offsets_cu_seqlen[req_idx].item())
+    special_end = int(mm_special_offsets_cu_seqlen[req_idx + 1].item())
+    special_offsets = mm_special_offsets[special_start:special_end].tolist()
+    counts: List[int] = []
+    mm_offset = 0
+    for item_len in item_lengths:
+        item_end = mm_offset + int(item_len)
+        num_special = sum(1 for off in special_offsets if mm_offset <= int(off) < item_end)
+        counts.append(num_special)
+        mm_offset = item_end
+    return counts
+
+
+def _compute_request_mrope_delta(
+    mm_item_types: torch.Tensor,
+    mm_token_lengths: torch.Tensor,
+    special_counts: Sequence[int],
+    image_grid_thw: Optional[torch.Tensor],
+    video_grid_thw: Optional[torch.Tensor],
+    spatial_merge_size: int,
+) -> int:
+    image_idx = 0
+    video_idx = 0
+    total_delta = 0
+    for item_type, item_len, num_special in zip(
+        mm_item_types.tolist(), mm_token_lengths.tolist(), special_counts
+    ):
+        num_placeholders = int(item_len) - int(num_special)
+        if item_type == 0:
+            if image_grid_thw is None:
+                raise ValueError("Expected image_grid_thw for image multimodal item")
+            t, h, w = [int(v) for v in image_grid_thw[image_idx].tolist()]
+            image_idx += 1
+        else:
+            if video_grid_thw is None:
+                raise ValueError("Expected video_grid_thw for video multimodal item")
+            t, h, w = [int(v) for v in video_grid_thw[video_idx].tolist()]
+            video_idx += 1
+        llm_grid_t = int(t)
+        llm_grid_h = int(h) // spatial_merge_size
+        llm_grid_w = int(w) // spatial_merge_size
+        total_delta += max(llm_grid_t, llm_grid_h, llm_grid_w) - num_placeholders
+    return total_delta
+
+
+@torch.library.custom_op("auto_deploy::qwen3_mrope_delta", mutates_args=())
+def qwen3_mrope_delta(
+    batch_info_host: torch.Tensor,
+    mm_item_cu_seqlen: torch.Tensor,
+    mm_item_types: torch.Tensor,
+    mm_token_lengths: torch.Tensor,
+    mm_special_offsets_cu_seqlen: torch.Tensor,
+    mm_special_offsets: torch.Tensor,
+    image_grid_thw: Optional[torch.Tensor],
+    video_grid_thw: Optional[torch.Tensor],
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    device = mm_item_cu_seqlen.device
+    out = torch.zeros((num_seq, 1), dtype=torch.int32, device=device)
+    video_grid_norm = _normalize_video_grid_for_mrope(video_grid_thw)
+    img_idx = 0
+    vid_idx = 0
+    for req_idx in range(num_prefill):
+        item_start = int(mm_item_cu_seqlen[req_idx].item())
+        item_end = int(mm_item_cu_seqlen[req_idx + 1].item())
+        req_item_types = mm_item_types[item_start:item_end]
+        req_item_lengths = mm_token_lengths[item_start:item_end]
+        if req_item_lengths.numel() == 0:
+            continue
+        num_images = int((req_item_types == 0).sum().item())
+        num_videos = int((req_item_types == 1).sum().item())
+        req_image_grid = image_grid_thw[img_idx : img_idx + num_images] if num_images > 0 else None
+        req_video_grid = video_grid_norm[vid_idx : vid_idx + num_videos] if num_videos > 0 else None
+        special_counts = _compute_mm_item_special_counts(
+            req_item_lengths,
+            mm_special_offsets_cu_seqlen,
+            mm_special_offsets,
+            req_idx,
+        )
+        out[req_idx, 0] = _compute_request_mrope_delta(
+            req_item_types,
+            req_item_lengths,
+            special_counts,
+            req_image_grid,
+            req_video_grid,
+            spatial_merge_size,
+        )
+        img_idx += num_images
+        vid_idx += num_videos
+    return out
+
+
+@qwen3_mrope_delta.register_fake
+def qwen3_mrope_delta_fake(
+    batch_info_host: torch.Tensor,
+    mm_item_cu_seqlen: torch.Tensor,
+    mm_item_types: torch.Tensor,
+    mm_token_lengths: torch.Tensor,
+    mm_special_offsets_cu_seqlen: torch.Tensor,
+    mm_special_offsets: torch.Tensor,
+    image_grid_thw: Optional[torch.Tensor],
+    video_grid_thw: Optional[torch.Tensor],
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    return torch.zeros((num_seq, 1), dtype=torch.int32, device=batch_info_host.device)
+
+
+@torch.library.custom_op(
+    "auto_deploy::qwen3_mrope_delta_with_cache", mutates_args=("mrope_delta_cache",)
+)
+def qwen3_mrope_delta_with_cache(
+    batch_info_host: torch.Tensor,
+    slot_idx: torch.Tensor,
+    mm_item_cu_seqlen: Optional[torch.Tensor],
+    mm_item_types: Optional[torch.Tensor],
+    mm_token_lengths: Optional[torch.Tensor],
+    mm_special_offsets_cu_seqlen: Optional[torch.Tensor],
+    mm_special_offsets: Optional[torch.Tensor],
+    image_grid_thw: Optional[torch.Tensor],
+    video_grid_thw: Optional[torch.Tensor],
+    mrope_delta_cache: torch.Tensor,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    out = torch.zeros((num_seq, 1), dtype=torch.int32, device=mrope_delta_cache.device)
+    video_grid_norm = _normalize_video_grid_for_mrope(video_grid_thw)
+    if num_prefill > 0:
+        has_mm_metadata = all(
+            arg is not None
+            for arg in (
+                mm_item_cu_seqlen,
+                mm_item_types,
+                mm_token_lengths,
+                mm_special_offsets_cu_seqlen,
+                mm_special_offsets,
+            )
+        )
+        if has_mm_metadata:
+            img_idx = 0
+            vid_idx = 0
+            for req_idx in range(num_prefill):
+                item_start = int(mm_item_cu_seqlen[req_idx].item())
+                item_end = int(mm_item_cu_seqlen[req_idx + 1].item())
+                req_item_types = mm_item_types[item_start:item_end]
+                req_item_lengths = mm_token_lengths[item_start:item_end]
+                if req_item_lengths.numel() == 0:
+                    continue
+                num_images = int((req_item_types == 0).sum().item())
+                num_videos = int((req_item_types == 1).sum().item())
+                req_image_grid = (
+                    image_grid_thw[img_idx : img_idx + num_images] if num_images > 0 else None
+                )
+                req_video_grid = (
+                    video_grid_norm[vid_idx : vid_idx + num_videos] if num_videos > 0 else None
+                )
+                special_counts = _compute_mm_item_special_counts(
+                    req_item_lengths,
+                    mm_special_offsets_cu_seqlen,
+                    mm_special_offsets,
+                    req_idx,
+                )
+                out[req_idx, 0] = _compute_request_mrope_delta(
+                    req_item_types,
+                    req_item_lengths,
+                    special_counts,
+                    req_image_grid,
+                    req_video_grid,
+                    spatial_merge_size,
+                )
+                img_idx += num_images
+                vid_idx += num_videos
+        mrope_delta_cache.index_copy_(
+            0,
+            slot_idx[:num_prefill].to(torch.long),
+            out[:num_prefill].to(mrope_delta_cache.dtype),
+        )
+    if num_decode > 0:
+        out[num_prefill:num_seq] = mrope_delta_cache[
+            slot_idx[num_prefill:num_seq].to(torch.long)
+        ].to(torch.int32)
+    return out
+
+
+@qwen3_mrope_delta_with_cache.register_fake
+def qwen3_mrope_delta_with_cache_fake(
+    batch_info_host: torch.Tensor,
+    slot_idx: torch.Tensor,
+    mm_item_cu_seqlen: Optional[torch.Tensor],
+    mm_item_types: Optional[torch.Tensor],
+    mm_token_lengths: Optional[torch.Tensor],
+    mm_special_offsets_cu_seqlen: Optional[torch.Tensor],
+    mm_special_offsets: Optional[torch.Tensor],
+    image_grid_thw: Optional[torch.Tensor],
+    video_grid_thw: Optional[torch.Tensor],
+    mrope_delta_cache: torch.Tensor,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    num_prefill, _, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    return torch.zeros((num_seq, 1), dtype=torch.int32, device=slot_idx.device)
+
+
 class Qwen3_5MoeModel(nn.Module):
     """Multimodal wrapper: vision tower + embedding merge + mRoPE + language model.
 
@@ -1598,6 +1823,7 @@ class Qwen3_5MoeModel(nn.Module):
         vision_grid = image_grid_thw if has_images else video_grid_thw if has_videos else None
         if batch_info is None:
             batch_info = kwargs.get("batch_info_host")
+        batch_info_host = kwargs.get("batch_info_host", batch_info)
         cu_seqlen = kwargs.get("cu_seqlen")
         if cu_seqlen is None:
             cu_seqlen = kwargs.get("cu_seqlen_host")
@@ -1614,8 +1840,11 @@ class Qwen3_5MoeModel(nn.Module):
         mm_item_cu_seqlen = kwargs.get("mm_item_cu_seqlen")
         mm_token_positions = kwargs.get("mm_token_positions")
         mm_token_lengths = kwargs.get("mm_token_lengths")
+        mm_item_types = kwargs.get("mm_item_types")
         mm_special_offsets_cu_seqlen = kwargs.get("mm_special_offsets_cu_seqlen")
         mm_special_offsets = kwargs.get("mm_special_offsets")
+        slot_idx = kwargs.get("slot_idx")
+        mrope_delta_cache = kwargs.get("mrope_delta_cache")
         has_chunk_mm_layout = (
             mm_item_cu_seqlen is not None
             and mm_token_positions is not None
@@ -1625,6 +1854,20 @@ class Qwen3_5MoeModel(nn.Module):
             and mm_token_positions.numel() > 0
             and mm_token_lengths.numel() > 0
         )
+        if mrope_delta_cache is not None and batch_info_host is not None and slot_idx is not None:
+            delta = torch.ops.auto_deploy.qwen3_mrope_delta_with_cache(
+                batch_info_host,
+                slot_idx,
+                mm_item_cu_seqlen,
+                mm_item_types,
+                mm_token_lengths,
+                mm_special_offsets_cu_seqlen,
+                mm_special_offsets,
+                image_grid_thw,
+                video_grid_thw,
+                mrope_delta_cache,
+                self.config.vision_config.spatial_merge_size,
+            ).to(input_ids.dtype)
 
         if (
             vision_grid is not None
@@ -1673,7 +1916,22 @@ class Qwen3_5MoeModel(nn.Module):
         else:
             if position_ids is None:
                 raise ValueError("position_ids is required for text-only or decode-only forward")
-            position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
+            if position_ids.ndim == 1:
+                token_delta = torch.zeros_like(position_ids)
+                if (
+                    delta is not None
+                    and cu_seqlen is not None
+                    and delta.ndim == 2
+                    and delta.shape[0] == cu_seqlen.numel() - 1
+                ):
+                    seq_lens = (cu_seqlen[1:] - cu_seqlen[:-1]).to(torch.long)
+                    token_delta = torch.repeat_interleave(
+                        delta.squeeze(-1).to(position_ids.device, position_ids.dtype),
+                        seq_lens.to(position_ids.device),
+                    )
+                position_ids_3d = (position_ids + token_delta).view(1, 1, -1).expand(3, 1, -1)
+            else:
+                position_ids_3d = (position_ids + delta)[None].expand(3, -1, -1)
 
         for key in (
             "input_pos",
@@ -1681,10 +1939,12 @@ class Qwen3_5MoeModel(nn.Module):
             "mm_chunk_flat_start",
             "mm_chunk_count",
             "mm_item_cu_seqlen",
+            "mm_item_types",
             "mm_token_positions",
             "mm_token_lengths",
             "mm_special_offsets_cu_seqlen",
             "mm_special_offsets",
+            "mrope_delta_cache",
         ):
             kwargs.pop(key, None)
 
@@ -2054,18 +2314,20 @@ class Qwen3_5MoeADInputProcessor:
         self,
         token_ids: List[int],
         inputs: Dict[str, Any],
-    ) -> Optional[Tuple[MultimodalInput, List[int]]]:
+    ) -> Optional[Tuple[MultimodalInput, List[int], List[int]]]:
         mm_data = inputs.get("multi_modal_data")
-        if not mm_data or "image" not in mm_data:
+        if not mm_data or not any(k in mm_data for k in ("image", "video")):
             return None
 
         image_token_id = int(self.processor.image_token_id)
+        video_token_id = int(self.processor.video_token_id)
         vision_start_token_id = int(self.processor.vision_start_token_id)
         ids = token_ids
 
         starts: List[int] = []
         lengths: List[int] = []
         special_offsets: List[int] = []
+        item_types: List[int] = []
         mm_union_offset = 0
         i = 0
         while i < len(ids):
@@ -2073,8 +2335,22 @@ class Qwen3_5MoeADInputProcessor:
                 i += 1
                 continue
 
+            if i + 1 >= len(ids):
+                i += 1
+                continue
+
+            if ids[i + 1] == image_token_id:
+                item_token_id = image_token_id
+                item_type = 0
+            elif ids[i + 1] == video_token_id:
+                item_token_id = video_token_id
+                item_type = 1
+            else:
+                i += 1
+                continue
+
             j = i + 1
-            while j < len(ids) and ids[j] == image_token_id:
+            while j < len(ids) and ids[j] == item_token_id:
                 j += 1
             if j == i + 1:
                 i += 1
@@ -2083,22 +2359,59 @@ class Qwen3_5MoeADInputProcessor:
             starts.append(i)
             lengths.append(j - i)
             special_offsets.append(mm_union_offset)
+            item_types.append(item_type)
             mm_union_offset += j - i
             i = j
 
-        images = mm_data["image"]
-        image_items = images if isinstance(images, list) else [images]
-        if len(starts) != len(image_items):
+        image_items = []
+        if "image" in mm_data:
+            images = mm_data["image"]
+            image_items = images if isinstance(images, list) else [images]
+        video_items = []
+        if "video" in mm_data:
+            videos = mm_data["video"]
+            video_items = videos if isinstance(videos, list) else [videos]
+
+        if len(starts) != len(image_items) + len(video_items):
             raise ValueError(
-                f"Expected {len(image_items)} image multimodal spans, found {len(starts)} in tokenized prompt"
+                "Mismatch between multimodal prompt spans and multimodal items: "
+                f"spans={len(starts)}, images={len(image_items)}, videos={len(video_items)}"
             )
 
         mm_uuids = inputs.get("multi_modal_uuids", None)
-        mm_hashes, mm_uuid_list = apply_mm_hashes({"image": image_items}, mm_uuids)
-        mm_hashes_flat = [hexdigest_to_int32(h) for h in mm_hashes["image"]]
+        mm_hash_inputs = {}
+        if image_items:
+            mm_hash_inputs["image"] = image_items
+        if video_items:
+            mm_hash_inputs["video"] = video_items
+        mm_hashes, _ = apply_mm_hashes(mm_hash_inputs, mm_uuids)
+
+        image_hashes = [hexdigest_to_int32(h) for h in mm_hashes.get("image", [])]
+        video_hashes = [hexdigest_to_int32(h) for h in mm_hashes.get("video", [])]
+        image_uuids = list((mm_uuids or {}).get("image", [None] * len(image_items)))
+        video_uuids = list((mm_uuids or {}).get("video", [None] * len(video_items)))
+        image_idx = 0
+        video_idx = 0
+        mm_hashes_flat: List[List[int]] = []
+        mm_uuid_list: List[Optional[str]] = []
+        for item_type in item_types:
+            if item_type == 0:
+                mm_hashes_flat.append(image_hashes[image_idx])
+                mm_uuid_list.append(image_uuids[image_idx])
+                image_idx += 1
+            else:
+                mm_hashes_flat.append(video_hashes[video_idx])
+                mm_uuid_list.append(video_uuids[video_idx])
+                video_idx += 1
         return (
-            MultimodalInput.from_components(mm_hashes_flat, starts, lengths, mm_uuid_list),
+            MultimodalInput.from_components(
+                mm_hashes_flat,
+                starts,
+                lengths,
+                mm_uuid_list if mm_uuids is not None else None,
+            ),
             special_offsets,
+            item_types,
         )
 
     def __call__(self, inputs, sampling_params):
@@ -2110,12 +2423,13 @@ class Qwen3_5MoeADInputProcessor:
         if built is None:
             return token_ids, extra_processed_inputs
 
-        multimodal_input, special_offsets = built
+        multimodal_input, special_offsets, item_types = built
         if extra_processed_inputs is None:
             extra_processed_inputs = {}
         extra_processed_inputs["multimodal_input"] = multimodal_input
         multimodal_data = extra_processed_inputs.get("multimodal_data", {})
         multimodal_data["special_token_offsets"] = torch.tensor(special_offsets, dtype=torch.int32)
+        multimodal_data["item_types"] = torch.tensor(item_types, dtype=torch.int32)
         extra_processed_inputs["multimodal_data"] = multimodal_data
         return token_ids, extra_processed_inputs
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -625,7 +625,7 @@ class ADEngine(ModelEngine):
             # store extra arguments
             if request.py_multimodal_data is not None:
                 for k, v in request.py_multimodal_data.items():
-                    if k == "special_token_offsets":
+                    if k in {"special_token_offsets", "item_types"}:
                         continue
                     extra_args[k].append(v)
 
@@ -703,17 +703,17 @@ class ADEngine(ModelEngine):
         batch_info.extend([num_extend, num_extend_tokens])
         batch_info.extend([num_decode, num_decode_tokens])
 
-        # Chunked prefill + multimodal: stage per-request multimodal layout metadata plus the
-        # per-prefill slice (flat_start, count) into full image embeddings so the VLM wrapper can
-        # reconstruct chunk-local mRoPE and scatter only the chunk's mm tokens.
-        if self._enable_chunked_prefill and num_prefill_seqs > 0:
-            flat_start_list: List[int] = []
-            count_list: List[int] = []
+        # Stage per-request multimodal layout metadata so the VLM wrapper can reconstruct
+        # chunk-local mRoPE and compute request-level mRoPE deltas from full multimodal state.
+        if num_prefill_seqs > 0:
             mm_item_cu_seqlen: List[int] = [0]
+            mm_item_types_flat: List[int] = []
             mm_token_positions_flat: List[int] = []
             mm_token_lengths_flat: List[int] = []
             mm_special_offsets_cu_seqlen: List[int] = [0]
             mm_special_offsets_flat: List[int] = []
+            flat_start_list: List[int] = []
+            count_list: List[int] = []
             cumsum_total_mm = 0
             for i in range(num_prefill_seqs):
                 req = ordered_requests[i]
@@ -721,6 +721,9 @@ class ADEngine(ModelEngine):
                 end_compute = begin_compute + (cu_seqlen[i + 1] - cu_seqlen[i])
                 mm_pos = getattr(req, "multimodal_positions", None)
                 mm_len = getattr(req, "multimodal_lengths", None)
+                mm_item_types = (
+                    req.py_multimodal_data.get("item_types", []) if req.py_multimodal_data else []
+                )
                 special_offsets = (
                     req.py_multimodal_data.get("special_token_offsets", [])
                     if req.py_multimodal_data
@@ -729,6 +732,7 @@ class ADEngine(ModelEngine):
                 mm_pos_list = list(mm_pos) if mm_pos is not None else []
                 mm_len_list = list(mm_len) if mm_len is not None else []
                 mm_item_cu_seqlen.append(mm_item_cu_seqlen[-1] + len(mm_pos_list))
+                mm_item_types_flat.extend(list(mm_item_types))
                 mm_token_positions_flat.extend(mm_pos_list)
                 mm_token_lengths_flat.extend(mm_len_list)
                 mm_special_offsets_cu_seqlen.append(
@@ -756,14 +760,11 @@ class ADEngine(ModelEngine):
                 flat_start_list.append(flat_start_i)
                 count_list.append(num_in_chunk - num_special_in_chunk)
                 cumsum_total_mm += total_mm_i - total_special_i
-            extra_args["mm_chunk_flat_start"] = [
-                torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
-            ]
-            extra_args["mm_chunk_count"] = [
-                torch.tensor(count_list, dtype=torch.int64, device="cpu")
-            ]
             extra_args["mm_item_cu_seqlen"] = [
                 torch.tensor(mm_item_cu_seqlen, dtype=torch.int32, device="cpu")
+            ]
+            extra_args["mm_item_types"] = [
+                torch.tensor(mm_item_types_flat, dtype=torch.int32, device="cpu")
             ]
             extra_args["mm_token_positions"] = [
                 torch.tensor(mm_token_positions_flat, dtype=torch.int32, device="cpu")
@@ -777,6 +778,13 @@ class ADEngine(ModelEngine):
             extra_args["mm_special_offsets"] = [
                 torch.tensor(mm_special_offsets_flat, dtype=torch.int32, device="cpu")
             ]
+            if self._enable_chunked_prefill:
+                extra_args["mm_chunk_flat_start"] = [
+                    torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
+                ]
+                extra_args["mm_chunk_count"] = [
+                    torch.tensor(count_list, dtype=torch.int64, device="cpu")
+                ]
 
         # update the sequence info object now (also triggers rescatter + host_prepare internally)
         self.cache_seq_interface.info.nest_sequences(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -75,6 +75,41 @@ from ..utils.logger import ad_logger
 from .interface import CachedSequenceInterface, GetInferenceModel
 
 
+def _unwrap_model(model: torch.nn.Module) -> torch.nn.Module:
+    """Walk the wrapper chain (e.g. CapturedGraph → GraphModule → ...) to the innermost model."""
+    while hasattr(model, "model") and model.model is not model:
+        model = model.model
+    return model
+
+
+def _collect_persistent_multimodal_keys(
+    persist_keys: set,
+    ordered_requests: list,
+    extra_args: Dict[str, List[torch.Tensor]],
+) -> None:
+    """Collect persistent multimodal metadata from all requests.
+
+    Models declare which ``py_multimodal_data`` keys should persist across
+    context and generation phases via a ``persistent_multimodal_keys`` class
+    attribute.  For each declared key this function gathers the value from
+    every request (context **and** generation), zero-filling for requests
+    that lack the key.
+    """
+    for key in persist_keys:
+        per_request: List[Optional[torch.Tensor]] = []
+        ref: Optional[torch.Tensor] = None
+        for request in ordered_requests:
+            mm = request.py_multimodal_data
+            if mm is not None and key in mm:
+                per_request.append(mm[key])
+                if ref is None:
+                    ref = mm[key]
+            else:
+                per_request.append(None)
+        if ref is not None:
+            extra_args[key] = [v if v is not None else torch.zeros_like(ref) for v in per_request]
+
+
 @dataclass
 class ReportingInfo:
     print_log: bool = False
@@ -533,6 +568,8 @@ class ADEngine(ModelEngine):
 
         # build model
         self.model = get_inference_model(self.cache_seq_interface)
+        inner = _unwrap_model(self.model)
+        self._persistent_multimodal_keys = getattr(inner, "persistent_multimodal_keys", set())
         # start fresh with fixed seed
         torch.manual_seed(42)
 
@@ -622,7 +659,8 @@ class ADEngine(ModelEngine):
             # store extra arguments
             if request.py_multimodal_data is not None:
                 for k, v in request.py_multimodal_data.items():
-                    extra_args[k].append(v)
+                    if k not in self._persistent_multimodal_keys:
+                        extra_args[k].append(v)
 
         # store num_prefill and num_prefill_tokens
         num_prefill = len(context_requests)
@@ -698,7 +736,11 @@ class ADEngine(ModelEngine):
         batch_info.extend([num_extend, num_extend_tokens])
         batch_info.extend([num_decode, num_decode_tokens])
 
-        # update the sequence info object now
+        _collect_persistent_multimodal_keys(
+            self._persistent_multimodal_keys, ordered_requests, extra_args
+        )
+
+        # update the sequence info object now (also triggers rescatter + host_prepare internally)
         self.cache_seq_interface.info.nest_sequences(
             input_ids,
             cu_seqlen=cu_seqlen,
@@ -715,6 +757,10 @@ class ADEngine(ModelEngine):
             _gather_slot_idx=slot_gather_indices,
             _ungathered_new_lens=new_tokens_lens,
             **extra_args,
+        )
+
+        self.cache_seq_interface.info._store_extra_arg(
+            "batch_info", [torch.tensor(batch_info, dtype=torch.int32)]
         )
 
         if spec_resource_manager is not None and isinstance(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -845,10 +845,6 @@ class ADEngine(ModelEngine):
             **extra_args,
         )
 
-        self.cache_seq_interface.info._store_extra_arg(
-            "batch_info", [torch.tensor(batch_info, dtype=torch.int32)]
-        )
-
         if spec_resource_manager is not None and isinstance(
             spec_resource_manager, ADHiddenStateManager
         ):

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -558,6 +558,104 @@ class ADEngine(ModelEngine):
             PyTorchModelEngine._execute_logit_post_processors, self
         )
 
+    def _store_prefill_multimodal_metadata(
+        self,
+        ordered_requests: RequestList,
+        input_pos: List[int],
+        cu_seqlen: List[int],
+        num_prefill_seqs: int,
+        extra_args: Dict[str, List[torch.Tensor]],
+    ) -> None:
+        """Stage per-request multimodal layout metadata needed by the VLM wrapper."""
+        if num_prefill_seqs == 0:
+            return
+
+        prefill_requests = ordered_requests[:num_prefill_seqs]
+        if not any(getattr(req, "multimodal_positions", None) for req in prefill_requests):
+            return
+
+        mm_item_cu_seqlen: List[int] = [0]
+        mm_item_types_flat: List[int] = []
+        mm_token_positions_flat: List[int] = []
+        mm_token_lengths_flat: List[int] = []
+        mm_special_offsets_cu_seqlen: List[int] = [0]
+        mm_special_offsets_flat: List[int] = []
+        flat_start_list: List[int] = []
+        count_list: List[int] = []
+        cumsum_total_mm = 0
+
+        for i, req in enumerate(prefill_requests):
+            begin_compute = input_pos[i]
+            end_compute = begin_compute + (cu_seqlen[i + 1] - cu_seqlen[i])
+            mm_pos = getattr(req, "multimodal_positions", None)
+            mm_len = getattr(req, "multimodal_lengths", None)
+            mm_item_types = (
+                req.py_multimodal_data.get("item_types", []) if req.py_multimodal_data else []
+            )
+            special_offsets = (
+                req.py_multimodal_data.get("special_token_offsets", [])
+                if req.py_multimodal_data
+                else []
+            )
+            mm_pos_list = list(mm_pos) if mm_pos is not None else []
+            mm_len_list = list(mm_len) if mm_len is not None else []
+            mm_item_cu_seqlen.append(mm_item_cu_seqlen[-1] + len(mm_pos_list))
+            mm_item_types_flat.extend(list(mm_item_types))
+            mm_token_positions_flat.extend(mm_pos_list)
+            mm_token_lengths_flat.extend(mm_len_list)
+            mm_special_offsets_cu_seqlen.append(
+                mm_special_offsets_cu_seqlen[-1] + len(special_offsets)
+            )
+            mm_special_offsets_flat.extend(list(special_offsets))
+            if not mm_pos or not mm_len:
+                flat_start_list.append(0)
+                count_list.append(0)
+                continue
+
+            runtime = MultimodalRuntimeData(
+                past_seen_token_num=begin_compute,
+                mm_token_positions=list(mm_pos),
+                mm_token_lengths=list(mm_len),
+                chunk_end_pos=end_compute,
+                special_token_offsets=list(special_offsets),
+            )
+            num_unseen = runtime.num_unseen_mm_tokens
+            num_in_chunk = runtime.num_mm_tokens_in_chunk
+            num_unseen_special = runtime.num_unseen_special_tokens
+            num_special_in_chunk = runtime.num_special_tokens_in_chunk
+            total_mm_i = runtime.total_mm_tokens_in_request
+            total_special_i = runtime.total_special_tokens_in_request
+            flat_start_i = cumsum_total_mm + num_unseen - num_unseen_special
+            flat_start_list.append(flat_start_i)
+            count_list.append(num_in_chunk - num_special_in_chunk)
+            cumsum_total_mm += total_mm_i - total_special_i
+
+        extra_args["mm_item_cu_seqlen"] = [
+            torch.tensor(mm_item_cu_seqlen, dtype=torch.int32, device="cpu")
+        ]
+        extra_args["mm_item_types"] = [
+            torch.tensor(mm_item_types_flat, dtype=torch.int32, device="cpu")
+        ]
+        extra_args["mm_token_positions"] = [
+            torch.tensor(mm_token_positions_flat, dtype=torch.int32, device="cpu")
+        ]
+        extra_args["mm_token_lengths"] = [
+            torch.tensor(mm_token_lengths_flat, dtype=torch.int32, device="cpu")
+        ]
+        extra_args["mm_special_offsets_cu_seqlen"] = [
+            torch.tensor(mm_special_offsets_cu_seqlen, dtype=torch.int32, device="cpu")
+        ]
+        extra_args["mm_special_offsets"] = [
+            torch.tensor(mm_special_offsets_flat, dtype=torch.int32, device="cpu")
+        ]
+        if self._enable_chunked_prefill:
+            extra_args["mm_chunk_flat_start"] = [
+                torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
+            ]
+            extra_args["mm_chunk_count"] = [
+                torch.tensor(count_list, dtype=torch.int64, device="cpu")
+            ]
+
     @nvtx_range("ad_prepare_inputs")
     def _prepare_inputs(
         self,
@@ -703,88 +801,13 @@ class ADEngine(ModelEngine):
         batch_info.extend([num_extend, num_extend_tokens])
         batch_info.extend([num_decode, num_decode_tokens])
 
-        # Stage per-request multimodal layout metadata so the VLM wrapper can reconstruct
-        # chunk-local mRoPE and compute request-level mRoPE deltas from full multimodal state.
-        if num_prefill_seqs > 0:
-            mm_item_cu_seqlen: List[int] = [0]
-            mm_item_types_flat: List[int] = []
-            mm_token_positions_flat: List[int] = []
-            mm_token_lengths_flat: List[int] = []
-            mm_special_offsets_cu_seqlen: List[int] = [0]
-            mm_special_offsets_flat: List[int] = []
-            flat_start_list: List[int] = []
-            count_list: List[int] = []
-            cumsum_total_mm = 0
-            for i in range(num_prefill_seqs):
-                req = ordered_requests[i]
-                begin_compute = input_pos[i]
-                end_compute = begin_compute + (cu_seqlen[i + 1] - cu_seqlen[i])
-                mm_pos = getattr(req, "multimodal_positions", None)
-                mm_len = getattr(req, "multimodal_lengths", None)
-                mm_item_types = (
-                    req.py_multimodal_data.get("item_types", []) if req.py_multimodal_data else []
-                )
-                special_offsets = (
-                    req.py_multimodal_data.get("special_token_offsets", [])
-                    if req.py_multimodal_data
-                    else []
-                )
-                mm_pos_list = list(mm_pos) if mm_pos is not None else []
-                mm_len_list = list(mm_len) if mm_len is not None else []
-                mm_item_cu_seqlen.append(mm_item_cu_seqlen[-1] + len(mm_pos_list))
-                mm_item_types_flat.extend(list(mm_item_types))
-                mm_token_positions_flat.extend(mm_pos_list)
-                mm_token_lengths_flat.extend(mm_len_list)
-                mm_special_offsets_cu_seqlen.append(
-                    mm_special_offsets_cu_seqlen[-1] + len(special_offsets)
-                )
-                mm_special_offsets_flat.extend(list(special_offsets))
-                if not mm_pos or not mm_len:
-                    flat_start_list.append(0)
-                    count_list.append(0)
-                    continue
-                runtime = MultimodalRuntimeData(
-                    past_seen_token_num=begin_compute,
-                    mm_token_positions=list(mm_pos),
-                    mm_token_lengths=list(mm_len),
-                    chunk_end_pos=end_compute,
-                    special_token_offsets=list(special_offsets),
-                )
-                num_unseen = runtime.num_unseen_mm_tokens
-                num_in_chunk = runtime.num_mm_tokens_in_chunk
-                num_unseen_special = runtime.num_unseen_special_tokens
-                num_special_in_chunk = runtime.num_special_tokens_in_chunk
-                total_mm_i = runtime.total_mm_tokens_in_request
-                total_special_i = runtime.total_special_tokens_in_request
-                flat_start_i = cumsum_total_mm + num_unseen - num_unseen_special
-                flat_start_list.append(flat_start_i)
-                count_list.append(num_in_chunk - num_special_in_chunk)
-                cumsum_total_mm += total_mm_i - total_special_i
-            extra_args["mm_item_cu_seqlen"] = [
-                torch.tensor(mm_item_cu_seqlen, dtype=torch.int32, device="cpu")
-            ]
-            extra_args["mm_item_types"] = [
-                torch.tensor(mm_item_types_flat, dtype=torch.int32, device="cpu")
-            ]
-            extra_args["mm_token_positions"] = [
-                torch.tensor(mm_token_positions_flat, dtype=torch.int32, device="cpu")
-            ]
-            extra_args["mm_token_lengths"] = [
-                torch.tensor(mm_token_lengths_flat, dtype=torch.int32, device="cpu")
-            ]
-            extra_args["mm_special_offsets_cu_seqlen"] = [
-                torch.tensor(mm_special_offsets_cu_seqlen, dtype=torch.int32, device="cpu")
-            ]
-            extra_args["mm_special_offsets"] = [
-                torch.tensor(mm_special_offsets_flat, dtype=torch.int32, device="cpu")
-            ]
-            if self._enable_chunked_prefill:
-                extra_args["mm_chunk_flat_start"] = [
-                    torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
-                ]
-                extra_args["mm_chunk_count"] = [
-                    torch.tensor(count_list, dtype=torch.int64, device="cpu")
-                ]
+        self._store_prefill_multimodal_metadata(
+            ordered_requests=ordered_requests,
+            input_pos=input_pos,
+            cu_seqlen=cu_seqlen,
+            num_prefill_seqs=num_prefill_seqs,
+            extra_args=extra_args,
+        )
 
         # update the sequence info object now (also triggers rescatter + host_prepare internally)
         self.cache_seq_interface.info.nest_sequences(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -665,7 +665,15 @@ class ADEngine(ModelEngine):
         extra_args["mm_special_offsets"] = [
             torch.tensor(mm_special_offsets_flat, dtype=torch.int32, device="cpu")
         ]
-        if self._enable_chunked_prefill:
+        # Export multimodal slice bounds whenever the current prefill step only needs a
+        # subset of the request's multimodal embeddings. This is required for regular
+        # chunked prefill, but also for KV-cache reuse where begin_compute > 0 even when
+        # chunked prefill is disabled in the config.
+        needs_mm_chunk_bounds = self._enable_chunked_prefill or any(
+            int(input_pos[i]) > 0 and getattr(req, "multimodal_positions", None)
+            for i, req in enumerate(prefill_requests)
+        )
+        if needs_mm_chunk_bounds:
             extra_args["mm_chunk_flat_start"] = [
                 torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
             ]

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -566,7 +566,12 @@ class ADEngine(ModelEngine):
         num_prefill_seqs: int,
         extra_args: Dict[str, List[torch.Tensor]],
     ) -> None:
-        """Stage per-request multimodal layout metadata needed by the VLM wrapper."""
+        """Stage per-request multimodal layout metadata needed by the VLM wrapper.
+
+        The standard attention metadata captures request geometry (batch_info, cu_seqlen,
+        seq_len_with_cache, input_pos), but not the original per-request multimodal span layout
+        or multimodal special-token offsets needed to rebuild chunk-aware mRoPE positions.
+        """
         if num_prefill_seqs == 0:
             return
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -37,6 +37,7 @@ from tensorrt_llm._torch.pyexecutor.seq_slot_manager import SeqSlotManager
 from tensorrt_llm._torch.speculative import get_spec_drafter
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3OneModelSampler, Eagle3ResourceManager
 from tensorrt_llm._utils import nvtx_range
+from tensorrt_llm.inputs.multimodal import MultimodalRuntimeData
 from tensorrt_llm.llmapi.llm_args import (
     ContextChunkingPolicy,
     EagleDecodingConfig,
@@ -73,41 +74,6 @@ from ..transform.optimizer import InferenceOptimizer
 from ..utils._graph import get_input_embeddings, get_lm_head_weights
 from ..utils.logger import ad_logger
 from .interface import CachedSequenceInterface, GetInferenceModel
-
-
-def _unwrap_model(model: torch.nn.Module) -> torch.nn.Module:
-    """Walk the wrapper chain (e.g. CapturedGraph → GraphModule → ...) to the innermost model."""
-    while hasattr(model, "model") and model.model is not model:
-        model = model.model
-    return model
-
-
-def _collect_persistent_multimodal_keys(
-    persist_keys: set,
-    ordered_requests: list,
-    extra_args: Dict[str, List[torch.Tensor]],
-) -> None:
-    """Collect persistent multimodal metadata from all requests.
-
-    Models declare which ``py_multimodal_data`` keys should persist across
-    context and generation phases via a ``persistent_multimodal_keys`` class
-    attribute.  For each declared key this function gathers the value from
-    every request (context **and** generation), zero-filling for requests
-    that lack the key.
-    """
-    for key in persist_keys:
-        per_request: List[Optional[torch.Tensor]] = []
-        ref: Optional[torch.Tensor] = None
-        for request in ordered_requests:
-            mm = request.py_multimodal_data
-            if mm is not None and key in mm:
-                per_request.append(mm[key])
-                if ref is None:
-                    ref = mm[key]
-            else:
-                per_request.append(None)
-        if ref is not None:
-            extra_args[key] = [v if v is not None else torch.zeros_like(ref) for v in per_request]
 
 
 @dataclass
@@ -548,11 +514,13 @@ class ADEngine(ModelEngine):
             self.spec_config = ad_config.speculative_config
             self._disable_overlap_scheduler = ad_config.disable_overlap_scheduler
             self.llm_args.max_stats_len = ad_config.max_stats_len
+            self._enable_chunked_prefill = getattr(ad_config, "enable_chunked_prefill", False)
         else:
             self.max_beam_width = 1
             self.spec_config = None
             self._disable_overlap_scheduler = False
             self.llm_args.max_stats_len = 1000
+            self._enable_chunked_prefill = False
 
         # check for max total draft tokens
         if self.spec_config is not None:
@@ -568,8 +536,6 @@ class ADEngine(ModelEngine):
 
         # build model
         self.model = get_inference_model(self.cache_seq_interface)
-        inner = _unwrap_model(self.model)
-        self._persistent_multimodal_keys = getattr(inner, "persistent_multimodal_keys", set())
         # start fresh with fixed seed
         torch.manual_seed(42)
 
@@ -659,8 +625,9 @@ class ADEngine(ModelEngine):
             # store extra arguments
             if request.py_multimodal_data is not None:
                 for k, v in request.py_multimodal_data.items():
-                    if k not in self._persistent_multimodal_keys:
-                        extra_args[k].append(v)
+                    if k == "special_token_offsets":
+                        continue
+                    extra_args[k].append(v)
 
         # store num_prefill and num_prefill_tokens
         num_prefill = len(context_requests)
@@ -736,9 +703,80 @@ class ADEngine(ModelEngine):
         batch_info.extend([num_extend, num_extend_tokens])
         batch_info.extend([num_decode, num_decode_tokens])
 
-        _collect_persistent_multimodal_keys(
-            self._persistent_multimodal_keys, ordered_requests, extra_args
-        )
+        # Chunked prefill + multimodal: stage per-request multimodal layout metadata plus the
+        # per-prefill slice (flat_start, count) into full image embeddings so the VLM wrapper can
+        # reconstruct chunk-local mRoPE and scatter only the chunk's mm tokens.
+        if self._enable_chunked_prefill and num_prefill_seqs > 0:
+            flat_start_list: List[int] = []
+            count_list: List[int] = []
+            mm_item_cu_seqlen: List[int] = [0]
+            mm_token_positions_flat: List[int] = []
+            mm_token_lengths_flat: List[int] = []
+            mm_special_offsets_cu_seqlen: List[int] = [0]
+            mm_special_offsets_flat: List[int] = []
+            cumsum_total_mm = 0
+            for i in range(num_prefill_seqs):
+                req = ordered_requests[i]
+                begin_compute = input_pos[i]
+                end_compute = begin_compute + (cu_seqlen[i + 1] - cu_seqlen[i])
+                mm_pos = getattr(req, "multimodal_positions", None)
+                mm_len = getattr(req, "multimodal_lengths", None)
+                special_offsets = (
+                    req.py_multimodal_data.get("special_token_offsets", [])
+                    if req.py_multimodal_data
+                    else []
+                )
+                mm_pos_list = list(mm_pos) if mm_pos is not None else []
+                mm_len_list = list(mm_len) if mm_len is not None else []
+                mm_item_cu_seqlen.append(mm_item_cu_seqlen[-1] + len(mm_pos_list))
+                mm_token_positions_flat.extend(mm_pos_list)
+                mm_token_lengths_flat.extend(mm_len_list)
+                mm_special_offsets_cu_seqlen.append(
+                    mm_special_offsets_cu_seqlen[-1] + len(special_offsets)
+                )
+                mm_special_offsets_flat.extend(list(special_offsets))
+                if not mm_pos or not mm_len:
+                    flat_start_list.append(0)
+                    count_list.append(0)
+                    continue
+                runtime = MultimodalRuntimeData(
+                    past_seen_token_num=begin_compute,
+                    mm_token_positions=list(mm_pos),
+                    mm_token_lengths=list(mm_len),
+                    chunk_end_pos=end_compute,
+                    special_token_offsets=list(special_offsets),
+                )
+                num_unseen = runtime.num_unseen_mm_tokens
+                num_in_chunk = runtime.num_mm_tokens_in_chunk
+                num_unseen_special = runtime.num_unseen_special_tokens
+                num_special_in_chunk = runtime.num_special_tokens_in_chunk
+                total_mm_i = runtime.total_mm_tokens_in_request
+                total_special_i = runtime.total_special_tokens_in_request
+                flat_start_i = cumsum_total_mm + num_unseen - num_unseen_special
+                flat_start_list.append(flat_start_i)
+                count_list.append(num_in_chunk - num_special_in_chunk)
+                cumsum_total_mm += total_mm_i - total_special_i
+            extra_args["mm_chunk_flat_start"] = [
+                torch.tensor(flat_start_list, dtype=torch.int64, device="cpu")
+            ]
+            extra_args["mm_chunk_count"] = [
+                torch.tensor(count_list, dtype=torch.int64, device="cpu")
+            ]
+            extra_args["mm_item_cu_seqlen"] = [
+                torch.tensor(mm_item_cu_seqlen, dtype=torch.int32, device="cpu")
+            ]
+            extra_args["mm_token_positions"] = [
+                torch.tensor(mm_token_positions_flat, dtype=torch.int32, device="cpu")
+            ]
+            extra_args["mm_token_lengths"] = [
+                torch.tensor(mm_token_lengths_flat, dtype=torch.int32, device="cpu")
+            ]
+            extra_args["mm_special_offsets_cu_seqlen"] = [
+                torch.tensor(mm_special_offsets_cu_seqlen, dtype=torch.int32, device="cpu")
+            ]
+            extra_args["mm_special_offsets"] = [
+                torch.tensor(mm_special_offsets_flat, dtype=torch.int32, device="cpu")
+            ]
 
         # update the sequence info object now (also triggers rescatter + host_prepare internally)
         self.cache_seq_interface.info.nest_sequences(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -616,8 +616,20 @@ class ADEngine(ModelEngine):
             )
             mm_pos_list = list(mm_pos) if mm_pos is not None else []
             mm_len_list = list(mm_len) if mm_len is not None else []
+            mm_item_types_list = list(mm_item_types)
+            if len(mm_pos_list) != len(mm_len_list):
+                raise ValueError(
+                    "Mismatch between multimodal_positions and multimodal_lengths in "
+                    f"request {i}: positions={len(mm_pos_list)}, lengths={len(mm_len_list)}"
+                )
+            if mm_item_types_list and len(mm_item_types_list) != len(mm_pos_list):
+                raise ValueError(
+                    "Mismatch between multimodal item_types and multimodal span arrays in "
+                    f"request {i}: item_types={len(mm_item_types_list)}, "
+                    f"positions={len(mm_pos_list)}, lengths={len(mm_len_list)}"
+                )
             mm_item_cu_seqlen.append(mm_item_cu_seqlen[-1] + len(mm_pos_list))
-            mm_item_types_flat.extend(list(mm_item_types))
+            mm_item_types_flat.extend(mm_item_types_list)
             mm_token_positions_flat.extend(mm_pos_list)
             mm_token_lengths_flat.extend(mm_len_list)
             mm_special_offsets_cu_seqlen.append(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -575,6 +575,13 @@ class ADEngine(ModelEngine):
         The standard attention metadata captures request geometry (batch_info, cu_seqlen,
         seq_len_with_cache, input_pos), but not the original per-request multimodal span layout
         or multimodal special-token offsets needed to rebuild chunk-aware mRoPE positions.
+
+        This tensorization happens in the executor because it still has the scheduled request
+        list, per-request chunk boundaries, input_pos, cu_seqlen, and access to the raw
+        request-side multimodal fields (multimodal_positions, multimodal_lengths, and
+        py_multimodal_data["layout_metadata"]). By the time control reaches the exported
+        wrapper/modeling path, Python request objects are gone and the model call can only
+        consume concrete tensor kwargs.
         """
         if num_prefill_seqs == 0:
             return

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -842,7 +842,7 @@ class ADEngine(ModelEngine):
             ordered_requests=ordered_requests,
             input_pos=input_pos,
             cu_seqlen=cu_seqlen,
-            num_prefill_seqs=num_prefill_seqs,
+            num_prefill_seqs=num_prefill,
             extra_args=extra_args,
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -75,6 +75,10 @@ from ..utils._graph import get_input_embeddings, get_lm_head_weights
 from ..utils.logger import ad_logger
 from .interface import CachedSequenceInterface, GetInferenceModel
 
+# `layout_metadata` is a reserved multimodal payload used to carry request-level
+# layout semantics that the wrapper reconstructs into tensor kwargs separately.
+_RESERVED_MM_DATA_KEYS = frozenset({"layout_metadata"})
+
 
 @dataclass
 class ReportingInfo:
@@ -594,13 +598,14 @@ class ADEngine(ModelEngine):
             end_compute = begin_compute + (cu_seqlen[i + 1] - cu_seqlen[i])
             mm_pos = getattr(req, "multimodal_positions", None)
             mm_len = getattr(req, "multimodal_lengths", None)
-            mm_item_types = (
-                req.py_multimodal_data.get("item_types", []) if req.py_multimodal_data else []
-            )
+            layout_metadata = {}
+            if req.py_multimodal_data:
+                layout_metadata = req.py_multimodal_data.get(
+                    "layout_metadata", req.py_multimodal_data
+                )
+            mm_item_types = layout_metadata.get("item_types", []) if layout_metadata else []
             special_offsets = (
-                req.py_multimodal_data.get("special_token_offsets", [])
-                if req.py_multimodal_data
-                else []
+                layout_metadata.get("special_token_offsets", []) if layout_metadata else []
             )
             mm_pos_list = list(mm_pos) if mm_pos is not None else []
             mm_len_list = list(mm_len) if mm_len is not None else []
@@ -728,7 +733,7 @@ class ADEngine(ModelEngine):
             # store extra arguments
             if request.py_multimodal_data is not None:
                 for k, v in request.py_multimodal_data.items():
-                    if k in {"special_token_offsets", "item_types"}:
+                    if k in _RESERVED_MM_DATA_KEYS:
                         continue
                     extra_args[k].append(v)
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
@@ -39,7 +39,7 @@ from ..interface import (
 )
 
 
-@TransformRegistry.register("initialize_qwen_mrope_delta_cache")
+@TransformRegistry.register("initialize_mrope_delta_cache")
 class InitializeMropeDeltaCache(BaseTransform):
     """Allocate a per-slot mrope_delta_cache for multimodal mRoPE models.
 
@@ -64,3 +64,7 @@ class InitializeMropeDeltaCache(BaseTransform):
         return mod, TransformInfo(
             skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True
         )
+
+
+# Backward-compatible alias for older model registry configs.
+TransformRegistry._registry["initialize_qwen_mrope_delta_cache"] = InitializeMropeDeltaCache

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
@@ -64,7 +64,3 @@ class InitializeMropeDeltaCache(BaseTransform):
         return mod, TransformInfo(
             skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True
         )
-
-
-# Backward-compatible alias for older model registry configs.
-TransformRegistry._registry["initialize_qwen_mrope_delta_cache"] = InitializeMropeDeltaCache

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transform to allocate a per-slot mRoPE position-delta cache.
+
+Multimodal models using mRoPE (multi-dimensional rotary position embeddings)
+compute a position delta during prefill that must be remembered for subsequent
+decode steps.  This transform allocates a tiny ``(max_slots, 1)`` int32 buffer
+and registers it as a state resource so that the runtime can write during prefill
+and read during decode.
+
+Detection: scans the model source for usage of the
+``auto_deploy::mrope_delta_with_cache`` custom op via ``torch.ops``.
+"""
+
+import inspect
+from typing import Tuple, Type
+
+import torch
+import torch.nn as nn
+
+from ...custom_ops.attention_interface import StateResourceHandler
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+_MROPE_DELTA_CACHE_OP = "mrope_delta_with_cache"
+
+
+def _model_uses_mrope_delta_cache(mod: nn.Module) -> bool:
+    """Return True if any submodule's forward references the mrope_delta_with_cache op."""
+    for m in mod.modules():
+        try:
+            src = inspect.getsource(type(m).forward)
+        except (TypeError, OSError):
+            continue
+        if _MROPE_DELTA_CACHE_OP in src:
+            return True
+    return False
+
+
+@TransformRegistry.register("initialize_qwen_mrope_delta_cache")
+class InitializeMropeDeltaCache(BaseTransform):
+    """Allocate a per-slot mrope_delta_cache for multimodal mRoPE models.
+
+    Skipped when no submodule forward method references the
+    ``qwen3_mrope_delta_with_cache`` custom op.
+    """
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply_to_full_model(
+        self,
+        mod: nn.Module,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[nn.Module, TransformInfo]:
+        if not _model_uses_mrope_delta_cache(mod):
+            return mod, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        cm.add_resource("mrope_delta_cache", StateResourceHandler(1, dtype=torch.int32))
+
+        return mod, TransformInfo(
+            skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py
@@ -17,15 +17,11 @@
 
 Multimodal models using mRoPE (multi-dimensional rotary position embeddings)
 compute a position delta during prefill that must be remembered for subsequent
-decode steps.  This transform allocates a tiny ``(max_slots, 1)`` int32 buffer
+decode steps. This transform allocates a tiny ``(max_slots, 1)`` int32 buffer
 and registers it as a state resource so that the runtime can write during prefill
 and read during decode.
-
-Detection: scans the model source for usage of the
-``auto_deploy::mrope_delta_with_cache`` custom op via ``torch.ops``.
 """
 
-import inspect
 from typing import Tuple, Type
 
 import torch
@@ -42,27 +38,14 @@ from ..interface import (
     TransformRegistry,
 )
 
-_MROPE_DELTA_CACHE_OP = "mrope_delta_with_cache"
-
-
-def _model_uses_mrope_delta_cache(mod: nn.Module) -> bool:
-    """Return True if any submodule's forward references the mrope_delta_with_cache op."""
-    for m in mod.modules():
-        try:
-            src = inspect.getsource(type(m).forward)
-        except (TypeError, OSError):
-            continue
-        if _MROPE_DELTA_CACHE_OP in src:
-            return True
-    return False
-
 
 @TransformRegistry.register("initialize_qwen_mrope_delta_cache")
 class InitializeMropeDeltaCache(BaseTransform):
     """Allocate a per-slot mrope_delta_cache for multimodal mRoPE models.
 
-    Skipped when no submodule forward method references the
-    ``qwen3_mrope_delta_with_cache`` custom op.
+    This transform is intentionally enabled per-model via config rather than
+    auto-detected. TODO: if we want to make this generic-by-default, add a
+    proper capability signal or reliable heuristic instead of source inspection.
     """
 
     @classmethod
@@ -76,11 +59,6 @@ class InitializeMropeDeltaCache(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[nn.Module, TransformInfo]:
-        if not _model_uses_mrope_delta_cache(mod):
-            return mod, TransformInfo(
-                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
-            )
-
         cm.add_resource("mrope_delta_cache", StateResourceHandler(1, dtype=torch.int32))
 
         return mod, TransformInfo(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -98,6 +98,53 @@ def is_quantized_linear_scale_tensor(node: "Node", weight_node_key: str) -> bool
     return is_fake_quantized_linear_op(node) and "_scale" in weight_node_key
 
 
+def _make_tp_plan_regex(key: str) -> str:
+    pattern_string = ("*" + key + "*").replace("*", "@")
+    return re.escape(pattern_string).replace("@", ".*")
+
+
+def _matches_tp_plan(weight_name: str, tp_plan: Dict[str, str]) -> bool:
+    return any(re.match(_make_tp_plan_regex(key), weight_name) for key in tp_plan)
+
+
+def _is_unmatched_moe_aux_gate_linear(weight_name: str, tp_plan: Dict[str, str]) -> bool:
+    if _matches_tp_plan(weight_name, tp_plan):
+        return False
+
+    segments = weight_name.split(".")
+    if len(segments) < 2 or segments[-1] != "weight":
+        return False
+
+    # Router gates and shared-expert scalar gates are intentionally replicated in TP config.
+    return segments[-2] in {"gate", "shared_expert_gate"}
+
+
+def _get_config_layer_linear_nodes(gm: GraphModule, tp_plan: Dict[str, str]) -> List[Node]:
+    linear_nodes = list(filtered_nodes(gm.graph.nodes, is_any_lin_op))
+    filtered_linear_nodes = []
+    num_skipped = 0
+
+    for lin_node in linear_nodes:
+        weight_name = extract_weight_name(lin_node)
+        if not weight_name:
+            filtered_linear_nodes.append(lin_node)
+            continue
+
+        if _is_unmatched_moe_aux_gate_linear(weight_name, tp_plan):
+            num_skipped += 1
+            continue
+
+        filtered_linear_nodes.append(lin_node)
+
+    if num_skipped > 0:
+        ad_logger.info(
+            f"Skipping {num_skipped} unmatched MoE auxiliary gate linear nodes during "
+            "config-driven TP layer recovery"
+        )
+
+    return filtered_linear_nodes
+
+
 ########################################################
 #  Helper enums
 ########################################################
@@ -2903,7 +2950,9 @@ def detect_sharding_from_config(
 
     # use layer_subgraphs to determine the layer_type
     # and check the validity of the sharding transform
-    layer_subgraphs, unprocessed_linear_nodes = get_all_layer_subgraphs(gm)
+    layer_subgraphs, unprocessed_linear_nodes = get_all_layer_subgraphs(
+        gm, linear_nodes=_get_config_layer_linear_nodes(gm, tp_plan)
+    )
 
     for lin_node in linear_nodes:
         # use node's weight name to get the module name
@@ -2928,12 +2977,7 @@ def detect_sharding_from_config(
 
         # use regex to find if module_name matches any of the keys in sharding_config
         for key in tp_plan.keys():
-            pattern_string = "*" + key + "*"
-            # convert it to regex. Escape dots, replace * with .*
-            # First, we substitute * with an unlikely character, e.g. @
-            # Then we escape dots, and finally we replace @ with .*
-            pattern_string = pattern_string.replace("*", "@")
-            pattern_regex = re.escape(pattern_string).replace("@", ".*")
+            pattern_regex = _make_tp_plan_regex(key)
             if re.match(pattern_regex, weight_name):
                 # we have a match. Get the config for this layer
                 config = tp_plan[key]

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -913,7 +913,9 @@ def identify_regions_between_residuals(gm: GraphModule) -> List[Node]:
     return boundary_nodes
 
 
-def get_all_layer_subgraphs(gm: GraphModule) -> tuple[List[LayerSubgraph], set[Node]]:
+def get_all_layer_subgraphs(
+    gm: GraphModule, linear_nodes: Optional[List[Node]] = None
+) -> tuple[List[LayerSubgraph], set[Node]]:
     """
     Get subgraphs for all consecutive layers (attention, MLP, SSM, MoE) in the graph.
 
@@ -946,7 +948,8 @@ def get_all_layer_subgraphs(gm: GraphModule) -> tuple[List[LayerSubgraph], set[N
 
     assert gm.graph.nodes, "Graph is empty"
     layer_subgraphs = []
-    linear_nodes = list(filtered_nodes(gm.graph.nodes, is_any_lin_op))
+    if linear_nodes is None:
+        linear_nodes = list(filtered_nodes(gm.graph.nodes, is_any_lin_op))
 
     # get residual add nodes to correctly identify layer boundaries
     residuals = identify_regions_between_residuals(gm)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2265,12 +2265,16 @@ class PyTorchModelEngine(ModelEngine):
             request.cached_tokens = num_cached_tokens_per_seq[-1]
 
             # Multimodal
+            layout_metadata = {}
+            if request.py_multimodal_data is not None:
+                layout_metadata = request.py_multimodal_data.get(
+                    'layout_metadata', request.py_multimodal_data)
             py_multimodal_runtime = MultimodalRuntimeData(
                 mm_token_lengths=request.multimodal_lengths,
                 mm_token_positions=request.multimodal_positions,
                 past_seen_token_num=past_seen_token_num,
                 chunk_end_pos=end_compute,
-                special_token_offsets=request.py_multimodal_data.get(
+                special_token_offsets=layout_metadata.get(
                     'special_token_offsets', []),
             ) if request.multimodal_hashes is not None else None
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2265,16 +2265,12 @@ class PyTorchModelEngine(ModelEngine):
             request.cached_tokens = num_cached_tokens_per_seq[-1]
 
             # Multimodal
-            layout_metadata = {}
-            if request.py_multimodal_data is not None:
-                layout_metadata = request.py_multimodal_data.get(
-                    'layout_metadata', request.py_multimodal_data)
             py_multimodal_runtime = MultimodalRuntimeData(
                 mm_token_lengths=request.multimodal_lengths,
                 mm_token_positions=request.multimodal_positions,
                 past_seen_token_num=past_seen_token_num,
                 chunk_end_pos=end_compute,
-                special_token_offsets=layout_metadata.get(
+                special_token_offsets=request.py_multimodal_data.get(
                     'special_token_offsets', []),
             ) if request.multimodal_hashes is not None else None
 

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,8 @@ from tensorrt_llm.quantization import QuantAlgo
 from tensorrt_llm.sampling_params import SamplingParams
 
 from ..conftest import get_device_count, llm_models_root, skip_pre_blackwell
-from .accuracy_core import GSM8K, MMLU, CnnDailymail, LlmapiAccuracyTestHarness
+from .accuracy_core import (GSM8K, MMLU, MMMU, CnnDailymail,
+                            LlmapiAccuracyTestHarness)
 
 _AD_CONFIGS_DIR = (Path(get_llm_root()) / 'examples' / 'auto_deploy' /
                    'model_registry' / 'configs')

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -978,13 +978,25 @@ class TestQwen3_5_35B_MoE(LlmapiAccuracyTestHarness):
     """
 
     MODEL_NAME = "Qwen/Qwen3.5-35B-A3B"
-    MAX_SEQ_LEN = max(MMMU.MAX_INPUT_LEN + MMMU.MAX_OUTPUT_LEN, 4096)
+    MAX_SEQ_LEN = max(MMMU.MAX_INPUT_LEN + MMMU.MAX_OUTPUT_LEN, 8192)
+    MAX_NUM_TOKENS = 4096
+    EXTRA_EVALUATOR_KWARGS = dict(chat_template_kwargs=dict(
+        enable_thinking=False))
 
     def get_default_kwargs(self):
-        return {
+        kwargs = {
+            "max_seq_len": self.MAX_SEQ_LEN,
+            "max_num_tokens": self.MAX_NUM_TOKENS,
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
         }
+        low_memory_overrides(kwargs,
+                             max_batch_size=32,
+                             free_gpu_memory_fraction=0.4,
+                             max_seq_len=self.MAX_SEQ_LEN,
+                             max_num_tokens=self.MAX_NUM_TOKENS,
+                             cuda_graph_batch_sizes=[1, 2, 4, 8, 16, 32])
+        return kwargs
 
     def get_default_sampling_params(self):
         eos_id = -1
@@ -995,25 +1007,24 @@ class TestQwen3_5_35B_MoE(LlmapiAccuracyTestHarness):
                               use_beam_search=beam_width > 1)
 
     @pytest.mark.skip_less_device_memory(60000)
-    @pytest.mark.parametrize("world_size", [8])
+    @pytest.mark.parametrize("world_size", [2])
     def test_bf16(self, world_size):
         if get_device_count() < world_size:
             pytest.skip("Not enough devices for world size, skipping test")
         kwargs = self.get_default_kwargs()
         self.get_default_sampling_params()
-        model_path = hf_id_to_local_model_dir(self.MODEL_NAME)
         yaml_paths, registry_world_size = _get_registry_yaml_extra(
             self.MODEL_NAME)
         assert registry_world_size == world_size
-        with AutoDeployLLM(model=model_path,
-                           tokenizer=model_path,
+        with AutoDeployLLM(model=self.MODEL_NAME,
+                           tokenizer=self.MODEL_NAME,
                            dtype="bfloat16",
                            world_size=world_size,
                            yaml_extra=yaml_paths,
                            **kwargs) as llm:
             task = MMMU(self.MODEL_NAME)
-            task.EVALUATE_KWARGS = {
-                "model_type": "qwen3_vl",
-                "is_force_single_image": False
-            }
-            task.evaluate(llm)
+            task.EVALUATE_KWARGS = dict(MMMU.EVALUATE_KWARGS,
+                                        model_type="qwen3_vl",
+                                        is_force_single_image=False)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -31,12 +31,33 @@ from .accuracy_core import GSM8K, MMLU, CnnDailymail, LlmapiAccuracyTestHarness
 
 _AD_CONFIGS_DIR = (Path(get_llm_root()) / 'examples' / 'auto_deploy' /
                    'model_registry' / 'configs')
+_AD_MODEL_REGISTRY_DIR = Path(
+    get_llm_root()) / 'examples' / 'auto_deploy' / 'model_registry'
 
 
 def _load_ad_config(config_name):
     """Load a YAML config from the AutoDeploy model registry configs directory."""
     with open(_AD_CONFIGS_DIR / config_name) as f:
         return yaml.safe_load(f)
+
+
+def _get_registry_yaml_extra(model_name: str) -> tuple[list[str], int]:
+    """Return (yaml_extra paths, world_size) from the AutoDeploy model registry."""
+    with open(_AD_MODEL_REGISTRY_DIR / "models.yaml") as f:
+        registry = yaml.safe_load(f)
+    for entry in registry["models"]:
+        if entry["name"] != model_name:
+            continue
+        config_dir = _AD_MODEL_REGISTRY_DIR / "configs"
+        paths = [str(config_dir / cfg) for cfg in entry["yaml_extra"]]
+        world_size = 1
+        for cfg in entry["yaml_extra"]:
+            cfg_name = str(cfg)
+            if "world_size_" in cfg_name and cfg_name.endswith(".yaml"):
+                world_size = int(
+                    cfg_name.replace("world_size_", "").replace(".yaml", ""))
+        return paths, world_size
+    raise ValueError(f"Model '{model_name}' not found in model registry")
 
 
 def _set_quant_config(llm, model_id: str) -> None:
@@ -703,7 +724,7 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
-class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
+class TestQwen3_5_397B_MoE(LlmapiAccuracyTestHarness):
     """Accuracy regression tests for Qwen3.5-397B-A17B via AutoDeploy.
 
     Runs the model via AutoDeploy and verifies benchmark performance on MMLU and GSM8K.
@@ -715,15 +736,11 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
     MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
                       GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
 
-    def _load_config(self):
-        """Load config from qwen3.5_moe_400b.yaml with test-specific overrides."""
-        config = _load_ad_config('qwen3.5_moe_400b.yaml')
-        config.pop('world_size', None)
-        config['max_seq_len'] = self.MAX_SEQ_LEN
-        config['max_num_tokens'] = self.MAX_SEQ_LEN
-        config.setdefault('skip_tokenizer_init', False)
-        config.setdefault('trust_remote_code', True)
-        return config
+    def get_default_kwargs(self):
+        return {
+            "skip_tokenizer_init": False,
+            "trust_remote_code": True,
+        }
 
     def get_default_sampling_params(self):
         eos_id = -1
@@ -738,12 +755,17 @@ class TestQwen3_5_MoE(LlmapiAccuracyTestHarness):
     def test_bf16(self, world_size):
         if get_device_count() < world_size:
             pytest.skip("Not enough devices for world size, skipping test")
-        kwargs = self._load_config()
+        kwargs = self.get_default_kwargs()
         sampling_params = self.get_default_sampling_params()
-        with AutoDeployLLM(model=self.MODEL_NAME,
-                           tokenizer=self.MODEL_NAME,
+        model_path = hf_id_to_local_model_dir(self.MODEL_NAME)
+        yaml_paths, registry_world_size = _get_registry_yaml_extra(
+            self.MODEL_NAME)
+        assert registry_world_size == world_size
+        with AutoDeployLLM(model=model_path,
+                           tokenizer=model_path,
                            dtype="bfloat16",
                            world_size=world_size,
+                           yaml_extra=yaml_paths,
                            **kwargs) as llm:
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm, sampling_params=sampling_params)
@@ -913,27 +935,6 @@ class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
         ),
     ]
 
-    @staticmethod
-    def _get_registry_yaml_extra(model_name: str) -> tuple[list[str], int]:
-        """Return (yaml_extra paths, world_size) from model registry."""
-        registry_path = (Path(__file__).resolve().parents[4] /
-                         "examples/auto_deploy/model_registry")
-        with open(registry_path / "models.yaml") as f:
-            registry = yaml.safe_load(f)
-        for entry in registry["models"]:
-            if entry["name"] == model_name:
-                config_dir = registry_path / "configs"
-                paths = [str(config_dir / f) for f in entry["yaml_extra"]]
-                # world_size from world_size_N.yaml (last match wins)
-                world_size = 1
-                for f in entry["yaml_extra"]:
-                    s = str(f)
-                    if "world_size_" in s and s.endswith(".yaml"):
-                        world_size = int(
-                            s.replace("world_size_", "").replace(".yaml", ""))
-                return paths, world_size
-        raise ValueError(f"Model '{model_name}' not found in model registry")
-
     def get_default_sampling_params(self):
         # Use end_id=None so _setup runs and tokenizes stop sequences (e.g. GSM8K).
         return SamplingParams(end_id=None,
@@ -948,8 +949,7 @@ class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
     def test_autodeploy_from_registry(self, model_name, config_overrides, tasks,
                                       accuracy_check):
         model_path = hf_id_to_local_model_dir(model_name)
-        yaml_paths, registry_world_size = self._get_registry_yaml_extra(
-            model_name)
+        yaml_paths, registry_world_size = _get_registry_yaml_extra(model_name)
         effective_world_size = config_overrides.get("world_size",
                                                     registry_world_size)
         if get_device_count() < effective_world_size:
@@ -969,44 +969,20 @@ class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
                         raise type(e)(f"[{task_cls.__name__}] {e}") from None
 
 
-class TestKimiK2_5(LlmapiAccuracyTestHarness):
-    """Accuracy regression tests for Kimi-K2.5 via AutoDeploy.
+class TestQwen3_5_35B_MoE(LlmapiAccuracyTestHarness):
+    """Accuracy regression tests for Qwen3.5-35B-A3B via AutoDeploy.
 
-    Runs the model via AutoDeploy and verifies benchmark performance on MMLU and GSM8K.
-    Configuration derived from examples/auto_deploy/model_registry/configs/kimi_k2.yaml.
+    Runs the model via AutoDeploy and verifies MMMU performance.
+    Configuration derived from the AutoDeploy model registry entry for Qwen3.5 35B.
     """
 
-    MODEL_NAME = "nvidia/Kimi-K2.5-NVFP4"
-    MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
-                      GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
+    MODEL_NAME = "Qwen/Qwen3.5-35B-A3B"
+    MAX_SEQ_LEN = max(MMMU.MAX_INPUT_LEN + MMMU.MAX_OUTPUT_LEN, 4096)
 
     def get_default_kwargs(self):
         return {
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
-            "enable_chunked_prefill": True,
-            "compile_backend": "torch-cudagraph",
-            "max_batch_size": 64,
-            "max_seq_len": self.MAX_SEQ_LEN,
-            "max_num_tokens": self.MAX_SEQ_LEN,
-            "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64],
-            "kv_cache_config": {
-                "dtype": "bfloat16",
-                "enable_block_reuse": False,
-                "free_gpu_memory_fraction": 0.7,
-                "tokens_per_block": 64,
-            },
-            "model_kwargs": {
-                "torch_dtype": "bfloat16",
-            },
-            "transforms": {
-                "export_to_gm": {
-                    "num_moe_experts_for_export": 2,
-                },
-                "fuse_nvfp4_moe": {
-                    "allow_different_input_scales": True,
-                },
-            },
         }
 
     def get_default_sampling_params(self):
@@ -1024,15 +1000,16 @@ class TestKimiK2_5(LlmapiAccuracyTestHarness):
             pytest.skip("Not enough devices for world size, skipping test")
         kwargs = self.get_default_kwargs()
         self.get_default_sampling_params()
-        with AutoDeployLLM(model=self.MODEL_NAME,
-                           tokenizer=self.MODEL_NAME,
+        model_path = hf_id_to_local_model_dir(self.MODEL_NAME)
+        yaml_paths, registry_world_size = _get_registry_yaml_extra(
+            self.MODEL_NAME)
+        assert registry_world_size == world_size
+        with AutoDeployLLM(model=model_path,
+                           tokenizer=model_path,
                            dtype="bfloat16",
                            world_size=world_size,
+                           yaml_extra=yaml_paths,
                            **kwargs) as llm:
-            # task = MMLU(self.MODEL_NAME)
-            # task.evaluate(llm, sampling_params=sampling_params)
-            # task = GSM8K(self.MODEL_NAME)
-            # task.evaluate(llm)
             task = MMMU(self.MODEL_NAME)
             task.EVALUATE_KWARGS = {
                 "model_type": "qwen3_vl",

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -967,3 +967,81 @@ class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
                         task.evaluate(llm, sampling_params=sampling_params)
                     except (AssertionError, RuntimeError, ValueError) as e:
                         raise type(e)(f"[{task_cls.__name__}] {e}") from None
+
+
+class TestKimiK2_5(LlmapiAccuracyTestHarness):
+    """Accuracy regression tests for Kimi-K2.5 via AutoDeploy.
+
+    Runs the model via AutoDeploy and verifies benchmark performance on MMLU and GSM8K.
+    Configuration derived from examples/auto_deploy/model_registry/configs/kimi_k2.yaml.
+    """
+
+    MODEL_NAME = "nvidia/Kimi-K2.5-NVFP4"
+    MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
+                      GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
+
+    def get_default_kwargs(self):
+        return {
+            "skip_tokenizer_init": False,
+            "trust_remote_code": True,
+            "enable_chunked_prefill": True,
+            "compile_backend": "torch-cudagraph",
+            "max_batch_size": 64,
+            "max_seq_len": self.MAX_SEQ_LEN,
+            "max_num_tokens": self.MAX_SEQ_LEN,
+            "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64],
+            "kv_cache_config": {
+                "dtype": "bfloat16",
+                "enable_block_reuse": False,
+                "free_gpu_memory_fraction": 0.7,
+                "tokens_per_block": 64,
+            },
+            "model_kwargs": {
+                "torch_dtype": "bfloat16",
+                "text_config": {
+                    "num_hidden_layers": 6,
+                },
+                "vision_config": {
+                    "depth": 2,
+                },
+            },
+            "transforms": {
+                "export_to_gm": {
+                    "num_moe_experts_for_export": 2,
+                },
+                "fuse_nvfp4_moe": {
+                    "allow_different_input_scales": True,
+                },
+            },
+        }
+
+    def get_default_sampling_params(self):
+        eos_id = -1
+        beam_width = 1
+        return SamplingParams(end_id=eos_id,
+                              pad_id=eos_id,
+                              n=beam_width,
+                              use_beam_search=beam_width > 1)
+
+    @pytest.mark.skip_less_device_memory(60000)
+    @pytest.mark.parametrize("world_size", [8])
+    def test_bf16(self, world_size):
+        if get_device_count() < world_size:
+            pytest.skip("Not enough devices for world size, skipping test")
+        kwargs = self.get_default_kwargs()
+        self.get_default_sampling_params()
+        with AutoDeployLLM(model=self.MODEL_NAME,
+                           tokenizer=self.MODEL_NAME,
+                           dtype="bfloat16",
+                           world_size=world_size,
+                           **kwargs) as llm:
+            # task = MMLU(self.MODEL_NAME)
+            # task.evaluate(llm, sampling_params=sampling_params)
+            # task = GSM8K(self.MODEL_NAME)
+            # task.evaluate(llm)
+            task = MMMU(self.MODEL_NAME)
+            task.EVALUATE_KWARGS = {
+                "model_type": "qwen3_vl",
+                "is_force_single_image": False
+            }
+            task.evaluate(llm)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -998,12 +998,6 @@ class TestKimiK2_5(LlmapiAccuracyTestHarness):
             },
             "model_kwargs": {
                 "torch_dtype": "bfloat16",
-                "text_config": {
-                    "num_hidden_layers": 6,
-                },
-                "vision_config": {
-                    "depth": 2,
-                },
             },
             "transforms": {
                 "export_to_gm": {

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -734,8 +734,8 @@ class TestQwen3_5_397B_MoE(LlmapiAccuracyTestHarness):
 
     MODEL_NAME = "Qwen/Qwen3.5-397B-A17B"
     MODEL_NAME_SMALL = "Qwen/Qwen3.5-35B-A3B"
-    MAX_SEQ_LEN = max(MMLU.MAX_INPUT_LEN + MMLU.MAX_OUTPUT_LEN,
-                      GSM8K.MAX_INPUT_LEN + GSM8K.MAX_OUTPUT_LEN)
+    EXTRA_EVALUATOR_KWARGS = dict(chat_template_kwargs=dict(
+        enable_thinking=False))
 
     def get_default_kwargs(self):
         return {
@@ -780,8 +780,9 @@ class TestQwen3_5_397B_MoE(LlmapiAccuracyTestHarness):
         return config, world_size
 
     @pytest.mark.skip_less_device_memory(80000)
-    def test_bf16_small(self):
-        config, world_size = self._load_small_config()
+    @pytest.mark.parametrize("world_size", [8])
+    def test_bf16_small(self, world_size):
+        config, _ = self._load_small_config()
         if get_device_count() < world_size:
             pytest.skip("Not enough devices for world size, skipping test")
         sampling_params = self.get_default_sampling_params()
@@ -794,6 +795,12 @@ class TestQwen3_5_397B_MoE(LlmapiAccuracyTestHarness):
             task.evaluate(llm, sampling_params=sampling_params)
             task = GSM8K(self.MODEL_NAME_SMALL)
             task.evaluate(llm)
+            task = MMMU(self.MODEL_NAME_SMALL)
+            task.EVALUATE_KWARGS = dict(MMMU.EVALUATE_KWARGS,
+                                        model_type="qwen3_vl",
+                                        is_force_single_image=False)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
 
 class TestMiniMaxM2(LlmapiAccuracyTestHarness):
@@ -968,63 +975,3 @@ class TestModelRegistryAccuracy(LlmapiAccuracyTestHarness):
                         task.evaluate(llm, sampling_params=sampling_params)
                     except (AssertionError, RuntimeError, ValueError) as e:
                         raise type(e)(f"[{task_cls.__name__}] {e}") from None
-
-
-class TestQwen3_5_35B_MoE(LlmapiAccuracyTestHarness):
-    """Accuracy regression tests for Qwen3.5-35B-A3B via AutoDeploy.
-
-    Runs the model via AutoDeploy and verifies MMMU performance.
-    Configuration derived from the AutoDeploy model registry entry for Qwen3.5 35B.
-    """
-
-    MODEL_NAME = "Qwen/Qwen3.5-35B-A3B"
-    MAX_SEQ_LEN = max(MMMU.MAX_INPUT_LEN + MMMU.MAX_OUTPUT_LEN, 8192)
-    MAX_NUM_TOKENS = 4096
-    EXTRA_EVALUATOR_KWARGS = dict(chat_template_kwargs=dict(
-        enable_thinking=False))
-
-    def get_default_kwargs(self):
-        kwargs = {
-            "max_seq_len": self.MAX_SEQ_LEN,
-            "max_num_tokens": self.MAX_NUM_TOKENS,
-            "skip_tokenizer_init": False,
-            "trust_remote_code": True,
-        }
-        low_memory_overrides(kwargs,
-                             max_batch_size=32,
-                             free_gpu_memory_fraction=0.4,
-                             max_seq_len=self.MAX_SEQ_LEN,
-                             max_num_tokens=self.MAX_NUM_TOKENS,
-                             cuda_graph_batch_sizes=[1, 2, 4, 8, 16, 32])
-        return kwargs
-
-    def get_default_sampling_params(self):
-        eos_id = -1
-        beam_width = 1
-        return SamplingParams(end_id=eos_id,
-                              pad_id=eos_id,
-                              n=beam_width,
-                              use_beam_search=beam_width > 1)
-
-    @pytest.mark.skip_less_device_memory(60000)
-    @pytest.mark.parametrize("world_size", [2])
-    def test_bf16(self, world_size):
-        if get_device_count() < world_size:
-            pytest.skip("Not enough devices for world size, skipping test")
-        kwargs = self.get_default_kwargs()
-        self.get_default_sampling_params()
-        yaml_paths, registry_world_size = _get_registry_yaml_extra(
-            self.MODEL_NAME)
-        assert registry_world_size == world_size
-        with AutoDeployLLM(model=self.MODEL_NAME,
-                           tokenizer=self.MODEL_NAME,
-                           dtype="bfloat16",
-                           world_size=world_size,
-                           yaml_extra=yaml_paths,
-                           **kwargs) as llm:
-            task = MMMU(self.MODEL_NAME)
-            task.EVALUATE_KWARGS = dict(MMMU.EVALUATE_KWARGS,
-                                        model_type="qwen3_vl",
-                                        is_force_single_image=False)
-            task.evaluate(llm,
-                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -1376,9 +1376,10 @@ def test_export_text_model_with_rope_cos_sin():
 
 @torch.no_grad()
 def test_vlm_wrapper_text_only_position_ids():
-    """Test that the VLM wrapper correctly uses executor-provided 2D position_ids
-    for text-only inputs, expanding them to 3D and producing the same result as
-    the text model with equivalent 3D position_ids.
+    """Test VLM wrapper uses executor-provided 2D position_ids for text-only inputs.
+
+    Expanding them to 3D and producing the same result as the text model with
+    equivalent 3D position_ids.
 
     This simulates the AD executor flow: the executor provides 2D position_ids
     with correct offsets for chunked prefill, and the VLM wrapper expands them
@@ -1647,8 +1648,10 @@ def test_qwen3_mrope_delta_with_cache_writes_prefill_and_reads_decode():
 
 @torch.no_grad()
 def test_vlm_wrapper_decode_after_image_uses_delta():
-    """Branch C: text-only decode with provided mrope_position_deltas should
-    adjust position_ids by that request-scoped delta."""
+    """Branch C: text-only decode with mrope_position_deltas adjusts position_ids.
+
+    The request-scoped delta should be applied to position_ids.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1745,8 +1748,11 @@ def test_vlm_wrapper_delta_is_request_scoped_no_cross_call_leakage():
 
 @torch.no_grad()
 def test_vlm_wrapper_no_delta_without_images():
-    """Branch A: when rope_deltas is None (no images ever), position_ids should
-    be expanded to 3D without any adjustment (same as before)."""
+    """Branch A: no rope_deltas means position_ids expand to 3D without adjustment.
+
+    When rope_deltas is None (no images ever), position_ids should be expanded
+    to 3D without any adjustment (same as before).
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1793,8 +1799,11 @@ def test_vlm_wrapper_requires_position_ids_for_text_only():
 
 @torch.no_grad()
 def test_vlm_wrapper_prefill_only_with_images():
-    """Prefill-only with images: the model forward should compute 3D mRoPE
-    positions from input_ids + image_grid_thw, matching compute_mrope_positions."""
+    """Prefill-only with images computes 3D mRoPE matching compute_mrope_positions.
+
+    The model forward should compute 3D mRoPE positions from input_ids +
+    image_grid_thw.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1851,8 +1860,11 @@ def test_vlm_wrapper_prefill_only_with_images():
 
 @torch.no_grad()
 def test_vlm_wrapper_mixed_prefill_decode_with_images():
-    """Mixed prefill+decode batch with images in prefill: the model forward
-    should compute 3D positions per prefill request and stitch with decode."""
+    """Mixed prefill+decode batch with images computes and stitches 3D positions.
+
+    The model forward should compute 3D positions per prefill request and
+    stitch with decode.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1935,9 +1947,11 @@ def test_vlm_wrapper_mixed_prefill_decode_with_images():
 
 @torch.no_grad()
 def test_vlm_wrapper_mixed_multimodal_text_prefill():
-    """Mixed prefill batch: 1 multimodal request + 1 text-only request.
+    """Mixed prefill batch with 1 multimodal and 1 text-only request.
+
     The model forward should compute 3D positions for the image request
-    and trivially expand positions for the text-only request."""
+    and trivially expand positions for the text-only request.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -2016,8 +2030,10 @@ def test_vlm_wrapper_mixed_multimodal_text_prefill():
 
 @torch.no_grad()
 def test_vlm_wrapper_chunked_prefill_inside_image_span():
-    """Chunked multimodal prefill should compute mRoPE from request metadata, even
-    when the chunk starts inside the image-token span."""
+    """Chunked multimodal prefill computes mRoPE from request metadata.
+
+    Even when the chunk starts inside the image-token span.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -2108,8 +2124,10 @@ def test_vlm_wrapper_chunked_prefill_inside_image_span():
 
 @torch.no_grad()
 def test_vlm_wrapper_decode_only_with_delta():
-    """Case 3: decode-only batch with deltas (no mrope_position_ids_3d) should
-    apply delta to all positions uniformly."""
+    """Case 3: decode-only batch with deltas applies delta to all positions.
+
+    No mrope_position_ids_3d; delta should be applied uniformly.
+    """
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -2140,3 +2140,44 @@ def test_vlm_wrapper_decode_only_with_delta():
         atol=1e-5,
         msg="Decode-only with deltas should apply delta-adjusted 3D expansion",
     )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_flattened_prefill_with_request_deltas():
+    """Flattened cached prefill should expand request deltas per token, not per batch."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    req1_len = 3
+    req2_len = 2
+    total_tokens = req1_len + req2_len
+
+    input_ids = torch.randint(0, 50, (1, total_tokens))
+    position_ids = torch.tensor([[10, 11, 12, 20, 21]])
+    deltas = torch.tensor([[7], [-4]])
+    batch_info = torch.tensor([2, total_tokens, 0], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, req1_len, total_tokens], dtype=torch.int32)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        mrope_position_deltas=deltas,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+    )
+
+    expected_token_delta = torch.tensor([[7, 7, 7, -4, -4]])
+    expected_pos_3d = (position_ids + expected_token_delta)[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Flattened cached prefill should repeat request deltas across tokens",
+    )

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -18,12 +18,19 @@ comparison tests (reference re-implementations on the same weights):
  10. get_rope_index correctness
  11. torch.export with cos/sin extra inputs
  12. VLM wrapper text-only position_ids passthrough (2D -> 3D)
- 13. Custom export info dynamic shapes for 3D mRoPE position_ids
- 14. Standalone compute_mrope_positions (text-only, with image, matches model)
- 15. VLM wrapper decode-after-image delta application
- 16. mrope_position_deltas kwarg override
- 17. VLM wrapper Branch A (no delta without images)
- 18. Qwen3_5MoeInputProcessor adds mrope_position_deltas to multimodal_data
+ 13. Standalone compute_mrope_positions (text-only, with image, matches model)
+ 14. VLM wrapper decode-after-image delta application (request-scoped delta)
+ 15. VLM wrapper ignores delta when not passed (no cross-call leakage)
+ 16. VLM wrapper Branch A (no delta without images)
+ 17. Qwen3_5MoeInputProcessor adds mrope_position_deltas to multimodal_data
+ 18. VLM wrapper validates position_ids for text-only path
+
+Mixed batch position handling (mRoPE computed in forward):
+ 19. persistent_multimodal_keys attribute on Qwen3_5MoeModel
+ 20. Forward computes 3D positions from input_ids + image_grid_thw (prefill-only)
+ 21. Forward handles mixed prefill+decode with per-request position computation
+ 22. Forward handles mixed multimodal+text prefill requests
+ 23. Decode-only with deltas (Case 2)
 """
 
 import pytest
@@ -43,7 +50,6 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeModel,
     Qwen3_5MoeSparseMoeBlock,
     Qwen3_5MoeTextConfig,
-    Qwen3_5MoeTextExportInfo,
     Qwen3_5MoeTextModel,
     Qwen3_5MoeTextRotaryEmbedding,
     Qwen3_5MoeTopKRouter,
@@ -1205,8 +1211,8 @@ def test_multimodal_forward_matches_reference():
     """Compare multimodal wrapper forward against step-by-step HF reference.
 
     Tests the full pipeline: vision encoding + embedding merge + mRoPE + LM.
-    Runs the same input through both the wrapper's forward() and the
-    ref_multimodal_forward() that re-implements each step explicitly.
+    The wrapper computes 3D mRoPE positions internally from input_ids +
+    image_grid_thw, matching the reference re-implementation.
     """
     config = _make_small_composite_config()
     torch.manual_seed(42)
@@ -1232,7 +1238,7 @@ def test_multimodal_forward_matches_reference():
     text_after = [4, 5]
     input_ids = torch.tensor([text_before + vision_part + text_after])
 
-    # Our wrapper forward
+    # Model computes 3D positions internally from input_ids + image_grid_thw
     our_output = model(
         input_ids=input_ids,
         pixel_values=pixel_values,
@@ -1411,58 +1417,6 @@ def test_vlm_wrapper_text_only_position_ids():
     )
 
 
-@torch.no_grad()
-def test_vlm_wrapper_position_ids_not_ignored():
-    """Verify that different position_ids produce different outputs, confirming
-    the executor's position_ids are actually used (not ignored/overwritten)."""
-    config = _make_small_composite_config()
-    torch.manual_seed(42)
-    model = Qwen3_5MoeForConditionalGeneration(config)
-    model.eval()
-
-    B, S = 1, 8
-    input_ids = torch.randint(0, 50, (B, S))
-
-    # Two different position_ids (simulating different chunk offsets)
-    pos_ids_a = torch.arange(0, S).unsqueeze(0)
-    pos_ids_b = torch.arange(100, 100 + S).unsqueeze(0)
-
-    output_a = model(input_ids=input_ids, position_ids=pos_ids_a)
-    output_b = model(input_ids=input_ids, position_ids=pos_ids_b)
-
-    assert not torch.allclose(output_a.logits, output_b.logits, atol=1e-4), (
-        "Different position_ids should produce different outputs -- "
-        "position_ids must not be ignored by the VLM wrapper"
-    )
-
-
-# =============================================================================
-# Custom Export Info Tests
-# =============================================================================
-
-
-@torch.no_grad()
-def test_custom_export_info_3d_position_ids():
-    """Verify Qwen3_5MoeTextExportInfo defines 3D position_ids dynamic shapes."""
-    from torch.export import Dim
-
-    config = _make_small_composite_config()
-    torch.manual_seed(42)
-    model = Qwen3_5MoeForConditionalGeneration(config)
-
-    export_info = Qwen3_5MoeTextExportInfo.from_autoinferred(model)
-    shapes = export_info.dynamic_shape_lookup
-
-    assert "position_ids" in shapes, "Export info should include position_ids"
-    pos_dims = shapes["position_ids"]
-    assert 1 in pos_dims and 2 in pos_dims, (
-        f"3D position_ids should have dynamic dims 1 (batch) and 2 (seq), got {pos_dims}"
-    )
-    assert 0 not in pos_dims, f"Dim 0 (=3 for mRoPE) should be static, but got dynamic: {pos_dims}"
-    assert isinstance(pos_dims[1], Dim), f"Dim 1 should be a Dim instance, got {type(pos_dims[1])}"
-    assert isinstance(pos_dims[2], Dim), f"Dim 2 should be a Dim instance, got {type(pos_dims[2])}"
-
-
 # =============================================================================
 # Standalone compute_mrope_positions Tests
 # =============================================================================
@@ -1571,8 +1525,8 @@ def test_compute_mrope_positions_matches_model_method():
 
 @torch.no_grad()
 def test_vlm_wrapper_decode_after_image_uses_delta():
-    """Branch C: after an image forward caches rope_deltas, a subsequent
-    text-only forward should adjust position_ids by the cached delta."""
+    """Branch C: text-only decode with provided mrope_position_deltas should
+    adjust position_ids by that request-scoped delta."""
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1581,15 +1535,17 @@ def test_vlm_wrapper_decode_after_image_uses_delta():
     B, S = 1, 8
     input_ids = torch.randint(0, 50, (B, S))
 
-    # Simulate: rope_deltas was cached from a previous image forward
     fake_delta = torch.tensor([[-2]])
-    model.model.rope_deltas = fake_delta
 
     # Position IDs from executor (sequential, as if no image compression)
     pos_ids_executor = torch.arange(100, 100 + S).unsqueeze(0)
 
     # VLM wrapper should apply delta: pos_ids = (100-2, 101-2, ...) = (98, 99, ...)
-    output_with_delta = model(input_ids=input_ids, position_ids=pos_ids_executor)
+    output_with_delta = model(
+        input_ids=input_ids,
+        position_ids=pos_ids_executor,
+        mrope_position_deltas=fake_delta,
+    )
 
     # Reference: manually apply delta and call text model directly
     corrected_pos = pos_ids_executor + fake_delta
@@ -1605,14 +1561,13 @@ def test_vlm_wrapper_decode_after_image_uses_delta():
         ref_logits,
         rtol=1e-5,
         atol=1e-5,
-        msg="Decode after image should apply cached rope_deltas to position_ids",
+        msg="Decode after image should apply request mrope_position_deltas",
     )
 
 
 @torch.no_grad()
-def test_vlm_wrapper_mrope_deltas_kwarg_overrides_cached():
-    """When mrope_position_deltas is passed as a kwarg, it should be used
-    instead of the cached self.rope_deltas."""
+def test_vlm_wrapper_delta_is_request_scoped_no_cross_call_leakage():
+    """Applying a delta in one call must not affect later calls that omit it."""
     config = _make_small_composite_config()
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
@@ -1622,32 +1577,47 @@ def test_vlm_wrapper_mrope_deltas_kwarg_overrides_cached():
     input_ids = torch.randint(0, 50, (B, S))
     pos_ids = torch.arange(50, 50 + S).unsqueeze(0)
 
-    # Set cached delta to -3
-    model.model.rope_deltas = torch.tensor([[-3]])
-
-    # But pass a different delta via kwarg (-5)
-    kwarg_delta = torch.tensor([[-5]])
-    output = model(
+    # Apply a delta in one call
+    delta = torch.tensor([[-5]])
+    output_with_delta = model(
         input_ids=input_ids,
         position_ids=pos_ids,
-        mrope_position_deltas=kwarg_delta,
+        mrope_position_deltas=delta,
     )
 
-    # Reference uses the kwarg delta (-5)
-    corrected_pos = pos_ids + kwarg_delta
+    # Then call again without delta: should behave like plain text-only expansion
+    output_without_delta = model(input_ids=input_ids, position_ids=pos_ids)
+
+    corrected_pos = pos_ids + delta
     corrected_pos_3d = corrected_pos[None].expand(3, -1, -1)
+    plain_pos_3d = pos_ids[None].expand(3, -1, -1)
     inputs_embeds = model.model.get_input_embeddings()(input_ids)
-    text_out = model.model.language_model(
+    text_out_with_delta = model.model.language_model(
         inputs_embeds=inputs_embeds, position_ids=corrected_pos_3d
     )
-    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+    text_out_plain = model.model.language_model(
+        inputs_embeds=inputs_embeds, position_ids=plain_pos_3d
+    )
+    ref_logits_with_delta = model.lm_head(
+        text_out_with_delta.last_hidden_state.to(model.lm_head.weight.dtype)
+    ).float()
+    ref_logits_plain = model.lm_head(
+        text_out_plain.last_hidden_state.to(model.lm_head.weight.dtype)
+    ).float()
 
     torch.testing.assert_close(
-        output.logits,
-        ref_logits,
+        output_with_delta.logits,
+        ref_logits_with_delta,
         rtol=1e-5,
         atol=1e-5,
-        msg="mrope_position_deltas kwarg should override cached rope_deltas",
+        msg="Call with mrope_position_deltas should apply the request delta",
+    )
+    torch.testing.assert_close(
+        output_without_delta.logits,
+        ref_logits_plain,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Call without mrope_position_deltas must not reuse previous delta",
     )
 
 
@@ -1659,8 +1629,6 @@ def test_vlm_wrapper_no_delta_without_images():
     torch.manual_seed(42)
     model = Qwen3_5MoeForConditionalGeneration(config)
     model.eval()
-
-    assert model.model.rope_deltas is None, "rope_deltas should start as None"
 
     B, S = 1, 8
     input_ids = torch.randint(0, 50, (B, S))
@@ -1680,6 +1648,290 @@ def test_vlm_wrapper_no_delta_without_images():
         rtol=1e-5,
         atol=1e-5,
         msg="Without images, VLM wrapper should do plain 2D→3D expansion",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_requires_position_ids_for_text_only():
+    """Text-only forward must provide position_ids."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    input_ids = torch.randint(0, 50, (1, 8))
+    with pytest.raises(ValueError, match="position_ids is required"):
+        _ = model(input_ids=input_ids)
+
+
+# =============================================================================
+# Mixed Batch Position Handling Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_persistent_multimodal_keys_attribute():
+    """Qwen3_5MoeModel should declare persistent_multimodal_keys."""
+    assert hasattr(Qwen3_5MoeModel, "persistent_multimodal_keys")
+    assert "mrope_position_deltas" in Qwen3_5MoeModel.persistent_multimodal_keys
+
+
+@torch.no_grad()
+def test_vlm_wrapper_prefill_only_with_images():
+    """Prefill-only with images: the model forward should compute 3D mRoPE
+    positions from input_ids + image_grid_thw, matching compute_mrope_positions."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_patches = grid_t * grid_h * grid_w
+    num_merged_tokens = num_patches // (merge**2)
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long)
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    text_before = [1, 2, 3]
+    vision_part = [config.vision_start_token_id] + [config.image_token_id] * num_merged_tokens
+    text_after = [4, 5]
+    input_ids = torch.tensor([text_before + vision_part + text_after])
+
+    output = model(
+        input_ids=input_ids,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+    )
+
+    # Reference: compute 3D positions and call text model directly
+    expected_pos_3d, _ = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    image_embeds = torch.cat(
+        model.model.get_image_features(pixel_values, image_grid_thw), dim=0
+    ).to(inputs_embeds.device, inputs_embeds.dtype)
+    image_mask = (input_ids == config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Prefill-only with images should compute 3D positions internally",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_mixed_prefill_decode_with_images():
+    """Mixed prefill+decode batch with images in prefill: the model forward
+    should compute 3D positions per prefill request and stitch with decode."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_patches = grid_t * grid_h * grid_w
+    num_merged_tokens = num_patches // (merge**2)
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long)
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    # Build prefill input_ids (1 image request)
+    text_before = [1, 2, 3]
+    vision_part = [config.vision_start_token_id] + [config.image_token_id] * num_merged_tokens
+    text_after = [4, 5]
+    prefill_tokens = text_before + vision_part + text_after
+    num_prefill_tokens = len(prefill_tokens)
+
+    # 1 decode token
+    decode_token = [6]
+    all_tokens = prefill_tokens + decode_token
+
+    input_ids = torch.tensor([all_tokens])
+    prefill_pos = list(range(num_prefill_tokens))
+    decode_pos = [200]
+    position_ids = torch.tensor([prefill_pos + decode_pos])
+
+    deltas = torch.tensor([[-2], [-3]])
+    batch_info = torch.tensor([1, num_prefill_tokens, 1], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, num_prefill_tokens, num_prefill_tokens + 1], dtype=torch.int32)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+        mrope_position_deltas=deltas,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+    )
+
+    # Reference: compute prefill 3D positions, stitch with decode
+    prefill_ids = input_ids[..., :num_prefill_tokens]
+    prefill_3d, _ = compute_mrope_positions(
+        input_ids=prefill_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    gen_deltas = deltas[1:]
+    decode_2d = position_ids[..., num_prefill_tokens:]
+    decode_adjusted = decode_2d + gen_deltas.T
+    decode_3d = decode_adjusted[None].expand(3, -1, -1)
+    expected_pos_3d = torch.cat([prefill_3d, decode_3d], dim=-1)
+
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    image_embeds = torch.cat(
+        model.model.get_image_features(pixel_values, image_grid_thw), dim=0
+    ).to(inputs_embeds.device, inputs_embeds.dtype)
+    image_mask = (input_ids == config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Mixed batch should compute prefill 3D positions and stitch with decode",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_mixed_multimodal_text_prefill():
+    """Mixed prefill batch: 1 multimodal request + 1 text-only request.
+    The model forward should compute 3D positions for the image request
+    and trivially expand positions for the text-only request."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_patches = grid_t * grid_h * grid_w
+    num_merged_tokens = num_patches // (merge**2)
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long)
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    # Request 1: multimodal prefill
+    text_before = [1, 2]
+    vision_part = [config.vision_start_token_id] + [config.image_token_id] * num_merged_tokens
+    text_after = [3]
+    req1_tokens = text_before + vision_part + text_after
+    req1_len = len(req1_tokens)
+
+    # Request 2: text-only prefill
+    req2_tokens = [10, 11, 12, 13]
+
+    all_tokens = req1_tokens + req2_tokens
+    total_tokens = len(all_tokens)
+
+    input_ids = torch.tensor([all_tokens])
+    position_ids = torch.tensor([list(range(total_tokens))])
+
+    batch_info = torch.tensor([2, total_tokens, 0], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, req1_len, total_tokens], dtype=torch.int32)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+    )
+
+    # Reference: compute expected 3D positions for both requests
+    req1_ids = input_ids[..., :req1_len]
+    req1_pos_3d, _ = compute_mrope_positions(
+        input_ids=req1_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    req2_pos = position_ids[..., req1_len:]
+    req2_pos_3d = req2_pos[None].expand(3, -1, -1)
+    expected_pos_3d = torch.cat([req1_pos_3d, req2_pos_3d], dim=-1)
+
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    image_embeds = torch.cat(
+        model.model.get_image_features(pixel_values, image_grid_thw), dim=0
+    ).to(inputs_embeds.device, inputs_embeds.dtype)
+    image_mask = (input_ids == config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Mixed multimodal+text prefill should compute correct 3D positions per request",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_decode_only_with_delta():
+    """Case 3: decode-only batch with deltas (no mrope_position_ids_3d) should
+    apply delta to all positions uniformly."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    # 3 decode sequences, each with 1 token -> position_ids = [3, 1]
+    B = 3
+    input_ids = torch.randint(0, 50, (B, 1))
+    position_ids = torch.tensor([[500], [300], [100]])
+    deltas = torch.tensor([[50], [0], [0]])
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        mrope_position_deltas=deltas,
+    )
+
+    # Reference: (position_ids + deltas)[None].expand(3, ...) -> [3, 3, 1]
+    expected_pos_3d = (position_ids + deltas)[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Decode-only with deltas should apply delta-adjusted 3D expansion",
     )
 
 

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -34,10 +34,12 @@ Mixed batch position handling (mRoPE computed in forward):
 import pytest
 import torch
 import torch.nn.functional as F
+from PIL import Image
 
 # Register autodeploy custom ops (torch_moe, torch_causal_conv1d, etc.)
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
+    Qwen3_5MoeADInputProcessor,
     Qwen3_5MoeAttention,
     Qwen3_5MoeConfig,
     Qwen3_5MoeDecoderLayer,
@@ -1641,6 +1643,92 @@ def test_qwen3_mrope_delta_with_cache_writes_prefill_and_reads_decode():
     torch.testing.assert_close(cache[slot : slot + 1], expected_delta_i32)
 
 
+class _DummyQwenProcessor:
+    def __init__(self, config):
+        self.image_token_id = config.image_token_id
+        self.video_token_id = config.video_token_id
+        self.vision_start_token_id = config.vision_start_token_id
+
+
+class _DummyQwenBaseProcessor:
+    def __init__(self, token_ids, config):
+        self._token_ids = token_ids
+        self.processor = _DummyQwenProcessor(config)
+        self.tokenizer = None
+
+    def __call__(self, inputs, sampling_params):
+        return self._token_ids, {}
+
+
+def test_qwen_ad_input_processor_duplicates_video_hashes_per_frame_span():
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+    frame_tokens = int((4 // merge) * (4 // merge))
+    token_ids = [
+        1,
+        config.vision_start_token_id,
+        *([config.video_token_id] * frame_tokens),
+        2,
+        config.vision_start_token_id,
+        *([config.video_token_id] * frame_tokens),
+        3,
+    ]
+    processor = Qwen3_5MoeADInputProcessor(_DummyQwenBaseProcessor(token_ids, config))
+    frames = [
+        Image.new("RGB", (4, 4), color="red"),
+        Image.new("RGB", (4, 4), color="blue"),
+    ]
+
+    multimodal_input, _, item_types = processor._build_multimodal_input(
+        token_ids, {"multi_modal_data": {"video": frames}}
+    )
+
+    assert multimodal_input.multimodal_positions == [1, 1 + (1 + frame_tokens) + 1]
+    assert item_types == [1, 1]
+    assert len(multimodal_input.multimodal_hashes) == 2
+    assert multimodal_input.multimodal_hashes[0] == multimodal_input.multimodal_hashes[1]
+
+
+def test_qwen_ad_input_processor_preserves_video_item_order_across_frame_spans():
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+    frame_tokens = int((4 // merge) * (4 // merge))
+    token_ids = [
+        1,
+        config.vision_start_token_id,
+        *([config.video_token_id] * frame_tokens),
+        2,
+        config.vision_start_token_id,
+        *([config.video_token_id] * frame_tokens),
+        3,
+        config.vision_start_token_id,
+        *([config.video_token_id] * frame_tokens),
+        4,
+    ]
+    processor = Qwen3_5MoeADInputProcessor(_DummyQwenBaseProcessor(token_ids, config))
+    videos = [
+        [
+            Image.new("RGB", (4, 4), color="red"),
+            Image.new("RGB", (4, 4), color="blue"),
+        ],
+        [Image.new("RGB", (4, 4), color="blue")],
+    ]
+
+    multimodal_input, _, item_types = processor._build_multimodal_input(
+        token_ids, {"multi_modal_data": {"video": videos}}
+    )
+
+    assert multimodal_input.multimodal_positions == [
+        1,
+        1 + (1 + frame_tokens) + 1,
+        1 + ((1 + frame_tokens) + 1) * 2,
+    ]
+    assert item_types == [1, 1, 1]
+    assert len(multimodal_input.multimodal_hashes) == 3
+    assert multimodal_input.multimodal_hashes[0] == multimodal_input.multimodal_hashes[1]
+    assert multimodal_input.multimodal_hashes[1] != multimodal_input.multimodal_hashes[2]
+
+
 # =============================================================================
 # VLM Wrapper Multimodal Forward Tests
 # =============================================================================
@@ -2208,6 +2296,92 @@ def test_vlm_wrapper_chunked_prefill_inside_image_span():
 
 
 @torch.no_grad()
+def test_vlm_wrapper_chunked_prefill_inside_video_span():
+    """Chunked video prefill should select the request-local video embedding slice."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    grid_t, grid_h, grid_w = 2, 4, 4
+    num_patches = grid_t * grid_h * grid_w
+    frame_tokens = (grid_h // merge) * (grid_w // merge)
+
+    video_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long)
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values_videos = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    text_before = [1, 2]
+    between_frames = [3]
+    text_after = [4]
+    frame_span = [config.vision_start_token_id] + [config.video_token_id] * frame_tokens
+    full_tokens = text_before + frame_span + between_frames + frame_span + text_after
+
+    second_frame_start = len(text_before) + len(frame_span) + len(between_frames)
+    chunk_start = second_frame_start + 2
+    chunk_tokens = full_tokens[chunk_start:]
+    chunk_len = len(chunk_tokens)
+
+    input_ids = torch.tensor([chunk_tokens])
+    position_ids = torch.arange(chunk_start, chunk_start + chunk_len).unsqueeze(0)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        pixel_values_videos=pixel_values_videos,
+        video_grid_thw=video_grid_thw,
+        batch_info=torch.tensor([1, chunk_len, 0], dtype=torch.int32),
+        cu_seqlen=torch.tensor([0, chunk_len], dtype=torch.int32),
+        input_pos=torch.tensor([chunk_start], dtype=torch.int32),
+        seq_len=torch.tensor([chunk_len], dtype=torch.int32),
+        mm_item_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_item_types=torch.tensor([1, 1], dtype=torch.int32),
+        mm_token_positions=torch.tensor([len(text_before), second_frame_start], dtype=torch.int32),
+        mm_token_lengths=torch.tensor([1 + frame_tokens, 1 + frame_tokens], dtype=torch.int32),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_special_offsets=torch.tensor([0, 1 + frame_tokens], dtype=torch.int32),
+    )
+
+    full_input_ids = torch.tensor([full_tokens])
+    full_pos_3d, _ = compute_mrope_positions(
+        input_ids=full_input_ids,
+        image_grid_thw=None,
+        video_grid_thw=video_grid_thw,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    expected_chunk_pos_3d = full_pos_3d[..., chunk_start:]
+
+    full_inputs_embeds = model.model.get_input_embeddings()(full_input_ids)
+    full_video_embeds = torch.cat(
+        model.model.get_video_features(pixel_values_videos, video_grid_thw), dim=0
+    ).to(full_inputs_embeds.device, full_inputs_embeds.dtype)
+    full_video_mask = (
+        (full_input_ids == config.video_token_id).unsqueeze(-1).expand_as(full_inputs_embeds)
+    )
+    full_inputs_embeds = full_inputs_embeds.masked_scatter(full_video_mask, full_video_embeds)
+    expected_chunk_embeds = full_inputs_embeds[:, chunk_start:]
+
+    text_out = model.model.language_model(
+        inputs_embeds=expected_chunk_embeds,
+        position_ids=expected_chunk_pos_3d,
+    )
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Chunked video prefill should match the full-request video mRoPE slice",
+    )
+
+
+@torch.no_grad()
 def test_build_chunked_multimodal_positions_handles_mixed_image_and_video_request():
     """Chunked mixed image+video requests should preserve item-type grid ordering."""
     config = _make_small_composite_config()
@@ -2216,28 +2390,29 @@ def test_build_chunked_multimodal_positions_handles_mixed_image_and_video_reques
 
     merge = config.vision_config.spatial_merge_size
     image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
-    video_grid_thw = torch.tensor([[1, 2, 4]], dtype=torch.long)
+    video_grid_thw = torch.tensor([[2, 2, 4]], dtype=torch.long)
     num_image_tokens = int(
         image_grid_thw[0, 0].item()
         * (image_grid_thw[0, 1].item() // merge)
         * (image_grid_thw[0, 2].item() // merge)
     )
-    num_video_tokens = int(
-        video_grid_thw[0, 0].item()
-        * (video_grid_thw[0, 1].item() // merge)
-        * (video_grid_thw[0, 2].item() // merge)
+    frame_tokens = int(
+        (video_grid_thw[0, 1].item() // merge) * (video_grid_thw[0, 2].item() // merge)
     )
 
     text_before = [1]
-    text_between = [2, 3]
+    text_between = [2]
+    between_video_frames = [3]
     text_after = [4]
+    image_span = [config.vision_start_token_id] + ([config.image_token_id] * num_image_tokens)
+    video_span = [config.vision_start_token_id] + ([config.video_token_id] * frame_tokens)
     full_tokens = (
         text_before
-        + [config.vision_start_token_id]
-        + ([config.image_token_id] * num_image_tokens)
+        + image_span
         + text_between
-        + [config.vision_start_token_id]
-        + ([config.video_token_id] * num_video_tokens)
+        + video_span
+        + between_video_frames
+        + video_span
         + text_after
     )
 
@@ -2252,8 +2427,9 @@ def test_build_chunked_multimodal_positions_handles_mixed_image_and_video_reques
         spatial_merge_size=merge,
     )
 
-    video_start = len(text_before) + 1 + num_image_tokens + len(text_between) + 1
-    chunk_start = video_start + 1
+    first_video_start = len(text_before) + len(image_span) + len(text_between)
+    second_video_start = first_video_start + len(video_span) + len(between_video_frames)
+    chunk_start = second_video_start + 1
     chunk_tokens = full_tokens[chunk_start:]
     chunk_len = len(chunk_tokens)
     input_ids = torch.tensor([chunk_tokens], dtype=torch.long)
@@ -2269,24 +2445,146 @@ def test_build_chunked_multimodal_positions_handles_mixed_image_and_video_reques
         seq_len=torch.tensor([chunk_len], dtype=torch.int32),
         image_grid_thw=image_grid_thw,
         video_grid_thw=video_grid_thw,
-        mm_item_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
-        mm_item_types=torch.tensor([0, 1], dtype=torch.int32),
+        mm_item_cu_seqlen=torch.tensor([0, 3], dtype=torch.int32),
+        mm_item_types=torch.tensor([0, 1, 1], dtype=torch.int32),
         mm_token_positions=torch.tensor(
-            [len(text_before), len(text_before) + 1 + num_image_tokens + len(text_between)],
+            [len(text_before), first_video_start, second_video_start],
             dtype=torch.int32,
         ),
         mm_token_lengths=torch.tensor(
-            [1 + num_image_tokens, 1 + num_video_tokens],
+            [1 + num_image_tokens, 1 + frame_tokens, 1 + frame_tokens],
             dtype=torch.int32,
         ),
-        mm_special_offsets_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
-        mm_special_offsets=torch.tensor([0, 1 + num_image_tokens], dtype=torch.int32),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 3], dtype=torch.int32),
+        mm_special_offsets=torch.tensor(
+            [0, 1 + num_image_tokens, 1 + num_image_tokens + 1 + frame_tokens],
+            dtype=torch.int32,
+        ),
     )
 
     torch.testing.assert_close(
         actual_pos_3d,
         full_pos_3d[..., chunk_start:],
         msg="Chunked mixed image+video requests should reconstruct positions using item types",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_chunked_prefill_inside_mixed_image_and_video_spans():
+    """Chunked mixed multimodal prefill should preserve prompt-order embed slices."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    video_grid_thw = torch.tensor([[2, 2, 4]], dtype=torch.long)
+    num_image_patches = int(image_grid_thw[0].prod().item())
+    num_video_patches = int(video_grid_thw[0].prod().item())
+    num_image_tokens = num_image_patches // (merge**2)
+    frame_tokens = int(
+        (video_grid_thw[0, 1].item() // merge) * (video_grid_thw[0, 2].item() // merge)
+    )
+
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_image_patches, vc.in_channels * t_ps * ps * ps)
+    pixel_values_videos = torch.randn(num_video_patches, vc.in_channels * t_ps * ps * ps)
+
+    text_before = [1]
+    text_between = [2]
+    between_video_frames = [3]
+    text_after = [4]
+    image_span = [config.vision_start_token_id] + ([config.image_token_id] * num_image_tokens)
+    video_span = [config.vision_start_token_id] + ([config.video_token_id] * frame_tokens)
+    full_tokens = (
+        text_before
+        + image_span
+        + text_between
+        + video_span
+        + between_video_frames
+        + video_span
+        + text_after
+    )
+
+    first_video_start = len(text_before) + len(image_span) + len(text_between)
+    second_video_start = first_video_start + len(video_span) + len(between_video_frames)
+    chunk_start = second_video_start + 1
+    chunk_tokens = full_tokens[chunk_start:]
+    chunk_len = len(chunk_tokens)
+
+    input_ids = torch.tensor([chunk_tokens], dtype=torch.long)
+    position_ids = torch.arange(chunk_start, chunk_start + chunk_len).unsqueeze(0)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        pixel_values=pixel_values,
+        pixel_values_videos=pixel_values_videos,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        batch_info=torch.tensor([1, chunk_len, 0], dtype=torch.int32),
+        cu_seqlen=torch.tensor([0, chunk_len], dtype=torch.int32),
+        input_pos=torch.tensor([chunk_start], dtype=torch.int32),
+        seq_len=torch.tensor([chunk_len], dtype=torch.int32),
+        mm_item_cu_seqlen=torch.tensor([0, 3], dtype=torch.int32),
+        mm_item_types=torch.tensor([0, 1, 1], dtype=torch.int32),
+        mm_token_positions=torch.tensor(
+            [len(text_before), first_video_start, second_video_start],
+            dtype=torch.int32,
+        ),
+        mm_token_lengths=torch.tensor(
+            [1 + num_image_tokens, 1 + frame_tokens, 1 + frame_tokens], dtype=torch.int32
+        ),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 3], dtype=torch.int32),
+        mm_special_offsets=torch.tensor(
+            [0, 1 + num_image_tokens, 1 + num_image_tokens + 1 + frame_tokens],
+            dtype=torch.int32,
+        ),
+    )
+
+    full_input_ids = torch.tensor([full_tokens], dtype=torch.long)
+    full_pos_3d, _ = compute_mrope_positions(
+        input_ids=full_input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    expected_chunk_pos_3d = full_pos_3d[..., chunk_start:]
+
+    full_inputs_embeds = model.model.get_input_embeddings()(full_input_ids)
+    full_image_embeds = torch.cat(
+        model.model.get_image_features(pixel_values, image_grid_thw), dim=0
+    ).to(full_inputs_embeds.device, full_inputs_embeds.dtype)
+    full_video_embeds = torch.cat(
+        model.model.get_video_features(pixel_values_videos, video_grid_thw), dim=0
+    ).to(full_inputs_embeds.device, full_inputs_embeds.dtype)
+    full_image_mask = (
+        (full_input_ids == config.image_token_id).unsqueeze(-1).expand_as(full_inputs_embeds)
+    )
+    full_video_mask = (
+        (full_input_ids == config.video_token_id).unsqueeze(-1).expand_as(full_inputs_embeds)
+    )
+    full_inputs_embeds = full_inputs_embeds.masked_scatter(full_image_mask, full_image_embeds)
+    full_inputs_embeds = full_inputs_embeds.masked_scatter(full_video_mask, full_video_embeds)
+    expected_chunk_embeds = full_inputs_embeds[:, chunk_start:]
+
+    text_out = model.model.language_model(
+        inputs_embeds=expected_chunk_embeds,
+        position_ids=expected_chunk_pos_3d,
+    )
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Chunked mixed multimodal prefill should match the full-request embed slice",
     )
 
 

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -2665,3 +2665,41 @@ def test_vlm_wrapper_flattened_prefill_with_request_deltas():
         atol=1e-5,
         msg="Flattened cached prefill should repeat request deltas across tokens",
     )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_flattened_prefill_without_request_deltas():
+    """Flattened cached prefill without deltas should preserve plain positions."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    req1_len = 3
+    req2_len = 2
+    total_tokens = req1_len + req2_len
+
+    input_ids = torch.randint(0, 50, (1, total_tokens))
+    position_ids = torch.tensor([[10, 11, 12, 20, 21]])
+    batch_info = torch.tensor([2, total_tokens, 0], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, req1_len, total_tokens], dtype=torch.int32)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+    )
+
+    expected_pos_3d = position_ids[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=expected_pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Flattened cached prefill without deltas should preserve plain positions",
+    )

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -57,6 +57,8 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     apply_rotary_pos_emb,
     apply_rotary_pos_emb_vision,
     compute_mrope_positions,
+    qwen3_mrope_delta,
+    qwen3_mrope_delta_with_cache,
 )
 
 
@@ -1513,6 +1515,129 @@ def test_compute_mrope_positions_matches_model_method():
 
     torch.testing.assert_close(pos_fn, pos_model)
     torch.testing.assert_close(deltas_fn, deltas_model)
+
+
+@torch.no_grad()
+def test_qwen3_mrope_delta_matches_compute_mrope_positions_for_mixed_items():
+    """The request-level mRoPE delta op should match the full reference delta."""
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+
+    image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+    video_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+
+    num_image_tokens = int(
+        image_grid_thw[0, 0].item()
+        * (image_grid_thw[0, 1].item() // merge)
+        * (image_grid_thw[0, 2].item() // merge)
+    )
+    num_video_tokens = int(
+        video_grid_thw[0, 0].item()
+        * (video_grid_thw[0, 1].item() // merge)
+        * (video_grid_thw[0, 2].item() // merge)
+    )
+
+    input_ids = torch.tensor(
+        [
+            [
+                1,
+                2,
+                config.vision_start_token_id,
+                *([config.image_token_id] * num_image_tokens),
+                3,
+                config.vision_start_token_id,
+                *([config.video_token_id] * num_video_tokens),
+                4,
+                5,
+            ]
+        ],
+        dtype=torch.long,
+    )
+
+    _, expected_delta = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=image_grid_thw.to(torch.long),
+        video_grid_thw=video_grid_thw.to(torch.long),
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+
+    actual_delta = qwen3_mrope_delta(
+        batch_info_host=torch.tensor([1, 0, 0], dtype=torch.int32),
+        mm_item_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_item_types=torch.tensor([0, 1], dtype=torch.int32),
+        mm_token_lengths=torch.tensor(
+            [1 + num_image_tokens, 1 + num_video_tokens], dtype=torch.int32
+        ),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_special_offsets=torch.tensor(
+            [0, 1 + num_image_tokens],
+            dtype=torch.int32,
+        ),
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        spatial_merge_size=merge,
+    )
+
+    torch.testing.assert_close(actual_delta, expected_delta.to(torch.int32))
+
+
+@torch.no_grad()
+def test_qwen3_mrope_delta_with_cache_writes_prefill_and_reads_decode():
+    """Prefill should write the per-slot delta and decode should read it back."""
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+
+    image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+    num_image_tokens = int(
+        image_grid_thw[0, 0].item()
+        * (image_grid_thw[0, 1].item() // merge)
+        * (image_grid_thw[0, 2].item() // merge)
+    )
+
+    input_ids = torch.tensor(
+        [
+            [
+                10,
+                config.vision_start_token_id,
+                *([config.image_token_id] * num_image_tokens),
+                11,
+            ]
+        ],
+        dtype=torch.long,
+    )
+    _, expected_delta = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=image_grid_thw.to(torch.long),
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+
+    cache = torch.zeros((8, 1), dtype=torch.int32)
+    slot = 3
+    deltas = qwen3_mrope_delta_with_cache(
+        batch_info_host=torch.tensor([1, 0, 1], dtype=torch.int32),
+        slot_idx=torch.tensor([slot, slot], dtype=torch.int32),
+        mm_item_cu_seqlen=torch.tensor([0, 1], dtype=torch.int32),
+        mm_item_types=torch.tensor([0], dtype=torch.int32),
+        mm_token_lengths=torch.tensor([1 + num_image_tokens], dtype=torch.int32),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 1], dtype=torch.int32),
+        mm_special_offsets=torch.tensor([0], dtype=torch.int32),
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        mrope_delta_cache=cache,
+        spatial_merge_size=merge,
+    )
+
+    expected_delta_i32 = expected_delta.to(torch.int32)
+    torch.testing.assert_close(deltas[0:1], expected_delta_i32)
+    torch.testing.assert_close(deltas[1:2], expected_delta_i32)
+    torch.testing.assert_close(cache[slot : slot + 1], expected_delta_i32)
 
 
 # =============================================================================

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -17,6 +17,8 @@ comparison tests (reference re-implementations on the same weights):
   9. position_embeddings passthrough equivalence
  10. get_rope_index correctness
  11. torch.export with cos/sin extra inputs
+ 12. VLM wrapper text-only position_ids passthrough (2D -> 3D)
+ 13. Custom export info dynamic shapes for 3D mRoPE position_ids
 """
 
 import pytest
@@ -35,6 +37,7 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeModel,
     Qwen3_5MoeSparseMoeBlock,
     Qwen3_5MoeTextConfig,
+    Qwen3_5MoeTextExportInfo,
     Qwen3_5MoeTextModel,
     Qwen3_5MoeTextRotaryEmbedding,
     Qwen3_5MoeTopKRouter,
@@ -600,8 +603,7 @@ def ref_multimodal_forward(model, input_ids, pixel_values=None, image_grid_thw=N
       2. vision model on pixel_values -> image_embeds
       3. masked_scatter image_embeds into inputs_embeds
       4. get_rope_index -> position_ids (3, B, S)
-      5. rotary_emb -> (cos, sin)
-      6. language_model(inputs_embeds, position_embeddings)
+      5. language_model(inputs_embeds, position_ids)
 
     This validates the multimodal wrapper orchestration: embedding merge,
     mRoPE position ID computation, and correct forwarding to the LM.
@@ -626,13 +628,10 @@ def ref_multimodal_forward(model, input_ids, pixel_values=None, image_grid_thw=N
     # 4. Compute mRoPE position IDs
     position_ids, _ = model.get_rope_index(input_ids, image_grid_thw)
 
-    # 5. Compute cos/sin from rotary embedding
-    position_embeddings = model.rotary_emb(inputs_embeds, position_ids)
-
-    # 6. Call language model with pre-computed position embeddings
+    # 5. Call language model with 3D position_ids (text model computes cos/sin internally)
     return model.language_model(
         inputs_embeds=inputs_embeds,
-        position_embeddings=position_embeddings,
+        position_ids=position_ids,
     )
 
 
@@ -1356,3 +1355,102 @@ def test_export_text_model_with_rope_cos_sin():
         atol=1e-5,
         msg="Dynamic shape export should work with different batch/seq dims",
     )
+
+
+# =============================================================================
+# VLM Wrapper Text-Only Position IDs Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_vlm_wrapper_text_only_position_ids():
+    """Test that the VLM wrapper correctly uses executor-provided 2D position_ids
+    for text-only inputs, expanding them to 3D and producing the same result as
+    the text model with equivalent 3D position_ids.
+
+    This simulates the AD executor flow: the executor provides 2D position_ids
+    with correct offsets for chunked prefill, and the VLM wrapper expands them
+    to 3D before passing to the text model graph.
+    """
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, 50, (B, S))
+
+    # Simulate executor-provided 2D position_ids with an offset (chunked prefill chunk 2)
+    offset = 64
+    position_ids_2d = torch.arange(offset, offset + S).unsqueeze(0).expand(B, -1)
+
+    # VLM wrapper path: receives 2D, expands to 3D internally
+    output_wrapper = model(input_ids=input_ids, position_ids=position_ids_2d)
+
+    # Direct text model path: manually expand 2D→3D and call text model
+    position_ids_3d = position_ids_2d[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_output = model.model.language_model(
+        inputs_embeds=inputs_embeds, position_ids=position_ids_3d
+    )
+    ref_logits = model.lm_head(text_output.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output_wrapper.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="VLM wrapper text-only should produce same output as direct text model with 3D pos IDs",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_position_ids_not_ignored():
+    """Verify that different position_ids produce different outputs, confirming
+    the executor's position_ids are actually used (not ignored/overwritten)."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    B, S = 1, 8
+    input_ids = torch.randint(0, 50, (B, S))
+
+    # Two different position_ids (simulating different chunk offsets)
+    pos_ids_a = torch.arange(0, S).unsqueeze(0)
+    pos_ids_b = torch.arange(100, 100 + S).unsqueeze(0)
+
+    output_a = model(input_ids=input_ids, position_ids=pos_ids_a)
+    output_b = model(input_ids=input_ids, position_ids=pos_ids_b)
+
+    assert not torch.allclose(output_a.logits, output_b.logits, atol=1e-4), (
+        "Different position_ids should produce different outputs -- "
+        "position_ids must not be ignored by the VLM wrapper"
+    )
+
+
+# =============================================================================
+# Custom Export Info Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_custom_export_info_3d_position_ids():
+    """Verify Qwen3_5MoeTextExportInfo defines 3D position_ids dynamic shapes."""
+    from torch.export import Dim
+
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+
+    export_info = Qwen3_5MoeTextExportInfo.from_autoinferred(model)
+    shapes = export_info.dynamic_shape_lookup
+
+    assert "position_ids" in shapes, "Export info should include position_ids"
+    pos_dims = shapes["position_ids"]
+    assert 1 in pos_dims and 2 in pos_dims, (
+        f"3D position_ids should have dynamic dims 1 (batch) and 2 (seq), got {pos_dims}"
+    )
+    assert 0 not in pos_dims, f"Dim 0 (=3 for mRoPE) should be static, but got dynamic: {pos_dims}"
+    assert isinstance(pos_dims[1], Dim), f"Dim 1 should be a Dim instance, got {type(pos_dims[1])}"
+    assert isinstance(pos_dims[2], Dim), f"Dim 2 should be a Dim instance, got {type(pos_dims[2])}"

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -22,15 +22,13 @@ comparison tests (reference re-implementations on the same weights):
  14. VLM wrapper decode-after-image delta application (request-scoped delta)
  15. VLM wrapper ignores delta when not passed (no cross-call leakage)
  16. VLM wrapper Branch A (no delta without images)
- 17. Qwen3_5MoeInputProcessor adds mrope_position_deltas to multimodal_data
- 18. VLM wrapper validates position_ids for text-only path
+ 17. VLM wrapper validates position_ids for text-only path
 
 Mixed batch position handling (mRoPE computed in forward):
- 19. persistent_multimodal_keys attribute on Qwen3_5MoeModel
- 20. Forward computes 3D positions from input_ids + image_grid_thw (prefill-only)
- 21. Forward handles mixed prefill+decode with per-request position computation
- 22. Forward handles mixed multimodal+text prefill requests
- 23. Decode-only with deltas (Case 2)
+ 18. Forward computes 3D positions from input_ids + image_grid_thw (prefill-only)
+ 19. Forward handles mixed prefill+decode with per-request position computation
+ 20. Forward handles mixed multimodal+text prefill requests
+ 21. Decode-only with deltas (Case 2)
 """
 
 import pytest
@@ -46,7 +44,6 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeForCausalLM,
     Qwen3_5MoeForConditionalGeneration,
     Qwen3_5MoeGatedDeltaNet,
-    Qwen3_5MoeInputProcessor,
     Qwen3_5MoeModel,
     Qwen3_5MoeSparseMoeBlock,
     Qwen3_5MoeTextConfig,
@@ -1670,13 +1667,6 @@ def test_vlm_wrapper_requires_position_ids_for_text_only():
 
 
 @torch.no_grad()
-def test_persistent_multimodal_keys_attribute():
-    """Qwen3_5MoeModel should declare persistent_multimodal_keys."""
-    assert hasattr(Qwen3_5MoeModel, "persistent_multimodal_keys")
-    assert "mrope_position_deltas" in Qwen3_5MoeModel.persistent_multimodal_keys
-
-
-@torch.no_grad()
 def test_vlm_wrapper_prefill_only_with_images():
     """Prefill-only with images: the model forward should compute 3D mRoPE
     positions from input_ids + image_grid_thw, matching compute_mrope_positions."""
@@ -1900,6 +1890,98 @@ def test_vlm_wrapper_mixed_multimodal_text_prefill():
 
 
 @torch.no_grad()
+def test_vlm_wrapper_chunked_prefill_inside_image_span():
+    """Chunked multimodal prefill should compute mRoPE from request metadata, even
+    when the chunk starts inside the image-token span."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    vc = config.vision_config
+    merge = vc.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_patches = grid_t * grid_h * grid_w
+    num_merged_tokens = num_patches // (merge**2)
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]], dtype=torch.long)
+    t_ps, ps = vc.temporal_patch_size, vc.patch_size
+    pixel_values = torch.randn(num_patches, vc.in_channels * t_ps * ps * ps)
+
+    text_before = [1, 2]
+    vision_part = [config.vision_start_token_id] + [config.image_token_id] * num_merged_tokens
+    text_after = [3, 4]
+    full_tokens = text_before + vision_part + text_after
+
+    # Start the chunk after the first two image tokens, so the chunk no longer contains the
+    # vision-start token and cannot be handled correctly from chunk-local input_ids alone.
+    chunk_start = len(text_before) + 1 + 2
+    chunk_tokens = full_tokens[chunk_start:]
+    chunk_len = len(chunk_tokens)
+
+    input_ids = torch.tensor([chunk_tokens])
+    position_ids = torch.arange(chunk_start, chunk_start + chunk_len).unsqueeze(0)
+    batch_info = torch.tensor([1, chunk_len, 0], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, chunk_len], dtype=torch.int32)
+    input_pos = torch.tensor([chunk_start], dtype=torch.int32)
+    seq_len = torch.tensor([chunk_len], dtype=torch.int32)
+
+    output = model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+        input_pos=input_pos,
+        seq_len=seq_len,
+        mm_chunk_flat_start=torch.tensor([2], dtype=torch.int64),
+        mm_chunk_count=torch.tensor([num_merged_tokens - 2], dtype=torch.int64),
+        mm_item_cu_seqlen=torch.tensor([0, 1], dtype=torch.int32),
+        mm_token_positions=torch.tensor([len(text_before) + 1], dtype=torch.int32),
+        mm_token_lengths=torch.tensor([num_merged_tokens], dtype=torch.int32),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 0], dtype=torch.int32),
+        mm_special_offsets=torch.empty(0, dtype=torch.int32),
+    )
+
+    full_input_ids = torch.tensor([full_tokens])
+    full_pos_3d, _ = compute_mrope_positions(
+        input_ids=full_input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    expected_chunk_pos_3d = full_pos_3d[..., chunk_start:]
+
+    full_inputs_embeds = model.model.get_input_embeddings()(full_input_ids)
+    full_image_embeds = torch.cat(
+        model.model.get_image_features(pixel_values, image_grid_thw), dim=0
+    ).to(full_inputs_embeds.device, full_inputs_embeds.dtype)
+    full_image_mask = (
+        (full_input_ids == config.image_token_id).unsqueeze(-1).expand_as(full_inputs_embeds)
+    )
+    full_inputs_embeds = full_inputs_embeds.masked_scatter(full_image_mask, full_image_embeds)
+    expected_chunk_embeds = full_inputs_embeds[:, chunk_start:]
+
+    text_out = model.model.language_model(
+        inputs_embeds=expected_chunk_embeds,
+        position_ids=expected_chunk_pos_3d,
+    )
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Chunked multimodal prefill should match the full-request mRoPE slice",
+    )
+
+
+@torch.no_grad()
 def test_vlm_wrapper_decode_only_with_delta():
     """Case 3: decode-only batch with deltas (no mrope_position_ids_3d) should
     apply delta to all positions uniformly."""
@@ -1933,84 +2015,3 @@ def test_vlm_wrapper_decode_only_with_delta():
         atol=1e-5,
         msg="Decode-only with deltas should apply delta-adjusted 3D expansion",
     )
-
-
-# =============================================================================
-# Qwen3_5MoeInputProcessor Tests
-# =============================================================================
-
-
-@torch.no_grad()
-def test_input_processor_adds_mrope_deltas():
-    """Qwen3_5MoeInputProcessor should compute and attach mrope_position_deltas
-    to the multimodal_data when image_grid_thw is present."""
-    config = _make_small_composite_config()
-    merge = config.vision_config.spatial_merge_size
-    grid_t, grid_h, grid_w = 1, 4, 4
-    num_vision_tokens = grid_t * (grid_h // merge) * (grid_w // merge)
-
-    # Build synthetic token_ids matching an image sequence
-    text_before = [1, 2, 3]
-    vision_start = [config.vision_start_token_id]
-    img_tokens = [config.image_token_id] * num_vision_tokens
-    text_after = [4, 5, 6]
-    fake_token_ids = text_before + vision_start + img_tokens + text_after
-
-    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]])
-    fake_extra = {
-        "multimodal_data": {
-            "pixel_values": torch.randn(1, 3, 4, 4),
-            "image_grid_thw": image_grid_thw,
-        }
-    }
-
-    def fake_base(inputs, sampling_params):
-        return (fake_token_ids, fake_extra)
-
-    processor = Qwen3_5MoeInputProcessor(base_processor=fake_base, config=config)
-
-    token_ids_out, extra_out = processor({"prompt": "test"}, None)
-
-    assert token_ids_out == fake_token_ids
-    mm_data = extra_out["multimodal_data"]
-    assert "mrope_position_deltas" in mm_data, (
-        "InputProcessor should add mrope_position_deltas to multimodal_data"
-    )
-
-    deltas = mm_data["mrope_position_deltas"]
-    assert deltas.shape == (1, 1), f"Expected shape (1, 1), got {deltas.shape}"
-    assert deltas.item() < 0, (
-        f"With spatial merge, delta should be negative (position compression), got {deltas.item()}"
-    )
-
-    # Verify it matches the standalone function
-    input_ids_t = torch.tensor([fake_token_ids], dtype=torch.long)
-    _, ref_deltas = compute_mrope_positions(
-        input_ids=input_ids_t,
-        image_grid_thw=image_grid_thw,
-        video_grid_thw=None,
-        image_token_id=config.image_token_id,
-        video_token_id=config.video_token_id,
-        vision_start_token_id=config.vision_start_token_id,
-        spatial_merge_size=merge,
-    )
-    torch.testing.assert_close(deltas, ref_deltas)
-
-
-@torch.no_grad()
-def test_input_processor_no_deltas_for_text_only():
-    """Qwen3_5MoeInputProcessor should not add mrope_position_deltas when
-    there's no multimodal data."""
-    config = _make_small_composite_config()
-    fake_token_ids = [1, 2, 3, 4, 5]
-
-    # Stub base processor that returns text-only data (no extra)
-    def fake_base(inputs, sampling_params):
-        return (fake_token_ids, None)
-
-    processor = Qwen3_5MoeInputProcessor(base_processor=fake_base, config=config)
-
-    token_ids_out, extra_out = processor({"prompt": "text only"}, None)
-
-    assert token_ids_out == fake_token_ids
-    assert extra_out is None

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -19,6 +19,11 @@ comparison tests (reference re-implementations on the same weights):
  11. torch.export with cos/sin extra inputs
  12. VLM wrapper text-only position_ids passthrough (2D -> 3D)
  13. Custom export info dynamic shapes for 3D mRoPE position_ids
+ 14. Standalone compute_mrope_positions (text-only, with image, matches model)
+ 15. VLM wrapper decode-after-image delta application
+ 16. mrope_position_deltas kwarg override
+ 17. VLM wrapper Branch A (no delta without images)
+ 18. Qwen3_5MoeInputProcessor adds mrope_position_deltas to multimodal_data
 """
 
 import pytest
@@ -34,6 +39,7 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeForCausalLM,
     Qwen3_5MoeForConditionalGeneration,
     Qwen3_5MoeGatedDeltaNet,
+    Qwen3_5MoeInputProcessor,
     Qwen3_5MoeModel,
     Qwen3_5MoeSparseMoeBlock,
     Qwen3_5MoeTextConfig,
@@ -47,6 +53,7 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_qwen3_5_moe import (
     Qwen3_5MoeVisionModel,
     apply_rotary_pos_emb,
     apply_rotary_pos_emb_vision,
+    compute_mrope_positions,
 )
 
 
@@ -1454,3 +1461,304 @@ def test_custom_export_info_3d_position_ids():
     assert 0 not in pos_dims, f"Dim 0 (=3 for mRoPE) should be static, but got dynamic: {pos_dims}"
     assert isinstance(pos_dims[1], Dim), f"Dim 1 should be a Dim instance, got {type(pos_dims[1])}"
     assert isinstance(pos_dims[2], Dim), f"Dim 2 should be a Dim instance, got {type(pos_dims[2])}"
+
+
+# =============================================================================
+# Standalone compute_mrope_positions Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_compute_mrope_positions_text_only():
+    """Text-only: all 3 dims identical, delta is 0."""
+    config = _make_small_composite_config()
+    B, S = 1, 10
+    input_ids = torch.randint(0, 50, (B, S))
+
+    pos, deltas = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=config.vision_config.spatial_merge_size,
+    )
+
+    assert pos.shape == (3, B, S)
+    torch.testing.assert_close(pos[0], pos[1])
+    torch.testing.assert_close(pos[0], pos[2])
+    assert deltas.item() == 0, f"Text-only delta should be 0, got {deltas.item()}"
+
+
+@torch.no_grad()
+def test_compute_mrope_positions_with_image():
+    """Multimodal: verify position compression and non-zero delta."""
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_vision_tokens = grid_t * (grid_h // merge) * (grid_w // merge)
+
+    # Build input_ids: [text, vision_start, img_tokens..., text]
+    text_before = torch.tensor([1, 2, 3])
+    vision_start = torch.tensor([config.vision_start_token_id])
+    img_tokens = torch.full((num_vision_tokens,), config.image_token_id)
+    text_after = torch.tensor([4, 5, 6])
+    input_ids = torch.cat([text_before, vision_start, img_tokens, text_after]).unsqueeze(0)
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]])
+
+    pos, deltas = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+
+    assert pos.shape[0] == 3
+    assert deltas.item() < 0, (
+        f"With spatial merge, mRoPE compresses positions -- delta should be negative, got {deltas.item()}"
+    )
+
+    # Text tokens before vision: all 3 dims should be the same
+    n_before = len(text_before) + len(vision_start)
+    torch.testing.assert_close(pos[0, 0, :n_before], pos[1, 0, :n_before])
+    torch.testing.assert_close(pos[0, 0, :n_before], pos[2, 0, :n_before])
+
+
+@torch.no_grad()
+def test_compute_mrope_positions_matches_model_method():
+    """Standalone function should match the model's get_rope_index method."""
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_vision_tokens = grid_t * (grid_h // merge) * (grid_w // merge)
+
+    text_before = torch.tensor([1, 2, 3])
+    vision_start = torch.tensor([config.vision_start_token_id])
+    img_tokens = torch.full((num_vision_tokens,), config.image_token_id)
+    text_after = torch.tensor([4, 5])
+    input_ids = torch.cat([text_before, vision_start, img_tokens, text_after]).unsqueeze(0)
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]])
+
+    # Standalone function
+    pos_fn, deltas_fn = compute_mrope_positions(
+        input_ids=input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+
+    # Model method
+    torch.manual_seed(42)
+    model = Qwen3_5MoeModel(config)
+    pos_model, deltas_model = model.get_rope_index(input_ids, image_grid_thw=image_grid_thw)
+
+    torch.testing.assert_close(pos_fn, pos_model)
+    torch.testing.assert_close(deltas_fn, deltas_model)
+
+
+# =============================================================================
+# VLM Wrapper Multimodal Forward Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_vlm_wrapper_decode_after_image_uses_delta():
+    """Branch C: after an image forward caches rope_deltas, a subsequent
+    text-only forward should adjust position_ids by the cached delta."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    B, S = 1, 8
+    input_ids = torch.randint(0, 50, (B, S))
+
+    # Simulate: rope_deltas was cached from a previous image forward
+    fake_delta = torch.tensor([[-2]])
+    model.model.rope_deltas = fake_delta
+
+    # Position IDs from executor (sequential, as if no image compression)
+    pos_ids_executor = torch.arange(100, 100 + S).unsqueeze(0)
+
+    # VLM wrapper should apply delta: pos_ids = (100-2, 101-2, ...) = (98, 99, ...)
+    output_with_delta = model(input_ids=input_ids, position_ids=pos_ids_executor)
+
+    # Reference: manually apply delta and call text model directly
+    corrected_pos = pos_ids_executor + fake_delta
+    corrected_pos_3d = corrected_pos[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(
+        inputs_embeds=inputs_embeds, position_ids=corrected_pos_3d
+    )
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output_with_delta.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Decode after image should apply cached rope_deltas to position_ids",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_mrope_deltas_kwarg_overrides_cached():
+    """When mrope_position_deltas is passed as a kwarg, it should be used
+    instead of the cached self.rope_deltas."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    B, S = 1, 6
+    input_ids = torch.randint(0, 50, (B, S))
+    pos_ids = torch.arange(50, 50 + S).unsqueeze(0)
+
+    # Set cached delta to -3
+    model.model.rope_deltas = torch.tensor([[-3]])
+
+    # But pass a different delta via kwarg (-5)
+    kwarg_delta = torch.tensor([[-5]])
+    output = model(
+        input_ids=input_ids,
+        position_ids=pos_ids,
+        mrope_position_deltas=kwarg_delta,
+    )
+
+    # Reference uses the kwarg delta (-5)
+    corrected_pos = pos_ids + kwarg_delta
+    corrected_pos_3d = corrected_pos[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(
+        inputs_embeds=inputs_embeds, position_ids=corrected_pos_3d
+    )
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="mrope_position_deltas kwarg should override cached rope_deltas",
+    )
+
+
+@torch.no_grad()
+def test_vlm_wrapper_no_delta_without_images():
+    """Branch A: when rope_deltas is None (no images ever), position_ids should
+    be expanded to 3D without any adjustment (same as before)."""
+    config = _make_small_composite_config()
+    torch.manual_seed(42)
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    assert model.model.rope_deltas is None, "rope_deltas should start as None"
+
+    B, S = 1, 8
+    input_ids = torch.randint(0, 50, (B, S))
+    pos_ids = torch.arange(0, S).unsqueeze(0)
+
+    output = model(input_ids=input_ids, position_ids=pos_ids)
+
+    # Reference: plain 2D → 3D expansion, no delta
+    pos_3d = pos_ids[None].expand(3, -1, -1)
+    inputs_embeds = model.model.get_input_embeddings()(input_ids)
+    text_out = model.model.language_model(inputs_embeds=inputs_embeds, position_ids=pos_3d)
+    ref_logits = model.lm_head(text_out.last_hidden_state.to(model.lm_head.weight.dtype)).float()
+
+    torch.testing.assert_close(
+        output.logits,
+        ref_logits,
+        rtol=1e-5,
+        atol=1e-5,
+        msg="Without images, VLM wrapper should do plain 2D→3D expansion",
+    )
+
+
+# =============================================================================
+# Qwen3_5MoeInputProcessor Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_input_processor_adds_mrope_deltas():
+    """Qwen3_5MoeInputProcessor should compute and attach mrope_position_deltas
+    to the multimodal_data when image_grid_thw is present."""
+    config = _make_small_composite_config()
+    merge = config.vision_config.spatial_merge_size
+    grid_t, grid_h, grid_w = 1, 4, 4
+    num_vision_tokens = grid_t * (grid_h // merge) * (grid_w // merge)
+
+    # Build synthetic token_ids matching an image sequence
+    text_before = [1, 2, 3]
+    vision_start = [config.vision_start_token_id]
+    img_tokens = [config.image_token_id] * num_vision_tokens
+    text_after = [4, 5, 6]
+    fake_token_ids = text_before + vision_start + img_tokens + text_after
+
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]])
+    fake_extra = {
+        "multimodal_data": {
+            "pixel_values": torch.randn(1, 3, 4, 4),
+            "image_grid_thw": image_grid_thw,
+        }
+    }
+
+    def fake_base(inputs, sampling_params):
+        return (fake_token_ids, fake_extra)
+
+    processor = Qwen3_5MoeInputProcessor(base_processor=fake_base, config=config)
+
+    token_ids_out, extra_out = processor({"prompt": "test"}, None)
+
+    assert token_ids_out == fake_token_ids
+    mm_data = extra_out["multimodal_data"]
+    assert "mrope_position_deltas" in mm_data, (
+        "InputProcessor should add mrope_position_deltas to multimodal_data"
+    )
+
+    deltas = mm_data["mrope_position_deltas"]
+    assert deltas.shape == (1, 1), f"Expected shape (1, 1), got {deltas.shape}"
+    assert deltas.item() < 0, (
+        f"With spatial merge, delta should be negative (position compression), got {deltas.item()}"
+    )
+
+    # Verify it matches the standalone function
+    input_ids_t = torch.tensor([fake_token_ids], dtype=torch.long)
+    _, ref_deltas = compute_mrope_positions(
+        input_ids=input_ids_t,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    torch.testing.assert_close(deltas, ref_deltas)
+
+
+@torch.no_grad()
+def test_input_processor_no_deltas_for_text_only():
+    """Qwen3_5MoeInputProcessor should not add mrope_position_deltas when
+    there's no multimodal data."""
+    config = _make_small_composite_config()
+    fake_token_ids = [1, 2, 3, 4, 5]
+
+    # Stub base processor that returns text-only data (no extra)
+    def fake_base(inputs, sampling_params):
+        return (fake_token_ids, None)
+
+    processor = Qwen3_5MoeInputProcessor(base_processor=fake_base, config=config)
+
+    token_ids_out, extra_out = processor({"prompt": "text only"}, None)
+
+    assert token_ids_out == fake_token_ids
+    assert extra_out is None

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -2029,6 +2029,90 @@ def test_vlm_wrapper_mixed_multimodal_text_prefill():
 
 
 @torch.no_grad()
+def test_build_mixed_positions_handles_mixed_image_and_video_request():
+    """Mixed image+video requests should not drift grid indices across requests."""
+    config = _make_small_composite_config()
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    merge = config.vision_config.spatial_merge_size
+    image_grid_thw = torch.tensor([[1, 4, 4], [1, 2, 4]], dtype=torch.long)
+    video_grid_thw = torch.tensor([[1, 2, 4]], dtype=torch.long)
+    num_image_tokens_0 = int(
+        image_grid_thw[0, 0].item()
+        * (image_grid_thw[0, 1].item() // merge)
+        * (image_grid_thw[0, 2].item() // merge)
+    )
+    num_image_tokens_1 = int(
+        image_grid_thw[1, 0].item()
+        * (image_grid_thw[1, 1].item() // merge)
+        * (image_grid_thw[1, 2].item() // merge)
+    )
+    num_video_tokens = int(
+        video_grid_thw[0, 0].item()
+        * (video_grid_thw[0, 1].item() // merge)
+        * (video_grid_thw[0, 2].item() // merge)
+    )
+
+    req1_tokens = [
+        1,
+        config.vision_start_token_id,
+        *([config.image_token_id] * num_image_tokens_0),
+        2,
+        config.vision_start_token_id,
+        *([config.video_token_id] * num_video_tokens),
+        3,
+    ]
+    req2_tokens = [
+        4,
+        config.vision_start_token_id,
+        *([config.image_token_id] * num_image_tokens_1),
+        5,
+    ]
+    all_tokens = req1_tokens + req2_tokens
+    input_ids = torch.tensor([all_tokens], dtype=torch.long)
+    position_ids = torch.arange(len(all_tokens)).unsqueeze(0)
+    batch_info = torch.tensor([2, len(all_tokens), 0], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0, len(req1_tokens), len(all_tokens)], dtype=torch.int32)
+
+    actual_pos_3d = model.model._build_mixed_positions(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        delta=0,
+        batch_info=batch_info,
+        cu_seqlen=cu_seqlen,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+    )
+
+    req1_pos_3d, _ = compute_mrope_positions(
+        input_ids=input_ids[..., : len(req1_tokens)],
+        image_grid_thw=image_grid_thw[:1],
+        video_grid_thw=video_grid_thw,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    req2_pos_3d, _ = compute_mrope_positions(
+        input_ids=input_ids[..., len(req1_tokens) :],
+        image_grid_thw=image_grid_thw[1:],
+        video_grid_thw=None,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+    expected_pos_3d = torch.cat([req1_pos_3d, req2_pos_3d], dim=-1)
+
+    torch.testing.assert_close(
+        actual_pos_3d,
+        expected_pos_3d,
+        msg="Mixed image+video requests should preserve request-local image/video grid indices",
+    )
+
+
+@torch.no_grad()
 def test_vlm_wrapper_chunked_prefill_inside_image_span():
     """Chunked multimodal prefill computes mRoPE from request metadata.
 
@@ -2079,6 +2163,7 @@ def test_vlm_wrapper_chunked_prefill_inside_image_span():
         mm_chunk_flat_start=torch.tensor([2], dtype=torch.int64),
         mm_chunk_count=torch.tensor([num_merged_tokens - 2], dtype=torch.int64),
         mm_item_cu_seqlen=torch.tensor([0, 1], dtype=torch.int32),
+        mm_item_types=torch.tensor([0], dtype=torch.int32),
         mm_token_positions=torch.tensor([len(text_before) + 1], dtype=torch.int32),
         mm_token_lengths=torch.tensor([num_merged_tokens], dtype=torch.int32),
         mm_special_offsets_cu_seqlen=torch.tensor([0, 0], dtype=torch.int32),
@@ -2119,6 +2204,89 @@ def test_vlm_wrapper_chunked_prefill_inside_image_span():
         rtol=1e-5,
         atol=1e-5,
         msg="Chunked multimodal prefill should match the full-request mRoPE slice",
+    )
+
+
+@torch.no_grad()
+def test_build_chunked_multimodal_positions_handles_mixed_image_and_video_request():
+    """Chunked mixed image+video requests should preserve item-type grid ordering."""
+    config = _make_small_composite_config()
+    model = Qwen3_5MoeForConditionalGeneration(config)
+    model.eval()
+
+    merge = config.vision_config.spatial_merge_size
+    image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    video_grid_thw = torch.tensor([[1, 2, 4]], dtype=torch.long)
+    num_image_tokens = int(
+        image_grid_thw[0, 0].item()
+        * (image_grid_thw[0, 1].item() // merge)
+        * (image_grid_thw[0, 2].item() // merge)
+    )
+    num_video_tokens = int(
+        video_grid_thw[0, 0].item()
+        * (video_grid_thw[0, 1].item() // merge)
+        * (video_grid_thw[0, 2].item() // merge)
+    )
+
+    text_before = [1]
+    text_between = [2, 3]
+    text_after = [4]
+    full_tokens = (
+        text_before
+        + [config.vision_start_token_id]
+        + ([config.image_token_id] * num_image_tokens)
+        + text_between
+        + [config.vision_start_token_id]
+        + ([config.video_token_id] * num_video_tokens)
+        + text_after
+    )
+
+    full_input_ids = torch.tensor([full_tokens], dtype=torch.long)
+    full_pos_3d, _ = compute_mrope_positions(
+        input_ids=full_input_ids,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+        spatial_merge_size=merge,
+    )
+
+    video_start = len(text_before) + 1 + num_image_tokens + len(text_between) + 1
+    chunk_start = video_start + 1
+    chunk_tokens = full_tokens[chunk_start:]
+    chunk_len = len(chunk_tokens)
+    input_ids = torch.tensor([chunk_tokens], dtype=torch.long)
+    position_ids = torch.arange(chunk_start, chunk_start + chunk_len).unsqueeze(0)
+
+    actual_pos_3d = model.model._build_chunked_multimodal_positions(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        delta=0,
+        batch_info=torch.tensor([1, chunk_len, 0], dtype=torch.int32),
+        cu_seqlen=torch.tensor([0, chunk_len], dtype=torch.int32),
+        input_pos=torch.tensor([chunk_start], dtype=torch.int32),
+        seq_len=torch.tensor([chunk_len], dtype=torch.int32),
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        mm_item_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_item_types=torch.tensor([0, 1], dtype=torch.int32),
+        mm_token_positions=torch.tensor(
+            [len(text_before), len(text_before) + 1 + num_image_tokens + len(text_between)],
+            dtype=torch.int32,
+        ),
+        mm_token_lengths=torch.tensor(
+            [1 + num_image_tokens, 1 + num_video_tokens],
+            dtype=torch.int32,
+        ),
+        mm_special_offsets_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
+        mm_special_offsets=torch.tensor([0, 1 + num_image_tokens], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(
+        actual_pos_3d,
+        full_pos_3d[..., chunk_start:],
+        msg="Chunked mixed image+video requests should reconstruct positions using item types",
     )
 
 

--- a/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py
@@ -1568,7 +1568,7 @@ def test_qwen3_mrope_delta_matches_compute_mrope_positions_for_mixed_items():
     )
 
     actual_delta = qwen3_mrope_delta(
-        batch_info_host=torch.tensor([1, 0, 0], dtype=torch.int32),
+        batch_info_host=torch.tensor([1, 0, 0, 0, 0, 0], dtype=torch.int32),
         mm_item_cu_seqlen=torch.tensor([0, 2], dtype=torch.int32),
         mm_item_types=torch.tensor([0, 1], dtype=torch.int32),
         mm_token_lengths=torch.tensor(
@@ -1624,7 +1624,7 @@ def test_qwen3_mrope_delta_with_cache_writes_prefill_and_reads_decode():
     cache = torch.zeros((8, 1), dtype=torch.int32)
     slot = 3
     deltas = qwen3_mrope_delta_with_cache(
-        batch_info_host=torch.tensor([1, 0, 1], dtype=torch.int32),
+        batch_info_host=torch.tensor([1, 0, 0, 0, 1, 1], dtype=torch.int32),
         slot_idx=torch.tensor([slot, slot], dtype=torch.int32),
         mm_item_cu_seqlen=torch.tensor([0, 1], dtype=torch.int32),
         mm_item_types=torch.tensor([0], dtype=torch.int32),

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -275,7 +275,7 @@ def test_ad_engine_chunked_prefill_stages_multimodal_runtime_metadata():
     req.py_multimodal_data = None
 
     scheduled_requests = ScheduledRequests()
-    scheduled_requests.context_requests.append(req)
+    scheduled_requests.context_requests_last_chunk.append(req)
 
     engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
 
@@ -328,7 +328,7 @@ def test_ad_engine_skips_multimodal_runtime_metadata_when_no_multimodal_requests
     req = _DummyRequest(tokens=[1, 2, 3, 4], begin=0, size=4, seq_slot=0)
 
     scheduled_requests = ScheduledRequests()
-    scheduled_requests.context_requests.append(req)
+    scheduled_requests.context_requests_last_chunk.append(req)
 
     engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
 

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -389,6 +389,53 @@ def test_ad_engine_stages_mm_chunk_bounds_for_multimodal_block_reuse():
     cache_seq_interface.shutdown()
 
 
+def test_ad_engine_rejects_mismatched_multimodal_layout_arrays():
+    """Per-request multimodal arrays should be validated before flattening."""
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
+
+    kv_cache_config = KvCacheConfig(tokens_per_block=8)
+    cache_seq_interface = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        device=device,
+        kv_cache_config=kv_cache_config,
+    )
+    cache_seq_interface.to(device)
+
+    engine = ADEngine(get_inference_model, cache_seq_interface)
+    engine._enable_chunked_prefill = True
+
+    kv_manager = _DummyKVCacheManager(tokens_per_block=8)
+    resource_manager = _DummyResourceManager(kv_manager)
+
+    tokens = [1, 2, 99, 99, 99, 99, 3, 4]
+    req = _DummyRequest(tokens=tokens, begin=4, size=4, seq_slot=0)
+    req.multimodal_positions = [2]
+    req.multimodal_lengths = [4]
+    req.py_multimodal_data = {
+        "layout_metadata": {
+            "item_types": torch.tensor([0, 1], dtype=torch.int32),
+            "special_token_offsets": torch.tensor([], dtype=torch.int32),
+        }
+    }
+
+    scheduled_requests = ScheduledRequests()
+    scheduled_requests.context_requests_last_chunk.append(req)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Mismatch between multimodal item_types and multimodal span arrays in request 0: "
+            "item_types=2, positions=1, lengths=1"
+        ),
+    ):
+        engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
+
+    cache_seq_interface.shutdown()
+
+
 # =============================================================================
 # Hybrid Cache Manager Integration Tests
 # =============================================================================

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -181,6 +181,8 @@ class _DummyRequest:
         self.py_seq_slot = seq_slot
         self.py_batch_idx = None
         self.py_multimodal_data = None
+        self.multimodal_positions = None
+        self.multimodal_lengths = None
 
     def get_tokens(self, _beam: int) -> List[int]:
         return self._tokens
@@ -241,6 +243,63 @@ def test_ad_engine_chunked_prefill_equivalence(tokens_per_block: int):
     logits_chunked_last = engine.forward(scheduled_requests_part2, resource_manager)["logits"][-1]
 
     torch.testing.assert_close(logits_full_last, logits_chunked_last)  # , atol=1e-5)
+
+    cache_seq_interface.shutdown()
+
+
+def test_ad_engine_chunked_prefill_stages_multimodal_runtime_metadata():
+    """Chunked prefill should stage per-request multimodal layout metadata for the VLM wrapper."""
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
+
+    kv_cache_config = KvCacheConfig(tokens_per_block=8)
+    cache_seq_interface = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        device=device,
+        kv_cache_config=kv_cache_config,
+    )
+    cache_seq_interface.to(device)
+
+    engine = ADEngine(get_inference_model, cache_seq_interface)
+    engine._enable_chunked_prefill = True
+
+    kv_manager = _DummyKVCacheManager(tokens_per_block=8)
+    resource_manager = _DummyResourceManager(kv_manager)
+
+    tokens = [1, 2, 99, 99, 99, 99, 3, 4]
+    req = _DummyRequest(tokens=tokens, begin=4, size=4, seq_slot=0)
+    req.multimodal_positions = [2]
+    req.multimodal_lengths = [4]
+    req.py_multimodal_data = None
+
+    scheduled_requests = ScheduledRequests()
+    scheduled_requests.context_requests.append(req)
+
+    engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
+
+    named_args = cache_seq_interface.named_args
+    assert "mm_item_cu_seqlen" in named_args
+    assert "mm_token_positions" in named_args
+    assert "mm_token_lengths" in named_args
+    assert "mm_special_offsets_cu_seqlen" in named_args
+    assert "mm_special_offsets" in named_args
+
+    torch.testing.assert_close(
+        named_args["mm_item_cu_seqlen"].cpu(), torch.tensor([0, 1], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        named_args["mm_token_positions"].cpu(), torch.tensor([2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        named_args["mm_token_lengths"].cpu(), torch.tensor([4], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        named_args["mm_special_offsets_cu_seqlen"].cpu(),
+        torch.tensor([0, 0], dtype=torch.int32),
+    )
+    assert named_args["mm_special_offsets"].numel() == 0
 
     cache_seq_interface.shutdown()
 

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -344,6 +344,51 @@ def test_ad_engine_skips_multimodal_runtime_metadata_when_no_multimodal_requests
     cache_seq_interface.shutdown()
 
 
+def test_ad_engine_stages_mm_chunk_bounds_for_multimodal_block_reuse():
+    """Multimodal partial prefill should stage mm_chunk bounds without chunked prefill."""
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
+
+    kv_cache_config = KvCacheConfig(tokens_per_block=8)
+    cache_seq_interface = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        device=device,
+        kv_cache_config=kv_cache_config,
+    )
+    cache_seq_interface.to(device)
+
+    engine = ADEngine(get_inference_model, cache_seq_interface)
+    engine._enable_chunked_prefill = False
+
+    kv_manager = _DummyKVCacheManager(tokens_per_block=8)
+    resource_manager = _DummyResourceManager(kv_manager)
+
+    tokens = [1, 2, 99, 99, 99, 99, 3, 4]
+    req = _DummyRequest(tokens=tokens, begin=4, size=4, seq_slot=0)
+    req.multimodal_positions = [2]
+    req.multimodal_lengths = [4]
+    req.py_multimodal_data = None
+
+    scheduled_requests = ScheduledRequests()
+    scheduled_requests.context_requests_last_chunk.append(req)
+
+    engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
+
+    named_args = cache_seq_interface.named_args
+    assert "mm_chunk_flat_start" in named_args
+    assert "mm_chunk_count" in named_args
+    torch.testing.assert_close(
+        named_args["mm_chunk_flat_start"].cpu(), torch.tensor([2], dtype=torch.int64)
+    )
+    torch.testing.assert_close(
+        named_args["mm_chunk_count"].cpu(), torch.tensor([2], dtype=torch.int64)
+    )
+
+    cache_seq_interface.shutdown()
+
+
 # =============================================================================
 # Hybrid Cache Manager Integration Tests
 # =============================================================================

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -304,6 +304,46 @@ def test_ad_engine_chunked_prefill_stages_multimodal_runtime_metadata():
     cache_seq_interface.shutdown()
 
 
+def test_ad_engine_skips_multimodal_runtime_metadata_when_no_multimodal_requests():
+    """Chunked prefill should not stage multimodal metadata for pure text requests."""
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
+
+    kv_cache_config = KvCacheConfig(tokens_per_block=8)
+    cache_seq_interface = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        device=device,
+        kv_cache_config=kv_cache_config,
+    )
+    cache_seq_interface.to(device)
+
+    engine = ADEngine(get_inference_model, cache_seq_interface)
+    engine._enable_chunked_prefill = True
+
+    kv_manager = _DummyKVCacheManager(tokens_per_block=8)
+    resource_manager = _DummyResourceManager(kv_manager)
+
+    req = _DummyRequest(tokens=[1, 2, 3, 4], begin=0, size=4, seq_slot=0)
+
+    scheduled_requests = ScheduledRequests()
+    scheduled_requests.context_requests.append(req)
+
+    engine._prepare_inputs(scheduled_requests, resource_manager, new_tokens=None)
+
+    named_args = cache_seq_interface.named_args
+    assert "mm_item_cu_seqlen" not in named_args
+    assert "mm_token_positions" not in named_args
+    assert "mm_token_lengths" not in named_args
+    assert "mm_special_offsets_cu_seqlen" not in named_args
+    assert "mm_special_offsets" not in named_args
+    assert "mm_chunk_flat_start" not in named_args
+    assert "mm_chunk_count" not in named_args
+
+    cache_seq_interface.shutdown()
+
+
 # =============================================================================
 # Hybrid Cache Manager Integration Tests
 # =============================================================================

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
@@ -13,7 +13,7 @@ from tensorrt_llm._torch.auto_deploy.transform.library.mrope_delta_cache import 
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[7]
+    return Path(__file__).resolve().parents[6]
 
 
 def test_initialize_qwen_mrope_delta_cache_registers_state_resource():
@@ -45,7 +45,7 @@ def test_initialize_qwen_mrope_delta_cache_disabled_in_default_config():
     with open(config_path) as f:
         config = yaml.safe_load(f)
 
-    assert config["initialize_qwen_mrope_delta_cache"]["enabled"] is False
+    assert config["transforms"]["initialize_qwen_mrope_delta_cache"]["enabled"] is False
 
 
 def test_qwen_registry_configs_explicitly_enable_mrope_delta_cache():

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
@@ -16,7 +16,7 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[6]
 
 
-def test_initialize_qwen_mrope_delta_cache_registers_state_resource():
+def test_initialize_mrope_delta_cache_registers_state_resource():
     cm = CachedSequenceInterface(
         max_seq_len=8,
         max_batch_size=2,
@@ -38,14 +38,14 @@ def test_initialize_qwen_mrope_delta_cache_registers_state_resource():
     assert cm._resource_lookup["mrope_delta_cache"] == StateResourceHandler(1, dtype=torch.int32)
 
 
-def test_initialize_qwen_mrope_delta_cache_disabled_in_default_config():
+def test_initialize_mrope_delta_cache_disabled_in_default_config():
     config_path = (
         _repo_root() / "tensorrt_llm" / "_torch" / "auto_deploy" / "config" / "default.yaml"
     )
     with open(config_path) as f:
         config = yaml.safe_load(f)
 
-    assert config["transforms"]["initialize_qwen_mrope_delta_cache"]["enabled"] is False
+    assert config["transforms"]["initialize_mrope_delta_cache"]["enabled"] is False
 
 
 def test_qwen_registry_configs_explicitly_enable_mrope_delta_cache():
@@ -54,4 +54,4 @@ def test_qwen_registry_configs_explicitly_enable_mrope_delta_cache():
         with open(config_dir / config_name) as f:
             config = yaml.safe_load(f)
 
-        assert config["transforms"]["initialize_qwen_mrope_delta_cache"]["enabled"] is True
+        assert config["transforms"]["initialize_mrope_delta_cache"]["enabled"] is True

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import yaml
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import StateResourceHandler
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig
+from tensorrt_llm._torch.auto_deploy.transform.library.mrope_delta_cache import (
+    InitializeMropeDeltaCache,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[7]
+
+
+def test_initialize_qwen_mrope_delta_cache_registers_state_resource():
+    cm = CachedSequenceInterface(
+        max_seq_len=8,
+        max_batch_size=2,
+        device="cpu",
+    )
+    transform = InitializeMropeDeltaCache.from_kwargs(stage="cache_init")
+
+    mod, info = transform._apply_to_full_model(
+        nn.Module(),
+        cm,
+        factory=None,
+        shared_config=SharedConfig(),
+    )
+
+    assert isinstance(mod, nn.Module)
+    assert not info.skipped
+    assert info.num_matches == 1
+    assert "mrope_delta_cache" in cm._resource_lookup
+    assert cm._resource_lookup["mrope_delta_cache"] == StateResourceHandler(1, dtype=torch.int32)
+
+
+def test_initialize_qwen_mrope_delta_cache_disabled_in_default_config():
+    config_path = (
+        _repo_root() / "tensorrt_llm" / "_torch" / "auto_deploy" / "config" / "default.yaml"
+    )
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    assert config["initialize_qwen_mrope_delta_cache"]["enabled"] is False
+
+
+def test_qwen_registry_configs_explicitly_enable_mrope_delta_cache():
+    config_dir = _repo_root() / "examples" / "auto_deploy" / "model_registry" / "configs"
+    for config_name in ("qwen3.5_moe_35b.yaml", "qwen3.5_moe_400b.yaml"):
+        with open(config_dir / config_name) as f:
+            config = yaml.safe_load(f)
+
+        assert config["transforms"]["initialize_qwen_mrope_delta_cache"]["enabled"] is True

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_mrope_delta_cache.py
@@ -34,8 +34,10 @@ def test_initialize_mrope_delta_cache_registers_state_resource():
     assert isinstance(mod, nn.Module)
     assert not info.skipped
     assert info.num_matches == 1
-    assert "mrope_delta_cache" in cm._resource_lookup
-    assert cm._resource_lookup["mrope_delta_cache"] == StateResourceHandler(1, dtype=torch.int32)
+    assert len(cm._resource_lookup) == 1
+    resource_name, resource_handler = next(iter(cm._resource_lookup.items()))
+    assert resource_name.endswith("_mrope_delta_cache")
+    assert resource_handler == StateResourceHandler(1, dtype=torch.int32)
 
 
 def test_initialize_mrope_delta_cache_disabled_in_default_config():


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/TensorRT-LLM/issues/12271 

This updates the Qwen3.5 MoE AutoDeploy multimodal path to make mRoPE delta handling request-scoped and cache-backed, while keeping Qwen-specific multimodal span construction in the Qwen model path instead of the generic input processor.

Implemented changes:
- derive exact Qwen multimodal spans from the tokenized `input_ids` in the Qwen-specific AutoDeploy path
- build chunk-aware multimodal 3D positions in the VLM wrapper
- add request-level mRoPE delta helpers and wire the wrapper to use a per-request `mrope_delta_cache` when available
- add the `initialize_qwen_mrope_delta_cache` transform to allocate a tiny per-slot cache resource
- make metadata-free prefill warmups a zero-delta no-op for the cached op
- fix the flattened cached `position_ids` fallback so request-level deltas are expanded to per-token deltas using `cu_seqlen`
- remove the temporary reduced-layer cap in the Qwen3.5 35B MoE AutoDeploy accuracy test after the e2e path was revalidated

## Test Coverage

Verified locally:
- `pytest -q tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_qwen3_5_moe.py -k "mrope_delta_matches_compute_mrope_positions_for_mixed_items or mrope_delta_with_cache_writes_prefill_and_reads_decode or flattened_prefill_with_request_deltas" -p no:cacheprovider`
- `TRTLLM_ACCURACY_NO_REFERENCE=1 TMPDIR=/tmp/trtqwen HF_HOME=/tmp/trtqwen/hf_home PYTHONDONTWRITEBYTECODE=1 pytest -q tests/integration/defs/accuracy/test_llm_api_autodeploy.py::TestQwen3_5_35B_MoE::test_bf16 -s`

Result from the full-model MMMU run:
- `mmmu_val` average accuracy: `40.11`
- test status: `1 passed`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Qwen 3.5 MoE model support with multimodal position handling capabilities.
  * Added automatic model factory registration for improved deployment configuration.

* **Tests**
  * Comprehensive multimodal model test coverage including position computation and caching scenarios.
  * New validation tests for deployment transform initialization and sharding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->