### PR TITLE
[#12116][fix] prevent KVBM hang when requests abort during KV cache transfer

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_connector.py
@@ -519,6 +519,23 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
 
         return saving_async
 
+    def abort_request(self, req: LlmRequest) -> None:
+        """Remove a request from all async tracking structures.
+
+        Must be called when a request is cancelled or fails to prevent
+        worker.get_finished() from blocking on transfers that will never complete.
+
+        Args:
+            req: The request to abort.
+        """
+        req_id = req.request_id
+        for store in (self.new_async_requests, self.pending_async_requests,
+                      self.local_finished_async_requests):
+            store.loading.pop(req_id, None)
+            store.saving.pop(req_id, None)
+        self.scheduler_output_manager.requests.pop(req_id, None)
+        self.scheduler_output_manager.external_loads.pop(req_id, None)
+
     def get_finished(self) -> List[LlmRequest]:
         """
         Process requests that have finished loading and saving.
@@ -533,9 +550,18 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
         self.pending_async_requests.add_from(self.new_async_requests)
 
         # Pass these newly finished requests into get_finished, and get the list of requests that have finished saving and loading.
-        (finished_saving,
-         finished_loading) = self.worker.get_finished(finished_gen_req_ids,
-                                                      started_loading_req_ids)
+        # Wrap in try/except so that a worker failure still reaches the mpi_allgather barrier,
+        # preventing a collective stall where other ranks wait indefinitely for this rank.
+        try:
+            (finished_saving, finished_loading) = self.worker.get_finished(
+                finished_gen_req_ids, started_loading_req_ids)
+        except Exception as e:
+            logger.error(
+                f"KV connector worker get_finished() raised an exception: {e}. "
+                "Reporting no completions this iteration to unblock mpi_allgather."
+            )
+            finished_saving = []
+            finished_loading = []
 
         # Remove the requests from our pending list that have finished locally.
         new_local_finished_async_requests = self.pending_async_requests.extract_by_id(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3175,6 +3175,8 @@ class PyExecutor:
             ]
         self._enqueue_responses(list(error_responses.items()))
         for request in failed_requests:
+            if self.kv_connector_manager is not None:
+                self.kv_connector_manager.abort_request(request)
             self._terminate_request(request)
 
     def _terminate_request(self, request: LlmRequest):
@@ -3202,6 +3204,10 @@ class PyExecutor:
         Returns:
             bool: True if the request can be canceled (either successfully cancelled or doesn't need cancellation).
         """
+        if self.kv_connector_manager is not None:
+            self.kv_connector_manager.abort_request(request)
+            return True
+
         if self.kv_cache_transceiver is None:
             return True
 

--- a/tests/unittest/_torch/test_connector.py
+++ b/tests/unittest/_torch/test_connector.py
@@ -175,6 +175,66 @@ def test_connector_manager_take_scheduled_requests(mpi_pool_executor):
     run_across_mpi(mpi_pool_executor, test, 2)
 
 
+def test_abort_request_cleans_async_state():
+    """Verify abort_request removes a request from all async tracking structures."""
+    worker = MagicMock()
+    scheduler = MagicMock()
+
+    manager = KvCacheConnectorManager(worker, scheduler=scheduler)
+
+    req = MagicMock()
+    req.request_id = 42
+
+    # Manually populate every tracking structure as if a transfer was in flight.
+    for store in (manager.new_async_requests, manager.pending_async_requests,
+                  manager.local_finished_async_requests):
+        store.loading[42] = req
+        store.saving[42] = req
+    manager.scheduler_output_manager.requests[42] = req
+    manager.scheduler_output_manager.external_loads[42] = req
+
+    manager.abort_request(req)
+
+    for store in (manager.new_async_requests, manager.pending_async_requests,
+                  manager.local_finished_async_requests):
+        assert 42 not in store.loading
+        assert 42 not in store.saving
+    assert 42 not in manager.scheduler_output_manager.requests
+    assert 42 not in manager.scheduler_output_manager.external_loads
+
+
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+@pytest.mark.threadleak(enabled=False)
+def test_connector_manager_get_finished_exception_unblocks_allgather(
+        mpi_pool_executor):
+    """Verify that a worker.get_finished() exception on rank 0 does not cause a collective stall."""
+
+    def test():
+        worker = MagicMock()
+
+        if mpi_rank() == 0:
+            scheduler = MagicMock()
+            scheduler.request_finished.return_value = True
+            # Simulate a Rust/KVBM panic on rank 0.
+            worker.get_finished.side_effect = RuntimeError(
+                "simulated KVBM worker failure")
+        else:
+            scheduler = None
+            worker.get_finished.return_value = ([], [])
+
+        manager = KvCacheConnectorManager(worker, scheduler=scheduler)
+
+        req = MagicMock()
+        req.request_id = 42
+        manager.request_finished(req, [])
+
+        # Should not raise, return empty, and both ranks must reach this point.
+        result = manager.get_finished()
+        assert result == []
+
+    run_across_mpi(mpi_pool_executor, test, 2)
+
+
 def test_scheduler_output_num_scheduled_tokens_with_mtp():
     """Test that num_scheduled_tokens is correctly set for MTP (multi-token prediction)."""
     NUM_DRAFT_TOKENS = 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request abort capability to improve resource management and cleanup.

* **Bug Fixes**
  * Enhanced error handling to prevent execution stalls during worker operations.
  * Improved request cancellation with proper system resource cleanup.

* **Tests**
  * Added validation tests for request cleanup and error recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
This PR addresses the root cause of #12116. While it ca be prevented by upstream (fixed by this [PR](https://github.com/ai-dynamo/dynamo/pull/6635)), the engine should not hang if a request fails during an active KV transfer, regardless of the failure reason. This change improves robustness by ensuring failed requests are always cleaned up before worker.get_finished() is called, avoiding the collective stall entirely.

When a request fails (e.g. prompt exceeds `max_seq_len`, GPU OOM, or a KVBM Rust panic), its in-flight async KV transfer state is not cleaned up.
On the next iteration, `worker.get_finished()` on rank 0 blocks indefinitely waiting for a transfer that will never complete. This prevents rank 0 from reaching the `mpi_allgather` barrier, causing a collective stall across all TP ranks. The `HangDetector` fires after 300s and shuts down all ranks.



## Test Coverage

I put 2 new test cases

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
