### PR TITLE
[TRTLLM-11362][feat] Add batch generation support to visual gen pipelines

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -21,7 +21,7 @@ class DiffusionRequest:
     """Request for diffusion inference with explicit model-specific parameters."""
 
     request_id: int
-    prompt: Union[str, List[str]]
+    prompt: List[str]
     negative_prompt: Optional[str] = None
     height: int = 720
     width: int = 1280

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -21,7 +21,7 @@ class DiffusionRequest:
     """Request for diffusion inference with explicit model-specific parameters."""
 
     request_id: int
-    prompt: str
+    prompt: Union[str, List[str]]
     negative_prompt: Optional[str] = None
     height: int = 720
     width: int = 1280

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -260,16 +260,14 @@ class FluxPipeline(BasePipeline):
             max_sequence_length: Maximum text sequence length
 
         Returns:
-            MediaOutput with image tensor (H, W, C) for single prompt,
-            or (B, H, W, C) for multiple prompts.
+            MediaOutput with image tensor (B, H, W, C).
         """
         pipeline_start = time.time()
 
         # Determine batch size
         if isinstance(prompt, str):
-            batch_size = 1
-        else:
-            batch_size = len(prompt)
+            prompt = [prompt]
+        batch_size = len(prompt)
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -347,20 +345,19 @@ class FluxPipeline(BasePipeline):
 
     def _encode_prompt(
         self,
-        prompt: Union[str, List[str]],
+        prompt: List[str],
         max_sequence_length: int,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Encode prompt(s) using CLIP and T5.
 
         Args:
-            prompt: Single prompt string or list of prompts.
+            prompt: List of prompts.
             max_sequence_length: Maximum T5 sequence length.
 
         Returns:
             Tuple of (T5 embeddings [B, seq, dim], CLIP pooled [B, dim],
             text position IDs [seq, 3])
         """
-        prompt = [prompt] if isinstance(prompt, str) else prompt
 
         # CLIP encoding (pooled embeddings)
         clip_inputs = self.tokenizer(
@@ -556,6 +553,4 @@ class FluxPipeline(BasePipeline):
         image = image.permute(0, 2, 3, 1)  # (B, C, H, W) -> (B, H, W, C)
         image = (image * 255).round().to(torch.uint8)
 
-        if batch_size == 1:
-            return image[0]  # (H, W, C) — backward compatible
         return image  # (B, H, W, C)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -333,9 +333,7 @@ class FluxPipeline(BasePipeline):
         # Decode
         logger.info("Decoding image...")
         decode_start = time.time()
-        image = self.decode_latents(
-            latents, lambda lat: self._decode_latents(lat, height, width, batch_size)
-        )
+        image = self.decode_latents(latents, lambda lat: self._decode_latents(lat, height, width))
 
         if self.rank == 0:
             logger.info(f"Image decoded in {time.time() - decode_start:.2f}s")
@@ -524,19 +522,16 @@ class FluxPipeline(BasePipeline):
 
         return latents, latent_ids
 
-    def _decode_latents(
-        self, latents: torch.Tensor, height: int, width: int, batch_size: int = 1
-    ) -> torch.Tensor:
+    def _decode_latents(self, latents: torch.Tensor, height: int, width: int) -> torch.Tensor:
         """Decode latents to image tensor.
 
         Args:
             latents: Packed latents [B, seq, 64].
             height: Output image height.
             width: Output image width.
-            batch_size: Number of images in batch.
 
         Returns:
-            Image tensor (H, W, C) for single image, (B, H, W, C) for batch.
+            Image tensor (B, H, W, C).
         """
         # Unpack latents: (batch, seq_len, channels) -> (batch, channels, h, w)
         latents = self._unpack_latents(latents, height, width)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -4,7 +4,7 @@
 """FLUX.1 Pipeline implementation following WAN pattern."""
 
 import time
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -238,7 +238,7 @@ class FluxPipeline(BasePipeline):
     @torch.inference_mode()
     def forward(
         self,
-        prompt: str,
+        prompt: Union[str, List[str]],
         height: int = 1024,
         width: int = 1024,
         num_inference_steps: int = 50,
@@ -246,21 +246,31 @@ class FluxPipeline(BasePipeline):
         seed: int = 42,
         max_sequence_length: int = 512,
     ):
-        """Generate image from text prompt.
+        """Generate image(s) from text prompt(s).
 
         Args:
-            prompt: Text prompt for image generation
+            prompt: Text prompt or list of prompts for image generation.
+                When a list is provided, generates one image per prompt in a
+                single batched forward pass.
             height: Output image height (default: 1024)
             width: Output image width (default: 1024)
             num_inference_steps: Number of denoising steps (50 for dev, 4 for schnell)
             guidance_scale: Embedded guidance scale (3.5 for dev)
-            seed: Random seed for reproducibility
+            seed: Random seed for reproducibility.
             max_sequence_length: Maximum text sequence length
 
         Returns:
-            MediaOutput with image tensor
+            MediaOutput with image tensor (H, W, C) for single prompt,
+            or (B, H, W, C) for multiple prompts.
         """
         pipeline_start = time.time()
+
+        # Determine batch size
+        if isinstance(prompt, str):
+            batch_size = 1
+        else:
+            batch_size = len(prompt)
+
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
         # Encode prompt
@@ -271,8 +281,7 @@ class FluxPipeline(BasePipeline):
         )
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
 
-        # Prepare latents
-        latents, latent_ids = self._prepare_latents(height, width, generator)
+        latents, latent_ids = self._prepare_latents(batch_size, height, width, generator)
         logger.info(f"Latents shape: {latents.shape}")
 
         # Prepare timesteps with dynamic shifting (FLUX uses mu parameter)
@@ -326,7 +335,9 @@ class FluxPipeline(BasePipeline):
         # Decode
         logger.info("Decoding image...")
         decode_start = time.time()
-        image = self.decode_latents(latents, lambda lat: self._decode_latents(lat, height, width))
+        image = self.decode_latents(
+            latents, lambda lat: self._decode_latents(lat, height, width, batch_size)
+        )
 
         if self.rank == 0:
             logger.info(f"Image decoded in {time.time() - decode_start:.2f}s")
@@ -336,17 +347,18 @@ class FluxPipeline(BasePipeline):
 
     def _encode_prompt(
         self,
-        prompt: str,
+        prompt: Union[str, List[str]],
         max_sequence_length: int,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Encode prompt using CLIP and T5.
+        """Encode prompt(s) using CLIP and T5.
 
         Args:
-            prompt: Text prompt
-            max_sequence_length: Maximum T5 sequence length
+            prompt: Single prompt string or list of prompts.
+            max_sequence_length: Maximum T5 sequence length.
 
         Returns:
-            Tuple of (T5 embeddings, CLIP pooled embeddings, text position IDs)
+            Tuple of (T5 embeddings [B, seq, dim], CLIP pooled [B, dim],
+            text position IDs [seq, 3])
         """
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
@@ -478,33 +490,57 @@ class FluxPipeline(BasePipeline):
 
     def _prepare_latents(
         self,
+        batch_size: int,
         height: int,
         width: int,
         generator: torch.Generator,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Prepare random latents in FLUX packed format and position IDs."""
+        """Prepare random latents in FLUX packed format and position IDs.
+
+        Args:
+            batch_size: Number of images to generate.
+            height: Output image height.
+            width: Output image width.
+            generator: Random generator.
+
+        Returns:
+            Tuple of (latents [B, seq, 64], latent_ids [seq, 3])
+        """
         latent_height = height // self.vae_scale_factor
         latent_width = width // self.vae_scale_factor
 
         # Use VAE channels (16), not transformer channels (64)
         # The packing will convert 16 -> 64
         vae_channels = self.vae.config.latent_channels  # 16
+        shape = (batch_size, vae_channels, latent_height, latent_width)
 
-        # Create random latents in VAE spatial format [B, 16, H, W]
-        shape = (1, vae_channels, latent_height, latent_width)
-        latents = randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
+        latents_4d = randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
-        # Prepare position IDs for packed format
+        # Prepare position IDs for packed format (shared across batch)
         latent_ids = self._prepare_latent_ids(height, width)
         latent_ids = latent_ids.to(self.device)
 
         # Pack latents to FLUX sequence format [B, seq_len, 64]
-        latents = self._pack_latents(latents, 1, vae_channels, latent_height, latent_width)
+        latents = self._pack_latents(
+            latents_4d, batch_size, vae_channels, latent_height, latent_width
+        )
 
         return latents, latent_ids
 
-    def _decode_latents(self, latents: torch.Tensor, height: int, width: int) -> torch.Tensor:
-        """Decode latents to image tensor."""
+    def _decode_latents(
+        self, latents: torch.Tensor, height: int, width: int, batch_size: int = 1
+    ) -> torch.Tensor:
+        """Decode latents to image tensor.
+
+        Args:
+            latents: Packed latents [B, seq, 64].
+            height: Output image height.
+            width: Output image width.
+            batch_size: Number of images in batch.
+
+        Returns:
+            Image tensor (H, W, C) for single image, (B, H, W, C) for batch.
+        """
         # Unpack latents: (batch, seq_len, channels) -> (batch, channels, h, w)
         latents = self._unpack_latents(latents, height, width)
 
@@ -515,9 +551,11 @@ class FluxPipeline(BasePipeline):
         latents = latents.to(self.vae.dtype)
         image = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process to tensor (H, W, C) uint8
+        # Post-process to tensor uint8
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.permute(0, 2, 3, 1)  # (B, C, H, W) -> (B, H, W, C)
         image = (image * 255).round().to(torch.uint8)
 
-        return image[0]  # Remove batch dimension
+        if batch_size == 1:
+            return image[0]  # (H, W, C) — backward compatible
+        return image  # (B, H, W, C)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -353,16 +353,14 @@ class Flux2Pipeline(BasePipeline):
             max_sequence_length: Maximum text sequence length
 
         Returns:
-            MediaOutput with image tensor (H, W, C) for single prompt,
-            or (B, H, W, C) for multiple prompts.
+            MediaOutput with image tensor (B, H, W, C).
         """
         pipeline_start = time.time()
 
         # Determine batch size
         if isinstance(prompt, str):
-            batch_size = 1
-        else:
-            batch_size = len(prompt)
+            prompt = [prompt]
+        batch_size = len(prompt)
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -438,7 +436,7 @@ class Flux2Pipeline(BasePipeline):
 
     def _encode_prompt(
         self,
-        prompt: Union[str, List[str]],
+        prompt: List[str],
         max_sequence_length: int,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Encode prompt(s) using multi-layer hidden state extraction.
@@ -448,13 +446,12 @@ class Flux2Pipeline(BasePipeline):
         - Qwen3: simple user message + Qwen2TokenizerFast chat template
 
         Args:
-            prompt: Single prompt string or list of prompts.
+            prompt: List of prompts.
             max_sequence_length: Maximum text sequence length.
 
         Returns:
             Tuple of (prompt_embeds [B, seq, dim], text_ids [seq, 4])
         """
-        prompt = [prompt] if isinstance(prompt, str) else prompt
 
         # Tokenize (format depends on text encoder type)
         text_encoder_class = getattr(
@@ -700,6 +697,4 @@ class Flux2Pipeline(BasePipeline):
         image = image.permute(0, 2, 3, 1)  # (B, C, H, W) -> (B, H, W, C)
         image = (image * 255).round().to(torch.uint8)
 
-        if batch_size == 1:
-            return image[0]  # (H, W, C) — backward compatible
         return image  # (B, H, W, C)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -424,9 +424,7 @@ class Flux2Pipeline(BasePipeline):
         # Decode
         logger.info("Decoding image...")
         decode_start = time.time()
-        image = self.decode_latents(
-            latents, lambda lat: self._decode_latents(lat, latent_ids, batch_size)
-        )
+        image = self.decode_latents(latents, lambda lat: self._decode_latents(lat, latent_ids))
 
         if self.rank == 0:
             logger.info(f"Image decoded in {time.time() - decode_start:.2f}s")
@@ -659,17 +657,15 @@ class Flux2Pipeline(BasePipeline):
         self,
         latents: torch.Tensor,
         latent_ids: torch.Tensor,
-        batch_size: int = 1,
     ) -> torch.Tensor:
         """Decode latents to image tensor.
 
         Args:
             latents: Packed latents [B, seq, C].
             latent_ids: Position IDs [seq, 4].
-            batch_size: Number of images in batch.
 
         Returns:
-            Image tensor (H, W, C) for single image, (B, H, W, C) for batch.
+            Image tensor (B, H, W, C).
         """
         # Unpack latents using position IDs
         latents = self._unpack_latents_with_ids(latents, latent_ids)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -21,7 +21,7 @@ Key differences from FLUX.1:
 import json
 import os
 import time
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -331,7 +331,7 @@ class Flux2Pipeline(BasePipeline):
     @torch.inference_mode()
     def forward(
         self,
-        prompt: str,
+        prompt: Union[str, List[str]],
         height: int = 1024,
         width: int = 1024,
         num_inference_steps: int = 50,
@@ -339,21 +339,31 @@ class Flux2Pipeline(BasePipeline):
         seed: int = 42,
         max_sequence_length: int = 512,
     ):
-        """Generate image from text prompt.
+        """Generate image(s) from text prompt(s).
 
         Args:
-            prompt: Text prompt for image generation
+            prompt: Text prompt or list of prompts for image generation.
+                When a list is provided, generates one image per prompt in a
+                single batched forward pass.
             height: Output image height (default: 1024)
             width: Output image width (default: 1024)
             num_inference_steps: Number of denoising steps
             guidance_scale: Embedded guidance scale
-            seed: Random seed for reproducibility
+            seed: Random seed for reproducibility.
             max_sequence_length: Maximum text sequence length
 
         Returns:
-            Dict with "image" key containing PIL.Image
+            MediaOutput with image tensor (H, W, C) for single prompt,
+            or (B, H, W, C) for multiple prompts.
         """
         pipeline_start = time.time()
+
+        # Determine batch size
+        if isinstance(prompt, str):
+            batch_size = 1
+        else:
+            batch_size = len(prompt)
+
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
         # Encode prompt using Mistral3 multi-layer extraction
@@ -362,8 +372,7 @@ class Flux2Pipeline(BasePipeline):
         prompt_embeds, text_ids = self._encode_prompt(prompt, max_sequence_length)
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
 
-        # Prepare latents
-        latents, latent_ids = self._prepare_latents(height, width, generator)
+        latents, latent_ids = self._prepare_latents(batch_size, height, width, generator)
         logger.info(f"Latents shape: {latents.shape}")
 
         # Prepare timesteps with dynamic shifting
@@ -417,7 +426,9 @@ class Flux2Pipeline(BasePipeline):
         # Decode
         logger.info("Decoding image...")
         decode_start = time.time()
-        image = self.decode_latents(latents, lambda lat: self._decode_latents(lat, latent_ids))
+        image = self.decode_latents(
+            latents, lambda lat: self._decode_latents(lat, latent_ids, batch_size)
+        )
 
         if self.rank == 0:
             logger.info(f"Image decoded in {time.time() - decode_start:.2f}s")
@@ -427,17 +438,21 @@ class Flux2Pipeline(BasePipeline):
 
     def _encode_prompt(
         self,
-        prompt: str,
+        prompt: Union[str, List[str]],
         max_sequence_length: int,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Encode prompt using multi-layer hidden state extraction.
+        """Encode prompt(s) using multi-layer hidden state extraction.
 
         Supports both text encoder types:
         - Mistral3: system message + PixtralProcessor chat template
         - Qwen3: simple user message + Qwen2TokenizerFast chat template
 
+        Args:
+            prompt: Single prompt string or list of prompts.
+            max_sequence_length: Maximum text sequence length.
+
         Returns:
-            Tuple of (prompt_embeds, text_ids)
+            Tuple of (prompt_embeds [B, seq, dim], text_ids [seq, 4])
         """
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
@@ -565,19 +580,29 @@ class Flux2Pipeline(BasePipeline):
 
     def _prepare_latents(
         self,
+        batch_size: int,
         height: int,
         width: int,
         generator: torch.Generator,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Prepare random latents in FLUX.2 packed format and position IDs."""
+        """Prepare random latents in FLUX.2 packed format and position IDs.
+
+        Args:
+            batch_size: Number of images to generate.
+            height: Output image height.
+            width: Output image width.
+            generator: Random generator.
+
+        Returns:
+            Tuple of (latents [B, seq, C], latent_ids [seq, 4])
+        """
         # FLUX.2: in_channels=128, VAE scale=8, 2x2 packing
         latent_height = 2 * (height // (self.vae_scale_factor * 2))
         latent_width = 2 * (width // (self.vae_scale_factor * 2))
 
         in_channels = self.transformer.config.in_channels  # 128
+        latent_shape = (batch_size, in_channels, latent_height // 2, latent_width // 2)
 
-        # Create 4D latents then pack (matches HF for seed reproducibility)
-        latent_shape = (1, in_channels, latent_height // 2, latent_width // 2)
         latents_4d = randn_tensor(
             latent_shape, generator=generator, device=self.device, dtype=self.dtype
         )
@@ -585,7 +610,7 @@ class Flux2Pipeline(BasePipeline):
         # Pack latents: [B, C, H, W] -> [B, H*W, C]
         latents = self._pack_latents(latents_4d)
 
-        # Prepare position IDs
+        # Prepare position IDs (shared across batch)
         latent_ids = self._prepare_latent_ids(height, width)
 
         return latents, latent_ids
@@ -633,8 +658,22 @@ class Flux2Pipeline(BasePipeline):
 
         return latents
 
-    def _decode_latents(self, latents: torch.Tensor, latent_ids: torch.Tensor) -> torch.Tensor:
-        """Decode latents to image tensor."""
+    def _decode_latents(
+        self,
+        latents: torch.Tensor,
+        latent_ids: torch.Tensor,
+        batch_size: int = 1,
+    ) -> torch.Tensor:
+        """Decode latents to image tensor.
+
+        Args:
+            latents: Packed latents [B, seq, C].
+            latent_ids: Position IDs [seq, 4].
+            batch_size: Number of images in batch.
+
+        Returns:
+            Image tensor (H, W, C) for single image, (B, H, W, C) for batch.
+        """
         # Unpack latents using position IDs
         latents = self._unpack_latents_with_ids(latents, latent_ids)
 
@@ -656,9 +695,11 @@ class Flux2Pipeline(BasePipeline):
         latents = latents.to(self.vae.dtype)
         image = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process to tensor (H, W, C) uint8
+        # Post-process to tensor uint8
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.permute(0, 2, 3, 1)  # (B, C, H, W) -> (B, H, W, C)
         image = (image * 255).round().to(torch.uint8)
 
-        return image[0]  # Remove batch dimension
+        if batch_size == 1:
+            return image[0]  # (H, W, C) — backward compatible
+        return image  # (B, H, W, C)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -1402,7 +1402,7 @@ class LTX2Pipeline(BasePipeline):
                 )
             )
             video = torch.cat(chunks, dim=2)
-            video = postprocess_video_tensor(video, remove_batch_dim=True)
+            video = postprocess_video_tensor(video)
             return video
 
         def decode_audio_fn(aud_latents):

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional
+from typing import List, Optional, Union
 
 import diffusers
 import torch
@@ -314,7 +314,7 @@ class WanPipeline(BasePipeline):
     @torch.no_grad()
     def forward(
         self,
-        prompt: str,
+        prompt: Union[str, List[str]],
         negative_prompt: Optional[str] = None,
         height: int = 720,
         width: int = 1280,
@@ -327,6 +327,13 @@ class WanPipeline(BasePipeline):
         max_sequence_length: int = 512,
     ):
         pipeline_start = time.time()
+
+        # Determine batch size
+        if isinstance(prompt, str):
+            batch_size = 1
+        else:
+            batch_size = len(prompt)
+
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
         # Use user-provided boundary_ratio if given, otherwise fall back to model config
@@ -377,7 +384,7 @@ class WanPipeline(BasePipeline):
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
 
         # Prepare Latents
-        latents = self._prepare_latents(height, width, num_frames, generator)
+        latents = self._prepare_latents(batch_size, height, width, num_frames, generator)
         logger.debug(f"Latents shape: {latents.shape}")
 
         self.scheduler.set_timesteps(num_inference_steps, device=self.device)
@@ -477,7 +484,7 @@ class WanPipeline(BasePipeline):
         # Decode
         logger.info("Decoding video...")
         decode_start = time.time()
-        video = self.decode_latents(latents, self._decode_latents)
+        video = self.decode_latents(latents, lambda lat: self._decode_latents(lat, batch_size))
 
         if self.rank == 0:
             logger.info(f"Video decoded in {time.time() - decode_start:.2f}s")
@@ -486,7 +493,12 @@ class WanPipeline(BasePipeline):
         return MediaOutput(video=video)
 
     @nvtx_range("_encode_prompt", color="blue")
-    def _encode_prompt(self, prompt, negative_prompt, max_sequence_length):
+    def _encode_prompt(
+        self,
+        prompt: Union[str, List[str]],
+        negative_prompt: Optional[str],
+        max_sequence_length: int,
+    ):
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
         def get_embeds(texts):
@@ -534,21 +546,31 @@ class WanPipeline(BasePipeline):
         return prompt_embeds, neg_embeds
 
     @nvtx_range("_prepare_latents", color="blue")
-    def _prepare_latents(self, height, width, num_frames, generator):
+    def _prepare_latents(
+        self,
+        batch_size: int,
+        height: int,
+        width: int,
+        num_frames: int,
+        generator: torch.Generator,
+    ) -> torch.Tensor:
+        """Prepare random latents for video generation."""
         num_channels_latents = 16
         num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
 
         shape = (
-            1,
+            batch_size,
             num_channels_latents,
             num_latent_frames,
             height // self.vae_scale_factor_spatial,
             width // self.vae_scale_factor_spatial,
         )
+
         return randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
     @nvtx_range("_decode_latents", color="blue")
-    def _decode_latents(self, latents):
+    def _decode_latents(self, latents: torch.Tensor, batch_size: int = 1) -> torch.Tensor:
+        """Decode latents to video tensor."""
         latents = latents.to(self.vae.dtype)
 
         # Denormalization
@@ -572,7 +594,8 @@ class WanPipeline(BasePipeline):
         # VAE decode: returns (B, C, T, H, W)
         video = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process video tensor: (B, C, T, H, W) -> (T, H, W, C) uint8
-        video = postprocess_video_tensor(video, remove_batch_dim=True)
+        # Post-process video tensor
+        # (B, C, T, H, W) -> (T, H, W, C) for batch=1, (B, T, H, W, C) for batch>1
+        video = postprocess_video_tensor(video, remove_batch_dim=(batch_size == 1))
 
         return video

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -483,7 +483,7 @@ class WanPipeline(BasePipeline):
         # Decode
         logger.info("Decoding video...")
         decode_start = time.time()
-        video = self.decode_latents(latents, lambda lat: self._decode_latents(lat, batch_size))
+        video = self.decode_latents(latents, self._decode_latents)
 
         if self.rank == 0:
             logger.info(f"Video decoded in {time.time() - decode_start:.2f}s")
@@ -566,7 +566,7 @@ class WanPipeline(BasePipeline):
         return randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
     @nvtx_range("_decode_latents", color="blue")
-    def _decode_latents(self, latents: torch.Tensor, batch_size: int = 1) -> torch.Tensor:
+    def _decode_latents(self, latents: torch.Tensor) -> torch.Tensor:
         """Decode latents to video tensor."""
         latents = latents.to(self.vae.dtype)
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -330,9 +330,8 @@ class WanPipeline(BasePipeline):
 
         # Determine batch size
         if isinstance(prompt, str):
-            batch_size = 1
-        else:
-            batch_size = len(prompt)
+            prompt = [prompt]
+        batch_size = len(prompt)
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -495,12 +494,10 @@ class WanPipeline(BasePipeline):
     @nvtx_range("_encode_prompt", color="blue")
     def _encode_prompt(
         self,
-        prompt: Union[str, List[str]],
+        prompt: List[str],
         negative_prompt: Optional[str],
         max_sequence_length: int,
     ):
-        prompt = [prompt] if isinstance(prompt, str) else prompt
-
         def get_embeds(texts):
             text_inputs = self.tokenizer(
                 texts,
@@ -594,8 +591,7 @@ class WanPipeline(BasePipeline):
         # VAE decode: returns (B, C, T, H, W)
         video = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process video tensor
-        # (B, C, T, H, W) -> (T, H, W, C) for batch=1, (B, T, H, W, C) for batch>1
-        video = postprocess_video_tensor(video, remove_batch_dim=(batch_size == 1))
+        # Post-process video tensor: (B, C, T, H, W) -> (B, T, H, W, C)
+        video = postprocess_video_tensor(video)
 
         return video

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -416,14 +416,13 @@ class WanImageToVideoPipeline(BasePipeline):
 
         # Determine batch size
         if isinstance(prompt, str):
-            batch_size = 1
-        else:
-            batch_size = len(prompt)
-            if batch_size > 1:
-                logger.info(
-                    f"Batch generation: {batch_size} prompts with a single input image. "
-                    "All videos will be conditioned on the same image."
-                )
+            prompt = [prompt]
+        batch_size = len(prompt)
+        if batch_size > 1:
+            logger.info(
+                f"Batch generation: {batch_size} prompts with a single input image. "
+                "All videos will be conditioned on the same image."
+            )
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -656,9 +655,8 @@ class WanImageToVideoPipeline(BasePipeline):
 
         return MediaOutput(video=video)
 
-    def _encode_prompt(self, prompt, negative_prompt, max_sequence_length):
+    def _encode_prompt(self, prompt: List[str], negative_prompt, max_sequence_length):
         """Encode text prompts to embeddings (same as T2V)."""
-        prompt = [prompt] if isinstance(prompt, str) else prompt
 
         def get_embeds(texts):
             text_inputs = self.tokenizer(
@@ -855,8 +853,7 @@ class WanImageToVideoPipeline(BasePipeline):
         # VAE decode: returns (B, C, T, H, W)
         video = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process video tensor
-        # (B, C, T, H, W) -> (T, H, W, C) for batch=1, (B, T, H, W, C) for batch>1
-        video = postprocess_video_tensor(video, remove_batch_dim=(batch_size == 1))
+        # Post-process video tensor: (B, C, T, H, W) -> (B, T, H, W, C)
+        video = postprocess_video_tensor(video)
 
         return video

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -647,7 +647,7 @@ class WanImageToVideoPipeline(BasePipeline):
         # Decode
         logger.info("Decoding video...")
         decode_start = time.time()
-        video = self.decode_latents(latents, lambda lat: self._decode_latents(lat, batch_size))
+        video = self.decode_latents(latents, self._decode_latents)
 
         if self.rank == 0:
             logger.info(f"Video decoded in {time.time() - decode_start:.2f}s")
@@ -828,7 +828,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
         return latents, condition
 
-    def _decode_latents(self, latents, batch_size=1):
+    def _decode_latents(self, latents):
         """Decode latents to video."""
         latents = latents.to(self.vae.dtype)
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import diffusers
 import PIL.Image
@@ -391,7 +391,7 @@ class WanImageToVideoPipeline(BasePipeline):
     def forward(
         self,
         image: Union[PIL.Image.Image, torch.Tensor, str],
-        prompt: str,
+        prompt: Union[str, List[str]],
         negative_prompt: Optional[str] = None,
         height: int = 480,
         width: int = 832,
@@ -405,6 +405,26 @@ class WanImageToVideoPipeline(BasePipeline):
         last_image: Optional[Union[PIL.Image.Image, torch.Tensor, str]] = None,
     ):
         pipeline_start = time.time()
+
+        # Validate image input — only single image is supported for batch generation
+        if not isinstance(image, (PIL.Image.Image, torch.Tensor, str)):
+            raise ValueError(
+                f"`image` must be a PIL.Image, torch.Tensor, or file path string, "
+                f"got {type(image)}. Batch of different images is not supported; "
+                f"use a single image with multiple prompts instead."
+            )
+
+        # Determine batch size
+        if isinstance(prompt, str):
+            batch_size = 1
+        else:
+            batch_size = len(prompt)
+            if batch_size > 1:
+                logger.info(
+                    f"Batch generation: {batch_size} prompts with a single input image. "
+                    "All videos will be conditioned on the same image."
+                )
+
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
         # Use user-provided boundary_ratio if given, otherwise fall back to model config
@@ -491,6 +511,9 @@ class WanImageToVideoPipeline(BasePipeline):
             # Wan 2.1 I2V: Compute CLIP image embeddings
             image_embeds = self._encode_image(image, last_image)
             image_embeds = image_embeds.to(self.dtype)
+            # Repeat for batch: single image, multiple prompts
+            if batch_size > 1:
+                image_embeds = image_embeds.repeat(batch_size, 1, 1)
         else:
             # Wan 2.2 I2V: No image embeddings needed
             image_embeds = None
@@ -499,7 +522,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
         # Prepare Latents with image conditioning (I2V-specific)
         latents, condition_data = self._prepare_latents(
-            image, height, width, num_frames, generator, last_image
+            batch_size, image, height, width, num_frames, generator, last_image
         )
 
         self.scheduler.set_timesteps(num_inference_steps, device=self.device)
@@ -559,11 +582,20 @@ class WanImageToVideoPipeline(BasePipeline):
             # Forward pass with I2V conditioning
             # Wan 2.1: image_embeds is not None (CLIP embeddings)
             # Wan 2.2 14B: image_embeds is None (no CLIP)
+            # Handle CFG: duplicate image_embeds if batch dimension doubled
+            image_embeds_to_use = image_embeds
+            if (
+                image_embeds_to_use is not None
+                and latents_input.shape[0] != image_embeds_to_use.shape[0]
+            ):
+                repeat_factor = latents_input.shape[0] // image_embeds_to_use.shape[0]
+                image_embeds_to_use = image_embeds_to_use.repeat(repeat_factor, 1, 1)
+
             return current_model(
                 hidden_states=latent_model_input,
                 timestep=timestep_input,
                 encoder_hidden_states=encoder_hidden_states,
-                encoder_hidden_states_image=image_embeds,
+                encoder_hidden_states_image=image_embeds_to_use,
             )
 
         # Two-stage denoising: model switching in forward_fn, guidance scale switching in denoise()
@@ -616,7 +648,7 @@ class WanImageToVideoPipeline(BasePipeline):
         # Decode
         logger.info("Decoding video...")
         decode_start = time.time()
-        video = self.decode_latents(latents, self._decode_latents)
+        video = self.decode_latents(latents, lambda lat: self._decode_latents(lat, batch_size))
 
         if self.rank == 0:
             logger.info(f"Video decoded in {time.time() - decode_start:.2f}s")
@@ -694,6 +726,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
     def _prepare_latents(
         self,
+        batch_size: int,
         image: Union[PIL.Image.Image, torch.Tensor, str],
         height: int,
         width: int,
@@ -707,8 +740,7 @@ class WanImageToVideoPipeline(BasePipeline):
         latent_height = height // self.vae_scale_factor_spatial
         latent_width = width // self.vae_scale_factor_spatial
 
-        # Create random noise latents
-        shape = (1, num_channels_latents, num_latent_frames, latent_height, latent_width)
+        shape = (batch_size, num_channels_latents, num_latent_frames, latent_height, latent_width)
         latents = randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
         # Load and preprocess image(s)
@@ -791,10 +823,15 @@ class WanImageToVideoPipeline(BasePipeline):
 
         # Concatenate mask and condition along channel dimension
         condition = torch.cat([mask_lat_size, latent_condition], dim=1)
+
+        # Repeat condition for batch (single image, multiple prompts)
+        if batch_size > 1:
+            condition = condition.repeat(batch_size, 1, 1, 1, 1)
+
         return latents, condition
 
-    def _decode_latents(self, latents):
-        """Decode latents to video (same as T2V)."""
+    def _decode_latents(self, latents, batch_size=1):
+        """Decode latents to video."""
         latents = latents.to(self.vae.dtype)
 
         # Denormalization
@@ -818,7 +855,8 @@ class WanImageToVideoPipeline(BasePipeline):
         # VAE decode: returns (B, C, T, H, W)
         video = self.vae.decode(latents, return_dict=False)[0]
 
-        # Post-process video tensor: (B, C, T, H, W) -> (T, H, W, C) uint8
-        video = postprocess_video_tensor(video, remove_batch_dim=True)
+        # Post-process video tensor
+        # (B, C, T, H, W) -> (T, H, W, C) for batch=1, (B, T, H, W, C) for batch>1
+        video = postprocess_video_tensor(video, remove_batch_dim=(batch_size == 1))
 
         return video

--- a/tensorrt_llm/_torch/visual_gen/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/utils.py
@@ -4,7 +4,7 @@ import torch
 
 
 @torch.compile
-def postprocess_video_tensor(video: torch.Tensor, remove_batch_dim: bool = True) -> torch.Tensor:
+def postprocess_video_tensor(video: torch.Tensor) -> torch.Tensor:
     """Post-process video tensor from VAE decoder output to final format.
 
     This is a more efficient implementation than using VideoProcessor for single-batch cases,
@@ -12,13 +12,9 @@ def postprocess_video_tensor(video: torch.Tensor, remove_batch_dim: bool = True)
 
     Args:
         video: Video tensor in (B, C, T, H, W) format from VAE decoder
-        remove_batch_dim: Whether to remove batch dimension. Default True for typical
-                         single-batch video generation.
 
     Returns:
-        Post-processed video tensor:
-        - If remove_batch_dim=True: (T, H, W, C) uint8 tensor
-        - If remove_batch_dim=False: (B, T, H, W, C) uint8 tensor
+        Post-processed video tensor in (B, T, H, W, C) uint8 format.
 
     Note:
         Assumes video values are in [-1, 1] range (standard VAE decoder output).
@@ -31,10 +27,6 @@ def postprocess_video_tensor(video: torch.Tensor, remove_batch_dim: bool = True)
 
     # Convert to uint8
     video = (video * 255).round().to(torch.uint8)
-
-    # Remove batch dimension if requested
-    if remove_batch_dim:
-        video = video[0]  # (B, T, H, W, C) -> (T, H, W, C)
 
     return video
 

--- a/tensorrt_llm/llmapi/visual_gen.py
+++ b/tensorrt_llm/llmapi/visual_gen.py
@@ -540,8 +540,31 @@ class VisualGen:
         elif isinstance(inputs, str):
             prompt = inputs
             negative_prompt = None
+        elif isinstance(inputs, (list, tuple)):
+            # Batch generation: list of prompts
+            if not inputs:
+                raise ValueError("Batch inputs must contain at least one item")
+
+            prompt = []
+            negative_prompts = []
+            for idx, inp in enumerate(inputs):
+                if isinstance(inp, str):
+                    prompt.append(inp)
+                    negative_prompts.append(None)
+                elif isinstance(inp, dict):
+                    item_prompt = inp.get("prompt")
+                    if item_prompt is None:
+                        raise ValueError(f"Batch input at index {idx} is missing 'prompt'")
+                    prompt.append(item_prompt)
+                    negative_prompts.append(inp.get("negative_prompt"))
+                else:
+                    raise ValueError(f"Invalid batch item type at index {idx}: {type(inp)}")
+
+            unique_negatives = {p for p in negative_prompts if p is not None}
+            if len(unique_negatives) > 1:
+                raise ValueError("Per-item negative_prompt is not supported for batch inputs")
+            negative_prompt = next(iter(unique_negatives), None)
         else:
-            # TODO: Support batch generation
             raise ValueError(f"Invalid inputs type: {type(inputs)}")
 
         request = DiffusionRequest(

--- a/tensorrt_llm/llmapi/visual_gen.py
+++ b/tensorrt_llm/llmapi/visual_gen.py
@@ -534,11 +534,13 @@ class VisualGen:
         req_id = self.req_counter
         self.req_counter += 1
 
+        # Normalize inputs to (prompt: List[str], negative_prompt: Optional[str])
+        # so DiffusionRequest.prompt is always a list.
         if isinstance(inputs, dict):
-            prompt = inputs.get("prompt")
+            prompt = [inputs.get("prompt")]
             negative_prompt = inputs.get("negative_prompt", None)
         elif isinstance(inputs, str):
-            prompt = inputs
+            prompt = [inputs]
             negative_prompt = None
         elif isinstance(inputs, (list, tuple)):
             # Batch generation: list of prompts

--- a/tensorrt_llm/serve/media_storage.py
+++ b/tensorrt_llm/serve/media_storage.py
@@ -517,7 +517,7 @@ class MediaStorage:
         """Save image to file.
 
         Args:
-            image: torch.Tensor (H, W, C) uint8
+            image: torch.Tensor (B, H, W, C) or (H, W, C) uint8
             output_path: Path to save the image
             format: Image format (png, jpg, webp). If None, infer from extension
             quality: Quality for lossy formats (1-100, higher is better)
@@ -525,6 +525,9 @@ class MediaStorage:
         Returns:
             Path where the image was saved
         """
+        # Extract first image from batch if needed
+        if hasattr(image, "dim") and image.dim() == 4:
+            image = image[0]
         # Ensure output directory exists
         output_dir = os.path.dirname(output_path)
         if output_dir:
@@ -634,7 +637,7 @@ class MediaStorage:
         """Save video to file with optional audio.
 
         Args:
-            video: Video frames as torch.Tensor (T, H, W, C) uint8
+            video: Video frames as torch.Tensor (B, T, H, W, C) or (T, H, W, C) uint8
             output_path: Path to save the video
             audio: Optional audio as torch.Tensor
             frame_rate: Frames per second (default: 24.0)
@@ -643,6 +646,9 @@ class MediaStorage:
         Returns:
             Path where the video was saved
         """
+        # Extract first video from batch if needed
+        if hasattr(video, "dim") and video.dim() == 5:
+            video = video[0]
         # Ensure output directory exists
         if isinstance(output_path, Path):
             output_path = str(output_path)

--- a/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
@@ -727,7 +727,7 @@ class TestFluxE2E:
             guidance_scale=3.5,
             seed=42,
         )
-        native_image = result.image.cpu().numpy()  # (H, W, 3) uint8
+        native_image = result.image[0].cpu().numpy()  # (H, W, 3) uint8
 
         # 4. Compute PSNR
         mse = ((hf_image.astype(float) - native_image.astype(float)) ** 2).mean()
@@ -780,7 +780,7 @@ class TestFluxE2E:
             guidance_scale=3.5,
             seed=42,
         )
-        native_image = result.image.cpu().numpy()  # (H, W, 3) uint8
+        native_image = result.image[0].cpu().numpy()  # (H, W, 3) uint8
 
         # 4. Compute PSNR
         mse = ((hf_image.astype(float) - native_image.astype(float)) ** 2).mean()
@@ -858,7 +858,8 @@ class TestFluxBatchGeneration:
             num_inference_steps=4,
             seed=42,
         )
-        assert single.image.dim() == 3, f"Expected 3D, got {single.image.shape}"
+        assert single.image.dim() == 4, f"Expected 4D, got {single.image.shape}"
+        assert single.image.shape[0] == 1
 
         # Batch prompts → (B, H, W, C)
         batch = flux1_pipeline.forward(

--- a/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
@@ -25,7 +25,12 @@ import torch.multiprocessing as mp
 import torch.nn.functional as F
 
 from tensorrt_llm._torch.modules.linear import Linear
-from tensorrt_llm._torch.visual_gen.config import AttentionConfig, PipelineConfig, VisualGenArgs
+from tensorrt_llm._torch.visual_gen.config import (
+    AttentionConfig,
+    PipelineConfig,
+    TorchCompileConfig,
+    VisualGenArgs,
+)
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 
 
@@ -704,7 +709,7 @@ class TestFluxE2E:
         gc.collect()
         torch.cuda.empty_cache()
 
-        # 2. Load TRT-LLM pipeline (full, no skip_components)
+        # 2. Load TRT-LLM pipeline
         args = VisualGenArgs(
             checkpoint_path=FLUX1_CHECKPOINT_PATH,
             device="cuda",
@@ -757,7 +762,7 @@ class TestFluxE2E:
         gc.collect()
         torch.cuda.empty_cache()
 
-        # 2. Load TRT-LLM pipeline (full, no skip_components)
+        # 2. Load TRT-LLM pipeline
         args = VisualGenArgs(
             checkpoint_path=FLUX2_CHECKPOINT_PATH,
             device="cuda",
@@ -788,6 +793,104 @@ class TestFluxE2E:
         del pipeline
         gc.collect()
         torch.cuda.empty_cache()
+
+
+class TestFluxBatchGeneration:
+    """Batch generation tests for FLUX pipelines.
+
+    Uses class-scoped fixtures to avoid redundant model loads across batch tests.
+    Separated from TestFluxE2E because HF+TRT-LLM pipelines don't fit in memory
+    simultaneously for large models (FLUX.2).
+    """
+
+    @pytest.fixture(scope="class")
+    def flux1_pipeline(self):
+        """Load FLUX.1 TRT-LLM pipeline once for all FLUX.1 batch tests."""
+        if not FLUX1_CHECKPOINT_PATH or not os.path.exists(FLUX1_CHECKPOINT_PATH):
+            pytest.skip(
+                f"FLUX.1 checkpoint not found at {FLUX1_CHECKPOINT_PATH}. "
+                "Set FLUX1_MODEL_PATH or LLM_MODELS_ROOT."
+            )
+        args = VisualGenArgs(
+            checkpoint_path=FLUX1_CHECKPOINT_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+            pipeline=PipelineConfig(),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        yield pipeline
+        del pipeline
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.fixture(scope="class")
+    def flux2_pipeline(self):
+        """Load FLUX.2 TRT-LLM pipeline once for all FLUX.2 batch tests."""
+        if not FLUX2_CHECKPOINT_PATH or not os.path.exists(FLUX2_CHECKPOINT_PATH):
+            pytest.skip(
+                f"FLUX.2 checkpoint not found at {FLUX2_CHECKPOINT_PATH}. "
+                "Set FLUX2_MODEL_PATH or LLM_MODELS_ROOT."
+            )
+        args = VisualGenArgs(
+            checkpoint_path=FLUX2_CHECKPOINT_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+            pipeline=PipelineConfig(),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        yield pipeline
+        del pipeline
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux1_batch_generation(self, flux1_pipeline):
+        """FLUX.1 batch generation: list of prompts produces (B, H, W, C) output."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+
+        # Single prompt → (H, W, C)
+        single = flux1_pipeline.forward(
+            prompt=prompts[0],
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+        )
+        assert single.image.dim() == 3, f"Expected 3D, got {single.image.shape}"
+
+        # Batch prompts → (B, H, W, C)
+        batch = flux1_pipeline.forward(
+            prompt=prompts,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+        )
+        assert batch.image.dim() == 4, f"Expected 4D, got {batch.image.shape}"
+        assert batch.image.shape[0] == 2
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux2_batch_generation(self, flux2_pipeline):
+        """FLUX.2 batch generation: list of prompts produces (B, H, W, C) output."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+
+        # Batch prompts → (B, H, W, C)
+        batch = flux2_pipeline.forward(
+            prompt=prompts,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+        )
+        assert batch.image.dim() == 4, f"Expected 4D, got {batch.image.shape}"
+        assert batch.image.shape == (2, 256, 256, 3), f"Unexpected shape: {batch.image.shape}"
+
+        # Verify per-sample seeding: images should differ (different prompts + seeds)
+        mse = ((batch.image[0].float() - batch.image[1].float()) ** 2).mean().item()
+        assert mse > 100, f"Batch images are too similar (MSE={mse:.1f}), seeding may be broken"
+        print(f"\n[Batch FLUX.2] Inter-image MSE = {mse:.1f} (images differ as expected)")
 
 
 # =============================================================================

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -413,5 +413,75 @@ class TestLTX2AttentionBackend:
         torch.cuda.empty_cache()
 
 
+# ============================================================================
+# Batch Support Unit Tests (no model loading required)
+# ============================================================================
+
+
+class TestLTX2BatchSupport:
+    """Test batch support logic without loading the full pipeline."""
+
+    def test_video_pixel_shape_batch_propagation(self):
+        """VideoPixelShape(batch=N) propagates through VideoLatentShape."""
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.types import (
+            VideoLatentShape,
+            VideoPixelShape,
+        )
+
+        for batch_size in [1, 2, 4]:
+            pixel_shape = VideoPixelShape(
+                batch=batch_size, frames=9, height=512, width=768, fps=24.0
+            )
+            video_shape = VideoLatentShape.from_pixel_shape(pixel_shape, latent_channels=128)
+            assert video_shape.batch == batch_size
+            torch_shape = video_shape.to_torch_shape()
+            assert torch_shape[0] == batch_size
+
+    def test_prompt_normalization(self):
+        """forward() normalizes str prompt to List[str] and computes batch_size."""
+        # Simulate the normalization logic from forward()
+        for prompt_input, expected_batch in [
+            ("a cat", 1),
+            (["a cat"], 1),
+            (["a cat", "a dog"], 2),
+        ]:
+            prompt = prompt_input
+            if isinstance(prompt, str):
+                prompt = [prompt]
+            assert len(prompt) == expected_batch
+
+    def test_negative_prompt_expansion(self):
+        """Negative prompt is expanded to match batch_size."""
+        # Simulate the negative prompt expansion logic from forward()
+        for neg_input, batch_size, expected_len in [
+            ("bad quality", 1, 1),
+            ("bad quality", 3, 3),
+            (["bad quality"], 3, 3),
+            (["bad 1", "bad 2", "bad 3"], 3, 3),
+        ]:
+            negative_prompt = neg_input
+            if isinstance(negative_prompt, str):
+                neg_prompt_list = [negative_prompt] * batch_size
+            else:
+                neg_prompt_list = list(negative_prompt)
+                if len(neg_prompt_list) == 1 and batch_size > 1:
+                    neg_prompt_list = neg_prompt_list * batch_size
+            assert len(neg_prompt_list) == expected_len
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_latent_shape_matches_batch(self):
+        """Latents created from VideoLatentShape have correct batch dim."""
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.types import (
+            VideoLatentShape,
+            VideoPixelShape,
+        )
+
+        batch_size = 2
+        pixel_shape = VideoPixelShape(batch=batch_size, frames=9, height=512, width=768, fps=24.0)
+        video_shape = VideoLatentShape.from_pixel_shape(pixel_shape, latent_channels=128)
+        latents = torch.randn(video_shape.to_torch_shape(), device="cuda", dtype=torch.float32)
+        assert latents.shape[0] == batch_size
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -185,7 +185,7 @@ class TestVisualGenArgsPickle:
 
 
 # =============================================================================
-# Batch Generation Input Parsing (TRTLLM-11362)
+# Batch Generation Input Parsing
 # =============================================================================
 
 

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -4,6 +4,7 @@
 """Tests for VisualGenArgs construction, validation, and serialization."""
 
 import pickle
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -181,3 +182,160 @@ class TestVisualGenArgsPickle:
         updated = args.model_copy(update={"device": "cuda:3"})
         assert updated.device == "cuda:3"
         assert args.device == "cuda"
+
+
+# =============================================================================
+# Batch Generation Input Parsing (TRTLLM-11362)
+# =============================================================================
+
+
+class TestDiffusionRequestBatchPrompt:
+    """DiffusionRequest accepts Union[str, List[str]] for prompt field."""
+
+    def test_single_prompt(self):
+        from tensorrt_llm._torch.visual_gen.executor import DiffusionRequest
+
+        req = DiffusionRequest(request_id=0, prompt="hello")
+        assert req.prompt == "hello"
+
+    def test_list_prompt(self):
+        from tensorrt_llm._torch.visual_gen.executor import DiffusionRequest
+
+        prompts = ["a sunset", "a city"]
+        req = DiffusionRequest(request_id=0, prompt=prompts)
+        assert req.prompt == prompts
+        assert len(req.prompt) == 2
+
+
+class TestVisualGenBatchInputParsing:
+    """Test that VisualGen.generate_async() correctly parses batch inputs.
+
+    Uses mocking to avoid spawning GPU worker processes.
+    """
+
+    def _make_visual_gen_with_mock_executor(self):
+        """Create a VisualGen instance with a mocked executor."""
+        from tensorrt_llm.llmapi.visual_gen import VisualGen
+
+        # Patch __init__ to avoid spawning workers
+        with patch.object(VisualGen, "__init__", lambda self, *a, **kw: None):
+            vg = VisualGen.__new__(VisualGen)
+            vg.model_path = "/tmp/fake"
+            vg.diffusion_args = VisualGenArgs(checkpoint_path="/tmp/fake")
+            vg.req_counter = 0
+            vg.executor = MagicMock()
+            return vg
+
+    def _make_params(self):
+        from tensorrt_llm.llmapi.visual_gen import VisualGenParams
+
+        return VisualGenParams()
+
+    def test_string_input(self):
+        """String input → single prompt in DiffusionRequest."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        vg.generate_async(inputs="a cat", params=params)
+
+        # Check the DiffusionRequest passed to enqueue_requests
+        call_args = vg.executor.enqueue_requests.call_args[0][0]
+        assert len(call_args) == 1
+        assert call_args[0].prompt == "a cat"
+
+    def test_dict_input(self):
+        """Dict input → prompt + negative_prompt extracted."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        vg.generate_async(
+            inputs={"prompt": "a cat", "negative_prompt": "blurry"},
+            params=params,
+        )
+
+        call_args = vg.executor.enqueue_requests.call_args[0][0]
+        assert call_args[0].prompt == "a cat"
+        assert call_args[0].negative_prompt == "blurry"
+
+    def test_list_of_strings_input(self):
+        """List of strings → batch prompt in single DiffusionRequest."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        vg.generate_async(inputs=["a sunset", "a city"], params=params)
+
+        call_args = vg.executor.enqueue_requests.call_args[0][0]
+        assert len(call_args) == 1
+        req = call_args[0]
+        assert req.prompt == ["a sunset", "a city"]
+        assert req.negative_prompt is None
+
+    def test_list_of_dicts_input(self):
+        """List of dicts → batch prompts with negative_prompt from first dict."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        vg.generate_async(
+            inputs=[
+                {"prompt": "a sunset", "negative_prompt": "dark"},
+                {"prompt": "a city"},
+            ],
+            params=params,
+        )
+
+        call_args = vg.executor.enqueue_requests.call_args[0][0]
+        req = call_args[0]
+        assert req.prompt == ["a sunset", "a city"]
+        assert req.negative_prompt == "dark"
+
+    def test_mixed_list_input(self):
+        """Mixed list of strings and dicts → batch prompts extracted."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        vg.generate_async(inputs=["a sunset", {"prompt": "a city"}], params=params)
+
+        call_args = vg.executor.enqueue_requests.call_args[0][0]
+        req = call_args[0]
+        assert req.prompt == ["a sunset", "a city"]
+
+    def test_conflicting_negative_prompt_raises(self):
+        """Conflicting per-item negative_prompt raises ValueError."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        with pytest.raises(ValueError, match="Per-item negative_prompt is not supported"):
+            vg.generate_async(
+                inputs=[
+                    {"prompt": "a sunset", "negative_prompt": "dark"},
+                    {"prompt": "a city", "negative_prompt": "light"},
+                ],
+                params=params,
+            )
+
+    def test_empty_batch_raises(self):
+        """Empty batch input raises ValueError."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        with pytest.raises(ValueError, match="at least one item"):
+            vg.generate_async(inputs=[], params=params)
+
+    def test_missing_prompt_in_dict_raises(self):
+        """Dict without 'prompt' key raises ValueError."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        with pytest.raises(ValueError, match="missing 'prompt'"):
+            vg.generate_async(
+                inputs=[{"negative_prompt": "dark"}],
+                params=params,
+            )
+
+    def test_invalid_input_raises(self):
+        """Invalid input type raises ValueError."""
+        vg = self._make_visual_gen_with_mock_executor()
+        params = self._make_params()
+
+        with pytest.raises(ValueError, match="Invalid inputs type"):
+            vg.generate_async(inputs=12345, params=params)

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -232,7 +232,7 @@ class TestVisualGenBatchInputParsing:
         return VisualGenParams()
 
     def test_string_input(self):
-        """String input → single prompt in DiffusionRequest."""
+        """String input → single-element list in DiffusionRequest."""
         vg = self._make_visual_gen_with_mock_executor()
         params = self._make_params()
 
@@ -241,10 +241,10 @@ class TestVisualGenBatchInputParsing:
         # Check the DiffusionRequest passed to enqueue_requests
         call_args = vg.executor.enqueue_requests.call_args[0][0]
         assert len(call_args) == 1
-        assert call_args[0].prompt == "a cat"
+        assert call_args[0].prompt == ["a cat"]
 
     def test_dict_input(self):
-        """Dict input → prompt + negative_prompt extracted."""
+        """Dict input → prompt wrapped in list + negative_prompt extracted."""
         vg = self._make_visual_gen_with_mock_executor()
         params = self._make_params()
 
@@ -254,7 +254,7 @@ class TestVisualGenBatchInputParsing:
         )
 
         call_args = vg.executor.enqueue_requests.call_args[0][0]
-        assert call_args[0].prompt == "a cat"
+        assert call_args[0].prompt == ["a cat"]
         assert call_args[0].negative_prompt == "blurry"
 
     def test_list_of_strings_input(self):

--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -3482,9 +3482,9 @@ class TestWanBatchGeneration:
             guidance_scale=5.0,
             seed=42,
         )
-        assert result.video.dim() == 4, f"Expected 4D (T,H,W,C), got {result.video.dim()}D"
-        _T, H, W, C = result.video.shape
-        assert H == 480 and W == 832 and C == 3
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 1 and H == 480 and W == 832 and C == 3
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_batch_prompt_shape(self, wan21_full_pipeline):

--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -3435,7 +3435,7 @@ class TestWanRobustness(unittest.TestCase):
 
 
 # =============================================================================
-# Batch Generation Tests (TRTLLM-11362)
+# Batch Generation Tests
 # =============================================================================
 
 

--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -3434,5 +3434,75 @@ class TestWanRobustness(unittest.TestCase):
         print("\n[Error Handling] ✓ Invalid quant_algo raises error as expected")
 
 
+# =============================================================================
+# Batch Generation Tests (TRTLLM-11362)
+# =============================================================================
+
+
+class TestWanBatchGeneration:
+    """Batch generation tests for WAN T2V pipeline.
+
+    Tests that passing a list of prompts produces batched output
+    and matches sequential generation with the same seeds.
+    """
+
+    @pytest.fixture(scope="class")
+    def wan21_full_pipeline(self):
+        """Load full Wan 2.1 pipeline (all components) for batch tests."""
+        if not CHECKPOINT_PATH or not os.path.exists(CHECKPOINT_PATH):
+            pytest.skip("Checkpoint not available. Set DIFFUSION_MODEL_PATH.")
+        if not is_wan21_checkpoint():
+            pytest.skip("Batch tests require Wan 2.1 checkpoint")
+
+        from tensorrt_llm._torch.visual_gen.config import TorchCompileConfig
+
+        args = VisualGenArgs(
+            checkpoint_path=CHECKPOINT_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        yield pipeline
+        del pipeline
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_single_prompt_backward_compat(self, wan21_full_pipeline):
+        """Single prompt returns (T, H, W, C) for backward compatibility."""
+        result = wan21_full_pipeline.forward(
+            prompt="a cat walking",
+            height=480,
+            width=832,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 4, f"Expected 4D (T,H,W,C), got {result.video.dim()}D"
+        _T, H, W, C = result.video.shape
+        assert H == 480 and W == 832 and C == 3
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_batch_prompt_shape(self, wan21_full_pipeline):
+        """List of prompts returns (B, T, H, W, C)."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        result = wan21_full_pipeline.forward(
+            prompt=prompts,
+            height=480,
+            width=832,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 2 and H == 480 and W == 832 and C == 3
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/unittest/_torch/visual_gen/test_wan_i2v.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_i2v.py
@@ -36,6 +36,7 @@ from tensorrt_llm._torch.visual_gen.config import (
     DiffusionModelConfig,
     ParallelConfig,
     TeaCacheConfig,
+    TorchCompileConfig,
     VisualGenArgs,
 )
 from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan_i2v import WanImageToVideoPipeline
@@ -1067,6 +1068,76 @@ class TestWanI2VRobustness:
         finally:
             del pipeline
             torch.cuda.empty_cache()
+
+
+# =============================================================================
+# Batch Generation Tests (I2V)
+# =============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.i2v
+class TestWanI2VBatchGeneration:
+    """Batch generation tests for WAN I2V pipeline (Wan 2.1 and Wan 2.2).
+
+    Tests that passing a list of prompts produces batched output
+    and matches sequential generation with the same seeds.
+    """
+
+    @pytest.fixture(scope="class")
+    def i2v_full_pipeline(self):
+        """Load full I2V pipeline (all components) for batch tests."""
+        if not CHECKPOINT_PATH or not os.path.exists(CHECKPOINT_PATH):
+            pytest.skip("Checkpoint not available. Set DIFFUSION_MODEL_PATH.")
+
+        args = VisualGenArgs(
+            checkpoint_path=CHECKPOINT_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        yield pipeline
+        del pipeline
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_single_prompt_backward_compat(self, i2v_full_pipeline, test_image):
+        """Single prompt returns (T, H, W, C) for backward compatibility."""
+        result = i2v_full_pipeline.forward(
+            prompt="a cat walking",
+            image=test_image,
+            height=480,
+            width=832,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 4, f"Expected 4D (T,H,W,C), got {result.video.dim()}D"
+        _T, H, W, C = result.video.shape
+        assert H == 480 and W == 832 and C == 3
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_batch_prompt_shape(self, i2v_full_pipeline, test_image):
+        """List of prompts returns (B, T, H, W, C)."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        result = i2v_full_pipeline.forward(
+            prompt=prompts,
+            image=test_image,
+            height=480,
+            width=832,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 2 and H == 480 and W == 832 and C == 3
 
 
 # ============================================================================

--- a/tests/unittest/_torch/visual_gen/test_wan_i2v.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_i2v.py
@@ -1117,9 +1117,9 @@ class TestWanI2VBatchGeneration:
             guidance_scale=5.0,
             seed=42,
         )
-        assert result.video.dim() == 4, f"Expected 4D (T,H,W,C), got {result.video.dim()}D"
-        _T, H, W, C = result.video.shape
-        assert H == 480 and W == 832 and C == 3
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 1 and H == 480 and W == 832 and C == 3
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_batch_prompt_shape(self, i2v_full_pipeline, test_image):


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added batch generation support across visual generation models (FLUX, WAN, WAN I2V)
* Prompts now accept both single strings and lists of strings for processing multiple items in one request
* Automatic batch size inference based on input type
* Returns appropriately shaped outputs for single and batched generations

**Tests**
* Added comprehensive batch generation tests for all visual generation pipelines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->


## Summary

Add batch inference support to all visual generation pipelines (FLUX.1, FLUX.2, WAN T2V, WAN I2V). A single `forward()` call can now accept a list of prompts and generate all outputs in parallel, with proper CFG (classifier-free guidance) handling for the full batch.

- `prompt` parameter accepts `Union[str, List[str]]` across all pipelines
- Single prompt returns original shape `(H,W,C)` / `(T,H,W,C)` for backward compatibility
- Batch prompts return `(B,H,W,C)` / `(B,T,H,W,C)` with batch dimension prepended
- Seed behavior aligned with HF diffusers: single generator with `batch_size` in tensor shape (not per-sample `seed+i`)
- API-level support in `DiffusionRequest` and `VisualGeneration.generate_async()`



<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- [x] `pytest tests/unittest/_torch/visual_gen/test_visual_gen_args.py` — API-level batch input parsing (no GPU)
- [x] `pytest tests/unittest/_torch/visual_gen/test_flux_pipeline.py -k "batch"` — FLUX batch generation (1x GPU)
- [x] `pytest tests/unittest/_torch/visual_gen/test_wan.py -k "batch"` — WAN T2V batch generation (1x GPU)
- [x] `pytest tests/unittest/_torch/visual_gen/test_wan_i2v.py -k "batch"` — WAN I2V batch generation (1x GPU)
- [x] Verified single-prompt backward compatibility (output shapes unchanged)
- [x] Verified seed alignment with HF diffusers (single generator, batch_size in shape)


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
