### PR TITLE
[#11083][feat] Add hardware-aware MLA defaults to get_model_defaults()

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -28,9 +28,12 @@
 import copy
 import math
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
+
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 import triton
 import triton.language as tl
 from torch import nn

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1914,6 +1914,26 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                resource_manager=resource_manager,
                                **kwargs)
 
+    @classmethod
+    def get_model_defaults(cls,
+                           llm_args: 'TorchLlmArgs',
+                           pretrained_config=None) -> dict:
+        """Model-specific defaults for DeepSeek V3 (MLA architecture).
+
+        Applies hardware-aware defaults for MLA features:
+        - KV cache block reuse requires SM90/SM100/SM103/SM120.
+        - Chunked prefill for MLA requires SM90/SM100/SM103/SM120.
+        """
+        defaults = {}
+        sm_version = get_sm_version()
+        mla_supported_sm = {90, 100, 103, 120}
+
+        if sm_version not in mla_supported_sm:
+            defaults["kv_cache_config"] = {"enable_block_reuse": False}
+            defaults["enable_chunked_prefill"] = False
+
+        return defaults
+
     def load_weights(self, weights: ConsumableWeightsDict):
         weight_loader = DeepseekV3WeightLoader(self)
         weight_loader.load_weights(weights)

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
@@ -1,6 +1,9 @@
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import torch
+
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 from torch import nn
 from tqdm import tqdm
 from transformers import PretrainedConfig

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
@@ -8,6 +8,7 @@ from transformers import PretrainedConfig
 from tensorrt_llm._torch.distributed import AllReduceParams
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
     ConsumableWeightsDict
+from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import PositionEmbeddingType
 
 from ..attention_backend import AttentionMetadata
@@ -624,6 +625,33 @@ class HunYuanDenseV1ForCausalLM(DecoderModelForCausalLM[HunYuanModel,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)
         self._execution_stats = None
+
+    @classmethod
+    def get_model_defaults(cls,
+                           llm_args: 'TorchLlmArgs',
+                           pretrained_config=None) -> dict:
+        """Model-specific defaults for HunyuanDense (MLA architecture).
+
+        When MLA is enabled, applies hardware-aware defaults:
+        - KV cache block reuse requires SM90/SM100/SM103/SM120.
+        - Chunked prefill for MLA requires SM90/SM100/SM103/SM120.
+        """
+        if pretrained_config is None:
+            return {}
+
+        use_mla = getattr(pretrained_config, 'use_mla', False)
+        if not use_mla:
+            return {}
+
+        defaults = {}
+        sm_version = get_sm_version()
+        mla_supported_sm = {90, 100, 103, 120}
+
+        if sm_version not in mla_supported_sm:
+            defaults["kv_cache_config"] = {"enable_block_reuse": False}
+            defaults["enable_chunked_prefill"] = False
+
+        return defaults
 
     def load_weights(self, weights: ConsumableWeightsDict):
         tp_size = self.model_config.mapping.tp_size

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -648,7 +648,9 @@ class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
         super().load_weights(weights=new_weights, weight_mapper=weight_mapper)
 
     @classmethod
-    def get_model_defaults(cls, llm_args: "TorchLlmArgs") -> dict:
+    def get_model_defaults(cls,
+                           llm_args: "TorchLlmArgs",
+                           pretrained_config=None) -> dict:
         """Model-specific defaults for NemotronH.
 
         Disables block reuse due to SSM/hybrid architecture constraints.

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1256,7 +1256,9 @@ class Qwen3NextForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel,
         self.preload_weight_modules = self.model.preload_weight_modules
 
     @classmethod
-    def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
+    def get_model_defaults(cls,
+                           llm_args: 'TorchLlmArgs',
+                           pretrained_config=None) -> dict:
         # TODO: Remove enable_block_reuse=False once KV cache block reuse
         # is supported for Mamba/SSM-based models
         return {"kv_cache_config": {"enable_block_reuse": False}}

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -524,7 +524,9 @@ class DecoderModelForCausalLM(nn.Module,
                 module.create_weights()
 
     @classmethod
-    def get_model_defaults(cls, llm_args: 'TorchLlmArgs') -> dict:
+    def get_model_defaults(cls,
+                           llm_args: 'TorchLlmArgs',
+                           pretrained_config=None) -> dict:
         """Return model-specific LLM API default overrides.
 
         Subclasses can override this to provide defaults that are applied
@@ -540,6 +542,13 @@ class DecoderModelForCausalLM(nn.Module,
 
         Model authors are encouraged to override this method for tuning default behavior
         informed by the model's capabilities and hardware.
+
+        Args:
+            llm_args: The user-provided LLM arguments (with Pydantic defaults).
+            pretrained_config: The loaded pretrained model config from the
+                checkpoint. Allows model-specific defaults to inspect model
+                architecture details (e.g., attention type, hidden sizes)
+                and hardware context for informed decision-making.
 
         The returned dict is deep-merged with the user's llm_args, with
         user-set values taking priority over these defaults.

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -4,9 +4,14 @@ import math
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (TYPE_CHECKING, Dict, Generic, List, Optional, Tuple, Type,
+                    TypeVar, Union)
 
 import torch
+
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+
 from torch import nn
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_any_only

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -266,7 +266,8 @@ class ModelLoader:
 
         # model_cls is None when the architecture is unknown/unsupported.
         if model_cls and hasattr(model_cls, 'get_model_defaults'):
-            model_defaults = model_cls.get_model_defaults(llm_args)
+            model_defaults = model_cls.get_model_defaults(
+                llm_args, pretrained_config=config)
             if model_defaults:
                 applied_defaults = apply_model_defaults_to_llm_args(
                     llm_args, model_defaults)

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -309,6 +309,126 @@ class TestModelDefaults:
         error_str = str(exc_info.value)
         assert "enable_block_reuse" in error_str or "max_tokens" in error_str
 
+    def test_get_model_defaults_accepts_pretrained_config(self):
+        """Test that get_model_defaults accepts the new pretrained_config param."""
+        from tensorrt_llm._torch.models.modeling_utils import \
+            DecoderModelForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        # Base class should return empty dict with or without pretrained_config
+        result = DecoderModelForCausalLM.get_model_defaults(llm_args)
+        assert result == {}
+        result = DecoderModelForCausalLM.get_model_defaults(
+            llm_args, pretrained_config=None)
+        assert result == {}
+
+    @pytest.mark.parametrize("sm_version,expect_disabled", [
+        (80, True),
+        (86, True),
+        (89, True),
+        (90, False),
+        (100, False),
+        (103, False),
+        (120, False),
+    ])
+    def test_deepseekv3_mla_defaults_sm_aware(self, sm_version,
+                                              expect_disabled):
+        """Test DeepseekV3 returns SM-version-aware MLA defaults."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=sm_version):
+            defaults = DeepseekV3ForCausalLM.get_model_defaults(llm_args)
+
+        if expect_disabled:
+            assert defaults.get("kv_cache_config",
+                                {}).get("enable_block_reuse") is False
+            assert defaults.get("enable_chunked_prefill") is False
+        else:
+            assert "kv_cache_config" not in defaults
+            assert "enable_chunked_prefill" not in defaults
+
+    def test_deepseekv3_defaults_applied_without_user_override(self):
+        """Test DeepseekV3 defaults are applied when user doesn't set them."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=80):
+            defaults = DeepseekV3ForCausalLM.get_model_defaults(llm_args)
+            applied = apply_model_defaults_to_llm_args(llm_args, defaults)
+
+        assert applied["kv_cache_config"]["enable_block_reuse"] is False
+        assert applied["enable_chunked_prefill"] is False
+        assert llm_args.kv_cache_config.enable_block_reuse is False
+        assert llm_args.enable_chunked_prefill is False
+
+    def test_deepseekv3_defaults_respect_user_override(self):
+        """Test DeepseekV3 defaults don't override explicit user settings."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+
+        # User explicitly enables block reuse and chunked prefill
+        llm_args = TorchLlmArgs(
+            model="/tmp/test",
+            kv_cache_config=KvCacheConfig(enable_block_reuse=True),
+            enable_chunked_prefill=True)
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=80):
+            defaults = DeepseekV3ForCausalLM.get_model_defaults(llm_args)
+            applied = apply_model_defaults_to_llm_args(llm_args, defaults)
+
+        # User overrides should win
+        assert llm_args.kv_cache_config.enable_block_reuse is True
+        assert llm_args.enable_chunked_prefill is True
+        # Applied dict should be empty since user overrode everything
+        assert "enable_chunked_prefill" not in applied
+
+    @pytest.mark.parametrize("use_mla,sm_version,expect_disabled", [
+        (False, 80, False),
+        (True, 80, True),
+        (True, 90, False),
+        (False, 90, False),
+    ])
+    def test_hunyuan_dense_mla_defaults_config_aware(self, use_mla, sm_version,
+                                                     expect_disabled):
+        """Test HunyuanDense applies MLA defaults only when use_mla=True."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_hunyuan_dense import \
+            HunYuanDenseV1ForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        pretrained_config = SimpleNamespace(use_mla=use_mla)
+
+        with patch(
+                'tensorrt_llm._torch.models.modeling_hunyuan_dense.get_sm_version',
+                return_value=sm_version):
+            defaults = HunYuanDenseV1ForCausalLM.get_model_defaults(
+                llm_args, pretrained_config=pretrained_config)
+
+        if expect_disabled:
+            assert defaults.get("kv_cache_config",
+                                {}).get("enable_block_reuse") is False
+            assert defaults.get("enable_chunked_prefill") is False
+        else:
+            assert defaults.get("kv_cache_config",
+                                {}).get("enable_block_reuse") is None
+            assert defaults.get("enable_chunked_prefill") is None
+
 
 def test_KvCacheConfig_declaration():
     config = KvCacheConfig(enable_block_reuse=True,

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -429,6 +429,109 @@ class TestModelDefaults:
                                 {}).get("enable_block_reuse") is None
             assert defaults.get("enable_chunked_prefill") is None
 
+    def test_hunyuan_dense_no_pretrained_config_returns_empty(self):
+        """Test HunyuanDense returns empty dict when pretrained_config is None."""
+        from tensorrt_llm._torch.models.modeling_hunyuan_dense import \
+            HunYuanDenseV1ForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        defaults = HunYuanDenseV1ForCausalLM.get_model_defaults(llm_args)
+        assert defaults == {}
+        defaults = HunYuanDenseV1ForCausalLM.get_model_defaults(
+            llm_args, pretrained_config=None)
+        assert defaults == {}
+
+    def test_kimi_k25_inherits_deepseekv3_mla_defaults(self):
+        """Test KimiK25 inherits SM-aware MLA defaults from DeepseekV3."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            KimiK25ForConditionalGeneration
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+
+        # On unsupported SM, Kimi K2.5 should disable MLA features
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=80):
+            defaults = KimiK25ForConditionalGeneration.get_model_defaults(
+                llm_args)
+        assert defaults.get("kv_cache_config",
+                            {}).get("enable_block_reuse") is False
+        assert defaults.get("enable_chunked_prefill") is False
+
+        # On supported SM, no defaults
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=90):
+            defaults = KimiK25ForConditionalGeneration.get_model_defaults(
+                llm_args)
+        assert defaults == {}
+
+    def test_nemotron_h_accepts_pretrained_config(self):
+        """Test NemotronH still works with the new pretrained_config param."""
+        from tensorrt_llm._torch.models.modeling_nemotron_h import \
+            NemotronHForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        # Without pretrained_config (backward compat)
+        defaults = NemotronHForCausalLM.get_model_defaults(llm_args)
+        assert defaults == {"kv_cache_config": {"enable_block_reuse": False}}
+        # With pretrained_config (new signature)
+        defaults = NemotronHForCausalLM.get_model_defaults(
+            llm_args, pretrained_config=object())
+        assert defaults == {"kv_cache_config": {"enable_block_reuse": False}}
+
+    def test_qwen3_next_accepts_pretrained_config(self):
+        """Test Qwen3Next still works with the new pretrained_config param."""
+        from tensorrt_llm._torch.models.modeling_qwen3_next import \
+            Qwen3NextForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        defaults = Qwen3NextForCausalLM.get_model_defaults(llm_args)
+        assert defaults == {"kv_cache_config": {"enable_block_reuse": False}}
+        defaults = Qwen3NextForCausalLM.get_model_defaults(
+            llm_args, pretrained_config=object())
+        assert defaults == {"kv_cache_config": {"enable_block_reuse": False}}
+
+    def test_deepseekv3_partial_user_override(self):
+        """Test partial override: user sets one field, other gets default."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+
+        # User only sets enable_block_reuse, leaves enable_chunked_prefill
+        llm_args = TorchLlmArgs(
+            model="/tmp/test",
+            kv_cache_config=KvCacheConfig(enable_block_reuse=True))
+        with patch(
+                'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                return_value=80):
+            defaults = DeepseekV3ForCausalLM.get_model_defaults(llm_args)
+            applied = apply_model_defaults_to_llm_args(llm_args, defaults)
+
+        # User override wins for block_reuse
+        assert llm_args.kv_cache_config.enable_block_reuse is True
+        # Default applied for chunked_prefill (user didn't set it)
+        assert llm_args.enable_chunked_prefill is False
+        assert applied.get("enable_chunked_prefill") is False
+
+    def test_deepseekv3_supported_sm_returns_empty_dict(self):
+        """Test DeepseekV3 returns exactly empty dict on supported SM."""
+        from unittest.mock import patch
+
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+
+        llm_args = TorchLlmArgs(model="/tmp/test")
+        for sm in [90, 100, 103, 120]:
+            with patch(
+                    'tensorrt_llm._torch.models.modeling_deepseekv3.get_sm_version',
+                    return_value=sm):
+                defaults = DeepseekV3ForCausalLM.get_model_defaults(llm_args)
+            assert defaults == {}, f"SM{sm}: expected empty dict, got {defaults}"
+
 
 def test_KvCacheConfig_declaration():
     config = KvCacheConfig(enable_block_reuse=True,

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1308,7 +1308,7 @@ class TestPyTorchBackendModelDefaults:
         self.get_model_defaults_called = False
         self.tmp_path = tmp_path
 
-        def mock_get_model_defaults(cls, llm_args):
+        def mock_get_model_defaults(cls, llm_args, pretrained_config=None):
             self.get_model_defaults_called = True
             return {
                 "enable_chunked_prefill": True,


### PR DESCRIPTION
Extend the get_model_defaults() framework to support pretrained_config parameter, enabling model-specific defaults that are both hardware-aware and model-config-aware.

Changes:
- Add optional pretrained_config parameter to get_model_defaults() base class and all existing overrides (NemotronH, Qwen3Next)
- Pass pretrained_config from ModelLoader.load_config_and_apply_defaults() to get_model_defaults() so models can inspect their architecture details
- Add get_model_defaults() to DeepseekV3ForCausalLM with SM-version-aware defaults: disable KV cache block reuse and chunked prefill on hardware that doesn't support MLA features (requires SM90/100/103/120)
- Add get_model_defaults() to HunYuanDenseV1ForCausalLM with config-aware MLA defaults (only applied when use_mla=True in pretrained config)
- Add comprehensive unit tests covering SM-version parametrization, user override preservation, and config-aware behavior

These defaults ensure DeepSeek V3 and HunyuanDense MLA models work OOTB on all hardware without manual configuration, while still allowing users to explicitly override settings when needed.

Ref: https://github.com/NVIDIA/TensorRT-LLM/issues/11083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent model defaults for DeepseekV3 and HunYuanDense models to optimize hardware compatibility and performance configurations.

* **Tests**
  * Added comprehensive unit tests for model defaults and configuration handling across multiple model architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
