### PR TITLE
[TRTLLM-11237][fix] [fix] Synchronize NCCL memory allocation error handling

### DIFF
--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -1424,3 +1424,16 @@ TRTLLM_NAMESPACE_END
     {                                                                                                                  \
         tensorrt_llm::common::checkEx((stat), {cudaSuccess, cudaErrorCudartUnloading}, #stat, __FILE__, __LINE__);     \
     } while (0)
+
+// Warn-only variant: log a warning on failure but do not throw or abort.
+// Use for cleanup/secondary operations where a CUDA error is non-fatal (e.g. free on an error path).
+#define TLLM_CUDA_CHECK_WARN(stat)                                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        cudaError_t const _tllm_cuda_warn_err = (stat);                                                                \
+        if (TLLM_UNLIKELY(_tllm_cuda_warn_err != cudaSuccess))                                                         \
+        {                                                                                                              \
+            TLLM_LOG_WARNING(                                                                                          \
+                "CUDA error in %s (%s:%d): %s", #stat, __FILE__, __LINE__, cudaGetErrorString(_tllm_cuda_warn_err));   \
+        }                                                                                                              \
+    } while (0)

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -24,6 +24,69 @@
 #include <limits>
 #include <stdexcept>
 
+namespace
+{
+
+// RAII guard for cudaMalloc — frees the pointer on destruction, logging a warning on failure.
+struct CudaMallocGuard
+{
+    void* ptr{nullptr};
+
+    explicit CudaMallocGuard(void* p) noexcept
+        : ptr(p)
+    {
+    }
+
+    ~CudaMallocGuard()
+    {
+        if (ptr)
+        {
+            TLLM_CUDA_CHECK_WARN(cudaFree(ptr));
+        }
+    }
+
+    void* release() noexcept
+    {
+        void* p = ptr;
+        ptr = nullptr;
+        return p;
+    }
+
+    CudaMallocGuard(CudaMallocGuard const&) = delete;
+    CudaMallocGuard& operator=(CudaMallocGuard const&) = delete;
+};
+
+// RAII guard for ncclMemAlloc — frees the pointer on destruction, logging a warning on failure.
+struct NcclMemGuard
+{
+    void* ptr{nullptr};
+
+    explicit NcclMemGuard(void* p) noexcept
+        : ptr(p)
+    {
+    }
+
+    ~NcclMemGuard()
+    {
+        if (ptr)
+        {
+            TLLM_NCCL_CHECK_WARN(ncclMemFree(ptr));
+        }
+    }
+
+    void* release() noexcept
+    {
+        void* p = ptr;
+        ptr = nullptr;
+        return p;
+    }
+
+    NcclMemGuard(NcclMemGuard const&) = delete;
+    NcclMemGuard& operator=(NcclMemGuard const&) = delete;
+};
+
+} // namespace
+
 namespace tensorrt_llm::common::nccl_util
 {
 
@@ -403,11 +466,9 @@ bool NCCLWindowAllocator::isCommValid(ncclComm_t comm) const noexcept
 
 NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm, size_t size, int handle)
 {
-    NCCLWindowBuffer buffer;
-    buffer.handle = handle;
-
-    // Allocate device memory using ncclMemAlloc (per-rank, non-collective — can fail asymmetrically)
-    ncclResult_t allocResult = ncclMemAlloc(&buffer.ptr, size);
+    // Step 1: Allocate symmetric memory (per-rank, non-collective — can fail asymmetrically).
+    void* ncclPtr = nullptr;
+    ncclResult_t allocResult = ncclMemAlloc(&ncclPtr, size);
     int localAllocOk = (allocResult == ncclSuccess) ? 1 : 0;
     if (!localAllocOk)
     {
@@ -416,98 +477,43 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
             "synchronizing with other ranks before aborting window registration.",
             allocResult, size);
     }
+    NcclMemGuard ncclGuard{ncclPtr}; // frees ncclPtr on any early return or exception
 
-    // ncclCommWindowRegister is collective: if any rank skips it, all other ranks hang.
-    // Synchronize the per-rank alloc status across all ranks before proceeding.
-    // Use a small cudaMalloc buffer (not ncclMemAlloc) so OOM on symmetric memory
-    // does not prevent us from allocating the flag.
+    // Step 2: ncclCommWindowRegister is collective — if any rank skips it, all other ranks hang.
+    // Synchronize the per-rank alloc status using a small cudaMalloc flag (not ncclMemAlloc, so
+    // OOM on symmetric memory does not prevent us from allocating the flag).
     int* rankSyncFlag = nullptr;
     if (cudaMalloc(&rankSyncFlag, sizeof(int)) != cudaSuccess)
     {
-        // This should be essentially impossible (4 bytes of regular device memory),
-        // but if it happens we cannot safely coordinate — abort on this rank.
-        if (localAllocOk)
-        {
-            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-            if (freeResult != ncclSuccess)
-            {
-                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during cudaMalloc error cleanup: %d", freeResult);
-            }
-        }
         TLLM_THROW("[NCCLUtil] cudaMalloc for rank-sync flag failed; cannot coordinate safely across ranks.");
     }
+    CudaMallocGuard flagGuard{rankSyncFlag}; // frees rankSyncFlag on any early return or exception
 
-    // Populate flag on device, reduce with min (0 if any rank failed), then read back.
+    // Step 3: Populate flag, reduce with min across ranks (0 if any rank failed), then read back.
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaError_t memcpyErr = cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
-    if (memcpyErr != cudaSuccess)
-    {
-        cudaError_t freeErr = cudaFree(rankSyncFlag);
-        if (freeErr != cudaSuccess)
-        {
-            TLLM_LOG_WARNING(
-                "[NCCLUtil] cudaFree failed during H2D memcpy error cleanup: %s", cudaGetErrorString(freeErr));
-        }
-        if (localAllocOk)
-        {
-            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-            if (freeResult != ncclSuccess)
-            {
-                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during H2D memcpy error cleanup: %d", freeResult);
-            }
-        }
-        TLLM_THROW("[NCCLUtil] cudaMemcpy H2D for rank-sync flag failed: %s", cudaGetErrorString(memcpyErr));
-    }
+    TLLM_CUDA_CHECK(cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice));
+
     ncclResult_t reduceResult = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
     if (reduceResult != ncclSuccess)
     {
-        cudaError_t freeErr = cudaFree(rankSyncFlag);
-        if (freeErr != cudaSuccess)
-        {
-            TLLM_LOG_WARNING(
-                "[NCCLUtil] cudaFree failed during ncclAllReduce error cleanup: %s", cudaGetErrorString(freeErr));
-        }
-        if (localAllocOk)
-        {
-            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-            if (freeResult != ncclSuccess)
-            {
-                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during ncclAllReduce error cleanup: %d", freeResult);
-            }
-        }
         TLLM_LOG_WARNING(
             "[NCCLUtil] ncclAllReduce for rank-sync flag failed (error: %d); "
             "aborting window registration on this rank.",
             reduceResult);
-        return NCCLWindowBuffer();
+        return NCCLWindowBuffer{}; // guards free rankSyncFlag and ncclPtr
     }
-    cudaError_t syncErr = cudaStreamSynchronize(stream);
-    if (syncErr != cudaSuccess)
-    {
-        TLLM_LOG_WARNING(
-            "[NCCLUtil] cudaStreamSynchronize failed after ncclAllReduce: %s", cudaGetErrorString(syncErr));
-    }
+    TLLM_CUDA_CHECK_WARN(cudaStreamSynchronize(stream));
+
     int allAllocOk = 0;
-    memcpyErr = cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
-    cudaError_t freeErr = cudaFree(rankSyncFlag);
-    if (freeErr != cudaSuccess)
-    {
-        TLLM_LOG_WARNING("[NCCLUtil] cudaFree failed for rank-sync flag: %s", cudaGetErrorString(freeErr));
-    }
-    if (memcpyErr != cudaSuccess)
+    cudaError_t d2hErr = cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
+    if (d2hErr != cudaSuccess)
     {
         TLLM_LOG_WARNING("[NCCLUtil] cudaMemcpy D2H for rank-sync flag failed: %s; assuming allocation failed.",
-            cudaGetErrorString(memcpyErr));
-        if (localAllocOk)
-        {
-            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-            if (freeResult != ncclSuccess)
-            {
-                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during D2H memcpy error cleanup: %d", freeResult);
-            }
-        }
-        return NCCLWindowBuffer();
+            cudaGetErrorString(d2hErr));
+        return NCCLWindowBuffer{}; // guards free rankSyncFlag and ncclPtr
     }
+    // flagGuard frees rankSyncFlag here at end of its scope
+
     if (!allAllocOk)
     {
         if (localAllocOk)
@@ -516,34 +522,24 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
                 "[NCCLUtil] ncclMemAlloc failed on at least one other rank; "
                 "freeing local allocation (size=%zu) and aborting window registration on all ranks.",
                 size);
-            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-            if (freeResult != ncclSuccess)
-            {
-                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during !allAllocOk cleanup: %d", freeResult);
-            }
         }
-        // Return an empty buffer — callers fall back to regular (non-symmetric) allreduce.
-        return NCCLWindowBuffer();
+        return NCCLWindowBuffer{}; // ncclGuard frees ncclPtr
     }
 
-    buffer.size = size;
-
-    // Register the buffer with NCCL as a window (collective — all ranks must reach this call)
-    ncclResult_t regResult = ncclCommWindowRegister(comm, buffer.ptr, size, &buffer.window, NCCL_WIN_COLL_SYMMETRIC);
+    // Step 4: Register with NCCL as a window (collective — all ranks must reach this call).
+    ncclWindow_t window = nullptr;
+    ncclResult_t regResult = ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
     if (regResult != ncclSuccess)
     {
-        ncclResult_t freeResult = ncclMemFree(buffer.ptr);
-        if (freeResult != ncclSuccess)
-        {
-            TLLM_LOG_WARNING(
-                "[NCCLUtil] ncclMemFree failed during ncclCommWindowRegister error cleanup: %d", freeResult);
-        }
         TLLM_THROW("ncclCommWindowRegister failed with error: %d", regResult);
+        // ncclGuard frees ncclPtr during stack unwinding
     }
 
+    // Step 5: Success — transfer ownership to the returned buffer.
+    ncclGuard.release();
+    NCCLWindowBuffer buffer{ncclPtr, handle, size, window};
     TLLM_LOG_TRACE("[NCCLUtil] Allocated and registered NCCL window buffer: handle=%d, ptr=%p, size=%zu, window=%p",
-        handle, buffer.ptr, size, static_cast<void*>(buffer.window));
-
+        handle, buffer.ptr, buffer.size, static_cast<void*>(buffer.window));
     return buffer;
 }
 

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -428,7 +428,11 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
         // but if it happens we cannot safely coordinate — abort on this rank.
         if (localAllocOk)
         {
-            ncclMemFree(buffer.ptr);
+            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+            if (freeResult != ncclSuccess)
+            {
+                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during cudaMalloc error cleanup: %d", freeResult);
+            }
         }
         TLLM_THROW("[NCCLUtil] cudaMalloc for rank-sync flag failed; cannot coordinate safely across ranks.");
     }
@@ -438,41 +442,72 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     cudaError_t memcpyErr = cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
     if (memcpyErr != cudaSuccess)
     {
-        cudaFree(rankSyncFlag);
+        cudaError_t freeErr = cudaFree(rankSyncFlag);
+        if (freeErr != cudaSuccess)
+        {
+            TLLM_LOG_WARNING(
+                "[NCCLUtil] cudaFree failed during H2D memcpy error cleanup: %s", cudaGetErrorString(freeErr));
+        }
         if (localAllocOk)
         {
-            ncclMemFree(buffer.ptr);
+            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+            if (freeResult != ncclSuccess)
+            {
+                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during H2D memcpy error cleanup: %d", freeResult);
+            }
         }
         TLLM_THROW("[NCCLUtil] cudaMemcpy H2D for rank-sync flag failed: %s", cudaGetErrorString(memcpyErr));
     }
     ncclResult_t reduceResult = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
-    cudaStreamSynchronize(stream);
+    if (reduceResult != ncclSuccess)
+    {
+        cudaError_t freeErr = cudaFree(rankSyncFlag);
+        if (freeErr != cudaSuccess)
+        {
+            TLLM_LOG_WARNING(
+                "[NCCLUtil] cudaFree failed during ncclAllReduce error cleanup: %s", cudaGetErrorString(freeErr));
+        }
+        if (localAllocOk)
+        {
+            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+            if (freeResult != ncclSuccess)
+            {
+                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during ncclAllReduce error cleanup: %d", freeResult);
+            }
+        }
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] ncclAllReduce for rank-sync flag failed (error: %d); "
+            "aborting window registration on this rank.",
+            reduceResult);
+        return NCCLWindowBuffer();
+    }
+    cudaError_t syncErr = cudaStreamSynchronize(stream);
+    if (syncErr != cudaSuccess)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] cudaStreamSynchronize failed after ncclAllReduce: %s", cudaGetErrorString(syncErr));
+    }
     int allAllocOk = 0;
     memcpyErr = cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
-    cudaFree(rankSyncFlag);
+    cudaError_t freeErr = cudaFree(rankSyncFlag);
+    if (freeErr != cudaSuccess)
+    {
+        TLLM_LOG_WARNING("[NCCLUtil] cudaFree failed for rank-sync flag: %s", cudaGetErrorString(freeErr));
+    }
     if (memcpyErr != cudaSuccess)
     {
         TLLM_LOG_WARNING("[NCCLUtil] cudaMemcpy D2H for rank-sync flag failed: %s; assuming allocation failed.",
             cudaGetErrorString(memcpyErr));
         if (localAllocOk)
         {
-            ncclMemFree(buffer.ptr);
+            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+            if (freeResult != ncclSuccess)
+            {
+                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during D2H memcpy error cleanup: %d", freeResult);
+            }
         }
         return NCCLWindowBuffer();
     }
-    if (reduceResult != ncclSuccess)
-    {
-        TLLM_LOG_WARNING(
-            "[NCCLUtil] ncclAllReduce for rank-sync flag failed (error: %d); "
-            "aborting window registration on this rank.",
-            reduceResult);
-        if (localAllocOk)
-        {
-            ncclMemFree(buffer.ptr);
-        }
-        return NCCLWindowBuffer();
-    }
-
     if (!allAllocOk)
     {
         if (localAllocOk)
@@ -481,7 +516,11 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
                 "[NCCLUtil] ncclMemAlloc failed on at least one other rank; "
                 "freeing local allocation (size=%zu) and aborting window registration on all ranks.",
                 size);
-            ncclMemFree(buffer.ptr);
+            ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+            if (freeResult != ncclSuccess)
+            {
+                TLLM_LOG_WARNING("[NCCLUtil] ncclMemFree failed during !allAllocOk cleanup: %d", freeResult);
+            }
         }
         // Return an empty buffer — callers fall back to regular (non-symmetric) allreduce.
         return NCCLWindowBuffer();
@@ -493,7 +532,12 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     ncclResult_t regResult = ncclCommWindowRegister(comm, buffer.ptr, size, &buffer.window, NCCL_WIN_COLL_SYMMETRIC);
     if (regResult != ncclSuccess)
     {
-        ncclMemFree(buffer.ptr);
+        ncclResult_t freeResult = ncclMemFree(buffer.ptr);
+        if (freeResult != ncclSuccess)
+        {
+            TLLM_LOG_WARNING(
+                "[NCCLUtil] ncclMemFree failed during ncclCommWindowRegister error cleanup: %d", freeResult);
+        }
         TLLM_THROW("ncclCommWindowRegister failed with error: %d", regResult);
     }
 

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -421,8 +421,8 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     // Synchronize the per-rank alloc status across all ranks before proceeding.
     // Use a small cudaMalloc buffer (not ncclMemAlloc) so OOM on symmetric memory
     // does not prevent us from allocating the flag.
-    int* dFlag = nullptr;
-    if (cudaMalloc(&dFlag, sizeof(int)) != cudaSuccess)
+    int* rankSyncFlag = nullptr;
+    if (cudaMalloc(&rankSyncFlag, sizeof(int)) != cudaSuccess)
     {
         // This should be essentially impossible (4 bytes of regular device memory),
         // but if it happens we cannot safely coordinate — abort on this rank.
@@ -435,12 +435,24 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
 
     // Populate flag on device, reduce with min (0 if any rank failed), then read back.
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaMemcpy(dFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
-    ncclAllReduce(dFlag, dFlag, 1, ncclInt32, ncclMin, comm, stream);
+    cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
+    ncclResult_t reduceResult = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
     cudaStreamSynchronize(stream);
-    int allAllocOk = 1;
-    cudaMemcpy(&allAllocOk, dFlag, sizeof(int), cudaMemcpyDeviceToHost);
-    cudaFree(dFlag);
+    int allAllocOk = 0;
+    cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaFree(rankSyncFlag);
+    if (reduceResult != ncclSuccess)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] ncclAllReduce for rank-sync flag failed (error: %d); "
+            "aborting window registration on this rank.",
+            reduceResult);
+        if (localAllocOk)
+        {
+            ncclMemFree(buffer.ptr);
+        }
+        return NCCLWindowBuffer();
+    }
 
     if (!allAllocOk)
     {

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -504,9 +504,15 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     }
 
     // Step 4: Register with NCCL as a window (collective — all ranks must reach this call).
-    // ncclGuard frees ncclPtr during stack unwinding on throw.
+    // Failure here is non-fatal: warn and fall back to regular allreduce.
+    // ncclGuard frees ncclPtr on return.
     ncclWindow_t window = nullptr;
-    TLLM_NCCL_CHECK(ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC));
+    ncclResult_t const regResult = ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
+    TLLM_NCCL_CHECK_WARN(regResult);
+    if (regResult != ncclSuccess)
+    {
+        return NCCLWindowBuffer{};
+    }
 
     // Step 5: Success — transfer ownership to the returned buffer.
     ncclGuard.release();

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -468,25 +468,15 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
 {
     // Step 1: Allocate symmetric memory (per-rank, non-collective — can fail asymmetrically).
     void* ncclPtr = nullptr;
-    ncclResult_t allocResult = ncclMemAlloc(&ncclPtr, size);
-    int localAllocOk = (allocResult == ncclSuccess) ? 1 : 0;
-    if (!localAllocOk)
-    {
-        TLLM_LOG_WARNING(
-            "[NCCLUtil] ncclMemAlloc failed on this rank (error: %d, size=%zu); "
-            "synchronizing with other ranks before aborting window registration.",
-            allocResult, size);
-    }
+    TLLM_NCCL_CHECK_WARN(ncclMemAlloc(&ncclPtr, size));
+    int const localAllocOk = (ncclPtr != nullptr) ? 1 : 0;
     NcclMemGuard ncclGuard{ncclPtr}; // frees ncclPtr on any early return or exception
 
     // Step 2: ncclCommWindowRegister is collective — if any rank skips it, all other ranks hang.
     // Synchronize the per-rank alloc status using a small cudaMalloc flag (not ncclMemAlloc, so
     // OOM on symmetric memory does not prevent us from allocating the flag).
     int* rankSyncFlag = nullptr;
-    if (cudaMalloc(&rankSyncFlag, sizeof(int)) != cudaSuccess)
-    {
-        TLLM_THROW("[NCCLUtil] cudaMalloc for rank-sync flag failed; cannot coordinate safely across ranks.");
-    }
+    TLLM_CUDA_CHECK(cudaMalloc(&rankSyncFlag, sizeof(int)));
     CudaMallocGuard flagGuard{rankSyncFlag}; // frees rankSyncFlag on any early return or exception
 
     // Step 3: Populate flag, reduce with min across ranks (0 if any rank failed), then read back.
@@ -527,13 +517,9 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     }
 
     // Step 4: Register with NCCL as a window (collective — all ranks must reach this call).
+    // ncclGuard frees ncclPtr during stack unwinding on throw.
     ncclWindow_t window = nullptr;
-    ncclResult_t regResult = ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
-    if (regResult != ncclSuccess)
-    {
-        TLLM_THROW("ncclCommWindowRegister failed with error: %d", regResult);
-        // ncclGuard frees ncclPtr during stack unwinding
-    }
+    TLLM_NCCL_CHECK(ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC));
 
     // Step 5: Success — transfer ownership to the returned buffer.
     ncclGuard.release();

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -480,28 +480,15 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     CudaMallocGuard flagGuard{rankSyncFlag}; // frees rankSyncFlag on any early return or exception
 
     // Step 3: Populate flag, reduce with min across ranks (0 if any rank failed), then read back.
+    // H2D failure is non-fatal: warn and continue — device flag may be stale but the allreduce
+    // must still be reached by all ranks. allreduce and D2H failures are catastrophic (throw).
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    TLLM_CUDA_CHECK(cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice));
-
-    ncclResult_t reduceResult = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
-    if (reduceResult != ncclSuccess)
-    {
-        TLLM_LOG_WARNING(
-            "[NCCLUtil] ncclAllReduce for rank-sync flag failed (error: %d); "
-            "aborting window registration on this rank.",
-            reduceResult);
-        return NCCLWindowBuffer{}; // guards free rankSyncFlag and ncclPtr
-    }
+    TLLM_CUDA_CHECK_WARN(cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice));
+    TLLM_NCCL_CHECK(ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream));
     TLLM_CUDA_CHECK_WARN(cudaStreamSynchronize(stream));
 
     int allAllocOk = 0;
-    cudaError_t d2hErr = cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
-    if (d2hErr != cudaSuccess)
-    {
-        TLLM_LOG_WARNING("[NCCLUtil] cudaMemcpy D2H for rank-sync flag failed: %s; assuming allocation failed.",
-            cudaGetErrorString(d2hErr));
-        return NCCLWindowBuffer{}; // guards free rankSyncFlag and ncclPtr
-    }
+    TLLM_CUDA_CHECK(cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost));
     // flagGuard frees rankSyncFlag here at end of its scope
 
     if (!allAllocOk)

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -406,15 +406,59 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     NCCLWindowBuffer buffer;
     buffer.handle = handle;
 
-    // Allocate device memory using ncclMemAlloc
+    // Allocate device memory using ncclMemAlloc (per-rank, non-collective — can fail asymmetrically)
     ncclResult_t allocResult = ncclMemAlloc(&buffer.ptr, size);
-    if (allocResult != ncclSuccess)
+    int localAllocOk = (allocResult == ncclSuccess) ? 1 : 0;
+    if (!localAllocOk)
     {
-        TLLM_THROW("ncclMemAlloc failed with error: %d", allocResult);
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] ncclMemAlloc failed on this rank (error: %d, size=%zu); "
+            "synchronizing with other ranks before aborting window registration.",
+            allocResult, size);
     }
+
+    // ncclCommWindowRegister is collective: if any rank skips it, all other ranks hang.
+    // Synchronize the per-rank alloc status across all ranks before proceeding.
+    // Use a small cudaMalloc buffer (not ncclMemAlloc) so OOM on symmetric memory
+    // does not prevent us from allocating the flag.
+    int* dFlag = nullptr;
+    if (cudaMalloc(&dFlag, sizeof(int)) != cudaSuccess)
+    {
+        // This should be essentially impossible (4 bytes of regular device memory),
+        // but if it happens we cannot safely coordinate — abort on this rank.
+        if (localAllocOk)
+        {
+            ncclMemFree(buffer.ptr);
+        }
+        TLLM_THROW("[NCCLUtil] cudaMalloc for rank-sync flag failed; cannot coordinate safely across ranks.");
+    }
+
+    // Populate flag on device, reduce with min (0 if any rank failed), then read back.
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    cudaMemcpy(dFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
+    ncclAllReduce(dFlag, dFlag, 1, ncclInt32, ncclMin, comm, stream);
+    cudaStreamSynchronize(stream);
+    int allAllocOk = 1;
+    cudaMemcpy(&allAllocOk, dFlag, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaFree(dFlag);
+
+    if (!allAllocOk)
+    {
+        if (localAllocOk)
+        {
+            TLLM_LOG_WARNING(
+                "[NCCLUtil] ncclMemAlloc failed on at least one other rank; "
+                "freeing local allocation (size=%zu) and aborting window registration on all ranks.",
+                size);
+            ncclMemFree(buffer.ptr);
+        }
+        // Return an empty buffer — callers fall back to regular (non-symmetric) allreduce.
+        return NCCLWindowBuffer();
+    }
+
     buffer.size = size;
 
-    // Register the buffer with NCCL as a window
+    // Register the buffer with NCCL as a window (collective — all ranks must reach this call)
     ncclResult_t regResult = ncclCommWindowRegister(comm, buffer.ptr, size, &buffer.window, NCCL_WIN_COLL_SYMMETRIC);
     if (regResult != ncclSuccess)
     {

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -435,12 +435,31 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
 
     // Populate flag on device, reduce with min (0 if any rank failed), then read back.
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
+    cudaError_t memcpyErr = cudaMemcpy(rankSyncFlag, &localAllocOk, sizeof(int), cudaMemcpyHostToDevice);
+    if (memcpyErr != cudaSuccess)
+    {
+        cudaFree(rankSyncFlag);
+        if (localAllocOk)
+        {
+            ncclMemFree(buffer.ptr);
+        }
+        TLLM_THROW("[NCCLUtil] cudaMemcpy H2D for rank-sync flag failed: %s", cudaGetErrorString(memcpyErr));
+    }
     ncclResult_t reduceResult = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
     cudaStreamSynchronize(stream);
     int allAllocOk = 0;
-    cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
+    memcpyErr = cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost);
     cudaFree(rankSyncFlag);
+    if (memcpyErr != cudaSuccess)
+    {
+        TLLM_LOG_WARNING("[NCCLUtil] cudaMemcpy D2H for rank-sync flag failed: %s; assuming allocation failed.",
+            cudaGetErrorString(memcpyErr));
+        if (localAllocOk)
+        {
+            ncclMemFree(buffer.ptr);
+        }
+        return NCCLWindowBuffer();
+    }
     if (reduceResult != ncclSuccess)
     {
         TLLM_LOG_WARNING(

--- a/cpp/tensorrt_llm/common/ncclUtils.h
+++ b/cpp/tensorrt_llm/common/ncclUtils.h
@@ -43,6 +43,19 @@
 
 #if ENABLE_MULTI_DEVICE
 
+// Warn-only variant: log a warning on NCCL failure but do not throw or abort.
+// Use for cleanup/secondary operations where an NCCL error is non-fatal (e.g. ncclMemFree on an error path).
+#define TLLM_NCCL_CHECK_WARN(cmd)                                                                                      \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        ncclResult_t const _tllm_nccl_warn_r = (cmd);                                                                  \
+        if (TLLM_UNLIKELY(_tllm_nccl_warn_r != ncclSuccess))                                                           \
+        {                                                                                                              \
+            TLLM_LOG_WARNING(                                                                                          \
+                "NCCL error in %s (%s:%d): %s", #cmd, __FILE__, __LINE__, ncclGetErrorString(_tllm_nccl_warn_r));      \
+        }                                                                                                              \
+    } while (0)
+
 TRTLLM_NAMESPACE_BEGIN
 
 namespace common::nccl_util

--- a/cpp/tensorrt_llm/common/ncclUtils.h
+++ b/cpp/tensorrt_llm/common/ncclUtils.h
@@ -43,6 +43,17 @@
 
 #if ENABLE_MULTI_DEVICE
 
+// Throw on NCCL failure. Use for operations where failure is unrecoverable.
+#define TLLM_NCCL_CHECK(cmd)                                                                                           \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        ncclResult_t const _tllm_nccl_r = (cmd);                                                                       \
+        if (TLLM_UNLIKELY(_tllm_nccl_r != ncclSuccess))                                                                \
+        {                                                                                                              \
+            TLLM_THROW("NCCL error in %s (%s:%d): %s", #cmd, __FILE__, __LINE__, ncclGetErrorString(_tllm_nccl_r));    \
+        }                                                                                                              \
+    } while (0)
+
 // Warn-only variant: log a warning on NCCL failure but do not throw or abort.
 // Use for cleanup/secondary operations where an NCCL error is non-fatal (e.g. ncclMemFree on an error path).
 #define TLLM_NCCL_CHECK_WARN(cmd)                                                                                      \

--- a/cpp/tensorrt_llm/common/ncclUtils.h
+++ b/cpp/tensorrt_llm/common/ncclUtils.h
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/runtime/utils/multiDeviceUtils.h"
 
 #if ENABLE_MULTI_DEVICE
 #include <ATen/cuda/CUDAContext.h>
@@ -43,16 +44,7 @@
 
 #if ENABLE_MULTI_DEVICE
 
-// Throw on NCCL failure. Use for operations where failure is unrecoverable.
-#define TLLM_NCCL_CHECK(cmd)                                                                                           \
-    do                                                                                                                 \
-    {                                                                                                                  \
-        ncclResult_t const _tllm_nccl_r = (cmd);                                                                       \
-        if (TLLM_UNLIKELY(_tllm_nccl_r != ncclSuccess))                                                                \
-        {                                                                                                              \
-            TLLM_THROW("NCCL error in %s (%s:%d): %s", #cmd, __FILE__, __LINE__, ncclGetErrorString(_tllm_nccl_r));    \
-        }                                                                                                              \
-    } while (0)
+// TLLM_NCCL_CHECK (throw on failure) is provided by multiDeviceUtils.h.
 
 // Warn-only variant: log a warning on NCCL failure but do not throw or abort.
 // Use for cleanup/secondary operations where an NCCL error is non-fatal (e.g. ncclMemFree on an error path).

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1427,7 +1427,6 @@ private:
     bool ifFallbackToNCCL(size_t seq_len, size_t message_size_bytes, size_t max_workspace_size)
     {
         // If messageSize is greater than maxWorkspaceSize or topology is unsuitable, use NCCL fallback.
-        // TODO: Use NCCL_SYMMETRIC once the memory allocation issue is resolved.
         if (message_size_bytes > max_workspace_size || !mIsP2PSupported || !mIsNVLINKSupported)
         {
             return true;

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py
@@ -175,6 +175,16 @@ class KimiK25Config(PretrainedConfig):
         self.use_unified_vision_chunk = use_unified_vision_chunk
         self.video_placeholder = video_placeholder
 
+        # Expose text model attributes at the top level so that model_config.py
+        # (and other infrastructure that accesses pretrained_config.hidden_size etc.)
+        # can find them without knowing about the VLM wrapper structure.
+        self.hidden_size = text_config.hidden_size
+        self.num_hidden_layers = text_config.num_hidden_layers
+        self.num_attention_heads = text_config.num_attention_heads
+        self.num_key_value_heads = text_config.num_key_value_heads
+        self.vocab_size = text_config.vocab_size
+        self.intermediate_size = text_config.intermediate_size
+
         super().__init__(pad_token_id=pad_token_id, **kwargs)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py
@@ -175,16 +175,6 @@ class KimiK25Config(PretrainedConfig):
         self.use_unified_vision_chunk = use_unified_vision_chunk
         self.video_placeholder = video_placeholder
 
-        # Expose text model attributes at the top level so that model_config.py
-        # (and other infrastructure that accesses pretrained_config.hidden_size etc.)
-        # can find them without knowing about the VLM wrapper structure.
-        self.hidden_size = text_config.hidden_size
-        self.num_hidden_layers = text_config.num_hidden_layers
-        self.num_attention_heads = text_config.num_attention_heads
-        self.num_key_value_heads = text_config.num_key_value_heads
-        self.vocab_size = text_config.vocab_size
-        self.intermediate_size = text_config.intermediate_size
-
         super().__init__(pad_token_id=pad_token_id, **kwargs)
 
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1821,11 +1821,11 @@ class AllReduceRunner(TunableRunner):
                                                 do_preparation=True)
             return input
         if tactic == -1:
-            # tactic == -1 means the autotuner cache missed for this shape,
-            # so we fall back to plain NCCL instead of NCCL_SYMMETRIC.
-            # NCCL_SYMMETRIC requires ncclMemAlloc which can fail asymmetrically
-            # across ranks under OOM, causing a deadlock at ncclCommWindowRegister.
-            tactic = AllReduceStrategy.NCCL.value
+            # tactic == -1 means the autotuner cache missed for this shape;
+            # fall back to NCCL_SYMMETRIC. Asymmetric ncclMemAlloc failures are
+            # handled by a cross-rank barrier in NCCLWindowAllocator, which
+            # falls back to plain NCCL if allocation fails on any rank.
+            tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
 
         return torch.ops.trtllm.allreduce(
             input,

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1711,6 +1711,10 @@ def _(
 class AllReduceRunner(TunableRunner):
     _prealloc_lock: ClassVar[threading.Lock] = threading.Lock()
     _prealloc_done: ClassVar[set] = set()
+    # Set from AllReduce.__init__ via extra_attrs when the model is built.
+    _prealloc_max_num_tokens: ClassVar[Optional[int]] = None
+    _prealloc_hidden_size: ClassVar[Optional[int]] = None
+    _prealloc_dtype: ClassVar[Optional[torch.dtype]] = None
     tuning_config = TuningConfig(
         dynamic_tensor_specs=(DynamicTensorSpec(
             0, 0, get_last_power_of_2_num_tokens_buckets(8192),
@@ -1743,7 +1747,10 @@ class AllReduceRunner(TunableRunner):
     def _maybe_preallocate_buffers(cls,
                                    input_tensor: torch.Tensor,
                                    group: List[int],
-                                   do_preparation: bool = False) -> None:
+                                   do_preparation: bool = False,
+                                   max_num_tokens: Optional[int] = None,
+                                   hidden_size: Optional[int] = None,
+                                   dtype: Optional[torch.dtype] = None) -> None:
         if not do_preparation:
             return
         if not hasattr(torch.ops.trtllm, "preallocate_nccl_window_buffer"):
@@ -1758,7 +1765,22 @@ class AllReduceRunner(TunableRunner):
                 # If capture status can't be queried, avoid prealloc to be safe.
                 return
 
-        num_tokens = int(input_tensor.size(0))
+        # If max_num_tokens and hidden_size are provided, pre-allocate at 2x
+        # the model-configured size to give the NCCL window allocator extra
+        # headroom beyond the nominal max shape.  dtype comes from the model
+        # spec; fall back to the actual input tensor's properties when any
+        # value is missing.
+        # The dummy tensor is created here, after the stream-capture guard,
+        # so it is never allocated inside a CUDA graph context.
+        if max_num_tokens is not None and hidden_size is not None:
+            prealloc_input = torch.empty(
+                [2 * max_num_tokens, hidden_size],
+                dtype=dtype if dtype is not None else input_tensor.dtype,
+                device=input_tensor.device)
+        else:
+            prealloc_input = input_tensor
+
+        num_tokens = int(prealloc_input.size(0))
         if num_tokens <= 0:
             return
         group_key = tuple(group)
@@ -1771,7 +1793,6 @@ class AllReduceRunner(TunableRunner):
         logger.debug(
             "[tunable_allreduce] Pre-allocating NCCL window buffers: "
             "tokens=%d group=%s", num_tokens, list(group))
-        prealloc_input = input_tensor
         torch.ops.trtllm.preallocate_nccl_window_buffer(prealloc_input, group,
                                                         2)
 
@@ -1816,9 +1837,14 @@ class AllReduceRunner(TunableRunner):
                                                    OptimizationProfile(),
                                                    **kwargs)
             if AllReduceStrategy.NCCL_SYMMETRIC.value in valid_tactics:
-                self._maybe_preallocate_buffers(input,
-                                                self.group,
-                                                do_preparation=True)
+                self._maybe_preallocate_buffers(
+                    input,
+                    self.group,
+                    do_preparation=True,
+                    max_num_tokens=AllReduceRunner._prealloc_max_num_tokens,
+                    hidden_size=AllReduceRunner._prealloc_hidden_size,
+                    dtype=AllReduceRunner._prealloc_dtype,
+                )
             return input
         if tactic == -1:
             # tactic == -1 means the autotuner cache missed for this shape;

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -10,6 +10,7 @@ from torch import nn
 from tensorrt_llm._mnnvl_utils import HelixCpMnnvlMemory, MnnvlMemory
 from tensorrt_llm._torch.distributed.symm_mem_allreduce import \
     SymmetricMemoryAllReduce
+from tensorrt_llm._torch.utils import get_model_extra_attrs
 from tensorrt_llm._utils import mpi_comm, mpi_disabled
 from tensorrt_llm.bindings import internal as _tllm_internal
 from tensorrt_llm.bindings.internal.runtime import McastGPUBuffer
@@ -691,6 +692,25 @@ class AllReduce(nn.Module):
         self._disable_mpi = mpi_disabled()
 
         self.all_reduce_op = torch.ops.trtllm.allreduce_pg if self._disable_mpi else torch.ops.trtllm.allreduce
+
+        # Propagate model-level prealloc config to AllReduceRunner once per
+        # process.  extra_attrs is only active during model __init__, so we
+        # read it here and stash the values as class-level attributes that
+        # AllReduceRunner.forward can use during the autotuner warm-up phase.
+        extra_attrs = get_model_extra_attrs()
+        if extra_attrs:
+            from tensorrt_llm._torch.custom_ops.torch_custom_ops import \
+                AllReduceRunner
+            max_num_tokens = extra_attrs.get('allreduce_max_num_tokens')
+            hidden_size = extra_attrs.get('allreduce_hidden_size')
+            if max_num_tokens is not None:
+                AllReduceRunner._prealloc_max_num_tokens = max_num_tokens
+            if hidden_size is not None:
+                AllReduceRunner._prealloc_hidden_size = hidden_size
+            prealloc_dtype = extra_attrs.get('allreduce_dtype')
+            if prealloc_dtype is not None:
+                AllReduceRunner._prealloc_dtype = prealloc_dtype
+
         if self.mapping.tp_size > 1 and not self.mapping.enable_attention_dp:
             # Initialize Symmetric Memory AllReduce if needed (before workspace allocation)
             if self.strategy == AllReduceStrategy.SYMM_MEM:

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -497,15 +497,22 @@ class ModelLoader:
         # Store nvfp4 config in extra_attrs for Linear layer access
         config.extra_attrs[
             'nvfp4_gemm_allowed_backends'] = config.nvfp4_gemm_allowed_backends
-        # Store allreduce pre-allocation config for AllReduce module access
-        config.extra_attrs['allreduce_max_num_tokens'] = config.max_num_tokens
+        # Store allreduce pre-allocation config for AllReduce module access.
         # VLM wrapper configs (e.g. NemotronH_Nano_VL_V2_Config, KimiK25Config)
-        # may not expose hidden_size at the top level.  The consumer in ops.py
-        # already handles None gracefully, so skip pre-allocation rather than crash.
-        config.extra_attrs['allreduce_hidden_size'] = getattr(
-            config.pretrained_config, 'hidden_size', None)
-        config.extra_attrs[
-            'allreduce_dtype'] = config.pretrained_config.torch_dtype
+        # may not expose these attributes at the top level; skip pre-allocation
+        # gracefully in that case — the consumer in ops.py handles None for each.
+        try:
+            config.extra_attrs[
+                'allreduce_max_num_tokens'] = config.max_num_tokens
+            config.extra_attrs[
+                'allreduce_hidden_size'] = config.pretrained_config.hidden_size
+            config.extra_attrs[
+                'allreduce_dtype'] = config.pretrained_config.torch_dtype
+        except AttributeError as e:
+            logger.warning(
+                f"Could not read allreduce pre-allocation config from "
+                f"{type(config.pretrained_config).__name__}: {e}. "
+                f"AllReduce pre-allocation will be skipped.")
 
         validate_and_set_kv_cache_quant(config,
                                         self.llm_args.kv_cache_config.dtype)

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -497,6 +497,12 @@ class ModelLoader:
         # Store nvfp4 config in extra_attrs for Linear layer access
         config.extra_attrs[
             'nvfp4_gemm_allowed_backends'] = config.nvfp4_gemm_allowed_backends
+        # Store allreduce pre-allocation config for AllReduce module access
+        config.extra_attrs['allreduce_max_num_tokens'] = config.max_num_tokens
+        config.extra_attrs[
+            'allreduce_hidden_size'] = config.pretrained_config.hidden_size
+        config.extra_attrs[
+            'allreduce_dtype'] = config.pretrained_config.torch_dtype
 
         validate_and_set_kv_cache_quant(config,
                                         self.llm_args.kv_cache_config.dtype)

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -499,8 +499,11 @@ class ModelLoader:
             'nvfp4_gemm_allowed_backends'] = config.nvfp4_gemm_allowed_backends
         # Store allreduce pre-allocation config for AllReduce module access
         config.extra_attrs['allreduce_max_num_tokens'] = config.max_num_tokens
-        config.extra_attrs[
-            'allreduce_hidden_size'] = config.pretrained_config.hidden_size
+        # VLM wrapper configs (e.g. NemotronH_Nano_VL_V2_Config, KimiK25Config)
+        # may not expose hidden_size at the top level.  The consumer in ops.py
+        # already handles None gracefully, so skip pre-allocation rather than crash.
+        config.extra_attrs['allreduce_hidden_size'] = getattr(
+            config.pretrained_config, 'hidden_size', None)
         config.extra_attrs[
             'allreduce_dtype'] = config.pretrained_config.torch_dtype
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -498,14 +498,17 @@ class ModelLoader:
         config.extra_attrs[
             'nvfp4_gemm_allowed_backends'] = config.nvfp4_gemm_allowed_backends
         # Store allreduce pre-allocation config for AllReduce module access.
-        # VLM wrapper configs (e.g. NemotronH_Nano_VL_V2_Config, KimiK25Config)
-        # may not expose these attributes at the top level; skip pre-allocation
-        # gracefully in that case — the consumer in ops.py handles None for each.
+        # Use get_text_config() so VLM wrapper configs (e.g. KimiK2VLConfig,
+        # KimiK25Config) that store the text config under .text_config are
+        # handled transparently.  For flat configs get_text_config() returns
+        # self, so this is safe for all config types.  Still guard with
+        # try/except for configs that lack hidden_size entirely.
         try:
             config.extra_attrs[
                 'allreduce_max_num_tokens'] = config.max_num_tokens
             config.extra_attrs[
-                'allreduce_hidden_size'] = config.pretrained_config.hidden_size
+                'allreduce_hidden_size'] = config.pretrained_config.get_text_config(
+                ).hidden_size
             config.extra_attrs[
                 'allreduce_dtype'] = config.pretrained_config.torch_dtype
         except AttributeError as e:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation error handling in multi-GPU distributed operations to prevent potential deadlocks by ensuring synchronized failure checks across all GPUs.
  * Enhanced stability for collective communication operations when allocation failures occur on any GPU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This adds a global sync before the window registration, so in case a rank OOMs registration fails gracefully.
This adds extra overhead in the registration path, but registration was slow before and we are re-using buffers to get this out of the critical path.

## Test Coverage

I am actively looking for the test that was breaking. Help!

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
