### PR TITLE
[None][perf] enable flashinfer mlp activation and fix piecewise graph for gemma3-1B

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -305,7 +305,6 @@ def setup_llm(args, **kwargs):
         enable_iter_perf_stats=args.print_iter_log,
         torch_compile_config=TorchCompileConfig(
             enable_fullgraph=args.use_torch_compile,
-            enable_inductor=args.use_torch_compile,
             enable_piecewise_cuda_graph= \
                 args.use_piecewise_cuda_graph)
         if args.use_torch_compile else None,

--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -146,9 +146,10 @@ class Backend:
             )
             return gm
 
+        self.input_num_tokens = None
         for node in gm.graph.nodes:
             if node.op == "placeholder":
-                if node.name == "l_input_ids_":
+                if node.name in ["l_input_ids_", "l_kwargs_input_ids_"]:
                     example_value = node.meta["example_value"]
                     assert isinstance(example_value, FakeTensor)
                     self.input_num_tokens = example_value.shape[0]

--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -23,9 +23,11 @@ __all__ = [
 if IS_FLASHINFER_AVAILABLE:
     from .flashinfer_custom_ops import (
         flashinfer_apply_rope_with_cos_sin_cache_inplace,
-        flashinfer_fused_add_rmsnorm, flashinfer_gemma_fused_add_rmsnorm,
-        flashinfer_gemma_rmsnorm, flashinfer_rmsnorm, flashinfer_silu_and_mul)
+        flashinfer_fused_add_rmsnorm, flashinfer_gelu_tanh_and_mul,
+        flashinfer_gemma_fused_add_rmsnorm, flashinfer_gemma_rmsnorm,
+        flashinfer_rmsnorm, flashinfer_silu_and_mul)
     __all__ += [
+        'flashinfer_gelu_tanh_and_mul',
         'flashinfer_silu_and_mul',
         'flashinfer_rmsnorm',
         'flashinfer_fused_add_rmsnorm',

--- a/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
@@ -3,7 +3,7 @@ import torch
 from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_env_enable_pdl
 
 if IS_FLASHINFER_AVAILABLE:
-    from flashinfer.activation import silu_and_mul
+    from flashinfer.activation import gelu_tanh_and_mul, silu_and_mul
     from flashinfer.norm import (fused_add_rmsnorm, gemma_fused_add_rmsnorm,
                                  gemma_rmsnorm, rmsnorm)
     from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
@@ -14,6 +14,15 @@ if IS_FLASHINFER_AVAILABLE:
         return silu_and_mul(x, enable_pdl=get_env_enable_pdl())
 
     @flashinfer_silu_and_mul.register_fake
+    def _(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x).chunk(2, dim=-1)[1].contiguous()
+
+    @torch.library.custom_op("trtllm::flashinfer_gelu_tanh_and_mul",
+                             mutates_args=())
+    def flashinfer_gelu_tanh_and_mul(x: torch.Tensor) -> torch.Tensor:
+        return gelu_tanh_and_mul(x, enable_pdl=get_env_enable_pdl())
+
+    @flashinfer_gelu_tanh_and_mul.register_fake
     def _(x: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(x).chunk(2, dim=-1)[1].contiguous()
 

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -15,6 +15,7 @@ from ..attention_backend import AttentionMetadata, FlashInferAttentionMetadata
 from ..attention_backend.interface import (AttentionMask, CustomAttentionMask,
                                            PositionalEmbeddingParams,
                                            PredefinedAttentionMask, RopeParams)
+from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
@@ -115,7 +116,10 @@ class Gemma3Attention(QKNormRoPEAttention):
 
 
 # This function is written to be compatible with TRTLLM's GatedMLP class.
-def pytorch_gelu_tanh(gate_x: torch.Tensor) -> torch.Tensor:
+def gelu_tanh(gate_x: torch.Tensor) -> torch.Tensor:
+    if IS_FLASHINFER_AVAILABLE:
+        return torch.ops.trtllm.flashinfer_gelu_tanh_and_mul(gate_x)
+
     gate, x = gate_x.chunk(2, dim=-1)
     return nn.functional.gelu(gate, approximate="tanh") * x
 
@@ -140,7 +144,7 @@ class Gemma3DecoderLayer(DecoderLayer):
         self.mlp = GatedMLP(hidden_size=config.hidden_size,
                             intermediate_size=config.intermediate_size,
                             bias=False,
-                            activation=pytorch_gelu_tanh,
+                            activation=gelu_tanh,
                             dtype=config.torch_dtype,
                             config=model_config,
                             layer_idx=layer_idx)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

1. Replaces PyTorch implementation of gelu tanh activation with fused kernel from flashinfer.
1. For gemma-3-1b-it, input_ids node name in fx graph is `l_kwargs_input_ids_`. For other models, the node name is `l_input_ids_`. This PR pattern matches against both names when estimating input_num_tokens.
2. Fixes initialization of input_num_tokens to avoid "Undefined variable" error when pattern match fails.
3. Common to all models: torch_inductor and piecewise_cuda_graph are incompatible according to our [docs](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/features/torch_compile_and_piecewise_cuda_graph.md#re-inplace-optimization). This PR keeps the default value `TorchCompileConfig.enable_inductor=False` in example script to avoid conflict with piecewise_cuda_graph. 

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
tests/unittest/_torch/modeling/test_modeling_gemma3.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
