### PR TITLE
[None][fix] Correct typo WORKER_EXECEPTION -> WORKER_EXCEPTION in scaffolding

### DIFF
--- a/tensorrt_llm/scaffolding/contrib/mcp/chat_handler.py
+++ b/tensorrt_llm/scaffolding/contrib/mcp/chat_handler.py
@@ -49,4 +49,4 @@ async def chat_handler(worker, task: ChatTask) -> TaskStatus:
     except Exception as e:
         # Handle errors
         print('Openai chat client get exception: ' + str(e))
-        return TaskStatus.WORKER_EXECEPTION
+        return TaskStatus.WORKER_EXCEPTION

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -39,7 +39,7 @@ class Task:
 class TaskStatus(Enum):
     SUCCESS = "success"
     WORKER_NOT_SUPPORTED = "worker_not_supported"
-    WORKER_EXECEPTION = "worker_exception"
+    WORKER_EXCEPTION = "worker_exception"
 
 
 @dataclass

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -113,7 +113,7 @@ class OpenaiWorker(Worker):
         except Exception as e:
             # Handle errors
             print('Openai client get exception: ' + str(e))
-            return TaskStatus.WORKER_EXECEPTION
+            return TaskStatus.WORKER_EXCEPTION
 
     def shutdown(self):
         # OpenAI client doesn't require explicit cleanup


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in error status reporting that appears when exceptions occur during task processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix a typo in `TaskStatus` enum member name: `WORKER_EXECEPTION` → `WORKER_EXCEPTION`.

The typo exists in the enum definition and all its references:
- `tensorrt_llm/scaffolding/task.py`: Fix enum member name definition
- `tensorrt_llm/scaffolding/worker.py`: Update reference in `OpenaiWorker`
- `tensorrt_llm/scaffolding/contrib/mcp/chat_handler.py`: Update reference in `chat_handler`

No logic change. Typo-only fix.

## Test Coverage

Typo-only change with no logic impact. No additional tests needed.
Existing tests (if any) referencing `TaskStatus` will continue to work since the enum value string `"worker_exception"` remains unchanged.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
