### PR TITLE
[TRTLLM-11037][bug] Fix MoE DeepEP/DeepEPLowLatency multi-GPU hang

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/communication/base.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/base.py
@@ -186,6 +186,15 @@ class Communication(ABC):
         """
         raise NotImplementedError
 
+    def destroy(self):
+        """Synchronously release resources held by this communication strategy.
+
+        Must be called on ALL ranks before the object is discarded.
+        Subclasses holding collective resources (e.g. DeepEP Buffers whose
+        destructors invoke intranode::barrier) override this to release them
+        explicitly, avoiding non-deterministic GC timing across ranks.
+        """
+
     def get_eplb_gathered_statistics(self) -> Optional[torch.Tensor]:
         """
         Return gathered EPLB statistics from the last dispatch, if available.

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep.py
@@ -76,6 +76,15 @@ class DeepEP(Communication):
         self.deep_ep_buffer = buffer_pool.get_buffer(mapping)
         self.deep_ep_buffer.reserve(hidden_size, weight_dtype)
 
+    def destroy(self):
+        """Release the DeepEP buffer to prevent deadlock/hang.
+
+        Buffer.__del__ calls intranode::barrier (collective op). Without
+        explicit release, non-deterministic GC timing across ranks causes
+        some ranks to block in the barrier indefinitely.
+        """
+        self.deep_ep_buffer = None
+
     @staticmethod
     def is_platform_supported() -> bool:
         """

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
@@ -97,6 +97,14 @@ class DeepEPLowLatency(Communication):
         self.deep_ep_buffer = buffer_pool.get_low_latency_buffer(mapping)
         self.deep_ep_buffer.reserve(self.deep_ep_max_num_tokens, hidden_size, num_slots)
 
+    def destroy(self):
+        """Release the DeepEP low-latency buffer to prevent deadlock/hang.
+
+        Same rationale as DeepEP.destroy(): Buffer.__del__ calls
+        intranode::barrier which requires all ranks simultaneously.
+        """
+        self.deep_ep_buffer = None
+
     @staticmethod
     def is_platform_supported() -> bool:
         """

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -375,8 +375,33 @@ class ConfigurableMoE(MoE):
                 f"Falling back to AllGatherReduceScatter."
             )
 
-            # Switch to AllGather (always works)
+            # Explicitly destroy the old strategy before replacing it.
+            # DeepEP/DeepEPLowLatency Buffer.__del__ calls intranode::barrier
+            # (collective op); without explicit synchronous release, GC timing
+            # differences across ranks cause indefinite hangs.
+            self.comm.destroy()
             self.comm = AllGatherReduceScatter(mapping=self.mapping)
+
+    def destroy(self):
+        """Release communication resources.
+
+        Must be called on ALL ranks before the module is discarded.
+        DeepEP Buffer.__del__ calls intranode::barrier (a collective op);
+        without an explicit, synchronous release, non-deterministic GC
+        timing across ranks causes some to enter the barrier while others
+        proceed, resulting in an indefinite hang.
+
+        Prefer using ConfigurableMoE as a context manager (``with``) so
+        that destroy() is called automatically on scope exit.
+        """
+        if self.comm is not None:
+            self.comm.destroy()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.destroy()
 
     def _create_comm_strategy_auto(self) -> Communication:
         """

--- a/tests/unittest/_torch/modules/moe/test_moe_module.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_module.py
@@ -825,17 +825,22 @@ def _get_comm_method_skip_reason(
                 f"Not supported on this platform."
             )
 
-    # DeepEP normal mode: is_workload_feasible (deep_ep.py:127) rejects
-    # non-bfloat16, causing a runtime fallback to AllGather. The fallback
-    # replaces self.comm, and when the old DeepEP object is GC'd its
-    # Buffer destructor calls intranode::barrier (deep_ep.cpp:90) which
-    # requires all ranks simultaneously -- non-deterministic GC timing
-    # across MPI ranks causes the barrier to timeout and crash.
-    if comm_method == "DEEPEP" and dtype is not None and dtype != torch.bfloat16:
+    # DeepEP and DeepEPLowLatency: is_workload_feasible
+    # (deep_ep.py:127, deep_ep_low_latency.py:155) rejects non-bfloat16,
+    # causing a runtime fallback to AllGather. The fallback replaces
+    # self.comm, and when the old DeepEP/DeepEPLowLatency object is GC'd
+    # its Buffer destructor calls intranode::barrier (deep_ep.cpp:90)
+    # which requires all ranks simultaneously -- non-deterministic GC
+    # timing across MPI ranks causes the barrier to timeout and hang.
+    if (
+        comm_method in ("DEEPEP", "DEEPEPLOWLATENCY")
+        and dtype is not None
+        and dtype != torch.bfloat16
+    ):
         return (
-            f"DeepEP is_workload_feasible rejects dtype={dtype} "
+            f"{comm_method} is_workload_feasible rejects dtype={dtype} "
             f"(requires bfloat16), and the runtime fallback triggers an "
-            f"unsafe Buffer destruction that crashes all ranks."
+            f"unsafe Buffer destruction that hangs all ranks."
         )
 
     if comm_method == "DEEPEPLOWLATENCY":


### PR DESCRIPTION
## Summary
- Fix timeout/hang in CUTLASS MoE multi-GPU tests (`test_configurable_moe_multi_gpu`) for W4A16_MXFP4, W8A16, FP8, and W4A8_AWQ quantization modes
- Root cause: `DeepEPLowLatency + non-bfloat16` test cases were not skipped, causing runtime fallback that triggers `Buffer.__del__` → `intranode::barrier` hang across MPI ranks
- Add explicit `destroy()` methods and context manager support for proper resource cleanup

## Root Cause
`_get_comm_method_skip_reason` only skipped `DEEPEP` for non-bfloat16 dtype, but **not** `DEEPEPLOWLATENCY`. Both reject non-bfloat16 in `is_workload_feasible()`, causing `determine_communication_method()` to replace `self.comm` with AllGather. The old comm object is GC'd, and its `Buffer.__del__` calls `intranode::barrier` (a collective op). Non-deterministic GC timing across MPI ranks causes indefinite hangs.

## Changes
1. **Test skip fix** (`test_moe_module.py`): Skip both `DEEPEP` and `DEEPEPLOWLATENCY` for non-bfloat16 dtype
2. **Explicit destroy** (`deep_ep.py`, `deep_ep_low_latency.py`): Add `destroy()` to release buffers synchronously before GC
3. **Base class** (`base.py`): Add `destroy()` to `Communication` base class
4. **Fallback safety** (`configurable_moe.py`): Call `destroy()` before replacing `self.comm` in `determine_communication_method()`; add `destroy()` and context manager (`__enter__`/`__exit__`) to `ConfigurableMoE`

## Test plan
- [ ] Verify CUTLASS MoE multi-GPU tests pass (W4A16_MXFP4, W8A16, FP8, W4A8_AWQ)
- [ ] Verify FP8_BLOCK_SCALES tests still pass (regression check)
- [ ] CI: `/bot run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle management methods for explicit resource cleanup in distributed inference scenarios.
  * Added context-manager support for the configurable MOE module to enable automatic resource release on scope exit.

* **Bug Fixes**
  * Enhanced communication strategy switching to prevent potential hangs in certain distributed configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->