### PR TITLE
[TRTLLM-11357][feat] Support interleaved thinking for trtllm-serve

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -1,12 +1,23 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Optional, Type
+from dataclasses import dataclass, field
+from typing import Any, List, Literal, Optional, Type
+
+
+@dataclass
+class ContentBlock:
+    """Typed content block for interleaved thinking responses."""
+    type: Literal["thinking", "text"]
+    content: str
 
 
 @dataclass
 class ReasoningParserResult:
     content: str = ""
     reasoning_content: str = ""
+    # For interleaved thinking: the ordered list of content blocks.
+    content_blocks: List[ContentBlock] = field(default_factory=list)
+    # For streaming: indicates what type of content the current delta belongs to.
+    current_block_type: Optional[Literal["thinking", "text"]] = None
 
 
 def register_reasoning_parser(*keys: str, **default_kwargs):
@@ -69,6 +80,21 @@ class BaseReasoningParser(ABC):
     def parse_delta(self, delta_text: str) -> ReasoningParserResult:
         raise NotImplementedError
 
+    def parse_to_blocks(self, text: str) -> List[ContentBlock]:
+        """Parse text into a list of interleaved thinking/text content blocks.
+
+        Default implementation delegates to parse() and converts to blocks.
+        Subclasses may override for more accurate multi-block parsing.
+        """
+        result = self.parse(text)
+        blocks: List[ContentBlock] = []
+        if result.reasoning_content:
+            blocks.append(
+                ContentBlock(type="thinking", content=result.reasoning_content))
+        if result.content:
+            blocks.append(ContentBlock(type="text", content=result.content))
+        return blocks
+
 
 @register_reasoning_parser("deepseek-r1", reasoning_at_start=True)
 @register_reasoning_parser("qwen3")
@@ -117,6 +143,84 @@ class DeepSeekR1Parser(BaseReasoningParser):
         return ReasoningParserResult(content=content,
                                      reasoning_content=reasoning_content)
 
+    def parse_to_blocks(self, text: str) -> List[ContentBlock]:
+        """Parse text into interleaved thinking/text content blocks.
+
+        Handles multiple <think>...</think> blocks, producing alternating
+        thinking and text blocks while preserving ordering.
+        """
+        blocks: List[ContentBlock] = []
+        remaining = text
+        in_reasoning = self.reasoning_at_start
+
+        if in_reasoning:
+            # Text starts in reasoning mode (e.g., deepseek-r1)
+            end_idx = remaining.find(self.reasoning_end)
+            if end_idx == -1:
+                # Entire text is reasoning
+                if remaining:
+                    blocks.append(
+                        ContentBlock(type="thinking", content=remaining))
+                return blocks
+            thinking_text = remaining[:end_idx]
+            if thinking_text:
+                blocks.append(
+                    ContentBlock(type="thinking", content=thinking_text))
+            remaining = remaining[end_idx + len(self.reasoning_end):]
+        else:
+            # For models like qwen3 where reasoning doesn't start immediately,
+            # find the first <think> tag
+            start_idx = remaining.find(self.reasoning_start)
+            if start_idx == -1:
+                # No thinking blocks at all
+                if remaining:
+                    blocks.append(ContentBlock(type="text", content=remaining))
+                return blocks
+            # Text before first <think> is dropped (consistent with parse())
+            remaining = remaining[start_idx + len(self.reasoning_start):]
+            end_idx = remaining.find(self.reasoning_end)
+            if end_idx == -1:
+                if remaining:
+                    blocks.append(
+                        ContentBlock(type="thinking", content=remaining))
+                return blocks
+            thinking_text = remaining[:end_idx]
+            if thinking_text:
+                blocks.append(
+                    ContentBlock(type="thinking", content=thinking_text))
+            remaining = remaining[end_idx + len(self.reasoning_end):]
+
+        # Process remaining text for interleaved blocks
+        while remaining:
+            start_idx = remaining.find(self.reasoning_start)
+            if start_idx == -1:
+                # No more thinking blocks, rest is text
+                if remaining:
+                    blocks.append(ContentBlock(type="text", content=remaining))
+                break
+
+            # Text before the next <think> tag
+            text_before = remaining[:start_idx]
+            if text_before:
+                blocks.append(ContentBlock(type="text", content=text_before))
+
+            remaining = remaining[start_idx + len(self.reasoning_start):]
+            end_idx = remaining.find(self.reasoning_end)
+            if end_idx == -1:
+                # Unclosed thinking block
+                if remaining:
+                    blocks.append(
+                        ContentBlock(type="thinking", content=remaining))
+                break
+
+            thinking_text = remaining[:end_idx]
+            if thinking_text:
+                blocks.append(
+                    ContentBlock(type="thinking", content=thinking_text))
+            remaining = remaining[end_idx + len(self.reasoning_end):]
+
+        return blocks
+
     def parse_delta(self, delta_text: str) -> ReasoningParserResult:
         self._buffer += delta_text
         delta_text = self._buffer
@@ -131,7 +235,8 @@ class DeepSeekR1Parser(BaseReasoningParser):
             begin_idx = delta_text.find(self.reasoning_start)
             if begin_idx == -1:
                 self._buffer = ""
-                return ReasoningParserResult(content=delta_text)
+                return ReasoningParserResult(content=delta_text,
+                                             current_block_type="text")
             self.in_reasoning = True
             # set reasoning_content, will be processed by the next block
             reasoning_content = delta_text[begin_idx +
@@ -150,13 +255,18 @@ class DeepSeekR1Parser(BaseReasoningParser):
                     self._buffer = ""
                     reasoning_content = delta_text
                 return ReasoningParserResult(
-                    reasoning_content=reasoning_content)
+                    reasoning_content=reasoning_content,
+                    current_block_type="thinking")
             reasoning_content = delta_text[:end_idx]
             content = delta_text[end_idx + len(self.reasoning_end):]
             self.in_reasoning = False
             self._buffer = ""
+            # Determine block type: if there's content after </think>, it's text;
+            # if only reasoning, it's thinking
+            block_type = "text" if content else "thinking"
             return ReasoningParserResult(content=content,
-                                         reasoning_content=reasoning_content)
+                                         reasoning_content=reasoning_content,
+                                         current_block_type=block_type)
         raise RuntimeError(
             "Unreachable code reached in `DeepSeekR1Parser.parse_delta`")
 

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -77,6 +77,34 @@ class OpenAIBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
+class ThinkingParams(OpenAIBaseModel):
+    """Parameters for controlling interleaved thinking in reasoning models."""
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    type: Literal["enabled", "disabled"] = "enabled"
+    budget_tokens: Optional[int] = Field(
+        default=None,
+        description=("Maximum number of thinking tokens the model may produce. "
+                     "Passed to the chat template as `thinking_budget`."),
+    )
+
+
+class ThinkingContentBlock(OpenAIBaseModel):
+    """A content block containing thinking/reasoning text."""
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["thinking"] = "thinking"
+    thinking: str
+
+
+class TextContentBlock(OpenAIBaseModel):
+    """A content block containing regular text."""
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["text"] = "text"
+    text: str
+
+
+ContentBlock = Union[ThinkingContentBlock, TextContentBlock]
+
+
 class StreamOptions(OpenAIBaseModel):
     include_usage: Optional[bool] = True
     continuous_usage_stats: Optional[bool] = False
@@ -495,7 +523,7 @@ class DeltaToolCall(OpenAIBaseModel):
 
 class ChatMessage(OpenAIBaseModel):
     role: str
-    content: Optional[str] = None
+    content: Optional[Union[str, List[ContentBlock]]] = None
     reasoning_content: Optional[str] = None
     reasoning: Optional[str] = None
     tool_calls: List[ToolCall] = Field(default_factory=list)
@@ -589,7 +617,7 @@ class ChatCompletionResponse(OpenAIBaseModel):
 
 class DeltaMessage(OpenAIBaseModel):
     role: Optional[str] = None
-    content: Optional[str] = None
+    content: Optional[Union[str, List[ContentBlock]]] = None
     reasoning_content: Optional[str] = None
     # For GPT-OSS style reasoning
     reasoning: Optional[str] = None
@@ -669,6 +697,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "reasoning is shown in the model's response. Options: "
                 "'low', 'medium', 'high'."),
         )
+    thinking: Optional[ThinkingParams] = Field(
+        default=None,
+        description=(
+            "Controls interleaved thinking for reasoning models. "
+            "When type is 'enabled', the model's thinking/reasoning tokens "
+            "are included in the response as typed content blocks. "
+            "When type is 'disabled', thinking tokens are suppressed. "
+            "When not set, the existing reasoning_content behavior is used."),
+    )
     prompt_ignore_length: Optional[int] = 0
 
     # doc: begin-chat-completion-sampling-params

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -820,6 +820,17 @@ class OpenAIServer:
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
 
+            # Handle interleaved thinking parameters
+            chat_template_kwargs = dict(request.chat_template_kwargs or {})
+            if request.thinking is not None:
+                if request.thinking.type == "enabled":
+                    chat_template_kwargs.setdefault("enable_thinking", True)
+                    if request.thinking.budget_tokens is not None:
+                        chat_template_kwargs.setdefault(
+                            "thinking_budget", request.thinking.budget_tokens)
+                elif request.thinking.type == "disabled":
+                    chat_template_kwargs.setdefault("enable_thinking", False)
+
             try:
                 conversation, mm_coroutines, mm_placeholder_counts = parse_chat_messages_coroutines(
                     request.messages, self.model_config,
@@ -845,7 +856,7 @@ class OpenAIServer:
                     tools=tool_dicts,
                     documents=request.documents,
                     chat_template=request.chat_template or self.chat_template,
-                    chat_template_kwargs=request.chat_template_kwargs or {},
+                    chat_template_kwargs=chat_template_kwargs,
                 )
             prompt = prompt_inputs(prompt)
 
@@ -862,6 +873,9 @@ class OpenAIServer:
             postproc_args.reasoning_parser = self.generator.args.reasoning_parser
             postproc_args.tool_parser = self.tool_parser
             postproc_args.tool_call_id_type = self.tool_call_id_type
+            # Update chat_template_kwargs on postproc_args to include
+            # thinking-derived kwargs for the reasoning parser.
+            postproc_args.chat_template_kwargs = chat_template_kwargs
             if conversation and conversation[-1].get(
                     "content") and conversation[-1].get("role") == get_role():
                 postproc_args.last_message_content = conversation[-1]["content"]

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -32,8 +32,10 @@ from .openai_protocol import (ChatCompletionLogProbs,
                               CompletionStreamResponse, DeltaFunctionCall,
                               DeltaMessage, DeltaToolCall, FunctionCall,
                               PromptTokensDetails, ResponsesRequest,
-                              ResponsesResponse, StreamOptions, ToolCall,
-                              UsageInfo, to_disaggregated_params)
+                              ResponsesResponse, StreamOptions,
+                              TextContentBlock, ThinkingContentBlock,
+                              ThinkingParams, ToolCall, UsageInfo,
+                              to_disaggregated_params)
 from .tool_parser.base_tool_parser import BaseToolParser
 from .tool_parser.core_types import ToolCallItem
 from .tool_parser.tool_parser_factory import ToolParserFactory
@@ -62,6 +64,7 @@ class ChatPostprocArgs(PostprocArgs):
     has_tool_call: dict[int, bool] = field(default_factory=dict)
     tool_call_id_type: str = "random"
     chat_template_kwargs: Optional[dict[str, Any]] = None
+    thinking: Optional[ThinkingParams] = None
 
     @classmethod
     def from_request(cls, request: ChatCompletionRequest):
@@ -77,6 +80,7 @@ class ChatPostprocArgs(PostprocArgs):
             return_logprobs=bool(request.logprobs),
             top_logprobs=bool(request.top_logprobs),
             chat_template_kwargs=request.chat_template_kwargs,
+            thinking=request.thinking,
         )
 
 
@@ -111,16 +115,21 @@ def create_logprobs(token_ids: List[int], tokenizer: TransformersTokenizer,
     return chat_logprobs
 
 
+def _get_or_create_reasoning_parser(args: ChatPostprocArgs, output_index: int):
+    """Get or create a reasoning parser for the given output index."""
+    if args.reasoning_parser is None:
+        return None
+    if output_index not in args.reasoning_parser_dict:
+        chat_template_kwargs = getattr(args, "chat_template_kwargs", None)
+        args.reasoning_parser_dict[
+            output_index] = ReasoningParserFactory.create_reasoning_parser(
+                args.reasoning_parser, chat_template_kwargs)
+    return args.reasoning_parser_dict[output_index]
+
+
 def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
                            streaming: bool) -> Tuple[str, str]:
-    reasoning_parser = None
-    if args.reasoning_parser is not None:
-        if output_index not in args.reasoning_parser_dict:
-            chat_template_kwargs = getattr(args, "chat_template_kwargs", None)
-            args.reasoning_parser_dict[
-                output_index] = ReasoningParserFactory.create_reasoning_parser(
-                    args.reasoning_parser, chat_template_kwargs)
-        reasoning_parser = args.reasoning_parser_dict[output_index]
+    reasoning_parser = _get_or_create_reasoning_parser(args, output_index)
 
     if reasoning_parser is not None:
         if not streaming:
@@ -132,6 +141,40 @@ def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
         content, reasoning_content = text, ""
 
     return content, reasoning_content
+
+
+def apply_reasoning_parser_with_blocks(args: ChatPostprocArgs,
+                                       output_index: int, text: str,
+                                       streaming: bool) -> Tuple[str, str, Any]:
+    """Apply reasoning parser and return content, reasoning_content, and extra info.
+
+    When thinking is enabled:
+    - For non-streaming: returns (content, reasoning_content, content_blocks)
+    - For streaming: returns (content, reasoning_content, current_block_type)
+    When thinking is not enabled:
+    - Returns (content, reasoning_content, None)
+    """
+    reasoning_parser = _get_or_create_reasoning_parser(args, output_index)
+    thinking_enabled = (args.thinking is not None
+                        and args.thinking.type == "enabled")
+
+    if reasoning_parser is not None:
+        if not streaming:
+            if thinking_enabled:
+                content_blocks = reasoning_parser.parse_to_blocks(text)
+                result = reasoning_parser.parse(text)
+                return result.content, result.reasoning_content, content_blocks
+            else:
+                result = reasoning_parser.parse(text)
+                return result.content, result.reasoning_content, None
+        else:
+            result = reasoning_parser.parse_delta(text)
+            if thinking_enabled:
+                return (result.content, result.reasoning_content,
+                        result.current_block_type)
+            return result.content, result.reasoning_content, None
+    else:
+        return text, "", None
 
 
 def apply_tool_parser(args: ChatPostprocArgs, output_index: int, text: str,
@@ -205,6 +248,9 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
                 )
         args.first_iteration = False
 
+    thinking_enabled = (args.thinking is not None
+                        and args.thinking.type == "enabled")
+
     for output in rsp.outputs:
         i = output.index
 
@@ -213,8 +259,8 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
 
         delta_text = output.text_diff
 
-        delta_text, reasoning_delta_text = apply_reasoning_parser(
-            args, i, delta_text, True)
+        delta_text, reasoning_delta_text, block_type = \
+            apply_reasoning_parser_with_blocks(args, i, delta_text, True)
 
         if args.tool_choice and type(
                 args.tool_choice) is ChatCompletionNamedToolChoiceParam:
@@ -253,10 +299,22 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
                         ),
                     ))
             if tool_calls or delta_text or reasoning_delta_text or output.finish_reason:
-                delta_message = DeltaMessage(
-                    content=delta_text,
-                    reasoning_content=reasoning_delta_text,
-                    tool_calls=tool_calls if tool_calls else None)
+                if thinking_enabled and block_type is not None:
+                    # Use typed content blocks for interleaved thinking
+                    content_blocks = []
+                    if reasoning_delta_text:
+                        content_blocks.append(
+                            ThinkingContentBlock(thinking=reasoning_delta_text))
+                    if delta_text:
+                        content_blocks.append(TextContentBlock(text=delta_text))
+                    delta_message = DeltaMessage(
+                        content=content_blocks if content_blocks else None,
+                        tool_calls=tool_calls if tool_calls else None)
+                else:
+                    delta_message = DeltaMessage(
+                        content=delta_text,
+                        reasoning_content=reasoning_delta_text,
+                        tool_calls=tool_calls if tool_calls else None)
             else:
                 continue
 
@@ -315,9 +373,11 @@ def chat_response_post_processor(
         args: ChatPostprocArgs) -> ChatCompletionResponse:
     choices: List[ChatCompletionResponseChoice] = []
     role = args.role
+    thinking_enabled = (args.thinking is not None
+                        and args.thinking.type == "enabled")
     for output in rsp.outputs:
-        text, reasoning_text = apply_reasoning_parser(args, output.index,
-                                                      output.text, False)
+        text, reasoning_text, extra = apply_reasoning_parser_with_blocks(
+            args, output.index, output.text, False)
 
         if args.tool_choice and isinstance(args.tool_choice,
                                            ChatCompletionNamedToolChoiceParam):
@@ -337,10 +397,22 @@ def chat_response_post_processor(
                                                arguments=call.parameters))
                 for call in calls
             ]
-            message = ChatMessage(role=role,
-                                  content=text,
-                                  reasoning_content=reasoning_text,
-                                  tool_calls=tool_calls)
+            if thinking_enabled and extra is not None:
+                # extra is content_blocks from parse_to_blocks
+                content_blocks = [
+                    ThinkingContentBlock(thinking=b.content) if b.type
+                    == "thinking" else TextContentBlock(text=b.content)
+                    for b in extra
+                ]
+                message = ChatMessage(
+                    role=role,
+                    content=content_blocks if content_blocks else text,
+                    tool_calls=tool_calls)
+            else:
+                message = ChatMessage(role=role,
+                                      content=text,
+                                      reasoning_content=reasoning_text,
+                                      tool_calls=tool_calls)
         disaggregated_params = to_disaggregated_params(
             output.disaggregated_params)
         choice = ChatCompletionResponseChoice(

--- a/tests/unittest/llmapi/test_interleaved_thinking.py
+++ b/tests/unittest/llmapi/test_interleaved_thinking.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for interleaved thinking support in trtllm-serve.
+
+Tests cover:
+- ThinkingParams protocol model
+- Content block types (ThinkingContentBlock, TextContentBlock)
+- ChatMessage with content blocks
+- DeltaMessage with content blocks
+- ChatCompletionRequest with thinking parameter
+"""
+
+import json
+
+import pytest
+
+from tensorrt_llm.llmapi.reasoning_parser import ContentBlock, ReasoningParserFactory
+from tensorrt_llm.serve.openai_protocol import (
+    ChatCompletionRequest,
+    ChatMessage,
+    DeltaMessage,
+    TextContentBlock,
+    ThinkingContentBlock,
+    ThinkingParams,
+)
+
+# ── ThinkingParams model tests ─────────────────────────────────────
+
+
+class TestThinkingParams:
+    def test_default_type_is_enabled(self):
+        params = ThinkingParams()
+        assert params.type == "enabled"
+        assert params.budget_tokens is None
+
+    def test_enabled_with_budget(self):
+        params = ThinkingParams(type="enabled", budget_tokens=1024)
+        assert params.type == "enabled"
+        assert params.budget_tokens == 1024
+
+    def test_disabled(self):
+        params = ThinkingParams(type="disabled")
+        assert params.type == "disabled"
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(Exception):
+            ThinkingParams(type="invalid")
+
+    def test_serialization(self):
+        params = ThinkingParams(type="enabled", budget_tokens=2048)
+        data = params.model_dump()
+        assert data["type"] == "enabled"
+        assert data["budget_tokens"] == 2048
+
+    def test_deserialization(self):
+        params = ThinkingParams.model_validate({"type": "enabled", "budget_tokens": 512})
+        assert params.type == "enabled"
+        assert params.budget_tokens == 512
+
+
+# ── Content block type tests ──────────────────────────────────────
+
+
+class TestContentBlocks:
+    def test_thinking_block(self):
+        block = ThinkingContentBlock(thinking="reasoning text")
+        assert block.type == "thinking"
+        assert block.thinking == "reasoning text"
+
+    def test_text_block(self):
+        block = TextContentBlock(text="response text")
+        assert block.type == "text"
+        assert block.text == "response text"
+
+    def test_thinking_block_serialization(self):
+        block = ThinkingContentBlock(thinking="let me think...")
+        data = block.model_dump()
+        assert data == {"type": "thinking", "thinking": "let me think..."}
+
+    def test_text_block_serialization(self):
+        block = TextContentBlock(text="the answer is 42")
+        data = block.model_dump()
+        assert data == {"type": "text", "text": "the answer is 42"}
+
+
+# ── ChatMessage with content blocks ──────────────────────────────
+
+
+class TestChatMessageContentBlocks:
+    def test_string_content_backward_compat(self):
+        msg = ChatMessage(role="assistant", content="hello")
+        assert msg.content == "hello"
+        assert msg.reasoning_content is None
+
+    def test_content_blocks(self):
+        blocks = [
+            ThinkingContentBlock(thinking="reasoning"),
+            TextContentBlock(text="answer"),
+        ]
+        msg = ChatMessage(role="assistant", content=blocks)
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+        assert msg.content[0].type == "thinking"
+        assert msg.content[1].type == "text"
+
+    def test_content_blocks_serialization(self):
+        blocks = [
+            ThinkingContentBlock(thinking="reasoning"),
+            TextContentBlock(text="answer"),
+        ]
+        msg = ChatMessage(role="assistant", content=blocks)
+        data = msg.model_dump(exclude_none=True)
+        assert data["content"] == [
+            {"type": "thinking", "thinking": "reasoning"},
+            {"type": "text", "text": "answer"},
+        ]
+
+    def test_interleaved_content_blocks(self):
+        blocks = [
+            ThinkingContentBlock(thinking="think1"),
+            TextContentBlock(text="text1"),
+            ThinkingContentBlock(thinking="think2"),
+            TextContentBlock(text="text2"),
+        ]
+        msg = ChatMessage(role="assistant", content=blocks)
+        data = msg.model_dump(exclude_none=True)
+        assert len(data["content"]) == 4
+        assert data["content"][0]["type"] == "thinking"
+        assert data["content"][1]["type"] == "text"
+        assert data["content"][2]["type"] == "thinking"
+        assert data["content"][3]["type"] == "text"
+
+    def test_json_serialization_roundtrip(self):
+        blocks = [
+            ThinkingContentBlock(thinking="reasoning"),
+            TextContentBlock(text="answer"),
+        ]
+        msg = ChatMessage(role="assistant", content=blocks)
+        json_str = msg.model_dump_json(exclude_none=True)
+        data = json.loads(json_str)
+        assert data["role"] == "assistant"
+        assert len(data["content"]) == 2
+
+
+# ── DeltaMessage with content blocks ─────────────────────────────
+
+
+class TestDeltaMessageContentBlocks:
+    def test_string_content_backward_compat(self):
+        delta = DeltaMessage(content="hello")
+        assert delta.content == "hello"
+
+    def test_thinking_content_block_in_delta(self):
+        delta = DeltaMessage(content=[ThinkingContentBlock(thinking="reasoning")])
+        assert isinstance(delta.content, list)
+        assert delta.content[0].type == "thinking"
+
+    def test_text_content_block_in_delta(self):
+        delta = DeltaMessage(content=[TextContentBlock(text="answer")])
+        assert isinstance(delta.content, list)
+        assert delta.content[0].type == "text"
+
+    def test_delta_serialization_with_blocks(self):
+        delta = DeltaMessage(content=[ThinkingContentBlock(thinking="let me think")])
+        data = delta.model_dump(exclude_none=True)
+        assert data["content"] == [{"type": "thinking", "thinking": "let me think"}]
+
+
+# ── ChatCompletionRequest with thinking param ─────────────────────
+
+
+class TestChatCompletionRequestThinking:
+    def test_thinking_param_default_none(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        assert req.thinking is None
+
+    def test_thinking_param_enabled(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            thinking=ThinkingParams(type="enabled", budget_tokens=1024),
+        )
+        assert req.thinking is not None
+        assert req.thinking.type == "enabled"
+        assert req.thinking.budget_tokens == 1024
+
+    def test_thinking_param_disabled(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            thinking=ThinkingParams(type="disabled"),
+        )
+        assert req.thinking.type == "disabled"
+
+    def test_thinking_param_from_dict(self):
+        req = ChatCompletionRequest.model_validate(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 2048,
+                },
+            }
+        )
+        assert req.thinking.type == "enabled"
+        assert req.thinking.budget_tokens == 2048
+
+
+# ── Reasoning parser interleaved blocks ──────────────────────────
+
+
+class TestReasoningParserInterleavedBlocks:
+    def test_deepseek_r1_single_block(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("deepseek-r1")
+        blocks = parser.parse_to_blocks("reasoning</think>content")
+        assert len(blocks) == 2
+        assert blocks[0] == ContentBlock("thinking", "reasoning")
+        assert blocks[1] == ContentBlock("text", "content")
+
+    def test_deepseek_r1_multiple_blocks(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("deepseek-r1")
+        text = "t1</think>c1<think>t2</think>c2<think>t3</think>c3"
+        blocks = parser.parse_to_blocks(text)
+        assert len(blocks) == 6
+        assert blocks[0] == ContentBlock("thinking", "t1")
+        assert blocks[1] == ContentBlock("text", "c1")
+        assert blocks[2] == ContentBlock("thinking", "t2")
+        assert blocks[3] == ContentBlock("text", "c2")
+        assert blocks[4] == ContentBlock("thinking", "t3")
+        assert blocks[5] == ContentBlock("text", "c3")
+
+    def test_qwen3_no_thinking(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+        blocks = parser.parse_to_blocks("just plain text")
+        assert len(blocks) == 1
+        assert blocks[0] == ContentBlock("text", "just plain text")
+
+    def test_qwen3_interleaved(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+        text = "<think>t1</think>c1<think>t2</think>c2"
+        blocks = parser.parse_to_blocks(text)
+        assert len(blocks) == 4
+        assert blocks[0] == ContentBlock("thinking", "t1")
+        assert blocks[1] == ContentBlock("text", "c1")
+        assert blocks[2] == ContentBlock("thinking", "t2")
+        assert blocks[3] == ContentBlock("text", "c2")
+
+    def test_streaming_block_type_tracking(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("deepseek-r1")
+        # First delta: reasoning content
+        result = parser.parse_delta("thinking")
+        assert result.current_block_type == "thinking"
+        # Second delta: end of reasoning, start of content
+        result = parser.parse_delta("</think>content")
+        assert result.current_block_type == "text"
+
+    def test_streaming_block_type_text_only(self):
+        parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+        result = parser.parse_delta("hello")
+        assert result.current_block_type == "text"

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+from tensorrt_llm.llmapi.reasoning_parser import (ContentBlock,
+                                                  ReasoningParserFactory)
 
 R1_START, R1_END = "<think>", "</think>"
 
@@ -160,3 +161,110 @@ def test_nano_v3_reasoning_parser_stream(delta_texts: list, content: list,
         print(f"delta_text: {delta_text}, result: {result}")
         assert result.content == content[i]
         assert result.reasoning_content == reasoning_context[i]
+
+
+# ── Interleaved thinking: parse_to_blocks ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_blocks"),
+    [
+        # deepseek-r1: reasoning starts immediately
+        ("think1</think>text1",
+         [ContentBlock("thinking", "think1"),
+          ContentBlock("text", "text1")]),
+        # Only reasoning, no closing tag
+        ("all reasoning", [ContentBlock("thinking", "all reasoning")]),
+        # Reasoning then text then reasoning (interleaved)
+        ("think1</think>text1<think>think2</think>text2", [
+            ContentBlock("thinking", "think1"),
+            ContentBlock("text", "text1"),
+            ContentBlock("thinking", "think2"),
+            ContentBlock("text", "text2"),
+        ]),
+        # Reasoning with empty text between thinking blocks
+        ("think1</think><think>think2</think>text2", [
+            ContentBlock("thinking", "think1"),
+            ContentBlock("thinking", "think2"),
+            ContentBlock("text", "text2"),
+        ]),
+        # Only reasoning with closing tag
+        ("all reasoning</think>", [ContentBlock("thinking", "all reasoning")]),
+        # Multiple interleaved blocks
+        ("t1</think>c1<think>t2</think>c2<think>t3</think>c3", [
+            ContentBlock("thinking", "t1"),
+            ContentBlock("text", "c1"),
+            ContentBlock("thinking", "t2"),
+            ContentBlock("text", "c2"),
+            ContentBlock("thinking", "t3"),
+            ContentBlock("text", "c3"),
+        ]),
+    ])
+def test_deepseek_r1_parse_to_blocks(text: str,
+                                     expected_blocks: list[ContentBlock]):
+    parser = ReasoningParserFactory.create_reasoning_parser("deepseek-r1")
+    blocks = parser.parse_to_blocks(text)
+    assert blocks == expected_blocks
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_blocks"),
+    [
+        # qwen3: reasoning doesn't start at beginning
+        ("<think>think1</think>text1",
+         [ContentBlock("thinking", "think1"),
+          ContentBlock("text", "text1")]),
+        # No thinking at all
+        ("just text", [ContentBlock("text", "just text")]),
+        # Interleaved thinking
+        ("<think>think1</think>text1<think>think2</think>text2", [
+            ContentBlock("thinking", "think1"),
+            ContentBlock("text", "text1"),
+            ContentBlock("thinking", "think2"),
+            ContentBlock("text", "text2"),
+        ]),
+        # Only thinking
+        ("<think>thinking only", [ContentBlock("thinking", "thinking only")]),
+        # Empty thinking
+        ("<think></think>text only", [ContentBlock("text", "text only")]),
+    ])
+def test_qwen3_parse_to_blocks(text: str, expected_blocks: list[ContentBlock]):
+    parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+    blocks = parser.parse_to_blocks(text)
+    assert blocks == expected_blocks
+
+
+# ── Interleaved thinking: streaming block type tracking ──────────
+
+
+@pytest.mark.parametrize(
+    ("delta_texts", "expected_block_types"),
+    [
+        # deepseek-r1 streaming: starts in reasoning, then transitions
+        (["think", f"ing{R1_END}text"], ["thinking", "text"]),
+        # All reasoning
+        (["think", "more"], ["thinking", "thinking"]),
+        # Transition to text then back to thinking
+        ([f"t1{R1_END}c1", f"{R1_START}t2{R1_END}c2"], ["text", "text"]),
+    ])
+def test_deepseek_r1_stream_block_type(delta_texts: list,
+                                       expected_block_types: list):
+    parser = ReasoningParserFactory.create_reasoning_parser("deepseek-r1")
+    for i, delta_text in enumerate(delta_texts):
+        result = parser.parse_delta(delta_text)
+        assert result.current_block_type == expected_block_types[i]
+
+
+@pytest.mark.parametrize(
+    ("delta_texts", "expected_block_types"),
+    [
+        # qwen3 streaming: starts with think tag
+        (["<think>a", f"l{R1_END}r"], ["thinking", "text"]),
+        # Text only
+        (["hello", "world"], ["text", "text"]),
+    ])
+def test_qwen3_stream_block_type(delta_texts: list, expected_block_types: list):
+    parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+    for i, delta_text in enumerate(delta_texts):
+        result = parser.parse_delta(delta_text)
+        assert result.current_block_type == expected_block_types[i]


### PR DESCRIPTION
## Summary
- Add `thinking` parameter to `ChatCompletionRequest` for controlling interleaved thinking in reasoning models (DeepSeek-R1, QwQ, etc.)
- When `thinking.type` is `"enabled"`, responses use typed content blocks (`ThinkingContentBlock`/`TextContentBlock`) instead of flat `content`/`reasoning_content` strings, preserving the interleaved order of thinking and text segments
- Extend reasoning parser with `parse_to_blocks()` for multi-block interleaved parsing and `current_block_type` tracking for streaming
- Wire `thinking` parameter to chat template kwargs (`enable_thinking`, `thinking_budget`) in the OpenAI server
- Full backward compatibility: when `thinking` is not set, existing `reasoning_content` behavior is preserved

### API Changes

**Request** - new optional `thinking` field:
```json
{
  "model": "deepseek-r1",
  "messages": [...],
  "thinking": {
    "type": "enabled",
    "budget_tokens": 1024
  }
}
```

**Non-streaming response** - `content` becomes a list of typed blocks:
```json
{
  "choices": [{
    "message": {
      "role": "assistant",
      "content": [
        {"type": "thinking", "thinking": "Let me reason..."},
        {"type": "text", "text": "The answer is 42."},
        {"type": "thinking", "thinking": "Let me verify..."},
        {"type": "text", "text": "Confirmed."}
      ]
    }
  }]
}
```

**Streaming response** - delta uses content blocks:
```json
{"choices": [{"delta": {"content": [{"type": "thinking", "thinking": "Let me "}]}}]}
{"choices": [{"delta": {"content": [{"type": "text", "text": "The answer"}]}}]}
```

### Files Changed
| File | Change |
|------|--------|
| `tensorrt_llm/serve/openai_protocol.py` | Add `ThinkingParams`, `ThinkingContentBlock`, `TextContentBlock`; add `thinking` to `ChatCompletionRequest`; update `ChatMessage`/`DeltaMessage` content type |
| `tensorrt_llm/llmapi/reasoning_parser.py` | Add `ContentBlock` dataclass; extend `ReasoningParserResult` with `content_blocks` and `current_block_type`; add `parse_to_blocks()` |
| `tensorrt_llm/serve/postprocess_handlers.py` | Update streaming/non-streaming handlers to emit content blocks when thinking is enabled |
| `tensorrt_llm/serve/openai_server.py` | Wire `thinking` param to chat template kwargs |
| `tests/unittest/llmapi/test_interleaved_thinking.py` | New: 29 tests for protocol, content blocks, request parsing |
| `tests/unittest/llmapi/test_reasoning_parser.py` | Add 16 tests for `parse_to_blocks()` and streaming block type |

## Test plan
- [x] All 94 unit tests pass (65 existing + 29 new)
- [x] Pre-commit hooks pass
- [x] Backward compatible: existing `reasoning_content` behavior unchanged when `thinking` is not set
- [ ] E2E test with DeepSeek-R1 or QwQ model with `thinking: {type: "enabled"}`
- [ ] E2E streaming test verifying interleaved content blocks

## Related
- Jira: TRTLLM-11357
- Similar feature in vLLM: https://docs.vllm.ai/en/latest/features/interleaved_thinking/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interleaved thinking and text blocks in chat responses.
  * Introduced thinking control parameter to manage reasoning output in requests.
  * Extended chat content structure to support mixed content block types.

* **Tests**
  * Added comprehensive test coverage for interleaved thinking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->