### PR TITLE
[None][feat] Support managed GPU weights and PyTorch preload aliasing

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1551,7 +1551,7 @@ public:
         std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
         std::optional<CacheTransceiverConfig> cacheTransceiverConfig = std::nullopt,
         bool gatherGenerationLogits = false, bool promptTableOffloading = false, bool enableTrtOverlap = false,
-        bool failFastOnAttentionWindowTooLarge = false);
+        bool failFastOnAttentionWindowTooLarge = false, bool aliasManagedWeightsFromGpu = false);
 
     [[nodiscard]] SizeType32 getMaxBeamWidth() const;
     [[nodiscard]] SchedulerConfig getSchedulerConfig() const;
@@ -1574,6 +1574,7 @@ public:
     [[nodiscard]] std::optional<DecodingConfig> getDecodingConfig() const;
     [[nodiscard]] bool getUseGpuDirectStorage() const;
     [[nodiscard]] float getGpuWeightsPercent() const;
+    [[nodiscard]] bool getAliasManagedWeightsFromGpu() const;
     [[nodiscard]] std::optional<SizeType32> getMaxQueueSize() const;
     [[nodiscard]] ExtendedRuntimePerfKnobConfig getExtendedRuntimePerfKnobConfig() const;
     [[nodiscard]] std::optional<DebugConfig> getDebugConfig() const;
@@ -1604,6 +1605,7 @@ public:
     void setDecodingConfig(DecodingConfig const& decodingConfig);
     void setUseGpuDirectStorage(bool const& useGpuDirectStorage);
     void setGpuWeightsPercent(float const& gpuWeightsPercent);
+    void setAliasManagedWeightsFromGpu(bool const& aliasManagedWeightsFromGpu);
     void setMaxQueueSize(std::optional<SizeType32> const& maxQueueSize);
     void setExtendedRuntimePerfKnobConfig(ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig);
     void setDebugConfig(DebugConfig const& debugConfig);
@@ -1707,6 +1709,9 @@ private:
     /// @brief Controls whether to fail fast when attention window is too large to fit even a single sequence in the KV
     /// cache.
     bool mFailFastOnAttentionWindowTooLarge{false};
+
+    /// @brief Alias managed GPU weights directly when loading from engine buffer instead of making a device copy.
+    bool mAliasManagedWeightsFromGpu{false};
 };
 
 struct KVCacheCreatedData

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
@@ -46,8 +46,11 @@ TrtEncoderModel::TrtEncoderModel(runtime::ModelConfig const& modelConfig, WorldC
     , mWorldConfig{worldConfig}
     , mDevice{runtime::utils::initDevice(worldConfig)}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}
-    , mRuntime{std::make_shared<TllmRuntime>(
-          rawEngine, mLogger.get(), executorConfig.getUseGpuDirectStorage(), executorConfig.getGpuWeightsPercent())}
+    , mRuntime{std::make_shared<TllmRuntime>(rawEngine, mLogger.get(),
+          /* useGpuDirectStorage = */ executorConfig.getUseGpuDirectStorage(),
+          /* gpuWeightsPercent = */ executorConfig.getGpuWeightsPercent(),
+          /* useShapeInference = */ true,
+          /* aliasManagedWeightsFromGpu = */ executorConfig.getAliasManagedWeightsFromGpu())}
     , mNumMicroBatches{1}
     , mNumBuffers{mNumMicroBatches}
     , mCopyBufferManager{std::make_shared<CudaStream>()}

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -183,8 +183,11 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
     , mAdditionalModelOutputs{worldConfig.isLastPipelineParallelRank() ? executorConfig.getAdditionalModelOutputs()
                                                                        : std::nullopt}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}
-    , mRuntime{std::make_unique<TllmRuntime>(rawEngine, mLogger.get(), executorConfig.getUseGpuDirectStorage(),
-          executorConfig.getGpuWeightsPercent(), modelConfig.useShapeInference())}
+    , mRuntime{std::make_unique<TllmRuntime>(rawEngine, mLogger.get(),
+          /* useGpuDirectStorage = */ executorConfig.getUseGpuDirectStorage(),
+          /* gpuWeightsPercent = */ executorConfig.getGpuWeightsPercent(),
+          /* useShapeInference = */ modelConfig.useShapeInference(),
+          /* aliasManagedWeightsFromGpu = */ executorConfig.getAliasManagedWeightsFromGpu())}
     , mCopyBufferManager{std::make_shared<CudaStream>()}
     , mCtxGenFusion(ctxGenFusion)
     , mOperatingBeamWidth{getMaxBeamWidth()}

--- a/cpp/tensorrt_llm/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/executor/executorConfig.cpp
@@ -34,7 +34,8 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
     std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
     std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
-    bool promptTableOffloading, bool enableTrtOverlap, bool failFastOnAttentionWindowTooLarge)
+    bool promptTableOffloading, bool enableTrtOverlap, bool failFastOnAttentionWindowTooLarge,
+    bool aliasManagedWeightsFromGpu)
     : mMaxBeamWidth(maxBeamWidth)
     , mSchedulerConfig(std::move(schedulerConfig))
     , mKvCacheConfig(std::move(kvCacheConfig))
@@ -64,6 +65,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     , mPromptTableOffloading(promptTableOffloading)
     , mEnableTrtOverlap(enableTrtOverlap)
     , mFailFastOnAttentionWindowTooLarge(failFastOnAttentionWindowTooLarge)
+    , mAliasManagedWeightsFromGpu(aliasManagedWeightsFromGpu)
 {
     TLLM_CHECK(iterStatsMaxIterations >= 0);
     TLLM_CHECK(requestStatsMaxIterations >= 0);
@@ -161,6 +163,11 @@ bool ExecutorConfig::getUseGpuDirectStorage() const
 float ExecutorConfig::getGpuWeightsPercent() const
 {
     return mGpuWeightsPercent;
+}
+
+bool ExecutorConfig::getAliasManagedWeightsFromGpu() const
+{
+    return mAliasManagedWeightsFromGpu;
 }
 
 std::optional<SizeType32> ExecutorConfig::getMaxQueueSize() const
@@ -313,6 +320,11 @@ void ExecutorConfig::setUseGpuDirectStorage(bool const& useGpuDirectStorage)
 void ExecutorConfig::setGpuWeightsPercent(float const& gpuWeightsPercent)
 {
     mGpuWeightsPercent = gpuWeightsPercent;
+}
+
+void ExecutorConfig::setAliasManagedWeightsFromGpu(bool const& aliasManagedWeightsFromGpu)
+{
+    mAliasManagedWeightsFromGpu = aliasManagedWeightsFromGpu;
 }
 
 void ExecutorConfig::setMaxQueueSize(std::optional<SizeType32> const& maxQueueSize)

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -1153,6 +1153,8 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
     auto decodingConfig = su::deserializeWithGetterType<decltype(&ExecutorConfig::getDecodingConfig)>(is);
     auto useGpuDirectStorage = su::deserializeWithGetterType<decltype(&ExecutorConfig::getUseGpuDirectStorage)>(is);
     auto gpuWeightsPercent = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGpuWeightsPercent)>(is);
+    auto aliasManagedWeightsFromGpu
+        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getAliasManagedWeightsFromGpu)>(is);
     auto maxQueueSize = su::deserializeWithGetterType<decltype(&ExecutorConfig::getMaxQueueSize)>(is);
     auto extendedRuntimePerfKnobConfig
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getExtendedRuntimePerfKnobConfig)>(is);
@@ -1170,13 +1172,15 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGatherGenerationLogits)>(is);
     auto promptTableOffloading = su::deserializeWithGetterType<decltype(&ExecutorConfig::getPromptTableOffloading)>(is);
     auto enableTrtOverlap = su::deserializeWithGetterType<decltype(&ExecutorConfig::getEnableTrtOverlap)>(is);
+    auto failFastOnAttentionWindowTooLarge
+        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getFailFastOnAttentionWindowTooLarge)>(is);
 
     return ExecutorConfig{maxBeamWidth, schedulerConfig, kvCacheConfig, enableChunkedContext, normalizeLogProbs,
         iterStatsMaxIterations, requestStatsMaxIterations, batchingType, maxBatchSize, maxNumTokens, parallelConfig,
         peftCacheConfig, std::nullopt, decodingConfig, useGpuDirectStorage, gpuWeightsPercent, maxQueueSize,
         extendedRuntimePerfKnobConfig, debugConfig, recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig,
         guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig, gatherGenerationLogits,
-        promptTableOffloading, enableTrtOverlap};
+        promptTableOffloading, enableTrtOverlap, failFastOnAttentionWindowTooLarge, aliasManagedWeightsFromGpu};
 }
 
 size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
@@ -1201,6 +1205,7 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getDecodingConfig());
     totalSize += su::serializedSize(executorConfig.getUseGpuDirectStorage());
     totalSize += su::serializedSize(executorConfig.getGpuWeightsPercent());
+    totalSize += su::serializedSize(executorConfig.getAliasManagedWeightsFromGpu());
     totalSize += su::serializedSize(executorConfig.getMaxQueueSize());
     totalSize += su::serializedSize(executorConfig.getExtendedRuntimePerfKnobConfig());
     totalSize += su::serializedSize(executorConfig.getDebugConfig());
@@ -1213,6 +1218,7 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getGatherGenerationLogits());
     totalSize += su::serializedSize(executorConfig.getPromptTableOffloading());
     totalSize += su::serializedSize(executorConfig.getEnableTrtOverlap());
+    totalSize += su::serializedSize(executorConfig.getFailFastOnAttentionWindowTooLarge());
 
     return totalSize;
 }
@@ -1237,6 +1243,7 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getDecodingConfig(), os);
     su::serialize(executorConfig.getUseGpuDirectStorage(), os);
     su::serialize(executorConfig.getGpuWeightsPercent(), os);
+    su::serialize(executorConfig.getAliasManagedWeightsFromGpu(), os);
     su::serialize(executorConfig.getMaxQueueSize(), os);
     su::serialize(executorConfig.getExtendedRuntimePerfKnobConfig(), os);
     su::serialize(executorConfig.getDebugConfig(), os);
@@ -1249,6 +1256,7 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getGatherGenerationLogits(), os);
     su::serialize(executorConfig.getPromptTableOffloading(), os);
     su::serialize(executorConfig.getEnableTrtOverlap(), os);
+    su::serialize(executorConfig.getFailFastOnAttentionWindowTooLarge(), os);
 }
 
 // KvCacheConfig

--- a/cpp/tensorrt_llm/nanobind/executor/executor.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.cpp
@@ -52,7 +52,7 @@ struct dtype_traits<half>
 
 namespace
 {
-tle::Tensor numpyToTensor(nb::object const& object)
+tle::Tensor arrayInterfaceToTensor(nb::object const& object)
 {
     std::string dtype_name = nb::cast<std::string>(object.attr("dtype").attr("name"));
     nb::object metadata = object.attr("dtype").attr("metadata");
@@ -108,6 +108,26 @@ tle::Tensor numpyToTensor(nb::object const& object)
     return tle::Tensor::of(dtype, data_ptr, shape);
 }
 
+tle::Tensor pythonObjectToTensor(nb::object const& object)
+{
+    try
+    {
+        // Use the custom caster path for torch.Tensor inputs (CPU or CUDA).
+        return nb::cast<tle::Tensor>(object);
+    }
+    catch (std::exception const&)
+    {
+        // Fallback to array interface path below.
+    }
+
+    if (nb::hasattr(object, "__array_interface__"))
+    {
+        return arrayInterfaceToTensor(object);
+    }
+
+    TLLM_THROW("Unsupported managed weight input. Expected torch.Tensor or an object with __array_interface__.");
+}
+
 } // namespace
 
 namespace tensorrt_llm::nanobind::executor
@@ -138,7 +158,7 @@ Executor::Executor(nb::bytes const& engineBuffer, std::string const& jsonConfigS
         {
             std::string name = nb::cast<std::string>(rawName);
             nb::object array_obj = nb::cast<nb::object>(rawArray);
-            managedWeightsMap->emplace(name, numpyToTensor(array_obj));
+            managedWeightsMap->emplace(name, pythonObjectToTensor(array_obj));
         }
     }
     mExecutor = std::make_unique<tle::Executor>(

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -547,7 +547,7 @@ void initConfigBindings(nb::module_& m)
             nb::cast<bool>(cpp_states[25]),                                                   // GatherGenerationLogits
             nb::cast<bool>(cpp_states[26]),                                                   // PromptTableOffloading
             nb::cast<bool>(cpp_states[27]),                                                   // EnableTrtOverlap
-            nb::cast<bool>(cpp_states[28]),                                                   // FailFastOnAttentionWindowTooLarge
+            nb::cast<bool>(cpp_states[28]),                         // FailFastOnAttentionWindowTooLarge
             numStates > 29 ? nb::cast<bool>(cpp_states[29]) : false // AliasManagedWeightsFromGpu
         );
 

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -496,7 +496,8 @@ void initConfigBindings(nb::module_& m)
             c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
             c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
             c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
-            c.getPromptTableOffloading(), c.getEnableTrtOverlap(), c.getFailFastOnAttentionWindowTooLarge());
+            c.getPromptTableOffloading(), c.getEnableTrtOverlap(), c.getFailFastOnAttentionWindowTooLarge(),
+            c.getAliasManagedWeightsFromGpu());
         auto pickle_tuple = nb::make_tuple(cpp_states, nb::getattr(self, "__dict__"));
         return pickle_tuple;
     };
@@ -509,7 +510,8 @@ void initConfigBindings(nb::module_& m)
         }
 
         auto cpp_states = nb::cast<nb::tuple>(state[0]);
-        if (cpp_states.size() != 29)
+        auto const numStates = cpp_states.size();
+        if (numStates != 29 && numStates != 30)
         {
             throw std::runtime_error("Invalid cpp_states!");
         }
@@ -545,7 +547,8 @@ void initConfigBindings(nb::module_& m)
             nb::cast<bool>(cpp_states[25]),                                                   // GatherGenerationLogits
             nb::cast<bool>(cpp_states[26]),                                                   // PromptTableOffloading
             nb::cast<bool>(cpp_states[27]),                                                   // EnableTrtOverlap
-            nb::cast<bool>(cpp_states[28]) // FailFastOnAttentionWindowTooLarge
+            nb::cast<bool>(cpp_states[28]),                                                   // FailFastOnAttentionWindowTooLarge
+            numStates > 29 ? nb::cast<bool>(cpp_states[29]) : false // AliasManagedWeightsFromGpu
         );
 
         // Restore Python data
@@ -585,7 +588,8 @@ void initConfigBindings(nb::module_& m)
                  bool,                                                   // GatherGenerationLogits
                  bool,                                                   // PromptTableOffloading
                  bool,                                                   // EnableTrtOverlap
-                 bool                                                    // FailFastOnAttentionWindowTooLarge
+                 bool,                                                   // FailFastOnAttentionWindowTooLarge
+                 bool                                                    // AliasManagedWeightsFromGpu
                  >(),
             nb::arg("max_beam_width") = 1, nb::arg("scheduler_config") = tle::SchedulerConfig(),
             nb::arg("kv_cache_config") = tle::KvCacheConfig(), nb::arg("enable_chunked_context") = false,
@@ -603,7 +607,8 @@ void initConfigBindings(nb::module_& m)
             nb::arg("spec_dec_config") = nb::none(), nb::arg("guided_decoding_config") = nb::none(),
             nb::arg("additional_model_outputs") = nb::none(), nb::arg("cache_transceiver_config") = nb::none(),
             nb::arg("gather_generation_logits") = false, nb::arg("mm_embedding_offloading") = false,
-            nb::arg("enable_trt_overlap") = false, nb::arg("fail_fast_on_attention_window_too_large") = false)
+            nb::arg("enable_trt_overlap") = false, nb::arg("fail_fast_on_attention_window_too_large") = false,
+            nb::arg("alias_managed_weights_from_gpu") = false)
         .def_prop_rw("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
         .def_prop_rw("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
         .def_prop_rw("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
@@ -632,6 +637,8 @@ void initConfigBindings(nb::module_& m)
             &tle::ExecutorConfig::setUseGpuDirectStorage)
         .def_prop_rw("gpu_weights_percent", &tle::ExecutorConfig::getGpuWeightsPercent,
             &tle::ExecutorConfig::setGpuWeightsPercent)
+        .def_prop_rw("alias_managed_weights_from_gpu", &tle::ExecutorConfig::getAliasManagedWeightsFromGpu,
+            &tle::ExecutorConfig::setAliasManagedWeightsFromGpu)
         .def_prop_rw("max_queue_size", &tle::ExecutorConfig::getMaxQueueSize, &tle::ExecutorConfig::setMaxQueueSize)
         .def_prop_rw("extended_runtime_perf_knob_config", &tle::ExecutorConfig::getExtendedRuntimePerfKnobConfig,
             &tle::ExecutorConfig::setExtendedRuntimePerfKnobConfig)

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
@@ -132,8 +132,8 @@ void initBindings(nb::module_& m)
                 bool use_shape_inference = true)
             {
                 // Using default logger by passing nullptr
-                new (self)
-                    tr::TllmRuntime(tr::RawEngine(engine_path), nullptr, gpu_weights_percent, use_shape_inference);
+                new (self) tr::TllmRuntime(
+                    tr::RawEngine(engine_path), nullptr, false, gpu_weights_percent, use_shape_inference);
             },
             nb::arg("engine_path"), nb::arg("gpu_weights_percent") = 1.0f, nb::arg("use_shape_inference") = true)
         .def(
@@ -143,7 +143,7 @@ void initBindings(nb::module_& m)
             {
                 if (engine_buffer.ndim() != 1)
                     throw std::runtime_error("Expected 1-D array for engine buffer");
-                new (self) tr::TllmRuntime(tr::RawEngine(engine_buffer.data(), engine_buffer.size()), nullptr,
+                new (self) tr::TllmRuntime(tr::RawEngine(engine_buffer.data(), engine_buffer.size()), nullptr, false,
                     gpu_weights_percent, use_shape_inference);
             },
             nb::arg("engine_buffer"), nb::arg("gpu_weights_percent") = 1.0f, nb::arg("use_shape_inference") = true)

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
@@ -16,6 +16,7 @@
 #include "tllmRuntime.h"
 #include "common.h"
 #include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/common/safetensors.h"
@@ -186,11 +187,12 @@ void assessLikelihoodOfRuntimeAllocation(
 } // namespace
 
 TllmRuntime::TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage,
-    float gpuWeightsPercent, bool useShapeInference)
+    float gpuWeightsPercent, bool useShapeInference, bool aliasManagedWeightsFromGpu)
     : mStream(std::make_shared<CudaStream>())
     , mBufferManager{mStream, true} // Ensure to trim the memory pool on destruction.
     , mRuntime{nvinfer1::createInferRuntime(static_cast<bool>(logger) ? *logger : defaultLogger)}
     , mUseShapeInference{useShapeInference}
+    , mAliasManagedWeightsFromGpu{aliasManagedWeightsFromGpu}
     , mUserBufferEnabled{false}
 {
     auto const startTime = std::chrono::high_resolution_clock::now();
@@ -803,7 +805,29 @@ void TllmRuntime::loadManagedWeights(RawEngine const& rawEngine, int localRank)
         {
             TLLM_LOG_DEBUG("Loading managed weight: %s", name.c_str());
             auto iTensor = tensorrt_llm::executor::detail::toITensor(weight);
-            auto weightsDevice = std::shared_ptr<ITensor>{manager.copyFrom(*iTensor, MemoryType::kGPU)};
+            std::shared_ptr<ITensor> weightsDevice;
+            if (mAliasManagedWeightsFromGpu && iTensor->getMemoryType() == MemoryType::kGPU)
+            {
+                // Verify that the GPU tensor resides on the same device as the runtime.
+                cudaPointerAttributes attrs{};
+                TLLM_CUDA_CHECK(cudaPointerGetAttributes(&attrs, iTensor->data()));
+                auto const runtimeDevice = mStream->getDevice();
+                if (attrs.device == runtimeDevice)
+                {
+                    weightsDevice = iTensor;
+                }
+                else
+                {
+                    TLLM_LOG_WARNING(
+                        "Managed weight '%s' is on device %d but runtime uses device %d; copying instead of aliasing.",
+                        name.c_str(), attrs.device, runtimeDevice);
+                    weightsDevice = std::shared_ptr<ITensor>{manager.copyFrom(*iTensor, MemoryType::kGPU)};
+                }
+            }
+            else
+            {
+                weightsDevice = std::shared_ptr<ITensor>{manager.copyFrom(*iTensor, MemoryType::kGPU)};
+            }
             mManagedWeightsMap.insert(std::make_pair(name, weightsDevice));
         }
     }

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.h
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.h
@@ -38,7 +38,7 @@ public:
     using TensorMap = StringPtrMap<ITensor>;
 
     explicit TllmRuntime(RawEngine const& rawEngine, nvinfer1::ILogger* logger, bool useGpuDirectStorage = false,
-        float gpuWeightsPercent = 1.0f, bool useShapeInference = true);
+        float gpuWeightsPercent = 1.0f, bool useShapeInference = true, bool aliasManagedWeightsFromGpu = false);
 
     SizeType32 getNbContexts() const
     {
@@ -230,6 +230,7 @@ private:
     std::unique_ptr<nvinfer1::IEngineInspector> mEngineInspector;
     std::unique_ptr<LayerProfiler> mLayerProfiler;
     bool mUseShapeInference;
+    bool mAliasManagedWeightsFromGpu;
     TensorMap mManagedWeightsMap;
     // List of input tensor names.
     // Names of static tensors are removed from this list when setStaticInputTensors is called.

--- a/cpp/tests/unit_tests/executor/executorTestSmall.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmall.cpp
@@ -95,11 +95,11 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(TrivialConstantDeco
     auto kvCacheConfig = executor::KvCacheConfig{};
     kvCacheConfig.setMaxTokens(DecoderTestShared<TLogits>::kKvCacheMaxTokens);
 
-    auto const executorConfig = tensorrt_llm::executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(),
-        kvCacheConfig, true, true, 1, 1, executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens,
-        std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, 1, std::nullopt,
-        executor::ExtendedRuntimePerfKnobConfig(), std::nullopt, 0,
-        executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt);
+    auto const executorConfig
+        = tensorrt_llm::executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(), kvCacheConfig, true,
+            true, 1, 1, executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens, std::nullopt,
+            std::nullopt, std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(),
+            std::nullopt, 0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt);
 
     auto model = std::make_shared<batch_manager::TrtGptModelInflightBatching>(
         logger, modelConfig, worldConfig, engine, false, executorConfig, false);

--- a/cpp/tests/unit_tests/executor/executorTestSmall.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmall.cpp
@@ -95,11 +95,11 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(TrivialConstantDeco
     auto kvCacheConfig = executor::KvCacheConfig{};
     kvCacheConfig.setMaxTokens(DecoderTestShared<TLogits>::kKvCacheMaxTokens);
 
-    auto const executorConfig
-        = tensorrt_llm::executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(), kvCacheConfig, true,
-            true, 1, 1, executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens, std::nullopt,
-            std::nullopt, std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(),
-            std::nullopt, 0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt);
+    auto const executorConfig = tensorrt_llm::executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(),
+        kvCacheConfig, true, true, 1, 1, executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens,
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, 1, std::nullopt,
+        executor::ExtendedRuntimePerfKnobConfig(), std::nullopt, 0,
+        executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt);
 
     auto model = std::make_shared<batch_manager::TrtGptModelInflightBatching>(
         logger, modelConfig, worldConfig, engine, false, executorConfig, false);

--- a/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
@@ -122,8 +122,8 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(
     auto const executorConfig
         = executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(), kvCacheConfig, true, true, 1, 1,
             executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens, std::nullopt, std::nullopt,
-            std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(), std::nullopt,
-            0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt,
+            std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(),
+            std::nullopt, 0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt,
             std::vector<executor::AdditionalModelOutput>{
                 executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, params.gatherContext}});
 

--- a/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
@@ -122,8 +122,8 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(
     auto const executorConfig
         = executor::ExecutorConfig(params.maxBeamWidth, executor::SchedulerConfig(), kvCacheConfig, true, true, 1, 1,
             executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens, std::nullopt, std::nullopt,
-            std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(),
-            std::nullopt, 0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt,
+            std::nullopt, std::nullopt, false, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(), std::nullopt,
+            0, executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt,
             std::vector<executor::AdditionalModelOutput>{
                 executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, params.gatherContext}});
 

--- a/tensorrt_llm/_torch/attention_backend/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/__init__.py
@@ -22,3 +22,12 @@ if IS_FLASHINFER_AVAILABLE:
         "FlashInferAttention", "FlashInferAttentionMetadata", "StarAttention",
         "StarAttentionMetadata"
     ]
+else:
+    # Provide fallback names so that model files (e.g. Gemma3, Cohere2)
+    # can be imported even when FlashInfer is not installed.  These names
+    # are intentionally *not* added to __all__ because they are not real
+    # implementations and should not be relied upon at runtime.
+    FlashInferAttention = TrtllmAttention
+    FlashInferAttentionMetadata = TrtllmAttentionMetadata
+    StarAttention = TrtllmAttention
+    StarAttentionMetadata = TrtllmAttentionMetadata

--- a/tensorrt_llm/_torch/attention_backend/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/__init__.py
@@ -23,11 +23,40 @@ if IS_FLASHINFER_AVAILABLE:
         "StarAttentionMetadata"
     ]
 else:
-    # Provide fallback names so that model files (e.g. Gemma3, Cohere2)
-    # can be imported even when FlashInfer is not installed.  These names
-    # are intentionally *not* added to __all__ because they are not real
-    # implementations and should not be relied upon at runtime.
-    FlashInferAttention = TrtllmAttention
-    FlashInferAttentionMetadata = TrtllmAttentionMetadata
-    StarAttention = TrtllmAttention
-    StarAttentionMetadata = TrtllmAttentionMetadata
+    # Provide stub classes so that model files (e.g. Gemma3, Cohere2)
+    # can be imported even when FlashInfer is not installed.  These are
+    # intentionally *not* subclasses of TrtllmAttention/Metadata so that
+    # isinstance() guards correctly return False, and instantiation gives
+    # a clear error instead of a late AttributeError.
+
+    class FlashInferAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "FlashInferAttention requires flashinfer to be installed. "
+                "Please install flashinfer or use a different attention backend."
+            )
+
+    class FlashInferAttentionMetadata:
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "FlashInferAttentionMetadata requires flashinfer to be "
+                "installed. Please install flashinfer or use a different "
+                "attention backend.")
+
+    class StarAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "StarAttention requires flashinfer to be installed. "
+                "Please install flashinfer or use a different attention backend."
+            )
+
+    class StarAttentionMetadata:
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "StarAttentionMetadata requires flashinfer to be installed. "
+                "Please install flashinfer or use a different attention backend."
+            )

--- a/tensorrt_llm/_torch/flashinfer_utils.py
+++ b/tensorrt_llm/_torch/flashinfer_utils.py
@@ -15,7 +15,9 @@ def get_env_enable_pdl() -> bool:
     return enabled
 
 
-if platform.system() != "Windows":
+if os.environ.get("TRTLLM_DISABLE_FLASHINFER", "0") == "1":
+    logger.info("flashinfer disabled by TRTLLM_DISABLE_FLASHINFER=1")
+elif platform.system() != "Windows":
     try:
         import flashinfer
         logger.info(f"flashinfer is available: {flashinfer.__version__}")

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
@@ -4,7 +4,8 @@ from typing import Callable, List, Union
 from torch import nn
 
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_utils import DecoderModelForCausalLM
+from tensorrt_llm._torch.models.modeling_utils import (
+    DecoderModelForCausalLM, maybe_alias_or_copy_tensor)
 
 
 class BaseWeightMapper(ABC):
@@ -126,10 +127,24 @@ class BaseWeightMapper(ABC):
                            n: str,
                            p: nn.Parameter,
                            allow_partial_loading: bool = False) -> None:
+        """Copy or alias a single weight tensor into a module parameter.
+
+        When the source tensor matches the destination in device, shape, dtype,
+        and contiguity, ``p.data`` is rebound to share storage with the source
+        (zero-copy aliasing). Otherwise, the data is copied via
+        ``Tensor.copy_()``.
+
+        Args:
+            module_name: Dot-separated module name (used only for diagnostics).
+            module_weights: Dict mapping parameter names to source tensors.
+            n: Name of the parameter inside ``module_weights``.
+            p: Destination ``nn.Parameter`` to populate.
+            allow_partial_loading: When ``True``, silently skip missing keys.
+        """
         if not allow_partial_loading:
             assert n in module_weights
         if n in module_weights:
-            p.data.copy_(module_weights[n][:])
+            maybe_alias_or_copy_tensor(p, module_weights[n][:])
 
     def does_require_special_handling(self, module_name: str) -> bool:
         return module_name in self.mapping

--- a/tensorrt_llm/_torch/models/modeling_bert.py
+++ b/tensorrt_llm/_torch/models/modeling_bert.py
@@ -14,7 +14,7 @@ from ..modules.attention import Attention
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.linear import Linear
-from .modeling_utils import register_auto_model
+from .modeling_utils import maybe_alias_or_copy_tensor, register_auto_model
 
 
 class MLP(nn.Module):
@@ -320,7 +320,7 @@ class BertForSequenceClassification(nn.Module):
                         for n, p in module._parameters.items():
                             if p is not None:
                                 weight = module_weights[n][:]
-                                p.data.copy_(weight)
+                                maybe_alias_or_copy_tensor(p, weight)
 
                 except Exception as e:
                     raise e

--- a/tensorrt_llm/_torch/models/modeling_cohere2.py
+++ b/tensorrt_llm/_torch/models/modeling_cohere2.py
@@ -22,7 +22,12 @@ from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.layer_norm import LayerNorm
 from ..modules.linear import Linear, TensorParallelMode
-from .modeling_utils import DecoderModel, DecoderModelForCausalLM, register_auto_model
+from .modeling_utils import (
+    DecoderModel,
+    DecoderModelForCausalLM,
+    maybe_alias_or_copy_tensor,
+    register_auto_model,
+)
 
 
 class Cohere2MLP(nn.Module):
@@ -305,4 +310,4 @@ class Cohere2ForCausalLM(DecoderModelForCausalLM[Cohere2Model, Cohere2Config]):
                 else:
                     for n, p in module._parameters.items():
                         if p is not None:
-                            p.data.copy_(module_weights[n][:])
+                            maybe_alias_or_copy_tensor(p, module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -76,7 +76,7 @@ from ..utils import (AuxStreamType, EventType, Fp4QuantizedTensor,
                      create_lm_head_tp_mapping)
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import (DecoderModel, EagerFusionConfig, filter_weights,
-                             register_auto_model)
+                             maybe_alias_or_copy_tensor, register_auto_model)
 
 
 @triton.jit
@@ -591,7 +591,7 @@ class DeepseekV3WeightLoader:
                         module.load_weights(weights=[module_weights])
                     else:
                         for n, p in module.named_parameters():
-                            p.data.copy_(module_weights[n][:])
+                            maybe_alias_or_copy_tensor(p, module_weights[n][:])
                     # Mark consumed weights
                     if can_mark_consumed:
                         weights.mark_consumed(name)
@@ -855,9 +855,10 @@ class DeepseekV3Gate(nn.Module):
     def load_weights(self, weights: List[Dict]):
         assert len(weights) == 1
 
-        self.weight.copy_(weights[0]["weight"][:])
+        maybe_alias_or_copy_tensor(self.weight, weights[0]["weight"][:])
 
-        self.e_score_correction_bias.copy_(
+        maybe_alias_or_copy_tensor(
+            self.e_score_correction_bias,
             weights[0]["e_score_correction_bias"][:].to(
                 self.e_score_correction_bias.dtype))
 

--- a/tensorrt_llm/_torch/models/modeling_glm.py
+++ b/tensorrt_llm/_torch/models/modeling_glm.py
@@ -43,6 +43,7 @@ from .modeling_utils import (
     EagerFusionConfig,
     duplicate_kv_weight,
     filter_weights,
+    maybe_alias_or_copy_tensor,
     register_auto_model,
 )
 
@@ -186,7 +187,7 @@ class Glm4WeightLoader:
                             if not allow_partial_loading:
                                 assert n in module_weights
                             if n in module_weights:
-                                p.data.copy_(module_weights[n][:])
+                                maybe_alias_or_copy_tensor(p, module_weights[n][:])
                     # Mark consumed weights
                     if can_mark_consumed:
                         weights.mark_consumed(name)

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -34,7 +34,8 @@ from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
 from ..utils import Fp4QuantizedTensor
 from .modeling_speculative import SpecDecOneEngineForCausalLM
-from .modeling_utils import DecoderModel, filter_weights, register_auto_model
+from .modeling_utils import (DecoderModel, filter_weights,
+                             maybe_alias_or_copy_tensor, register_auto_model)
 
 # Use TinyGEMM when the number of tokens is not larger than this threshold
 MIN_LATENCY_TINYGEMM_NUM_TOKENS = 128
@@ -816,7 +817,7 @@ class GptOssForCausalLM(SpecDecOneEngineForCausalLM[Transformer, GptOssConfig]):
 
                 for n, p in module._parameters.items():
                     if p is not None:
-                        p.data.copy_(module_weights[n][:])
+                        maybe_alias_or_copy_tensor(p, module_weights[n][:])
 
     def load_nvfp4_weights(self, weights: Dict):
         num_expert = self.config.num_local_experts
@@ -921,4 +922,4 @@ class GptOssForCausalLM(SpecDecOneEngineForCausalLM[Transformer, GptOssConfig]):
 
                 for n, p in module._parameters.items():
                     if p is not None:
-                        p.data.copy_(module_weights[n][:])
+                        maybe_alias_or_copy_tensor(p, module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_dense.py
@@ -24,7 +24,8 @@ from ..modules.rms_norm import RMSNorm
 from ..modules.rotary_embedding import RotaryEmbedding
 from ..utils import AuxStreamType, Fp4QuantizedTensor
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
-                             duplicate_kv_weight, register_auto_model)
+                             duplicate_kv_weight, maybe_alias_or_copy_tensor,
+                             register_auto_model)
 
 
 class HunYuanPretrainedConfig(PretrainedConfig):
@@ -689,7 +690,8 @@ class HunYuanDenseV1ForCausalLM(DecoderModelForCausalLM[HunYuanModel,
                     else:
                         for n, p in module._parameters.items():
                             if p is not None:
-                                p.data.copy_(module_weights[n][:])
+                                maybe_alias_or_copy_tensor(
+                                    p, module_weights[n][:])
                     # Mark consumed weights
                     if can_mark_consumed:
                         weights.mark_consumed(original_name)

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
@@ -26,7 +26,8 @@ from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..utils import AuxStreamType, Fp4QuantizedTensor
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
-                             duplicate_kv_weight, register_auto_model)
+                             duplicate_kv_weight, maybe_alias_or_copy_tensor,
+                             register_auto_model)
 
 
 class HunyuanMoE(nn.Module):
@@ -429,7 +430,8 @@ class HunYuanMoEV1ForCausalLM(DecoderModelForCausalLM[HunYuanModel,
                     else:
                         for n, p in module._parameters.items():
                             if p is not None:
-                                p.data.copy_(module_weights[n][:])
+                                maybe_alias_or_copy_tensor(
+                                    p, module_weights[n][:])
                     # Mark consumed weights
                     if can_mark_consumed:
                         weights.mark_consumed(original_name)

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -28,7 +28,7 @@ from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
                                         get_multimodal_embeddings)
 from .modeling_siglip import SiglipVisionModel
-from .modeling_utils import register_auto_model
+from .modeling_utils import maybe_alias_or_copy_tensor, register_auto_model
 
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
@@ -859,7 +859,7 @@ class HCXVisionModel(nn.Module):
         mm_projector_weights = _filter_weights(weights, "mm_projector.")
         self.mm_projector.load_state_dict(mm_projector_weights, strict=True)
 
-        self.image_newline.data.copy_(weights["image_newline"])
+        maybe_alias_or_copy_tensor(self.image_newline, weights["image_newline"])
 
     def _parse_and_batch_multimodal_data(
         self, multimodal_params: List[MultimodalParams]

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1048,6 +1048,8 @@ class LlamaModel(DecoderModel):
                         model_config.mapping.tp_rank,
                         dim=0)  # split by vocabulary dimension
                 x = weight.to(self.embed_tokens.dtype)
+                # Keep a dedicated embedding buffer here; aliasing would
+                # introduce tied storage instead of a one-time initialization.
                 self.embed_tokens.weight.data.copy_(x)
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -30,7 +30,8 @@ from .modeling_auto import AutoModelForCausalLM
 from .modeling_clip import CLIPVisionModel
 from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
                                         get_multimodal_embeddings)
-from .modeling_utils import register_auto_model, register_vision_encoder
+from .modeling_utils import (maybe_alias_or_copy_tensor, register_auto_model,
+                             register_vision_encoder)
 
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
@@ -440,7 +441,7 @@ class LlavaNextVisionModel(nn.Module):
         self.vision_model.load_weights(visual_model_weights)
         mm_projector_weights = filter_weights("multi_modal_projector.", weights)
         self.mm_projector.load_state_dict(mm_projector_weights, strict=True)
-        self.image_newline.data.copy_(weights["image_newline"])
+        maybe_alias_or_copy_tensor(self.image_newline, weights["image_newline"])
 
     def post_config(self):
         self.config = self.pretrained_config.vision_config

--- a/tensorrt_llm/_torch/models/modeling_minimaxm2.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm2.py
@@ -31,11 +31,7 @@ from ..modules.fused_moe import MiniMaxM2MoeRoutingMethod, create_moe
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
 from ..utils import AuxStreamType
-from .modeling_utils import (
-    DecoderModel,
-    DecoderModelForCausalLM,
-    register_auto_model,
-)
+from .modeling_utils import DecoderModel, DecoderModelForCausalLM, register_auto_model
 
 
 # MiniMax M2/M2.1 requires the implementation of the following two additional components:

--- a/tensorrt_llm/_torch/models/modeling_minimaxm2.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm2.py
@@ -31,7 +31,11 @@ from ..modules.fused_moe import MiniMaxM2MoeRoutingMethod, create_moe
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
 from ..utils import AuxStreamType
-from .modeling_utils import DecoderModel, DecoderModelForCausalLM, register_auto_model
+from .modeling_utils import (
+    DecoderModel,
+    DecoderModelForCausalLM,
+    register_auto_model,
+)
 
 
 # MiniMax M2/M2.1 requires the implementation of the following two additional components:

--- a/tensorrt_llm/_torch/models/modeling_mistral_large3.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral_large3.py
@@ -6,7 +6,10 @@ from torch import nn
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.mistral.weight_mapper import MistralLarge3WeightMapper
 from tensorrt_llm._torch.models.modeling_deepseekv3 import DeepseekV3ForCausalLM
-from tensorrt_llm._torch.models.modeling_utils import register_auto_model
+from tensorrt_llm._torch.models.modeling_utils import (
+    maybe_alias_or_copy_tensor,
+    register_auto_model,
+)
 from tensorrt_llm._torch.modules.fused_moe import RenormalizeNaiveMoeRoutingMethod
 from tensorrt_llm.quantization.mode import QuantAlgo
 
@@ -37,7 +40,7 @@ class Mistral3Gate(nn.Module):
     def load_weights(self, weights: List[Dict]):
         assert len(weights) == 1
 
-        self.weight.copy_(weights[0]["weight"][:])
+        maybe_alias_or_copy_tensor(self.weight, weights[0]["weight"][:])
 
 
 @register_auto_model("MistralLarge3ForCausalLM")

--- a/tensorrt_llm/_torch/models/modeling_mllama.py
+++ b/tensorrt_llm/_torch/models/modeling_mllama.py
@@ -35,7 +35,7 @@ from ..modules.logits_processor import LogitsProcessor
 from ..modules.rms_norm import RMSNorm
 from .modeling_llama import LlamaAttention
 from .modeling_utils import (duplicate_kv_weight, filter_weights,
-                             register_auto_model)
+                             maybe_alias_or_copy_tensor, register_auto_model)
 
 
 class MllamaDecoderLayer(DecoderLayer):
@@ -384,4 +384,4 @@ class MllamaForConditionalGeneration(nn.Module):
                         for n, p in module._parameters.items():
                             if p is not None:
                                 weight = module_weights[n][:]
-                                p.data.copy_(weight)
+                                maybe_alias_or_copy_tensor(p, weight)

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
@@ -230,6 +230,8 @@ class NemotronNASModel(DecoderModel):
                         model_config.mapping.tp_rank,
                         dim=0)  # split by vocabulary dimension
                 x = weight.to(self.embed_tokens.dtype)
+                # Keep a dedicated embedding buffer here; aliasing would
+                # introduce tied storage instead of a one-time initialization.
                 self.embed_tokens.weight.data.copy_(x)
 
         self.layers = nn.ModuleList([

--- a/tensorrt_llm/_torch/models/modeling_phi3.py
+++ b/tensorrt_llm/_torch/models/modeling_phi3.py
@@ -9,9 +9,9 @@ from tensorrt_llm._torch.attention_backend import AttentionMetadata
 from tensorrt_llm._torch.attention_backend.interface import (
     PositionalEmbeddingParams, RopeParams)
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_utils import (DecoderModel,
-                                                       DecoderModelForCausalLM,
-                                                       register_auto_model)
+from tensorrt_llm._torch.models.modeling_utils import (
+    DecoderModel, DecoderModelForCausalLM, maybe_alias_or_copy_tensor,
+    register_auto_model)
 from tensorrt_llm._torch.modules.attention import Attention
 from tensorrt_llm._torch.modules.decoder_layer import DecoderLayer
 from tensorrt_llm._torch.modules.embedding import Embedding
@@ -300,4 +300,4 @@ class Phi3ForCausalLM(DecoderModelForCausalLM[Phi3Model, Phi3Config]):
                 else:
                     for n, p in module._parameters.items():
                         if p is not None:
-                            p.data.copy_(module_weights[n][:])
+                            maybe_alias_or_copy_tensor(p, module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -25,7 +25,8 @@ from ..speculative import SpecMetadata
 from ..utils import AuxStreamType
 from .modeling_qwen3 import Qwen3Attention
 from .modeling_speculative import SpecDecOneEngineForCausalLM
-from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
+from .modeling_utils import (DecoderModel, EagerFusionConfig,
+                             maybe_alias_or_copy_tensor, register_auto_model)
 
 
 class Qwen3Gate(nn.Module):
@@ -66,7 +67,7 @@ class Qwen3Gate(nn.Module):
         if not allow_partial_loading:
             assert w is not None, "Qwen3Gate expects weight when partial loading is disabled"
         if w is not None:
-            self.weight.copy_(w[:])
+            maybe_alias_or_copy_tensor(self.weight, w[:])
 
     @property
     def routing_method(self) -> BaseMoeRoutingMethod:

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -55,7 +55,8 @@ from ..speculative import SpecMetadata
 from ..utils import AuxStreamType, EventType, create_lm_head_tp_mapping
 from .modeling_qwen3 import Qwen3Attention
 from .modeling_speculative import SpecDecOneEngineForCausalLM
-from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
+from .modeling_utils import (DecoderModel, EagerFusionConfig,
+                             maybe_alias_or_copy_tensor, register_auto_model)
 
 
 class Qwen3NextGate(nn.Module):
@@ -90,7 +91,7 @@ class Qwen3NextGate(nn.Module):
     def load_weights(self, weights: List[Dict]):
         assert len(weights) == 1
 
-        self.weight.copy_(weights[0]["weight"][:])
+        maybe_alias_or_copy_tensor(self.weight, weights[0]["weight"][:])
 
     @property
     def routing_method(self) -> BaseMoeRoutingMethod:

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -38,6 +38,27 @@ def timing(message: str):
     print(f"{message} -- {(end-start):.2f}s")
 
 
+def maybe_alias_or_copy_tensor(dest: Union[torch.Tensor, nn.Parameter],
+                               src: torch.Tensor) -> bool:
+    """Alias ``src`` into ``dest`` when device, shape, dtype, and contiguity all match.
+
+    Returns ``True`` when ``dest.data`` is rebound to ``src`` storage, and ``False``
+    when the helper falls back to ``copy_()``. The alias path only triggers when the
+    caller already provides a tensor on the destination device, so the default
+    HuggingFace checkpoint loader still behaves like ``copy_()`` and custom
+    GPU-preloaded checkpoint loaders opt into the zero-copy path.
+    """
+    dest_tensor = dest.data
+    if (src.device == dest_tensor.device and src.shape == dest_tensor.shape
+            and src.dtype == dest_tensor.dtype and src.is_contiguous()):
+        dest.data = src
+        return True
+
+    with torch.no_grad():
+        dest_tensor.copy_(src)
+    return False
+
+
 @dataclass
 class EagerFusionConfig:
     PRE_MOE_FUSION: bool = False
@@ -398,6 +419,8 @@ class DecoderModelForCausalLM(nn.Module,
                             config.mapping.tp_rank,
                             dim=0)  # split by vocabulary dimension
                     x = weight.to(self.lm_head.dtype).cuda()
+                    # Keep custom lm_head storage distinct; aliasing here would
+                    # implicitly tie weights rather than loading checkpoint data.
                     self.lm_head.weight.data.copy_(x)
 
         # use embedding weights in lm_head if tie word embedding is enabled
@@ -968,7 +991,8 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                             if not allow_partial_loading:
                                 assert n in module_weights
                             if n in module_weights:
-                                p.data.copy_(module_weights[n][:])
+                                maybe_alias_or_copy_tensor(
+                                    p, module_weights[n][:])
 
                     # Mark consumed weights
                     if hasattr(weights, 'mark_consumed'):

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -40,17 +40,19 @@ def timing(message: str):
 
 def maybe_alias_or_copy_tensor(dest: Union[torch.Tensor, nn.Parameter],
                                src: torch.Tensor) -> bool:
-    """Alias ``src`` into ``dest`` when device, shape, dtype, and contiguity all match.
+    """Alias ``src`` into ``dest`` when device, shape, dtype, stride, and layout all match.
 
     Returns ``True`` when ``dest.data`` is rebound to ``src`` storage, and ``False``
     when the helper falls back to ``copy_()``. The alias path only triggers when the
-    caller already provides a tensor on the destination device, so the default
-    HuggingFace checkpoint loader still behaves like ``copy_()`` and custom
-    GPU-preloaded checkpoint loaders opt into the zero-copy path.
+    caller already provides a fully-compatible tensor on the destination device, so
+    the default HuggingFace checkpoint loader still behaves like ``copy_()`` and
+    custom GPU-preloaded checkpoint loaders get the zero-copy path.
     """
     dest_tensor = dest.data
     if (src.device == dest_tensor.device and src.shape == dest_tensor.shape
-            and src.dtype == dest_tensor.dtype and src.is_contiguous()):
+            and src.dtype == dest_tensor.dtype
+            and src.stride() == dest_tensor.stride()
+            and src.layout == dest_tensor.layout and src.is_contiguous()):
         dest.data = src
         return True
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -156,9 +156,7 @@ def load_weight_shard(
     return maybe_convert_to_torch_tensor(weight, tuple(slice_obj))
 
 
-def copy_weight(dst: Parameter,
-                src: torch.Tensor,
-                allow_alias: bool = False):
+def copy_weight(dst: Parameter, src: torch.Tensor, allow_alias: bool = False):
     dst_tensor = dst.data
     if (allow_alias and src.device == dst_tensor.device
             and src.shape == dst_tensor.shape and src.dtype == dst_tensor.dtype

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -156,12 +156,20 @@ def load_weight_shard(
     return maybe_convert_to_torch_tensor(weight, tuple(slice_obj))
 
 
-def copy_weight(dst: Parameter, src: torch.Tensor):
-    # TODO check that is it a reasonable change or not
+def copy_weight(dst: Parameter,
+                src: torch.Tensor,
+                allow_alias: bool = False):
+    dst_tensor = dst.data
+    if (allow_alias and src.device == dst_tensor.device
+            and src.shape == dst_tensor.shape and src.dtype == dst_tensor.dtype
+            and src.stride() == dst_tensor.stride()
+            and src.layout == dst_tensor.layout and src.is_contiguous()):
+        dst.data = src
+        return
     if dst.dtype != src.dtype:
         src = src.to(dst.dtype)
     assert dst.dtype == src.dtype, f"Incompatible dtype. dst: {dst.dtype}, src: {src.dtype}"
-    dst.data.copy_(src)
+    dst_tensor.copy_(src)
 
 
 def copy_weight_shard(dst: Parameter, src: torch.Tensor, shard_offset: int,

--- a/tests/unittest/_torch/modeling/test_weight_loading_alias.py
+++ b/tests/unittest/_torch/modeling/test_weight_loading_alias.py
@@ -1,0 +1,105 @@
+import pytest
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import (
+    _load_weights_impl,
+    _load_weights_impl_v2,
+    maybe_alias_or_copy_tensor,
+)
+
+
+class DummyConfig(PretrainedConfig):
+    def __init__(self):
+        super().__init__()
+        self.architectures = ["DummyAliasModel"]
+        self.tie_word_embeddings = False
+        self.num_attention_heads = 1
+        self.num_key_value_heads = 1
+
+
+class TinyWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model_config = ModelConfig(pretrained_config=DummyConfig())
+        self.config = self.model_config.pretrained_config
+        self.layer = nn.Linear(4, 3, bias=False)
+
+
+class DummyWeightMapper(BaseWeightMapper):
+    def map_weights(self) -> None:
+        self._mapping = {}
+
+    def apply_callbacks(
+        self, module: nn.Module, module_name: str, module_names_breakdown: list[str], weights: dict
+    ) -> list[dict]:
+        raise AssertionError("apply_callbacks should not be reached in this test")
+
+
+def _configure_cpu_weight_load(monkeypatch):
+    monkeypatch.setenv("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL", "1")
+    monkeypatch.setattr(torch.cuda, "set_device", lambda *_args, **_kwargs: None)
+
+
+def test_maybe_alias_or_copy_tensor_aliases_matching_tensor():
+    dest = nn.Parameter(torch.zeros((2, 3), dtype=torch.float32))
+    src = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    aliased = maybe_alias_or_copy_tensor(dest, src)
+
+    assert aliased is True
+    assert dest.data_ptr() == src.data_ptr()
+    assert torch.equal(dest, src)
+
+
+def test_maybe_alias_or_copy_tensor_copies_noncontiguous_tensor():
+    dest = nn.Parameter(torch.zeros((2, 3), dtype=torch.float32))
+    src = torch.arange(12, dtype=torch.float32).reshape(2, 6)[:, ::2]
+
+    aliased = maybe_alias_or_copy_tensor(dest, src)
+
+    assert aliased is False
+    assert dest.data_ptr() != src.data_ptr()
+    assert torch.equal(dest, src)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_maybe_alias_or_copy_tensor_aliases_matching_gpu_tensor():
+    dest = nn.Parameter(torch.zeros((2, 3), dtype=torch.float32, device="cuda"))
+    src = torch.arange(6, dtype=torch.float32, device="cuda").reshape(2, 3)
+
+    aliased = maybe_alias_or_copy_tensor(dest, src)
+
+    assert aliased is True
+    assert dest.data_ptr() == src.data_ptr()
+    assert torch.equal(dest, src)
+
+
+def test_load_weights_impl_aliases_matching_tensor(monkeypatch):
+    _configure_cpu_weight_load(monkeypatch)
+    model = TinyWeightModel()
+    src = torch.arange(model.layer.weight.numel(), dtype=model.layer.weight.dtype).reshape_as(
+        model.layer.weight
+    )
+
+    _load_weights_impl(model, {"layer.weight": src})
+
+    assert model.layer.weight.data_ptr() == src.data_ptr()
+    assert torch.equal(model.layer.weight, src)
+
+
+def test_load_weights_impl_v2_aliases_matching_tensor(monkeypatch):
+    _configure_cpu_weight_load(monkeypatch)
+    model = TinyWeightModel()
+    mapper = DummyWeightMapper()
+    src = torch.arange(model.layer.weight.numel(), dtype=model.layer.weight.dtype).reshape_as(
+        model.layer.weight
+    )
+
+    _load_weights_impl_v2(model, {"layer.weight": src}, mapper)
+
+    assert model.layer.weight.data_ptr() == src.data_ptr()
+    assert torch.equal(model.layer.weight, src)

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -70,7 +70,6 @@ def test_executor_from_memory(model_files, model_path):
 
 def test_executor_with_managed_weights(model_files, model_path):
     """Test executor constructor with standard dtypes in managed weights."""
-
     executor_config = trtllm.ExecutorConfig(
         1, kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.5))
     engine_buffer = open(model_path / "rank0.engine", mode="rb").read()
@@ -102,13 +101,11 @@ def test_executor_with_managed_weights(model_files, model_path):
     assert executor.can_enqueue_requests()
 
 
-@pytest.mark.parametrize("alias_from_gpu",
-                         [False] +
+@pytest.mark.parametrize("alias_from_gpu", [False] +
                          ([True] if torch.cuda.is_available() else []))
 def test_executor_with_torch_managed_weights(model_files, model_path,
                                              alias_from_gpu):
     """Test executor constructor with torch.Tensor managed weights."""
-
     executor_config = trtllm.ExecutorConfig(
         1,
         kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.5),

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -99,7 +99,38 @@ def test_executor_with_managed_weights(model_files, model_path):
                                trtllm.ModelType.DECODER_ONLY, executor_config,
                                managed_weights)
 
-    assert executor.can_enqueue_requests() == True
+    assert executor.can_enqueue_requests()
+
+
+@pytest.mark.parametrize("alias_from_gpu",
+                         [False] +
+                         ([True] if torch.cuda.is_available() else []))
+def test_executor_with_torch_managed_weights(model_files, model_path,
+                                             alias_from_gpu):
+    """Test executor constructor with torch.Tensor managed weights."""
+
+    executor_config = trtllm.ExecutorConfig(
+        1,
+        kv_cache_config=trtllm.KvCacheConfig(free_gpu_memory_fraction=0.5),
+        alias_managed_weights_from_gpu=alias_from_gpu)
+    engine_buffer = open(model_path / "rank0.engine", mode="rb").read()
+    json_config_str = open(model_path / "config.json", 'r').read()
+
+    managed_weights = {
+        "weight_float32":
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "weight_int32":
+        torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+    }
+    if torch.cuda.is_available():
+        managed_weights["weight_fp16_cuda"] = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]], dtype=torch.float16, device="cuda")
+
+    executor = trtllm.Executor(engine_buffer, json_config_str,
+                               trtllm.ModelType.DECODER_ONLY, executor_config,
+                               managed_weights)
+
+    assert executor.can_enqueue_requests()
 
 
 def test_executor_invalid_ctor():
@@ -1748,6 +1779,7 @@ def test_executor_config():
     assert config.additional_model_outputs is None
     assert config.gather_generation_logits is False
     assert config.use_gpu_direct_storage is False
+    assert config.alias_managed_weights_from_gpu is False
     assert config.mm_embedding_offloading is False
     assert config.enable_trt_overlap is False
 
@@ -1800,6 +1832,8 @@ def test_executor_config():
         True,
         "use_gpu_direct_storage":
         True,
+        "alias_managed_weights_from_gpu":
+        True,
         "mm_embedding_offloading":
         True,
         "enable_trt_overlap":
@@ -1827,6 +1861,7 @@ def test_executor_config():
     assert config.additional_model_outputs[0].gather_context is False
     assert config.gather_generation_logits is True
     assert config.use_gpu_direct_storage is True
+    assert config.alias_managed_weights_from_gpu is True
     assert config.mm_embedding_offloading is True
     assert config.enable_trt_overlap is True
 
@@ -2632,6 +2667,8 @@ def test_executor_config_pickle():
         [trtllm.AdditionalModelOutput("topKLogits")],
         "gather_generation_logits":
         True,
+        "alias_managed_weights_from_gpu":
+        True,
         "mm_embedding_offloading":
         True,
         "enable_trt_overlap":
@@ -2665,6 +2702,7 @@ def test_executor_config_pickle():
     assert config.backend == config_copy.backend
     assert config.spec_dec_config.fast_logits == config_copy.spec_dec_config.fast_logits
     assert config.use_gpu_direct_storage == config_copy.use_gpu_direct_storage
+    assert config.alias_managed_weights_from_gpu == config_copy.alias_managed_weights_from_gpu
 
     assert config_copy.guided_decoding_config.backend == config.guided_decoding_config.backend
     assert config_copy.guided_decoding_config.encoded_vocab == config.guided_decoding_config.encoded_vocab


### PR DESCRIPTION
Reworked PR following up on comment/review in https://github.com/NVIDIA/TensorRT-LLM/pull/12019#issuecomment-4036334359

full proof of concept PR that loads models in OCI images to GPU is here : https://github.com/dims/oci2gdsd/commit/654fbca506f1d8c15b59057865f1564a5a9cc12d

## Description

This PR adds executor/runtime plumbing for managed weights with optional GPU aliasing, aliases matching preloaded tensors in the PyTorch loader when device/shape/dtype/layout already match, and keeps the TensorRT-LLM PyTorch runtime path compatible with the downstream `oci2gdsd` verification flow.

## Test Coverage

- `tests/unittest/_torch/modeling/test_weight_loading_alias.py`
- `tests/unittest/bindings/test_executor_bindings.py`
- Downstream validation with the `oci2gdsd` TensorRT-LLM PyTorch verify flow on A100

## PR Checklist

- No new dependencies were added.
- `CODEOWNERS` does not need updates for this change set.
- Documentation and the tava architecture diagram do not need updates for this PR.
- Reviewer routing should follow the existing `CODEOWNERS` entries for executor and `_torch` ownership.

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aliasManagedWeightsFromGpu` configuration option to enable zero-copy weight aliasing when loading GPU-resident managed weights.
  * Implemented smart weight-loading optimization that aliases tensors when possible, avoiding unnecessary memory copies.

* **Improvements**
  * Added fallback support for attention backends when FlashInfer is unavailable, improving compatibility across configurations.
  * Made FlashInfer loading optional via environment variable, providing better control over dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->