### PR TITLE
[https://nvbugs/5823135][fix] Fix min_tokens not respected when prompt is long

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -3872,13 +3872,18 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         Returns:
             The logits with min length penalty applied
         """
-        if any(r.py_min_length and r.max_beam_num_tokens < r.py_min_length[0] for r in requests):
+        if any(
+            r.py_min_length and (r.max_beam_num_tokens - r.py_orig_prompt_len) < r.py_min_length[0]
+            for r in requests
+        ):
             current_offset = 0
             for index, r in enumerate(requests):
                 if r.py_min_length:
                     for beam_idx in range(num_beams[index]):
                         for step in range(num_steps[index]):
-                            if r.get_num_tokens(beam_idx) + step < r.py_min_length[0]:
+                            if (
+                                r.get_num_tokens(beam_idx) - r.py_orig_prompt_len
+                            ) + step < r.py_min_length[0]:
                                 # NOTE(jthomson04): We can NOT just assign logits[...] = float("-inf").
                                 # This introduces a pageable HtoD transfer, which wreaks havoc on TPOT (up to ~20%)
                                 # Instead, we create a little tensor on device, then assign to that.

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1076,6 +1076,44 @@ def test_min_tokens(use_speculative: bool):
     assert len(res.outputs[0].token_ids) == output_len
 
 
+@pytest.mark.part0
+def test_min_tokens_long_prompt():
+    """Check min_tokens is respected when prompt is longer than min_tokens.
+
+    Regression test for NVBug 5823135: _apply_min_length_penalty compared
+    total token count (prompt + generated) against the raw min_tokens value
+    instead of comparing generated token count only.  When prompt_len >=
+    min_tokens the EOS suppression was never activated, allowing early
+    termination.
+    """
+    min_tok = 50
+    max_tok = 100
+    # Prompt long enough so that prompt_len > min_tok.  "Hello " tokenises
+    # to ~1-2 tokens with most tokenizers, so 200 repetitions ≈ 200-400
+    # tokens >> min_tok.
+    long_prompt = "Hello " * 200
+
+    llm = LLM(
+        model=llama_model_path,
+        max_batch_size=2,
+        kv_cache_config=global_kvcache_config,
+        max_num_tokens=2048,
+    )
+
+    sampling_params = SamplingParams(
+        max_tokens=max_tok,
+        min_tokens=min_tok,
+        temperature=1,
+    )
+    res = llm.generate(long_prompt, sampling_params=sampling_params)
+
+    assert len(res.outputs) == 1
+    generated_len = len(res.outputs[0].token_ids)
+    assert generated_len >= min_tok, (
+        f"Generated only {generated_len} tokens with min_tokens={min_tok} "
+        f"and a long prompt.  Bug 5823135 regression.")
+
+
 @skip_ray
 @pytest.mark.parametrize(
     "prompt_logprobs, logprobs, return_context_logits, return_generation_logits, backend",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed minimum token generation constraint to correctly account for original prompt length, ensuring generated token counts respect the `min_tokens` setting even with long input prompts.

* **Tests**
  * Added regression test validating minimum token constraint behavior with long prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes NVBug 5823135: when a client sets `min_tokens` (e.g. `min_tokens=2048`) and the prompt is longer than `min_tokens` tokens, `trtllm-serve` sometimes generates only a handful of tokens instead of the expected minimum.

**Root cause:** `_apply_min_length_penalty()` in `TorchSampler` compared the **total** token count (prompt + generated) against the raw `min_tokens` value. When `prompt_len >= min_tokens`, the EOS-suppression check always evaluated to false, so the model could emit EOS at any time and terminate early.

**Fix:** Subtract `py_orig_prompt_len` from token counts before comparing with `py_min_length[0]` so the comparison is against **generated-only** tokens. This is consistent with how `min_tokens` is semantically defined — it constrains the number of *output* tokens, not the total sequence length.

Changes in two lines in `sampler.py`:
```python
# Before (buggy):
if any(r.py_min_length and r.max_beam_num_tokens < r.py_min_length[0] ...)
    if r.get_num_tokens(beam_idx) + step < r.py_min_length[0]:

# After (fixed):
if any(r.py_min_length and (r.max_beam_num_tokens - r.py_orig_prompt_len) < r.py_min_length[0] ...)
    if (r.get_num_tokens(beam_idx) - r.py_orig_prompt_len) + step < r.py_min_length[0]:
```

## Test Coverage

- Added `test_min_tokens_long_prompt` regression test in `tests/unittest/llmapi/test_llm_pytorch.py` that verifies min_tokens is respected when the prompt is longer than the min_tokens value.
- Existing `test_min_tokens` (short prompt) continues to pass.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows TRT-LLM CODING GUIDELINES.
- Test cases are provided for new code paths.

- [x] Please check this after reviewing the above items as appropriate for this PR.