### PR TITLE
[https://nvbugs/5962320][perf] Detect PCT support via CPUID and set C…

### DIFF
--- a/docs/source/deployment-guide/configuring-cpu-affinity.md
+++ b/docs/source/deployment-guide/configuring-cpu-affinity.md
@@ -29,6 +29,35 @@ environment variable as follows:
 | 0 or any other value            | Affinity remains as configured by the user and/or environment                                                                |
 
 
+## Intel Priority Core Turbo
+
+Intel Granite Rapids platforms, such as the Intel Xeon 6, include the [Priority
+Core Turbo](https://cdrdv2-public.intel.com/846906/846906_PCT_Technology_Technical_Article_Rev_1_5_1.pdf)
+(PCT) feature. PCT allows designated high-priority cores to operate at elevated
+turbo frequencies, while other cores run at lower base speeds. The
+high-priority cores provide substantial benefit to CPU-intensive AI
+applications like TensorRT-LLM, where GPU work submission is on the critical
+path. However, due to the large disparity in performance between high and low-priority
+cores, precise CPU affinity configuration is imperative. For this reason,
+TensorRT-LLM automatically restricts worker CPU affinity to high-priority PCT
+cores. The per-GPU affinity is determined by intersecting the set of PCT cores
+with the NVML-reported NUMA affinity for each device, so the correct NUMA-local
+subset is selected automatically.
+
+This behavior differs from the generic NUMA-aware affinity in two ways:
+
+1. It is applied **unconditionally by default**, regardless of whether the
+   process already has constrained affinity (e.g. from OpenMPI, Slurm, or
+   numactl). A warning is logged when existing constraints are overridden.
+2. It can only be disabled by explicitly setting
+   `TLLM_NUMA_AWARE_WORKER_AFFINITY=0`.
+
+| TLLM_NUMA_AWARE_WORKER_AFFINITY | Behavior on Granite Rapids                                      |
+|---------------------------------|-----------------------------------------------------------------|
+| \<unset\>                       | PCT-aware affinity is applied (overrides any existing affinity) |
+| 1                               | PCT-aware affinity is applied (overrides any existing affinity) |
+| 0                               | Affinity remains as configured by the user and/or environment   |
+
 ## Other environmental considerations
 
 Whether or not the user chooses to manually configure CPU affinity or have

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import platform
 from pathlib import Path
 from typing import List
 
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.dist import Distribution
 
 
@@ -382,6 +382,13 @@ else:
 # internal absolute imports (e.g., "from triton_kernels.foo import bar") work.
 packages += find_packages(include=["triton_kernels", "triton_kernels.*"])
 
+# x86-only C extension for CPUID-based CPU feature detection (e.g. PCT)
+ext_modules = []
+if platform.machine() in ('x86_64', 'AMD64'):
+    ext_modules.append(
+        Extension('tensorrt_llm.llmapi._cpuid_utils',
+                  sources=['tensorrt_llm/llmapi/cpuid_utils.c']))
+
 # https://setuptools.pypa.io/en/latest/references/keywords.html
 setup(
     name='tensorrt_llm',
@@ -404,6 +411,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.12",
     ],
+    ext_modules=ext_modules,
     distclass=BinaryDistribution,
     license="Apache License 2.0",
     keywords="nvidia tensorrt deeplearning inference",

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -21,7 +21,8 @@ from ..builder import ConfigEncoder, Engine, EngineConfig
 from ..llmapi.llm_args import BaseLlmArgs, PybindMirror
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import _SyncQueue, get_numa_aware_cpu_affinity, logger_debug
+from ..llmapi.utils import (_SyncQueue, get_numa_aware_cpu_affinity,
+                            get_pct_high_priority_cpu_affinity, logger_debug)
 from ..lora_manager import LoraManager
 from ..metrics import RequestEventTiming
 from ..prompt_adapter_manager import PromptAdapterManager
@@ -123,8 +124,12 @@ class BaseWorker(GenerationExecutor):
             device_id: The CUDA device ID to determine optimal CPU affinity.
 
         Note:
-            If the process already has constrained affinity, a warning is logged.
-            Configuration is handled as follows:
+            On Intel systems with Priority Core Turbo (e.g. Intel Granite
+            Rapids), affinity is set to a NUMA-local set of high-priority
+            cores. The user may opt out by setting
+            TLLM_NUMA_AWARE_WORKER_AFFINITY = 0
+
+            On other platforms, behavior is as follows:
                 TLLM_NUMA_AWARE_WORKER_AFFINITY = <unset>
                     -> Affinity is automatically configured if it is unconstrained,
                        and deleted if it is constrained externally by the user.
@@ -143,6 +148,31 @@ class BaseWorker(GenerationExecutor):
 
         constrained_affinity = (cpu_affinity != all_cpus)
         numa_aware_affinity = os.environ.get("TLLM_NUMA_AWARE_WORKER_AFFINITY")
+
+        # On Intel systems that support the Priority Core Turbo feature, always
+        # set affinity to a NUMA-local set of high-priority cores, unless the
+        # user opts out
+        pct_hp_affinity = get_pct_high_priority_cpu_affinity(device_id)
+        if pct_hp_affinity is not None:
+            if numa_aware_affinity == "0":
+                logger.info(
+                    f"Worker process {pid}: PCT high priority CPU affinity "
+                    f"disabled by TLLM_NUMA_AWARE_WORKER_AFFINITY=0.")
+                return
+            if cpu_affinity != all_cpus:
+                logger.warning(
+                    f"Worker process {pid} has constrained CPU affinity: "
+                    f"{cpu_affinity}. Overriding with PCT high priority "
+                    f"affinity. Set TLLM_NUMA_AWARE_WORKER_AFFINITY=0 to "
+                    f"disable.")
+            process.cpu_affinity(pct_hp_affinity)
+            logger.info(
+                f"Worker process {pid} CPU affinity set to "
+                f"{process.cpu_affinity()} to explicitly select PCT high "
+                f"priority cores")
+            return
+
+        # Generic NUMA-aware affinity path for other platforms.
 
         # If affinity is constrained but the user hasn't explicitly
         # requested NUMA-aware affinity, remove the constraints.

--- a/tensorrt_llm/llmapi/cpuid_utils.c
+++ b/tensorrt_llm/llmapi/cpuid_utils.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Minimal x86 CPUID Python extension for querying CPU feature flags.
+ *
+ * Exposes has_pct_support() to Python, which checks whether the CPU
+ * supports Intel Priority Core Turbo (PCT) via CPUID.
+ */
+
+#include <Python.h>
+#include <cpuid.h>
+#include <stdint.h>
+
+/*
+ * Check whether the CPU supports Intel Priority Core Turbo (PCT).
+ *
+ * PCT requires both:
+ *   1. Intel Granite Rapids CPU (Family 6, Model 0xAD or 0xAE)
+ *   2. SST (Speed Select Technology) support: CPUID leaf 0x06, EAX bit 10
+ *
+ * Returns 1 if supported, 0 otherwise.
+ */
+static int has_pct_support(void)
+{
+    unsigned int eax, ebx, ecx, edx;
+
+    /* Leaf 1: CPU family and model identification */
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+        return 0;
+
+    uint32_t family = (eax >> 8) & 0xF;
+    uint32_t model = (eax >> 4) & 0xF;
+    uint32_t extended_family = (eax >> 20) & 0xFF;
+    uint32_t extended_model = (eax >> 16) & 0xF;
+
+    uint32_t display_family = (family == 0xF) ? family + extended_family : family;
+    uint32_t display_model = (family == 0x6 || family == 0xF)
+                                 ? (extended_model << 4) | model
+                                 : model;
+
+    if (display_family != 6 || (display_model != 0xAD && display_model != 0xAE))
+        return 0;
+
+    /* Leaf 0x06: Thermal and Power Management — bit 10 = SST support */
+    if (!__get_cpuid(0x06, &eax, &ebx, &ecx, &edx))
+        return 0;
+
+    return (eax >> 10) & 1;
+}
+
+static PyObject* py_has_pct_support(PyObject* self, PyObject* args)
+{
+    return PyBool_FromLong(has_pct_support());
+}
+
+static PyMethodDef cpuid_methods[] = {{"has_pct_support", py_has_pct_support, METH_NOARGS,
+                                          "Return True if the CPU supports Intel Priority Core Turbo (PCT)."},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef cpuid_module = {PyModuleDef_HEAD_INIT, "_cpuid_utils",
+    "x86 CPUID utilities for detecting CPU features such as PCT.", -1, cpuid_methods};
+
+PyMODINIT_FUNC PyInit__cpuid_utils(void)
+{
+    return PyModule_Create(&cpuid_module);
+}

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import ctypes
 import datetime
+import functools
 import hashlib
 import inspect
 import io
@@ -546,6 +547,96 @@ class _SyncQueue:
                 time.sleep(0.01)
 
 
+@functools.lru_cache(maxsize=1)
+def _has_pct_support():
+    '''Detect if the CPU supports Intel Priority Core Turbo (PCT).
+
+    Queries CPUID leaf 0x06 (Thermal and Power Management), EAX bit 10, which
+    indicates Intel Speed Select Technology - Turbo Frequency (SST-TF) support
+    and CPU leaf 1 (family/model). If SST-TF is supported and the model is
+    Granite Rapids, PCT is supported.
+
+    The _cpuid_utils extension is only built on x86_64 platforms.
+
+    Returns:
+        True if PCT is supported, False otherwise.
+    '''
+    try:
+        from ._cpuid_utils import has_pct_support
+        return has_pct_support()
+    except ImportError:
+        return False
+
+
+# PCT core IDs on Intel Granite Rapids platforms. The per-GPU affinity is
+# determined by intersecting this set with the NVML-reported NUMA affinity
+# for each device, so the correct subset is selected automatically.
+#
+# FIXME: These core IDs are currently hardcoded because there is no userspace
+# API to query PCT cores at runtime. When Intel provides such a capability,
+# replace this static set with a dynamic query.
+_GRANITE_RAPIDS_PCT_CORES = frozenset([
+    0,
+    1,
+    16,
+    17,
+    32,
+    33,
+    48,
+    49,
+    64,
+    65,
+    80,
+    81,
+    96,
+    97,
+    112,
+    113,
+    128,
+    129,
+    144,
+    145,
+    160,
+    161,
+    176,
+    177,
+    192,
+    193,
+    208,
+    209,
+    224,
+    225,
+    240,
+    241,
+])
+
+
+@functools.lru_cache(maxsize=None)
+def get_pct_high_priority_cpu_affinity(device_id):
+    '''
+    Returns CPU affinity corresponding to a NUMA-local set of PCT High Priority
+    cores, if the PCT feature is supported and None otherwise.
+
+    Intersects the PCT High Priority (HP) core set with the NVML-reported NUMA
+    affinity for the given device, so the correct NUMA-local subset of HP PCT
+    cores is selected automatically.
+
+    Args:
+        device_id: The CUDA device ID.
+
+    Returns:
+        Sorted list of CPU IDs for the device, or None if this is not a
+        Granite Rapids system.
+    '''
+    if not _has_pct_support():
+        return None
+
+    numa_cpus = get_numa_aware_cpu_affinity(device_id)
+    affinity = sorted(_GRANITE_RAPIDS_PCT_CORES & set(numa_cpus))
+    return affinity if affinity else None
+
+
+@functools.lru_cache(maxsize=None)
 def get_numa_aware_cpu_affinity(device_id):
     '''Query NVML for NUMA-aware CPU affinity for the specified CUDA device.
 
@@ -578,9 +669,11 @@ def get_numa_aware_cpu_affinity(device_id):
         # Determine how large our cpu set array from NVML needs to be
         cpu_set_size = math.ceil(cpu_count / c_ulong_bits)
 
-        # Get the optimal CPU affinity for this device according to the NUMA
-        # topology
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
+        # Resolve the NVML handle via UUID so that CUDA_VISIBLE_DEVICES
+        # remapping is handled correctly (NVML indices are physical and
+        # unaffected by CUDA_VISIBLE_DEVICES).
+        from .._torch.utils import get_device_uuid
+        handle = pynvml.nvmlDeviceGetHandleByUUID(get_device_uuid(device_id))
         affinity_masks = pynvml.nvmlDeviceGetCpuAffinity(handle, cpu_set_size)
 
         # Convert CPU masks to python list


### PR DESCRIPTION
…PU affinity to high-priority cores

On Intel Granite Rapids platforms with Priority Core Turbo (PCT), automatically restrict worker CPU affinity to NUMA-local high-priority cores. PCT cores operate at elevated turbo frequencies and provide substantial benefit to CPU-intensive GPU work submission.

Detection uses a C extension (cpuid_utils.c, built only on x86_64) that queries CPUID leaf 1 for Granite Rapids family/model and leaf 0x06 EAX bit 10 for SST-TF support.

Also fixes a pre-existing bug in get_numa_aware_cpu_affinity where the NVML device handle was looked up by index rather than UUID, which returned incorrect NUMA affinity when CUDA_VISIBLE_DEVICES remapped logical device IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and optimization for Intel Priority Core Turbo (PCT) on Granite Rapids CPUs, improving worker thread affinity to high-priority cores by default.
  * Introduced `TLLM_NUMA_AWARE_WORKER_AFFINITY` environment variable to control PCT-based affinity behavior (set to `0` to disable).

* **Documentation**
  * Added comprehensive guide on Intel Priority Core Turbo support, compatibility behavior, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
