### PR TITLE
[https://nvbugs/5944411][fix] Handle anyOf parameter schemas in Qwen3Coder tool parser

### DIFF
--- a/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_coder_parser.py
@@ -374,6 +374,9 @@ class Qwen3CoderToolParser(BaseToolParser):
 
         if isinstance(param_config[param_name], dict) and "type" in param_config[param_name]:
             param_type = str(param_config[param_name]["type"]).strip().lower()
+        elif isinstance(param_config[param_name], dict) and "anyOf" in param_config[param_name]:
+            # anyOf has no top-level "type"; treat as object to trigger json.loads.
+            param_type = "object"
         else:
             param_type = "string"
 

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -1007,6 +1007,127 @@ class TestQwen3CoderToolParser(BaseToolParserTestClass):
             }
         }
 
+    def test_parse_anyof_parameter_type_conversion(self, parser):
+        """Test that parameters using anyOf schemas are correctly type-converted."""
+        tool_def = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="create_record",
+                description="Create a record with various optional fields",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "count": {
+                            "anyOf": [{
+                                "type": "integer"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                        "score": {
+                            "anyOf": [{
+                                "type": "number"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                        "active": {
+                            "anyOf": [{
+                                "type": "boolean"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                        "metadata": {
+                            "anyOf": [{
+                                "type": "object"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                        "tags": {
+                            "anyOf": [{
+                                "type": "array"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                        "label": {
+                            "anyOf": [{
+                                "type": "string"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                    },
+                    "required": ["name"],
+                },
+            ),
+        )
+
+        text = ("<tool_call>\n"
+                "<function=create_record>\n"
+                "<parameter=name>test</parameter>\n"
+                "<parameter=count>42</parameter>\n"
+                "<parameter=score>3.14</parameter>\n"
+                "<parameter=active>true</parameter>\n"
+                '<parameter=metadata>{"key": "value"}</parameter>\n'
+                "<parameter=tags>[1, 2, 3]</parameter>\n"
+                "<parameter=label>hello</parameter>\n"
+                "</function>\n"
+                "</tool_call>")
+
+        result = parser.detect_and_parse(text, [tool_def])
+
+        assert len(result.calls) == 1
+        params = json.loads(result.calls[0].parameters)
+        assert params["name"] == "test"
+        assert params["count"] == 42
+        assert isinstance(params["count"], int)
+        assert params["score"] == 3.14
+        assert isinstance(params["score"], float)
+        assert params["active"] is True
+        assert params["metadata"] == {"key": "value"}
+        assert params["tags"] == [1, 2, 3]
+        assert params["label"] == "hello"
+
+    def test_parse_anyof_null_value(self, parser):
+        """Test that null values are handled correctly for anyOf parameters."""
+        tool_def = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="set_value",
+                description="Set a value",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "anyOf": [{
+                                "type": "integer"
+                            }, {
+                                "type": "null"
+                            }],
+                        },
+                    },
+                },
+            ),
+        )
+
+        text = ("<tool_call>\n"
+                "<function=set_value>\n"
+                "<parameter=value>null</parameter>\n"
+                "</function>\n"
+                "</tool_call>")
+
+        result = parser.detect_and_parse(text, [tool_def])
+
+        assert len(result.calls) == 1
+        params = json.loads(result.calls[0].parameters)
+        assert params["value"] is None
+
     def test_qwen3_coder_format_compliance(
         self,
         parser,


### PR DESCRIPTION
Parameters using anyOf (e.g. Optional[int]) have no top-level "type" key, causing _convert_param_value to always default to "string". Treat anyOf schemas as "object" to trigger json.loads, which correctly parses integers, floats, booleans, objects, and arrays.


Made-with: Cursor

Fix cherry picked from https://github.com/vllm-project/vllm/pull/36032 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenAPI-style anyOf schemas in parameter definitions, enabling proper type conversion and handling of union types.

* **Tests**
  * Added comprehensive unit tests for anyOf schema parameter parsing, validating type conversion and null value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
