### PR TITLE
[TRTLLM-11357][feat] Support interleaved thinking for trtllm-serve

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -72,6 +72,9 @@ class BaseReasoningParser(ABC):
 
 @register_reasoning_parser("deepseek-r1", reasoning_at_start=True)
 @register_reasoning_parser("qwen3")
+@register_reasoning_parser("glm45", reasoning_at_start=True)
+@register_reasoning_parser("minimax_m2", reasoning_at_start=True)
+@register_reasoning_parser("minimax_m2_append_think", reasoning_at_start=True)
 class DeepSeekR1Parser(BaseReasoningParser):
     """
     Reasoning parser for DeepSeek-R1. Reasoning format: <think>(.*)</think>.

--- a/tensorrt_llm/serve/tool_parser/glm47_parser.py
+++ b/tensorrt_llm/serve/tool_parser/glm47_parser.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from typing import List
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.serve.openai_protocol import ChatCompletionToolsParam as Tool
+from tensorrt_llm.serve.tool_parser.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from tensorrt_llm.serve.tool_parser.glm4_parser import Glm4ToolParser
+
+
+class Glm47ToolParser(Glm4ToolParser):
+    r"""Tool parser for GLM-4.7 models.
+
+    Extends the GLM-4 tool parser with support for:
+    - Optional arguments (tool calls with no parameters)
+    - Flexible whitespace handling between function name and arguments
+
+    GLM-4.7 tool call format:
+        <tool_call>get_weather
+        <arg_key>city</arg_key>
+        <arg_value>Beijing</arg_value>
+        </tool_call>
+
+    Or without arguments:
+        <tool_call>get_current_time</tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Override regex to make arguments optional
+        self.func_detail_regex = re.compile(
+            r"<tool_call>(.*?)(?:(?:\\n|\n)(.*?))?</tool_call>", re.DOTALL
+        )
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        """One-time parsing with support for optional arguments."""
+        idx = text.find(self.bot_token)
+        normal_text = text[:idx].strip() if idx != -1 else text
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        calls = []
+        try:
+            for match_result in match_result_list:
+                func_detail = self.func_detail_regex.search(match_result)
+                if func_detail is None:
+                    continue
+                func_name = func_detail.group(1).strip() if func_detail.group(1) else ""
+                func_args = func_detail.group(2) if func_detail.group(2) else ""
+
+                if not func_name:
+                    continue
+
+                if func_args:
+                    func_args = func_args.strip()
+                    pairs = self.func_arg_regex.findall(func_args)
+                    arguments = self._parse_argument_pairs(pairs, func_name, tools) if pairs else {}
+                else:
+                    arguments = {}
+
+                match_result_dict = {"name": func_name, "parameters": arguments}
+                calls.extend(self.parse_base_json(match_result_dict, tools))
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+        except Exception as e:
+            logger.error(f"Error in Glm47ToolParser detect_and_parse: {e}")
+            return StreamingParseResult(normal_text=text)
+
+    def parse_streaming_increment(self, new_text: str, tools: List[Tool]) -> StreamingParseResult:
+        """Streaming incremental parsing for GLM-4.7 format.
+
+        Extends the GLM-4 streaming parser to handle tool calls with no arguments.
+        """
+        self._buffer += new_text
+        current_text = self._buffer
+
+        has_tool_call = self.bot_token in current_text
+
+        if not has_tool_call:
+            is_potential_start = any(
+                self.bot_token.startswith(current_text[-i:])
+                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            )
+
+            if not is_potential_start:
+                output_text = current_text
+                self._buffer = ""
+                if self.eot_token in output_text:
+                    output_text = output_text.replace(self.eot_token, "")
+                return StreamingParseResult(normal_text=output_text)
+            return StreamingParseResult(normal_text="", calls=[])
+
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
+        calls: list[ToolCallItem] = []
+        try:
+            # Match partial tool calls (may or may not have closing tag)
+            partial_match = re.search(
+                pattern=r"<tool_call>(.*?)(?:(?:\\n|\n)(.*?))?(</tool_call>|$)",
+                string=current_text,
+                flags=re.DOTALL,
+            )
+            if partial_match:
+                func_name_raw = partial_match.group(1)
+                func_args_raw = partial_match.group(2)
+                is_tool_end = partial_match.group(3)
+
+                if func_name_raw is None or not func_name_raw.strip():
+                    return StreamingParseResult(normal_text="", calls=[])
+
+                func_name = func_name_raw.strip()
+                func_args_raw = func_args_raw.strip() if func_args_raw else ""
+
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = [""]
+                    self._streamed_raw_length = 0
+                    self.current_tool_name_sent = False
+                    self._reset_streaming_state()
+
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+
+                if not self.current_tool_name_sent:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=func_name,
+                            parameters="",
+                        )
+                    )
+                    self.current_tool_name_sent = True
+                    self._streamed_raw_length = 0
+                    self._reset_streaming_state()
+                    self.prev_tool_call_arr[self.current_tool_id] = {
+                        "name": func_name,
+                        "arguments": {},
+                    }
+                else:
+                    if func_args_raw:
+                        current_raw_length = len(func_args_raw)
+
+                        if current_raw_length > self._streamed_raw_length:
+                            raw_increment = func_args_raw[self._streamed_raw_length :]
+
+                            json_increment = self._process_xml_to_json_streaming(
+                                raw_increment, func_name, tools
+                            )
+
+                            self._streamed_raw_length = current_raw_length
+
+                            if json_increment:
+                                calls.append(
+                                    ToolCallItem(
+                                        tool_index=self.current_tool_id,
+                                        name=None,
+                                        parameters=json_increment,
+                                    )
+                                )
+                                self._last_arguments += json_increment
+                                self.streamed_args_for_tool[self.current_tool_id] += json_increment
+
+                    if is_tool_end == self.eot_token:
+                        # Handle tool calls with no arguments
+                        if not func_args_raw or (self._is_first_param and not self._last_arguments):
+                            empty_object = "{}"
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=empty_object,
+                                )
+                            )
+                            self._last_arguments += empty_object
+                        elif not self._last_arguments.endswith("}"):
+                            closing_brace = "}"
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=closing_brace,
+                                )
+                            )
+                            self._last_arguments += closing_brace
+                            self.streamed_args_for_tool[self.current_tool_id] += closing_brace
+
+                        if func_args_raw:
+                            try:
+                                pairs = self.func_arg_regex.findall(func_args_raw)
+                                if pairs:
+                                    arguments = self._parse_argument_pairs(pairs, func_name, tools)
+                                    self.prev_tool_call_arr[self.current_tool_id]["arguments"] = (
+                                        arguments
+                                    )
+                            except Exception as e:
+                                logger.debug(f"Failed to parse arguments: {e}")
+
+                        self._buffer = current_text[partial_match.end(3) :]
+
+                        result = StreamingParseResult(normal_text="", calls=calls)
+                        self.current_tool_id += 1
+                        self._last_arguments = ""
+                        self.current_tool_name_sent = False
+                        self._streamed_raw_length = 0
+                        self._reset_streaming_state()
+                        return result
+
+            return StreamingParseResult(normal_text="", calls=calls)
+
+        except Exception as e:
+            logger.error(f"Error in Glm47ToolParser parse_streaming_increment: {e}")
+            return StreamingParseResult(normal_text=current_text)
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError()

--- a/tensorrt_llm/serve/tool_parser/minimax_m2_parser.py
+++ b/tensorrt_llm/serve/tool_parser/minimax_m2_parser.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.serve.openai_protocol import ChatCompletionToolsParam as Tool
+from tensorrt_llm.serve.tool_parser.base_tool_parser import BaseToolParser
+from tensorrt_llm.serve.tool_parser.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+
+
+def _get_param_types(param_name: str, func_name: str, tools: List[Tool]) -> Optional[str]:
+    """Get the expected type of a parameter from tool definitions."""
+    for tool in tools:
+        if tool.function.name == func_name:
+            props = (tool.function.parameters or {}).get("properties", {})
+            if param_name in props:
+                type_val = props[param_name].get("type")
+                if isinstance(type_val, str):
+                    return type_val
+                if isinstance(type_val, list):
+                    non_null = [t for t in type_val if t != "null"]
+                    return non_null[0] if non_null else "string"
+    return None
+
+
+def _parse_param_value(value_str: str, param_type: Optional[str]) -> Any:
+    """Parse a parameter value string into the appropriate Python type."""
+    value_str = value_str.strip()
+
+    # Try JSON parsing first
+    try:
+        parsed = json.loads(value_str)
+        return parsed
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # For numeric types, try numeric conversion
+    if param_type in ("number", "integer"):
+        try:
+            if "." in value_str or "e" in value_str.lower():
+                return float(value_str)
+            return int(value_str)
+        except (ValueError, TypeError):
+            pass
+
+    # For boolean type
+    if param_type == "boolean":
+        if value_str.lower() == "true":
+            return True
+        if value_str.lower() == "false":
+            return False
+
+    # Default: return as string
+    return value_str
+
+
+class MiniMaxM2ToolParser(BaseToolParser):
+    r"""Tool parser for MiniMax-M2 models.
+
+    Parses the MiniMax-M2 tool call format:
+        <minimax:tool_call>
+          <invoke name="function_name">
+            <parameter name="param1">value1</parameter>
+            <parameter name="param2">value2</parameter>
+          </invoke>
+        </minimax:tool_call>
+
+    Supports both single and parallel (multiple <invoke> blocks) tool calls.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<minimax:tool_call>"  # nosec B105
+        self.eot_token = "</minimax:tool_call>"  # nosec B105
+
+        # Regex patterns for parsing
+        self.tool_call_block_regex = re.compile(
+            r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
+        )
+        self.invoke_regex = re.compile(
+            r'<invoke\s+name=["\']?(.*?)["\']?\s*>(.*?)</invoke>', re.DOTALL
+        )
+        self.param_regex = re.compile(
+            r'<parameter\s+name=["\']?(.*?)["\']?\s*>(.*?)</parameter>', re.DOTALL
+        )
+
+        # Streaming state
+        self._streamed_raw_length = 0
+        self._current_invoke_count = 0
+        self._json_buffers: Dict[int, str] = {}
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        """One-time parsing: detect and parse all tool calls in the text."""
+        idx = text.find(self.bot_token)
+        normal_text = text[:idx].strip() if idx != -1 else text
+
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        calls: List[ToolCallItem] = []
+        tool_call_blocks = self.tool_call_block_regex.findall(text)
+        tool_index = 0
+
+        for block in tool_call_blocks:
+            invocations = self.invoke_regex.findall(block)
+            for func_name, params_text in invocations:
+                func_name = func_name.strip()
+                params = self.param_regex.findall(params_text)
+
+                arguments: Dict[str, Any] = {}
+                for param_name, param_value in params:
+                    param_name = param_name.strip()
+                    param_type = _get_param_types(param_name, func_name, tools)
+                    arguments[param_name] = _parse_param_value(param_value, param_type)
+
+                calls.append(
+                    ToolCallItem(
+                        tool_index=tool_index,
+                        name=func_name,
+                        parameters=json.dumps(arguments, ensure_ascii=False),
+                    )
+                )
+                tool_index += 1
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def parse_streaming_increment(self, new_text: str, tools: List[Tool]) -> StreamingParseResult:
+        """Streaming incremental parsing for MiniMax-M2 tool call format."""
+        self._buffer += new_text
+        current_text = self._buffer
+
+        has_tool = self.bot_token in current_text
+
+        if not has_tool:
+            # Check for partial bot token
+            is_potential_start = any(
+                self.bot_token.startswith(current_text[-i:])
+                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            )
+
+            if not is_potential_start:
+                output_text = current_text
+                self._buffer = ""
+                # Clean up end tokens
+                if self.eot_token in output_text:
+                    output_text = output_text.replace(self.eot_token, "")
+                return StreamingParseResult(normal_text=output_text)
+            return StreamingParseResult(normal_text="", calls=[])
+
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
+        calls: List[ToolCallItem] = []
+
+        try:
+            # Extract content after <minimax:tool_call>
+            tc_start = current_text.find(self.bot_token)
+            inner_text = current_text[tc_start + len(self.bot_token) :]
+
+            # Find all complete invoke blocks
+            complete_invocations = list(self.invoke_regex.finditer(inner_text))
+            # Check for partial invoke (started but not closed)
+            partial_invoke = re.search(
+                r'<invoke\s+name=["\']?(.*?)["\']?\s*>((?:(?!</invoke>).)*?)$',
+                inner_text,
+                re.DOTALL,
+            )
+
+            # Process complete invocations that haven't been processed yet
+            for i, match in enumerate(complete_invocations):
+                if i < self._current_invoke_count:
+                    continue
+                func_name = match.group(1).strip()
+                params_text = match.group(2)
+
+                params = self.param_regex.findall(params_text)
+                arguments: Dict[str, Any] = {}
+                for param_name, param_value in params:
+                    param_name = param_name.strip()
+                    param_type = _get_param_types(param_name, func_name, tools)
+                    arguments[param_name] = _parse_param_value(param_value, param_type)
+
+                # Send function name
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id + 1 if self.current_tool_id >= 0 else 0,
+                        name=func_name,
+                        parameters="",
+                    )
+                )
+                # Send complete arguments
+                args_json = json.dumps(arguments, ensure_ascii=False)
+                self.current_tool_id = self.current_tool_id + 1 if self.current_tool_id >= 0 else 0
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None,
+                        parameters=args_json,
+                    )
+                )
+                self._current_invoke_count = i + 1
+
+            # Handle partial invoke (streaming in progress)
+            if partial_invoke and len(complete_invocations) == self._current_invoke_count:
+                func_name = partial_invoke.group(1).strip()
+                partial_params_text = partial_invoke.group(2)
+
+                # If we haven't sent the name for this tool yet
+                if (
+                    not self.current_tool_name_sent
+                    or self.current_tool_id < self._current_invoke_count
+                ):
+                    if func_name:
+                        self.current_tool_id = self._current_invoke_count
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=func_name,
+                                parameters="",
+                            )
+                        )
+                        self.current_tool_name_sent = True
+                        self._json_buffers[self.current_tool_id] = ""
+
+                # Stream partial arguments
+                if self.current_tool_name_sent and partial_params_text:
+                    complete_params = self.param_regex.findall(partial_params_text)
+                    if complete_params:
+                        arguments = {}
+                        for param_name, param_value in complete_params:
+                            param_name = param_name.strip()
+                            param_type = _get_param_types(param_name, func_name, tools)
+                            arguments[param_name] = _parse_param_value(param_value, param_type)
+                        new_args_json = json.dumps(arguments, ensure_ascii=False)
+                        prev_json = self._json_buffers.get(self.current_tool_id, "")
+                        if new_args_json != prev_json:
+                            # Send incremental diff
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=new_args_json,
+                                )
+                            )
+                            self._json_buffers[self.current_tool_id] = new_args_json
+
+            # Check if tool call block is complete
+            if self.eot_token in current_text:
+                self._buffer = current_text[
+                    current_text.find(self.eot_token) + len(self.eot_token) :
+                ]
+                self.current_tool_name_sent = False
+                self._current_invoke_count = 0
+                self._json_buffers.clear()
+
+            return StreamingParseResult(normal_text="", calls=calls)
+
+        except Exception as e:
+            logger.error(f"Error in MiniMaxM2 parse_streaming_increment: {e}")
+            return StreamingParseResult(normal_text=current_text)
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError()

--- a/tensorrt_llm/serve/tool_parser/tool_parser_factory.py
+++ b/tensorrt_llm/serve/tool_parser/tool_parser_factory.py
@@ -5,7 +5,9 @@ from .deepseekv3_parser import DeepSeekV3Parser
 from .deepseekv31_parser import DeepSeekV31Parser
 from .deepseekv32_parser import DeepSeekV32Parser
 from .glm4_parser import Glm4ToolParser
+from .glm47_parser import Glm47ToolParser
 from .kimi_k2_tool_parser import KimiK2ToolParser
+from .minimax_m2_parser import MiniMaxM2ToolParser
 from .qwen3_coder_parser import Qwen3CoderToolParser
 from .qwen3_tool_parser import Qwen3ToolParser
 
@@ -19,6 +21,8 @@ class ToolParserFactory:
         "deepseek_v31": DeepSeekV31Parser,
         "deepseek_v32": DeepSeekV32Parser,
         "glm4": Glm4ToolParser,
+        "glm47": Glm47ToolParser,
+        "minimax_m2": MiniMaxM2ToolParser,
     }
 
     @staticmethod

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -27,7 +27,9 @@ from tensorrt_llm.serve.tool_parser.deepseekv3_parser import DeepSeekV3Parser
 from tensorrt_llm.serve.tool_parser.deepseekv31_parser import DeepSeekV31Parser
 from tensorrt_llm.serve.tool_parser.deepseekv32_parser import DeepSeekV32Parser
 from tensorrt_llm.serve.tool_parser.glm4_parser import Glm4ToolParser
+from tensorrt_llm.serve.tool_parser.glm47_parser import Glm47ToolParser
 from tensorrt_llm.serve.tool_parser.kimi_k2_tool_parser import KimiK2ToolParser
+from tensorrt_llm.serve.tool_parser.minimax_m2_parser import MiniMaxM2ToolParser
 from tensorrt_llm.serve.tool_parser.qwen3_coder_parser import \
     Qwen3CoderToolParser
 from tensorrt_llm.serve.tool_parser.qwen3_tool_parser import Qwen3ToolParser
@@ -1624,6 +1626,493 @@ class TestToolParserIntegration:
 
         assert result1.calls[0].name == "get_weather"
         assert result2.calls[0].name == "search_web"
+
+
+# ============================================================================
+# Glm47ToolParser Tests
+# ============================================================================
+
+
+class TestGlm47ToolParser(BaseToolParserTestClass):
+    """Test suite for Glm47ToolParser class."""
+
+    def make_parser(self):
+        return Glm47ToolParser()
+
+    def make_tool_parser_test_cases(self):
+        single_text = ("Normal text"
+                       "<tool_call>get_weather\n"
+                       "<arg_key>location</arg_key>\n"
+                       "<arg_value>NYC</arg_value>\n"
+                       "</tool_call>")
+        single_expected_normal = "Normal text"
+        single_expected_name = "get_weather"
+        single_expected_params = {"location": "NYC"}
+
+        multiple_text = ("<tool_call>get_weather\n"
+                         "<arg_key>location</arg_key>\n"
+                         "<arg_value>LA</arg_value>\n"
+                         "</tool_call>"
+                         "<tool_call>search_web\n"
+                         "<arg_key>query</arg_key>\n"
+                         "<arg_value>AI</arg_value>\n"
+                         "</tool_call>")
+        multiple_names = ("get_weather", "search_web")
+
+        malformed_text = ("<tool_call>"
+                          "MALFORMED_NO_FUNCTION</tool_call>")
+
+        with_parameters_text = ("<tool_call>search_web\n"
+                                "<arg_key>query</arg_key>\n"
+                                "<arg_value>test</arg_value>\n"
+                                "</tool_call>")
+        with_parameters_name = "search_web"
+        with_parameters_params = {"query": "test"}
+
+        partial_bot_token = "<tool_cal"
+
+        undefined_tool_text = ("<tool_call>undefined_func\n"
+                               "<arg_key>arg</arg_key>\n"
+                               "<arg_value>value</arg_value>\n"
+                               "</tool_call>")
+
+        return ToolParserTestCases(
+            has_tool_call_true=
+            "Some text <tool_call>get_weather\n<arg_key>location</arg_key>\n<arg_value>NYC</arg_value>\n</tool_call>",
+            detect_and_parse_single_tool=(
+                single_text,
+                single_expected_normal,
+                single_expected_name,
+                single_expected_params,
+            ),
+            detect_and_parse_multiple_tools=(multiple_text, multiple_names),
+            detect_and_parse_malformed_tool=malformed_text,
+            detect_and_parse_with_parameters_key=(
+                with_parameters_text,
+                with_parameters_name,
+                with_parameters_params,
+            ),
+            parse_streaming_increment_partial_bot_token=partial_bot_token,
+            undefined_tool=undefined_tool_text,
+        )
+
+    def test_initialization(self, parser):
+        """Test that Glm47ToolParser initializes correctly."""
+        assert parser.bot_token == "<tool_call>"
+        assert parser.eot_token == "</tool_call>"
+
+    def test_detect_and_parse_no_arguments(self, sample_tools):
+        """Test GLM-4.7 specific: tool call with no arguments."""
+        parser = Glm47ToolParser()
+        text = "<tool_call>get_weather</tool_call>"
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {}
+
+    def test_detect_and_parse_with_arguments(self, sample_tools):
+        """Test GLM-4.7 with normal arguments."""
+        parser = Glm47ToolParser()
+        text = ("<tool_call>get_weather\n"
+                "<arg_key>location</arg_key>\n"
+                "<arg_value>Tokyo</arg_value>\n"
+                "</tool_call>")
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {"location": "Tokyo"}
+
+    def test_streaming_no_args_tool_call(self, sample_tools):
+        """Test streaming a GLM-4.7 tool call with no arguments."""
+        parser = Glm47ToolParser()
+
+        # First increment sends the tool name
+        result1 = parser.parse_streaming_increment("<tool_call>get_weather",
+                                                   sample_tools)
+        names = [c.name for c in result1.calls if c.name]
+        assert "get_weather" in names
+
+        # Close the tool call directly (no args)
+        result2 = parser.parse_streaming_increment("</tool_call>", sample_tools)
+        params = "".join(c.parameters for c in result2.calls)
+        assert "{}" in params
+
+    def test_streaming_with_arguments(self, sample_tools):
+        """Test streaming a GLM-4.7 tool call with arguments."""
+        parser = Glm47ToolParser()
+
+        # Send bot token with function name
+        result = parser.parse_streaming_increment("<tool_call>get_weather\n",
+                                                  sample_tools)
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+
+        # Send arguments and close
+        result = parser.parse_streaming_increment(
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>SF</arg_value>\n"
+            "</tool_call>", sample_tools)
+
+        all_params = "".join(call.parameters for call in result.calls
+                             if call.parameters)
+        assert "location" in all_params
+        assert "SF" in all_params
+
+    def test_supports_structural_tag(self, parser):
+        """Test that supports_structural_tag returns False."""
+        assert parser.supports_structural_tag() is False
+
+
+# ============================================================================
+# MiniMaxM2ToolParser Tests
+# ============================================================================
+
+
+class TestMiniMaxM2ToolParser:
+    """Test suite for MiniMaxM2ToolParser class."""
+
+    @pytest.fixture
+    def parser(self):
+        return MiniMaxM2ToolParser()
+
+    def test_initialization(self, parser):
+        """Test that MiniMaxM2ToolParser initializes correctly."""
+        assert parser.bot_token == "<minimax:tool_call>"
+        assert parser.eot_token == "</minimax:tool_call>"
+
+    def test_has_tool_call_true(self, parser):
+        """Test has_tool_call returns True when tool call present."""
+        text = '<minimax:tool_call><invoke name="get_weather"><parameter name="location">NYC</parameter></invoke></minimax:tool_call>'
+        assert parser.has_tool_call(text) is True
+
+    def test_has_tool_call_false(self, parser):
+        """Test has_tool_call returns False when no tool call present."""
+        text = "Just some regular text without tool calls"
+        assert parser.has_tool_call(text) is False
+
+    def test_detect_and_parse_single_tool(self, sample_tools, parser):
+        """Test detect_and_parse with a single tool call."""
+        text = ('I will check the weather.'
+                '<minimax:tool_call>'
+                '<invoke name="get_weather">'
+                '<parameter name="location">NYC</parameter>'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert "I will check the weather." in result.normal_text
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        params = json.loads(result.calls[0].parameters)
+        assert params == {"location": "NYC"}
+
+    def test_detect_and_parse_multiple_tools(self, sample_tools, parser):
+        """Test detect_and_parse with multiple tool calls (parallel)."""
+        text = ('<minimax:tool_call>'
+                '<invoke name="get_weather">'
+                '<parameter name="location">NYC</parameter>'
+                '</invoke>'
+                '<invoke name="search_web">'
+                '<parameter name="query">AI news</parameter>'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 2
+        assert result.calls[0].name == "get_weather"
+        assert result.calls[1].name == "search_web"
+        assert json.loads(result.calls[0].parameters) == {"location": "NYC"}
+        assert json.loads(result.calls[1].parameters) == {"query": "AI news"}
+
+    def test_detect_and_parse_no_tool_call(self, sample_tools, parser):
+        """Test detect_and_parse with text containing no tool calls."""
+        text = "This is just a regular response."
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == text
+        assert len(result.calls) == 0
+
+    def test_detect_and_parse_with_thinking(self, sample_tools, parser):
+        """Test detect_and_parse with interleaved thinking content before tool call."""
+        text = ('Let me think about this...\n'
+                '<minimax:tool_call>'
+                '<invoke name="search_web">'
+                '<parameter name="query">weather forecast</parameter>'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert "Let me think about this..." in result.normal_text
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "search_web"
+
+    def test_detect_and_parse_multiple_params(self, sample_tools, parser):
+        """Test parsing with multiple parameters."""
+        text = ('<minimax:tool_call>'
+                '<invoke name="get_weather">'
+                '<parameter name="location">Tokyo</parameter>'
+                '<parameter name="unit">celsius</parameter>'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        params = json.loads(result.calls[0].parameters)
+        assert params == {"location": "Tokyo", "unit": "celsius"}
+
+    def test_detect_and_parse_no_params(self):
+        """Test parsing tool call with no parameters."""
+        parser = MiniMaxM2ToolParser()
+        tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(
+                    name="get_time",
+                    description="Get current time",
+                    parameters={
+                        "type": "object",
+                        "properties": {},
+                    },
+                ),
+            )
+        ]
+        text = ('<minimax:tool_call>'
+                '<invoke name="get_time">'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.detect_and_parse(text, tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_time"
+        assert json.loads(result.calls[0].parameters) == {}
+
+    def test_parse_streaming_increment_normal_text(self, sample_tools, parser):
+        """Test streaming parser handles normal text without tool calls."""
+        text = "Hello, how can I help?"
+
+        result = parser.parse_streaming_increment(text, sample_tools)
+
+        assert result.normal_text == text
+        assert len(result.calls) == 0
+
+    def test_parse_streaming_increment_partial_bot_token(
+            self, sample_tools, parser):
+        """Test streaming parser buffers partial bot token."""
+        result = parser.parse_streaming_increment("<minimax:tool_cal",
+                                                  sample_tools)
+
+        assert result.normal_text == ""
+        assert len(result.calls) == 0
+
+    def test_parse_streaming_increment_complete_tool(self, sample_tools):
+        """Test streaming parser with complete tool call."""
+        parser = MiniMaxM2ToolParser()
+
+        # Send the complete tool call
+        result = parser.parse_streaming_increment(
+            '<minimax:tool_call>'
+            '<invoke name="get_weather">'
+            '<parameter name="location">NYC</parameter>'
+            '</invoke>'
+            '</minimax:tool_call>', sample_tools)
+
+        # Should have parsed the tool call
+        names = [c.name for c in result.calls if c.name]
+        assert "get_weather" in names
+
+    def test_supports_structural_tag(self, parser):
+        """Test that supports_structural_tag returns False."""
+        assert parser.supports_structural_tag() is False
+
+
+# ============================================================================
+# Reasoning Parser Tests for Interleaved Thinking
+# ============================================================================
+
+
+class TestInterleavedThinkingReasoningParsers:
+    """Test reasoning parsers used for interleaved thinking models."""
+
+    def test_glm45_reasoning_parser_registered(self):
+        """Test that glm45 reasoning parser is registered."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        assert "glm45" in ReasoningParserFactory.keys()
+
+    def test_minimax_m2_reasoning_parser_registered(self):
+        """Test that minimax_m2 reasoning parser is registered."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        assert "minimax_m2" in ReasoningParserFactory.keys()
+
+    def test_minimax_m2_append_think_reasoning_parser_registered(self):
+        """Test that minimax_m2_append_think reasoning parser is registered."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        assert "minimax_m2_append_think" in ReasoningParserFactory.keys()
+
+    def test_glm45_parser_handles_think_tags(self):
+        """Test GLM-4.5 reasoning parser correctly extracts thinking content."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        parser = ReasoningParserFactory.create_reasoning_parser("glm45")
+
+        text = "I need to analyze this request.\nLet me think step by step.</think>The weather in NYC is sunny."
+        result = parser.parse(text)
+
+        assert result.reasoning_content == "I need to analyze this request.\nLet me think step by step."
+        assert result.content == "The weather in NYC is sunny."
+
+    def test_glm45_parser_streaming(self):
+        """Test GLM-4.5 reasoning parser streaming behavior."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        parser = ReasoningParserFactory.create_reasoning_parser("glm45")
+
+        # Streaming: first chunk is reasoning content
+        result1 = parser.parse_delta("I need to think")
+        assert result1.reasoning_content == "I need to think"
+        assert result1.content == ""
+
+        # Then thinking ends
+        result2 = parser.parse_delta("</think>Final answer")
+        assert result2.content == "Final answer"
+
+    def test_minimax_m2_parser_handles_think_tags(self):
+        """Test MiniMax-M2 reasoning parser correctly extracts thinking content."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+        parser = ReasoningParserFactory.create_reasoning_parser("minimax_m2")
+
+        text = "Let me reason about this...</think>Here is the answer."
+        result = parser.parse(text)
+
+        assert result.reasoning_content == "Let me reason about this..."
+        assert result.content == "Here is the answer."
+
+    def test_interleaved_thinking_with_tool_call(self):
+        """Test that reasoning parser + tool parser work together for interleaved thinking.
+
+        This simulates the key interleaved thinking pattern:
+        <think>reasoning</think><tool_call>...</tool_call>
+        """
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+
+        # The reasoning parser extracts thinking, leaving tool call in content
+        parser = ReasoningParserFactory.create_reasoning_parser("glm45")
+        text = ("I need to check the weather first.</think>"
+                "<tool_call>get_weather\n"
+                "<arg_key>location</arg_key>\n"
+                "<arg_value>NYC</arg_value>\n"
+                "</tool_call>")
+
+        result = parser.parse(text)
+
+        assert result.reasoning_content == "I need to check the weather first."
+        # The tool call should be in the content, ready for the tool parser
+        assert "<tool_call>" in result.content
+        assert "get_weather" in result.content
+
+        # Now the tool parser processes the content
+        tool_parser = Glm47ToolParser()
+        tool_result = tool_parser.detect_and_parse(result.content, [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                ),
+            )
+        ])
+        assert len(tool_result.calls) == 1
+        assert tool_result.calls[0].name == "get_weather"
+
+    def test_interleaved_thinking_minimax_with_tool_call(self):
+        """Test MiniMax-M2 reasoning + tool parsing pipeline."""
+        from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+
+        parser = ReasoningParserFactory.create_reasoning_parser(
+            "minimax_m2_append_think")
+        text = ("Let me search for the latest news.</think>"
+                '<minimax:tool_call>'
+                '<invoke name="search_web">'
+                '<parameter name="query">latest AI news</parameter>'
+                '</invoke>'
+                '</minimax:tool_call>')
+
+        result = parser.parse(text)
+
+        assert result.reasoning_content == "Let me search for the latest news."
+        assert "<minimax:tool_call>" in result.content
+
+        # Tool parser processes the content
+        tool_parser = MiniMaxM2ToolParser()
+        tool_result = tool_parser.detect_and_parse(result.content, [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(
+                    name="search_web",
+                    description="Search",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                ),
+            )
+        ])
+        assert len(tool_result.calls) == 1
+        assert tool_result.calls[0].name == "search_web"
+
+
+# ============================================================================
+# Tool Parser Factory Tests
+# ============================================================================
+
+
+class TestToolParserFactory:
+    """Test that the tool parser factory registers all expected parsers."""
+
+    def test_glm47_registered(self):
+        """Test that glm47 parser is registered in factory."""
+        from tensorrt_llm.serve.tool_parser.tool_parser_factory import \
+            ToolParserFactory
+        assert "glm47" in ToolParserFactory.parsers
+
+    def test_minimax_m2_registered(self):
+        """Test that minimax_m2 parser is registered in factory."""
+        from tensorrt_llm.serve.tool_parser.tool_parser_factory import \
+            ToolParserFactory
+        assert "minimax_m2" in ToolParserFactory.parsers
+
+    def test_create_glm47_parser(self):
+        """Test creating glm47 parser via factory."""
+        from tensorrt_llm.serve.tool_parser.tool_parser_factory import \
+            ToolParserFactory
+        parser = ToolParserFactory.create_tool_parser("glm47")
+        assert isinstance(parser, Glm47ToolParser)
+
+    def test_create_minimax_m2_parser(self):
+        """Test creating minimax_m2 parser via factory."""
+        from tensorrt_llm.serve.tool_parser.tool_parser_factory import \
+            ToolParserFactory
+        parser = ToolParserFactory.create_tool_parser("minimax_m2")
+        assert isinstance(parser, MiniMaxM2ToolParser)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GLM-4.7 models with tool calling capabilities and streaming parsing.
  * Added support for MiniMax-M2 models with tool calling capabilities and streaming parsing.
  * Introduced new model aliases: "glm45", "minimax_m2", and "minimax_m2_append_think" for reasoning support.
  * Tool calls now support optional arguments for both new model implementations.

* **Tests**
  * Added comprehensive test coverage for new model parsers and streaming functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds interleaved thinking support (reasoning between tool calls) for MiniMax-M2 and GLM-4.7 model families in `trtllm-serve`, similar to [vLLM's interleaved thinking feature](https://docs.vllm.ai/en/latest/features/interleaved_thinking/).

### Changes

**New Tool Parsers:**
- `MiniMaxM2ToolParser` — Parses the `<minimax:tool_call><invoke name="..."><parameter name="...">value</parameter></invoke></minimax:tool_call>` XML format with support for single/parallel tool calls and streaming.
- `Glm47ToolParser` — Extends `Glm4ToolParser` for GLM-4.7 models, adding support for tool calls with optional arguments.

**New Reasoning Parser Registrations:**
- `glm45` (reasoning_at_start=True) — For GLM-4.5/4.6/4.7 thinking models using `<think>...</think>` format.
- `minimax_m2` (reasoning_at_start=True) — For MiniMax-M2 thinking models.
- `minimax_m2_append_think` (reasoning_at_start=True) — For MiniMax-M2 variants that append think tokens.

**Factory Registration:**
- Registered `glm47` and `minimax_m2` in `ToolParserFactory`.

### Usage

To enable interleaved thinking for these models via `trtllm-serve`:
```bash
# MiniMax-M2 with interleaved thinking
trtllm-serve serve <model> --reasoning_parser minimax_m2 --tool_parser minimax_m2

# GLM-4.7 with interleaved thinking
trtllm-serve serve <model> --reasoning_parser glm45 --tool_parser glm47
```

The reasoning parser extracts `<think>...</think>` content as `reasoning_content`, then the tool parser processes the remaining content for tool calls. This enables models to reason between tool calls in a multi-step workflow.

## Test Coverage

- `TestGlm47ToolParser` — Tests for GLM-4.7 parser including no-argument tool calls, single/parallel calls, streaming.
- `TestMiniMaxM2ToolParser` — Tests for MiniMax-M2 parser including single/multiple tool calls, multiple parameters, streaming, and thinking content.
- `TestInterleavedThinkingReasoningParsers` — Integration tests verifying the reasoning→tool parsing pipeline works correctly for interleaved thinking scenarios.
- `TestToolParserFactory` — Factory registration tests for all parsers including new ones.

All tests located in `tests/unittest/llmapi/apps/test_tool_parsers.py`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows TRT-LLM CODING GUIDELINES.
- Test cases are provided for new code paths.

- [x] Please check this after reviewing the above items as appropriate for this PR.