### PR TITLE
[None][fix] return an explicit error if the requests can't be schedul…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1790,6 +1790,38 @@ class PyExecutor:
                 )
                 self._check_disagg_ctx_cache_transfer_status(1)
 
+            # In gen-only benchmark mode, all requests must fit in KV cache
+            # simultaneously. If some requests are stuck in INIT state and the
+            # scheduler could not allocate KV for any of them, the benchmark
+            # will hang forever because in-progress generation requests won't
+            # release their KV cache.
+            if (self.benchmark_req_queues_size > 0 and self.kv_cache_transceiver
+                    and not self.is_warmup
+                    and not fitting_disagg_gen_init_requests):
+                stuck_init_requests = [
+                    req for req in self.active_requests
+                    if req.is_disagg_generation_init_state
+                ]
+                # Only fail once all benchmark requests have been fetched
+                # so that _handle_errors covers every request and every
+                # client receives an error response.
+                if (stuck_init_requests and self.num_fetch_requests
+                        >= self.benchmark_req_queues_size):
+                    error_msg = (
+                        f"Insufficient KV cache for gen-only benchmark mode: "
+                        f"{len(stuck_init_requests)} request(s) are waiting for "
+                        f"KV cache allocation but the scheduler could not fit "
+                        f"any of them. Increase free_gpu_memory_fraction or "
+                        f"reduce TLLM_BENCHMARK_REQ_QUEUES_SIZE (currently "
+                        f"{self.benchmark_req_queues_size}).")
+                    logger.error(error_msg)
+                    # Fail all active and waiting requests so every
+                    # client receives an error instead of hanging.
+                    all_requests = list(self.active_requests) + list(
+                        self.waiting_queue)
+                    self._handle_errors(error_msg, requests=all_requests)
+                    self.waiting_queue.clear()
+
         self.num_scheduled_requests = scheduled_batch.batch_size
         logger.debug(
             f'has {len(self.active_requests)} active_requests, '

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1795,8 +1795,7 @@ class PyExecutor:
             # scheduler could not allocate KV for any of them, the benchmark
             # will hang forever because in-progress generation requests won't
             # release their KV cache.
-            if (self.benchmark_req_queues_size > 0 and self.kv_cache_transceiver
-                    and not self.is_warmup
+            if (self.benchmark_req_queues_size > 0 and not self.is_warmup
                     and not fitting_disagg_gen_init_requests):
                 stuck_init_requests = [
                     req for req in self.active_requests
@@ -1817,10 +1816,9 @@ class PyExecutor:
                     logger.error(error_msg)
                     # Fail all active and waiting requests so every
                     # client receives an error instead of hanging.
-                    all_requests = list(self.active_requests) + list(
-                        self.waiting_queue)
-                    self._handle_errors(error_msg, requests=all_requests)
-                    self.waiting_queue.clear()
+                    self._handle_errors(error_msg,
+                                        requests=self.active_requests)
+                    return None, None
 
         self.num_scheduled_requests = scheduled_batch.batch_size
         logger.debug(

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -13,7 +13,7 @@ from ..llmapi.tokenizer import TransformersTokenizer, load_hf_tokenizer
 from ..llmapi.utils import print_traceback_on_error
 from ..sampling_params import SamplingParams
 from .ipc import ZeroMqQueue
-from .utils import is_llm_response
+from .utils import ErrorResponse, is_llm_response
 
 if TYPE_CHECKING:
     from .result import (DetokenizedGenerationResultBase, GenerationResult,
@@ -182,6 +182,12 @@ class PostprocWorker:
                 inp, PostprocWorker.Input
             ), f"Expect PostprocWorker.Input, got {type(inp)}."
             client_id = inp.rsp.client_id
+            # ErrorResponse has no 'result' attribute; pass it through
+            # directly so the proxy handles it via its ErrorResponse path.
+            if isinstance(inp.rsp, ErrorResponse):
+                batch.append(inp.rsp)
+                self._records.pop(client_id, None)
+                return
             is_final = inp.rsp.result.is_final if is_llm_response(
                 inp.rsp) else True
             res, metrics, perf_metrics, disaggregated_params = await self._handle_input(

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -538,6 +538,7 @@ class GenerationResultBase:
                     handler := self._background_error_handler()):
                 handler()
         elif isinstance(response, ErrorResponse):
+            self._done = True
             if self._background_error_handler is not None and (
                     handler := self._background_error_handler()):
                 handler(response.error_msg)

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1122,9 +1122,7 @@ class OpenAIServer:
                         "type": "server_error",
                         "code": None,
                         "param": None,
-                        "object": "error"
-                    },
-                    "object": "error",
+                    }
                 })
                 yield f"data: {error_data}\n\n"
                 yield "data: [DONE]\n\n"

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1116,12 +1116,18 @@ class OpenAIServer:
                 # chunk, so we cannot change the status code.  Yield
                 # an SSE error event so the stream terminates cleanly
                 # instead of breaking the HTTP connection.
-                error_data = json.dumps(
-                    {"error": {
+                error_data = json.dumps({
+                    "error": {
                         "message": str(e),
-                        "type": "server_error"
-                    }})
+                        "type": "server_error",
+                        "code": None,
+                        "param": None,
+                        "object": "error"
+                    },
+                    "object": "error",
+                })
                 yield f"data: {error_data}\n\n"
+                yield "data: [DONE]\n\n"
 
         async def merge_generators(generators: List[AsyncIterator[Any]]):
             result_queue = asyncio.Queue()

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import asyncio
 import base64
+import json
 import os
 import re
 import signal
@@ -1109,9 +1110,18 @@ class OpenAIServer:
                     for pp_res in pp_result:
                         yield pp_res
                 await self._extract_metrics(output, raw_request)
-            except:
+            except Exception as e:
                 logger.error(traceback.format_exc())
-                raise
+                # StreamingResponse commits HTTP 200 before the first
+                # chunk, so we cannot change the status code.  Yield
+                # an SSE error event so the stream terminates cleanly
+                # instead of breaking the HTTP connection.
+                error_data = json.dumps(
+                    {"error": {
+                        "message": str(e),
+                        "type": "server_error"
+                    }})
+                yield f"data: {error_data}\n\n"
 
         async def merge_generators(generators: List[AsyncIterator[Any]]):
             result_queue = asyncio.Queue()

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only_insufficient_kv.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only_insufficient_kv.yaml
@@ -3,13 +3,21 @@ model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 backend: pytorch
 cuda_graph_config: null
 context_servers:
-  num_instances: 0
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.2
+    enable_block_reuse: false
+    enable_partial_reuse: false
+  cache_transceiver_config:
+    backend: DEFAULT
 generation_servers:
   num_instances: 1
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   kv_cache_config:
-    max_tokens: 128
+    max_tokens: 64
     enable_block_reuse: false
     enable_partial_reuse: false
   cache_transceiver_config:

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only_insufficient_kv.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only_insufficient_kv.yaml
@@ -1,0 +1,19 @@
+hostname: localhost
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+backend: pytorch
+cuda_graph_config: null
+context_servers:
+  num_instances: 0
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  kv_cache_config:
+    max_tokens: 128
+    enable_block_reuse: false
+    enable_partial_reuse: false
+  cache_transceiver_config:
+    backend: DEFAULT
+  print_iter_log: true
+  env_overrides:
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: "64"

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -739,12 +739,17 @@ def test_disaggregated_benchmark_gen_only_insufficient_kv(
 
         def send_request():
             try:
-                return client.completions.create(
+                stream = client.completions.create(
                     model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
                     prompt="What is the capital of Germany?",
                     max_tokens=10,
                     temperature=0.0,
                     stream=True)
+                # Must iterate the stream to receive SSE error chunks
+                chunks = []
+                for chunk in stream:
+                    chunks.append(chunk.choices[0].text)
+                return "".join(chunks)
             except Exception as e:
                 return e
 

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -153,6 +153,8 @@ def get_test_config(test_desc, example_dir, test_root):
         f"{test_configs_root}/disagg_config_gen_only_trt_backend.yaml",
         "gen_only_bs1":
         f"{test_configs_root}/disagg_config_gen_only_bs1.yaml",
+        "gen_only_insufficient_kv":
+        f"{test_configs_root}/disagg_config_gen_only_insufficient_kv.yaml",
         "4_ranks":
         f"{test_configs_root}/disagg_config_ctxtp2_gentp1.yaml",
         "4_ranks_trt_backend":
@@ -701,6 +703,61 @@ def test_disaggregated_benchmark_gen_only_trt_backend(
                            "gen_only_trt_backend",
                            env=env,
                            cwd=llm_venv.get_working_directory())
+
+
+@pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
+                         indirect=True)
+def test_disaggregated_benchmark_gen_only_insufficient_kv(
+        disaggregated_test_root, disaggregated_example_root, llm_venv,
+        llama_model_root):
+    """Test that gen-only benchmark mode raises an error when KV cache is too
+    small to hold all benchmark requests, instead of hanging forever."""
+    import openai
+
+    setup_model_symlink(llm_venv, llama_model_root,
+                        "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+
+    env = llm_venv._new_env.copy()
+    env['TRTLLM_DISAGG_BENCHMARK_GEN_ONLY'] = '1'
+    env['TLLM_BENCHMARK_REQ_QUEUES_SIZE'] = '64'
+
+    config_file = get_test_config("gen_only_insufficient_kv",
+                                  disaggregated_example_root,
+                                  os.path.dirname(__file__))
+    config, ctx_workers, gen_workers, disagg_server, server_port, work_dir = \
+        setup_disagg_cluster(config_file,
+                             env=env,
+                             cwd=llm_venv.get_working_directory())
+
+    try:
+        client = openai.OpenAI(api_key="tensorrt_llm",
+                               base_url=f"http://localhost:{server_port}/v1")
+
+        # Send 64 concurrent requests to trigger the benchmark fill loop
+        # and the insufficient KV cache error.
+        import concurrent.futures
+
+        def send_request():
+            try:
+                return client.completions.create(
+                    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+                    prompt="What is the capital of Germany?",
+                    max_tokens=10,
+                    temperature=0.0,
+                    stream=True)
+            except Exception as e:
+                return e
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=64) as pool:
+            futures = [pool.submit(send_request) for _ in range(64)]
+            results = [f.result(timeout=120) for f in futures]
+
+        errors = [r for r in results if isinstance(r, Exception)]
+        assert len(errors) > 0, \
+            "Expected at least one error due to insufficient KV cache"
+    finally:
+        terminate(*ctx_workers, *gen_workers, disagg_server)
+        shutil.rmtree(work_dir, ignore_errors=True)
 
 
 @pytest.mark.skip_less_device(4)

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -54,6 +54,7 @@ l0_a10:
   - disaggregated/test_disaggregated.py::test_disaggregated_perf_metrics[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_cache_aware_balance[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_conditional[TinyLlama-1.1B-Chat-v1.0]
+  - disaggregated/test_disaggregated.py::test_disaggregated_benchmark_gen_only_insufficient_kv[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_ngram[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_chat_completion_tool_calls[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_workers.py::test_workers_conditional_disaggregation[TinyLlama-1.1B-Chat-v1.0]


### PR DESCRIPTION
## Description

In gen-only disaggregated benchmark mode, when the KV cache is too small to hold all benchmark requests, the executor gets stuck: requests waiting for KV cache allocation can never be scheduled because in-progress generation requests hold the cache indefinitely. Previously this caused the benchmark to hang silently with no error.

This PR detects the condition and returns an explicit error to every client, allowing the benchmark to terminate cleanly instead of hanging.

### Root cause

In gen-only mode the benchmark fill loop pre-queues all requests before the first forward pass.  When the KV cache is insufficient, some requests remain in `DISAGG_GENERATION_INIT` state permanently because the scheduler cannot allocate KV blocks for them while existing generation requests hold theirs.

### Fix (4 files)

1. **`py_executor.py`** – After all benchmark requests have been fetched (`num_fetch_requests >= benchmark_req_queues_size`), detect stuck init requests and call `_handle_errors` on all active + waiting requests so every client receives an error response.

2. **`postproc_worker.py`** – `ErrorResponse` objects lack a `result` attribute which crashed the postproc worker.  Forward them directly to the proxy instead.

3. **`result.py`** – Set `_done = True` when `GenerationResult` receives an `ErrorResponse` so the async result completes instead of looping forever.

4. **`openai_server.py`** – `StreamingResponse` commits HTTP 200 before the generator yields, so raising an exception breaks the connection (`ClientPayloadError`).  Yield an SSE error event instead so the stream terminates cleanly.

## Test Coverage

- `tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_benchmark_gen_only_insufficient_kv`
  – Launches a gen-only disagg cluster with a tiny KV cache (`max_tokens=128`)
  and 64 concurrent requests, then asserts the gen worker process terminates
  instead of hanging.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for this PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming responses; errors now gracefully terminate streams instead of propagating exceptions
  * Added safeguard to prevent indefinite waiting when KV cache is insufficient in generation-only benchmark mode

* **Tests**
  * Added test coverage for generation-only mode with insufficient KV cache scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->