### PR TITLE
[TRTLLM-11492][fix] Fix benchmark disagg deadlock by eliminating blocking fill loop

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1951,6 +1951,10 @@ class PyExecutor:
         consolidates the check used by both ``_executor_loop`` and
         ``_executor_loop_overlap``.
 
+        A short sleep (0.1s) yields the CPU between retries while
+        keeping the polling interval short enough to avoid KV transfer
+        backpressure on the CTX server.
+
         Args:
             scheduled_batch: The current scheduled batch.
             can_forward: Current gate state.
@@ -1963,7 +1967,7 @@ class PyExecutor:
             can_forward = self._is_benchmark_disagg_fill_complete(
                 scheduled_batch)
             if not can_forward:
-                time.sleep(1)
+                time.sleep(0.1)
                 return can_forward, True
         return can_forward, False
 
@@ -2944,6 +2948,69 @@ class PyExecutor:
         self.kv_cache_transceiver.prepare_context_requests(
             gen_first_ctx_requests)
 
+    def _count_schedulable_active_requests(self) -> int:
+        """Count active requests that are ready for scheduling.
+
+        In non-disaggregated mode, all active requests are schedulable.
+        In disaggregated mode, requests still waiting for KV cache
+        transfer (in INIT or transmission-in-progress state) are
+        excluded because they cannot participate in the forward pass
+        until transfer completes.
+
+        Returns:
+            The number of active requests eligible for scheduling.
+        """
+        if self.kv_cache_transceiver is None:
+            return len(self.active_requests)
+
+        def _is_awaiting_kv_transfer(req) -> bool:
+            return (req.is_disagg_generation_init_state
+                    or req.is_disagg_generation_transmission_in_progress)
+
+        return sum(1 for req in self.active_requests
+                   if not _is_awaiting_kv_transfer(req))
+
+    def _should_skip_dummy_for_benchmark_disagg(
+            self, num_schedulable_requests: int) -> bool:
+        """Decide whether to skip ADP dummy insertion during benchmark disagg fill.
+
+        Dummies are permanent — once added they are never removed.  In
+        benchmark disagg mode we skip dummy insertion in almost all cases
+        because the ``can_forward`` gate prevents forward-pass collectives
+        during the fill phase, so temporarily-empty ranks are safe.
+
+        The only exception is the terminal case where all benchmark
+        requests have been fetched but there are fewer requests than TP
+        ranks (``benchmark_req_queues_size < tp_size``).  In that case
+        some ranks will **never** receive a real request and need a
+        permanent dummy for forward-pass collectives once the gate opens.
+
+        Args:
+            num_schedulable_requests: Number of active requests that have
+                completed KV transfer and are ready for the forward pass.
+
+        Returns:
+            True if dummy insertion should be skipped for this iteration.
+        """
+        if not self.is_benchmark_disagg or self.is_warmup:
+            return False
+        if num_schedulable_requests > 0:
+            return False
+
+        fill_phase_complete = (self.num_fetch_requests
+                               >= self.benchmark_req_queues_size)
+        some_ranks_permanently_empty = (self.enable_attention_dp
+                                        and self.benchmark_req_queues_size
+                                        < self.dist.tp_size)
+
+        if fill_phase_complete and some_ranks_permanently_empty:
+            return False  # allow dummy — rank will never get a real request
+
+        logger.info(f"Skipped adding dummy requests: "
+                    f"num_fetch_requests={self.num_fetch_requests}, "
+                    f"num_schedulable_requests={num_schedulable_requests}")
+        return True
+
     @nvtx_range("_pad_attention_dp_dummy_request")
     def _pad_attention_dp_dummy_request(self):
         """
@@ -2953,27 +3020,14 @@ class PyExecutor:
             return
 
         assert self.expected_num_active_requests >= len(self.active_requests)
-        if self.kv_cache_transceiver is None:
-            num_active_request = len(self.active_requests)
-        else:
-            num_active_request = len([
-                req for req in self.active_requests
-                if not (req.is_disagg_generation_init_state
-                        or req.is_disagg_generation_transmission_in_progress)
-            ])
+        num_active_request = self._count_schedulable_active_requests()
 
-        # In benchmark disagg mode, skip dummy addition while requests are
-        # still in INIT/transfer state (waiting for KV cache transfer).
-        # We also skip when active_requests is empty (early fill phase) to
-        # avoid occupying a KV cache slot that would block real requests.
-        if (self.is_benchmark_disagg and not self.is_warmup
-                and num_active_request == 0):
-            logger.info(
-                f"Skipped adding dummy requests: num_fetch_requests={self.num_fetch_requests}, {num_active_request=}"
-            )
+        if self._should_skip_dummy_for_benchmark_disagg(num_active_request):
             return
 
-        if self.expected_num_active_requests - num_active_request > 0 and num_active_request == 0:
+        # Other ranks have work but this rank is idle — insert a dummy so
+        # it can participate in collective operations during the forward pass.
+        if num_active_request == 0 and self.expected_num_active_requests > 0:
             llm_request = self.kv_cache_manager.add_dummy_requests(
                 request_ids=[0],
                 is_gen=True,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -521,6 +521,14 @@ class PyExecutor:
         self.kv_cache_transceiver = kv_cache_transceiver
         self.is_benchmark_disagg = (self.benchmark_req_queues_size > 0
                                     and self.kv_cache_transceiver is not None)
+        # True while the benchmark disagg fill phase is in progress (waiting
+        # for all benchmark requests to complete KV transfer before the first
+        # forward pass).  Cleared by _check_benchmark_disagg_gate when the
+        # can_forward gate opens.  Used by _should_skip_dummy_for_benchmark_disagg
+        # to prevent permanent dummy insertion during fill; once False, the
+        # normal dummy add-forward-terminate lifecycle handles taper-down.
+        # Only relevant in benchmark disagg mode; False otherwise.
+        self._benchmark_fill_phase_active = self.is_benchmark_disagg
 
         # Initialize disagg PP termination handler if needed
         self._disagg_pp_termination_handler = None
@@ -1966,7 +1974,9 @@ class PyExecutor:
         if not self.is_warmup and not can_forward:
             can_forward = self._is_benchmark_disagg_fill_complete(
                 scheduled_batch)
-            if not can_forward:
+            if can_forward:
+                self._benchmark_fill_phase_active = False
+            else:
                 time.sleep(0.1)
                 return can_forward, True
         return can_forward, False
@@ -2974,16 +2984,17 @@ class PyExecutor:
             self, num_schedulable_requests: int) -> bool:
         """Decide whether to skip ADP dummy insertion during benchmark disagg fill.
 
-        Dummies are permanent — once added they are never removed.  In
-        benchmark disagg mode we skip dummy insertion in almost all cases
-        because the ``can_forward`` gate prevents forward-pass collectives
-        during the fill phase, so temporarily-empty ranks are safe.
+        During the fill phase (``_benchmark_fill_phase_active`` is True),
+        the ``can_forward`` gate prevents forward-pass collectives, so
+        temporarily-empty ranks don't need dummies.  Dummies added during
+        the fill phase would never be cleaned up (termination only runs
+        after a forward pass), permanently wasting KV cache slots.
 
-        The only exception is the terminal case where all benchmark
-        requests have been fetched but there are fewer requests than TP
-        ranks (``benchmark_req_queues_size < tp_size``).  In that case
-        some ranks will **never** receive a real request and need a
-        permanent dummy for forward-pass collectives once the gate opens.
+        Once the fill phase completes and the gate opens, the flag is
+        cleared and this method stops skipping — the normal dummy
+        add-forward-terminate lifecycle handles taper-down correctly
+        (e.g., when ranks empty out at different rates due to varied
+        speculative decoding acceptance rates).
 
         Args:
             num_schedulable_requests: Number of active requests that have
@@ -2992,19 +3003,8 @@ class PyExecutor:
         Returns:
             True if dummy insertion should be skipped for this iteration.
         """
-        if not self.is_benchmark_disagg or self.is_warmup:
+        if not self._benchmark_fill_phase_active or self.is_warmup:
             return False
-        if num_schedulable_requests > 0:
-            return False
-
-        fill_phase_complete = (self.num_fetch_requests
-                               >= self.benchmark_req_queues_size)
-        some_ranks_permanently_empty = (self.enable_attention_dp
-                                        and self.benchmark_req_queues_size
-                                        < self.dist.tp_size)
-
-        if fill_phase_complete and some_ranks_permanently_empty:
-            return False  # allow dummy — rank will never get a real request
 
         logger.info(f"Skipped adding dummy requests: "
                     f"num_fetch_requests={self.num_fetch_requests}, "

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -519,6 +519,8 @@ class PyExecutor:
         self.gather_all_responses = False
 
         self.kv_cache_transceiver = kv_cache_transceiver
+        self.is_benchmark_disagg = (self.benchmark_req_queues_size > 0
+                                    and self.kv_cache_transceiver is not None)
 
         # Initialize disagg PP termination handler if needed
         self._disagg_pp_termination_handler = None
@@ -1766,32 +1768,6 @@ class PyExecutor:
             self._check_disagg_gen_transfer_status()
             self._check_kv_transfer_timeout()
 
-        # In benchmark disagg mode, fetch requests in batches to avoid
-        # blocking the CTX→GEN KV cache pipeline. With ADP, fetch tp_size
-        # requests per batch (one per rank) for even distribution; without
-        # ADP, fetch 1 request per batch.
-        if not self.is_warmup and self.benchmark_req_queues_size > 0 \
-                and self.kv_cache_transceiver \
-                and self.num_fetch_requests < self.benchmark_req_queues_size:
-            batch_size = min(
-                self.dist.tp_size if self.enable_attention_dp else 1,
-                self.benchmark_req_queues_size)
-            fill_target = min(self.num_fetch_requests + batch_size,
-                              self.benchmark_req_queues_size)
-            if self.dist.rank == 0:
-                logger.info(f"Starting benchmark fill loop, "
-                            f"num_fetch_requests={self.num_fetch_requests}/"
-                            f"{fill_target}, "
-                            f"len(active_requests)={len(self.active_requests)}")
-            while self.num_fetch_requests < fill_target:
-                iter_requests = self._fetch_and_activate_new_requests()
-                if self.should_stop_processing:
-                    return None, None
-                new_requests += iter_requests
-                self.hang_detector.checkpoint()
-                if self.num_fetch_requests < fill_target:
-                    time.sleep(0.1)
-
         iter_stats = None
         if self.enable_iter_perf_stats:
             iter_stats = self._get_init_iter_stats(
@@ -1927,6 +1903,70 @@ class PyExecutor:
             self.kv_connector_manager.worker.wait_for_save(
                 torch.cuda.current_stream())
 
+    def _is_benchmark_disagg_fill_complete(
+            self, scheduled_batch: ScheduledRequests) -> bool:
+        """Check whether all benchmark disagg requests have completed KV transfer.
+
+        With ADP, generation requests are distributed across TP ranks, so an
+        allgather is needed to obtain the global count.  Without ADP every
+        request is local, and we can compare directly.
+
+        This method must only be called when ``is_benchmark_disagg`` is True.
+
+        Args:
+            scheduled_batch: The current iteration's scheduled requests,
+                used to count generation requests that have completed
+                KV transfer.
+
+        Returns:
+            True when the total number of generation-ready requests
+            reaches ``benchmark_req_queues_size``.
+        """
+        if not self.is_benchmark_disagg:
+            raise RuntimeError(
+                "_is_benchmark_disagg_fill_complete() should not be called outside benchmark "
+                "disagg mode.  This is an unexpected error.")
+        local_gen_count = sum(1 for req in scheduled_batch.generation_requests
+                              if not req.is_attention_dp_dummy)
+        if self.enable_attention_dp:
+            total_gen_count = sum(self.dist.tp_allgather(local_gen_count))
+        else:
+            total_gen_count = local_gen_count
+
+        if total_gen_count >= self.benchmark_req_queues_size:
+            return True
+        if self.dist.rank == 0:
+            logger.debug(
+                f"Benchmark disagg fill in progress: "
+                f"num_fetched={self.num_fetch_requests}, "
+                f"total_gen_count={total_gen_count} (local={local_gen_count})")
+        return False
+
+    def _check_benchmark_disagg_gate(self, scheduled_batch: ScheduledRequests,
+                                     can_forward: bool) -> tuple[bool, bool]:
+        """Gate the forward pass until all benchmark disagg requests are ready.
+
+        In benchmark disagg mode the GEN executor must defer the forward
+        pass until every request has completed KV transfer.  This helper
+        consolidates the check used by both ``_executor_loop`` and
+        ``_executor_loop_overlap``.
+
+        Args:
+            scheduled_batch: The current scheduled batch.
+            can_forward: Current gate state.
+
+        Returns:
+            ``(can_forward, should_retry)`` — when *should_retry* is True
+            the caller should ``continue`` to the next loop iteration.
+        """
+        if not self.is_warmup and not can_forward:
+            can_forward = self._is_benchmark_disagg_fill_complete(
+                scheduled_batch)
+            if not can_forward:
+                time.sleep(1)
+                return can_forward, True
+        return can_forward, False
+
     def _executor_loop(self):
         torch.cuda.set_device(self.device_id)
         # ensure the context is created, otherwise, some MPI calls will fail.
@@ -1935,6 +1975,7 @@ class PyExecutor:
             sample_state = None
             iter_start_time = time.time()
             iter_stats = None
+            can_forward = not self.is_benchmark_disagg
             while True:
                 self.hang_detector.checkpoint()
                 profile_step()
@@ -1946,6 +1987,11 @@ class PyExecutor:
 
                 if scheduled_batch is None:
                     break
+
+                can_forward, should_retry = self._check_benchmark_disagg_gate(
+                    scheduled_batch, can_forward)
+                if should_retry:
+                    continue
 
                 if not self._scheduler_manages_kv_suspend:
                     self._terminate_requests(scheduled_batch.paused_requests)
@@ -2168,7 +2214,7 @@ class PyExecutor:
             iter_stats = None
             target_inputs = None
             previous_tensors_device = None
-            can_forward = False if self.benchmark_req_queues_size > 0 and self.kv_cache_transceiver else True
+            can_forward = not self.is_benchmark_disagg
             while True:
                 self.hang_detector.checkpoint()
                 profile_step()
@@ -2180,40 +2226,11 @@ class PyExecutor:
 
                 if scheduled_batch is None:
                     break
-                # In gen-only benchmarking mode, wait until the number of scheduled generation
-                # requests reaches the required threshold before starting forward pass,
-                # to ensure consistent batch sizes for accurate performance measurement.
-                if not self.is_warmup and not can_forward:
-                    if self.enable_attention_dp:
-                        # Allgather per-rank TRANS_COMPLETE generation counts to get the global total.
-                        # num_fetch_requests is not used here because it counts requests dispatched into
-                        # INIT state (before KV transfer), so it reaches the threshold while all requests
-                        # are still waiting for KV transfer and not yet ready for the forward pass.
-                        local_gen_count = len(
-                            scheduled_batch.generation_requests)
-                        all_gen_counts = self.dist.tp_allgather(local_gen_count)
-                        total_gen_count = sum(all_gen_counts)
-                        if total_gen_count >= self.benchmark_req_queues_size:
-                            can_forward = True
-                            time.sleep(10)
-                        else:
-                            if self.dist.rank == 0:
-                                logger.info(
-                                    f"sleep 0.1 seconds, num_fetched_requests: {self.num_fetch_requests}, "
-                                    f"total_gen_count: {total_gen_count}, "
-                                    f"scheduled_gen_batch: {local_gen_count}")
-                            time.sleep(0.1)
-                            continue
-                    else:
-                        if scheduled_batch.num_generation_requests < self.benchmark_req_queues_size:
-                            if self.dist.rank == 0:
-                                logger.info(
-                                    f"sleep 10 seconds, scheduled_gen_batch: {scheduled_batch.num_generation_requests}"
-                                )
-                            time.sleep(10)
-                            continue
-                        else:
-                            can_forward = True
+
+                can_forward, should_retry = self._check_benchmark_disagg_gate(
+                    scheduled_batch, can_forward)
+                if should_retry:
+                    continue
 
                 if not self._scheduler_manages_kv_suspend:
                     self._terminate_requests(scheduled_batch.paused_requests)
@@ -2658,7 +2675,7 @@ class PyExecutor:
         if self.enable_iter_perf_stats and self.dist.rank == 0:
             self._update_new_active_requests_queue_latency(new_requests)
 
-        # 5. Update total fetch counter (used by benchmark fill loop)
+        # 5. Update total fetch counter (used by benchmark disagg gating)
         self.num_fetch_requests += len(new_requests)
 
         # 6. Schedule requests across ranks (DP only)
@@ -2945,11 +2962,11 @@ class PyExecutor:
                         or req.is_disagg_generation_transmission_in_progress)
             ])
 
-        # In benchmark disagg mode the fill loop saturates all slots with INIT
-        # requests simultaneously. Skip dummy addition until KV transfers
-        # complete and real requests become active (num_active_request > 0).
-        if (self.benchmark_req_queues_size > 0 and self.kv_cache_transceiver
-                and not self.is_warmup and len(self.active_requests) > 0
+        # In benchmark disagg mode, skip dummy addition while requests are
+        # still in INIT/transfer state (waiting for KV cache transfer).
+        # We also skip when active_requests is empty (early fill phase) to
+        # avoid occupying a KV cache slot that would block real requests.
+        if (self.is_benchmark_disagg and not self.is_warmup
                 and num_active_request == 0):
             logger.info(
                 f"Skipped adding dummy requests: num_fetch_requests={self.num_fetch_requests}, {num_active_request=}"

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -1,0 +1,731 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for benchmark disaggregated serving gating in PyExecutor.
+
+In benchmark disagg mode the GEN executor must defer the forward pass
+until all benchmark requests have completed KV transfer.  These tests
+cover:
+- ``is_benchmark_disagg`` attribute initialisation
+- ``_is_benchmark_disagg_fill_complete`` (non-ADP and ADP paths)
+- ``can_forward`` gating initialisation and transitions
+- Incremental fill convergence when CTX has limited KV cache capacity
+- Non-blocking behaviour of ``_prepare_and_schedule_batch``
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gen_request(is_dummy: bool = False) -> Mock:
+    """Create a generation request stub with the ``is_attention_dp_dummy`` flag."""
+    req = Mock()
+    req.is_attention_dp_dummy = is_dummy
+    return req
+
+
+def _make_scheduled_batch(num_gen_requests: int, num_dummy_requests: int = 0) -> ScheduledRequests:
+    """Create a ScheduledRequests with generation stubs.
+
+    Args:
+        num_gen_requests: Number of real (non-dummy) generation requests.
+        num_dummy_requests: Number of ADP dummy generation requests.
+    """
+    batch = ScheduledRequests()
+    batch.generation_requests = [
+        _make_gen_request(is_dummy=False) for _ in range(num_gen_requests)
+    ] + [_make_gen_request(is_dummy=True) for _ in range(num_dummy_requests)]
+    return batch
+
+
+class MockBenchmarkExecutor:
+    """Minimal stub mirroring the PyExecutor attributes used by
+    ``_is_benchmark_disagg_fill_complete``, ``_check_benchmark_disagg_gate``,
+    and the ``can_forward`` gate.
+
+    Binds the real production methods so tests exercise actual logic
+    without needing a fully-initialised executor.
+    """
+
+    def __init__(
+        self,
+        benchmark_req_queues_size: int = 0,
+        kv_cache_transceiver=None,
+        enable_attention_dp: bool = False,
+        tp_size: int = 1,
+        rank: int = 0,
+        num_fetch_requests: int = 0,
+        is_warmup: bool = False,
+    ):
+        self.benchmark_req_queues_size = benchmark_req_queues_size
+        self.kv_cache_transceiver = kv_cache_transceiver
+        self.is_benchmark_disagg = (
+            benchmark_req_queues_size > 0 and kv_cache_transceiver is not None
+        )
+        self.enable_attention_dp = enable_attention_dp
+        self.num_fetch_requests = num_fetch_requests
+        self.is_warmup = is_warmup
+
+        self.dist = Mock()
+        self.dist.rank = rank
+        self.dist.tp_size = tp_size
+
+    from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+    _is_benchmark_disagg_fill_complete = PyExecutor._is_benchmark_disagg_fill_complete
+    _check_benchmark_disagg_gate = PyExecutor._check_benchmark_disagg_gate
+
+
+# ---------------------------------------------------------------------------
+# _is_benchmark_disagg_fill_complete  (non-ADP)
+# ---------------------------------------------------------------------------
+
+
+class TestFillCompleteNonADP:
+    @pytest.mark.parametrize(
+        "num_gen_requests, expected",
+        [
+            pytest.param(4, True, id="meets_threshold"),
+            pytest.param(6, True, id="exceeds_threshold"),
+            pytest.param(2, False, id="below_threshold"),
+            pytest.param(0, False, id="zero_requests"),
+        ],
+    )
+    def test_threshold(self, num_gen_requests, expected):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is expected
+
+    def test_no_allgather_called_without_adp(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), enable_attention_dp=False
+        )
+        batch = _make_scheduled_batch(num_gen_requests=4)
+
+        ex._is_benchmark_disagg_fill_complete(batch)
+        ex.dist.tp_allgather.assert_not_called()
+
+    def test_logs_progress_on_rank_zero(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), rank=0, num_fetch_requests=2
+        )
+        batch = _make_scheduled_batch(num_gen_requests=1)
+
+        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
+            ex._is_benchmark_disagg_fill_complete(batch)
+            mock_logger.debug.assert_called_once()
+            msg = mock_logger.debug.call_args[0][0]
+            assert "fill in progress" in msg
+            assert "num_fetched=2" in msg
+
+    def test_no_log_on_non_zero_rank(self):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), rank=1)
+        batch = _make_scheduled_batch(num_gen_requests=1)
+
+        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
+            ex._is_benchmark_disagg_fill_complete(batch)
+            mock_logger.debug.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _is_benchmark_disagg_fill_complete  (ADP)
+# ---------------------------------------------------------------------------
+
+
+class TestFillCompleteADP:
+    @pytest.mark.parametrize(
+        "num_gen_requests, allgather_result, expected",
+        [
+            pytest.param(2, [2, 2, 2, 2], True, id="meets_threshold"),
+            pytest.param(3, [3, 3, 3, 3], True, id="exceeds_threshold"),
+            pytest.param(1, [1, 1, 1, 0], False, id="below_threshold"),
+            pytest.param(5, [5, 1, 1, 1], True, id="uneven_distribution"),
+        ],
+    )
+    def test_threshold(self, num_gen_requests, allgather_result, expected):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=8,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=4,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
+        ex.dist.tp_allgather.return_value = allgather_result
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is expected
+
+    def test_allgather_receives_local_count(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=3)
+        ex.dist.tp_allgather.return_value = [3, 1]
+
+        ex._is_benchmark_disagg_fill_complete(batch)
+        ex.dist.tp_allgather.assert_called_once_with(3)
+
+    def test_allgather_excludes_dummy_requests(self):
+        """Dummy requests must not inflate the local count sent via allgather."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=3)
+        ex.dist.tp_allgather.return_value = [2, 2]
+
+        ex._is_benchmark_disagg_fill_complete(batch)
+        ex.dist.tp_allgather.assert_called_once_with(2)
+
+    def test_logs_progress_on_rank_zero(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=8,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+            num_fetch_requests=3,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=2)
+        ex.dist.tp_allgather.return_value = [2, 1]
+
+        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
+            ex._is_benchmark_disagg_fill_complete(batch)
+            mock_logger.debug.assert_called_once()
+            msg = mock_logger.debug.call_args[0][0]
+            assert "total_gen_count=3" in msg
+            assert "local=2" in msg
+
+    def test_no_log_on_non_zero_rank(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=8,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+            rank=1,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=1)
+        ex.dist.tp_allgather.return_value = [1, 0]
+
+        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
+            ex._is_benchmark_disagg_fill_complete(batch)
+            mock_logger.debug.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ADP regression: mixed real + dummy generation requests
+# ---------------------------------------------------------------------------
+
+
+class TestFillCompleteADPDummyExclusion:
+    """Verify that ADP dummy requests do not inflate the fill threshold.
+
+    In ADP, ``_pad_attention_dp_dummy_request`` injects dummy generation
+    requests on ranks with no active work.  These dummies must be excluded
+    from the ``total_gen_count`` so the ``can_forward`` gate only opens
+    after the required number of *real* requests complete KV transfer.
+    """
+
+    def test_dummies_do_not_trigger_threshold(self):
+        """8 dummies + 0 real must not satisfy a threshold of 4."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=0, num_dummy_requests=8)
+        ex.dist.tp_allgather.return_value = [0, 0]
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is False
+
+    def test_mixed_real_and_dummy_only_counts_real(self):
+        """2 real + 3 dummies on each rank: total real = 4, threshold = 4."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=3)
+        ex.dist.tp_allgather.return_value = [2, 2]
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is True
+
+    def test_mixed_below_threshold(self):
+        """1 real + 5 dummies on each rank: total real = 2, threshold = 4."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=True,
+            tp_size=2,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=1, num_dummy_requests=5)
+        ex.dist.tp_allgather.return_value = [1, 1]
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is False
+
+    def test_non_adp_dummies_excluded(self):
+        """Without ADP, dummies should also be excluded from the local count."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=False,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=5)
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is False
+
+    def test_non_adp_real_only_meets_threshold(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            enable_attention_dp=False,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=4, num_dummy_requests=3)
+
+        assert ex._is_benchmark_disagg_fill_complete(batch) is True
+
+
+# ---------------------------------------------------------------------------
+# can_forward gating  (unit-level, no real executor loop)
+# ---------------------------------------------------------------------------
+
+
+class TestCanForwardGating:
+    """Verify can_forward initialisation and state transitions.
+
+    The can_forward gate is shared by _executor_loop and
+    _executor_loop_overlap to defer the forward pass in benchmark
+    disagg mode until all requests are generation-ready.
+    """
+
+    @pytest.mark.parametrize(
+        "benchmark_size, transceiver, is_disagg, can_forward",
+        [
+            pytest.param(0, None, False, True, id="no_benchmark"),
+            pytest.param(8, None, False, True, id="benchmark_without_disagg"),
+            pytest.param(0, "mock", False, True, id="disagg_without_benchmark"),
+            pytest.param(8, "mock", True, False, id="benchmark_and_disagg"),
+        ],
+    )
+    def test_initial_value(self, benchmark_size, transceiver, is_disagg, can_forward):
+        kv = Mock() if transceiver == "mock" else None
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=benchmark_size, kv_cache_transceiver=kv
+        )
+        assert ex.is_benchmark_disagg is is_disagg
+        assert (not ex.is_benchmark_disagg) is can_forward
+
+    @pytest.mark.parametrize(
+        "num_gen_requests, expected_after_fill",
+        [
+            pytest.param(4, True, id="complete_fill"),
+            pytest.param(2, False, id="incomplete_fill"),
+        ],
+    )
+    def test_transition(self, num_gen_requests, expected_after_fill):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        can_forward = not ex.is_benchmark_disagg
+        assert can_forward is False
+
+        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
+        can_forward = ex._is_benchmark_disagg_fill_complete(batch)
+        assert can_forward is expected_after_fill
+
+    def test_can_forward_stays_true_once_set(self):
+        """can_forward is latching: once True it must not revert."""
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        can_forward = not ex.is_benchmark_disagg
+
+        batch_partial = _make_scheduled_batch(num_gen_requests=4)
+        can_forward = ex._is_benchmark_disagg_fill_complete(batch_partial)
+        assert can_forward is True
+
+        batch_empty = _make_scheduled_batch(num_gen_requests=0)
+        # After can_forward is True, the gate is never re-entered in the
+        # real loop (guarded by `if not can_forward`).  Verify that calling
+        # the helper again with an empty batch would return False, but
+        # can_forward itself is not mutated.
+        result = ex._is_benchmark_disagg_fill_complete(batch_empty)
+        assert result is False
+        assert can_forward is True  # local variable unchanged
+
+
+# ---------------------------------------------------------------------------
+# _check_benchmark_disagg_gate  (consolidated gate helper)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBenchmarkDisaggGate:
+    """Verify the consolidated gate helper used by both executor loops."""
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
+    def test_gate_opens_when_fill_complete(self, mock_time):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        batch = _make_scheduled_batch(num_gen_requests=4)
+
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
+        assert can_forward is True
+        assert should_retry is False
+        mock_time.sleep.assert_not_called()
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
+    def test_gate_blocks_and_sleeps_when_incomplete(self, mock_time):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        batch = _make_scheduled_batch(num_gen_requests=1)
+
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
+        assert can_forward is False
+        assert should_retry is True
+        mock_time.sleep.assert_called_once_with(1)
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
+    def test_warmup_bypasses_gate(self, mock_time):
+        """During warmup, the gate must not block even in benchmark disagg mode."""
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=Mock(),
+            is_warmup=True,
+        )
+        batch = _make_scheduled_batch(num_gen_requests=0)
+
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
+        assert can_forward is False
+        assert should_retry is False
+        mock_time.sleep.assert_not_called()
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
+    def test_already_forwarding_skips_check(self, mock_time):
+        """Once can_forward is True, the gate is a no-op."""
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
+        batch = _make_scheduled_batch(num_gen_requests=0)
+
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, True)
+        assert can_forward is True
+        assert should_retry is False
+        mock_time.sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _pad_attention_dp_dummy_request  (benchmark disagg condition)
+# ---------------------------------------------------------------------------
+
+
+def _make_active_request(in_init: bool = False, in_transfer: bool = False) -> Mock:
+    """Create an active request stub for _pad_attention_dp_dummy_request."""
+    req = Mock()
+    req.is_disagg_generation_init_state = in_init
+    req.is_disagg_generation_transmission_in_progress = in_transfer
+    return req
+
+
+class MockPadDummyExecutor:
+    """Stub mirroring the PyExecutor attributes used by
+    ``_pad_attention_dp_dummy_request``.
+
+    Only the benchmark disagg early-return guard and the dummy-addition
+    branch are exercised; the rest is mocked out.
+    """
+
+    def __init__(
+        self,
+        *,
+        is_benchmark_disagg: bool = False,
+        is_warmup: bool = False,
+        enable_attention_dp: bool = True,
+        kv_cache_transceiver=None,
+        active_requests=None,
+        expected_num_active_requests: int = 1,
+        num_fetch_requests: int = 0,
+    ):
+        self.is_benchmark_disagg = is_benchmark_disagg
+        self.is_warmup = is_warmup
+        self.enable_attention_dp = enable_attention_dp
+        self.kv_cache_transceiver = kv_cache_transceiver
+        self.active_requests = active_requests if active_requests is not None else []
+        self.expected_num_active_requests = expected_num_active_requests
+        self.num_fetch_requests = num_fetch_requests
+        self.max_total_draft_tokens = 0
+
+        self.kv_cache_manager = Mock()
+        dummy_req = Mock()
+        dummy_req.is_attention_dp_dummy = True
+        self.kv_cache_manager.add_dummy_requests.return_value = [dummy_req]
+
+        self.resource_manager = Mock()
+        self.resource_manager.get_resource_manager.return_value = None
+
+    from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+    _pad_attention_dp_dummy_request = PyExecutor._pad_attention_dp_dummy_request
+
+
+class TestPadAttentionDpDummyBenchmarkDisagg:
+    """Verify _pad_attention_dp_dummy_request skips dummy insertion correctly.
+
+    The guard ``if (self.is_benchmark_disagg and not self.is_warmup
+    and num_active_request == 0)`` must:
+    - Skip dummy insertion when benchmark disagg is active, not warming up,
+      and no requests have completed KV transfer (including when
+      active_requests is empty — the "early fill" case).
+    - Allow dummy insertion during warmup even in benchmark disagg mode.
+    - Allow dummy insertion when not in benchmark disagg mode.
+    """
+
+    def test_skips_dummy_when_active_requests_empty(self):
+        """Early fill: no requests fetched yet, active_requests is empty."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[],
+            expected_num_active_requests=1,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_skips_dummy_when_all_requests_in_transfer(self):
+        """Requests exist but all are in INIT/transfer state."""
+        reqs = [_make_active_request(in_init=True), _make_active_request(in_transfer=True)]
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=reqs,
+            expected_num_active_requests=3,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_allows_dummy_during_warmup(self):
+        """Warmup must bypass the benchmark disagg guard."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            is_warmup=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[],
+            expected_num_active_requests=1,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
+
+    def test_allows_dummy_when_not_benchmark_disagg(self):
+        """Non-benchmark or non-disagg mode: normal dummy insertion."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=False,
+            active_requests=[],
+            expected_num_active_requests=1,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
+
+    def test_allows_dummy_when_active_requests_ready(self):
+        """Some requests have completed KV transfer: guard does not trigger."""
+        ready_req = _make_active_request(in_init=False, in_transfer=False)
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[ready_req],
+            expected_num_active_requests=2,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_skips_when_adp_disabled(self):
+        """_pad_attention_dp_dummy_request early-returns when ADP is off."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            enable_attention_dp=False,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _prepare_and_schedule_batch is non-blocking
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalFillScenario:
+    """Simulate incremental request arrival when CTX has limited KV cache.
+
+    Setup: the CTX server can only send a few requests per iteration
+    (limited KV cache), while the GEN server has enough capacity for all
+    requests.  The GEN executor must cycle its main loop — fetching a
+    batch, servicing KV transfers, checking readiness — so the CTX
+    server can free KV cache and make progress incrementally.
+
+    These tests replay the outer-loop logic over multiple iterations
+    with controlled request arrival and KV-transfer completion to verify
+    the system converges without blocking.
+    """
+
+    TOTAL_REQUESTS = 8
+    CTX_CAPACITY = 2  # CTX can only release this many per iteration
+
+    def test_gen_side_processes_requests_incrementally(self):
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=self.TOTAL_REQUESTS,
+            kv_cache_transceiver=Mock(),
+        )
+
+        fetched = 0
+        gen_ready = 0
+
+        def simulate_fetch():
+            nonlocal fetched
+            new = min(self.CTX_CAPACITY, self.TOTAL_REQUESTS - fetched)
+            fetched += new
+            ex.num_fetch_requests = fetched
+
+        def simulate_kv_transfer():
+            nonlocal gen_ready
+            gen_ready = fetched
+
+        can_forward = not ex.is_benchmark_disagg
+        assert can_forward is False
+
+        iterations = 0
+        MAX_ITER = 50
+
+        while not can_forward and iterations < MAX_ITER:
+            simulate_fetch()
+            simulate_kv_transfer()
+            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
+            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
+            iterations += 1
+
+        assert can_forward is True
+        assert fetched == self.TOTAL_REQUESTS
+        assert gen_ready == self.TOTAL_REQUESTS
+        assert iterations > 1, "Should take multiple iterations (not a single blocking call)"
+
+    def test_kv_transfer_lag_still_converges(self):
+        """KV transfers complete one iteration behind request fetching.
+
+        Iteration 1: fetch 2, gen_ready 0
+        Iteration 2: fetch 4, gen_ready 2  (transfers from iter 1 complete)
+        ...
+        This models the realistic case where KV transfer takes time.
+        """
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=self.TOTAL_REQUESTS,
+            kv_cache_transceiver=Mock(),
+        )
+
+        fetched = 0
+        gen_ready = 0
+        prev_fetched = 0
+
+        can_forward = not ex.is_benchmark_disagg
+        iterations = 0
+        MAX_ITER = 50
+
+        while not can_forward and iterations < MAX_ITER:
+            gen_ready = prev_fetched
+            prev_fetched = fetched
+
+            new = min(self.CTX_CAPACITY, self.TOTAL_REQUESTS - fetched)
+            fetched += new
+            ex.num_fetch_requests = fetched
+
+            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
+            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
+            iterations += 1
+
+        assert can_forward is True
+        assert gen_ready >= self.TOTAL_REQUESTS
+        assert iterations > 2, "With transfer lag, should take more iterations than without"
+
+    def test_single_request_at_a_time(self):
+        """Worst case: CTX releases exactly 1 request per iteration."""
+        total = 4
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=total,
+            kv_cache_transceiver=Mock(),
+        )
+
+        gen_ready = 0
+        can_forward = not ex.is_benchmark_disagg
+        iterations = 0
+
+        while not can_forward and iterations < 50:
+            gen_ready = min(gen_ready + 1, total)
+            ex.num_fetch_requests = gen_ready
+            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
+            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
+            iterations += 1
+
+        assert can_forward is True
+        assert iterations == total
+
+
+class TestPrepareAndScheduleBatchNoBlock:
+    """_prepare_and_schedule_batch must not block on request fetching.
+
+    It should call _fetch_and_activate_new_requests exactly once per
+    invocation, regardless of benchmark_req_queues_size, so the outer
+    executor loop remains free to service KV transfers between iterations.
+
+    NOTE: This test uses ``object.__new__(PyExecutor)`` to bypass __init__
+    and manually sets internal attributes.  This is inherently fragile —
+    if _prepare_and_schedule_batch gains new attribute references the test
+    will fail with AttributeError.  Keep the attribute list below in sync
+    with the method's implementation.
+    """
+
+    def test_fetch_called_once_even_in_benchmark_disagg(self):
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+        ex = object.__new__(PyExecutor)
+        ex.benchmark_req_queues_size = 8
+        ex.kv_cache_transceiver = Mock()
+        ex.is_benchmark_disagg = True
+        ex.enable_attention_dp = False
+        ex.num_fetch_requests = 0
+        ex.dist = Mock(rank=0, tp_size=1)
+        ex.is_shutdown = False
+        ex._is_warmup = False
+        ex.enable_iter_perf_stats = False
+        ex.active_requests = []
+        ex.waiting_queue = []
+        ex.expected_num_active_requests = 0
+        ex.drafter = None
+        ex.inflight_req_ids = set()
+        ex.kv_connector_manager = None
+        ex.enable_partial_reuse_for_disagg = False
+
+        mock_fetch = Mock(return_value=[])
+        ex._fetch_and_activate_new_requests = mock_fetch
+        ex._check_disagg_ctx_schedulable_status = Mock()
+        ex._check_disagg_gen_transfer_status = Mock()
+        ex._check_kv_transfer_timeout = Mock()
+        ex._check_disagg_ctx_cache_transfer_status = Mock()
+        ex._pad_attention_dp_dummy_request = Mock()
+        ex._schedule = Mock(return_value=(ScheduledRequests(), [], 0))
+        ex._prepare_disagg_gen_init = Mock()
+
+        ex._prepare_and_schedule_batch()
+
+        mock_fetch.assert_called_once()

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -393,14 +393,14 @@ class TestCheckBenchmarkDisaggGate:
         mock_time.sleep.assert_not_called()
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
-    def test_gate_blocks_and_sleeps_when_incomplete(self, mock_time):
+    def test_gate_retries_with_short_sleep_when_incomplete(self, mock_time):
         ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
         batch = _make_scheduled_batch(num_gen_requests=1)
 
         can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
         assert can_forward is False
         assert should_retry is True
-        mock_time.sleep.assert_called_once_with(1)
+        mock_time.sleep.assert_called_once_with(0.1)
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
     def test_warmup_bypasses_gate(self, mock_time):
@@ -460,6 +460,8 @@ class MockPadDummyExecutor:
         active_requests=None,
         expected_num_active_requests: int = 1,
         num_fetch_requests: int = 0,
+        benchmark_req_queues_size: int = 8,
+        tp_size: int = 1,
     ):
         self.is_benchmark_disagg = is_benchmark_disagg
         self.is_warmup = is_warmup
@@ -468,7 +470,11 @@ class MockPadDummyExecutor:
         self.active_requests = active_requests if active_requests is not None else []
         self.expected_num_active_requests = expected_num_active_requests
         self.num_fetch_requests = num_fetch_requests
+        self.benchmark_req_queues_size = benchmark_req_queues_size
         self.max_total_draft_tokens = 0
+
+        self.dist = Mock()
+        self.dist.tp_size = tp_size
 
         self.kv_cache_manager = Mock()
         dummy_req = Mock()
@@ -481,32 +487,38 @@ class MockPadDummyExecutor:
     from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
 
     _pad_attention_dp_dummy_request = PyExecutor._pad_attention_dp_dummy_request
+    _count_schedulable_active_requests = PyExecutor._count_schedulable_active_requests
+    _should_skip_dummy_for_benchmark_disagg = PyExecutor._should_skip_dummy_for_benchmark_disagg
 
 
 class TestPadAttentionDpDummyBenchmarkDisagg:
     """Verify _pad_attention_dp_dummy_request skips dummy insertion correctly.
 
-    The guard ``if (self.is_benchmark_disagg and not self.is_warmup
-    and num_active_request == 0)`` must:
-    - Skip dummy insertion when benchmark disagg is active, not warming up,
-      and no requests have completed KV transfer (including when
-      active_requests is empty — the "early fill" case).
-    - Allow dummy insertion during warmup even in benchmark disagg mode.
-    - Allow dummy insertion when not in benchmark disagg mode.
+    Dummies are permanent (never removed), so in benchmark disagg mode
+    they should only be added in the terminal case where all benchmark
+    requests have been fetched but there are fewer than tp_size (some
+    ranks will never get a real request).
+
+    In all other benchmark disagg cases — including the entire fill
+    phase — dummies are skipped because the can_forward gate prevents
+    forward-pass collectives.
     """
 
-    def test_skips_dummy_when_active_requests_empty(self):
-        """Early fill: no requests fetched yet, active_requests is empty."""
+    def test_skips_during_fill_phase(self):
+        """During fill (not all fetched yet), skip dummies."""
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             kv_cache_transceiver=Mock(),
             active_requests=[],
             expected_num_active_requests=1,
+            num_fetch_requests=2,
+            benchmark_req_queues_size=8,
+            tp_size=4,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
 
-    def test_skips_dummy_when_all_requests_in_transfer(self):
+    def test_skips_when_all_requests_in_transfer(self):
         """Requests exist but all are in INIT/transfer state."""
         reqs = [_make_active_request(in_init=True), _make_active_request(in_transfer=True)]
         ex = MockPadDummyExecutor(
@@ -514,9 +526,40 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
             kv_cache_transceiver=Mock(),
             active_requests=reqs,
             expected_num_active_requests=3,
+            num_fetch_requests=4,
+            benchmark_req_queues_size=8,
+            tp_size=2,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_skips_after_fill_when_enough_requests_for_all_ranks(self):
+        """All fetched and benchmark_size >= tp_size: every rank has work."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[_make_active_request(in_init=True)],
+            expected_num_active_requests=2,
+            num_fetch_requests=8,
+            benchmark_req_queues_size=8,
+            tp_size=4,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_allows_dummy_terminal_case_fewer_requests_than_ranks(self):
+        """All fetched but benchmark_size < tp_size: some ranks need permanent dummies."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[],
+            expected_num_active_requests=1,
+            num_fetch_requests=2,
+            benchmark_req_queues_size=2,
+            tp_size=4,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
 
     def test_allows_dummy_during_warmup(self):
         """Warmup must bypass the benchmark disagg guard."""
@@ -557,6 +600,20 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             enable_attention_dp=False,
+        )
+        ex._pad_attention_dp_dummy_request()
+        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
+
+    def test_skips_during_early_fill_even_with_empty_ranks(self):
+        """During fill, skip dummies even if some ADP ranks are empty."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            kv_cache_transceiver=Mock(),
+            active_requests=[],
+            expected_num_active_requests=1,
+            num_fetch_requests=1,
+            benchmark_req_queues_size=8,
+            tp_size=4,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -80,6 +80,7 @@ class MockBenchmarkExecutor:
         self.is_benchmark_disagg = (
             benchmark_req_queues_size > 0 and kv_cache_transceiver is not None
         )
+        self._benchmark_fill_phase_active = self.is_benchmark_disagg
         self.enable_attention_dp = enable_attention_dp
         self.num_fetch_requests = num_fetch_requests
         self.is_warmup = is_warmup
@@ -386,10 +387,12 @@ class TestCheckBenchmarkDisaggGate:
     def test_gate_opens_when_fill_complete(self, mock_time):
         ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
         batch = _make_scheduled_batch(num_gen_requests=4)
+        assert ex._benchmark_fill_phase_active is True
 
         can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
         assert can_forward is True
         assert should_retry is False
+        assert ex._benchmark_fill_phase_active is False
         mock_time.sleep.assert_not_called()
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
@@ -454,6 +457,7 @@ class MockPadDummyExecutor:
         self,
         *,
         is_benchmark_disagg: bool = False,
+        benchmark_fill_phase_active: bool | None = None,
         is_warmup: bool = False,
         enable_attention_dp: bool = True,
         kv_cache_transceiver=None,
@@ -464,6 +468,11 @@ class MockPadDummyExecutor:
         tp_size: int = 1,
     ):
         self.is_benchmark_disagg = is_benchmark_disagg
+        self._benchmark_fill_phase_active = (
+            benchmark_fill_phase_active
+            if benchmark_fill_phase_active is not None
+            else is_benchmark_disagg
+        )
         self.is_warmup = is_warmup
         self.enable_attention_dp = enable_attention_dp
         self.kv_cache_transceiver = kv_cache_transceiver
@@ -494,69 +503,47 @@ class MockPadDummyExecutor:
 class TestPadAttentionDpDummyBenchmarkDisagg:
     """Verify _pad_attention_dp_dummy_request skips dummy insertion correctly.
 
-    Dummies are permanent (never removed), so in benchmark disagg mode
-    they should only be added in the terminal case where all benchmark
-    requests have been fetched but there are fewer than tp_size (some
-    ranks will never get a real request).
+    During the fill phase (_benchmark_fill_phase_active=True), dummies
+    are skipped because the can_forward gate prevents forward-pass
+    collectives and stuck dummies would permanently waste KV cache slots.
 
-    In all other benchmark disagg cases — including the entire fill
-    phase — dummies are skipped because the can_forward gate prevents
-    forward-pass collectives.
+    Once the fill phase ends (_benchmark_fill_phase_active=False), the
+    normal dummy add-forward-terminate lifecycle resumes to handle
+    taper-down (ranks emptying at different rates due to e.g. speculative
+    decoding acceptance variance).
     """
 
     def test_skips_during_fill_phase(self):
-        """During fill (not all fetched yet), skip dummies."""
+        """During fill phase, skip dummies."""
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             kv_cache_transceiver=Mock(),
             active_requests=[],
             expected_num_active_requests=1,
-            num_fetch_requests=2,
-            benchmark_req_queues_size=8,
-            tp_size=4,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
 
-    def test_skips_when_all_requests_in_transfer(self):
-        """Requests exist but all are in INIT/transfer state."""
+    def test_skips_during_fill_even_with_requests_in_transfer(self):
+        """Fill phase: requests in INIT/transfer, still skip dummies."""
         reqs = [_make_active_request(in_init=True), _make_active_request(in_transfer=True)]
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             kv_cache_transceiver=Mock(),
             active_requests=reqs,
             expected_num_active_requests=3,
-            num_fetch_requests=4,
-            benchmark_req_queues_size=8,
-            tp_size=2,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
 
-    def test_skips_after_fill_when_enough_requests_for_all_ranks(self):
-        """All fetched and benchmark_size >= tp_size: every rank has work."""
+    def test_allows_dummy_after_fill_phase_taper_down(self):
+        """After fill phase, rank empties due to taper-down: allow dummy."""
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
-            kv_cache_transceiver=Mock(),
-            active_requests=[_make_active_request(in_init=True)],
-            expected_num_active_requests=2,
-            num_fetch_requests=8,
-            benchmark_req_queues_size=8,
-            tp_size=4,
-        )
-        ex._pad_attention_dp_dummy_request()
-        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
-
-    def test_allows_dummy_terminal_case_fewer_requests_than_ranks(self):
-        """All fetched but benchmark_size < tp_size: some ranks need permanent dummies."""
-        ex = MockPadDummyExecutor(
-            is_benchmark_disagg=True,
+            benchmark_fill_phase_active=False,
             kv_cache_transceiver=Mock(),
             active_requests=[],
             expected_num_active_requests=1,
-            num_fetch_requests=2,
-            benchmark_req_queues_size=2,
-            tp_size=4,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_called_once()
@@ -583,11 +570,12 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_called_once()
 
-    def test_allows_dummy_when_active_requests_ready(self):
-        """Some requests have completed KV transfer: guard does not trigger."""
+    def test_no_dummy_needed_when_active_requests_ready(self):
+        """Rank has ready requests: needs_dummy condition is False."""
         ready_req = _make_active_request(in_init=False, in_transfer=False)
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
+            benchmark_fill_phase_active=False,
             kv_cache_transceiver=Mock(),
             active_requests=[ready_req],
             expected_num_active_requests=2,
@@ -600,20 +588,6 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             enable_attention_dp=False,
-        )
-        ex._pad_attention_dp_dummy_request()
-        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
-
-    def test_skips_during_early_fill_even_with_empty_ranks(self):
-        """During fill, skip dummies even if some ADP ranks are empty."""
-        ex = MockPadDummyExecutor(
-            is_benchmark_disagg=True,
-            kv_cache_transceiver=Mock(),
-            active_requests=[],
-            expected_num_active_requests=1,
-            num_fetch_requests=1,
-            benchmark_req_queues_size=8,
-            tp_size=4,
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced benchmark disaggregated execution with improved gating logic for KV cache transfer synchronization and more efficient control flow across execution loops.

* **Tests**
  * Added comprehensive test suite for benchmark disaggregated mode, covering fill-completion detection, batch preparation, and allgather handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fix a deadlock in benchmark disaggregated serving mode and improve code quality.

**Problem:** In benchmark disagg mode, the GEN executor's `_prepare_and_schedule_batch` contained a blocking fill loop that held control until a batch of requests was fetched. During this blocking wait, the executor could not service KV transfers, check timeouts, detect errors, or handle control requests.

The severity depends on the transport backend:
- **MPI:** Sends can block until the receiver posts a matching receive. Since `_check_disagg_gen_transfer_status` never runs inside the fill loop, GEN never receives, CTX's sends block, and CTX cannot free KV cache blocks — causing a **hard deadlock** when CTX capacity < `batch_size`.
- **RDMA (NIXL/UCX):** CTX frees blocks based on send completion independently, so the deadlock is less likely. However, the fill loop still starves all other executor work (timeout handling, error detection, hang detector, control requests) for the duration of the wait.

**Solution:** Replace the blocking fill loop with a non-blocking `can_forward` gate in the executor loops. Each main-loop iteration now performs a full processing cycle — fetch, service transfers, check timeouts, handle errors — then checks readiness via `_is_benchmark_disagg_fill_complete`. This eliminates the deadlock for all backends and ensures the executor remains responsive during the fill phase.

### Key changes

**Core fix:**
- Remove blocking fill loop from `_prepare_and_schedule_batch`, making it fully non-blocking (single fetch per call)
- Add `_is_benchmark_disagg_fill_complete` helper that counts generation-ready requests (excludes ADP dummy requests) and uses TP allgather for ADP, local counting otherwise
- Add `_check_benchmark_disagg_gate` helper that consolidates the gate logic shared by both `_executor_loop` and `_executor_loop_overlap`
- Add `can_forward` gate to `_executor_loop` (previously only existed in `_executor_loop_overlap`)
- Align gate retry sleep to 0.1s consistent with PR #12640

**ADP dummy request fix:**
- Refactor `_pad_attention_dp_dummy_request` into focused helpers: `_count_schedulable_active_requests` (counts requests past KV transfer) and `_should_skip_dummy_for_benchmark_disagg` (encapsulates skip decision)
- Add `_benchmark_fill_phase_active` flag to distinguish the fill phase (dummies skipped — gate blocks collectives, stuck dummies waste KV slots) from taper-down (dummies allowed — normal add-forward-terminate lifecycle handles ranks emptying at different rates due to e.g. speculative decoding acceptance variance)
- Flag starts `True` in benchmark disagg mode and is cleared when `can_forward` gate opens
- Exclude `is_attention_dp_dummy` requests from the generation count in the fill-complete check, preventing premature gate opening

**Code quality:**
- Extract `is_benchmark_disagg` attribute for consistent condition checks (replaces repeated `benchmark_req_queues_size > 0 and kv_cache_transceiver is not None`)
- Use `RuntimeError` for precondition violation in `_is_benchmark_disagg_fill_complete`
- Use `tuple[bool, bool]` return type annotation on `_check_benchmark_disagg_gate`
- Use `logger.debug` for fill-progress messages (avoids log spam at 0.1s intervals)

This PR is co-worked with Cursor agent.

## Test Coverage

Added `tests/unittest/_torch/executor/test_benchmark_disagg.py` with 40 tests across 8 test classes:

| Test class | # | What it covers |
|---|---|---|
| `TestFillCompleteNonADP` | 7 | Threshold (meets/exceeds/below/zero), no-allgather path, rank-0 debug logging, no log on non-zero rank |
| `TestFillCompleteADP` | 7 | Allgather path with threshold variants (meets/exceeds/below/uneven), allgather receives correct local count, dummy exclusion from allgather, logging |
| `TestFillCompleteADPDummyExclusion` | 5 | Regression: dummies alone don't trigger threshold, mixed real+dummy only counts real, below-threshold with dummies, non-ADP dummy exclusion, real-only meets threshold |
| `TestCanForwardGating` | 7 | Gate initialization for all 4 (benchmark\_size, transceiver) combinations, state transitions (complete/incomplete fill), latching (stays True once set) |
| `TestCheckBenchmarkDisaggGate` | 4 | Consolidated gate helper: opens when fill complete (clears fill phase flag), retries with short sleep when incomplete, warmup bypasses gate, already-forwarding skips check |
| `TestPadAttentionDpDummyBenchmarkDisagg` | 7 | Skips during fill phase, skips during fill with requests in transfer, allows dummy after fill phase (taper-down), allows during warmup, allows when not benchmark disagg, no dummy needed when active requests ready, skips when ADP disabled |
| `TestIncrementalFillScenario` | 3 | Multi-iteration convergence with limited CTX capacity, KV transfer lag (one iteration behind), worst-case single-request-at-a-time |
| `TestPrepareAndScheduleBatchNoBlock` | 1 | Verifies `_prepare_and_schedule_batch` calls fetch exactly once per invocation (non-blocking) |
| **Total** | **40** (originally 44, refined after review) | |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
