### PR TITLE
[None][feat] Add support for Phi4 family in AutoDeploy

### DIFF
--- a/examples/auto_deploy/model_registry/configs/phi4-multimodal-instruct.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-multimodal-instruct.yaml
@@ -2,7 +2,10 @@
 # exports the prefill-only causal LM entrypoint registered via AutoModelForCausalLMFactory.
 # This is only a model-construction/runtime config override for the e2e AD run.
 model_factory: AutoModelForCausalLM
-world_size: 1
 model_kwargs:
+  # HF tries to dispatch Phi4MM to flash-attention 2 during model construction, which fails before
+  # the AD custom model can be built. Force eager attention for this text-only validation path.
   attn_implementation: eager
+  # The onboarding e2e validates only the exported text path. Keep the multimodal embedding wrapper
+  # disabled here so image/audio tower hooks do not participate in text-only AD export.
   embd_layer: null

--- a/examples/auto_deploy/model_registry/configs/phi4-multimodal-instruct.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-multimodal-instruct.yaml
@@ -1,0 +1,8 @@
+# Phi-4 multimodal uses a remote-code text+media wrapper, but the AD onboarding path
+# exports the prefill-only causal LM entrypoint registered via AutoModelForCausalLMFactory.
+# This is only a model-construction/runtime config override for the e2e AD run.
+model_factory: AutoModelForCausalLM
+world_size: 1
+model_kwargs:
+  attn_implementation: eager
+  embd_layer: null

--- a/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+model_factory: AutoModelForCausalLM
+model_kwargs:
+  attn_implementation: eager
+
+trust_remote_code: true
+skip_tokenizer_init: false
+
+max_batch_size: 1
+max_seq_len: 4096
+max_num_tokens: 4096
+enable_chunked_prefill: false
+
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.7

--- a/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-model_factory: AutoModelForCausalLM
 model_kwargs:
   attn_implementation: eager
 

--- a/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+model_factory: Phi4VisionRAutoModelForImageTextToText
+
 model_kwargs:
   # The remote Phi-4 reasoning-vision wrapper defaults to FA2-backed attention construction,
   # but the AD text-only onboarding path keeps the VLM wrapper and exports only the text stack.

--- a/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
+++ b/examples/auto_deploy/model_registry/configs/phi4-reasoning-vision-15b.yaml
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 model_kwargs:
+  # The remote Phi-4 reasoning-vision wrapper defaults to FA2-backed attention construction,
+  # but the AD text-only onboarding path keeps the VLM wrapper and exports only the text stack.
+  # Force eager attention so model construction succeeds on this registry path.
   attn_implementation: eager
 
 trust_remote_code: true
 skip_tokenizer_init: false
-
-max_batch_size: 1
-max_seq_len: 4096
-max_num_tokens: 4096
-enable_chunked_prefill: false
 
 kv_cache_config:
   enable_block_reuse: false

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -324,7 +324,7 @@ models:
 - name: microsoft/Phi-4-multimodal-instruct
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml', 'phi4-multimodal-instruct.yaml']
 - name: microsoft/Phi-4-reasoning-vision-15B
-  yaml_extra: ['dashboard_default.yaml', 'world_size_4.yaml', 'multimodal.yaml', 'phi4-reasoning-vision-15b.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_1.yaml', 'multimodal.yaml', 'phi4-reasoning-vision-15b.yaml']
 # --- MiniMax M2 (2025) ---
 - name: MiniMaxAI/MiniMax-M2
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml']

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -456,7 +456,7 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
 # --- Phi-4-mini flash reasoning (2025) ---
 - name: microsoft/Phi-4-mini-flash-reasoning
-  yaml_extra: ['dashboard_default.yaml', 'world_size_1.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_1.yaml', 'phi4-mini-flash-reasoning.yaml']
 # --- Qwen2.5-VL (2025) - top VLM family ---
 - name: Qwen/Qwen2.5-VL-7B-Instruct
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml']

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -324,7 +324,7 @@ models:
 - name: microsoft/Phi-4-multimodal-instruct
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml', 'phi4-multimodal-instruct.yaml']
 - name: microsoft/Phi-4-reasoning-vision-15B
-  yaml_extra: ['dashboard_default.yaml', 'world_size_4.yaml', 'multimodal.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_4.yaml', 'multimodal.yaml', 'phi4-reasoning-vision-15b.yaml']
 # --- MiniMax M2 (2025) ---
 - name: MiniMaxAI/MiniMax-M2
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml']

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -322,7 +322,7 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'multimodal.yaml', 'llama4_maverick_lite.yaml']
 # --- Phi-4 variants (2025) ---
 - name: microsoft/Phi-4-multimodal-instruct
-  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml']
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml', 'phi4-multimodal-instruct.yaml']
 - name: microsoft/Phi-4-reasoning-vision-15B
   yaml_extra: ['dashboard_default.yaml', 'world_size_4.yaml', 'multimodal.yaml']
 # --- MiniMax M2 (2025) ---

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -100,7 +100,9 @@ The table below lists the operators grouped by category.
 | Operator Name | Description |
 |--------------|-------------|
 | `torch.ops.auto_deploy.torch_ssm` | State Space Model (SSM) computation (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_ysamba_ssm` | ySamba/Phi-4-Flash-style SSM with per-state decay matrix (PyTorch backend) |
 | `torch.ops.auto_deploy.torch_cached_ssm` | Cached SSM with state management (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_cached_ysamba_ssm` | Cached ySamba/Phi-4-Flash-style SSM with state management (PyTorch backend) |
 | `torch.ops.auto_deploy.triton_cached_ssm` | Cached SSM with state management (Triton backend) |
 | `torch.ops.auto_deploy.flashinfer_cached_ssm` | Cached SSM with state management (FlashInfer backend) |
 | `torch.ops.auto_deploy.mamba_ssm_prepare_metadata` | Mamba SSM metadata preparation (chunk indices, offsets, seq_idx) |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -38,7 +38,7 @@ from ..attention_interface import (
     ResourceHandlerDict,
     SSMResourceHandler,
 )
-from .torch_mamba import _torch_ssm_prefill
+from .torch_mamba import _torch_ssm_prefill, _torch_ysamba_ssm_prefill
 
 
 def _torch_cached_ssm_decode(
@@ -115,8 +115,71 @@ def _torch_cached_ssm_decode(
     return y, updated_ssm_state
 
 
+def _torch_cached_ysamba_ssm_decode(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+    ssm_state_cache: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    del chunk_size
+    batch_size, _, num_heads, head_dim = hidden_states.shape
+    d_inner = num_heads * head_dim
+    n_groups, ssm_state_size = B.shape[2:]
+
+    hidden_states_flat = hidden_states.reshape(batch_size, d_inner).to(torch.float32)
+    dt = dt[:, 0].to(torch.float32)
+    dt = torch.nn.functional.softplus(dt + dt_bias.to(torch.float32))
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+
+    B = B[:, 0].reshape(batch_size, n_groups, ssm_state_size).to(torch.float32)
+    C = C[:, 0].reshape(batch_size, n_groups, ssm_state_size).to(torch.float32)
+    if n_groups != d_inner:
+        repeat_factor = d_inner // n_groups
+        B = B.repeat_interleave(repeat_factor, dim=1, output_size=d_inner)
+        C = C.repeat_interleave(repeat_factor, dim=1, output_size=d_inner)
+
+    A = A.to(torch.float32).reshape(d_inner, ssm_state_size)
+    D = D.to(torch.float32).reshape(d_inner)
+    ssm_state_flat = ssm_state_cache.reshape(batch_size, d_inner, ssm_state_size).to(torch.float32)
+
+    dA = torch.exp(dt.unsqueeze(-1) * A.unsqueeze(0))
+    dB = dt.unsqueeze(-1) * B
+    updated_state = ssm_state_flat * dA + hidden_states_flat.unsqueeze(-1) * dB
+    y = torch.einsum("bdn,bdn->bd", updated_state, C) + D.unsqueeze(0) * hidden_states_flat
+    return (
+        y.reshape(batch_size, 1, num_heads, head_dim).to(hidden_states.dtype),
+        updated_state.reshape(batch_size, num_heads, head_dim, ssm_state_size),
+    )
+
+
 def _update_ssm_state_cache(ssm_cache: torch.Tensor, ssm_state: torch.Tensor) -> None:
     ssm_cache.copy_(ssm_state)
+
+
+def _split_cached_ssm_batch(
+    batch_info_host: torch.Tensor,
+    seq_len: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+) -> Tuple[int, int, int, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    return (
+        num_prefill,
+        num_prefill_tokens,
+        num_decode,
+        seq_len[:num_seq],
+        cu_seqlen[:num_seq],
+        slot_idx[:num_seq].to(torch.long),
+        use_initial_states[:num_seq],
+    )
 
 
 # ---------------------------------------------------------------
@@ -156,15 +219,16 @@ def _torch_cached_ssm(
       describe per-sequence segments. We'll process each segment and scatter final states to caches.
     """
     b, s = hidden_states.shape[:2]
-    num_seq = seq_len.shape[0]
-
-    # get cleaned up metadata
-    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    (
+        num_prefill,
+        num_prefill_tokens,
+        num_decode,
+        seq_len,
+        seq_start,
+        slot_idx,
+        use_initial_states,
+    ) = _split_cached_ssm_batch(batch_info_host, seq_len, cu_seqlen, slot_idx, use_initial_states)
     num_seq = num_prefill + num_decode
-    seq_len = seq_len[:num_seq]
-    seq_start = cu_seqlen[:num_seq]
-    slot_idx = slot_idx[:num_seq].to(torch.long)
-    use_initial_states = use_initial_states[:num_seq]
 
     if s == 1:
         # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
@@ -190,8 +254,9 @@ def _torch_cached_ssm(
         # return in the same dtype as the input
         return y.to(hidden_states.dtype)
 
-    # Prefill
-    if any(use_initial_states):
+    # Chunked prefill is only relevant to context sequences, not decode sequences flattened into
+    # the same batch. Decode requests legitimately have `use_initial_states=True`.
+    if torch.any(use_initial_states[:num_prefill]):
         # TODO(https://github.com/NVIDIA/TensorRT-LLM/issues/8170): update torch
         # reference implementation to support chunked prefill.
         raise ValueError(
@@ -211,11 +276,12 @@ def _torch_cached_ssm(
     C_flat = C.reshape(bs, *C.shape[2:])
     dt_flat = dt.reshape(bs, *dt.shape[2:])
 
+    num_total_tokens = num_prefill_tokens + num_decode
     # NOTE: need contiguous format to process it sequentially
-    y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
+    y = torch.zeros_like(hidden_states, memory_format=torch.contiguous_format)
     y_flat = y.view(bs, *y.shape[2:])
 
-    for i in range(num_seq):
+    for i in range(num_prefill):
         length_i = seq_len[i]
         # Skip empty sequences without synchronizing to host
         if length_i.eq(0):
@@ -246,6 +312,148 @@ def _torch_cached_ssm(
         slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
         ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
 
+    if num_decode > 0:
+        decode_slice = slice(num_prefill_tokens, num_total_tokens)
+        decode_slot_idx = slot_idx[num_prefill:num_seq]
+        hs_decode = hs_flat[decode_slice].unsqueeze(1)
+        B_decode = B_flat[decode_slice].unsqueeze(1)
+        C_decode = C_flat[decode_slice].unsqueeze(1)
+        dt_decode = dt_flat[decode_slice].unsqueeze(1)
+        ssm_batch = ssm_state_cache.index_select(0, decode_slot_idx)
+        y_decode, updated_state = _torch_cached_ssm_decode(
+            hs_decode,
+            A,
+            B_decode,
+            C_decode,
+            D,
+            dt_decode,
+            dt_bias,
+            time_step_limit,
+            chunk_size,
+            ssm_batch,
+        )
+        y_flat.index_copy_(
+            0,
+            torch.arange(num_prefill_tokens, num_total_tokens, device=y.device),
+            y_decode[:, 0].to(y_flat.dtype),
+        )
+        ssm_state_cache.index_copy_(0, decode_slot_idx, updated_state.to(ssm_state_cache.dtype))
+
+    return y
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_ysamba_ssm", mutates_args={})
+def _torch_cached_ysamba_ssm(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    ssm_state_cache: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    b, s = hidden_states.shape[:2]
+    (
+        num_prefill,
+        num_prefill_tokens,
+        num_decode,
+        seq_len,
+        seq_start,
+        slot_idx,
+        use_initial_states,
+    ) = _split_cached_ssm_batch(batch_info_host, seq_len, cu_seqlen, slot_idx, use_initial_states)
+    num_seq = num_prefill + num_decode
+
+    if s == 1:
+        slot_idx_long = slot_idx.to(torch.long)
+        ssm_batch = ssm_state_cache.index_select(dim=0, index=slot_idx_long)
+        y, updated_state = _torch_cached_ysamba_ssm_decode(
+            hidden_states,
+            A,
+            B,
+            C,
+            D,
+            dt,
+            dt_bias,
+            time_step_limit,
+            chunk_size,
+            ssm_batch,
+        )
+        ssm_state_cache.index_copy_(0, slot_idx_long, updated_state.to(ssm_state_cache.dtype))
+        return y.to(hidden_states.dtype)
+
+    if torch.any(use_initial_states[:num_prefill]):
+        raise ValueError(
+            "torch ySamba backend does not yet support chunked prefill and can not correctly "
+            "handle initial states."
+        )
+
+    bs = b * s
+    num_total_tokens = num_prefill_tokens + num_decode
+    flat_idx = torch.arange(bs, device=hidden_states.device, dtype=torch.long)
+    hs_flat = hidden_states.reshape(bs, *hidden_states.shape[2:])
+    B_flat = B.reshape(bs, *B.shape[2:])
+    C_flat = C.reshape(bs, *C.shape[2:])
+    dt_flat = dt.reshape(bs, *dt.shape[2:])
+    y = torch.zeros_like(hidden_states, memory_format=torch.contiguous_format)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    for i in range(num_prefill):
+        length_i = seq_len[i]
+        if length_i.eq(0):
+            continue
+        start_i = seq_start[i]
+        end_i = start_i + length_i
+        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
+        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+
+        hs_seq = hs_flat.index_select(0, idx_i).unsqueeze(0)
+        B_seq = B_flat.index_select(0, idx_i).unsqueeze(0)
+        C_seq = C_flat.index_select(0, idx_i).unsqueeze(0)
+        dt_seq = dt_flat.index_select(0, idx_i).unsqueeze(0)
+
+        y_seq, ssm_state_i = _torch_ysamba_ssm_prefill(
+            hs_seq, A, B_seq, C_seq, D, dt_seq, dt_bias, time_step_limit, chunk_size
+        )
+        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
+        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
+        ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
+
+    if num_decode > 0:
+        decode_slice = slice(num_prefill_tokens, num_total_tokens)
+        decode_slot_idx = slot_idx[num_prefill:num_seq]
+        hs_decode = hs_flat[decode_slice].unsqueeze(1)
+        B_decode = B_flat[decode_slice].unsqueeze(1)
+        C_decode = C_flat[decode_slice].unsqueeze(1)
+        dt_decode = dt_flat[decode_slice].unsqueeze(1)
+        ssm_batch = ssm_state_cache.index_select(0, decode_slot_idx)
+        y_decode, updated_state = _torch_cached_ysamba_ssm_decode(
+            hs_decode,
+            A,
+            B_decode,
+            C_decode,
+            D,
+            dt_decode,
+            dt_bias,
+            time_step_limit,
+            chunk_size,
+            ssm_batch,
+        )
+        y_flat.index_copy_(
+            0,
+            torch.arange(num_prefill_tokens, num_total_tokens, device=y.device),
+            y_decode[:, 0].to(y_flat.dtype),
+        )
+        ssm_state_cache.index_copy_(0, decode_slot_idx, updated_state.to(ssm_state_cache.dtype))
+
     return y
 
 
@@ -270,6 +478,31 @@ def _torch_cached_ssm_fake(
     # CACHES
     ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
     # CONSTANTS
+    time_step_limit: List[float],
+    chunk_size: int,
+):
+    return torch.empty_like(
+        hidden_states,
+        memory_format=torch.contiguous_format,
+        dtype=torch.float32,
+    )
+
+
+@_torch_cached_ysamba_ssm.register_fake
+def _torch_cached_ysamba_ssm_fake(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    slot_idx: torch.Tensor,
+    use_initial_states: torch.Tensor,
+    ssm_state_cache: torch.Tensor,
     time_step_limit: List[float],
     chunk_size: int,
 ):
@@ -342,3 +575,14 @@ class TorchBackendSSM(AttentionDescriptor):
             source_attn_node, "time_step_limit", "chunk_size"
         )
         return [time_step_limit, chunk_size]
+
+
+@AttentionRegistry.register("torch_ysamba_ssm")
+class TorchBackendYSambaSSM(TorchBackendSSM):
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_ysamba_ssm
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_cached_ysamba_ssm.default

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -228,7 +228,6 @@ def _torch_cached_ssm(
         slot_idx,
         use_initial_states,
     ) = _split_cached_ssm_batch(batch_info_host, seq_len, cu_seqlen, slot_idx, use_initial_states)
-    num_seq = num_prefill + num_decode
 
     if s == 1:
         # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
@@ -276,7 +275,6 @@ def _torch_cached_ssm(
     C_flat = C.reshape(bs, *C.shape[2:])
     dt_flat = dt.reshape(bs, *dt.shape[2:])
 
-    num_total_tokens = num_prefill_tokens + num_decode
     # NOTE: need contiguous format to process it sequentially
     y = torch.zeros_like(hidden_states, memory_format=torch.contiguous_format)
     y_flat = y.view(bs, *y.shape[2:])
@@ -311,33 +309,6 @@ def _torch_cached_ssm(
         # Scatter the final state to the slot-indexed cache using device index
         slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
         ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
-
-    if num_decode > 0:
-        decode_slice = slice(num_prefill_tokens, num_total_tokens)
-        decode_slot_idx = slot_idx[num_prefill:num_seq]
-        hs_decode = hs_flat[decode_slice].unsqueeze(1)
-        B_decode = B_flat[decode_slice].unsqueeze(1)
-        C_decode = C_flat[decode_slice].unsqueeze(1)
-        dt_decode = dt_flat[decode_slice].unsqueeze(1)
-        ssm_batch = ssm_state_cache.index_select(0, decode_slot_idx)
-        y_decode, updated_state = _torch_cached_ssm_decode(
-            hs_decode,
-            A,
-            B_decode,
-            C_decode,
-            D,
-            dt_decode,
-            dt_bias,
-            time_step_limit,
-            chunk_size,
-            ssm_batch,
-        )
-        y_flat.index_copy_(
-            0,
-            torch.arange(num_prefill_tokens, num_total_tokens, device=y.device),
-            y_decode[:, 0].to(y_flat.dtype),
-        )
-        ssm_state_cache.index_copy_(0, decode_slot_idx, updated_state.to(ssm_state_cache.dtype))
 
     return y
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_backend_mamba.py
@@ -162,26 +162,6 @@ def _update_ssm_state_cache(ssm_cache: torch.Tensor, ssm_state: torch.Tensor) ->
     ssm_cache.copy_(ssm_state)
 
 
-def _split_cached_ssm_batch(
-    batch_info_host: torch.Tensor,
-    seq_len: torch.Tensor,
-    cu_seqlen: torch.Tensor,
-    slot_idx: torch.Tensor,
-    use_initial_states: torch.Tensor,
-) -> Tuple[int, int, int, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
-    num_seq = num_prefill + num_decode
-    return (
-        num_prefill,
-        num_prefill_tokens,
-        num_decode,
-        seq_len[:num_seq],
-        cu_seqlen[:num_seq],
-        slot_idx[:num_seq].to(torch.long),
-        use_initial_states[:num_seq],
-    )
-
-
 # ---------------------------------------------------------------
 # Metadata + flattened cached op that integrates with the AD i/f
 # ---------------------------------------------------------------
@@ -219,15 +199,12 @@ def _torch_cached_ssm(
       describe per-sequence segments. We'll process each segment and scatter final states to caches.
     """
     b, s = hidden_states.shape[:2]
-    (
-        num_prefill,
-        num_prefill_tokens,
-        num_decode,
-        seq_len,
-        seq_start,
-        slot_idx,
-        use_initial_states,
-    ) = _split_cached_ssm_batch(batch_info_host, seq_len, cu_seqlen, slot_idx, use_initial_states)
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
+    num_seq = num_prefill + num_decode
+    seq_len = seq_len[:num_seq]
+    seq_start = cu_seqlen[:num_seq]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
 
     if s == 1:
         # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
@@ -332,16 +309,12 @@ def _torch_cached_ysamba_ssm(
     chunk_size: int,
 ) -> torch.Tensor:
     b, s = hidden_states.shape[:2]
-    (
-        num_prefill,
-        num_prefill_tokens,
-        num_decode,
-        seq_len,
-        seq_start,
-        slot_idx,
-        use_initial_states,
-    ) = _split_cached_ssm_batch(batch_info_host, seq_len, cu_seqlen, slot_idx, use_initial_states)
+    num_prefill, num_prefill_tokens, num_decode = batch_info_host.tolist()
     num_seq = num_prefill + num_decode
+    seq_len = seq_len[:num_seq]
+    seq_start = cu_seqlen[:num_seq]
+    slot_idx = slot_idx[:num_seq].to(torch.long)
+    use_initial_states = use_initial_states[:num_seq]
 
     if s == 1:
         slot_idx_long = slot_idx.to(torch.long)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mamba/torch_mamba.py
@@ -177,6 +177,59 @@ def _torch_ssm_prefill(
     return y, ssm_state
 
 
+def _torch_ysamba_ssm_prefill(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    del chunk_size
+    batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+    d_inner = num_heads * head_dim
+    n_groups, ssm_state_size = B.shape[2:]
+
+    hidden_states_flat = hidden_states.reshape(batch_size, seq_len, d_inner).to(torch.float32)
+    dt = torch.nn.functional.softplus(dt.to(torch.float32) + dt_bias.to(torch.float32))
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    B = B.reshape(batch_size, seq_len, n_groups, ssm_state_size).to(torch.float32)
+    C = C.reshape(batch_size, seq_len, n_groups, ssm_state_size).to(torch.float32)
+    if n_groups != d_inner:
+        repeat_factor = d_inner // n_groups
+        B = B.repeat_interleave(repeat_factor, dim=2, output_size=d_inner)
+        C = C.repeat_interleave(repeat_factor, dim=2, output_size=d_inner)
+
+    A = A.to(torch.float32).reshape(d_inner, ssm_state_size)
+    D = D.to(torch.float32).reshape(d_inner)
+
+    ssm_state = torch.zeros(
+        batch_size,
+        d_inner,
+        ssm_state_size,
+        device=hidden_states.device,
+        dtype=torch.float32,
+    )
+    outputs = []
+    for token_idx in range(seq_len):
+        x_t = hidden_states_flat[:, token_idx]
+        dt_t = dt[:, token_idx]
+        B_t = B[:, token_idx]
+        C_t = C[:, token_idx]
+
+        dA = torch.exp(dt_t.unsqueeze(-1) * A.unsqueeze(0))
+        dB = dt_t.unsqueeze(-1) * B_t
+        ssm_state = ssm_state * dA + x_t.unsqueeze(-1) * dB
+        y_t = torch.einsum("bdn,bdn->bd", ssm_state, C_t) + D.unsqueeze(0) * x_t
+        outputs.append(y_t)
+
+    y = torch.stack(outputs, dim=1).reshape(batch_size, seq_len, num_heads, head_dim)
+    return y, ssm_state.reshape(batch_size, num_heads, head_dim, ssm_state_size)
+
+
 @torch.library.custom_op("auto_deploy::torch_ssm", mutates_args={})
 def _torch_ssm(
     hidden_states: torch.Tensor,
@@ -195,8 +248,41 @@ def _torch_ssm(
     return y
 
 
+@torch.library.custom_op("auto_deploy::torch_ysamba_ssm", mutates_args={})
+def _torch_ysamba_ssm(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    y, _ = _torch_ysamba_ssm_prefill(
+        hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size
+    )
+    return y.to(hidden_states.dtype)
+
+
 @_torch_ssm.register_fake
 def _torch_ssm_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states, dtype=torch.float32)
+
+
+@_torch_ysamba_ssm.register_fake
+def _torch_ysamba_ssm_meta(
     hidden_states: torch.Tensor,
     A: torch.Tensor,
     B: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/torch_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/torch_rope.py
@@ -41,8 +41,11 @@ def torch_apply_rope_with_explicit_cos_sin(
     sin = sin.type_as(q)
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
-    q_embed = (q * cos) + (rotate_half(q) * sin)
-    k_embed = (k * cos) + (rotate_half(k) * sin)
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    q_embed = torch.cat([(q_rot * cos) + (rotate_half(q_rot) * sin), q_pass], dim=-1)
+    k_embed = torch.cat([(k_rot * cos) + (rotate_half(k_rot) * sin), k_pass], dim=-1)
     return q_embed, k_embed
 
 

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -26,6 +26,28 @@ class ADInputProcessor(DefaultInputProcessor):
         # NOTE: HF's tokenizer/processor that has the apply_chat_template method
         self.processor = processor or getattr(tokenizer, "tokenizer", None)
 
+    def _is_phi4_reasoning_vision_processor(self) -> bool:
+        return type(self.processor).__name__ == "Phi4VisionRProcessor"
+
+    def _get_chat_template_target(self) -> Any:
+        if self.processor is None:
+            return None
+
+        tokenizer = getattr(self.processor, "tokenizer", None)
+        if (
+            self._is_phi4_reasoning_vision_processor()
+            and getattr(tokenizer, "chat_template", None) is not None
+        ):
+            return tokenizer
+
+        if getattr(self.processor, "chat_template", None) is not None:
+            return self.processor
+
+        if getattr(tokenizer, "chat_template", None) is not None:
+            return tokenizer
+
+        return self.processor
+
     def __call__(
         self, inputs: Dict[str, Any], sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
@@ -41,22 +63,37 @@ class ADInputProcessor(DefaultInputProcessor):
                 "truncation": True,
                 "max_length": sampling_params.truncate_prompt_tokens,
             }
+
+        if (
+            self._is_phi4_reasoning_vision_processor()
+            and "messages" not in inputs
+            and "prompt" in inputs
+        ):
+            inputs = {
+                **inputs,
+                "messages": [{"role": "user", "content": inputs["prompt"]}],
+            }
+
         # check for messages field and if yes, use the apply_chat_template method
         if "messages" in inputs:
             # multi_modal_data should not be present in the messages field
             assert "multi_modal_data" not in inputs, f"unexpected multi_modal_data key in {inputs=}"
+            messages = inputs["messages"]
+            chat_template_target = self._get_chat_template_target()
+            if chat_template_target is None:
+                raise ValueError("processor or tokenizer with apply_chat_template is required")
 
             # TODO: we don't really need this but it makes for a good sanity check. Consider
             # removing this in the future if we need to speed things up.
-            prompt = self.processor.apply_chat_template(
-                inputs["messages"],
+            prompt = chat_template_target.apply_chat_template(
+                messages,
                 add_generation_prompt=True,
                 tokenize=False,
             )
             inputs["prompt"] = prompt
 
-            all_args = self.processor.apply_chat_template(
-                inputs["messages"],
+            all_args = chat_template_target.apply_chat_template(
+                messages,
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -26,18 +26,12 @@ class ADInputProcessor(DefaultInputProcessor):
         # NOTE: HF's tokenizer/processor that has the apply_chat_template method
         self.processor = processor or getattr(tokenizer, "tokenizer", None)
 
-    def _is_phi4_reasoning_vision_processor(self) -> bool:
-        return type(self.processor).__name__ == "Phi4VisionRProcessor"
-
     def _get_chat_template_target(self) -> Any:
         if self.processor is None:
             return None
 
         tokenizer = getattr(self.processor, "tokenizer", None)
-        if (
-            self._is_phi4_reasoning_vision_processor()
-            and getattr(tokenizer, "chat_template", None) is not None
-        ):
+        if getattr(tokenizer, "chat_template", None) is not None:
             return tokenizer
 
         if getattr(self.processor, "chat_template", None) is not None:
@@ -47,6 +41,16 @@ class ADInputProcessor(DefaultInputProcessor):
             return tokenizer
 
         return self.processor
+
+    def _should_apply_chat_template_to_prompt(self, inputs: Dict[str, Any]) -> bool:
+        if "messages" in inputs or "prompt" not in inputs or "multi_modal_data" in inputs:
+            return False
+
+        # When a multimodal processor wraps a tokenizer with a chat template, route prompt-only
+        # requests through that template instead of falling back to raw tokenizer.encode().
+        return getattr(self.processor, "tokenizer", None) is not None and (
+            self._get_chat_template_target() is not None
+        )
 
     def __call__(
         self, inputs: Dict[str, Any], sampling_params: SamplingParams
@@ -64,11 +68,7 @@ class ADInputProcessor(DefaultInputProcessor):
                 "max_length": sampling_params.truncate_prompt_tokens,
             }
 
-        if (
-            self._is_phi4_reasoning_vision_processor()
-            and "messages" not in inputs
-            and "prompt" in inputs
-        ):
+        if self._should_apply_chat_template_to_prompt(inputs):
             inputs = {
                 **inputs,
                 "messages": [{"role": "user", "content": inputs["prompt"]}],

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -41,7 +41,6 @@ class ADInputProcessor(DefaultInputProcessor):
                 "truncation": True,
                 "max_length": sampling_params.truncate_prompt_tokens,
             }
-
         # check for messages field and if yes, use the apply_chat_template method
         if "messages" in inputs:
             # multi_modal_data should not be present in the messages field

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -26,32 +26,6 @@ class ADInputProcessor(DefaultInputProcessor):
         # NOTE: HF's tokenizer/processor that has the apply_chat_template method
         self.processor = processor or getattr(tokenizer, "tokenizer", None)
 
-    def _get_chat_template_target(self) -> Any:
-        if self.processor is None:
-            return None
-
-        tokenizer = getattr(self.processor, "tokenizer", None)
-        if getattr(tokenizer, "chat_template", None) is not None:
-            return tokenizer
-
-        if getattr(self.processor, "chat_template", None) is not None:
-            return self.processor
-
-        if getattr(tokenizer, "chat_template", None) is not None:
-            return tokenizer
-
-        return self.processor
-
-    def _should_apply_chat_template_to_prompt(self, inputs: Dict[str, Any]) -> bool:
-        if "messages" in inputs or "prompt" not in inputs or "multi_modal_data" in inputs:
-            return False
-
-        # When a multimodal processor wraps a tokenizer with a chat template, route prompt-only
-        # requests through that template instead of falling back to raw tokenizer.encode().
-        return getattr(self.processor, "tokenizer", None) is not None and (
-            self._get_chat_template_target() is not None
-        )
-
     def __call__(
         self, inputs: Dict[str, Any], sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
@@ -68,32 +42,22 @@ class ADInputProcessor(DefaultInputProcessor):
                 "max_length": sampling_params.truncate_prompt_tokens,
             }
 
-        if self._should_apply_chat_template_to_prompt(inputs):
-            inputs = {
-                **inputs,
-                "messages": [{"role": "user", "content": inputs["prompt"]}],
-            }
-
         # check for messages field and if yes, use the apply_chat_template method
         if "messages" in inputs:
             # multi_modal_data should not be present in the messages field
             assert "multi_modal_data" not in inputs, f"unexpected multi_modal_data key in {inputs=}"
-            messages = inputs["messages"]
-            chat_template_target = self._get_chat_template_target()
-            if chat_template_target is None:
-                raise ValueError("processor or tokenizer with apply_chat_template is required")
 
             # TODO: we don't really need this but it makes for a good sanity check. Consider
             # removing this in the future if we need to speed things up.
-            prompt = chat_template_target.apply_chat_template(
-                messages,
+            prompt = self.processor.apply_chat_template(
+                inputs["messages"],
                 add_generation_prompt=True,
                 tokenize=False,
             )
             inputs["prompt"] = prompt
 
-            all_args = chat_template_target.apply_chat_template(
-                messages,
+            all_args = self.processor.apply_chat_template(
+                inputs["messages"],
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -3,6 +3,8 @@ from .modeling_glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .modeling_kimi_k2 import KimiK2ForCausalLM, KimiK25ForConditionalGeneration
 from .modeling_nemotron_flash import NemotronFlashForCausalLM, NemotronFlashPreTrainedTokenizerFast
 from .modeling_nemotron_h import NemotronHForCausalLM
+from .modeling_phi4 import Phi4ForCausalLM
+from .modeling_phi4flash import Phi4FlashForCausalLM
 from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM, Qwen3_5MoeForConditionalGeneration
 
 __all__ = (
@@ -13,6 +15,8 @@ __all__ = (
     "NemotronFlashForCausalLM",
     "NemotronFlashPreTrainedTokenizerFast",
     "NemotronHForCausalLM",
+    "Phi4ForCausalLM",
+    "Phi4FlashForCausalLM",
     "Qwen3_5MoeForCausalLM",
     "Qwen3_5MoeForConditionalGeneration",
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -4,7 +4,9 @@ from .modeling_kimi_k2 import KimiK2ForCausalLM, KimiK25ForConditionalGeneration
 from .modeling_nemotron_flash import NemotronFlashForCausalLM, NemotronFlashPreTrainedTokenizerFast
 from .modeling_nemotron_h import NemotronHForCausalLM
 from .modeling_phi4 import Phi4ForCausalLM
+from .modeling_phi4_visionr import Phi4VisionRForConditionalGeneration
 from .modeling_phi4flash import Phi4FlashForCausalLM
+from .modeling_phi4mm import Phi4MMForCausalLM
 from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM, Qwen3_5MoeForConditionalGeneration
 
 __all__ = (
@@ -16,7 +18,9 @@ __all__ = (
     "NemotronFlashPreTrainedTokenizerFast",
     "NemotronHForCausalLM",
     "Phi4ForCausalLM",
+    "Phi4MMForCausalLM",
     "Phi4FlashForCausalLM",
+    "Phi4VisionRForConditionalGeneration",
     "Qwen3_5MoeForCausalLM",
     "Qwen3_5MoeForConditionalGeneration",
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Slimmed down PyTorch Phi-4 model implementation for auto_deploy export.
+
+Source:
+https://huggingface.co/microsoft/phi-4
+
+This implementation differs from the original HuggingFace version in the following ways:
+* Simplified for prefill-only inference (no KV caching)
+* Uses auto_deploy custom ops for export compatibility
+* Removed flash attention variants (uses torch_attention custom op)
+* Removed gradient checkpointing and training code paths
+* Removed attention dropout and residual dropout (inference only)
+* Removed attention mask (AD manages masking via transforms and runtime)
+
+Phi-4 uses Phi3Config (model_type="phi3") with GQA, fused QKV projection,
+fused gate+up MLP (SwiGLU), and standard RoPE.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.phi3.configuration_phi3 import Phi3Config
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+
+class Phi4RMSNorm(nn.Module):
+    """RMS Normalization for Phi-4.
+
+    Uses standard torch operations so AD fusion passes can replace with
+    the appropriate backend (flashinfer/triton) based on config.
+    """
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class Phi4RotaryEmbedding(nn.Module):
+    """Rotary Position Embedding for Phi-4.
+
+    Precomputes and caches cos/sin values. Returns full cached values
+    (not sliced by seq_len) to enable export.
+
+    Uses _ad_ prefix for buffer names to work with AutoDeploy's lift_to_meta.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int = 4096,
+        base: float = 10000.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float() / self.dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+        # Build cos/sin cache with AD-specific naming
+        self._set_cos_sin_cache(max_position_embeddings)
+
+    def _set_cos_sin_cache(self, seq_len: int):
+        self.max_seq_len_cached = seq_len
+        t = torch.arange(seq_len, dtype=self.inv_freq.dtype)
+        freqs = torch.outer(t, self.inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        # Use _ad_ prefix for AutoDeploy compatibility with lift_to_meta
+        self.register_buffer("_ad_cos_cached", emb.cos(), persistent=False)
+        self.register_buffer("_ad_sin_cached", emb.sin(), persistent=False)
+
+    def forward(
+        self, x: torch.Tensor, seq_len: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Return full cached cos/sin (not sliced) for export compatibility
+        return (
+            self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
+        )
+
+
+class Phi4MLP(nn.Module):
+    """MLP layer for Phi-4 (SwiGLU activation with fused gate+up projection).
+
+    Uses fused gate_up_proj to match HF checkpoint format.
+    """
+
+    def __init__(self, config: Phi3Config):
+        super().__init__()
+        self.gate_up_proj = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.activation_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        up_states = self.gate_up_proj(hidden_states)
+        gate, up_states = up_states.chunk(2, dim=-1)
+        up_states = up_states * self.activation_fn(gate)
+        return self.down_proj(up_states)
+
+
+class Phi4Attention(nn.Module):
+    """Multi-head attention with GQA for Phi-4.
+
+    Uses fused QKV projection to match HF checkpoint format.
+    Receives position embeddings from the model level (shared rotary embedding).
+    """
+
+    def __init__(self, config: Phi3Config, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim ** (-0.5)
+
+        # Fused QKV projection (matches HF checkpoint key: qkv_proj.weight)
+        op_size = self.num_heads * self.head_dim + 2 * (self.num_key_value_heads * self.head_dim)
+        self.qkv_proj = nn.Linear(config.hidden_size, op_size, bias=False)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        bsz, q_len, _ = hidden_states.size()
+
+        # Fused QKV projection and split
+        qkv = self.qkv_proj(hidden_states)
+        query_pos = self.num_heads * self.head_dim
+        kv_pos = self.num_key_value_heads * self.head_dim
+
+        query_states = qkv[..., :query_pos]
+        key_states = qkv[..., query_pos : query_pos + kv_pos]
+        value_states = qkv[..., query_pos + kv_pos :]
+
+        # Reshape to [B, S, N, head_dim] (BSND layout)
+        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+
+        # Get cos/sin from position_embeddings (full cached from shared rotary embedding)
+        cos = position_embeddings[0]  # Full table: [max_seq_len, head_dim]
+        sin = position_embeddings[1]  # Full table: [max_seq_len, head_dim]
+        cos = cos[position_ids]  # [B, S, head_dim]
+        sin = sin[position_ids]  # [B, S, head_dim]
+
+        # Apply RoPE using custom op (BSND layout, unsqueeze_dim=2)
+        query_states, key_states = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
+            query_states,
+            key_states,
+            cos,
+            sin,
+            2,  # unsqueeze_dim=2 for BSND layout
+        )
+
+        # Attention using custom op (BSND layout with GQA support)
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            query_states,
+            key_states,
+            value_states,
+            is_causal=True,
+            scale=self.scaling,
+            layout="bsnd",
+        )
+
+        # Reshape output [B, S, N, head_dim] -> [B, S, hidden_size]
+        attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.head_dim)
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output
+
+
+class Phi4DecoderLayer(nn.Module):
+    """Transformer decoder layer for Phi-4."""
+
+    def __init__(self, config: Phi3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Phi4Attention(config, layer_idx=layer_idx)
+        self.mlp = Phi4MLP(config)
+        self.input_layernorm = Phi4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Phi4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        # Self attention
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, position_ids, position_embeddings)
+        hidden_states = residual + hidden_states
+
+        # MLP
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+@dataclass
+class Phi4ModelOutput(ModelOutput):
+    """Output for Phi4Model."""
+
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Phi4CausalLMOutput(ModelOutput):
+    """Output for Phi4ForCausalLM."""
+
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Phi4PreTrainedModel(PreTrainedModel):
+    """Base class for Phi-4 models."""
+
+    config_class = Phi3Config
+    base_model_prefix = "model"
+    _no_split_modules = ["Phi4DecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Phi4Model(Phi4PreTrainedModel):
+    """Phi-4 transformer decoder model."""
+
+    def __init__(self, config: Phi3Config):
+        super().__init__(config)
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Phi4DecoderLayer(config, layer_idx=idx) for idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Phi4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # Shared rotary embedding at model level
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        rotary_dim = int(head_dim * config.partial_rotary_factor)
+        self.rotary_emb = Phi4RotaryEmbedding(
+            rotary_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            base=config.rope_theta,
+        )
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi4ModelOutput:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("Cannot specify both input_ids and inputs_embeds")
+        elif input_ids is None and inputs_embeds is None:
+            raise ValueError("Must specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        batch_size, seq_length = inputs_embeds.shape[:2]
+
+        if position_ids is None:
+            device = input_ids.device if input_ids is not None else inputs_embeds.device
+            position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
+            position_ids = position_ids.unsqueeze(0).expand(batch_size, -1)
+
+        # Compute position embeddings once from shared rotary embedding
+        position_embeddings = self.rotary_emb(inputs_embeds)
+
+        hidden_states = inputs_embeds
+
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(hidden_states, position_ids, position_embeddings)
+
+        hidden_states = self.norm(hidden_states)
+
+        return Phi4ModelOutput(last_hidden_state=hidden_states)
+
+
+class Phi4ForCausalLM(Phi4PreTrainedModel, GenerationMixin):
+    """Phi-4 model with language modeling head."""
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Phi3Config, **kwargs):
+        super().__init__(config)
+        self.model = Phi4Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi4CausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        logits = self.lm_head(hidden_states).float()
+
+        return Phi4CausalLMOutput(logits=logits)
+
+
+# Register with AutoModelForCausalLMFactory
+# Phi-4 uses Phi3Config (model_type="phi3") so we register against "Phi3Config"
+AutoModelForCausalLMFactory.register_custom_model_cls("Phi3Config", Phi4ForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4.py
@@ -346,6 +346,25 @@ class Phi4ForCausalLM(Phi4PreTrainedModel, GenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
+    @classmethod
+    def supports_model_config(
+        cls, config: Phi3Config, model_name_or_path: Optional[str] = None
+    ) -> bool:
+        """Limit this custom path to the Phi-4 mini text-family geometry.
+
+        The larger Phi-4 text models also use ``Phi3Config``, but they have a different attention
+        projection layout in the checkpoint and must continue through the upstream HF
+        ``Phi3ForCausalLM`` implementation instead of this slimmed-down mini wrapper.
+        """
+        return (
+            getattr(config, "hidden_size", None) == 3072
+            and getattr(config, "intermediate_size", None) == 8192
+            and getattr(config, "num_hidden_layers", None) == 32
+            and getattr(config, "num_attention_heads", None) == 24
+            and getattr(config, "num_key_value_heads", None) == 8
+            and getattr(config, "partial_rotary_factor", None) == 0.75
+        )
+
     def __init__(self, config: Phi3Config, **kwargs):
         super().__init__(config)
         self.model = Phi4Model(config)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
@@ -43,7 +43,10 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.models.phi3.configuration_phi3 import Phi3Config
 from transformers.utils import ModelOutput
 
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.auto_deploy.models.hf import (
+    AutoModelForCausalLMFactory,
+    AutoModelForImageTextToTextFactory,
+)
 
 IGNORE_INDEX = -100
 IMAGE_TOKEN_INDEX = -200
@@ -969,5 +972,11 @@ AutoModelForCausalLMFactory.register_custom_model_cls(
     "Phi4VisionRConfig", Phi4VisionRForConditionalGeneration
 )
 AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Phi4VisionR", Phi4VisionRForConditionalGeneration
+)
+AutoModelForImageTextToTextFactory.register_custom_model_cls(
+    "Phi4VisionRConfig", Phi4VisionRForConditionalGeneration
+)
+AutoModelForImageTextToTextFactory.register_custom_model_cls(
     "Phi4VisionR", Phi4VisionRForConditionalGeneration
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
@@ -28,12 +28,15 @@ This implementation differs from the Hugging Face version in the following ways:
   exported text submodule.
 """
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
+from accelerate import init_empty_weights
 from torch import nn
+from torch._prims_common import DeviceLikeType
 from transformers import AutoConfig, Siglip2VisionConfig
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
@@ -43,10 +46,13 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.models.phi3.configuration_phi3 import Phi3Config
 from transformers.utils import ModelOutput
 
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     AutoModelForImageTextToTextFactory,
 )
+from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
+from tensorrt_llm.tokenizer.tokenizer import TransformersTokenizer
 
 IGNORE_INDEX = -100
 IMAGE_TOKEN_INDEX = -200
@@ -958,6 +964,72 @@ class Phi4VisionRForConditionalGeneration(PreTrainedModel, GenerationMixin):
         )
         logits = self.lm_head(outputs.last_hidden_state).float()
         return Phi4VisionCausalLMOutput(logits=logits)
+
+
+class Phi4VisionRTokenizer(TransformersTokenizer):
+    """Tokenizer wrapper that applies the default chat template for raw text prompts."""
+
+    def encode(self, text: str, *args, **kwargs) -> List[int]:
+        if (
+            getattr(self.tokenizer, "chat_template", None) is not None
+            and "<|im_start|>" not in text
+        ):
+            text = self.tokenizer.apply_chat_template(
+                [{"role": "user", "content": text}],
+                add_generation_prompt=True,
+                tokenize=False,
+            )
+        return super().encode(text, *args, **kwargs)
+
+
+class Phi4VisionRProcessorWrapper:
+    """Processor wrapper that uses the tokenizer chat template for text-only messages."""
+
+    def __init__(self, processor):
+        self.processor = processor
+        self.tokenizer = Phi4VisionRTokenizer(processor.tokenizer)
+
+    def __call__(self, *args, **kwargs):
+        return self.processor(*args, **kwargs)
+
+    def apply_chat_template(self, conversation, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(conversation, *args, **kwargs)
+
+
+@ModelFactoryRegistry.register("Phi4VisionRAutoModelForImageTextToText")
+class Phi4VisionRAutoModelForImageTextToTextFactory(AutoModelForImageTextToTextFactory):
+    """Model-specific ImageTextToText factory that keeps Phi-4 prompt templating out of llm.py."""
+
+    def _build_model(self, device: DeviceLikeType) -> nn.Module:
+        model_config, unused_kwargs = self._get_model_config()
+        with (init_empty_weights if device == "meta" else nullcontext)():
+            ad_logger.info(
+                f"Using custom model implementation {Phi4VisionRForConditionalGeneration}"
+            )
+            model = Phi4VisionRForConditionalGeneration._from_config(model_config, **unused_kwargs)
+
+        if device == "meta":
+            if hasattr(model, "post_init"):
+                model.post_init()
+        else:
+            model.to(device)
+
+        self._set_sharding_config(model.config)
+        self._checkpoint_conversion_mapping = getattr(model, "_checkpoint_conversion_mapping", None)
+        model.eval()
+        return model
+
+    def init_processor(self) -> Optional[Phi4VisionRProcessorWrapper]:
+        processor = super().init_processor()
+        if processor is None:
+            return None
+        return Phi4VisionRProcessorWrapper(processor)
+
+    def init_tokenizer(self) -> Optional[Phi4VisionRTokenizer]:
+        processor = self.init_processor()
+        if processor is None:
+            return None
+        return processor.tokenizer
 
 
 try:

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4_visionr.py
@@ -1,0 +1,973 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Slimmed down Phi-4-reasoning-vision-15B implementation for auto_deploy export.
+
+Source:
+https://huggingface.co/microsoft/Phi-4-reasoning-vision-15B
+
+This implementation differs from the Hugging Face version in the following ways:
+* The top-level config is flattened to match the checkpoint config.json, but a nested
+  ``text_config`` is created internally so AutoDeploy can export the text submodule.
+* The text decoder is prefill-only (no KV cache / decode-time runtime args).
+* The text attention uses AutoDeploy reference ops (``torch_attention`` and
+  ``torch_rope_with_explicit_cos_sin``).
+* The SigLIP2 vision tower stays in eager mode and is used only by the wrapper path.
+* Vision placeholders are expanded into embeddings in plain PyTorch before calling the
+  exported text submodule.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import AutoConfig, Siglip2VisionConfig
+from transformers.activations import ACT2FN
+from transformers.configuration_utils import PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.phi3.configuration_phi3 import Phi3Config
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+IGNORE_INDEX = -100
+IMAGE_TOKEN_INDEX = -200
+
+
+def _infer_siglip_patch_size(mm_vision_tower: Optional[str], vision_config: Dict) -> int:
+    patch_size = vision_config.get("patch_size", None)
+    if patch_size is not None:
+        return patch_size
+    tower_name = (mm_vision_tower or "").lower()
+    if "patch14" in tower_name:
+        return 14
+    return 16
+
+
+def build_vision_projector(config: "Phi4VisionRConfig") -> nn.Module:
+    """Build the MLP projector used by the HF checkpoint."""
+    projector_type = getattr(config, "mm_projector_type", "mlp2x_gelu")
+
+    if projector_type == "linear":
+        return nn.Linear(config.mm_hidden_size, config.text_config.hidden_size)
+
+    if projector_type.startswith("mlp") and projector_type.endswith("x_gelu"):
+        depth = int(projector_type[len("mlp") : projector_type.index("x_gelu")])
+        modules: List[nn.Module] = [
+            nn.Linear(config.mm_hidden_size, config.text_config.hidden_size)
+        ]
+        for _ in range(1, depth):
+            modules.append(nn.GELU())
+            modules.append(
+                nn.Linear(config.text_config.hidden_size, config.text_config.hidden_size)
+            )
+        return nn.Sequential(*modules)
+
+    if projector_type == "identity":
+        return nn.Identity()
+
+    raise ValueError(f"Unsupported mm_projector_type: {projector_type}")
+
+
+class Phi4VisionRConfig(PretrainedConfig):
+    """Flattened config for Phi-4-reasoning-vision-15B with nested text_config."""
+
+    model_type = "phi4-siglip"
+
+    def __init__(
+        self,
+        text_config: Optional[Union[Phi3Config, Dict]] = None,
+        vision_config: Optional[Union[Siglip2VisionConfig, Dict]] = None,
+        mm_vision_tower: Optional[str] = None,
+        mm_projector_type: str = "mlp2x_gelu",
+        mm_hidden_size: int = 1152,
+        min_num_patches: int = 256,
+        max_num_patches: int = 3600,
+        tokenizer_model_max_length: int = 16384,
+        tokenizer_padding_side: str = "right",
+        use_mm_proj: bool = True,
+        image_aspect_ratio: str = "square",
+        freeze_mm_mlp_adapter: bool = False,
+        tune_mm_mlp_adapter: bool = False,
+        unfreeze_vision_tower: bool = True,
+        use_s2: bool = False,
+        mm_projector_lr: Optional[float] = None,
+        **kwargs,
+    ):
+        if text_config is None:
+            text_kwargs = dict(kwargs)
+            text_config = Phi3Config(**text_kwargs)
+        elif isinstance(text_config, dict):
+            text_config = Phi3Config(**text_config)
+
+        vision_config_dict: Dict
+        if vision_config is None:
+            vision_config_dict = {}
+        elif isinstance(vision_config, Siglip2VisionConfig):
+            vision_config_dict = vision_config.to_dict()
+        else:
+            vision_config_dict = dict(vision_config)
+
+        vision_config_dict.setdefault(
+            "patch_size", _infer_siglip_patch_size(mm_vision_tower, vision_config_dict)
+        )
+        self.vision_config = Siglip2VisionConfig(**vision_config_dict)
+        self.text_config = text_config
+
+        self.mm_vision_tower = mm_vision_tower
+        self.mm_projector_type = mm_projector_type
+        self.mm_hidden_size = mm_hidden_size
+        self.min_num_patches = min_num_patches
+        self.max_num_patches = max_num_patches
+        self.tokenizer_model_max_length = tokenizer_model_max_length
+        self.tokenizer_padding_side = tokenizer_padding_side
+        self.use_mm_proj = use_mm_proj
+        self.image_aspect_ratio = image_aspect_ratio
+        self.freeze_mm_mlp_adapter = freeze_mm_mlp_adapter
+        self.tune_mm_mlp_adapter = tune_mm_mlp_adapter
+        self.unfreeze_vision_tower = unfreeze_vision_tower
+        self.use_s2 = use_s2
+        self.mm_projector_lr = mm_projector_lr
+
+        # Mirror common text attributes on the top-level config for compatibility.
+        self.vocab_size = self.text_config.vocab_size
+        self.hidden_size = self.text_config.hidden_size
+        self.intermediate_size = self.text_config.intermediate_size
+        self.num_hidden_layers = self.text_config.num_hidden_layers
+        self.num_attention_heads = self.text_config.num_attention_heads
+        self.num_key_value_heads = self.text_config.num_key_value_heads
+        self.hidden_act = self.text_config.hidden_act
+        self.max_position_embeddings = self.text_config.max_position_embeddings
+        self.original_max_position_embeddings = getattr(
+            self.text_config,
+            "original_max_position_embeddings",
+            self.text_config.max_position_embeddings,
+        )
+        self.rms_norm_eps = self.text_config.rms_norm_eps
+        self.rope_theta = self.text_config.rope_theta
+        self.partial_rotary_factor = self.text_config.partial_rotary_factor
+        self.initializer_range = self.text_config.initializer_range
+        self.attention_bias = self.text_config.attention_bias
+        self.attention_dropout = self.text_config.attention_dropout
+        self.pad_token_id = self.text_config.pad_token_id
+        self.bos_token_id = self.text_config.bos_token_id
+        self.eos_token_id = self.text_config.eos_token_id
+        self.tie_word_embeddings = self.text_config.tie_word_embeddings
+
+        super().__init__(
+            pad_token_id=self.text_config.pad_token_id,
+            bos_token_id=self.text_config.bos_token_id,
+            eos_token_id=self.text_config.eos_token_id,
+            tie_word_embeddings=self.text_config.tie_word_embeddings,
+        )
+
+
+def _coerce_phi4_visionr_config(config: PretrainedConfig) -> Phi4VisionRConfig:
+    if isinstance(config, Phi4VisionRConfig):
+        return config
+
+    if hasattr(config, "text_config"):
+        return Phi4VisionRConfig(
+            text_config=getattr(config, "text_config"),
+            vision_config=getattr(config, "vision_config", None),
+            mm_vision_tower=getattr(config, "mm_vision_tower", None),
+            mm_projector_type=getattr(config, "mm_projector_type", "mlp2x_gelu"),
+            mm_hidden_size=getattr(config, "mm_hidden_size", 1152),
+            min_num_patches=getattr(config, "min_num_patches", 256),
+            max_num_patches=getattr(config, "max_num_patches", 3600),
+            tokenizer_model_max_length=getattr(config, "tokenizer_model_max_length", 16384),
+            tokenizer_padding_side=getattr(config, "tokenizer_padding_side", "right"),
+            use_mm_proj=getattr(config, "use_mm_proj", True),
+            image_aspect_ratio=getattr(config, "image_aspect_ratio", "square"),
+            freeze_mm_mlp_adapter=getattr(config, "freeze_mm_mlp_adapter", False),
+            tune_mm_mlp_adapter=getattr(config, "tune_mm_mlp_adapter", False),
+            unfreeze_vision_tower=getattr(config, "unfreeze_vision_tower", True),
+            use_s2=getattr(config, "use_s2", False),
+            mm_projector_lr=getattr(config, "mm_projector_lr", None),
+        )
+
+    text_config_kwargs = {}
+    for key in (
+        "vocab_size",
+        "hidden_size",
+        "intermediate_size",
+        "num_hidden_layers",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "hidden_act",
+        "max_position_embeddings",
+        "original_max_position_embeddings",
+        "rms_norm_eps",
+        "rope_theta",
+        "rope_scaling",
+        "partial_rotary_factor",
+        "attention_dropout",
+        "attention_bias",
+        "resid_pdrop",
+        "pad_token_id",
+        "bos_token_id",
+        "eos_token_id",
+        "tie_word_embeddings",
+        "initializer_range",
+        "head_dim",
+    ):
+        if hasattr(config, key):
+            text_config_kwargs[key] = getattr(config, key)
+
+    return Phi4VisionRConfig(
+        text_config=Phi3Config(**text_config_kwargs),
+        vision_config=getattr(config, "vision_config", None),
+        mm_vision_tower=getattr(config, "mm_vision_tower", None),
+        mm_projector_type=getattr(config, "mm_projector_type", "mlp2x_gelu"),
+        mm_hidden_size=getattr(config, "mm_hidden_size", 1152),
+        min_num_patches=getattr(config, "min_num_patches", 256),
+        max_num_patches=getattr(config, "max_num_patches", 3600),
+        tokenizer_model_max_length=getattr(config, "tokenizer_model_max_length", 16384),
+        tokenizer_padding_side=getattr(config, "tokenizer_padding_side", "right"),
+        use_mm_proj=getattr(config, "use_mm_proj", True),
+        image_aspect_ratio=getattr(config, "image_aspect_ratio", "square"),
+        freeze_mm_mlp_adapter=getattr(config, "freeze_mm_mlp_adapter", False),
+        tune_mm_mlp_adapter=getattr(config, "tune_mm_mlp_adapter", False),
+        unfreeze_vision_tower=getattr(config, "unfreeze_vision_tower", True),
+        use_s2=getattr(config, "use_s2", False),
+        mm_projector_lr=getattr(config, "mm_projector_lr", None),
+    )
+
+
+class Phi4VisionRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class Phi4VisionRotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int = 4096,
+        base: float = 10000.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float() / self.dim))
+        self.register_buffer("_ad_inv_freq", inv_freq, persistent=False)
+        self._set_cos_sin_cache(max_position_embeddings)
+
+    def _set_cos_sin_cache(self, seq_len: int):
+        t = torch.arange(seq_len, dtype=self._ad_inv_freq.dtype)
+        freqs = torch.outer(t, self._ad_inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("_ad_cos_cached", emb.cos(), persistent=False)
+        self.register_buffer("_ad_sin_cached", emb.sin(), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return (
+            self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
+        )
+
+
+class Phi4VisionMLP(nn.Module):
+    def __init__(self, config: Phi3Config):
+        super().__init__()
+        self.gate_up_proj = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.activation_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        up_states = self.gate_up_proj(hidden_states)
+        gate, up_states = up_states.chunk(2, dim=-1)
+        up_states = up_states * self.activation_fn(gate)
+        return self.down_proj(up_states)
+
+
+class Phi4VisionAttention(nn.Module):
+    def __init__(self, config: Phi3Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim ** (-0.5)
+
+        op_size = self.num_heads * self.head_dim + 2 * (self.num_key_value_heads * self.head_dim)
+        self.qkv_proj = nn.Linear(config.hidden_size, op_size, bias=False)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+
+        qkv = self.qkv_proj(hidden_states)
+        query_pos = self.num_heads * self.head_dim
+        kv_pos = self.num_key_value_heads * self.head_dim
+
+        query_states = qkv[..., :query_pos]
+        key_states = qkv[..., query_pos : query_pos + kv_pos]
+        value_states = qkv[..., query_pos + kv_pos :]
+
+        query_states = query_states.view(batch_size, seq_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(
+            batch_size, seq_len, self.num_key_value_heads, self.head_dim
+        )
+
+        cos, sin = position_embeddings
+        cos = cos[position_ids]
+        sin = sin[position_ids]
+
+        query_states, key_states = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
+            query_states, key_states, cos, sin, 2
+        )
+
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            query_states,
+            key_states,
+            value_states,
+            is_causal=True,
+            scale=self.scaling,
+            layout="bsnd",
+        )
+        attn_output = attn_output.reshape(batch_size, seq_len, self.num_heads * self.head_dim)
+        return self.o_proj(attn_output)
+
+
+class Phi4VisionDecoderLayer(nn.Module):
+    def __init__(self, config: Phi3Config, layer_idx: int):
+        super().__init__()
+        self.self_attn = Phi4VisionAttention(config, layer_idx=layer_idx)
+        self.mlp = Phi4VisionMLP(config)
+        self.input_layernorm = Phi4VisionRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Phi4VisionRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, position_ids, position_embeddings)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+@dataclass
+class Phi4VisionTextOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Phi4VisionCausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+def _prepare_4d_attention_mask(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    mask = attention_mask[:, None, None, :].to(dtype)
+    return (1.0 - mask) * torch.finfo(dtype).min
+
+
+def _eager_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+) -> torch.Tensor:
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        attn_weights = attn_weights + attention_mask
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    return torch.matmul(attn_weights, value).transpose(1, 2).contiguous()
+
+
+class Phi4VisionSiglip2Embeddings(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.patch_size = config.patch_size
+        self.patch_embedding = nn.Linear(
+            config.num_channels * self.patch_size * self.patch_size,
+            self.embed_dim,
+        )
+        self.num_patches = config.num_patches
+        self.position_embedding_size = int(self.num_patches**0.5)
+        self.position_embedding = nn.Embedding(self.num_patches, self.embed_dim)
+
+    @staticmethod
+    def resize_positional_embeddings(
+        positional_embeddings: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+        max_length: int,
+    ) -> torch.Tensor:
+        batch_size = spatial_shapes.shape[0]
+        embed_dim = positional_embeddings.shape[-1]
+        source_dtype = positional_embeddings.dtype
+        resized_embeddings = torch.empty(
+            (batch_size, max_length, embed_dim),
+            device=positional_embeddings.device,
+            dtype=source_dtype,
+        )
+        positional_embeddings = positional_embeddings.permute(2, 0, 1).unsqueeze(0)
+        if positional_embeddings.device.type == "cpu":
+            positional_embeddings = positional_embeddings.to(torch.float32)
+
+        for idx in range(batch_size):
+            height, width = spatial_shapes[idx]
+            resized = F.interpolate(
+                positional_embeddings,
+                size=(int(height), int(width)),
+                mode="bilinear",
+                align_corners=False,
+                antialias=True,
+            )
+            resized = resized.reshape(embed_dim, int(height) * int(width)).transpose(0, 1)
+            resized = resized.to(source_dtype)
+            resized_embeddings[idx, : int(height) * int(width)] = resized
+            resized_embeddings[idx, int(height) * int(width) :] = resized[0]
+        return resized_embeddings
+
+    def forward(
+        self, pixel_values: torch.FloatTensor, spatial_shapes: torch.LongTensor
+    ) -> torch.Tensor:
+        patch_embeds = self.patch_embedding(
+            pixel_values.to(dtype=self.patch_embedding.weight.dtype)
+        )
+        positional_embeddings = self.position_embedding.weight.reshape(
+            self.position_embedding_size, self.position_embedding_size, -1
+        )
+        resized_positional_embeddings = self.resize_positional_embeddings(
+            positional_embeddings,
+            spatial_shapes,
+            max_length=pixel_values.shape[1],
+        )
+        return patch_embeds + resized_positional_embeddings
+
+
+class Phi4VisionSiglip2Attention(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        batch_size, seq_length, embed_dim = hidden_states.shape
+        query_states = (
+            self.q_proj(hidden_states)
+            .view(batch_size, seq_length, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        key_states = (
+            self.k_proj(hidden_states)
+            .view(batch_size, seq_length, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        value_states = (
+            self.v_proj(hidden_states)
+            .view(batch_size, seq_length, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        attn_output = _eager_attention(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask=attention_mask,
+            scaling=self.scale,
+        )
+        attn_output = attn_output.reshape(batch_size, seq_length, embed_dim)
+        return self.out_proj(attn_output), None
+
+
+class Phi4VisionSiglip2MLP(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class Phi4VisionSiglip2EncoderLayer(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.self_attn = Phi4VisionSiglip2Attention(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = Phi4VisionSiglip2MLP(config)
+
+    def forward(self, hidden_states: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states, _ = self.self_attn(hidden_states, attention_mask=attention_mask)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class Phi4VisionSiglip2Encoder(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [Phi4VisionSiglip2EncoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        output_hidden_states: bool = False,
+    ) -> BaseModelOutput:
+        hidden_states = inputs_embeds
+        all_hidden_states = [hidden_states] if output_hidden_states else None
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, attention_mask)
+            if output_hidden_states:
+                all_hidden_states.append(hidden_states)
+        return BaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=tuple(all_hidden_states) if output_hidden_states else None,
+        )
+
+
+class Phi4VisionSiglip2MultiheadAttentionPoolingHead(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.probe = nn.Parameter(torch.randn(1, 1, config.hidden_size))
+        self.attention = nn.MultiheadAttention(
+            config.hidden_size, config.num_attention_heads, batch_first=True
+        )
+        self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = Phi4VisionSiglip2MLP(config)
+        self.num_heads = config.num_attention_heads
+
+    def forward(
+        self, hidden_state: torch.Tensor, attention_mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        batch_size = hidden_state.shape[0]
+        probe = self.probe.repeat(batch_size, 1, 1)
+        if attention_mask is not None:
+            target_len, source_len = probe.shape[1], hidden_state.shape[1]
+            attn_mask = _prepare_4d_attention_mask(attention_mask, hidden_state.dtype)
+            attn_mask = attn_mask.repeat(1, self.num_heads, target_len, 1)
+            attn_mask = attn_mask.reshape(-1, target_len, source_len)
+        else:
+            attn_mask = None
+        hidden_state = self.attention(probe, hidden_state, hidden_state, attn_mask=attn_mask)[0]
+        residual = hidden_state
+        hidden_state = self.layernorm(hidden_state)
+        hidden_state = residual + self.mlp(hidden_state)
+        return hidden_state[:, 0]
+
+
+class Phi4VisionSiglip2VisionTransformer(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.embeddings = Phi4VisionSiglip2Embeddings(config)
+        self.encoder = Phi4VisionSiglip2Encoder(config)
+        self.post_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.head = Phi4VisionSiglip2MultiheadAttentionPoolingHead(config)
+
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        attention_mask: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+        output_hidden_states: bool = False,
+    ) -> BaseModelOutputWithPooling:
+        hidden_states = self.embeddings(pixel_values, spatial_shapes)
+        encoder_attention_mask = _prepare_4d_attention_mask(attention_mask, hidden_states.dtype)
+        encoder_outputs = self.encoder(
+            inputs_embeds=hidden_states,
+            attention_mask=encoder_attention_mask,
+            output_hidden_states=output_hidden_states,
+        )
+        last_hidden_state = self.post_layernorm(encoder_outputs.last_hidden_state)
+        pooler_output = self.head(last_hidden_state, attention_mask)
+        hidden_states_out = None
+        if output_hidden_states and encoder_outputs.hidden_states is not None:
+            hidden_states_out = tuple(
+                self.post_layernorm(hs) if idx == len(encoder_outputs.hidden_states) - 1 else hs
+                for idx, hs in enumerate(encoder_outputs.hidden_states)
+            )
+        return BaseModelOutputWithPooling(
+            last_hidden_state=last_hidden_state,
+            pooler_output=pooler_output,
+            hidden_states=hidden_states_out,
+        )
+
+
+class Phi4VisionSiglip2VisionModel(nn.Module):
+    def __init__(self, config: Siglip2VisionConfig):
+        super().__init__()
+        self.vision_model = Phi4VisionSiglip2VisionTransformer(config)
+
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        pixel_attention_mask: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+        output_hidden_states: bool = False,
+    ) -> BaseModelOutputWithPooling:
+        return self.vision_model(
+            pixel_values=pixel_values,
+            attention_mask=pixel_attention_mask,
+            spatial_shapes=spatial_shapes,
+            output_hidden_states=output_hidden_states,
+        )
+
+
+class Phi4VisionTower(nn.Module):
+    """Vision tower wrapper with the checkpoint-compatible nested ``vision_tower`` path."""
+
+    def __init__(self, config: Phi4VisionRConfig):
+        super().__init__()
+        self.vision_tower = Phi4VisionSiglip2VisionModel(config.vision_config)
+        self.select_layer = -2
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_attention_mask: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+    ) -> List[torch.Tensor]:
+        outputs = self.vision_tower(
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            spatial_shapes=spatial_shapes,
+            output_hidden_states=True,
+        )
+        hidden_states = outputs.hidden_states[self.select_layer]
+        return [
+            hidden_states[idx][pixel_attention_mask[idx].bool()]
+            for idx in range(hidden_states.shape[0])
+        ]
+
+
+class Phi4VisionRModel(nn.Module):
+    """Multimodal wrapper that keeps vision eager and calls the exported text model."""
+
+    def __init__(self, config: Phi4VisionRConfig):
+        super().__init__()
+        config = _coerce_phi4_visionr_config(config)
+        self.full_config = config
+        self.config = config.text_config
+        self.padding_idx = self.config.pad_token_id
+        self.embed_tokens = nn.Embedding(
+            self.config.vocab_size, self.config.hidden_size, self.padding_idx
+        )
+        self.layers = nn.ModuleList(
+            [
+                Phi4VisionDecoderLayer(self.config, layer_idx=idx)
+                for idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        self.norm = Phi4VisionRMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
+        head_dim = getattr(
+            self.config, "head_dim", self.config.hidden_size // self.config.num_attention_heads
+        )
+        rotary_dim = int(head_dim * self.config.partial_rotary_factor)
+        self.rotary_emb = Phi4VisionRotaryEmbedding(
+            rotary_dim,
+            max_position_embeddings=self.config.max_position_embeddings,
+            base=self.config.rope_theta,
+        )
+        self.vision_tower = Phi4VisionTower(config)
+        self.mm_projector = build_vision_projector(config)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def _forward_text(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ) -> Phi4VisionTextOutput:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("Cannot specify both input_ids and inputs_embeds")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("Must specify either input_ids or inputs_embeds")
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if position_ids is None:
+            raise ValueError("position_ids must be provided")
+
+        position_embeddings = self.rotary_emb(inputs_embeds)
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(hidden_states, position_ids, position_embeddings)
+        hidden_states = self.norm(hidden_states)
+        return Phi4VisionTextOutput(last_hidden_state=hidden_states)
+
+    def encode_images(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_attention_mask: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+    ) -> List[torch.Tensor]:
+        features = self.vision_tower(
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            spatial_shapes=spatial_shapes,
+        )
+        return [self.mm_projector(feat) for feat in features]
+
+    def _normalize_vision_inputs(
+        self,
+        pixel_values: Union[torch.Tensor, Sequence[torch.Tensor]],
+        pixel_attention_mask: Union[torch.Tensor, Sequence[torch.Tensor]],
+        spatial_shapes: Union[torch.Tensor, Sequence[torch.Tensor]],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if isinstance(pixel_values, (list, tuple)):
+            pixel_values = torch.cat(list(pixel_values), dim=0)
+        if isinstance(pixel_attention_mask, (list, tuple)):
+            pixel_attention_mask = torch.cat(list(pixel_attention_mask), dim=0)
+        if isinstance(spatial_shapes, (list, tuple)):
+            spatial_shapes = torch.cat(list(spatial_shapes), dim=0)
+        return pixel_values, pixel_attention_mask, spatial_shapes
+
+    def _merge_image_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        image_features: List[torch.Tensor],
+    ) -> List[torch.Tensor]:
+        embeds_per_sample: List[torch.Tensor] = []
+        image_idx = 0
+        embedding = self.get_input_embeddings()
+
+        for sample_ids in input_ids:
+            image_positions = torch.where(sample_ids == IMAGE_TOKEN_INDEX)[0].tolist()
+            if not image_positions:
+                embeds_per_sample.append(embedding(sample_ids))
+                continue
+
+            pieces: List[torch.Tensor] = []
+            cursor = 0
+            for pos in image_positions:
+                if cursor < pos:
+                    pieces.append(embedding(sample_ids[cursor:pos]))
+                pieces.append(image_features[image_idx])
+                image_idx += 1
+                cursor = pos + 1
+            if cursor < sample_ids.numel():
+                pieces.append(embedding(sample_ids[cursor:]))
+            embeds_per_sample.append(torch.cat(pieces, dim=0))
+
+        if image_idx != len(image_features):
+            raise ValueError(
+                f"Consumed {image_idx} image feature groups, but received {len(image_features)}."
+            )
+        return embeds_per_sample
+
+    def _forward_with_images(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: torch.Tensor,
+        pixel_attention_mask: torch.Tensor,
+        spatial_shapes: torch.LongTensor,
+    ) -> Phi4VisionTextOutput:
+        pixel_values, pixel_attention_mask, spatial_shapes = self._normalize_vision_inputs(
+            pixel_values,
+            pixel_attention_mask,
+            spatial_shapes,
+        )
+        image_features = self.encode_images(pixel_values, pixel_attention_mask, spatial_shapes)
+        inputs_embeds_per_sample = self._merge_image_embeddings(input_ids, image_features)
+
+        outputs = []
+        max_seq_len = max(embed.shape[0] for embed in inputs_embeds_per_sample)
+        for embeds in inputs_embeds_per_sample:
+            seq_len = embeds.shape[0]
+            position_ids = torch.arange(seq_len, device=embeds.device, dtype=torch.long).unsqueeze(
+                0
+            )
+            hidden_states = self._forward_text(
+                inputs_embeds=embeds.unsqueeze(0),
+                position_ids=position_ids,
+            ).last_hidden_state.squeeze(0)
+            if seq_len < max_seq_len:
+                hidden_states = torch.cat(
+                    [
+                        hidden_states,
+                        hidden_states.new_zeros(max_seq_len - seq_len, hidden_states.shape[-1]),
+                    ],
+                    dim=0,
+                )
+            outputs.append(hidden_states)
+
+        return Phi4VisionTextOutput(last_hidden_state=torch.stack(outputs, dim=0))
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pixel_values: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        pixel_attention_mask: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        spatial_shapes: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        **kwargs,
+    ) -> Phi4VisionTextOutput:
+        if pixel_values is not None:
+            if input_ids is None:
+                raise ValueError("input_ids must be provided when pixel_values are present")
+            if pixel_attention_mask is None or spatial_shapes is None:
+                raise ValueError(
+                    "pixel_attention_mask and spatial_shapes must be provided with pixel_values"
+                )
+            return self._forward_with_images(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                pixel_attention_mask=pixel_attention_mask,
+                spatial_shapes=spatial_shapes,
+            )
+
+        return self._forward_text(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+
+
+class Phi4VisionRForConditionalGeneration(PreTrainedModel, GenerationMixin):
+    """Top-level Phi-4-reasoning-vision-15B model for AutoDeploy."""
+
+    config_class = Phi4VisionRConfig
+    base_model_prefix = "model"
+    _tied_weights_keys = ["lm_head.weight"]
+    _no_split_modules = ["Phi4VisionDecoderLayer"]
+
+    def __init__(self, config: Phi4VisionRConfig, **kwargs):
+        config = _coerce_phi4_visionr_config(config)
+        super().__init__(config)
+        self.model = Phi4VisionRModel(config)
+        self.vocab_size = config.text_config.vocab_size
+        self.lm_head = nn.Linear(
+            config.text_config.hidden_size, config.text_config.vocab_size, bias=False
+        )
+        self.post_init()
+
+    def _init_weights(self, module):
+        std = self.config.text_config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pixel_values: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        pixel_attention_mask: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        spatial_shapes: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]] = None,
+        **kwargs,
+    ) -> Phi4VisionCausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            spatial_shapes=spatial_shapes,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state).float()
+        return Phi4VisionCausalLMOutput(logits=logits)
+
+
+try:
+    AutoConfig.register("phi4-siglip", Phi4VisionRConfig, exist_ok=True)
+except TypeError:
+    try:
+        AutoConfig.register("phi4-siglip", Phi4VisionRConfig)
+    except ValueError:
+        pass
+
+AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Phi4VisionRConfig", Phi4VisionRForConditionalGeneration
+)
+AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Phi4VisionR", Phi4VisionRForConditionalGeneration
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4flash.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4flash.py
@@ -137,6 +137,10 @@ def _lambda_init_fn(depth: int) -> float:
     return 0.8 - 0.6 * math.exp(-0.3 * depth)
 
 
+def _swiglu(gate: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    return value * ACT2FN["silu"](gate)
+
+
 def _split_heads(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     x = x.view(*x.shape[:-2], x.shape[-2] // 2, 2, x.shape[-1])
     return x[..., 0, :], x[..., 1, :]
@@ -323,31 +327,15 @@ class Phi4FlashMamba(nn.Module):
             )
             self.x_proj = nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False)
             self.dt_proj = nn.Linear(self.dt_rank, self.d_inner, bias=True)
-            A = torch.arange(1, self.num_heads + 1, dtype=torch.float32)
+            A = (
+                torch.arange(1, self.d_state + 1, dtype=torch.float32)
+                .unsqueeze(0)
+                .expand(self.d_inner, -1)
+                .contiguous()
+            )
             self.A_log = nn.Parameter(torch.log(A))
             self.D = nn.Parameter(torch.ones(self.d_inner))
             self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=config.mamba_proj_bias)
-            self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
-
-    def _load_state_dict_pre_hook(
-        self,
-        state_dict,
-        prefix,
-        local_metadata,
-        strict,
-        missing_keys,
-        unexpected_keys,
-        error_msgs,
-    ):
-        del local_metadata, strict, missing_keys, unexpected_keys, error_msgs
-        a_log_key = f"{prefix}A_log"
-        if a_log_key not in state_dict:
-            return
-        a_log = state_dict[a_log_key]
-        if a_log.ndim == 2 and a_log.shape[0] == self.num_heads:
-            # Phi4Flash checkpoints store A_log as [d_inner, d_state]. The AD SSM backend
-            # expects one decay scalar per head, so collapse the state dimension here.
-            state_dict[a_log_key] = a_log.to(torch.float32).mean(dim=-1).to(a_log.dtype)
 
     def forward(
         self,
@@ -357,7 +345,7 @@ class Phi4FlashMamba(nn.Module):
         dtype = hidden_states.dtype
         if self.yoco_cross:
             out = self.in_proj(hidden_states)
-            out = out * torch.sigmoid(yoco_key_values)
+            out = _swiglu(out, yoco_key_values)
             return self.out_proj(out), yoco_key_values
 
         xz = self.in_proj(hidden_states)
@@ -375,7 +363,7 @@ class Phi4FlashMamba(nn.Module):
         x = self.act(x)
         x_dbl = self.x_proj(x)
         dt, B, C = torch.split(x_dbl, [self.dt_rank, self.d_state, self.d_state], dim=-1)
-        y = torch.ops.auto_deploy.torch_ssm(
+        y = torch.ops.auto_deploy.torch_ysamba_ssm(
             hidden_states=x.view(
                 hidden_states.shape[0], hidden_states.shape[1], self.num_heads, self.head_dim
             ),
@@ -389,10 +377,11 @@ class Phi4FlashMamba(nn.Module):
             chunk_size=256,
         ).view(hidden_states.shape[0], hidden_states.shape[1], -1)
 
-        yoco_out = y if self.yoco_kv else None
         if self.yoco_kv:
-            y = y * torch.sigmoid(z)
+            yoco_out = y
+            y = _swiglu(z, y)
         else:
+            yoco_out = None
             y = y * self.act(z)
         return self.out_proj(y.to(dtype)), yoco_out
 

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4flash.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4flash.py
@@ -1,0 +1,553 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Slimmed down PyTorch Phi-4 Flash model implementation for auto_deploy export.
+
+Source:
+https://huggingface.co/microsoft/Phi-4-mini-flash-reasoning
+
+This implementation differs from the original HuggingFace version in the following ways:
+* Bundled config class (Phi4FlashConfig) for transformers compatibility
+* Simplified for prefill-only inference (no KV caching)
+* Uses auto_deploy custom ops for export compatibility (torch_attention,
+  torch_causal_conv1d, torch_ssm)
+* Replaces flash-attention / mamba custom kernels with PyTorch reference ops
+* Removed training-only code paths and dropout
+* Removed attention masks from the exported entry point; AD manages causal masking
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import AutoConfig
+from transformers.activations import ACT2FN
+from transformers.configuration_utils import PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+
+class Phi4FlashConfig(PretrainedConfig):
+    """Configuration for Phi-4-mini-flash-reasoning."""
+
+    model_type = "phi4flash"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 51200,
+        hidden_size: int = 2560,
+        intermediate_size: int = 9216,
+        num_hidden_layers: int = 32,
+        num_attention_heads: int = 40,
+        num_key_value_heads: Optional[int] = 4,
+        resid_pdrop: float = 0.0,
+        embd_pdrop: float = 0.0,
+        attention_dropout: float = 0.0,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 4096,
+        initializer_range: float = 0.02,
+        layer_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        tie_word_embeddings: bool = True,
+        rope_theta: float = 10000.0,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        pad_token_id: int = 0,
+        sliding_window: int = 2047,
+        mb_per_layer: int = 2,
+        mamba_d_state: int = 16,
+        mamba_d_conv: int = 4,
+        mamba_expand: int = 2,
+        mamba_dt_rank: str | int = "auto",
+        mamba_conv_bias: bool = True,
+        mamba_proj_bias: bool = False,
+        mlp_bias: bool = False,
+        lm_head_bias: bool = False,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = (
+            num_attention_heads if num_key_value_heads is None else num_key_value_heads
+        )
+        self.resid_pdrop = resid_pdrop
+        self.embd_pdrop = embd_pdrop
+        self.attention_dropout = attention_dropout
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.mb_per_layer = mb_per_layer
+        self.sliding_window = [
+            sliding_window if layer_idx < num_hidden_layers // 2 and layer_idx % 2 == 1 else None
+            for layer_idx in range(num_hidden_layers)
+        ]
+        self.mamba_d_state = mamba_d_state
+        self.mamba_d_conv = mamba_d_conv
+        self.mamba_expand = mamba_expand
+        self.mamba_dt_rank = (
+            math.ceil(hidden_size / 16) if mamba_dt_rank == "auto" else mamba_dt_rank
+        )
+        self.mamba_conv_bias = mamba_conv_bias
+        self.mamba_proj_bias = mamba_proj_bias
+        self.mlp_bias = mlp_bias
+        self.lm_head_bias = lm_head_bias
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+    @property
+    def layers_block_type(self):
+        layer_block_types = []
+        for idx in range(self.num_hidden_layers):
+            if idx % 2 == 1:
+                layer_block_type = (
+                    "attention" if idx <= (self.num_hidden_layers // 2 + 1) else "shared_attention"
+                )
+            else:
+                layer_block_type = "mamba"
+            layer_block_types.append(layer_block_type)
+        return layer_block_types
+
+
+try:
+    AutoConfig.register("phi4flash", Phi4FlashConfig, exist_ok=True)
+except TypeError:
+    try:
+        AutoConfig.register("phi4flash", Phi4FlashConfig)
+    except ValueError:
+        pass
+
+
+def _lambda_init_fn(depth: int) -> float:
+    return 0.8 - 0.6 * math.exp(-0.3 * depth)
+
+
+def _split_heads(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    x = x.view(*x.shape[:-2], x.shape[-2] // 2, 2, x.shape[-1])
+    return x[..., 0, :], x[..., 1, :]
+
+
+class Phi4FlashRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class Phi4FlashMLP(nn.Module):
+    def __init__(self, config: Phi4FlashConfig):
+        super().__init__()
+        self.config = config
+        self.fc1 = nn.Linear(
+            config.hidden_size,
+            2 * config.intermediate_size,
+            bias=config.mlp_bias,
+        )
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_bias)
+        self.activation_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        y = self.fc1(hidden_states)
+        gate, up = y.chunk(2, dim=-1)
+        up = up * self.activation_fn(gate)
+        return self.fc2(up)
+
+
+class Phi4FlashDiffAttention(nn.Module):
+    def __init__(self, head_dim: int, depth: int):
+        super().__init__()
+        self.head_dim = head_dim
+        self.lambda_init = _lambda_init_fn(depth)
+        self.lambda_q1 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_k1 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_q2 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_k2 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.subln = Phi4FlashRMSNorm(2 * head_dim, eps=1e-5)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        sliding_window: Optional[int] = None,
+    ) -> torch.Tensor:
+        q1, q2 = _split_heads(q)
+        k1, k2 = _split_heads(k)
+        v1, v2 = _split_heads(v)
+
+        attn11 = torch.ops.auto_deploy.torch_attention(
+            q1, k1, v1, is_causal=True, layout="bsnd", sliding_window=sliding_window
+        )
+        attn12 = torch.ops.auto_deploy.torch_attention(
+            q1, k1, v2, is_causal=True, layout="bsnd", sliding_window=sliding_window
+        )
+        attn21 = torch.ops.auto_deploy.torch_attention(
+            q2, k2, v1, is_causal=True, layout="bsnd", sliding_window=sliding_window
+        )
+        attn22 = torch.ops.auto_deploy.torch_attention(
+            q2, k2, v2, is_causal=True, layout="bsnd", sliding_window=sliding_window
+        )
+
+        attn1 = torch.cat([attn11, attn12], dim=-1)
+        attn2 = torch.cat([attn21, attn22], dim=-1)
+
+        lambda_1 = torch.exp(torch.sum(self.lambda_q1 * self.lambda_k1, dim=-1).float()).type_as(q)
+        lambda_2 = torch.exp(torch.sum(self.lambda_q2 * self.lambda_k2, dim=-1).float()).type_as(q)
+        lambda_full = lambda_1 - lambda_2 + self.lambda_init
+
+        attn = attn1 - lambda_full * attn2
+        attn = self.subln(attn)
+        attn = attn * (1 - self.lambda_init)
+        return attn.view(*attn.shape[:-2], attn.shape[-2] * 2, self.head_dim)
+
+
+class Phi4FlashAttention(nn.Module):
+    def __init__(self, config: Phi4FlashConfig, layer_idx: int, yoco_cross: bool = False):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.yoco_cross = yoco_cross
+
+        op_size = self.num_heads * self.head_dim + 2 * (self.num_key_value_heads * self.head_dim)
+        self.out_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=True)
+        if yoco_cross:
+            self.Wqkv = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
+        else:
+            self.Wqkv = nn.Linear(self.hidden_size, op_size, bias=True)
+        self.inner_cross_attn = Phi4FlashDiffAttention(self.head_dim, layer_idx)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        yoco_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        bsz, q_len, _ = hidden_states.size()
+
+        if self.yoco_cross:
+            query_states = self.Wqkv(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim)
+            key_states, value_states = yoco_key_values
+            sliding_window = None
+        else:
+            qkv = self.Wqkv(hidden_states)
+            query_pos = self.num_heads * self.head_dim
+            kv_pos = self.num_key_value_heads * self.head_dim
+            query_states = qkv[..., :query_pos].view(bsz, q_len, self.num_heads, self.head_dim)
+            key_states = qkv[..., query_pos : query_pos + kv_pos].view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+            value_states = qkv[..., query_pos + kv_pos :].view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+            sliding_window = self.config.sliding_window[self.layer_idx]
+
+        attn_output = self.inner_cross_attn(
+            query_states,
+            key_states,
+            value_states,
+            sliding_window=sliding_window,
+        )
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size).contiguous()
+        return self.out_proj(attn_output), (key_states, value_states)
+
+
+class Phi4FlashMamba(nn.Module):
+    def __init__(
+        self,
+        config: Phi4FlashConfig,
+        layer_idx: int,
+        yoco_cross: bool = False,
+        yoco_kv: bool = False,
+    ):
+        super().__init__()
+        self.d_model = config.hidden_size
+        self.d_state = config.mamba_d_state
+        self.d_conv = config.mamba_d_conv
+        self.expand = config.mamba_expand
+        self.d_inner = int(self.expand * self.d_model)
+        self.num_heads = self.d_inner
+        self.head_dim = 1
+        self.n_groups = 1
+        self.dt_rank = config.mamba_dt_rank
+        self.layer_idx = layer_idx
+        self.yoco_cross = yoco_cross
+        self.yoco_kv = yoco_kv
+        self.activation = "silu"
+        self.act = nn.SiLU()
+
+        if self.yoco_cross:
+            self.in_proj = nn.Linear(self.d_model, self.d_inner, bias=config.mamba_proj_bias)
+            self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=config.mamba_proj_bias)
+        else:
+            self.in_proj = nn.Linear(self.d_model, self.d_inner * 2, bias=config.mamba_proj_bias)
+            self.conv1d = nn.Conv1d(
+                in_channels=self.d_inner,
+                out_channels=self.d_inner,
+                bias=config.mamba_conv_bias,
+                kernel_size=self.d_conv,
+                groups=self.d_inner,
+                padding=self.d_conv - 1,
+            )
+            self.x_proj = nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False)
+            self.dt_proj = nn.Linear(self.dt_rank, self.d_inner, bias=True)
+            A = torch.arange(1, self.num_heads + 1, dtype=torch.float32)
+            self.A_log = nn.Parameter(torch.log(A))
+            self.D = nn.Parameter(torch.ones(self.d_inner))
+            self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=config.mamba_proj_bias)
+            self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
+
+    def _load_state_dict_pre_hook(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        del local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+        a_log_key = f"{prefix}A_log"
+        if a_log_key not in state_dict:
+            return
+        a_log = state_dict[a_log_key]
+        if a_log.ndim == 2 and a_log.shape[0] == self.num_heads:
+            # Phi4Flash checkpoints store A_log as [d_inner, d_state]. The AD SSM backend
+            # expects one decay scalar per head, so collapse the state dimension here.
+            state_dict[a_log_key] = a_log.to(torch.float32).mean(dim=-1).to(a_log.dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        yoco_key_values: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        dtype = hidden_states.dtype
+        if self.yoco_cross:
+            out = self.in_proj(hidden_states)
+            out = out * torch.sigmoid(yoco_key_values)
+            return self.out_proj(out), yoco_key_values
+
+        xz = self.in_proj(hidden_states)
+        x, z = xz.chunk(2, dim=-1)
+        x = torch.ops.auto_deploy.torch_causal_conv1d(
+            x,
+            self.conv1d.weight,
+            self.conv1d.bias,
+            self.conv1d.stride[0],
+            self.conv1d.padding[0],
+            self.conv1d.dilation[0],
+            self.conv1d.groups,
+            self.conv1d.padding_mode,
+        )
+        x = self.act(x)
+        x_dbl = self.x_proj(x)
+        dt, B, C = torch.split(x_dbl, [self.dt_rank, self.d_state, self.d_state], dim=-1)
+        y = torch.ops.auto_deploy.torch_ssm(
+            hidden_states=x.view(
+                hidden_states.shape[0], hidden_states.shape[1], self.num_heads, self.head_dim
+            ),
+            A=-torch.exp(self.A_log.float()),
+            B=B.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
+            C=C.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
+            D=self.D,
+            dt=torch.matmul(dt, self.dt_proj.weight.t()),
+            dt_bias=self.dt_proj.bias,
+            time_step_limit=[0.0, float("inf")],
+            chunk_size=256,
+        ).view(hidden_states.shape[0], hidden_states.shape[1], -1)
+
+        yoco_out = y if self.yoco_kv else None
+        if self.yoco_kv:
+            y = y * torch.sigmoid(z)
+        else:
+            y = y * self.act(z)
+        return self.out_proj(y.to(dtype)), yoco_out
+
+
+class Phi4FlashDecoderLayer(nn.Module):
+    def __init__(self, config: Phi4FlashConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.mlp = Phi4FlashMLP(config)
+        self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.post_attention_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        self.yoco_mb = layer_idx >= config.num_hidden_layers // 2
+        self.yoco_cross = layer_idx >= (config.num_hidden_layers // 2 + 2)
+        attn_config = config
+        if layer_idx >= (config.num_hidden_layers // 2 + 1):
+            attn_config = Phi4FlashConfig(**config.to_dict())
+            attn_config.sliding_window = [None] * config.num_hidden_layers
+
+        self.use_mamba = config.mb_per_layer > 0 and layer_idx % config.mb_per_layer == 0
+        if self.use_mamba:
+            self.attn = Phi4FlashMamba(
+                config=attn_config,
+                layer_idx=layer_idx,
+                yoco_cross=self.yoco_cross,
+                yoco_kv=self.yoco_mb,
+            )
+        else:
+            self.attn = Phi4FlashAttention(
+                config=attn_config,
+                layer_idx=layer_idx,
+                yoco_cross=self.yoco_cross,
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        ssm_output: Optional[torch.Tensor] = None,
+        yoco_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        if self.use_mamba:
+            attn_outputs, ssm_output = self.attn(hidden_states, yoco_key_values=ssm_output)
+        else:
+            attn_outputs, yoco_key_values = self.attn(
+                hidden_states, yoco_key_values=yoco_key_values
+            )
+
+        hidden_states = residual + attn_outputs
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+        return hidden_states, ssm_output, yoco_key_values
+
+
+@dataclass
+class Phi4FlashModelOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Phi4FlashCausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Phi4FlashPreTrainedModel(PreTrainedModel):
+    config_class = Phi4FlashConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Phi4FlashDecoderLayer"]
+    _supports_flash_attn_2 = False
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Phi4FlashModel(Phi4FlashPreTrainedModel):
+    def __init__(self, config: Phi4FlashConfig):
+        config._attn_implementation = "eager"
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [
+                Phi4FlashDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.final_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: torch.LongTensor,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi4FlashModelOutput:
+        del position_ids
+        del kwargs
+        hidden_states = self.embed_tokens(input_ids) if inputs_embeds is None else inputs_embeds
+        ssm_output = None
+        yoco_key_values = None
+        for decoder_layer in self.layers:
+            hidden_states, ssm_output, yoco_key_values = decoder_layer(
+                hidden_states,
+                ssm_output=ssm_output,
+                yoco_key_values=yoco_key_values,
+            )
+        hidden_states = self.final_layernorm(hidden_states)
+        return Phi4FlashModelOutput(last_hidden_state=hidden_states)
+
+
+class Phi4FlashForCausalLM(Phi4FlashPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Phi4FlashConfig):
+        config._attn_implementation = "eager"
+        super().__init__(config)
+        self.model = Phi4FlashModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=config.lm_head_bias)
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: torch.LongTensor,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi4FlashCausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state)
+        return Phi4FlashCausalLMOutput(logits=logits)
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Phi4FlashConfig", Phi4FlashForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4mm.py
@@ -19,16 +19,15 @@ import importlib.util
 import math
 import pathlib
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple
 
 import torch
 from huggingface_hub import snapshot_download
 from torch import nn
-from transformers import AutoConfig
 from transformers.activations import ACT2FN
-from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
+from transformers.models.phi4_multimodal.configuration_phi4_multimodal import Phi4MultimodalConfig
 from transformers.utils import ModelOutput
 
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
@@ -44,6 +43,9 @@ class InputMode(enum.IntEnum):
     VISION_SPEECH = 3
 
 
+Phi4MMConfig = Phi4MultimodalConfig
+
+
 def _load_hf_aux_module(model_name_or_path: str, filename: str, module_name: str):
     root = pathlib.Path(model_name_or_path)
     module_path = root / filename
@@ -56,101 +58,6 @@ def _load_hf_aux_module(model_name_or_path: str, filename: str, module_name: str
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-class Phi4MMConfig(PretrainedConfig):
-    model_type = "phi4mm"
-
-    def __init__(
-        self,
-        vocab_size: int = 200064,
-        hidden_size: int = 3072,
-        intermediate_size: int = 8192,
-        num_hidden_layers: int = 32,
-        num_attention_heads: int = 32,
-        num_key_value_heads: Optional[int] = None,
-        resid_pdrop: float = 0.0,
-        embd_pdrop: float = 0.0,
-        attention_dropout: float = 0.0,
-        hidden_act: str = "silu",
-        max_position_embeddings: int = 4096,
-        original_max_position_embeddings: int = 4096,
-        initializer_range: float = 0.02,
-        rms_norm_eps: float = 1e-5,
-        tie_word_embeddings: bool = True,
-        rope_theta: float = 10000.0,
-        rope_scaling=None,
-        partial_rotary_factor: float = 1.0,
-        bos_token_id: int = 199999,
-        eos_token_id: Union[int, list[int]] = 199999,
-        pad_token_id: int = 199999,
-        sliding_window=None,
-        embd_layer=None,
-        img_processor=None,
-        audio_processor=None,
-        vision_lora=None,
-        speech_lora=None,
-        **kwargs,
-    ):
-        self.embd_layer = embd_layer
-        self.img_processor = img_processor
-        self.audio_processor = audio_processor
-        self.vision_lora = vision_lora
-        self.speech_lora = speech_lora
-        self.vocab_size = vocab_size
-        self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
-        self.num_hidden_layers = num_hidden_layers
-        self.num_attention_heads = num_attention_heads
-        self.num_key_value_heads = (
-            num_attention_heads if num_key_value_heads is None else num_key_value_heads
-        )
-        self.resid_pdrop = resid_pdrop
-        self.embd_pdrop = embd_pdrop
-        self.attention_dropout = attention_dropout
-        self.hidden_act = hidden_act
-        self.max_position_embeddings = max_position_embeddings
-        self.original_max_position_embeddings = original_max_position_embeddings
-        self.initializer_range = initializer_range
-        self.rms_norm_eps = rms_norm_eps
-        self.rope_theta = rope_theta
-        self.rope_scaling = rope_scaling
-        self.partial_rotary_factor = partial_rotary_factor
-        self.sliding_window = sliding_window
-        self._rope_scaling_adjustment()
-        self._rope_scaling_validation()
-        super().__init__(
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            pad_token_id=pad_token_id,
-            tie_word_embeddings=tie_word_embeddings,
-            **kwargs,
-        )
-
-    def _rope_scaling_adjustment(self):
-        if self.rope_scaling is None:
-            return
-        rope_scaling_type = self.rope_scaling.get("type", None)
-        if rope_scaling_type in ["su", "yarn"]:
-            self.rope_scaling["type"] = "longrope"
-
-    def _rope_scaling_validation(self):
-        if self.rope_scaling is None:
-            return
-        if not isinstance(self.rope_scaling, dict) or len(self.rope_scaling) != 3:
-            raise ValueError(
-                "`rope_scaling` must be a dictionary with fields `type`, `short_factor`, and `long_factor`."
-            )
-        rope_scaling_type = self.rope_scaling.get("type", None)
-        if rope_scaling_type != "longrope":
-            raise ValueError(f"`rope_scaling.type` must be `longrope`, got {rope_scaling_type}")
-        rotary_ndims = int(
-            self.hidden_size // self.num_attention_heads * self.partial_rotary_factor
-        )
-        for key in ["short_factor", "long_factor"]:
-            factors = self.rope_scaling.get(key, None)
-            if not isinstance(factors, list) or len(factors) != rotary_ndims // 2:
-                raise ValueError(f"`rope_scaling.{key}` must have length {rotary_ndims // 2}")
 
 
 class Phi4MMLoRALinear(nn.Module):
@@ -283,15 +190,15 @@ class Phi4MMMLP(nn.Module):
         self.gate_up_proj = Phi4MMLoRALinear(
             config.hidden_size,
             2 * config.intermediate_size,
-            vision_lora=config.vision_lora,
-            speech_lora=config.speech_lora,
+            vision_lora=getattr(config, "vision_lora", None),
+            speech_lora=getattr(config, "speech_lora", None),
             bias=False,
         )
         self.down_proj = Phi4MMLoRALinear(
             config.intermediate_size,
             config.hidden_size,
-            vision_lora=config.vision_lora,
-            speech_lora=config.speech_lora,
+            vision_lora=getattr(config, "vision_lora", None),
+            speech_lora=getattr(config, "speech_lora", None),
             bias=False,
         )
         self.activation_fn = ACT2FN[config.hidden_act]
@@ -325,15 +232,15 @@ class Phi4MMAttention(nn.Module):
         self.qkv_proj = Phi4MMLoRALinear(
             config.hidden_size,
             op_size,
-            vision_lora=config.vision_lora,
-            speech_lora=config.speech_lora,
+            vision_lora=getattr(config, "vision_lora", None),
+            speech_lora=getattr(config, "speech_lora", None),
             bias=False,
         )
         self.o_proj = Phi4MMLoRALinear(
             self.num_heads * self.head_dim,
             config.hidden_size,
-            vision_lora=config.vision_lora,
-            speech_lora=config.speech_lora,
+            vision_lora=getattr(config, "vision_lora", None),
+            speech_lora=getattr(config, "speech_lora", None),
             bias=False,
         )
         self.rotary_emb = Phi4MMRotaryEmbedding(self.rotary_ndims, config)
@@ -609,7 +516,7 @@ class Phi4MMAudioEmbedding(nn.Module):
         aux = _load_hf_aux_module(
             config._name_or_path, "speech_conformer_encoder.py", "phi4mm_audio_aux"
         )
-        encoder_config = config.audio_processor["config"]
+        encoder_config = getattr(config, "audio_processor", None)["config"]
         self.encoder = aux.ConformerEncoder(**encoder_config)
         hidden_size = config.hidden_size
         downsample_rate = kwargs.get("downsample_rate", 1)
@@ -757,8 +664,9 @@ class Phi4MMModel(Phi4MMPreTrainedModel):
         self.padding_idx = config.pad_token_id
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.embed_tokens_extend = None
-        if isinstance(config.embd_layer, dict):
-            self.embed_tokens_extend = Phi4MMImageAudioEmbedding(config, **config.embd_layer)
+        embd_layer = getattr(config, "embd_layer", None)
+        if isinstance(embd_layer, dict):
+            self.embed_tokens_extend = Phi4MMImageAudioEmbedding(config, **embd_layer)
         self.layers = nn.ModuleList(
             [Phi4MMDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
@@ -908,12 +816,4 @@ class Phi4MMForCausalLM(Phi4MMPreTrainedModel, GenerationMixin):
         return Phi4MMCausalLMOutput(logits=logits)
 
 
-try:
-    AutoConfig.register("phi4mm", Phi4MMConfig, exist_ok=True)
-except TypeError:
-    try:
-        AutoConfig.register("phi4mm", Phi4MMConfig)
-    except ValueError:
-        pass
-
-AutoModelForCausalLMFactory.register_custom_model_cls("Phi4MMConfig", Phi4MMForCausalLM)
+AutoModelForCausalLMFactory.register_custom_model_cls("Phi4MultimodalConfig", Phi4MMForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi4mm.py
@@ -1,0 +1,919 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prefill-only Phi-4 multimodal implementation for AutoDeploy export."""
+
+import enum
+import importlib.util
+import math
+import pathlib
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple, Union
+
+import torch
+from huggingface_hub import snapshot_download
+from torch import nn
+from transformers import AutoConfig
+from transformers.activations import ACT2FN
+from transformers.configuration_utils import PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+_IMAGE_SPECIAL_TOKEN_ID = 200010
+_AUDIO_SPECIAL_TOKEN_ID = 200011
+
+
+class InputMode(enum.IntEnum):
+    LANGUAGE = 0
+    VISION = 1
+    SPEECH = 2
+    VISION_SPEECH = 3
+
+
+def _load_hf_aux_module(model_name_or_path: str, filename: str, module_name: str):
+    root = pathlib.Path(model_name_or_path)
+    module_path = root / filename
+    if not module_path.exists():
+        snapshot_path = snapshot_download(model_name_or_path, allow_patterns=[filename])
+        module_path = pathlib.Path(snapshot_path) / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Failed to load module {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Phi4MMConfig(PretrainedConfig):
+    model_type = "phi4mm"
+
+    def __init__(
+        self,
+        vocab_size: int = 200064,
+        hidden_size: int = 3072,
+        intermediate_size: int = 8192,
+        num_hidden_layers: int = 32,
+        num_attention_heads: int = 32,
+        num_key_value_heads: Optional[int] = None,
+        resid_pdrop: float = 0.0,
+        embd_pdrop: float = 0.0,
+        attention_dropout: float = 0.0,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 4096,
+        original_max_position_embeddings: int = 4096,
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-5,
+        tie_word_embeddings: bool = True,
+        rope_theta: float = 10000.0,
+        rope_scaling=None,
+        partial_rotary_factor: float = 1.0,
+        bos_token_id: int = 199999,
+        eos_token_id: Union[int, list[int]] = 199999,
+        pad_token_id: int = 199999,
+        sliding_window=None,
+        embd_layer=None,
+        img_processor=None,
+        audio_processor=None,
+        vision_lora=None,
+        speech_lora=None,
+        **kwargs,
+    ):
+        self.embd_layer = embd_layer
+        self.img_processor = img_processor
+        self.audio_processor = audio_processor
+        self.vision_lora = vision_lora
+        self.speech_lora = speech_lora
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = (
+            num_attention_heads if num_key_value_heads is None else num_key_value_heads
+        )
+        self.resid_pdrop = resid_pdrop
+        self.embd_pdrop = embd_pdrop
+        self.attention_dropout = attention_dropout
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.original_max_position_embeddings = original_max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.partial_rotary_factor = partial_rotary_factor
+        self.sliding_window = sliding_window
+        self._rope_scaling_adjustment()
+        self._rope_scaling_validation()
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+    def _rope_scaling_adjustment(self):
+        if self.rope_scaling is None:
+            return
+        rope_scaling_type = self.rope_scaling.get("type", None)
+        if rope_scaling_type in ["su", "yarn"]:
+            self.rope_scaling["type"] = "longrope"
+
+    def _rope_scaling_validation(self):
+        if self.rope_scaling is None:
+            return
+        if not isinstance(self.rope_scaling, dict) or len(self.rope_scaling) != 3:
+            raise ValueError(
+                "`rope_scaling` must be a dictionary with fields `type`, `short_factor`, and `long_factor`."
+            )
+        rope_scaling_type = self.rope_scaling.get("type", None)
+        if rope_scaling_type != "longrope":
+            raise ValueError(f"`rope_scaling.type` must be `longrope`, got {rope_scaling_type}")
+        rotary_ndims = int(
+            self.hidden_size // self.num_attention_heads * self.partial_rotary_factor
+        )
+        for key in ["short_factor", "long_factor"]:
+            factors = self.rope_scaling.get(key, None)
+            if not isinstance(factors, list) or len(factors) != rotary_ndims // 2:
+                raise ValueError(f"`rope_scaling.{key}` must have length {rotary_ndims // 2}")
+
+
+class Phi4MMLoRALinear(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        vision_lora: Optional[Dict],
+        speech_lora: Optional[Dict],
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.base_layer = nn.Linear(in_features, out_features, bias=bias)
+        self.lora_A = nn.ModuleDict()
+        self.lora_B = nn.ModuleDict()
+        self.scaling: Dict[str, float] = {}
+        self.active_adapter: Optional[str] = None
+        self.adapters_enabled = False
+
+        if vision_lora is not None:
+            rank = vision_lora["r"]
+            self.lora_A["vision"] = nn.Linear(in_features, rank, bias=False)
+            self.lora_B["vision"] = nn.Linear(rank, out_features, bias=False)
+            self.scaling["vision"] = vision_lora["lora_alpha"] / rank
+        if speech_lora is not None:
+            rank = speech_lora["r"]
+            self.lora_A["speech"] = nn.Linear(in_features, rank, bias=False)
+            self.lora_B["speech"] = nn.Linear(rank, out_features, bias=False)
+            self.scaling["speech"] = speech_lora["lora_alpha"] / rank
+
+    def set_adapter(self, adapter_name: Optional[str]):
+        self.active_adapter = adapter_name
+        self.adapters_enabled = adapter_name in self.lora_A
+
+    def disable_adapter(self):
+        self.active_adapter = None
+        self.adapters_enabled = False
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.base_layer(x)
+        if self.adapters_enabled and self.active_adapter is not None:
+            adapter = self.active_adapter
+            out = out + self.lora_B[adapter](self.lora_A[adapter](x)) * self.scaling[adapter]
+        return out
+
+
+class Phi4MMRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class Phi4MMRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, config: Phi4MMConfig):
+        super().__init__()
+        self.dim = dim
+        self.base = config.rope_theta
+        self.original_max_position_embeddings = config.original_max_position_embeddings
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_scaling = config.rope_scaling
+        self._set_cos_sin_cache()
+
+    def _compute_inv_freq(self, scale_factors: Optional[list[float]] = None) -> torch.Tensor:
+        inv_freq_shape = torch.arange(0, self.dim, 2, dtype=torch.float32) / self.dim
+        if scale_factors is None:
+            return 1.0 / (self.base**inv_freq_shape)
+        ext_factors = torch.tensor(scale_factors, dtype=torch.float32)
+        return 1.0 / (ext_factors * (self.base**inv_freq_shape))
+
+    def _build_cache(
+        self, inv_freq: torch.Tensor, scaling_factor: float
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        timesteps = torch.arange(self.max_position_embeddings, dtype=torch.float32)
+        freqs = torch.outer(timesteps, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return emb.cos() * scaling_factor, emb.sin() * scaling_factor
+
+    def _set_cos_sin_cache(self):
+        scaling_factor = 1.0
+        if self.rope_scaling is not None:
+            scale = self.max_position_embeddings / self.original_max_position_embeddings
+            if scale > 1.0:
+                scaling_factor = math.sqrt(
+                    1 + math.log(scale) / math.log(self.original_max_position_embeddings)
+                )
+
+        default_cos, default_sin = self._build_cache(self._compute_inv_freq(), scaling_factor)
+        self.register_buffer("_ad_cos_cached", default_cos, persistent=False)
+        self.register_buffer("_ad_sin_cached", default_sin, persistent=False)
+
+        if self.rope_scaling is None:
+            return
+
+        short_cos, short_sin = self._build_cache(
+            self._compute_inv_freq(self.rope_scaling["short_factor"]), scaling_factor
+        )
+        long_cos, long_sin = self._build_cache(
+            self._compute_inv_freq(self.rope_scaling["long_factor"]), scaling_factor
+        )
+        self.register_buffer("_ad_short_cos_cached", short_cos, persistent=False)
+        self.register_buffer("_ad_short_sin_cached", short_sin, persistent=False)
+        self.register_buffer("_ad_long_cos_cached", long_cos, persistent=False)
+        self.register_buffer("_ad_long_sin_cached", long_sin, persistent=False)
+
+    def forward(self, x: torch.Tensor):
+        if self.rope_scaling is None:
+            return (
+                self._ad_cos_cached.to(dtype=x.dtype, device=x.device),
+                self._ad_sin_cached.to(dtype=x.dtype, device=x.device),
+            )
+        return (
+            self._ad_short_cos_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_short_sin_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_long_cos_cached.to(dtype=x.dtype, device=x.device),
+            self._ad_long_sin_cached.to(dtype=x.dtype, device=x.device),
+        )
+
+
+class Phi4MMMLP(nn.Module):
+    def __init__(self, config: Phi4MMConfig):
+        super().__init__()
+        self.gate_up_proj = Phi4MMLoRALinear(
+            config.hidden_size,
+            2 * config.intermediate_size,
+            vision_lora=config.vision_lora,
+            speech_lora=config.speech_lora,
+            bias=False,
+        )
+        self.down_proj = Phi4MMLoRALinear(
+            config.intermediate_size,
+            config.hidden_size,
+            vision_lora=config.vision_lora,
+            speech_lora=config.speech_lora,
+            bias=False,
+        )
+        self.activation_fn = ACT2FN[config.hidden_act]
+
+    def set_adapter(self, adapter_name: Optional[str]):
+        self.gate_up_proj.set_adapter(adapter_name)
+        self.down_proj.set_adapter(adapter_name)
+
+    def disable_adapter(self):
+        self.gate_up_proj.disable_adapter()
+        self.down_proj.disable_adapter()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        up_states = self.gate_up_proj(hidden_states)
+        gate, up_states = up_states.chunk(2, dim=-1)
+        up_states = up_states * self.activation_fn(gate)
+        return self.down_proj(up_states)
+
+
+class Phi4MMAttention(nn.Module):
+    def __init__(self, config: Phi4MMConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.rotary_ndims = int(self.head_dim * config.partial_rotary_factor)
+        op_size = self.num_heads * self.head_dim + 2 * (self.num_key_value_heads * self.head_dim)
+        self.qkv_proj = Phi4MMLoRALinear(
+            config.hidden_size,
+            op_size,
+            vision_lora=config.vision_lora,
+            speech_lora=config.speech_lora,
+            bias=False,
+        )
+        self.o_proj = Phi4MMLoRALinear(
+            self.num_heads * self.head_dim,
+            config.hidden_size,
+            vision_lora=config.vision_lora,
+            speech_lora=config.speech_lora,
+            bias=False,
+        )
+        self.rotary_emb = Phi4MMRotaryEmbedding(self.rotary_ndims, config)
+        self.scaling = self.head_dim ** (-0.5)
+
+    def set_adapter(self, adapter_name: Optional[str]):
+        self.qkv_proj.set_adapter(adapter_name)
+        self.o_proj.set_adapter(adapter_name)
+
+    def disable_adapter(self):
+        self.qkv_proj.disable_adapter()
+        self.o_proj.disable_adapter()
+
+    def forward(self, hidden_states: torch.Tensor, position_ids: torch.LongTensor) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        qkv = self.qkv_proj(hidden_states)
+        query_pos = self.num_heads * self.head_dim
+        kv_pos = self.num_key_value_heads * self.head_dim
+        query_states = qkv[..., :query_pos]
+        key_states = qkv[..., query_pos : query_pos + kv_pos]
+        value_states = qkv[..., query_pos + kv_pos :]
+
+        query_states = query_states.view(batch_size, seq_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(
+            batch_size, seq_len, self.num_key_value_heads, self.head_dim
+        )
+
+        position_embeddings = self.rotary_emb(value_states)
+        if self.rotary_emb.rope_scaling is None:
+            cos, sin = position_embeddings
+        else:
+            short_cos, short_sin, long_cos, long_sin = position_embeddings
+            if position_ids.is_meta:
+                cos, sin = short_cos, short_sin
+            else:
+                seq_len = int(position_ids.max().item()) + 1
+                if seq_len <= self.rotary_emb.original_max_position_embeddings:
+                    cos, sin = short_cos, short_sin
+                else:
+                    cos, sin = long_cos, long_sin
+        cos = cos[position_ids]
+        sin = sin[position_ids]
+        query_rot = query_states[..., : self.rotary_ndims]
+        query_pass = query_states[..., self.rotary_ndims :]
+        key_rot = key_states[..., : self.rotary_ndims]
+        key_pass = key_states[..., self.rotary_ndims :]
+        query_rot, key_rot = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
+            query_rot,
+            key_rot,
+            cos,
+            sin,
+            2,
+        )
+        query_states = torch.cat((query_rot, query_pass), dim=-1)
+        key_states = torch.cat((key_rot, key_pass), dim=-1)
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            query_states,
+            key_states,
+            value_states,
+            is_causal=True,
+            scale=self.scaling,
+            layout="bsnd",
+        )
+        attn_output = attn_output.reshape(batch_size, seq_len, self.num_heads * self.head_dim)
+        return self.o_proj(attn_output)
+
+
+class Phi4MMDecoderLayer(nn.Module):
+    def __init__(self, config: Phi4MMConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Phi4MMAttention(config, layer_idx)
+        self.mlp = Phi4MMMLP(config)
+        self.input_layernorm = Phi4MMRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Phi4MMRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def set_adapter(self, adapter_name: Optional[str]):
+        self.self_attn.set_adapter(adapter_name)
+        self.mlp.set_adapter(adapter_name)
+
+    def disable_adapter(self):
+        self.self_attn.disable_adapter()
+        self.mlp.disable_adapter()
+
+    def forward(self, hidden_states: torch.Tensor, position_ids: torch.LongTensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, position_ids)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Phi4MMImageEmbedding(nn.Module):
+    def __init__(self, config: Phi4MMConfig, **kwargs):
+        super().__init__()
+        aux = _load_hf_aux_module(
+            config._name_or_path, "vision_siglip_navit.py", "phi4mm_vision_aux"
+        )
+        self.img_processor = aux.get_siglip_vision_model()
+        hidden_size = config.hidden_size
+        pe_weight = self.img_processor.embeddings.position_embedding.weight
+        length, image_dim_out = pe_weight.size()
+        size = int(math.sqrt(length))
+        self.image_dim_out = image_dim_out
+        self.base_feat_height_target = size
+        self.base_feat_height_reduction = 1
+        self.use_hd_transform = kwargs.get("use_hd_transform", False)
+        self.hd_transform_order = kwargs.get("hd_transform_order", "sub_glb")
+        self.crop_size = kwargs.get("crop_size", 448)
+        if kwargs.get("image_token_compression_cls") == "avg_pool_2d":
+            self.image_token_compression = nn.AvgPool2d(kernel_size=2, stride=2)
+            self.base_feat_height_target //= 2
+            self.base_feat_height_reduction = 2
+        else:
+            self.image_token_compression = None
+        reduced_dim = image_dim_out * self.base_feat_height_reduction**2
+        self.glb_GN = nn.Parameter(torch.zeros([1, 1, reduced_dim]))
+        self.sub_GN = nn.Parameter(torch.zeros([1, 1, 1, reduced_dim]))
+        self.img_projection = nn.Sequential(
+            nn.Linear(reduced_dim, hidden_size),
+            nn.GELU(),
+            nn.Linear(hidden_size, hidden_size),
+        )
+        self.layer_idx = -2
+
+    def get_img_features(
+        self, img_embeds: torch.FloatTensor, attention_mask: Optional[torch.Tensor]
+    ) -> torch.FloatTensor:
+        outputs = self.img_processor(
+            img_embeds,
+            output_hidden_states=True,
+            patch_attention_mask=attention_mask,
+        )
+        patch_feature = outputs.hidden_states[self.layer_idx]
+        if self.image_token_compression is not None:
+            width = int(math.sqrt(patch_feature.size(1)))
+            patch_feature = patch_feature.view(-1, width, width, patch_feature.size(-1))
+            patch_feature = patch_feature.permute(0, 3, 1, 2)
+            patch_feature = self.image_token_compression(patch_feature)
+            patch_feature = patch_feature.permute(0, 2, 3, 1)
+            patch_feature = patch_feature.view(
+                -1, patch_feature.size(1) * patch_feature.size(2), patch_feature.size(-1)
+            )
+        return patch_feature
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_embeds: torch.FloatTensor,
+        image_sizes=None,
+        image_attention_mask=None,
+        wte=None,
+    ) -> torch.FloatTensor:
+        input_shape = input_ids.size()
+        input_ids = input_ids.view(-1, input_shape[-1])
+        positions_tuple = torch.nonzero(input_ids == _IMAGE_SPECIAL_TOKEN_ID, as_tuple=True)
+        if len(positions_tuple[0]) == 0:
+            return wte(input_ids)
+        target_device = self.img_projection[0].weight.device
+        target_dtype = self.img_projection[0].weight.dtype
+        img_embeds = input_embeds.to(device=target_device, dtype=target_dtype)
+        attn_mask = None
+        if image_attention_mask is not None and image_attention_mask.numel() > 0:
+            attn_mask = image_attention_mask.flatten(0, 1).to(
+                dtype=torch.bool, device=target_device
+            )
+        img_features = self.get_img_features(img_embeds.flatten(0, 1), attn_mask)
+        batch_size = input_embeds.shape[0]
+        base_feat_size = int(math.sqrt(img_features.shape[1]))
+        img_features = img_features.view(
+            batch_size, -1, base_feat_size * base_feat_size, self.image_dim_out
+        )
+        image_sizes = image_sizes.view(-1, 2)
+        output_imgs = []
+        for idx in range(batch_size):
+            height, width = image_sizes[idx]
+            height_ratio = max(int(height.item() // self.crop_size), 1)
+            width_ratio = max(int(width.item() // self.crop_size), 1)
+            global_img = img_features[idx, :1].reshape(
+                1, base_feat_size, base_feat_size, self.image_dim_out
+            )
+            global_img = global_img.reshape(
+                1,
+                base_feat_size // self.base_feat_height_reduction,
+                self.base_feat_height_reduction,
+                base_feat_size // self.base_feat_height_reduction,
+                self.base_feat_height_reduction,
+                self.image_dim_out,
+            )
+            global_img = global_img.permute(0, 1, 3, 2, 4, 5).reshape(
+                1,
+                base_feat_size // self.base_feat_height_reduction,
+                base_feat_size // self.base_feat_height_reduction,
+                -1,
+            )
+            global_img = torch.cat(
+                [
+                    global_img,
+                    self.sub_GN.repeat(1, base_feat_size // self.base_feat_height_reduction, 1, 1),
+                ],
+                dim=2,
+            ).reshape(1, -1, global_img.shape[-1])
+            area_ratio = height_ratio * width_ratio
+            sub_img = img_features[idx, 1 : area_ratio + 1]
+            sub_img = sub_img.reshape(
+                area_ratio, base_feat_size, base_feat_size, self.image_dim_out
+            )
+            sub_img = sub_img.reshape(
+                area_ratio,
+                base_feat_size // self.base_feat_height_reduction,
+                self.base_feat_height_reduction,
+                base_feat_size // self.base_feat_height_reduction,
+                self.base_feat_height_reduction,
+                self.image_dim_out,
+            )
+            sub_img = sub_img.permute(0, 1, 3, 2, 4, 5).reshape(
+                area_ratio, -1, global_img.shape[-1]
+            )
+            sub_img = (
+                sub_img.reshape(
+                    1,
+                    height_ratio,
+                    width_ratio,
+                    base_feat_size // self.base_feat_height_reduction,
+                    base_feat_size // self.base_feat_height_reduction,
+                    global_img.shape[-1],
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .reshape(
+                    1,
+                    height_ratio * base_feat_size // self.base_feat_height_reduction,
+                    width_ratio * base_feat_size // self.base_feat_height_reduction,
+                    global_img.shape[-1],
+                )
+            )
+            sub_img = torch.cat(
+                [
+                    sub_img,
+                    self.sub_GN.repeat(
+                        1,
+                        height_ratio * base_feat_size // self.base_feat_height_reduction,
+                        1,
+                        1,
+                    ),
+                ],
+                dim=2,
+            ).reshape(1, -1, sub_img.shape[-1])
+            if self.hd_transform_order == "sub_glb":
+                merged = torch.cat([sub_img, self.glb_GN, global_img], dim=1)
+            else:
+                merged = torch.cat([global_img, self.glb_GN, sub_img], dim=1)
+            output_imgs.append(self.img_projection(merged))
+        merged_img_set_tensor = (
+            torch.cat(output_imgs, dim=1)
+            .squeeze(0)
+            .to(device=wte.weight.device, dtype=wte.weight.dtype)
+        )
+        hidden_states = wte(input_ids)
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
+            hidden_states = hidden_states.index_put(
+                positions_tuple, merged_img_set_tensor, accumulate=False
+            )
+        return hidden_states
+
+
+class Phi4MMAudioEmbedding(nn.Module):
+    def __init__(self, config: Phi4MMConfig, **kwargs):
+        super().__init__()
+        aux = _load_hf_aux_module(
+            config._name_or_path, "speech_conformer_encoder.py", "phi4mm_audio_aux"
+        )
+        encoder_config = config.audio_processor["config"]
+        self.encoder = aux.ConformerEncoder(**encoder_config)
+        hidden_size = config.hidden_size
+        downsample_rate = kwargs.get("downsample_rate", 1)
+        audio_dim_out = encoder_config["attention_dim"]
+        self.audio_dim_in = encoder_config["input_size"]
+
+        def _proj():
+            return nn.Sequential(
+                nn.Linear(audio_dim_out * downsample_rate, hidden_size),
+                nn.GELU(),
+                nn.Linear(hidden_size, hidden_size),
+            )
+
+        self.audio_projection = nn.ModuleDict({"speech": _proj(), "vision": _proj()})
+
+    def post_init(self):
+        self.encoder.post_init({})
+
+    def get_audio_features(
+        self,
+        input_embeds: torch.FloatTensor,
+        audio_attention_mask: Optional[torch.Tensor],
+        audio_projection_mode: str,
+    ) -> torch.FloatTensor:
+        audio_features, _ = self.encoder(input_embeds, audio_attention_mask)
+        return self.audio_projection[audio_projection_mode](audio_features)
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_embeds: torch.FloatTensor,
+        audio_embed_sizes=None,
+        audio_attention_mask=None,
+        audio_projection_mode: str = "speech",
+        wte=None,
+    ) -> torch.FloatTensor:
+        input_shape = input_ids.size()
+        input_ids = input_ids.view(-1, input_shape[-1])
+        positions_tuple = torch.nonzero(input_ids == _AUDIO_SPECIAL_TOKEN_ID, as_tuple=True)
+        hidden_states = wte(input_ids)
+        if len(positions_tuple[0]) == 0:
+            return hidden_states
+        target_device = self.audio_projection[audio_projection_mode][0].weight.device
+        target_dtype = self.audio_projection[audio_projection_mode][0].weight.dtype
+        input_embeds = input_embeds.to(device=target_device, dtype=target_dtype)
+        audio_set_tensor = self.get_audio_features(
+            input_embeds, audio_attention_mask, audio_projection_mode
+        )
+        merged_audio_set_tensor = torch.cat(
+            [audio_set_tensor[i, : audio_embed_sizes[i], :] for i in range(len(audio_embed_sizes))],
+            dim=0,
+        ).to(device=hidden_states.device, dtype=hidden_states.dtype)
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
+            hidden_states = hidden_states.index_put(
+                positions_tuple, merged_audio_set_tensor, accumulate=False
+            )
+        return hidden_states
+
+
+class Phi4MMImageAudioEmbedding(nn.Module):
+    def __init__(self, config: Phi4MMConfig, **kwargs):
+        super().__init__()
+        self.image_embed = Phi4MMImageEmbedding(config, **kwargs["image_embd_layer"])
+        self.audio_embed = Phi4MMAudioEmbedding(config, **kwargs["audio_embd_layer"])
+
+    def post_init(self):
+        self.audio_embed.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_image_embeds: Optional[torch.FloatTensor] = None,
+        image_sizes=None,
+        image_attention_mask=None,
+        input_audio_embeds: Optional[torch.FloatTensor] = None,
+        audio_embed_sizes=None,
+        audio_attention_mask=None,
+        audio_projection_mode: str = "speech",
+        wte=None,
+    ) -> torch.FloatTensor:
+        image_hidden_states = None
+        audio_hidden_states = None
+        image_position_mask = (input_ids == _IMAGE_SPECIAL_TOKEN_ID).unsqueeze(-1)
+        non_image_position_mask = ~image_position_mask
+        if input_image_embeds is not None and input_image_embeds.numel() > 0:
+            image_hidden_states = self.image_embed(
+                input_ids=input_ids,
+                input_embeds=input_image_embeds,
+                image_sizes=image_sizes,
+                image_attention_mask=image_attention_mask,
+                wte=wte,
+            )
+        if input_audio_embeds is not None and input_audio_embeds.numel() > 0:
+            audio_hidden_states = self.audio_embed(
+                input_ids=input_ids,
+                input_embeds=input_audio_embeds,
+                audio_embed_sizes=audio_embed_sizes,
+                audio_attention_mask=audio_attention_mask,
+                audio_projection_mode=audio_projection_mode,
+                wte=wte,
+            )
+        if image_hidden_states is not None and audio_hidden_states is not None:
+            dtype = image_hidden_states.dtype
+            return image_hidden_states * image_position_mask.to(
+                dtype
+            ) + audio_hidden_states * non_image_position_mask.to(dtype)
+        if image_hidden_states is not None:
+            return image_hidden_states
+        if audio_hidden_states is not None:
+            return audio_hidden_states
+        return wte(input_ids)
+
+
+@dataclass
+class Phi4MMModelOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Phi4MMCausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Phi4MMPreTrainedModel(PreTrainedModel):
+    config_class = Phi4MMConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Phi4MMDecoderLayer"]
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Phi4MMModel(Phi4MMPreTrainedModel):
+    def __init__(self, config: Phi4MMConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.embed_tokens_extend = None
+        if isinstance(config.embd_layer, dict):
+            self.embed_tokens_extend = Phi4MMImageAudioEmbedding(config, **config.embd_layer)
+        self.layers = nn.ModuleList(
+            [Phi4MMDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Phi4MMRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_init()
+        if self.embed_tokens_extend is not None:
+            self.embed_tokens_extend.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def set_lora_adapter(self, adapter_name: Optional[str]):
+        for layer in self.layers:
+            layer.set_adapter(adapter_name)
+
+    def unset_lora_adapter(self):
+        for layer in self.layers:
+            layer.disable_adapter()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        input_image_embeds: Optional[torch.FloatTensor] = None,
+        image_sizes: Optional[torch.LongTensor] = None,
+        image_attention_mask: Optional[torch.Tensor] = None,
+        input_audio_embeds: Optional[torch.FloatTensor] = None,
+        audio_embed_sizes=None,
+        audio_attention_mask=None,
+        audio_projection_mode: str = "speech",
+        **kwargs,
+    ) -> Phi4MMModelOutput:
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+        if inputs_embeds is None:
+            if self.embed_tokens_extend is not None and (
+                (input_image_embeds is not None and input_image_embeds.numel() > 0)
+                or (input_audio_embeds is not None and input_audio_embeds.numel() > 0)
+            ):
+                inputs_embeds = self.embed_tokens_extend(
+                    input_ids=input_ids,
+                    input_image_embeds=input_image_embeds,
+                    image_sizes=image_sizes,
+                    image_attention_mask=image_attention_mask,
+                    input_audio_embeds=input_audio_embeds,
+                    audio_embed_sizes=audio_embed_sizes,
+                    audio_attention_mask=audio_attention_mask,
+                    audio_projection_mode=audio_projection_mode,
+                    wte=self.embed_tokens,
+                )
+            else:
+                inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            seq_len = inputs_embeds.shape[1]
+            position_ids = torch.arange(seq_len, device=inputs_embeds.device).unsqueeze(0)
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(hidden_states, position_ids)
+        hidden_states = self.norm(hidden_states)
+        return Phi4MMModelOutput(last_hidden_state=hidden_states)
+
+
+class Phi4MMForCausalLM(Phi4MMPreTrainedModel, GenerationMixin):
+    def __init__(self, config: Phi4MMConfig):
+        super().__init__(config)
+        self.model = Phi4MMModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+        self.tie_weights()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def _resolve_input_mode(
+        self,
+        input_mode,
+        input_image_embeds: Optional[torch.Tensor],
+        input_audio_embeds: Optional[torch.Tensor],
+    ) -> InputMode:
+        if isinstance(input_mode, torch.Tensor):
+            input_mode = int(input_mode.flatten()[0].item())
+        if input_mode is None:
+            has_image = input_image_embeds is not None and input_image_embeds.numel() > 0
+            has_audio = input_audio_embeds is not None and input_audio_embeds.numel() > 0
+            if has_image and has_audio:
+                input_mode = InputMode.VISION_SPEECH
+            elif has_image:
+                input_mode = InputMode.VISION
+            elif has_audio:
+                input_mode = InputMode.SPEECH
+            else:
+                input_mode = InputMode.LANGUAGE
+        return InputMode(int(input_mode))
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        input_image_embeds: Optional[torch.FloatTensor] = None,
+        image_sizes: Optional[torch.LongTensor] = None,
+        image_attention_mask: Optional[torch.Tensor] = None,
+        input_audio_embeds: Optional[torch.FloatTensor] = None,
+        audio_embed_sizes=None,
+        audio_attention_mask=None,
+        input_mode=None,
+        **kwargs,
+    ) -> Phi4MMCausalLMOutput:
+        mode = self._resolve_input_mode(input_mode, input_image_embeds, input_audio_embeds)
+        if mode in [InputMode.VISION, InputMode.VISION_SPEECH]:
+            self.model.set_lora_adapter("vision")
+            audio_projection_mode = "vision"
+        elif mode == InputMode.SPEECH:
+            self.model.set_lora_adapter("speech")
+            audio_projection_mode = "speech"
+        else:
+            self.model.unset_lora_adapter()
+            audio_projection_mode = "speech"
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            input_image_embeds=input_image_embeds,
+            image_sizes=image_sizes,
+            image_attention_mask=image_attention_mask,
+            input_audio_embeds=input_audio_embeds,
+            audio_embed_sizes=audio_embed_sizes,
+            audio_attention_mask=audio_attention_mask,
+            audio_projection_mode=audio_projection_mode,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state).float()
+        return Phi4MMCausalLMOutput(logits=logits)
+
+
+try:
+    AutoConfig.register("phi4mm", Phi4MMConfig, exist_ok=True)
+except TypeError:
+    try:
+        AutoConfig.register("phi4mm", Phi4MMConfig)
+    except ValueError:
+        pass
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Phi4MMConfig", Phi4MMForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -210,8 +210,7 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
         """Build the model on the desired device."""
         model_config, unused_kwargs = self._get_model_config()
 
-        config_cls_name = type(model_config).__name__
-        custom_model_cls = self._custom_model_mapping.get(config_cls_name, None)
+        custom_model_cls = self._get_custom_model_cls(model_config)
         with (init_empty_weights if device == "meta" else nullcontext)():
             if custom_model_cls is not None:
                 # `_from_config` has some behavior we would like to use where possible. It is
@@ -250,6 +249,23 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
             model = self._quant_config_reader.post_process_model(model, model_config)
 
         return model
+
+    def _get_custom_model_cls(
+        self, model_config: PretrainedConfig
+    ) -> Optional[Type[AutoModelForCausalLM]]:
+        """Resolve a registered custom model implementation for ``model_config`` if supported."""
+        config_cls_name = type(model_config).__name__
+        custom_model_cls = self._custom_model_mapping.get(config_cls_name, None)
+        if custom_model_cls is None:
+            return None
+
+        supports_model_config = getattr(custom_model_cls, "supports_model_config", None)
+        if supports_model_config is not None and not supports_model_config(
+            model_config, model_name_or_path=self.model
+        ):
+            return None
+
+        return custom_model_cls
 
     def _set_sharding_config(self, model_config: PretrainedConfig):
         """Set the sharding config for the model."""

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rope.py
@@ -722,6 +722,16 @@ def _optimize_explicit(
         return
 
     head_dim = cos_node.meta["val"].shape[-1]
+    q_head_dim = q_fake.shape[-1] if q_fake is not None else None
+    k_fake = k_node.meta.get("val", None)
+    k_head_dim = k_fake.shape[-1] if k_fake is not None else None
+
+    # FlashInfer's explicit-rope kernel expects q/k head_dim to match the
+    # cos/sin cache width. Skip Phi-4-style partial RoPE on full-width q/k
+    # tensors and keep the safe torch-reference rope op in the graph.
+    if head_dim != q_head_dim or head_dim != k_head_dim:
+        return
+
     half_head_dim = head_dim // 2
 
     # Try trace-back to find full cos/sin tables and real position_ids.

--- a/tests/unittest/auto_deploy/singlegpu/models/test_hf.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_hf.py
@@ -1,5 +1,5 @@
 import copy
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 import torch
@@ -186,6 +186,38 @@ def test_build_model_uses_custom_model_cls_from_config(mock_factory):
         pytest.raises(MyError),
     ):
         mock_factory.build_model(device="meta")
+
+
+def test_build_model_skips_custom_model_cls_when_config_is_not_supported(mock_factory):
+    custom_model_cls = MagicMock(spec=AutoModelForCausalLM)
+    custom_model_cls.configure_mock(
+        supports_model_config=MagicMock(return_value=False),
+        _from_config=MagicMock(side_effect=MyError),
+    )
+    AutoModelForCausalLMFactory.register_custom_model_cls(
+        config_cls_name=FooConfig.__name__, custom_model_cls=custom_model_cls
+    )
+
+    default_model = MagicMock(spec=nn.Module)
+    default_model.config = FooConfig()
+
+    with (
+        patch.object(
+            AutoModelForCausalLMFactory,
+            "_get_model_config",
+            return_value=(FooConfig(), {}),
+        ),
+        patch.object(
+            AutoModelForCausalLM, "from_config", return_value=default_model
+        ) as from_config,
+    ):
+        assert mock_factory.build_model(device="meta") is default_model
+
+    custom_model_cls.supports_model_config.assert_called_once_with(
+        ANY, model_name_or_path="/dummy/path"
+    )
+    custom_model_cls._from_config.assert_not_called()
+    from_config.assert_called_once()
 
 
 def test_custom_model_mapping_in_parent_does_not_affect_children():

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_modeling.py
@@ -1,0 +1,524 @@
+"""Tests for Phi-4 custom model implementation.
+
+This module tests the custom Phi-4 model implementation which uses
+auto_deploy custom ops (torch_attention, torch_rope_with_explicit_cos_sin)
+for export compatibility.
+
+Hierarchical test levels:
+1. Block equivalence (MLP, Attention, RMSNorm)
+2. Layer equivalence (DecoderLayer)
+3. Full model equivalence (ForCausalLM) — on both CPU and CUDA
+4. Export test (torch_export_to_gm with dynamic shapes, eager vs graph comparison)
+"""
+
+import pytest
+import torch
+from _model_test_utils import assert_rmse_close
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4 import (
+    Phi4Attention,
+    Phi4DecoderLayer,
+    Phi4ForCausalLM,
+    Phi4MLP,
+    Phi4RMSNorm,
+    Phi4RotaryEmbedding,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _create_small_config():
+    """Create a small Phi3Config for testing."""
+    from transformers.models.phi3.configuration_phi3 import Phi3Config
+
+    return Phi3Config(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,  # GQA
+        hidden_act="silu",
+        max_position_embeddings=512,
+        original_max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        pad_token_id=0,
+        attention_dropout=0.0,
+        resid_pdrop=0.0,
+    )
+
+
+# =============================================================================
+# HF Reference Helpers
+# =============================================================================
+
+
+def _create_hf_config():
+    """Create a HF Phi3Config with _attn_implementation set for direct instantiation.
+
+    When creating HF models directly (not through from_pretrained), the
+    _attn_implementation attribute may not be set. We set it to "eager"
+    explicitly to avoid KeyError in the HF attention forward pass.
+    """
+    config = _create_small_config()
+    config._attn_implementation = "eager"
+    return config
+
+
+def _make_causal_mask(S, device, dtype):
+    """Create a causal attention mask for HF attention.
+
+    HF eager attention expects mask of shape [B, 1, S, S] with 0 for allowed
+    positions and large negative values for masked positions.
+    """
+    mask = torch.full((S, S), torch.finfo(dtype).min, device=device, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    return mask.unsqueeze(0).unsqueeze(0)  # [1, 1, S, S]
+
+
+def _get_hf_model_class():
+    """Get the HF Phi3ForCausalLM class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3ForCausalLM
+
+        return Phi3ForCausalLM
+    except ImportError:
+        return None
+
+
+def _get_hf_attention_class():
+    """Get the HF Phi3Attention class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3Attention
+
+        return Phi3Attention
+    except ImportError:
+        return None
+
+
+def _get_hf_mlp_class():
+    """Get the HF Phi3MLP class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3MLP
+
+        return Phi3MLP
+    except ImportError:
+        return None
+
+
+def _get_hf_norm_class():
+    """Get the HF Phi3RMSNorm class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3RMSNorm
+
+        return Phi3RMSNorm
+    except ImportError:
+        return None
+
+
+def _get_hf_decoder_layer_class():
+    """Get the HF Phi3DecoderLayer class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3DecoderLayer
+
+        return Phi3DecoderLayer
+    except ImportError:
+        return None
+
+
+def _get_hf_rotary_class():
+    """Get the HF Phi3RotaryEmbedding class."""
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3RotaryEmbedding
+
+        return Phi3RotaryEmbedding
+    except ImportError:
+        return None
+
+
+# =============================================================================
+# Structural Tests
+# =============================================================================
+
+
+def test_phi4_config_uses_phi3():
+    """Test that the model correctly uses Phi3Config."""
+    config = _create_small_config()
+    assert config.model_type == "phi3"
+    assert hasattr(config, "hidden_size")
+    assert hasattr(config, "num_attention_heads")
+    assert hasattr(config, "num_key_value_heads")
+    assert hasattr(config, "partial_rotary_factor")
+
+
+def test_phi4_gqa_structure():
+    """Test that GQA is set up correctly (fewer KV heads than Q heads)."""
+    config = _create_small_config()
+    model = Phi4ForCausalLM(config)
+
+    attn = model.model.layers[0].self_attn
+    assert attn.num_heads == config.num_attention_heads
+    assert attn.num_key_value_heads == config.num_key_value_heads
+    assert attn.num_key_value_groups == config.num_attention_heads // config.num_key_value_heads
+
+    # Check QKV proj output size
+    expected_qkv_size = (
+        config.num_attention_heads * attn.head_dim + 2 * config.num_key_value_heads * attn.head_dim
+    )
+    assert attn.qkv_proj.out_features == expected_qkv_size
+
+
+# =============================================================================
+# Numerical Equivalence Tests (Level 1: Block Equivalence)
+# =============================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi4_rmsnorm_numerical_equivalence(B, S, dtype):
+    """Test RMSNorm produces identical output to HF implementation."""
+    HFNorm = _get_hf_norm_class()
+    if HFNorm is None:
+        pytest.skip("transformers doesn't have Phi3RMSNorm")
+
+    device = "cuda"
+    config = _create_small_config()
+    H = config.hidden_size
+
+    hf_norm = HFNorm(H, eps=config.rms_norm_eps).to(device=device, dtype=dtype)
+    custom_norm = Phi4RMSNorm(H, eps=config.rms_norm_eps).to(device=device, dtype=dtype)
+
+    # Load same weights
+    custom_norm.load_state_dict(hf_norm.state_dict())
+
+    x = torch.randn(B, S, H, device=device, dtype=dtype)
+
+    hf_out = hf_norm(x)
+    custom_out = custom_norm(x)
+
+    torch.testing.assert_close(custom_out, hf_out, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi4_mlp_numerical_equivalence(B, S, dtype):
+    """Test MLP produces identical output to HF implementation."""
+    HFMLP = _get_hf_mlp_class()
+    if HFMLP is None:
+        pytest.skip("transformers doesn't have Phi3MLP")
+
+    device = "cuda"
+    config = _create_small_config()
+    H = config.hidden_size
+
+    hf_mlp = HFMLP(config).to(device=device, dtype=dtype)
+    hf_mlp.eval()
+
+    custom_mlp = Phi4MLP(config).to(device=device, dtype=dtype)
+    custom_mlp.load_state_dict(hf_mlp.state_dict())
+    custom_mlp.eval()
+
+    x = torch.randn(B, S, H, device=device, dtype=dtype)
+
+    hf_out = hf_mlp(x)
+    custom_out = custom_mlp(x)
+
+    torch.testing.assert_close(custom_out, hf_out, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi4_attention_numerical_equivalence(B, S, dtype):
+    """Test Attention produces numerically equivalent output to HF implementation."""
+    HFAttention = _get_hf_attention_class()
+    HFRotary = _get_hf_rotary_class()
+    if HFAttention is None or HFRotary is None:
+        pytest.skip("transformers doesn't have Phi3Attention or Phi3RotaryEmbedding")
+
+    device = "cuda"
+    config = _create_small_config()
+    hf_config = _create_hf_config()
+    H = config.hidden_size
+
+    # Create HF attention and rotary
+    hf_attn = HFAttention(hf_config, layer_idx=0).to(device=device, dtype=dtype)
+    hf_attn.eval()
+    hf_rotary = HFRotary(hf_config).to(device=device, dtype=dtype)
+
+    # Create custom attention and rotary
+    custom_attn = Phi4Attention(config, layer_idx=0).to(device=device, dtype=dtype)
+    custom_attn.load_state_dict(hf_attn.state_dict())
+    custom_attn.eval()
+
+    head_dim = H // config.num_attention_heads
+    rotary_dim = int(head_dim * config.partial_rotary_factor)
+    custom_rotary = Phi4RotaryEmbedding(
+        rotary_dim,
+        max_position_embeddings=config.max_position_embeddings,
+        base=config.rope_theta,
+    ).to(device=device, dtype=dtype)
+
+    x = torch.randn(B, S, H, device=device, dtype=dtype)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    # Create causal mask for HF (our custom attention uses is_causal=True internally)
+    causal_mask = _make_causal_mask(S, device, dtype)
+
+    # HF forward
+    hf_position_embeddings = hf_rotary(x, position_ids)
+    hf_out, _ = hf_attn(
+        hidden_states=x,
+        position_embeddings=hf_position_embeddings,
+        attention_mask=causal_mask,
+    )
+
+    # Custom forward
+    custom_position_embeddings = custom_rotary(x)
+    custom_out = custom_attn(x, position_ids, custom_position_embeddings)
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.10, msg="Attention output mismatch")
+
+
+# =============================================================================
+# Numerical Equivalence Tests (Level 2: Layer Equivalence)
+# =============================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi4_decoder_layer_numerical_equivalence(B, S, dtype):
+    """Test decoder layer produces numerically equivalent output to HF implementation."""
+    HFDecoderLayer = _get_hf_decoder_layer_class()
+    HFRotary = _get_hf_rotary_class()
+    if HFDecoderLayer is None or HFRotary is None:
+        pytest.skip("transformers doesn't have Phi3DecoderLayer or Phi3RotaryEmbedding")
+
+    device = "cuda"
+    config = _create_small_config()
+    hf_config = _create_hf_config()
+    H = config.hidden_size
+
+    # Create HF layer and rotary
+    hf_layer = HFDecoderLayer(hf_config, layer_idx=0).to(device=device, dtype=dtype)
+    hf_layer.eval()
+    hf_rotary = HFRotary(hf_config).to(device=device, dtype=dtype)
+
+    # Create custom layer and rotary
+    custom_layer = Phi4DecoderLayer(config, layer_idx=0).to(device=device, dtype=dtype)
+
+    # Load weights from HF layer - filter out dropout layers we don't have
+    hf_sd = hf_layer.state_dict()
+    custom_sd = {k: v for k, v in hf_sd.items() if "dropout" not in k}
+    custom_layer.load_state_dict(custom_sd)
+    custom_layer.eval()
+
+    head_dim = H // config.num_attention_heads
+    rotary_dim = int(head_dim * config.partial_rotary_factor)
+    custom_rotary = Phi4RotaryEmbedding(
+        rotary_dim,
+        max_position_embeddings=config.max_position_embeddings,
+        base=config.rope_theta,
+    ).to(device=device, dtype=dtype)
+
+    x = torch.randn(B, S, H, device=device, dtype=dtype)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    # Create causal mask for HF (our custom attention uses is_causal=True internally)
+    causal_mask = _make_causal_mask(S, device, dtype)
+
+    # HF forward
+    hf_position_embeddings = hf_rotary(x, position_ids)
+    hf_out = hf_layer(
+        hidden_states=x,
+        position_embeddings=hf_position_embeddings,
+        attention_mask=causal_mask,
+    )
+
+    # Custom forward
+    custom_position_embeddings = custom_rotary(x)
+    custom_out = custom_layer(x, position_ids, custom_position_embeddings)
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.05, msg="Decoder layer output mismatch")
+
+
+# =============================================================================
+# Numerical Equivalence Tests (Level 3: Full Model Equivalence)
+# =============================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi4_full_model_numerical_equivalence(B, S, dtype):
+    """Test full model produces numerically equivalent output to HF on CUDA."""
+    HFModel = _get_hf_model_class()
+    if HFModel is None:
+        pytest.skip("transformers doesn't have Phi3ForCausalLM")
+
+    device = "cuda"
+    config = _create_small_config()
+    hf_config = _create_hf_config()
+
+    # Create HF model
+    hf_model = HFModel(hf_config)
+    hf_model.to(device=device, dtype=dtype)
+    hf_model.eval()
+
+    # Create custom model and load weights
+    custom_model = Phi4ForCausalLM(config)
+    custom_model.to(device=device, dtype=dtype)
+
+    # Convert HF state dict - filter out dropout-related keys
+    hf_sd = hf_model.state_dict()
+    custom_sd = {k: v for k, v in hf_sd.items() if "dropout" not in k}
+    custom_model.load_state_dict(custom_sd)
+    custom_model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    # Run both
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids)
+    custom_out = custom_model(input_ids=input_ids, position_ids=position_ids)
+
+    assert_rmse_close(
+        custom_out.logits.float(),
+        hf_out.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Full model logits mismatch",
+    )
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.float32])
+@torch.no_grad()
+def test_phi4_full_model_numerical_equivalence_cpu(B, S, dtype):
+    """Test full model produces numerically equivalent output to HF on CPU.
+
+    Confirms no GPU-only ops in the model's forward path.
+    """
+    HFModel = _get_hf_model_class()
+    if HFModel is None:
+        pytest.skip("transformers doesn't have Phi3ForCausalLM")
+
+    device = "cpu"
+    config = _create_small_config()
+    hf_config = _create_hf_config()
+
+    # Create HF model
+    hf_model = HFModel(hf_config)
+    hf_model.to(device=device, dtype=dtype)
+    hf_model.eval()
+
+    # Create custom model and load weights
+    custom_model = Phi4ForCausalLM(config)
+    custom_model.to(device=device, dtype=dtype)
+
+    hf_sd = hf_model.state_dict()
+    custom_sd = {k: v for k, v in hf_sd.items() if "dropout" not in k}
+    custom_model.load_state_dict(custom_sd)
+    custom_model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids)
+    custom_out = custom_model(input_ids=input_ids, position_ids=position_ids)
+
+    assert_rmse_close(
+        custom_out.logits.float(),
+        hf_out.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Full model logits mismatch (CPU)",
+    )
+
+
+# =============================================================================
+# Export Test (Level 4)
+# =============================================================================
+
+
+def test_phi4_model_can_be_exported():
+    """Test that the custom model can be exported with torch_export_to_gm.
+
+    Verifies:
+    1. Export succeeds without graph breaks
+    2. Exported graph output matches eager model output (assert_rmse_close)
+    3. Dynamic shapes work with a second input shape
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    config = _create_small_config()
+
+    model = Phi4ForCausalLM(config)
+    model.to(device=device, dtype=dtype)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    # Get eager model output for comparison
+    with torch.inference_mode():
+        eager_out = model(input_ids=input_ids, position_ids=position_ids)
+
+    # Define dynamic shapes
+    batch_size_dynamic = Dim.DYNAMIC
+    seq_len_dynamic = Dim.DYNAMIC
+    dynamic_shapes = (
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
+        {0: batch_size_dynamic, 1: seq_len_dynamic},
+    )
+
+    # Export the model
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    move_to_device(gm, device)
+
+    # Verify exported graph output matches eager model output
+    with torch.inference_mode():
+        out_gm = gm(input_ids=input_ids, position_ids=position_ids)
+
+    assert "logits" in out_gm, "Output should contain 'logits' key"
+    logits = out_gm["logits"]
+    assert logits.shape == (B, S, config.vocab_size)
+    assert torch.isfinite(logits).all(), "Logits should not contain NaN or Inf"
+
+    assert_rmse_close(
+        logits.float(),
+        eager_out.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Exported graph output does not match eager model output",
+    )
+
+    # Test with different input shape to verify dynamic shapes work
+    B2, S2 = 1, 4
+    input_ids2 = torch.randint(0, config.vocab_size, (B2, S2), device=device)
+    position_ids2 = torch.arange(S2, device=device).unsqueeze(0).expand(B2, -1)
+
+    with torch.inference_mode():
+        out_gm2 = gm(input_ids=input_ids2, position_ids=position_ids2)
+
+    logits2 = out_gm2["logits"]
+    assert logits2.shape == (B2, S2, config.vocab_size)
+    assert torch.isfinite(logits2).all()

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_modeling.py
@@ -162,6 +162,27 @@ def test_phi4_config_uses_phi3():
     assert hasattr(config, "partial_rotary_factor")
 
 
+def test_phi4_custom_model_only_claims_mini_family_configs():
+    """Test that the custom Phi-4 wrapper opts out of larger Phi-4 text configs."""
+    mini_config = _create_small_config()
+    mini_config.hidden_size = 3072
+    mini_config.intermediate_size = 8192
+    mini_config.num_hidden_layers = 32
+    mini_config.num_attention_heads = 24
+    mini_config.num_key_value_heads = 8
+    mini_config.partial_rotary_factor = 0.75
+    assert Phi4ForCausalLM.supports_model_config(mini_config)
+
+    large_config = _create_small_config()
+    large_config.hidden_size = 5120
+    large_config.intermediate_size = 17920
+    large_config.num_hidden_layers = 40
+    large_config.num_attention_heads = 40
+    large_config.num_key_value_heads = 10
+    large_config.partial_rotary_factor = 1.0
+    assert not Phi4ForCausalLM.supports_model_config(large_config)
+
+
 def test_phi4_gqa_structure():
     """Test that GQA is set up correctly (fewer KV heads than Q heads)."""
     config = _create_small_config()

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
@@ -31,7 +31,6 @@ from transformers.models.siglip2.image_processing_siglip2 import Siglip2ImagePro
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.llm import ADInputProcessor
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4_visionr import (
     IMAGE_TOKEN_INDEX,
     Phi4VisionAttention,
@@ -40,6 +39,8 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4_visionr import 
     Phi4VisionRConfig,
     Phi4VisionRForConditionalGeneration,
     Phi4VisionRotaryEmbedding,
+    Phi4VisionRProcessorWrapper,
+    Phi4VisionRTokenizer,
     build_vision_projector,
 )
 from tensorrt_llm._torch.auto_deploy.models.hf import (
@@ -47,7 +48,6 @@ from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForImageTextToTextFactory,
 )
 from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
-from tensorrt_llm.sampling_params import SamplingParams
 
 _BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
 _HF_MODEL_DIR = "models--microsoft--Phi-4-reasoning-vision-15B"
@@ -230,7 +230,7 @@ def test_phi4_visionr_is_registered_for_both_hf_factories():
     )
 
 
-def test_ad_input_processor_falls_back_to_tokenizer_chat_template():
+def test_phi4_visionr_processor_wrapper_uses_tokenizer_chat_template():
     class FakeTokenizer:
         def __init__(self):
             self.chat_template = "{{ messages }}"
@@ -246,51 +246,43 @@ def test_ad_input_processor_falls_back_to_tokenizer_chat_template():
         def __init__(self, tokenizer):
             self.tokenizer = tokenizer
 
-    tokenizer = FakeTokenizer()
-    processor = FakeProcessor(tokenizer)
-    input_processor = ADInputProcessor(tokenizer=None, processor=processor)
+    wrapped_processor = Phi4VisionRProcessorWrapper(FakeProcessor(FakeTokenizer()))
 
-    prompt_token_ids, extra_processed_inputs = input_processor(
-        inputs={"messages": [{"role": "user", "content": "hello"}]},
-        sampling_params=SamplingParams(),
+    prompt_token_ids = wrapped_processor.apply_chat_template(
+        [{"role": "user", "content": "hello"}],
+        tokenize=True,
+        return_dict=True,
     )
 
-    assert prompt_token_ids == [11, 12, 13]
-    assert extra_processed_inputs is None
-    assert len(tokenizer.calls) == 2
+    assert torch.equal(
+        prompt_token_ids["input_ids"], torch.tensor([[11, 12, 13]], dtype=torch.long)
+    )
+    assert len(wrapped_processor.tokenizer.tokenizer.calls) == 1
 
 
-def test_ad_input_processor_prompt_uses_wrapped_tokenizer_chat_template():
+def test_phi4_visionr_tokenizer_wraps_prompt_with_chat_template():
     class FakeTokenizer:
         def __init__(self):
             self.chat_template = "{{ messages }}"
             self.calls = []
+            self.encoded = []
 
         def apply_chat_template(self, messages, **kwargs):
             self.calls.append((messages, kwargs))
-            if kwargs["tokenize"]:
-                return {"input_ids": torch.tensor([[21, 22]], dtype=torch.long)}
             return "formatted phi4 prompt"
 
-    class FakeProcessor:
-        def __init__(self):
-            self.tokenizer = FakeTokenizer()
-            self.calls = []
+        def encode(self, text, *args, **kwargs):
+            self.encoded.append((text, kwargs))
+            return [21, 22]
 
-    processor = FakeProcessor()
-    input_processor = ADInputProcessor(tokenizer=None, processor=processor)
-
-    prompt_token_ids, extra_processed_inputs = input_processor(
-        inputs={"prompt": "Where is the capital of Iceland?"},
-        sampling_params=SamplingParams(),
-    )
+    tokenizer = Phi4VisionRTokenizer(FakeTokenizer())
+    prompt_token_ids = tokenizer.encode("Where is the capital of Iceland?")
 
     assert prompt_token_ids == [21, 22]
-    assert extra_processed_inputs is None
-    assert processor.tokenizer.calls[0][0] == [
+    assert tokenizer.tokenizer.calls[0][0] == [
         {"role": "user", "content": "Where is the capital of Iceland?"}
     ]
-    assert not processor.calls
+    assert tokenizer.tokenizer.encoded[0][0] == "formatted phi4 prompt"
 
 
 def test_phi4_visionr_state_dict_hierarchy_matches_checkpoint_layout():

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
@@ -31,6 +31,7 @@ from transformers.models.siglip2.image_processing_siglip2 import Siglip2ImagePro
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.llm import ADInputProcessor
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4_visionr import (
     IMAGE_TOKEN_INDEX,
     Phi4VisionAttention,
@@ -41,7 +42,12 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4_visionr import 
     Phi4VisionRotaryEmbedding,
     build_vision_projector,
 )
+from tensorrt_llm._torch.auto_deploy.models.hf import (
+    AutoModelForCausalLMFactory,
+    AutoModelForImageTextToTextFactory,
+)
 from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+from tensorrt_llm.sampling_params import SamplingParams
 
 _BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
 _HF_MODEL_DIR = "models--microsoft--Phi-4-reasoning-vision-15B"
@@ -211,6 +217,80 @@ def test_phi4_visionr_accepts_flat_remote_like_config():
     assert model.model.config.model_type == "phi3"
     assert model.model.full_config.model_type == "phi4-siglip"
     assert model.model.full_config.text_config.hidden_size == 64
+
+
+def test_phi4_visionr_is_registered_for_both_hf_factories():
+    assert (
+        AutoModelForCausalLMFactory._custom_model_mapping["Phi4VisionR"]
+        is Phi4VisionRForConditionalGeneration
+    )
+    assert (
+        AutoModelForImageTextToTextFactory._custom_model_mapping["Phi4VisionR"]
+        is Phi4VisionRForConditionalGeneration
+    )
+
+
+def test_ad_input_processor_falls_back_to_tokenizer_chat_template():
+    class FakeTokenizer:
+        def __init__(self):
+            self.chat_template = "{{ messages }}"
+            self.calls = []
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.calls.append(kwargs)
+            if kwargs["tokenize"]:
+                return {"input_ids": torch.tensor([[11, 12, 13]], dtype=torch.long)}
+            return "formatted prompt"
+
+    class FakeProcessor:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+    tokenizer = FakeTokenizer()
+    processor = FakeProcessor(tokenizer)
+    input_processor = ADInputProcessor(tokenizer=None, processor=processor)
+
+    prompt_token_ids, extra_processed_inputs = input_processor(
+        inputs={"messages": [{"role": "user", "content": "hello"}]},
+        sampling_params=SamplingParams(),
+    )
+
+    assert prompt_token_ids == [11, 12, 13]
+    assert extra_processed_inputs is None
+    assert len(tokenizer.calls) == 2
+
+
+def test_ad_input_processor_phi4_prompt_uses_default_chat_template():
+    class FakeTokenizer:
+        def __init__(self):
+            self.chat_template = "{{ messages }}"
+            self.calls = []
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.calls.append((messages, kwargs))
+            if kwargs["tokenize"]:
+                return {"input_ids": torch.tensor([[21, 22]], dtype=torch.long)}
+            return "formatted phi4 prompt"
+
+    class Phi4VisionRProcessor:
+        def __init__(self):
+            self.tokenizer = FakeTokenizer()
+            self.calls = []
+
+    processor = Phi4VisionRProcessor()
+    input_processor = ADInputProcessor(tokenizer=None, processor=processor)
+
+    prompt_token_ids, extra_processed_inputs = input_processor(
+        inputs={"prompt": "Where is the capital of Iceland?"},
+        sampling_params=SamplingParams(),
+    )
+
+    assert prompt_token_ids == [21, 22]
+    assert extra_processed_inputs is None
+    assert processor.tokenizer.calls[0][0] == [
+        {"role": "user", "content": "Where is the capital of Iceland?"}
+    ]
+    assert not processor.calls
 
 
 def test_phi4_visionr_state_dict_hierarchy_matches_checkpoint_layout():

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
@@ -260,7 +260,7 @@ def test_ad_input_processor_falls_back_to_tokenizer_chat_template():
     assert len(tokenizer.calls) == 2
 
 
-def test_ad_input_processor_phi4_prompt_uses_default_chat_template():
+def test_ad_input_processor_prompt_uses_wrapped_tokenizer_chat_template():
     class FakeTokenizer:
         def __init__(self):
             self.chat_template = "{{ messages }}"
@@ -272,12 +272,12 @@ def test_ad_input_processor_phi4_prompt_uses_default_chat_template():
                 return {"input_ids": torch.tensor([[21, 22]], dtype=torch.long)}
             return "formatted phi4 prompt"
 
-    class Phi4VisionRProcessor:
+    class FakeProcessor:
         def __init__(self):
             self.tokenizer = FakeTokenizer()
             self.calls = []
 
-    processor = Phi4VisionRProcessor()
+    processor = FakeProcessor()
     input_processor = ADInputProcessor(tokenizer=None, processor=processor)
 
     prompt_token_ids, extra_processed_inputs = input_processor(

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
@@ -1,0 +1,491 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Phi-4-reasoning-vision-15B custom model implementation."""
+
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from _model_test_utils import assert_rmse_close
+from PIL import Image
+from torch.export import Dim
+from transformers import Siglip2VisionModel
+from transformers.models.phi3.configuration_phi3 import Phi3Config
+from transformers.models.siglip2.image_processing_siglip2 import Siglip2ImageProcessor
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4_visionr import (
+    IMAGE_TOKEN_INDEX,
+    Phi4VisionAttention,
+    Phi4VisionDecoderLayer,
+    Phi4VisionMLP,
+    Phi4VisionRConfig,
+    Phi4VisionRForConditionalGeneration,
+    Phi4VisionRotaryEmbedding,
+    build_vision_projector,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
+_HF_MODEL_DIR = "models--microsoft--Phi-4-reasoning-vision-15B"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _create_small_config() -> Phi4VisionRConfig:
+    return Phi4VisionRConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=256,
+        original_max_position_embeddings=256,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        attention_dropout=0.0,
+        attention_bias=False,
+        resid_pdrop=0.0,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        initializer_range=0.02,
+        mm_vision_tower="google/siglip2-so400m-patch16-naflex",
+        mm_projector_type="mlp2x_gelu",
+        mm_hidden_size=32,
+        min_num_patches=4,
+        max_num_patches=16,
+        tokenizer_model_max_length=256,
+        vision_config={
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "patch_size": 16,
+            "num_patches": 16,
+        },
+    )
+
+
+def _create_hf_text_config():
+    config = Phi3Config(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=256,
+        original_max_position_embeddings=256,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        attention_dropout=0.0,
+        attention_bias=False,
+        resid_pdrop=0.0,
+        pad_token_id=0,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+class _RemoteLikePhi4VisionRConfig(Phi3Config):
+    model_type = "phi4-siglip"
+
+
+def _make_small_multimodal_inputs():
+    processor = Siglip2ImageProcessor(patch_size=16, max_num_patches=16)
+    image = Image.fromarray(np.full((32, 48, 3), 127, dtype=np.uint8))
+    vision_inputs = processor(images=image, return_tensors="pt")
+    input_ids = torch.tensor([[5, IMAGE_TOKEN_INDEX, 6, 7]], dtype=torch.long)
+    return input_ids, vision_inputs
+
+
+def _make_causal_mask(seq_len, device, dtype):
+    mask = torch.full((seq_len, seq_len), torch.finfo(dtype).min, device=device, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    return mask.unsqueeze(0).unsqueeze(0)
+
+
+def _find_checkpoint_index() -> Path | None:
+    hf_home = os.environ.get("HF_HOME")
+    candidate_roots = [Path(".tmp/hf_home")]
+    if hf_home:
+        candidate_roots.insert(0, Path(hf_home))
+    candidate_roots.append(Path.home() / ".cache" / "huggingface")
+
+    for root in candidate_roots:
+        snapshot_dir = root / "hub" / _HF_MODEL_DIR / "snapshots"
+        if not snapshot_dir.exists():
+            continue
+        for index_path in sorted(snapshot_dir.glob("*/model.safetensors.index.json")):
+            return index_path
+    return None
+
+
+def test_phi4_visionr_config_parses_flat_text_and_vision():
+    config = _create_small_config()
+    assert config.model_type == "phi4-siglip"
+    assert config.text_config.model_type == "phi3"
+    assert config.vision_config.model_type == "siglip2_vision_model"
+    assert config.vision_config.patch_size == 16
+    assert config.mm_projector_type == "mlp2x_gelu"
+
+
+def test_phi4_visionr_text_forward_requires_position_ids():
+    config = _create_small_config()
+    model = Phi4VisionRForConditionalGeneration(config).model.eval()
+    input_ids = torch.randint(0, config.text_config.vocab_size, (1, 4), dtype=torch.long)
+
+    with pytest.raises(ValueError, match="position_ids must be provided"):
+        model(input_ids=input_ids)
+
+
+def test_phi4_visionr_accepts_flat_remote_like_config():
+    remote_config = _RemoteLikePhi4VisionRConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=256,
+        original_max_position_embeddings=256,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        attention_dropout=0.0,
+        attention_bias=False,
+        resid_pdrop=0.0,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        initializer_range=0.02,
+        mm_vision_tower="google/siglip2-so400m-patch16-naflex",
+        mm_projector_type="mlp2x_gelu",
+        mm_hidden_size=32,
+        min_num_patches=4,
+        max_num_patches=16,
+        tokenizer_model_max_length=256,
+        vision_config={
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "patch_size": 16,
+            "num_patches": 16,
+        },
+    )
+
+    model = Phi4VisionRForConditionalGeneration(remote_config).eval()
+    assert model.model.config.model_type == "phi3"
+    assert model.model.full_config.model_type == "phi4-siglip"
+    assert model.model.full_config.text_config.hidden_size == 64
+
+
+def test_phi4_visionr_state_dict_hierarchy_matches_checkpoint_layout():
+    config = _create_small_config()
+    model = Phi4VisionRForConditionalGeneration(config).eval()
+    state_dict = model.state_dict()
+    assert "model.embed_tokens.weight" in state_dict
+    assert "model.layers.0.self_attn.qkv_proj.weight" in state_dict
+    assert "model.norm.weight" in state_dict
+    assert (
+        "model.vision_tower.vision_tower.vision_model.embeddings.patch_embedding.weight"
+        in state_dict
+    )
+    assert "model.mm_projector.0.weight" in state_dict
+
+
+def test_phi4_visionr_state_dict_matches_real_checkpoint_index():
+    index_path = _find_checkpoint_index()
+    if index_path is None:
+        pytest.skip("Missing HF checkpoint index in the local Hugging Face cache")
+
+    weight_map = json.loads(index_path.read_text())["weight_map"]
+    expected_keys = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.qkv_proj.weight",
+        "model.norm.weight",
+        "model.vision_tower.vision_tower.vision_model.embeddings.patch_embedding.weight",
+        "model.vision_tower.vision_tower.vision_model.encoder.layers.0.self_attn.q_proj.weight",
+        "model.vision_tower.vision_tower.vision_model.post_layernorm.weight",
+        "model.mm_projector.0.weight",
+        "lm_head.weight",
+    ]
+    for key in expected_keys:
+        assert key in weight_map, f"Expected checkpoint key missing from HF index: {key}"
+
+    config = _create_small_config()
+    model = Phi4VisionRForConditionalGeneration(config).eval()
+    state_dict = model.state_dict()
+    for key in expected_keys:
+        assert key in state_dict, f"Expected model state_dict key missing: {key}"
+
+
+@torch.no_grad()
+def test_phi4_visionr_mlp_block_matches_hf_phi3():
+    from transformers.models.phi3.modeling_phi3 import Phi3MLP
+
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config().text_config
+    hf_mlp = Phi3MLP(_create_hf_text_config()).to(device=device, dtype=dtype).eval()
+    custom_mlp = Phi4VisionMLP(config).to(device=device, dtype=dtype).eval()
+    custom_mlp.load_state_dict(hf_mlp.state_dict())
+
+    hidden_states = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
+    hf_out = hf_mlp(hidden_states)
+    custom_out = custom_mlp(hidden_states)
+    torch.testing.assert_close(custom_out, hf_out, rtol=1e-4, atol=1e-4)
+
+
+@torch.no_grad()
+def test_phi4_visionr_attention_block_matches_hf_phi3():
+    from transformers.models.phi3.modeling_phi3 import Phi3Attention, Phi3RotaryEmbedding
+
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config().text_config
+    hf_config = _create_hf_text_config()
+
+    hf_attention = Phi3Attention(hf_config, layer_idx=0).to(device=device, dtype=dtype).eval()
+    custom_attention = (
+        Phi4VisionAttention(config, layer_idx=0).to(device=device, dtype=dtype).eval()
+    )
+    custom_attention.load_state_dict(hf_attention.state_dict())
+
+    rotary_dim = config.hidden_size // config.num_attention_heads
+    hf_rotary = Phi3RotaryEmbedding(hf_config).to(device=device, dtype=dtype)
+    custom_rotary = Phi4VisionRotaryEmbedding(
+        rotary_dim,
+        max_position_embeddings=config.max_position_embeddings,
+        base=config.rope_theta,
+    ).to(device=device, dtype=dtype)
+
+    batch_size, seq_len = 2, 6
+    hidden_states = torch.randn(batch_size, seq_len, config.hidden_size, device=device, dtype=dtype)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    hf_position_embeddings = hf_rotary(hidden_states, position_ids)
+    hf_out, _ = hf_attention(
+        hidden_states=hidden_states,
+        position_embeddings=hf_position_embeddings,
+        attention_mask=_make_causal_mask(seq_len, device, dtype),
+    )
+
+    custom_out = custom_attention(hidden_states, position_ids, custom_rotary(hidden_states))
+    assert_rmse_close(custom_out.float(), hf_out.float(), rmse_ratio_tol=0.10)
+
+
+@torch.no_grad()
+def test_phi4_visionr_decoder_layer_matches_hf_phi3():
+    from transformers.models.phi3.modeling_phi3 import Phi3DecoderLayer, Phi3RotaryEmbedding
+
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config().text_config
+    hf_config = _create_hf_text_config()
+
+    hf_layer = Phi3DecoderLayer(hf_config, layer_idx=0).to(device=device, dtype=dtype).eval()
+    custom_layer = Phi4VisionDecoderLayer(config, layer_idx=0).to(device=device, dtype=dtype).eval()
+    custom_layer.load_state_dict(hf_layer.state_dict())
+
+    rotary_dim = config.hidden_size // config.num_attention_heads
+    hf_rotary = Phi3RotaryEmbedding(hf_config).to(device=device, dtype=dtype)
+    custom_rotary = Phi4VisionRotaryEmbedding(
+        rotary_dim,
+        max_position_embeddings=config.max_position_embeddings,
+        base=config.rope_theta,
+    ).to(device=device, dtype=dtype)
+
+    batch_size, seq_len = 2, 6
+    hidden_states = torch.randn(batch_size, seq_len, config.hidden_size, device=device, dtype=dtype)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    hf_position_embeddings = hf_rotary(hidden_states, position_ids)
+    hf_out = hf_layer(
+        hidden_states=hidden_states,
+        position_ids=position_ids,
+        position_embeddings=hf_position_embeddings,
+        attention_mask=_make_causal_mask(seq_len, device, dtype),
+    )
+    custom_out = custom_layer(hidden_states, position_ids, custom_rotary(hidden_states))
+    assert_rmse_close(custom_out.float(), hf_out.float(), rmse_ratio_tol=0.05)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4_visionr_text_model_matches_hf_phi3(B, S):
+    from transformers.models.phi3.modeling_phi3 import Phi3Model
+
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config()
+    hf_config = _create_hf_text_config()
+
+    custom_model = Phi4VisionRForConditionalGeneration(config).model
+    custom_model.to(device=device, dtype=dtype)
+    custom_model.eval()
+
+    hf_model = Phi3Model(hf_config).to(device=device, dtype=dtype)
+    hf_model.eval()
+
+    custom_model.load_state_dict(hf_model.state_dict(), strict=False)
+
+    input_ids = torch.randint(0, config.text_config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    custom_out = custom_model(input_ids=input_ids, position_ids=position_ids).last_hidden_state
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids).last_hidden_state
+
+    assert_rmse_close(custom_out.float(), hf_out.float(), rmse_ratio_tol=0.05)
+
+
+@torch.no_grad()
+def test_phi4_visionr_multimodal_forward_matches_reference():
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config()
+    model = Phi4VisionRForConditionalGeneration(config).to(device=device, dtype=dtype).eval()
+
+    input_ids, vision_inputs = _make_small_multimodal_inputs()
+    input_ids = input_ids.to(device)
+    vision_inputs = {k: v.to(device) for k, v in vision_inputs.items()}
+
+    actual = model(
+        input_ids=input_ids,
+        pixel_values=vision_inputs["pixel_values"],
+        pixel_attention_mask=vision_inputs["pixel_attention_mask"],
+        spatial_shapes=vision_inputs["spatial_shapes"],
+    )
+
+    hf_vision_config = deepcopy(config.vision_config)
+    hf_vision_config._attn_implementation = "eager"
+    hf_vision_model = Siglip2VisionModel(hf_vision_config).to(device=device, dtype=dtype).eval()
+    hf_vision_model.load_state_dict(model.model.vision_tower.vision_tower.state_dict())
+
+    ref_projector = build_vision_projector(config).to(device=device, dtype=dtype).eval()
+    ref_projector.load_state_dict(model.model.mm_projector.state_dict())
+
+    ref_lm_head = (
+        torch.nn.Linear(config.text_config.hidden_size, config.text_config.vocab_size, bias=False)
+        .to(device=device, dtype=dtype)
+        .eval()
+    )
+    ref_lm_head.load_state_dict(model.lm_head.state_dict())
+
+    from transformers.models.phi3.modeling_phi3 import Phi3Model
+
+    hf_text_model = Phi3Model(_create_hf_text_config()).to(device=device, dtype=dtype).eval()
+    hf_text_model.load_state_dict(
+        {
+            key: value
+            for key, value in model.model.state_dict().items()
+            if key.startswith(("embed_tokens.", "layers.", "norm."))
+        },
+        strict=False,
+    )
+
+    vision_outputs = hf_vision_model(
+        vision_inputs["pixel_values"],
+        vision_inputs["pixel_attention_mask"],
+        vision_inputs["spatial_shapes"],
+        output_hidden_states=True,
+    )
+    image_features = vision_outputs.hidden_states[-2][0][
+        vision_inputs["pixel_attention_mask"][0].bool()
+    ]
+    image_features = ref_projector(image_features)
+
+    embed_tokens = hf_text_model.embed_tokens
+    ref_inputs_embeds = torch.cat(
+        [
+            embed_tokens(input_ids[:, :1]).squeeze(0),
+            image_features,
+            embed_tokens(input_ids[:, 2:]).squeeze(0),
+        ],
+        dim=0,
+    ).unsqueeze(0)
+    ref_position_ids = torch.arange(
+        ref_inputs_embeds.shape[1], dtype=torch.long, device=device
+    ).unsqueeze(0)
+    ref_hidden = hf_text_model(
+        input_ids=None,
+        inputs_embeds=ref_inputs_embeds,
+        position_ids=ref_position_ids,
+    ).last_hidden_state
+    ref_logits = ref_lm_head(ref_hidden).float()
+
+    assert_rmse_close(actual.logits.float(), ref_logits.float(), rmse_ratio_tol=0.05)
+
+
+@torch.no_grad()
+def test_phi4_visionr_text_model_can_be_exported():
+    device = "cpu"
+    dtype = torch.float32
+    config = _create_small_config()
+    model = Phi4VisionRForConditionalGeneration(config).model
+    model.to(device=device, dtype=dtype)
+    model.eval()
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(
+        0, config.text_config.vocab_size, (batch_size, seq_len), device=device
+    )
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+    move_to_device(gm, device)
+
+    eager_out = model(input_ids=input_ids, position_ids=position_ids).last_hidden_state
+    exported_out = gm(input_ids=input_ids, position_ids=position_ids)["last_hidden_state"]
+
+    torch.testing.assert_close(exported_out.float(), eager_out.float(), rtol=1e-4, atol=1e-4)
+
+    input_ids_2 = torch.randint(0, config.text_config.vocab_size, (1, 4), device=device)
+    position_ids_2 = torch.arange(4, device=device).unsqueeze(0)
+    exported_out_2 = gm(input_ids=input_ids_2, position_ids=position_ids_2)["last_hidden_state"]
+
+    assert exported_out_2.shape == (1, 4, config.text_config.hidden_size)
+    assert torch.isfinite(exported_out_2).all()

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4flash_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4flash_modeling.py
@@ -1,0 +1,517 @@
+"""Tests for Phi-4 Flash custom model implementation.
+
+Hierarchical test levels:
+1. Block equivalence — MLP, attention, Mamba
+2. Layer equivalence — standard and YOCO/shared layers
+3. Full model equivalence — end-to-end logits comparison
+4. Export test — torch_export_to_gm with dynamic shapes
+"""
+
+import math
+from typing import Optional, Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.mamba.torch_mamba import _torch_ssm_prefill
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4flash import (
+    Phi4FlashAttention,
+    Phi4FlashConfig,
+    Phi4FlashDecoderLayer,
+    Phi4FlashForCausalLM,
+    Phi4FlashMamba,
+    Phi4FlashMLP,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def assert_rmse_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    rmse_ratio_tol: float,
+    msg: str = "",
+) -> None:
+    actual_f = actual.float()
+    expected_f = expected.float()
+    diff_rmse = torch.sqrt(torch.mean((actual_f - expected_f) ** 2))
+    expected_rmse = torch.sqrt(torch.mean(expected_f**2))
+    ratio = diff_rmse / max(expected_rmse, torch.tensor(1e-12, device=expected_f.device))
+    assert ratio <= rmse_ratio_tol, (
+        f"{msg}rmse(actual-expected)/rmse(expected)={ratio.item():.6f} > {rmse_ratio_tol}"
+    )
+
+
+def _create_small_config() -> Phi4FlashConfig:
+    return Phi4FlashConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=512,
+        layer_norm_eps=1e-5,
+        pad_token_id=0,
+        sliding_window=4,
+        mb_per_layer=2,
+        mamba_d_state=8,
+        mamba_d_conv=3,
+        mamba_expand=2,
+        mamba_dt_rank=4,
+    )
+
+
+def _lambda_init_fn(depth: int) -> float:
+    return 0.8 - 0.6 * math.exp(-0.3 * depth)
+
+
+def _split_heads(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    x = x.view(*x.shape[:-2], x.shape[-2] // 2, 2, x.shape[-1])
+    return x[..., 0, :], x[..., 1, :]
+
+
+def _repeat_kv(q: torch.Tensor, kv: torch.Tensor) -> torch.Tensor:
+    n_heads = q.shape[2]
+    bs, slen, n_kv_heads, head_dim = kv.shape
+    n_rep = n_heads // n_kv_heads
+    return (
+        kv[:, :, :, None, :]
+        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
+        .reshape(bs, slen, n_heads, head_dim)
+    )
+
+
+def _reference_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sliding_window: Optional[int] = None,
+) -> torch.Tensor:
+    if q.shape[2] != k.shape[2]:
+        k = _repeat_kv(q, k)
+        v = _repeat_kv(q, v)
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    attn_mask = None
+    is_causal = sliding_window is None
+    if sliding_window is not None:
+        q_len = q.shape[-2]
+        k_len = k.shape[-2]
+        q_pos = torch.arange(q_len, device=q.device)[:, None]
+        k_pos = torch.arange(k_len, device=q.device)[None, :]
+        blocked = (k_pos > q_pos) | ((q_pos - k_pos) >= sliding_window)
+        attn_mask = torch.zeros((q_len, k_len), dtype=q.dtype, device=q.device)
+        attn_mask.masked_fill_(blocked, float("-inf"))
+    out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, is_causal=is_causal)
+    return out.transpose(1, 2).contiguous()
+
+
+class RefPhi4FlashRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class RefPhi4FlashMLP(nn.Module):
+    def __init__(self, config: Phi4FlashConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=config.mlp_bias)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_bias)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        gate, up = self.fc1(hidden_states).chunk(2, dim=-1)
+        return self.fc2(up * F.silu(gate))
+
+
+class RefPhi4FlashDiffAttention(nn.Module):
+    def __init__(self, head_dim: int, depth: int):
+        super().__init__()
+        self.head_dim = head_dim
+        self.lambda_init = _lambda_init_fn(depth)
+        self.lambda_q1 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_k1 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_q2 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.lambda_k2 = nn.Parameter(
+            torch.zeros(head_dim, dtype=torch.float32).normal_(mean=0, std=0.1)
+        )
+        self.subln = RefPhi4FlashRMSNorm(2 * head_dim, eps=1e-5)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        sliding_window: Optional[int] = None,
+    ) -> torch.Tensor:
+        q1, q2 = _split_heads(q)
+        k1, k2 = _split_heads(k)
+        v1, v2 = _split_heads(v)
+
+        attn11 = _reference_attention(q1, k1, v1, sliding_window)
+        attn12 = _reference_attention(q1, k1, v2, sliding_window)
+        attn21 = _reference_attention(q2, k2, v1, sliding_window)
+        attn22 = _reference_attention(q2, k2, v2, sliding_window)
+        attn1 = torch.cat([attn11, attn12], dim=-1)
+        attn2 = torch.cat([attn21, attn22], dim=-1)
+
+        lambda_1 = torch.exp(torch.sum(self.lambda_q1 * self.lambda_k1, dim=-1).float()).type_as(q)
+        lambda_2 = torch.exp(torch.sum(self.lambda_q2 * self.lambda_k2, dim=-1).float()).type_as(q)
+        lambda_full = lambda_1 - lambda_2 + self.lambda_init
+        attn = self.subln(attn1 - lambda_full * attn2)
+        attn = attn * (1 - self.lambda_init)
+        return attn.view(*attn.shape[:-2], attn.shape[-2] * 2, self.head_dim)
+
+
+class RefPhi4FlashAttention(nn.Module):
+    def __init__(self, config: Phi4FlashConfig, layer_idx: int, yoco_cross: bool = False):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.yoco_cross = yoco_cross
+        op_size = self.num_heads * self.head_dim + 2 * (self.num_key_value_heads * self.head_dim)
+        self.out_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=True)
+        self.Wqkv = nn.Linear(
+            self.hidden_size,
+            self.num_heads * self.head_dim if yoco_cross else op_size,
+            bias=True,
+        )
+        self.inner_cross_attn = RefPhi4FlashDiffAttention(self.head_dim, layer_idx)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        yoco_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        bsz, q_len, _ = hidden_states.shape
+        if self.yoco_cross:
+            q = self.Wqkv(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim)
+            k, v = yoco_key_values
+            sliding_window = None
+        else:
+            qkv = self.Wqkv(hidden_states)
+            q_pos = self.num_heads * self.head_dim
+            kv_pos = self.num_key_value_heads * self.head_dim
+            q = qkv[..., :q_pos].view(bsz, q_len, self.num_heads, self.head_dim)
+            k = qkv[..., q_pos : q_pos + kv_pos].view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+            v = qkv[..., q_pos + kv_pos :].view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+            sliding_window = self.config.sliding_window[self.layer_idx]
+        out = self.inner_cross_attn(q, k, v, sliding_window)
+        return self.out_proj(out.reshape(bsz, q_len, self.hidden_size)), (k, v)
+
+
+class RefPhi4FlashMamba(nn.Module):
+    def __init__(self, config: Phi4FlashConfig, yoco_cross: bool = False, yoco_kv: bool = False):
+        super().__init__()
+        self.d_model = config.hidden_size
+        self.d_state = config.mamba_d_state
+        self.d_conv = config.mamba_d_conv
+        self.d_inner = config.mamba_expand * config.hidden_size
+        self.num_heads = self.d_inner
+        self.head_dim = 1
+        self.n_groups = 1
+        self.dt_rank = config.mamba_dt_rank
+        self.yoco_cross = yoco_cross
+        self.yoco_kv = yoco_kv
+        self.in_proj = nn.Linear(
+            self.d_model,
+            self.d_inner if yoco_cross else self.d_inner * 2,
+            bias=config.mamba_proj_bias,
+        )
+        if not yoco_cross:
+            self.conv1d = nn.Conv1d(
+                self.d_inner,
+                self.d_inner,
+                kernel_size=self.d_conv,
+                groups=self.d_inner,
+                padding=self.d_conv - 1,
+                bias=config.mamba_conv_bias,
+            )
+            self.x_proj = nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False)
+            self.dt_proj = nn.Linear(self.dt_rank, self.d_inner, bias=True)
+            A = torch.arange(1, self.num_heads + 1, dtype=torch.float32)
+            self.A_log = nn.Parameter(torch.log(A))
+            self.D = nn.Parameter(torch.ones(self.d_inner))
+        self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=config.mamba_proj_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        yoco_key_values: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        dtype = hidden_states.dtype
+        if self.yoco_cross:
+            out = self.in_proj(hidden_states)
+            out = out * torch.sigmoid(yoco_key_values)
+            return self.out_proj(out), yoco_key_values
+
+        x, z = self.in_proj(hidden_states).chunk(2, dim=-1)
+        x = self.conv1d(x.transpose(1, 2))[..., : hidden_states.shape[1]].transpose(1, 2)
+        x = F.silu(x)
+        dt, B, C = torch.split(self.x_proj(x), [self.dt_rank, self.d_state, self.d_state], dim=-1)
+        y, _ = _torch_ssm_prefill(
+            hidden_states=x.view(
+                hidden_states.shape[0], hidden_states.shape[1], self.num_heads, self.head_dim
+            ),
+            A=-torch.exp(self.A_log.float()),
+            B=B.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
+            C=C.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
+            D=self.D,
+            dt=torch.matmul(dt, self.dt_proj.weight.t()),
+            dt_bias=self.dt_proj.bias,
+            time_step_limit=[0.0, float("inf")],
+            chunk_size=256,
+        )
+        y = y.view(hidden_states.shape[0], hidden_states.shape[1], -1)
+        yoco_out = y if self.yoco_kv else None
+        y = y * (torch.sigmoid(z) if self.yoco_kv else F.silu(z))
+        return self.out_proj(y.to(dtype)), yoco_out
+
+
+class RefPhi4FlashDecoderLayer(nn.Module):
+    def __init__(self, config: Phi4FlashConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.mlp = RefPhi4FlashMLP(config)
+        self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.post_attention_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        yoco_mb = layer_idx >= config.num_hidden_layers // 2
+        yoco_cross = layer_idx >= (config.num_hidden_layers // 2 + 2)
+        attn_config = config
+        if layer_idx >= (config.num_hidden_layers // 2 + 1):
+            attn_config = Phi4FlashConfig(**config.to_dict())
+            attn_config.sliding_window = [None] * config.num_hidden_layers
+
+        self.use_mamba = config.mb_per_layer > 0 and layer_idx % config.mb_per_layer == 0
+        if self.use_mamba:
+            self.attn = RefPhi4FlashMamba(attn_config, yoco_cross=yoco_cross, yoco_kv=yoco_mb)
+        else:
+            self.attn = RefPhi4FlashAttention(
+                attn_config, layer_idx=layer_idx, yoco_cross=yoco_cross
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        ssm_output: Optional[torch.Tensor] = None,
+        yoco_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        if self.use_mamba:
+            attn_outputs, ssm_output = self.attn(hidden_states, yoco_key_values=ssm_output)
+        else:
+            attn_outputs, yoco_key_values = self.attn(
+                hidden_states, yoco_key_values=yoco_key_values
+            )
+        hidden_states = residual + attn_outputs
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+        return hidden_states, ssm_output, yoco_key_values
+
+
+class RefPhi4FlashForCausalLM(nn.Module):
+    def __init__(self, config: Phi4FlashConfig):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, config.pad_token_id
+        )
+        self.model.layers = nn.ModuleList(
+            [RefPhi4FlashDecoderLayer(config, layer_idx=i) for i in range(config.num_hidden_layers)]
+        )
+        self.model.final_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=config.lm_head_bias)
+
+    def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor):
+        del position_ids
+        hidden_states = self.model.embed_tokens(input_ids)
+        ssm_output = None
+        yoco_key_values = None
+        for layer in self.model.layers:
+            hidden_states, ssm_output, yoco_key_values = layer(
+                hidden_states,
+                ssm_output=ssm_output,
+                yoco_key_values=yoco_key_values,
+            )
+        hidden_states = self.model.final_layernorm(hidden_states)
+        return self.lm_head(hidden_states)
+
+
+def _assert_same_state_dict(custom: nn.Module, ref: nn.Module):
+    missing, unexpected = ref.load_state_dict(custom.state_dict(), strict=False)
+    assert not missing
+    assert not unexpected
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4flash_mlp_equivalence(B, S):
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashMLP(config).to(device=device, dtype=dtype)
+    ref = RefPhi4FlashMLP(config).to(device=device, dtype=dtype)
+    _assert_same_state_dict(custom, ref)
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    torch.testing.assert_close(custom(x), ref(x), rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4flash_attention_equivalence(B, S):
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashAttention(config, layer_idx=1).to(device=device, dtype=dtype)
+    ref = RefPhi4FlashAttention(config, layer_idx=1).to(device=device, dtype=dtype)
+    _assert_same_state_dict(custom, ref)
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    custom_out, _ = custom(x)
+    ref_out, _ = ref(x)
+    assert_rmse_close(custom_out, ref_out, rmse_ratio_tol=0.10, msg="Attention: ")
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4flash_mamba_equivalence(B, S):
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashMamba(config, layer_idx=0, yoco_cross=False, yoco_kv=False).to(
+        device=device, dtype=dtype
+    )
+    ref = RefPhi4FlashMamba(config, yoco_cross=False, yoco_kv=False).to(device=device, dtype=dtype)
+    _assert_same_state_dict(custom, ref)
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    custom_out, _ = custom(x)
+    ref_out, _ = ref(x)
+    assert_rmse_close(custom_out, ref_out, rmse_ratio_tol=0.05, msg="Mamba: ")
+
+
+@torch.no_grad()
+def test_phi4flash_shared_mamba_equivalence():
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashMamba(config, layer_idx=4, yoco_cross=True, yoco_kv=True).to(
+        device=device, dtype=dtype
+    )
+    ref = RefPhi4FlashMamba(config, yoco_cross=True, yoco_kv=True).to(device=device, dtype=dtype)
+    _assert_same_state_dict(custom, ref)
+    x = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
+    ssm = torch.randn(2, 6, config.mamba_expand * config.hidden_size, device=device, dtype=dtype)
+    custom_out, _ = custom(x, yoco_key_values=ssm)
+    ref_out, _ = ref(x, yoco_key_values=ssm)
+    torch.testing.assert_close(custom_out, ref_out, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("layer_idx", [1, 5])
+@torch.no_grad()
+def test_phi4flash_decoder_layer_equivalence(layer_idx):
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    layer = Phi4FlashDecoderLayer(config, layer_idx=layer_idx).to(device=device, dtype=dtype)
+    ref = RefPhi4FlashDecoderLayer(config, layer_idx=layer_idx).to(device=device, dtype=dtype)
+    _assert_same_state_dict(layer, ref)
+    x = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
+    ssm = torch.randn(2, 6, config.mamba_expand * config.hidden_size, device=device, dtype=dtype)
+    head_dim = config.hidden_size // config.num_attention_heads
+    kv = (
+        torch.randn(2, 6, config.num_key_value_heads, head_dim, device=device, dtype=dtype),
+        torch.randn(2, 6, config.num_key_value_heads, head_dim, device=device, dtype=dtype),
+    )
+    out, next_ssm, next_kv = layer(x, ssm_output=ssm, yoco_key_values=kv)
+    ref_out, ref_ssm, ref_kv = ref(x, ssm_output=ssm, yoco_key_values=kv)
+    assert_rmse_close(out, ref_out, rmse_ratio_tol=0.05, msg=f"Layer {layer_idx}: ")
+    if next_ssm is not None and ref_ssm is not None:
+        assert_rmse_close(next_ssm, ref_ssm, rmse_ratio_tol=0.05, msg=f"Layer {layer_idx} ssm: ")
+    if next_kv is not None and ref_kv is not None:
+        assert_rmse_close(next_kv[0], ref_kv[0], rmse_ratio_tol=0.05, msg=f"Layer {layer_idx} k: ")
+        assert_rmse_close(next_kv[1], ref_kv[1], rmse_ratio_tol=0.05, msg=f"Layer {layer_idx} v: ")
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4flash_full_model_equivalence(B, S):
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashForCausalLM(config).to(device=device, dtype=dtype)
+    ref = RefPhi4FlashForCausalLM(config).to(device=device, dtype=dtype)
+    _assert_same_state_dict(custom, ref)
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+    custom_out = custom(input_ids=input_ids, position_ids=position_ids)
+    ref_out = ref(input_ids=input_ids, position_ids=position_ids)
+    assert_rmse_close(custom_out.logits, ref_out, rmse_ratio_tol=0.05, msg="Full model: ")
+
+
+@torch.no_grad()
+def test_phi4flash_model_can_be_exported():
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    model = Phi4FlashForCausalLM(config).to(device=device, dtype=dtype)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+    move_to_device(gm, device)
+    out = gm(input_ids=input_ids, position_ids=position_ids)
+    assert "logits" in out
+    assert out["logits"].shape == (B, S, config.vocab_size)
+    assert torch.isfinite(out["logits"]).all()
+
+    input_ids2 = torch.randint(0, config.vocab_size, (1, 4), device=device)
+    position_ids2 = torch.arange(4, device=device).unsqueeze(0)
+    out2 = gm(input_ids=input_ids2, position_ids=position_ids2)
+    assert out2["logits"].shape == (1, 4, config.vocab_size)
+    assert torch.isfinite(out2["logits"]).all()

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4flash_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4flash_modeling.py
@@ -7,6 +7,7 @@ Hierarchical test levels:
 4. Export test — torch_export_to_gm with dynamic shapes
 """
 
+import copy
 import math
 from typing import Optional, Tuple
 
@@ -16,7 +17,6 @@ import torch.nn.functional as F
 from torch import nn
 from torch.export import Dim
 
-from tensorrt_llm._torch.auto_deploy.custom_ops.mamba.torch_mamba import _torch_ssm_prefill
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4flash import (
     Phi4FlashAttention,
@@ -75,6 +75,54 @@ def _create_small_config() -> Phi4FlashConfig:
 
 def _lambda_init_fn(depth: int) -> float:
     return 0.8 - 0.6 * math.exp(-0.3 * depth)
+
+
+def _swiglu(gate: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+    return value * F.silu(gate)
+
+
+def _hf_phi4flash_ssm_prefill(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    yoco_kv: bool,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    batch_size, seq_len, d_inner = x.shape
+    d_state = B.shape[-1]
+    state = torch.zeros(batch_size, d_inner, d_state, device=x.device, dtype=torch.float32)
+    A_fp32 = A.to(torch.float32)
+    D_fp32 = D.to(torch.float32)
+    dt_bias_fp32 = dt_bias.to(torch.float32)
+
+    outputs = []
+    yoco_key_values = []
+    for token_idx in range(seq_len):
+        x_t = x[:, token_idx].to(torch.float32)
+        z_t = z[:, token_idx].to(torch.float32)
+        dt_t = F.softplus(dt[:, token_idx].to(torch.float32) + dt_bias_fp32)
+        B_t = B[:, token_idx].to(torch.float32)
+        C_t = C[:, token_idx].to(torch.float32)
+
+        dA = torch.exp(dt_t.unsqueeze(-1) * A_fp32.unsqueeze(0))
+        dB = dt_t.unsqueeze(-1) * B_t.unsqueeze(1)
+        state = state * dA + x_t.unsqueeze(-1) * dB
+
+        y_t = torch.einsum("bdn,bn->bd", state, C_t) + D_fp32.unsqueeze(0) * x_t
+        if yoco_kv:
+            yoco_key_values.append(y_t.to(dtype=x.dtype))
+            y_t = _swiglu(z_t, y_t)
+        else:
+            y_t = y_t * F.silu(z_t)
+        outputs.append(y_t.to(dtype=x.dtype))
+
+    y = torch.stack(outputs, dim=1)
+    yoco_out = torch.stack(yoco_key_values, dim=1) if yoco_kv else None
+    return y, yoco_out
 
 
 def _split_heads(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -238,6 +286,7 @@ class RefPhi4FlashMamba(nn.Module):
         self.d_model = config.hidden_size
         self.d_state = config.mamba_d_state
         self.d_conv = config.mamba_d_conv
+        self.expand = config.mamba_expand
         self.d_inner = config.mamba_expand * config.hidden_size
         self.num_heads = self.d_inner
         self.head_dim = 1
@@ -261,8 +310,8 @@ class RefPhi4FlashMamba(nn.Module):
             )
             self.x_proj = nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False)
             self.dt_proj = nn.Linear(self.dt_rank, self.d_inner, bias=True)
-            A = torch.arange(1, self.num_heads + 1, dtype=torch.float32)
-            self.A_log = nn.Parameter(torch.log(A))
+            A = torch.arange(1, self.d_state + 1, dtype=torch.float32).unsqueeze(0)
+            self.A_log = nn.Parameter(torch.log(A.expand(self.d_inner, -1).contiguous()))
             self.D = nn.Parameter(torch.ones(self.d_inner))
         self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=config.mamba_proj_bias)
 
@@ -274,29 +323,24 @@ class RefPhi4FlashMamba(nn.Module):
         dtype = hidden_states.dtype
         if self.yoco_cross:
             out = self.in_proj(hidden_states)
-            out = out * torch.sigmoid(yoco_key_values)
+            out = _swiglu(out, yoco_key_values)
             return self.out_proj(out), yoco_key_values
 
         x, z = self.in_proj(hidden_states).chunk(2, dim=-1)
         x = self.conv1d(x.transpose(1, 2))[..., : hidden_states.shape[1]].transpose(1, 2)
         x = F.silu(x)
         dt, B, C = torch.split(self.x_proj(x), [self.dt_rank, self.d_state, self.d_state], dim=-1)
-        y, _ = _torch_ssm_prefill(
-            hidden_states=x.view(
-                hidden_states.shape[0], hidden_states.shape[1], self.num_heads, self.head_dim
-            ),
+        y, yoco_out = _hf_phi4flash_ssm_prefill(
+            x=x,
+            z=z,
             A=-torch.exp(self.A_log.float()),
-            B=B.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
-            C=C.view(hidden_states.shape[0], hidden_states.shape[1], self.n_groups, self.d_state),
+            B=B,
+            C=C,
             D=self.D,
             dt=torch.matmul(dt, self.dt_proj.weight.t()),
             dt_bias=self.dt_proj.bias,
-            time_step_limit=[0.0, float("inf")],
-            chunk_size=256,
+            yoco_kv=self.yoco_kv,
         )
-        y = y.view(hidden_states.shape[0], hidden_states.shape[1], -1)
-        yoco_out = y if self.yoco_kv else None
-        y = y * (torch.sigmoid(z) if self.yoco_kv else F.silu(z))
         return self.out_proj(y.to(dtype)), yoco_out
 
 
@@ -356,6 +400,8 @@ class RefPhi4FlashForCausalLM(nn.Module):
         )
         self.model.final_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=config.lm_head_bias)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor):
         del position_ids
@@ -374,6 +420,12 @@ class RefPhi4FlashForCausalLM(nn.Module):
 
 def _assert_same_state_dict(custom: nn.Module, ref: nn.Module):
     missing, unexpected = ref.load_state_dict(custom.state_dict(), strict=False)
+    assert not missing
+    assert not unexpected
+
+
+def _load_hf_reference_state_dict(custom: nn.Module, ref: nn.Module):
+    missing, unexpected = custom.load_state_dict(copy.deepcopy(ref.state_dict()), strict=False)
     assert not missing
     assert not unexpected
 
@@ -416,11 +468,29 @@ def test_phi4flash_mamba_equivalence(B, S):
         device=device, dtype=dtype
     )
     ref = RefPhi4FlashMamba(config, yoco_cross=False, yoco_kv=False).to(device=device, dtype=dtype)
-    _assert_same_state_dict(custom, ref)
+    _load_hf_reference_state_dict(custom, ref)
     x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
     custom_out, _ = custom(x)
     ref_out, _ = ref(x)
     assert_rmse_close(custom_out, ref_out, rmse_ratio_tol=0.05, msg="Mamba: ")
+
+
+@torch.no_grad()
+def test_phi4flash_mamba_load_preserves_hf_a_log():
+    config = _create_small_config()
+    dtype = torch.bfloat16
+    device = "cpu"
+    custom = Phi4FlashMamba(config, layer_idx=0, yoco_cross=False, yoco_kv=False).to(
+        device=device, dtype=dtype
+    )
+    ref = RefPhi4FlashMamba(config, yoco_cross=False, yoco_kv=False).to(device=device, dtype=dtype)
+    ref_state = copy.deepcopy(ref.state_dict())
+    expected = ref_state["A_log"]
+
+    missing, unexpected = custom.load_state_dict(ref_state, strict=False)
+    assert not missing
+    assert not unexpected
+    torch.testing.assert_close(custom.A_log, expected, rtol=0.0, atol=0.0)
 
 
 @torch.no_grad()
@@ -432,7 +502,7 @@ def test_phi4flash_shared_mamba_equivalence():
         device=device, dtype=dtype
     )
     ref = RefPhi4FlashMamba(config, yoco_cross=True, yoco_kv=True).to(device=device, dtype=dtype)
-    _assert_same_state_dict(custom, ref)
+    _load_hf_reference_state_dict(custom, ref)
     x = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
     ssm = torch.randn(2, 6, config.mamba_expand * config.hidden_size, device=device, dtype=dtype)
     custom_out, _ = custom(x, yoco_key_values=ssm)
@@ -448,7 +518,7 @@ def test_phi4flash_decoder_layer_equivalence(layer_idx):
     device = "cpu"
     layer = Phi4FlashDecoderLayer(config, layer_idx=layer_idx).to(device=device, dtype=dtype)
     ref = RefPhi4FlashDecoderLayer(config, layer_idx=layer_idx).to(device=device, dtype=dtype)
-    _assert_same_state_dict(layer, ref)
+    _load_hf_reference_state_dict(layer, ref)
     x = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
     ssm = torch.randn(2, 6, config.mamba_expand * config.hidden_size, device=device, dtype=dtype)
     head_dim = config.hidden_size // config.num_attention_heads
@@ -474,7 +544,7 @@ def test_phi4flash_full_model_equivalence(B, S):
     device = "cpu"
     custom = Phi4FlashForCausalLM(config).to(device=device, dtype=dtype)
     ref = RefPhi4FlashForCausalLM(config).to(device=device, dtype=dtype)
-    _assert_same_state_dict(custom, ref)
+    _load_hf_reference_state_dict(custom, ref)
     input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
     position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
     custom_out = custom(input_ids=input_ids, position_ids=position_ids)

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi4mm_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi4mm_modeling.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Phi-4 multimodal AutoDeploy custom model."""
+
+import pytest
+import torch
+from _model_test_utils import assert_rmse_close
+from torch.export import Dim
+from transformers.models.phi4_multimodal.configuration_phi4_multimodal import (
+    Phi4MultimodalAudioConfig,
+    Phi4MultimodalConfig,
+    Phi4MultimodalVisionConfig,
+)
+from transformers.models.phi4_multimodal.modeling_phi4_multimodal import (
+    Phi4MultimodalAttention,
+    Phi4MultimodalDecoderLayer,
+    Phi4MultimodalForCausalLM,
+    Phi4MultimodalMLP,
+    Phi4MultimodalRMSNorm,
+    Phi4MultimodalRotaryEmbedding,
+)
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi4mm import (
+    InputMode,
+    Phi4MMAttention,
+    Phi4MMConfig,
+    Phi4MMDecoderLayer,
+    Phi4MMForCausalLM,
+    Phi4MMMLP,
+    Phi4MMRMSNorm,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _create_hf_config() -> Phi4MultimodalConfig:
+    config = Phi4MultimodalConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=512,
+        original_max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        attention_dropout=0.0,
+        resid_pdrop=0.0,
+        tie_word_embeddings=False,
+        pad_token_id=0,
+        vision_config=Phi4MultimodalVisionConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            image_size=28,
+            patch_size=14,
+        ),
+        audio_config=Phi4MultimodalAudioConfig(
+            hidden_size=32,
+            intermediate_size=48,
+            num_blocks=2,
+            num_attention_heads=4,
+            input_size=16,
+            ext_pw_out_channel=32,
+            depthwise_separable_out_channel=32,
+            nemo_conv_channels=32,
+            time_reduction=2,
+        ),
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _create_custom_config() -> Phi4MMConfig:
+    return Phi4MMConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=512,
+        original_max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        partial_rotary_factor=1.0,
+        attention_dropout=0.0,
+        resid_pdrop=0.0,
+        tie_word_embeddings=False,
+        pad_token_id=0,
+        embd_layer=None,
+        vision_lora={"r": 4, "lora_alpha": 4, "dp": 0.0, "layer": ""},
+        speech_lora={"r": 4, "lora_alpha": 4, "dp": 0.0, "layer": ""},
+    )
+
+
+def _make_causal_mask(batch_size: int, seq_len: int, device, dtype):
+    mask = torch.full((seq_len, seq_len), torch.finfo(dtype).min, device=device, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    return mask.unsqueeze(0).unsqueeze(0).expand(batch_size, -1, -1, -1)
+
+
+def _map_hf_state_dict_to_custom(hf_state_dict):
+    mapped = {}
+    for key, value in hf_state_dict.items():
+        new_key = key
+        for pattern in [
+            "qkv_proj.weight",
+            "o_proj.weight",
+            "gate_up_proj.weight",
+            "down_proj.weight",
+        ]:
+            if key.endswith(pattern):
+                new_key = key.replace(".weight", ".base_layer.weight")
+                break
+        mapped[new_key] = value
+    return mapped
+
+
+def _load_text_weights(custom_module, hf_module):
+    custom_module.load_state_dict(
+        _map_hf_state_dict_to_custom(hf_module.state_dict()), strict=False
+    )
+
+
+def test_phi4mm_lora_structure():
+    config = _create_custom_config()
+    model = Phi4MMForCausalLM(config)
+    qkv_proj = model.model.layers[0].self_attn.qkv_proj
+    assert "vision" in qkv_proj.lora_A
+    assert "speech" in qkv_proj.lora_A
+    assert qkv_proj.base_layer.weight.shape[1] == config.hidden_size
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4mm_rmsnorm_equivalence(B, S):
+    device = "cpu"
+    config = _create_custom_config()
+    hidden_size = config.hidden_size
+
+    hf_norm = Phi4MultimodalRMSNorm(hidden_size, eps=config.rms_norm_eps).to(device)
+    custom_norm = Phi4MMRMSNorm(hidden_size, eps=config.rms_norm_eps).to(device)
+    custom_norm.load_state_dict(hf_norm.state_dict())
+
+    x = torch.randn(B, S, hidden_size, device=device)
+    torch.testing.assert_close(custom_norm(x), hf_norm(x), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4mm_mlp_equivalence(B, S):
+    device = "cpu"
+    hf_config = _create_hf_config()
+    custom_config = _create_custom_config()
+
+    hf_mlp = Phi4MultimodalMLP(hf_config).to(device).eval()
+    custom_mlp = Phi4MMMLP(custom_config).to(device).eval()
+    _load_text_weights(custom_mlp, hf_mlp)
+    custom_mlp.disable_adapter()
+
+    x = torch.randn(B, S, custom_config.hidden_size, device=device)
+    torch.testing.assert_close(custom_mlp(x), hf_mlp(x), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4mm_attention_equivalence(B, S):
+    device = "cpu"
+    hf_config = _create_hf_config()
+    custom_config = _create_custom_config()
+
+    hf_attn = Phi4MultimodalAttention(hf_config, layer_idx=0).to(device).eval()
+    hf_rotary = Phi4MultimodalRotaryEmbedding(hf_config).to(device).eval()
+    custom_attn = Phi4MMAttention(custom_config, layer_idx=0).to(device).eval()
+    _load_text_weights(custom_attn, hf_attn)
+    custom_attn.disable_adapter()
+
+    x = torch.randn(B, S, custom_config.hidden_size, device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+    position_embeddings = hf_rotary(x, position_ids)
+    attention_mask = _make_causal_mask(B, S, device, x.dtype)
+
+    hf_out = hf_attn(
+        hidden_states=x,
+        position_embeddings=position_embeddings,
+        attention_mask=attention_mask,
+    )[0]
+    custom_out = custom_attn(x, position_ids)
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.05)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4mm_decoder_layer_equivalence(B, S):
+    device = "cpu"
+    hf_config = _create_hf_config()
+    custom_config = _create_custom_config()
+
+    hf_layer = Phi4MultimodalDecoderLayer(hf_config, layer_idx=0).to(device).eval()
+    custom_layer = Phi4MMDecoderLayer(custom_config, layer_idx=0).to(device).eval()
+    _load_text_weights(custom_layer, hf_layer)
+    custom_layer.disable_adapter()
+
+    x = torch.randn(B, S, custom_config.hidden_size, device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+    position_embeddings = Phi4MultimodalRotaryEmbedding(hf_config).to(device)(x, position_ids)
+    attention_mask = _make_causal_mask(B, S, device, x.dtype)
+
+    hf_out = hf_layer(
+        hidden_states=x,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        position_embeddings=position_embeddings,
+    )
+    custom_out = custom_layer(x, position_ids)
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.05)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@torch.no_grad()
+def test_phi4mm_full_model_equivalence(B, S):
+    device = "cpu"
+    hf_config = _create_hf_config()
+    custom_config = _create_custom_config()
+
+    hf_model = Phi4MultimodalForCausalLM(hf_config).to(device).eval()
+    custom_model = Phi4MMForCausalLM(custom_config).to(device).eval()
+    custom_model.load_state_dict(_map_hf_state_dict_to_custom(hf_model.state_dict()), strict=False)
+    custom_model.model.unset_lora_adapter()
+
+    input_ids = torch.randint(0, custom_config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+    attention_mask = torch.ones(B, S, device=device, dtype=torch.long)
+
+    hf_logits = hf_model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+    ).logits
+    custom_logits = custom_model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        input_mode=InputMode.LANGUAGE,
+    ).logits
+
+    assert_rmse_close(custom_logits, hf_logits, rmse_ratio_tol=0.05)
+
+
+def test_phi4mm_model_can_be_exported():
+    device = "cpu"
+    config = _create_custom_config()
+    model = Phi4MMForCausalLM(config).to(device).eval()
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len), device=device)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        None,
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "input_mode": InputMode.LANGUAGE,
+        },
+        dynamic_shapes=dynamic_shapes,
+    )
+    move_to_device(gm, device)
+
+    out_gm = gm(input_ids=input_ids, position_ids=position_ids, input_mode=InputMode.LANGUAGE)
+    assert "logits" in out_gm
+    logits = out_gm["logits"]
+    assert logits.shape == (batch_size, seq_len, config.vocab_size)
+    assert torch.isfinite(logits).all()
+
+    batch_size_2, seq_len_2 = 1, 4
+    input_ids_2 = torch.randint(0, config.vocab_size, (batch_size_2, seq_len_2), device=device)
+    position_ids_2 = torch.arange(seq_len_2, device=device).unsqueeze(0).expand(batch_size_2, -1)
+    out_gm_2 = gm(
+        input_ids=input_ids_2,
+        position_ids=position_ids_2,
+        input_mode=InputMode.LANGUAGE,
+    )
+    logits_2 = out_gm_2["logits"]
+    assert logits_2.shape == (batch_size_2, seq_len_2, config.vocab_size)
+    assert torch.isfinite(logits_2).all()

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rope_transformation.py
@@ -143,6 +143,45 @@ class RoPEModel(torch.nn.Module):
         return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
 
 
+class PartialRotaryRoPEModel(torch.nn.Module):
+    """Phi4-style partial rotary model.
+
+    Applies RoPE to full-width q/k tensors while the cos/sin cache only covers
+    the rotary prefix. optimize_rope must not rewrite this into flashinfer_rope.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        partial_rotary_factor: float,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = hidden_size // num_heads
+        self.rotary_dim = int(self.head_dim * partial_rotary_factor)
+        self.linear_q = torch.nn.Linear(hidden_size, num_heads * self.head_dim)
+        self.linear_k = torch.nn.Linear(hidden_size, num_kv_heads * self.head_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, s, _ = x.shape
+        q = self.linear_q(x).view(b, s, self.num_heads, self.head_dim)
+        k = self.linear_k(x).view(b, s, self.num_kv_heads, self.head_dim)
+        cos, sin = _precompute_freqs_cis_explicit(
+            s, self.rotary_dim, rope_theta=10000, dtype=x.dtype
+        )
+        cos = cos.to(x.device).unsqueeze(0).expand(b, -1, -1)
+        sin = sin.to(x.device).unsqueeze(0).expand(b, -1, -1)
+        q_out, k_out = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(q, k, cos, sin, 2)
+        return torch.cat([q_out.reshape(b, s, -1), k_out.reshape(b, s, -1)], dim=-1)
+
+    def get_dynamic_shapes(self):
+        return {0: Dim.DYNAMIC, 1: Dim.DYNAMIC}
+
+
 @pytest.mark.parametrize(
     "transformation,variant,layout,batch_size,seq_len,num_heads,num_kv_heads,atol,rtol, target_layout",
     [
@@ -556,6 +595,47 @@ def test_optimize_interleaved_rope(num_heads, num_kv_heads):
         None,  # check_num_matches
         False,  # skip_output_assert
     )
+
+
+@torch.inference_mode()
+def test_optimize_rope_skips_partial_rotary_full_width_qk():
+    hidden_size = 3072
+    num_heads = 24
+    num_kv_heads = 8
+    partial_rotary_factor = 0.75
+    batch, seq = 2, 12
+    model = PartialRotaryRoPEModel(
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        partial_rotary_factor=partial_rotary_factor,
+    ).to("cuda", torch.float16)
+
+    x = torch.randn(batch, seq, hidden_size, device="cuda", dtype=torch.float16)
+    dynamic_shapes = model.get_dynamic_shapes()
+    gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
+
+    assert any(
+        is_op(n, torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin) for n in gm.graph.nodes
+    ), "Expected explicit rope op in graph before optimization"
+
+    gm_transformed = InferenceOptimizer(
+        None,
+        {"optimize_rope": {"stage": "pattern_matcher"}},
+    )(None, gm)
+    gm_transformed.to("cuda")
+
+    assert not any(
+        is_op(n, torch.ops.auto_deploy.flashinfer_rope) for n in gm_transformed.graph.nodes
+    ), "optimize_rope should skip flashinfer_rope for partial-rotary full-width q/k"
+    assert any(
+        is_op(n, torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin)
+        for n in gm_transformed.graph.nodes
+    ), "Expected explicit rope op to remain after optimization"
+
+    y_ref = model(x)
+    y_opt = gm_transformed(x)
+    torch.testing.assert_close(y_opt, y_ref, atol=1e-3, rtol=1e-3)
 
 
 class DSExplicitRotaryEmbedding(torch.nn.Module):


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR adds AutoDeploy onboarding support for the Phi-4 family variants in this branch, including microsoft/Phi-4-reasoning-vision-15B in text-only mode while keeping the remote VLM wrapper and the registry entry on ImageTextToText.

For Phi-4 reasoning-vision specifically, the final follow-up keeps llm.py untouched relative to the PR base and localizes the prompt-templating behavior into the Phi-4-specific ImageTextToText path in modeling_phi4_visionr.py via Phi4VisionRTokenizer, Phi4VisionRProcessorWrapper, and Phi4VisionRAutoModelForImageTextToTextFactory. The model-specific registry config points to that factory and still relies on eager attention construction for the remote wrapper while AutoDeploy exports only the text stack.

## Test Coverage

- pytest -p no:cacheprovider -q tests/unittest/auto_deploy/singlegpu/models/test_phi4_visionr_modeling.py
  - Result: 15 passed, 4 warnings
- Registry e2e: python examples/auto_deploy/build_and_run_ad.py --model microsoft/Phi-4-reasoning-vision-15B --use-registry
  - Log: ad_run_logs/ad_run_phi4_reasoning_vision_15b_use_registry_20260312_110116.log
  - Result: completed 10/10 prompts with coherent generation, including The capital of Iceland is Reykjavik, a correct gravity explanation, and a good northern-lights answer.

## Reviewer Follow-up

- Latest reviewer request on llm.py is addressed.
- git diff origin/feat/paperclip_maximizer -- tensorrt_llm/_torch/auto_deploy/llm.py is now empty.
- The onboarding update reviewer gave a final PASS/READY on branch bala/phi4 at commit ea655a1966.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
