### PR TITLE
[None][fix] Fix NVFP4 fused MoE dropping w3_alpha during weight stacking

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2024,9 +2024,7 @@ def _stack_nvfp4_cutlass_moe_weights(
         else:
             return torch.empty(0, device=device, dtype=dtype)
 
-    def _adjust_w3_blockscales_for_alpha_diff(
-        w3_blockscale_fp8, w1_alpha, w3_alpha
-    ):
+    def _adjust_w3_blockscales_for_alpha_diff(w3_blockscale_fp8, w1_alpha, w3_alpha):
         """Adjust w3 block scales when w1 and w3 have different alpha (weight global scales).
 
         The CUTLASS fused MoE kernel uses a single fc1_alpha per expert for both
@@ -2065,9 +2063,7 @@ def _stack_nvfp4_cutlass_moe_weights(
         # Broadcast ratio [E] → [E, 1, 1] over block dimensions
         w3_bs_float = w3_bs_float * alpha_ratio.view(-1, *([1] * (w3_bs_float.ndim - 1)))
         w3_bs_fp8 = w3_bs_float.to(torch.float8_e4m3fn)
-        w3_bs_swizzled = torch.ops.trtllm.block_scale_interleave(
-            w3_bs_fp8.view(torch.uint8)
-        )
+        w3_bs_swizzled = torch.ops.trtllm.block_scale_interleave(w3_bs_fp8.view(torch.uint8))
         return w3_bs_swizzled.view(torch.float8_e4m3fn).reshape(original_shape)
 
     def _prepare_args_cutlass_format_nvfp4():
@@ -2121,9 +2117,7 @@ def _stack_nvfp4_cutlass_moe_weights(
                     effective_w3_alpha = w3_alpha_stacked
                 else:
                     # Recompute w3 alpha with the global input scale, same formula as w1
-                    effective_w3_alpha = (
-                        w3_alpha_stacked * w3_input_scale_stacked / fc1_act_scale
-                    )
+                    effective_w3_alpha = w3_alpha_stacked * w3_input_scale_stacked / fc1_act_scale
                 w3_weight_blockscale_fp8_stacked = _adjust_w3_blockscales_for_alpha_diff(
                     w3_weight_blockscale_fp8_stacked, fc1_alpha_stacked, effective_w3_alpha
                 )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2011,6 +2011,7 @@ def _stack_nvfp4_cutlass_moe_weights(
             "w3_weight_scale",
             "w1_alpha",
             "w2_alpha",
+            "w3_alpha",
             "is_gated_mlp",
             "act_fn",
         )
@@ -2023,14 +2024,56 @@ def _stack_nvfp4_cutlass_moe_weights(
         else:
             return torch.empty(0, device=device, dtype=dtype)
 
-    def _prepare_args_cutlass_format_nvfp4():
-        if is_gated_mlp:
-            # For gated MLP, concatenate w1 and w3 as [w3, w1]
-            fc1_expert_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
-            fc1_weight_blockscale_fp8_stacked = torch.cat(
-                [w3_weight_blockscale_fp8_stacked, w1_weight_blockscale_fp8_stacked], dim=1
-            ).contiguous()
+    def _adjust_w3_blockscales_for_alpha_diff(
+        w3_blockscale_fp8, w1_alpha, w3_alpha
+    ):
+        """Adjust w3 block scales when w1 and w3 have different alpha (weight global scales).
 
+        The CUTLASS fused MoE kernel uses a single fc1_alpha per expert for both
+        the w1 and w3 GEMM outputs. When w1_alpha != w3_alpha (due to different
+        per-expert weight_scale_2), the w3 output would be incorrectly scaled.
+
+        Fix: bake the alpha ratio into w3's per-block scales so that using w1_alpha
+        for both produces correct dequantization:
+            adjusted_w3_bs = original_w3_bs * (w3_alpha / w1_alpha)
+
+        Args:
+            w3_blockscale_fp8: Stacked w3 block scales [E, M, N_blocks] as float8_e4m3fn
+            w1_alpha: Per-expert alpha for w1 [E]
+            w3_alpha: Per-expert alpha for w3 [E]
+
+        Returns:
+            Adjusted w3 block scales with same shape and dtype.
+        """
+        alpha_ratio = w3_alpha / w1_alpha  # [E]
+
+        if torch.allclose(alpha_ratio, torch.ones_like(alpha_ratio), rtol=1e-3, atol=1e-6):
+            return w3_blockscale_fp8
+
+        ad_logger.warning_once(
+            "NVFP4 MoE: w3 alpha differs from w1 alpha (different per-expert weight global "
+            "scales). Adjusting w3 block scales to compensate. This is expected for checkpoints "
+            "with per-expert weight scales not synced across experts.",
+            key="nvfp4_moe_w3_alpha_adjustment",
+        )
+
+        original_shape = w3_blockscale_fp8.shape
+        # Unswizzle → float → scale → float8 → reswizzle
+        w3_bs_uint8 = w3_blockscale_fp8.view(torch.uint8)
+        w3_bs_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(w3_bs_uint8)
+        w3_bs_float = w3_bs_unswizzled.view(torch.float8_e4m3fn).float()
+        # Broadcast ratio [E] → [E, 1, 1] over block dimensions
+        w3_bs_float = w3_bs_float * alpha_ratio.view(-1, *([1] * (w3_bs_float.ndim - 1)))
+        w3_bs_fp8 = w3_bs_float.to(torch.float8_e4m3fn)
+        w3_bs_swizzled = torch.ops.trtllm.block_scale_interleave(
+            w3_bs_fp8.view(torch.uint8)
+        )
+        return w3_bs_swizzled.view(torch.float8_e4m3fn).reshape(original_shape)
+
+    def _prepare_args_cutlass_format_nvfp4():
+        nonlocal w3_weight_blockscale_fp8_stacked
+
+        if is_gated_mlp:
             # Check if all w1 and w3 input scales are identical across experts
             all_scales_equal = (
                 torch.all(w1_input_scale_stacked == w1_input_scale_stacked[0])
@@ -2065,6 +2108,31 @@ def _stack_nvfp4_cutlass_moe_weights(
                 # Formula: new_alpha = old_alpha * per_expert_input_scale / global_input_scale
                 # This ensures alpha is consistent with the global fc1_act_scale used by the kernel.
                 fc1_alpha_stacked = w1_alpha_stacked * w1_input_scale_stacked / fc1_act_scale
+
+            # The fused CUTLASS kernel uses a single fc1_alpha for both w1 and w3.
+            # When w1 and w3 have different weight global scales (weight_scale_2),
+            # their alphas differ. Compensate by adjusting w3's block scales so that
+            # using fc1_alpha (based on w1) still produces correct dequantization for w3.
+            #
+            # Compute the effective w3 alpha that SHOULD be used (accounting for any
+            # input_scale recomputation), then compare against the actual fc1_alpha.
+            if w3_alpha_stacked.numel() > 0:
+                if all_scales_equal:
+                    effective_w3_alpha = w3_alpha_stacked
+                else:
+                    # Recompute w3 alpha with the global input scale, same formula as w1
+                    effective_w3_alpha = (
+                        w3_alpha_stacked * w3_input_scale_stacked / fc1_act_scale
+                    )
+                w3_weight_blockscale_fp8_stacked = _adjust_w3_blockscales_for_alpha_diff(
+                    w3_weight_blockscale_fp8_stacked, fc1_alpha_stacked, effective_w3_alpha
+                )
+
+            # For gated MLP, concatenate w1 and w3 as [w3, w1]
+            fc1_expert_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
+            fc1_weight_blockscale_fp8_stacked = torch.cat(
+                [w3_weight_blockscale_fp8_stacked, w1_weight_blockscale_fp8_stacked], dim=1
+            ).contiguous()
         else:
             fc1_expert_weights = w1_stacked
             fc1_weight_blockscale_fp8_stacked = w1_weight_blockscale_fp8_stacked
@@ -2220,6 +2288,7 @@ def _stack_nvfp4_cutlass_moe_weights(
             w3_weight_scale,
             w1_alpha,
             w2_alpha,
+            w3_alpha,
             is_gated_mlp,
             act_fn,
         ) = _extract_op_args(node)
@@ -2251,6 +2320,12 @@ def _stack_nvfp4_cutlass_moe_weights(
 
         w1_alpha_stacked = _stack(w1_alpha, dim=0)
         w2_alpha_stacked = _stack(w2_alpha, dim=0)
+        w3_alpha_stacked = _stack(
+            w3_alpha,
+            dim=0,
+            device=w1_alpha_stacked.device,
+            dtype=w1_alpha_stacked.dtype,
+        )
 
         args, kwargs = _prepare_args_cutlass_format_nvfp4()
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
@@ -313,3 +313,216 @@ def test_fp4_moe_op_run(dtype):
     rtol, atol = 1.5, 1.0
     torch.testing.assert_close(output_torch_fp4_moe, output_torch_moe, rtol=rtol, atol=atol)
     torch.testing.assert_close(output_torch_fp4_moe, ref_output, rtol=rtol, atol=atol)
+
+
+def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, w2_weight,
+                                   w3_weight, num_experts):
+    """Quantize per-expert weights and prepare stacked args for trtllm_quant_nvfp4_moe_fused.
+
+    Returns the fused kernel arguments and the per-expert reference op output.
+    """
+    from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import (
+        TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
+    )
+
+    scaling_vector_size = TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+
+    w1_fp4_list, w2_fp4_list, w3_fp4_list = [], [], []
+    w1_is, w2_is, w3_is = [], [], []
+    w1_ws, w2_ws, w3_ws = [], [], []
+    w1_al, w2_al, w3_al = [], [], []
+
+    for i in range(num_experts):
+        inp_scale = fp4_global_scale(x)
+        wt_s2_w1 = fp4_global_scale(w1_weight[i])
+        wt_s2_w2 = fp4_global_scale(w2_weight[i])
+        wt_s2_w3 = fp4_global_scale(w3_weight[i])
+
+        w1_fp4, w1_sc = torch.ops.trtllm.fp4_quantize(w1_weight[i], wt_s2_w1, scaling_vector_size, False)
+        w2_fp4, w2_sc = torch.ops.trtllm.fp4_quantize(w2_weight[i], wt_s2_w2, scaling_vector_size, False)
+        w3_fp4, w3_sc = torch.ops.trtllm.fp4_quantize(w3_weight[i], wt_s2_w3, scaling_vector_size, False)
+
+        w1_fp4_list.append(w1_fp4)
+        w2_fp4_list.append(w2_fp4)
+        w3_fp4_list.append(w3_fp4)
+        w1_is.append(inp_scale)
+        w2_is.append(inp_scale)
+        w3_is.append(inp_scale)
+        w1_ws.append(w1_sc)
+        w2_ws.append(w2_sc)
+        w3_ws.append(w3_sc)
+        w1_al.append(1 / (inp_scale * wt_s2_w1))
+        w2_al.append(1 / (inp_scale * wt_s2_w2))
+        w3_al.append(1 / (inp_scale * wt_s2_w3))
+
+    # Get reference output from the per-expert op (known correct)
+    with torch.inference_mode():
+        ref_output = torch.ops.auto_deploy.torch_quant_nvfp4_moe(
+            x, selected_experts, final_scales,
+            w1_fp4_list, w2_fp4_list, w3_fp4_list,
+            w1_is, w2_is, w3_is,
+            w1_ws, w2_ws, w3_ws,
+            w1_al, w2_al, w3_al,
+        )
+
+    # Prepare stacked tensors for the fused kernel (mimics _stack_nvfp4_moe_weights)
+    w1_stacked = torch.stack(w1_fp4_list, dim=0)
+    w2_stacked = torch.stack(w2_fp4_list, dim=0)
+    w3_stacked = torch.stack(w3_fp4_list, dim=0)
+
+    w1_is_t = torch.stack(w1_is)
+    w2_is_t = torch.stack(w2_is)
+    w3_is_t = torch.stack(w3_is)
+
+    w1_ws_t = torch.stack(w1_ws).view(torch.float8_e4m3fn)
+    w2_ws_t = torch.stack(w2_ws).view(torch.float8_e4m3fn)
+    w3_ws_t = torch.stack(w3_ws).view(torch.float8_e4m3fn)
+
+    w1_al_t = torch.stack(w1_al)
+    w2_al_t = torch.stack(w2_al)
+    w3_al_t = torch.stack(w3_al)
+
+    # Check if w1/w3 alphas differ and adjust w3 block scales if needed
+    alpha_ratio = w3_al_t / w1_al_t
+    if not torch.allclose(alpha_ratio, torch.ones_like(alpha_ratio), rtol=1e-3, atol=1e-6):
+        # Unswizzle → adjust → reswizzle (same as _adjust_w3_blockscales_for_alpha_diff)
+        w3_bs_uint8 = w3_ws_t.view(torch.uint8)
+        w3_bs_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(w3_bs_uint8)
+        w3_bs_float = w3_bs_unswizzled.view(torch.float8_e4m3fn).float()
+        w3_bs_float = w3_bs_float * alpha_ratio.view(-1, *([1] * (w3_bs_float.ndim - 1)))
+        w3_bs_fp8 = w3_bs_float.to(torch.float8_e4m3fn)
+        w3_ws_t = torch.ops.trtllm.block_scale_interleave(
+            w3_bs_fp8.view(torch.uint8)
+        ).view(torch.float8_e4m3fn).reshape(w3_ws_t.shape)
+
+    # Concatenate for gated MLP: FC1 = [w3, w1]
+    fc1_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
+    fc1_blockscale = torch.cat([w3_ws_t, w1_ws_t], dim=1).contiguous()
+
+    # FC1 uses a single input scale (all experts share input)
+    fc1_act_scale = w1_is_t[0]
+
+    # FC1 alpha: use w1's alpha (w3 block scales already compensated)
+    fc1_alpha = w1_al_t
+
+    # FC2
+    fc2_weights = w2_stacked
+    fc2_act_scale = w2_is_t
+    fc2_alpha = w2_al_t
+    fc2_blockscale = w2_ws_t
+
+    return (
+        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
+        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        ref_output,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(
+    not fp4_compatible() or not trtllm_ops_available(),
+    reason="Requires fp4 and trtllm support",
+)
+def test_fp4_fused_moe_with_different_weight_scales(dtype):
+    """Test that the fused NVFP4 MoE kernel produces correct output when
+    w1 and w3 have different per-expert weight global scales (weight_scale_2).
+
+    This is a regression test for the bug where _stack_nvfp4_moe_weights
+    ignored w3_alpha, causing incorrect dequantization of the w3 (up-projection)
+    part of FC1 in the fused CUTLASS kernel.
+    """
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        _,
+        _,
+    ) = setup_moe_test(dtype, num_experts)
+
+    # Deliberately scale w3 weights to create different weight_scale_2 per expert
+    # This simulates checkpoints where per-expert weight scales are not synced
+    for i in range(num_experts):
+        w3_weight[i] = w3_weight[i] * (2.0 + i * 0.5)
+
+    (
+        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
+        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        ref_output,
+    ) = _prepare_nvfp4_moe_fused_args(
+        x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
+    )
+
+    with torch.inference_mode():
+        fused_output = torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused(
+            x,
+            selected_experts,
+            final_scales,
+            fc1_weights,
+            fc2_weights,
+            fc1_blockscale,
+            fc2_blockscale,
+            fc1_act_scale,
+            fc2_act_scale,
+            fc1_alpha,
+            fc2_alpha,
+        )
+
+    torch.cuda.synchronize()
+    # Tolerance is higher for fused kernel due to FP8 block scale rounding from adjustment
+    rtol, atol = 2.0, 1.5
+    torch.testing.assert_close(fused_output, ref_output, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(
+    not fp4_compatible() or not trtllm_ops_available(),
+    reason="Requires fp4 and trtllm support",
+)
+def test_fp4_fused_moe_with_same_weight_scales(dtype):
+    """Test that the fused NVFP4 MoE kernel produces correct output when
+    w1 and w3 have the same weight scales (common case, no adjustment needed).
+    """
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        _,
+        _,
+    ) = setup_moe_test(dtype, num_experts)
+
+    (
+        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
+        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        ref_output,
+    ) = _prepare_nvfp4_moe_fused_args(
+        x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
+    )
+
+    with torch.inference_mode():
+        fused_output = torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused(
+            x,
+            selected_experts,
+            final_scales,
+            fc1_weights,
+            fc2_weights,
+            fc1_blockscale,
+            fc2_blockscale,
+            fc1_act_scale,
+            fc2_act_scale,
+            fc1_alpha,
+            fc2_alpha,
+        )
+
+    torch.cuda.synchronize()
+    rtol, atol = 1.5, 1.0
+    torch.testing.assert_close(fused_output, ref_output, rtol=rtol, atol=atol)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
@@ -315,8 +315,9 @@ def test_fp4_moe_op_run(dtype):
     torch.testing.assert_close(output_torch_fp4_moe, ref_output, rtol=rtol, atol=atol)
 
 
-def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, w2_weight,
-                                   w3_weight, num_experts):
+def _prepare_nvfp4_moe_fused_args(
+    x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
+):
     """Quantize per-expert weights and prepare stacked args for trtllm_quant_nvfp4_moe_fused.
 
     Returns the fused kernel arguments and the per-expert reference op output.
@@ -338,9 +339,15 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
         wt_s2_w2 = fp4_global_scale(w2_weight[i])
         wt_s2_w3 = fp4_global_scale(w3_weight[i])
 
-        w1_fp4, w1_sc = torch.ops.trtllm.fp4_quantize(w1_weight[i], wt_s2_w1, scaling_vector_size, False)
-        w2_fp4, w2_sc = torch.ops.trtllm.fp4_quantize(w2_weight[i], wt_s2_w2, scaling_vector_size, False)
-        w3_fp4, w3_sc = torch.ops.trtllm.fp4_quantize(w3_weight[i], wt_s2_w3, scaling_vector_size, False)
+        w1_fp4, w1_sc = torch.ops.trtllm.fp4_quantize(
+            w1_weight[i], wt_s2_w1, scaling_vector_size, False
+        )
+        w2_fp4, w2_sc = torch.ops.trtllm.fp4_quantize(
+            w2_weight[i], wt_s2_w2, scaling_vector_size, False
+        )
+        w3_fp4, w3_sc = torch.ops.trtllm.fp4_quantize(
+            w3_weight[i], wt_s2_w3, scaling_vector_size, False
+        )
 
         w1_fp4_list.append(w1_fp4)
         w2_fp4_list.append(w2_fp4)
@@ -358,11 +365,21 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
     # Get reference output from the per-expert op (known correct)
     with torch.inference_mode():
         ref_output = torch.ops.auto_deploy.torch_quant_nvfp4_moe(
-            x, selected_experts, final_scales,
-            w1_fp4_list, w2_fp4_list, w3_fp4_list,
-            w1_is, w2_is, w3_is,
-            w1_ws, w2_ws, w3_ws,
-            w1_al, w2_al, w3_al,
+            x,
+            selected_experts,
+            final_scales,
+            w1_fp4_list,
+            w2_fp4_list,
+            w3_fp4_list,
+            w1_is,
+            w2_is,
+            w3_is,
+            w1_ws,
+            w2_ws,
+            w3_ws,
+            w1_al,
+            w2_al,
+            w3_al,
         )
 
     # Prepare stacked tensors for the fused kernel (mimics _stack_nvfp4_moe_weights)
@@ -372,7 +389,6 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
 
     w1_is_t = torch.stack(w1_is)
     w2_is_t = torch.stack(w2_is)
-    w3_is_t = torch.stack(w3_is)
 
     w1_ws_t = torch.stack(w1_ws).view(torch.float8_e4m3fn)
     w2_ws_t = torch.stack(w2_ws).view(torch.float8_e4m3fn)
@@ -385,15 +401,17 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
     # Check if w1/w3 alphas differ and adjust w3 block scales if needed
     alpha_ratio = w3_al_t / w1_al_t
     if not torch.allclose(alpha_ratio, torch.ones_like(alpha_ratio), rtol=1e-3, atol=1e-6):
-        # Unswizzle → adjust → reswizzle (same as _adjust_w3_blockscales_for_alpha_diff)
+        # Unswizzle -> adjust -> reswizzle (same as _adjust_w3_blockscales_for_alpha_diff)
         w3_bs_uint8 = w3_ws_t.view(torch.uint8)
         w3_bs_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(w3_bs_uint8)
         w3_bs_float = w3_bs_unswizzled.view(torch.float8_e4m3fn).float()
         w3_bs_float = w3_bs_float * alpha_ratio.view(-1, *([1] * (w3_bs_float.ndim - 1)))
         w3_bs_fp8 = w3_bs_float.to(torch.float8_e4m3fn)
-        w3_ws_t = torch.ops.trtllm.block_scale_interleave(
-            w3_bs_fp8.view(torch.uint8)
-        ).view(torch.float8_e4m3fn).reshape(w3_ws_t.shape)
+        w3_ws_t = (
+            torch.ops.trtllm.block_scale_interleave(w3_bs_fp8.view(torch.uint8))
+            .view(torch.float8_e4m3fn)
+            .reshape(w3_ws_t.shape)
+        )
 
     # Concatenate for gated MLP: FC1 = [w3, w1]
     fc1_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
@@ -412,8 +430,14 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
     fc2_blockscale = w2_ws_t
 
     return (
-        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
-        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        fc1_weights,
+        fc2_weights,
+        fc1_blockscale,
+        fc2_blockscale,
+        fc1_act_scale,
+        fc2_act_scale,
+        fc1_alpha,
+        fc2_alpha,
         ref_output,
     )
 
@@ -424,8 +448,7 @@ def _prepare_nvfp4_moe_fused_args(x, selected_experts, final_scales, w1_weight, 
     reason="Requires fp4 and trtllm support",
 )
 def test_fp4_fused_moe_with_different_weight_scales(dtype):
-    """Test that the fused NVFP4 MoE kernel produces correct output when
-    w1 and w3 have different per-expert weight global scales (weight_scale_2).
+    """Test fused NVFP4 MoE kernel with different per-expert weight global scales.
 
     This is a regression test for the bug where _stack_nvfp4_moe_weights
     ignored w3_alpha, causing incorrect dequantization of the w3 (up-projection)
@@ -450,8 +473,14 @@ def test_fp4_fused_moe_with_different_weight_scales(dtype):
         w3_weight[i] = w3_weight[i] * (2.0 + i * 0.5)
 
     (
-        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
-        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        fc1_weights,
+        fc2_weights,
+        fc1_blockscale,
+        fc2_blockscale,
+        fc1_act_scale,
+        fc2_act_scale,
+        fc1_alpha,
+        fc2_alpha,
         ref_output,
     ) = _prepare_nvfp4_moe_fused_args(
         x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
@@ -484,9 +513,7 @@ def test_fp4_fused_moe_with_different_weight_scales(dtype):
     reason="Requires fp4 and trtllm support",
 )
 def test_fp4_fused_moe_with_same_weight_scales(dtype):
-    """Test that the fused NVFP4 MoE kernel produces correct output when
-    w1 and w3 have the same weight scales (common case, no adjustment needed).
-    """
+    """Test fused NVFP4 MoE kernel with same weight scales (no adjustment needed)."""
     num_experts = 3
     (
         x,
@@ -501,8 +528,14 @@ def test_fp4_fused_moe_with_same_weight_scales(dtype):
     ) = setup_moe_test(dtype, num_experts)
 
     (
-        fc1_weights, fc2_weights, fc1_blockscale, fc2_blockscale,
-        fc1_act_scale, fc2_act_scale, fc1_alpha, fc2_alpha,
+        fc1_weights,
+        fc2_weights,
+        fc1_blockscale,
+        fc2_blockscale,
+        fc1_act_scale,
+        fc2_act_scale,
+        fc1_alpha,
+        fc2_alpha,
         ref_output,
     ) = _prepare_nvfp4_moe_fused_args(
         x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
@@ -528,8 +561,9 @@ def test_fp4_fused_moe_with_same_weight_scales(dtype):
     torch.testing.assert_close(fused_output, ref_output, rtol=rtol, atol=atol)
 
 
-def _build_nvfp4_moe_graph_module(x, selected_experts, final_scales, w1_weight,
-                                   w2_weight, w3_weight, num_experts):
+def _build_nvfp4_moe_graph_module(
+    x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
+):
     """Build an FX GraphModule with a torch_quant_nvfp4_moe node and real quantized weights.
 
     This constructs the same graph structure that quantize_nvfp4_moe produces so
@@ -564,9 +598,15 @@ def _build_nvfp4_moe_graph_module(x, selected_experts, final_scales, w1_weight,
         fp4_2, sc_2 = torch.ops.trtllm.fp4_quantize(w2_weight[i], s2_w2, sv, False)
         fp4_3, sc_3 = torch.ops.trtllm.fp4_quantize(w3_weight[i], s2_w3, sv, False)
 
-        w1_fp4.append(fp4_1); w2_fp4.append(fp4_2); w3_fp4.append(fp4_3)
-        w1_is.append(inp_s); w2_is.append(inp_s); w3_is.append(inp_s)
-        w1_ws.append(sc_1); w2_ws.append(sc_2); w3_ws.append(sc_3)
+        w1_fp4.append(fp4_1)
+        w2_fp4.append(fp4_2)
+        w3_fp4.append(fp4_3)
+        w1_is.append(inp_s)
+        w2_is.append(inp_s)
+        w3_is.append(inp_s)
+        w1_ws.append(sc_1)
+        w2_ws.append(sc_2)
+        w3_ws.append(sc_3)
         w1_al.append(1 / (inp_s * s2_w1))
         w2_al.append(1 / (inp_s * s2_w2))
         w3_al.append(1 / (inp_s * s2_w3))
@@ -598,11 +638,21 @@ def _build_nvfp4_moe_graph_module(x, selected_experts, final_scales, w1_weight,
     moe_node = graph.call_function(
         torch.ops.auto_deploy.torch_quant_nvfp4_moe.default,
         args=(
-            x_n, se_n, rw_n,
-            _attrs("w1"), _attrs("w2"), _attrs("w3"),
-            _attrs("w1_is"), _attrs("w2_is"), _attrs("w3_is"),
-            _attrs("w1_ws"), _attrs("w2_ws"), _attrs("w3_ws"),
-            _attrs("w1_al"), _attrs("w2_al"), _attrs("w3_al"),
+            x_n,
+            se_n,
+            rw_n,
+            _attrs("w1"),
+            _attrs("w2"),
+            _attrs("w3"),
+            _attrs("w1_is"),
+            _attrs("w2_is"),
+            _attrs("w3_is"),
+            _attrs("w1_ws"),
+            _attrs("w2_ws"),
+            _attrs("w3_ws"),
+            _attrs("w1_al"),
+            _attrs("w2_al"),
+            _attrs("w3_al"),
         ),
         kwargs={"is_gated_mlp": True, "act_fn": int(ActivationType.Silu)},
     )
@@ -629,16 +679,20 @@ def test_fuse_nvfp4_moe_end_to_end_different_w3_alpha(dtype):
     fusion pass (_stack_nvfp4_moe_weights), and executes the rewritten graph.
     This exercises the code path that extracts w3_alpha and adjusts block scales.
     """
-    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import (
-        _stack_nvfp4_moe_weights,
-    )
+    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import _stack_nvfp4_moe_weights
     from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
     num_experts = 3
     (
-        x, selected_experts, final_scales,
-        w1_weight, w2_weight, w3_weight,
-        weights, _, _,
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        _,
+        _,
     ) = setup_moe_test(dtype, num_experts)
 
     # Scale w3 per expert so w1_alpha != w3_alpha
@@ -646,15 +700,17 @@ def test_fuse_nvfp4_moe_end_to_end_different_w3_alpha(dtype):
         w3_weight[i] = w3_weight[i] * (2.0 + i * 0.5)
 
     gm, ref_output = _build_nvfp4_moe_graph_module(
-        x, selected_experts, final_scales,
-        w1_weight, w2_weight, w3_weight, num_experts,
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        num_experts,
     )
 
     # Verify unfused op present before fusion
-    assert any(
-        is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe)
-        for n in gm.graph.nodes
-    )
+    assert any(is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe) for n in gm.graph.nodes)
 
     # Run the actual fusion pass
     count = _stack_nvfp4_moe_weights(gm)
@@ -662,13 +718,11 @@ def test_fuse_nvfp4_moe_end_to_end_different_w3_alpha(dtype):
 
     # Verify graph was rewritten
     assert any(
-        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused)
-        for n in gm.graph.nodes
+        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused) for n in gm.graph.nodes
     ), "Fused op not found after _stack_nvfp4_moe_weights"
-    assert not any(
-        is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe)
-        for n in gm.graph.nodes
-    ), "Unfused op still present after fusion"
+    assert not any(is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe) for n in gm.graph.nodes), (
+        "Unfused op still present after fusion"
+    )
 
     # Execute the fused graph
     with torch.inference_mode():
@@ -685,29 +739,37 @@ def test_fuse_nvfp4_moe_end_to_end_different_w3_alpha(dtype):
 )
 def test_fuse_nvfp4_moe_end_to_end_same_alpha(dtype):
     """End-to-end fusion test with identical w1/w3 alphas (common case, no adjustment)."""
-    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import (
-        _stack_nvfp4_moe_weights,
-    )
+    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import _stack_nvfp4_moe_weights
     from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
     num_experts = 3
     (
-        x, selected_experts, final_scales,
-        w1_weight, w2_weight, w3_weight,
-        weights, _, _,
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        _,
+        _,
     ) = setup_moe_test(dtype, num_experts)
 
     gm, ref_output = _build_nvfp4_moe_graph_module(
-        x, selected_experts, final_scales,
-        w1_weight, w2_weight, w3_weight, num_experts,
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        num_experts,
     )
 
     count = _stack_nvfp4_moe_weights(gm)
     assert count == 1
 
     assert any(
-        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused)
-        for n in gm.graph.nodes
+        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused) for n in gm.graph.nodes
     )
 
     with torch.inference_mode():

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
@@ -329,38 +329,38 @@ def _prepare_nvfp4_moe_fused_args(
     scaling_vector_size = TRTLLM_NVFP4_SCALING_VECTOR_SIZE
 
     w1_fp4_list, w2_fp4_list, w3_fp4_list = [], [], []
-    w1_is, w2_is, w3_is = [], [], []
-    w1_ws, w2_ws, w3_ws = [], [], []
-    w1_al, w2_al, w3_al = [], [], []
+    w1_input_scale, w2_input_scale, w3_input_scale = [], [], []
+    w1_weight_scale, w2_weight_scale, w3_weight_scale = [], [], []
+    w1_alpha, w2_alpha, w3_alpha = [], [], []
 
     for i in range(num_experts):
         inp_scale = fp4_global_scale(x)
-        wt_s2_w1 = fp4_global_scale(w1_weight[i])
-        wt_s2_w2 = fp4_global_scale(w2_weight[i])
-        wt_s2_w3 = fp4_global_scale(w3_weight[i])
+        wt_global_w1 = fp4_global_scale(w1_weight[i])
+        wt_global_w2 = fp4_global_scale(w2_weight[i])
+        wt_global_w3 = fp4_global_scale(w3_weight[i])
 
         w1_fp4, w1_sc = torch.ops.trtllm.fp4_quantize(
-            w1_weight[i], wt_s2_w1, scaling_vector_size, False
+            w1_weight[i], wt_global_w1, scaling_vector_size, False
         )
         w2_fp4, w2_sc = torch.ops.trtllm.fp4_quantize(
-            w2_weight[i], wt_s2_w2, scaling_vector_size, False
+            w2_weight[i], wt_global_w2, scaling_vector_size, False
         )
         w3_fp4, w3_sc = torch.ops.trtllm.fp4_quantize(
-            w3_weight[i], wt_s2_w3, scaling_vector_size, False
+            w3_weight[i], wt_global_w3, scaling_vector_size, False
         )
 
         w1_fp4_list.append(w1_fp4)
         w2_fp4_list.append(w2_fp4)
         w3_fp4_list.append(w3_fp4)
-        w1_is.append(inp_scale)
-        w2_is.append(inp_scale)
-        w3_is.append(inp_scale)
-        w1_ws.append(w1_sc)
-        w2_ws.append(w2_sc)
-        w3_ws.append(w3_sc)
-        w1_al.append(1 / (inp_scale * wt_s2_w1))
-        w2_al.append(1 / (inp_scale * wt_s2_w2))
-        w3_al.append(1 / (inp_scale * wt_s2_w3))
+        w1_input_scale.append(inp_scale)
+        w2_input_scale.append(inp_scale)
+        w3_input_scale.append(inp_scale)
+        w1_weight_scale.append(w1_sc)
+        w2_weight_scale.append(w2_sc)
+        w3_weight_scale.append(w3_sc)
+        w1_alpha.append(1 / (inp_scale * wt_global_w1))
+        w2_alpha.append(1 / (inp_scale * wt_global_w2))
+        w3_alpha.append(1 / (inp_scale * wt_global_w3))
 
     # Get reference output from the per-expert op (known correct)
     with torch.inference_mode():
@@ -371,15 +371,15 @@ def _prepare_nvfp4_moe_fused_args(
             w1_fp4_list,
             w2_fp4_list,
             w3_fp4_list,
-            w1_is,
-            w2_is,
-            w3_is,
-            w1_ws,
-            w2_ws,
-            w3_ws,
-            w1_al,
-            w2_al,
-            w3_al,
+            w1_input_scale,
+            w2_input_scale,
+            w3_input_scale,
+            w1_weight_scale,
+            w2_weight_scale,
+            w3_weight_scale,
+            w1_alpha,
+            w2_alpha,
+            w3_alpha,
         )
 
     # Prepare stacked tensors for the fused kernel (mimics _stack_nvfp4_moe_weights)
@@ -387,47 +387,47 @@ def _prepare_nvfp4_moe_fused_args(
     w2_stacked = torch.stack(w2_fp4_list, dim=0)
     w3_stacked = torch.stack(w3_fp4_list, dim=0)
 
-    w1_is_t = torch.stack(w1_is)
-    w2_is_t = torch.stack(w2_is)
+    w1_input_scale_t = torch.stack(w1_input_scale)
+    w2_input_scale_t = torch.stack(w2_input_scale)
 
-    w1_ws_t = torch.stack(w1_ws).view(torch.float8_e4m3fn)
-    w2_ws_t = torch.stack(w2_ws).view(torch.float8_e4m3fn)
-    w3_ws_t = torch.stack(w3_ws).view(torch.float8_e4m3fn)
+    w1_weight_scale_t = torch.stack(w1_weight_scale).view(torch.float8_e4m3fn)
+    w2_weight_scale_t = torch.stack(w2_weight_scale).view(torch.float8_e4m3fn)
+    w3_weight_scale_t = torch.stack(w3_weight_scale).view(torch.float8_e4m3fn)
 
-    w1_al_t = torch.stack(w1_al)
-    w2_al_t = torch.stack(w2_al)
-    w3_al_t = torch.stack(w3_al)
+    w1_alpha_t = torch.stack(w1_alpha)
+    w2_alpha_t = torch.stack(w2_alpha)
+    w3_alpha_t = torch.stack(w3_alpha)
 
     # Check if w1/w3 alphas differ and adjust w3 block scales if needed
-    alpha_ratio = w3_al_t / w1_al_t
+    alpha_ratio = w3_alpha_t / w1_alpha_t
     if not torch.allclose(alpha_ratio, torch.ones_like(alpha_ratio), rtol=1e-3, atol=1e-6):
         # Unswizzle -> adjust -> reswizzle (same as _adjust_w3_blockscales_for_alpha_diff)
-        w3_bs_uint8 = w3_ws_t.view(torch.uint8)
+        w3_bs_uint8 = w3_weight_scale_t.view(torch.uint8)
         w3_bs_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(w3_bs_uint8)
         w3_bs_float = w3_bs_unswizzled.view(torch.float8_e4m3fn).float()
         w3_bs_float = w3_bs_float * alpha_ratio.view(-1, *([1] * (w3_bs_float.ndim - 1)))
         w3_bs_fp8 = w3_bs_float.to(torch.float8_e4m3fn)
-        w3_ws_t = (
+        w3_weight_scale_t = (
             torch.ops.trtllm.block_scale_interleave(w3_bs_fp8.view(torch.uint8))
             .view(torch.float8_e4m3fn)
-            .reshape(w3_ws_t.shape)
+            .reshape(w3_weight_scale_t.shape)
         )
 
     # Concatenate for gated MLP: FC1 = [w3, w1]
     fc1_weights = torch.cat([w3_stacked, w1_stacked], dim=1).contiguous()
-    fc1_blockscale = torch.cat([w3_ws_t, w1_ws_t], dim=1).contiguous()
+    fc1_blockscale = torch.cat([w3_weight_scale_t, w1_weight_scale_t], dim=1).contiguous()
 
     # FC1 uses a single input scale (all experts share input)
-    fc1_act_scale = w1_is_t[0]
+    fc1_act_scale = w1_input_scale_t[0]
 
     # FC1 alpha: use w1's alpha (w3 block scales already compensated)
-    fc1_alpha = w1_al_t
+    fc1_alpha_stacked = w1_alpha_t
 
     # FC2
     fc2_weights = w2_stacked
-    fc2_act_scale = w2_is_t
-    fc2_alpha = w2_al_t
-    fc2_blockscale = w2_ws_t
+    fc2_act_scale = w2_input_scale_t
+    fc2_alpha_stacked = w2_alpha_t
+    fc2_blockscale = w2_weight_scale_t
 
     return (
         fc1_weights,
@@ -436,8 +436,8 @@ def _prepare_nvfp4_moe_fused_args(
         fc2_blockscale,
         fc1_act_scale,
         fc2_act_scale,
-        fc1_alpha,
-        fc2_alpha,
+        fc1_alpha_stacked,
+        fc2_alpha_stacked,
         ref_output,
     )
 
@@ -479,8 +479,8 @@ def test_fp4_fused_moe_with_different_weight_scales(dtype):
         fc2_blockscale,
         fc1_act_scale,
         fc2_act_scale,
-        fc1_alpha,
-        fc2_alpha,
+        fc1_alpha_stacked,
+        fc2_alpha_stacked,
         ref_output,
     ) = _prepare_nvfp4_moe_fused_args(
         x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
@@ -497,8 +497,8 @@ def test_fp4_fused_moe_with_different_weight_scales(dtype):
             fc2_blockscale,
             fc1_act_scale,
             fc2_act_scale,
-            fc1_alpha,
-            fc2_alpha,
+            fc1_alpha_stacked,
+            fc2_alpha_stacked,
         )
 
     torch.cuda.synchronize()
@@ -534,8 +534,8 @@ def test_fp4_fused_moe_with_same_weight_scales(dtype):
         fc2_blockscale,
         fc1_act_scale,
         fc2_act_scale,
-        fc1_alpha,
-        fc2_alpha,
+        fc1_alpha_stacked,
+        fc2_alpha_stacked,
         ref_output,
     ) = _prepare_nvfp4_moe_fused_args(
         x, selected_experts, final_scales, w1_weight, w2_weight, w3_weight, num_experts
@@ -552,8 +552,8 @@ def test_fp4_fused_moe_with_same_weight_scales(dtype):
             fc2_blockscale,
             fc1_act_scale,
             fc2_act_scale,
-            fc1_alpha,
-            fc2_alpha,
+            fc1_alpha_stacked,
+            fc2_alpha_stacked,
         )
 
     torch.cuda.synchronize()
@@ -584,47 +584,47 @@ def _build_nvfp4_moe_graph_module(
     # Quantize per-expert weights
     root = torch.nn.Module()
     w1_fp4, w2_fp4, w3_fp4 = [], [], []
-    w1_is, w2_is, w3_is = [], [], []
-    w1_ws, w2_ws, w3_ws = [], [], []
-    w1_al, w2_al, w3_al = [], [], []
+    w1_input_scale, w2_input_scale, w3_input_scale = [], [], []
+    w1_weight_scale, w2_weight_scale, w3_weight_scale = [], [], []
+    w1_alpha, w2_alpha, w3_alpha = [], [], []
 
     for i in range(num_experts):
-        inp_s = fp4_global_scale(x)
-        s2_w1 = fp4_global_scale(w1_weight[i])
-        s2_w2 = fp4_global_scale(w2_weight[i])
-        s2_w3 = fp4_global_scale(w3_weight[i])
+        inp_scale = fp4_global_scale(x)
+        wt_global_w1 = fp4_global_scale(w1_weight[i])
+        wt_global_w2 = fp4_global_scale(w2_weight[i])
+        wt_global_w3 = fp4_global_scale(w3_weight[i])
 
-        fp4_1, sc_1 = torch.ops.trtllm.fp4_quantize(w1_weight[i], s2_w1, sv, False)
-        fp4_2, sc_2 = torch.ops.trtllm.fp4_quantize(w2_weight[i], s2_w2, sv, False)
-        fp4_3, sc_3 = torch.ops.trtllm.fp4_quantize(w3_weight[i], s2_w3, sv, False)
+        fp4_1, sc_1 = torch.ops.trtllm.fp4_quantize(w1_weight[i], wt_global_w1, sv, False)
+        fp4_2, sc_2 = torch.ops.trtllm.fp4_quantize(w2_weight[i], wt_global_w2, sv, False)
+        fp4_3, sc_3 = torch.ops.trtllm.fp4_quantize(w3_weight[i], wt_global_w3, sv, False)
 
         w1_fp4.append(fp4_1)
         w2_fp4.append(fp4_2)
         w3_fp4.append(fp4_3)
-        w1_is.append(inp_s)
-        w2_is.append(inp_s)
-        w3_is.append(inp_s)
-        w1_ws.append(sc_1)
-        w2_ws.append(sc_2)
-        w3_ws.append(sc_3)
-        w1_al.append(1 / (inp_s * s2_w1))
-        w2_al.append(1 / (inp_s * s2_w2))
-        w3_al.append(1 / (inp_s * s2_w3))
+        w1_input_scale.append(inp_scale)
+        w2_input_scale.append(inp_scale)
+        w3_input_scale.append(inp_scale)
+        w1_weight_scale.append(sc_1)
+        w2_weight_scale.append(sc_2)
+        w3_weight_scale.append(sc_3)
+        w1_alpha.append(1 / (inp_scale * wt_global_w1))
+        w2_alpha.append(1 / (inp_scale * wt_global_w2))
+        w3_alpha.append(1 / (inp_scale * wt_global_w3))
 
     # Register everything on root module
     for i in range(num_experts):
         root.register_parameter(f"w1_{i}", torch.nn.Parameter(w1_fp4[i], requires_grad=False))
         root.register_parameter(f"w2_{i}", torch.nn.Parameter(w2_fp4[i], requires_grad=False))
         root.register_parameter(f"w3_{i}", torch.nn.Parameter(w3_fp4[i], requires_grad=False))
-        root.register_buffer(f"w1_is_{i}", w1_is[i])
-        root.register_buffer(f"w2_is_{i}", w2_is[i])
-        root.register_buffer(f"w3_is_{i}", w3_is[i])
-        root.register_buffer(f"w1_ws_{i}", w1_ws[i])
-        root.register_buffer(f"w2_ws_{i}", w2_ws[i])
-        root.register_buffer(f"w3_ws_{i}", w3_ws[i])
-        root.register_buffer(f"w1_al_{i}", w1_al[i])
-        root.register_buffer(f"w2_al_{i}", w2_al[i])
-        root.register_buffer(f"w3_al_{i}", w3_al[i])
+        root.register_buffer(f"w1_input_scale_{i}", w1_input_scale[i])
+        root.register_buffer(f"w2_input_scale_{i}", w2_input_scale[i])
+        root.register_buffer(f"w3_input_scale_{i}", w3_input_scale[i])
+        root.register_buffer(f"w1_weight_scale_{i}", w1_weight_scale[i])
+        root.register_buffer(f"w2_weight_scale_{i}", w2_weight_scale[i])
+        root.register_buffer(f"w3_weight_scale_{i}", w3_weight_scale[i])
+        root.register_buffer(f"w1_alpha_{i}", w1_alpha[i])
+        root.register_buffer(f"w2_alpha_{i}", w2_alpha[i])
+        root.register_buffer(f"w3_alpha_{i}", w3_alpha[i])
 
     # Build FX graph with the same node layout as quantize_nvfp4_moe produces
     graph = fx.Graph()
@@ -644,15 +644,15 @@ def _build_nvfp4_moe_graph_module(
             _attrs("w1"),
             _attrs("w2"),
             _attrs("w3"),
-            _attrs("w1_is"),
-            _attrs("w2_is"),
-            _attrs("w3_is"),
-            _attrs("w1_ws"),
-            _attrs("w2_ws"),
-            _attrs("w3_ws"),
-            _attrs("w1_al"),
-            _attrs("w2_al"),
-            _attrs("w3_al"),
+            _attrs("w1_input_scale"),
+            _attrs("w2_input_scale"),
+            _attrs("w3_input_scale"),
+            _attrs("w1_weight_scale"),
+            _attrs("w2_weight_scale"),
+            _attrs("w3_weight_scale"),
+            _attrs("w1_alpha"),
+            _attrs("w2_alpha"),
+            _attrs("w3_alpha"),
         ),
         kwargs={"is_gated_mlp": True, "act_fn": int(ActivationType.Silu)},
     )

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
@@ -768,9 +768,7 @@ def test_fuse_nvfp4_moe_end_to_end_same_alpha(dtype):
     count = _stack_nvfp4_moe_weights(gm)
     assert count == 1
 
-    assert any(
-        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused) for n in gm.graph.nodes
-    )
+    assert any(is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused) for n in gm.graph.nodes)
 
     with torch.inference_mode():
         fused_output = gm(x, selected_experts, final_scales)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_ad_moe_op.py
@@ -526,3 +526,192 @@ def test_fp4_fused_moe_with_same_weight_scales(dtype):
     torch.cuda.synchronize()
     rtol, atol = 1.5, 1.0
     torch.testing.assert_close(fused_output, ref_output, rtol=rtol, atol=atol)
+
+
+def _build_nvfp4_moe_graph_module(x, selected_experts, final_scales, w1_weight,
+                                   w2_weight, w3_weight, num_experts):
+    """Build an FX GraphModule with a torch_quant_nvfp4_moe node and real quantized weights.
+
+    This constructs the same graph structure that quantize_nvfp4_moe produces so
+    that _stack_nvfp4_moe_weights can be called on it directly.
+
+    Returns:
+        (gm, ref_output): the unfused GraphModule and its reference output.
+    """
+    import torch.fx as fx
+
+    from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import (
+        TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
+    )
+    from tensorrt_llm._torch.utils import ActivationType
+
+    sv = TRTLLM_NVFP4_SCALING_VECTOR_SIZE
+
+    # Quantize per-expert weights
+    root = torch.nn.Module()
+    w1_fp4, w2_fp4, w3_fp4 = [], [], []
+    w1_is, w2_is, w3_is = [], [], []
+    w1_ws, w2_ws, w3_ws = [], [], []
+    w1_al, w2_al, w3_al = [], [], []
+
+    for i in range(num_experts):
+        inp_s = fp4_global_scale(x)
+        s2_w1 = fp4_global_scale(w1_weight[i])
+        s2_w2 = fp4_global_scale(w2_weight[i])
+        s2_w3 = fp4_global_scale(w3_weight[i])
+
+        fp4_1, sc_1 = torch.ops.trtllm.fp4_quantize(w1_weight[i], s2_w1, sv, False)
+        fp4_2, sc_2 = torch.ops.trtllm.fp4_quantize(w2_weight[i], s2_w2, sv, False)
+        fp4_3, sc_3 = torch.ops.trtllm.fp4_quantize(w3_weight[i], s2_w3, sv, False)
+
+        w1_fp4.append(fp4_1); w2_fp4.append(fp4_2); w3_fp4.append(fp4_3)
+        w1_is.append(inp_s); w2_is.append(inp_s); w3_is.append(inp_s)
+        w1_ws.append(sc_1); w2_ws.append(sc_2); w3_ws.append(sc_3)
+        w1_al.append(1 / (inp_s * s2_w1))
+        w2_al.append(1 / (inp_s * s2_w2))
+        w3_al.append(1 / (inp_s * s2_w3))
+
+    # Register everything on root module
+    for i in range(num_experts):
+        root.register_parameter(f"w1_{i}", torch.nn.Parameter(w1_fp4[i], requires_grad=False))
+        root.register_parameter(f"w2_{i}", torch.nn.Parameter(w2_fp4[i], requires_grad=False))
+        root.register_parameter(f"w3_{i}", torch.nn.Parameter(w3_fp4[i], requires_grad=False))
+        root.register_buffer(f"w1_is_{i}", w1_is[i])
+        root.register_buffer(f"w2_is_{i}", w2_is[i])
+        root.register_buffer(f"w3_is_{i}", w3_is[i])
+        root.register_buffer(f"w1_ws_{i}", w1_ws[i])
+        root.register_buffer(f"w2_ws_{i}", w2_ws[i])
+        root.register_buffer(f"w3_ws_{i}", w3_ws[i])
+        root.register_buffer(f"w1_al_{i}", w1_al[i])
+        root.register_buffer(f"w2_al_{i}", w2_al[i])
+        root.register_buffer(f"w3_al_{i}", w3_al[i])
+
+    # Build FX graph with the same node layout as quantize_nvfp4_moe produces
+    graph = fx.Graph()
+    x_n = graph.placeholder("x")
+    se_n = graph.placeholder("selected_experts")
+    rw_n = graph.placeholder("routing_weights")
+
+    def _attrs(prefix):
+        return [graph.get_attr(f"{prefix}_{i}") for i in range(num_experts)]
+
+    moe_node = graph.call_function(
+        torch.ops.auto_deploy.torch_quant_nvfp4_moe.default,
+        args=(
+            x_n, se_n, rw_n,
+            _attrs("w1"), _attrs("w2"), _attrs("w3"),
+            _attrs("w1_is"), _attrs("w2_is"), _attrs("w3_is"),
+            _attrs("w1_ws"), _attrs("w2_ws"), _attrs("w3_ws"),
+            _attrs("w1_al"), _attrs("w2_al"), _attrs("w3_al"),
+        ),
+        kwargs={"is_gated_mlp": True, "act_fn": int(ActivationType.Silu)},
+    )
+    graph.output(moe_node)
+
+    gm = fx.GraphModule(root, graph)
+
+    with torch.inference_mode():
+        ref_output = gm(x, selected_experts, final_scales)
+
+    return gm, ref_output
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(
+    not fp4_compatible() or not trtllm_ops_available(),
+    reason="Requires fp4 and trtllm support",
+)
+def test_fuse_nvfp4_moe_end_to_end_different_w3_alpha(dtype):
+    """End-to-end test through _stack_nvfp4_moe_weights with different w1/w3 alphas.
+
+    Unlike the kernel-level tests above, this builds an FX graph containing a
+    torch_quant_nvfp4_moe node with real quantized weights, runs the actual
+    fusion pass (_stack_nvfp4_moe_weights), and executes the rewritten graph.
+    This exercises the code path that extracts w3_alpha and adjusts block scales.
+    """
+    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import (
+        _stack_nvfp4_moe_weights,
+    )
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+    num_experts = 3
+    (
+        x, selected_experts, final_scales,
+        w1_weight, w2_weight, w3_weight,
+        weights, _, _,
+    ) = setup_moe_test(dtype, num_experts)
+
+    # Scale w3 per expert so w1_alpha != w3_alpha
+    for i in range(num_experts):
+        w3_weight[i] = w3_weight[i] * (2.0 + i * 0.5)
+
+    gm, ref_output = _build_nvfp4_moe_graph_module(
+        x, selected_experts, final_scales,
+        w1_weight, w2_weight, w3_weight, num_experts,
+    )
+
+    # Verify unfused op present before fusion
+    assert any(
+        is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe)
+        for n in gm.graph.nodes
+    )
+
+    # Run the actual fusion pass
+    count = _stack_nvfp4_moe_weights(gm)
+    assert count == 1, f"Expected 1 fused node, got {count}"
+
+    # Verify graph was rewritten
+    assert any(
+        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused)
+        for n in gm.graph.nodes
+    ), "Fused op not found after _stack_nvfp4_moe_weights"
+    assert not any(
+        is_op(n, torch.ops.auto_deploy.torch_quant_nvfp4_moe)
+        for n in gm.graph.nodes
+    ), "Unfused op still present after fusion"
+
+    # Execute the fused graph
+    with torch.inference_mode():
+        fused_output = gm(x, selected_experts, final_scales)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(fused_output, ref_output, rtol=2.0, atol=1.5)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(
+    not fp4_compatible() or not trtllm_ops_available(),
+    reason="Requires fp4 and trtllm support",
+)
+def test_fuse_nvfp4_moe_end_to_end_same_alpha(dtype):
+    """End-to-end fusion test with identical w1/w3 alphas (common case, no adjustment)."""
+    from tensorrt_llm._torch.auto_deploy.transform.library.fused_moe import (
+        _stack_nvfp4_moe_weights,
+    )
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+    num_experts = 3
+    (
+        x, selected_experts, final_scales,
+        w1_weight, w2_weight, w3_weight,
+        weights, _, _,
+    ) = setup_moe_test(dtype, num_experts)
+
+    gm, ref_output = _build_nvfp4_moe_graph_module(
+        x, selected_experts, final_scales,
+        w1_weight, w2_weight, w3_weight, num_experts,
+    )
+
+    count = _stack_nvfp4_moe_weights(gm)
+    assert count == 1
+
+    assert any(
+        is_op(n, torch.ops.auto_deploy.trtllm_quant_nvfp4_moe_fused)
+        for n in gm.graph.nodes
+    )
+
+    with torch.inference_mode():
+        fused_output = gm(x, selected_experts, final_scales)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(fused_output, ref_output, rtol=1.5, atol=1.0)


### PR DESCRIPTION
## Summary

- Fixes #12183 — `_stack_nvfp4_moe_weights` was silently skipping `w3_alpha` when fusing per-expert NVFP4 MoE weights into the CUTLASS kernel format. The fused FC1 = cat(w3, w1) used only `w1_alpha` for dequantization, so the w3 (up-projection) half gets the wrong scale whenever `weight_scale_2` differs between w1 and w3 per expert. This is exactly the case for the Super-120B NVFP4 checkpoint where per-expert weight scales are not synced.
- Now we extract `w3_alpha`, compare it against `w1_alpha`, and when they differ we bake the ratio into w3's per-block scales (unswizzle → scale → reswizzle) before concatenation. This way the single `fc1_alpha` the kernel uses still produces correct output for both halves.
- Also handles the `allow_different_input_scales` recomputation path correctly.
- Added two fused-kernel-level unit tests covering both the divergent and identical w1/w3 weight scale scenarios.

## Test plan

- [x] Existing `test_fp4_moe_op_run` still passes (no regression on reference op path)
- [x] New `test_fp4_fused_moe_with_same_weight_scales` — fused kernel matches reference when scales are identical
- [x] New `test_fp4_fused_moe_with_different_weight_scales` — fused kernel matches reference when w3 scales deliberately diverge per expert
- [x] Run on Super-120B NVFP4 checkpoint to confirm coherent output with fused CUTLASS MoE backend