### PR TITLE
[None][fix] port retry loop and exception handling

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -18,6 +18,16 @@ from ..utils.logger import ad_logger
 
 _MASTER_ADDR = "127.0.0.1"
 
+# Sentinel exit code used by init_and_run_process to signal a port conflict
+# (DistNetworkError during init_process_group).  spawn_multiprocess_job detects
+# this code and retries with a fresh port, recovering from the TOCTOU race
+# between _is_port_available() and dist.init_process_group().
+_PORT_CONFLICT_EXIT_CODE = 2
+
+
+class _PortConflictError(RuntimeError):
+    """Raised internally when a spawned process exits due to a port conflict."""
+
 
 class _DistGroup:
     """Global instance to set/get the default process group for distributed ops."""
@@ -251,9 +261,15 @@ def init_and_run_process(
     job, rank, size, port, port_recv_conn=None, port_send_conns=None, **kwargs
 ):
     try:
-        initialize_or_skip(
-            rank, size, port, port_recv_conn=port_recv_conn, port_send_conns=port_send_conns
-        )
+        try:
+            initialize_or_skip(
+                rank, size, port, port_recv_conn=port_recv_conn, port_send_conns=port_send_conns
+            )
+        except dist.DistNetworkError:
+            # Port conflict: init_process_group failed to bind (EADDRINUSE).
+            # Exit with a sentinel code so spawn_multiprocess_job can retry
+            # with a fresh port rather than treating this as a test failure.
+            sys.exit(_PORT_CONFLICT_EXIT_CODE)
         job(rank, size, **kwargs)
     except Exception as e:
         # Close the input and output queues to parent process can exit.
@@ -354,13 +370,39 @@ def _join_multiprocess_job(processes):
         # Check exitcode via hasattr rather than isinstance(p, mp.Process), because
         # spawn-context processes (SpawnProcess) don't inherit from mp.Process.
         if hasattr(p, "exitcode"):
+            if p.exitcode == _PORT_CONFLICT_EXIT_CODE:
+                raise _PortConflictError(
+                    f"Process {p.pid} exited with port conflict code {p.exitcode}"
+                )
             assert p.exitcode == 0, f"Process {p.pid} exited with code {p.exitcode}"
 
 
-def spawn_multiprocess_job(job: Callable[[int, int], None], size: Optional[int] = None):
-    processes = _start_multiprocess_job(job, size)
-    if processes:
-        _join_multiprocess_job(processes)
+def spawn_multiprocess_job(
+    job: Callable[[int, int], None], size: Optional[int] = None, max_retries: int = 5
+):
+    for attempt in range(max_retries):
+        processes = _start_multiprocess_job(job, size)
+        if not processes:
+            break
+        try:
+            _join_multiprocess_job(processes)
+            break  # success
+        except _PortConflictError:
+            # Kill any surviving sibling processes and retry with a fresh port.
+            # This recovers from the TOCTOU race between _is_port_available() and
+            # dist.init_process_group() where an external process grabbed the port.
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+                    p.join(timeout=5)
+            if attempt == max_retries - 1:
+                raise RuntimeError(
+                    f"Failed to initialize distributed group after {max_retries} "
+                    "attempts due to repeated port conflicts"
+                )
+            ad_logger.warning(
+                f"Port conflict on attempt {attempt + 1}/{max_retries}, retrying with new port..."
+            )
     cleanup()
 
 


### PR DESCRIPTION
 1. init_and_run_process: Added an inner try/except dist.DistNetworkError around
  initialize_or_skip. On port conflict, exits with sentinel code 2 rather than re-raising (which
  would look like a test failure to the parent).
  2. _join_multiprocess_job: Detects sentinel exit code 2 and raises _PortConflictError instead
  of AssertionError.
  3. spawn_multiprocess_job: Wraps the spawn+join in a retry loop (up to 5 attempts). On
  _PortConflictError, kills any surviving sibling processes and retries — _start_multiprocess_job
   picks a fresh port on each retry via get_free_port().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved robustness of distributed deployment with automatic retry mechanism when port conflicts occur during multi-process initialization. The system will automatically attempt to recover with new ports (up to 5 retries by default) before failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
