### PR TITLE
[TRTLLM-11288][fix] Adapt LTX2 pipeline to CompilationConfig warmup interface

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -235,6 +235,28 @@ class CompilationConfig(StrictBaseModel):
     More warmup shapes = slower startup, but lower risk of torch.compile
     recompilation delays on first requests. Fewer shapes = faster startup,
     but first request with an un-warmed shape triggers recompilation.
+
+    If not configured, each model pipeline uses its own defaults
+    (e.g., Wan uses [(480, 832), (720, 1280)] x [33, 81]).
+
+    YAML usage (via ``--extra_visual_gen_options``)::
+
+        # Custom warmup: 2 resolutions x 2 frame counts = 4 shapes
+        compilation:
+          resolutions:
+            - [480, 832]
+            - [720, 1280]
+          num_frames: [33, 81]
+
+        # Only override resolutions (frame counts use model defaults)
+        compilation:
+          resolutions:
+            - [1920, 1080]
+
+        # Skip warmup entirely
+        compilation:
+          resolutions: []
+          num_frames: []
     """
 
     resolutions: Optional[List[Tuple[int, int]]] = PydanticField(

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -270,24 +270,24 @@ class LTX2Pipeline(BasePipeline):
         return self.model_config.torch_dtype
 
     @property
-    def common_warmup_shapes(self) -> list:
-        """Return list of common warmup shapes (height, width, num_frames)."""
-        return [(512, 768, 121)]
+    def default_warmup_resolutions(self):
+        return [(512, 768)]
 
-    def _run_warmup(self, warmup_steps: int) -> None:
-        """Run warmup inference to trigger torch.compile and CUDA init."""
-        for height, width, num_frames in self.common_warmup_shapes:
-            logger.info(f"Warmup: LTX2 {height}x{width}, {num_frames} frames, {warmup_steps} steps")
-            self.forward(
-                prompt="warmup",
-                negative_prompt="",
-                height=height,
-                width=width,
-                num_frames=num_frames,
-                num_inference_steps=warmup_steps,
-                guidance_scale=4.0,
-                seed=0,
-            )
+    @property
+    def default_warmup_num_frames(self):
+        return [121]
+
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        self.forward(
+            prompt="warmup",
+            negative_prompt="",
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=steps,
+            guidance_scale=4.0,
+            seed=42,
+        )
 
     # ------------------------------------------------------------------
     # Transformer weight loading


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the LTX2 visual generation pipeline warmup mechanism to support explicit per-call parameter specification (height, width, frame count, and steps) instead of batch-based predefined configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adapt LTX2 pipeline to the new `CompilationConfig` warmup interface introduced in #12107.

LTX2 was merged after #12107 and still uses the old warmup interface (`common_warmup_shapes` + `_run_warmup(warmup_steps)`). This PR migrates it to the new interface:
- `common_warmup_shapes` → `default_warmup_resolutions` + `default_warmup_num_frames`
- `_run_warmup(warmup_steps)` → `_run_warmup(height, width, num_frames, steps)`
- warmup seed `0` → `42` (consistency with other pipelines)

## Test Coverage

- Existing `test_warmup.py` tests cover the base pipeline warmup logic
- LTX2-specific tests in CI use `skip_warmup=True` and are not affected

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
