### PR TITLE
[None][feat] Align AttentionPlugin with EdgeLLM interface

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
@@ -29,7 +29,9 @@ import torch
 @torch.library.custom_op("auto_deploy::torch_onnx_attention_plugin", mutates_args=())
 def attention_plugin(
     # Inputs
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -39,6 +41,8 @@ def attention_plugin(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fused attention operation with integrated RoPE (Rotary Position Embedding).
 
@@ -48,10 +52,11 @@ def attention_plugin(
 
     Note:
         This is a placeholder implementation for ONNX export. The actual computation
-        is performed by the backend runtime (e.g., TensorRT, EdgeLLM
+        is performed by the backend runtime (e.g., TensorRT, EdgeLLM).
     Args:
-        qkv: Concatenated query, key, value tensor of shape
-            [batch_size, seq_len, (num_q_heads + 2 * num_kv_heads) * head_size].
+        q: Query tensor of shape [batch_size, seq_len, num_q_heads * head_size].
+        k: Key tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
+        v: Value tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
         past_key_values: KV-cache tensor of shape
             [batch_size, 2, num_kv_heads, past_seq_len, head_size].
         context_lengths: Sequence lengths for each batch element, shape [batch_size].
@@ -63,6 +68,8 @@ def attention_plugin(
         head_size: Dimension of each attention head.
         num_kv_heads: Number of key-value heads (for grouped-query attention).
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: Whether to use FP8 KV cache (0 or 1). Default 0.
+        sliding_window_size: Sliding window size for attention (-1 = no window). Default -1.
 
     Returns:
         A tuple containing:
@@ -71,12 +78,14 @@ def attention_plugin(
             - present_key_values: Updated KV-cache tensor of shape
               [batch_size, 2, num_kv_heads, present_seq_len, head_size].
     """
-    return qkv.new_empty(0), past_key_values.new_empty(0)
+    return q.new_empty(0), past_key_values.new_empty(0)
 
 
 @attention_plugin.register_fake
 def attention_plugin_fake(
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -85,6 +94,8 @@ def attention_plugin_fake(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fake implementation of attention_plugin for torch.compile shape inference.
 
@@ -92,7 +103,9 @@ def attention_plugin_fake(
     enabling torch.compile to trace through the custom operation.
 
     Args:
-        qkv: Concatenated QKV tensor.
+        q: Query tensor.
+        k: Key tensor.
+        v: Value tensor.
         past_key_values: Previous KV-cache tensor.
         context_lengths: Sequence lengths per batch.
         rope_rotary_cos_sin: RoPE embedding values.
@@ -101,18 +114,20 @@ def attention_plugin_fake(
         head_size: Attention head dimension.
         num_kv_heads: Number of KV heads.
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: FP8 KV cache flag (unused in shape).
+        sliding_window_size: Sliding window size (unused in shape).
 
     Returns:
         Tuple of empty tensors with correct shapes for attention output and
         present KV-cache.
     """
-    batch_size = qkv.size(0)
-    seq_len = qkv.size(1)
+    batch_size = q.size(0)
+    seq_len = q.size(1)
     past_len = past_key_values.size(3)
     present_kv_len = seq_len + past_len
     attn_shape = (batch_size, seq_len, num_q_heads, head_size)
     present_kv_shape = (batch_size, 2, num_kv_heads, present_kv_len, head_size)
-    return torch.empty(attn_shape, device=qkv.device, dtype=qkv.dtype), torch.empty(
+    return torch.empty(attn_shape, device=q.device, dtype=q.dtype), torch.empty(
         present_kv_shape, device=past_key_values.device, dtype=past_key_values.dtype
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
@@ -85,8 +85,18 @@ _attention_plugin_schema = defs.OpSchema(
     doc="Fused RoPE + Attention operation for efficient inference.",
     inputs=[
         defs.OpSchema.FormalParameter(
-            name="qkv",
-            description="Concatenated Q, K, V tensors in shape [batch, seq_len, qkv_hidden_size]",
+            name="q",
+            description="Query tensor in shape [batch, seq_len, num_q_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="k",
+            description="Key tensor in shape [batch, seq_len, num_kv_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="v",
+            description="Value tensor in shape [batch, seq_len, num_kv_heads * head_size]",
             type_str="T",
         ),
         defs.OpSchema.FormalParameter(
@@ -158,6 +168,18 @@ _attention_plugin_schema = defs.OpSchema(
             type=defs.OpSchema.AttrType.INT,
             description="Number of query heads.",
             required=True,
+        ),
+        defs.OpSchema.Attribute(
+            name="enable_fp8_kv_cache",
+            type=defs.OpSchema.AttrType.INT,
+            description="Whether to use FP8 KV cache (0 or 1). Default 0.",
+            required=False,
+        ),
+        defs.OpSchema.Attribute(
+            name="sliding_window_size",
+            type=defs.OpSchema.AttrType.INT,
+            description="Sliding window size for attention (-1 = no window). Default -1.",
+            required=False,
         ),
     ],
 )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
@@ -81,7 +81,9 @@ def _translate_gather_nd_op(data: ir.Tensor, indices: ir.Tensor, batch_dims: int
 
 
 def _translate_rope_attention_op(
-    qkv: ir.Tensor,
+    q: ir.Tensor,
+    k: ir.Tensor,
+    v: ir.Tensor,
     past_key_values: ir.Tensor,
     context_lengths: ir.Tensor,
     rope_rotary_cos_sin: ir.Tensor,
@@ -90,6 +92,8 @@ def _translate_rope_attention_op(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ):
     """
     ONNX custom op translation function for AttentionPlugin.
@@ -103,7 +107,9 @@ def _translate_rope_attention_op(
     """
     # Call the custom op from the trt domain
     return _onnx_schemas.trt_opset.AttentionPlugin(
-        qkv,
+        q,
+        k,
+        v,
         past_key_values,
         context_lengths,
         rope_rotary_cos_sin,
@@ -112,6 +118,8 @@ def _translate_rope_attention_op(
         head_size=head_size,
         num_kv_heads=num_kv_heads,
         num_q_heads=num_q_heads,
+        enable_fp8_kv_cache=enable_fp8_kv_cache,
+        sliding_window_size=sliding_window_size,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
@@ -345,11 +345,10 @@ class FuseRopeAttention(BaseTransform):
         For each matched pattern, this method:
             1. Creates a past_key_values input placeholder for KV-cache
             2. Reshape Q, K, V to (batch_size, seq_len, -1)
-            3. Concatenates reshaped Q, K, V tensors into a single QKV tensor
-            4. Inserts the fused AttentionPlugin operation
-            5. Creates getitem nodes to extract attention output and present KV-cache
-            6. Replaces the original attention node with the fused output
-            7. Adds present_key_values to graph outputs
+            3. Cast Q, K, V to float16 and insert the fused AttentionPlugin (q, k, v separate)
+            4. Creates getitem nodes to extract attention output and present KV-cache
+            5. Replaces the original attention node with the fused output
+            6. Adds present_key_values to graph outputs
 
         Args:
             gm: The GraphModule being transformed.
@@ -410,28 +409,22 @@ class FuseRopeAttention(BaseTransform):
                 f"Reshaped Q, K, V to (batch_size, seq_len, -1): {q_node.name}, {k_node.name}, {v_node.name}"
             )
 
-            # 3. Concatenate reshaped Q, K, V to (batch_size, seq_len, -1)
-            with graph.inserting_before(match.attn_node):
-                qkv_node = graph.call_function(
-                    torch.ops.aten.cat.default, args=([q_node, k_node, v_node], -1)
-                )
-
-            ad_logger.debug(f"Created qkv concat node: {qkv_node.name}")
-
-            # 4. Create AttentionPlugin node
+            # 3. Cast Q, K, V to float16 and create AttentionPlugin node (q, k, v as separate inputs)
             enable_tree_attention = 0
             head_dim = match.head_dim
             num_kv_heads = match.num_kv_heads
             num_q_heads = match.num_q_heads
 
             with graph.inserting_before(match.attn_node):
-                cast_node = graph.call_function(
-                    torch.ops.aten.to.dtype, args=(qkv_node, torch.float16)
-                )
+                cast_q = graph.call_function(torch.ops.aten.to.dtype, args=(q_node, torch.float16))
+                cast_k = graph.call_function(torch.ops.aten.to.dtype, args=(k_node, torch.float16))
+                cast_v = graph.call_function(torch.ops.aten.to.dtype, args=(v_node, torch.float16))
                 rope_attn_node = graph.call_function(
                     torch.ops.auto_deploy.torch_onnx_attention_plugin.default,
                     args=(
-                        cast_node,
+                        cast_q,
+                        cast_k,
+                        cast_v,
                         past_key_values_node,
                         context_lengths_node,
                         rope_rotary_cos_sin_node,
@@ -441,6 +434,7 @@ class FuseRopeAttention(BaseTransform):
                         num_kv_heads,
                         num_q_heads,
                     ),
+                    kwargs={"enable_fp8_kv_cache": 0, "sliding_window_size": -1},
                 )
 
             ad_logger.debug(f"Created AttentionPlugin node: {rope_attn_node.name}")


### PR DESCRIPTION
# PR Title

```
[None][feat] Align AttentionPlugin with EdgeLLM interface (q/k/v split, FP8 KV, sliding window)
```

---

## Description

EdgeLLM’s AttentionPlugin op interface was updated: the single concatenated `qkv` input was replaced by separate `q`, `k`, and `v` inputs, and two optional attributes were added (`enable_fp8_kv_cache`, `sliding_window_size`). This PR updates TensorRT-LLM’s AutoDeploy path so that the custom op definition, ONNX schema, export translation, and fuse_rope_attention transform match the new EdgeLLM contract.

**Changes:**
- **`onnx_attention.py`**: `attention_plugin` / `attention_plugin_fake` now take `q`, `k`, `v` instead of `qkv`, and add optional `enable_fp8_kv_cache` (default 0) and `sliding_window_size` (default -1).
- **`_onnx_schemas.py`**: AttentionPlugin schema updated to three inputs (q, k, v) and two optional attributes.
- **`export_to_onnx.py`**: `_translate_rope_attention_op` passes q/k/v and the new attributes through to the ONNX custom op.
- **`fuse_rope_attention.py`**: Fused op is built with separate cast q/k/v and the new kwargs instead of concatenating to a single qkv tensor.

This keeps TRT-LLM’s exported ONNX and runtime behavior compatible with the current EdgeLLM AttentionPlugin implementation.

## Test Coverage

- `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_fuse_rope_attention.py` — exercises `fuse_rope_attention` and asserts the graph contains `torch_onnx_attention_plugin.default` with the expected pattern.
- Manual: Export an AutoDeploy model that uses RoPE+attention and verify the generated ONNX uses the updated AttentionPlugin signature (q, k, v + attributes).

## PR Checklist

- [x] PR description clearly explains what and why
- [x] Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md)
- [x] Test cases provided for new code paths
- [x] New dependencies scanned for license and vulnerabilities
- [x] [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- [x] Documentation updated as needed
- [x] Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- [x] Reviewers assigned appropriately
- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FP8 KV cache support option for improved memory efficiency.
  * Added sliding window attention size configuration for flexible attention control.

* **Refactor**
  * Improved attention mechanism to use separate query, key, and value tensors instead of concatenated inputs, enabling better processing flexibility and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->