### PR TITLE
[#12227][fix] Add timeout to MultiProcessExecutor shutdown to prevent test hangs

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -358,13 +358,25 @@ def _start_multiprocess_job(
     return processes
 
 
-def _join_multiprocess_job(processes):
+def _join_multiprocess_job(processes, timeout=None):
     if not processes:
         ad_logger.warning("No valid processes")
         return
 
     for p in processes:
-        p.join()
+        p.join(timeout=timeout)
+
+        if p.is_alive():
+            ad_logger.warning(
+                f"Process {p.pid} did not exit within {timeout}s, terminating..."
+            )
+            p.terminate()
+            p.join(timeout=5)
+            if p.is_alive():
+                ad_logger.warning(f"Process {p.pid} still alive after SIGTERM, killing...")
+                p.kill()
+                p.join(timeout=5)
+            continue
 
         # Ensure that all processes have exited successfully.
         # Check exitcode via hasattr rather than isinstance(p, mp.Process), because
@@ -444,8 +456,17 @@ class MultiProcessExecutor:
 
         for i in range(self.world_size):
             self.input_queues[i].put(None)
-        _join_multiprocess_job(self.processes)
+        _join_multiprocess_job(self.processes, timeout=30)
         self.processes = None
+
+        # Drain the output queue before closing to prevent join_thread() from
+        # blocking when the internal buffer feeder thread still holds data.
+        try:
+            while not self.output_queue.empty():
+                self.output_queue.get_nowait()
+        except Exception:
+            pass
+
         for q in self.input_queues:
             q.close()
             q.join_thread()

--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -4,6 +4,7 @@ import atexit
 import os
 import socket
 import sys
+from queue import Empty
 from typing import Callable, List, Optional, Tuple
 
 import torch
@@ -460,9 +461,9 @@ class MultiProcessExecutor:
         # Drain the output queue before closing to prevent join_thread() from
         # blocking when the internal buffer feeder thread still holds data.
         try:
-            while not self.output_queue.empty():
+            while True:
                 self.output_queue.get_nowait()
-        except Exception:
+        except Empty:
             pass
 
         for q in self.input_queues:

--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -367,9 +367,7 @@ def _join_multiprocess_job(processes, timeout=None):
         p.join(timeout=timeout)
 
         if p.is_alive():
-            ad_logger.warning(
-                f"Process {p.pid} did not exit within {timeout}s, terminating..."
-            )
+            ad_logger.warning(f"Process {p.pid} did not exit within {timeout}s, terminating...")
             p.terminate()
             p.join(timeout=5)
             if p.is_alive():


### PR DESCRIPTION
## Summary

- Add a bounded timeout (30s) to `MultiProcessExecutor.stop()` so that hung worker processes are forcefully terminated instead of blocking indefinitely.
- Drain the output queue before closing to prevent `join_thread()` deadlocks.

Fixes #12227

## Problem

`accuracy/test_llm_api_autodeploy.py` Nemotron Nano v3 accuracy tests sporadically hang when multiple test cases run sequentially. The root cause is in `_join_multiprocess_job`: it calls `p.join()` with no timeout, so if a worker process is stuck (e.g., in an NCCL collective, a queue `get()`, or during `dist.destroy_process_group()`), the main process blocks forever and all subsequent tests never execute.

A secondary issue is that `output_queue.join_thread()` can deadlock if the queue's internal buffer feeder thread still holds unsent data when `close()` is called.

## Root Cause

1. `_join_multiprocess_job` calls `p.join()` without a timeout — if any worker hangs during shutdown (common when NCCL collectives are interrupted or when the process group is in a bad state), the join blocks forever.
2. `MultiProcessExecutor.stop()` sends `None` sentinels to input queues, but workers stuck in `all_reduce` or other blocking operations never consume them.
3. The output queue may still contain data when `close()` + `join_thread()` is called, causing the feeder thread to deadlock.

## Fix

- `_join_multiprocess_job` now accepts an optional `timeout` parameter. When a process doesn't exit within the timeout, it is terminated with escalating signals (SIGTERM → SIGKILL).
- `MultiProcessExecutor.stop()` passes `timeout=30` to bound the shutdown duration.
- The output queue is drained before closing to prevent feeder thread deadlocks.
- Callers that don't pass a timeout (e.g., `spawn_multiprocess_job`) retain the original blocking behavior.

## Test Plan

- [x] Verify the fix compiles and passes pre-commit checks locally.
- [x] Run `pytest accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[fp8-1-trtllm]` and `[fp8-4-trtllm]` sequentially to confirm no hanging.
- [x] Run the full `TestNemotronNanoV3` test suite to verify no regressions.
- [x] CI: `/bot run --extra-stage "DGX_B200-4_GPUs-AutoDeploy-1, DGX_H100-4_GPUs-AutoDeploy-1"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented timeout-based process termination to prevent indefinitely hanging processes during shutdown.
  * Enhanced error detection and reporting for port conflicts during distributed deployment setup.
  * Improved shutdown procedure with queue draining to ensure complete and graceful cleanup.
  * Better handling of lingering processes with forced termination when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->