### PR TITLE
[None][feat] Initial Qwen3.5 text model support for PyT backend (BF16/FP8)

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -12,8 +12,9 @@ import transformers
 from transformers.utils import HF_MODULES_CACHE
 
 from tensorrt_llm import logger
-from tensorrt_llm._torch.pyexecutor.config_utils import (is_nemotron_hybrid,
-                                                         load_pretrained_config)
+from tensorrt_llm._torch.pyexecutor.config_utils import (
+    get_qwen3_hybrid_num_attention_layers, is_nemotron_hybrid, is_qwen3_hybrid,
+    load_pretrained_config)
 from tensorrt_llm._utils import get_sm_version, torch_dtype_to_binding
 from tensorrt_llm.bindings import LayerType as LayerTypeCpp
 from tensorrt_llm.functional import AllReduceStrategy
@@ -776,12 +777,7 @@ class ModelConfig(Generic[TConfig]):
     def get_num_attention_layers(self):
         if is_nemotron_hybrid(self.pretrained_config):
             return self.pretrained_config.hybrid_override_pattern.count("*")
-        elif hasattr(
-                self.pretrained_config, "architectures"
-        ) and self.pretrained_config.architectures is not None and self.pretrained_config.architectures[
-                0] in ["Qwen3NextForCausalLM"]:
-            # Qwen3NextForCausalLM has hybrid attention pattern(1:3 full attention:linear attention),
-            # we need to calculate the number of fullattention layers
-            return self.pretrained_config.num_hidden_layers // self.pretrained_config.full_attention_interval
+        elif is_qwen3_hybrid(self.pretrained_config):
+            return get_qwen3_hybrid_num_attention_layers(self.pretrained_config)
         else:
             return self.pretrained_config.num_hidden_layers

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -29,6 +29,7 @@ from .modeling_qwen import (Qwen2ForCausalLM, Qwen2ForProcessRewardModel,
                             Qwen2ForRewardModel)
 from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
 from .modeling_qwen3 import Qwen3ForCausalLM
+from .modeling_qwen3_5 import Qwen3_5MoeForCausalLM
 from .modeling_qwen3_moe import Qwen3MoeForCausalLM
 from .modeling_qwen3_next import Qwen3NextForCausalLM
 from .modeling_qwen3vl import Qwen3VLModel
@@ -76,6 +77,7 @@ __all__ = [
     "Qwen2_5_VLModel",
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
+    "Qwen3_5MoeForCausalLM",
     "Qwen3NextForCausalLM",
     "Qwen3MoeVLModel",
     "GptOssForCausalLM",

--- a/tensorrt_llm/_torch/models/checkpoints/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/__init__.py
@@ -8,6 +8,7 @@ from .hf.mixtral_weight_mapper import MixtralHfWeightMapper
 from .hf.nemotron_h_weight_mapper import NemotronHHfWeightMapper
 from .hf.qwen2_moe_weight_mapper import Qwen2MoeHfWeightMapper
 from .hf.qwen2vl_weight_mapper import Qwen2VLHfWeightMapper
+from .hf.qwen3_5_weight_mapper import Qwen3_5MoeHfWeightMapper
 from .hf.qwen3_moe_weight_mapper import Qwen3MoeHfWeightMapper
 from .hf.qwen3_next_weight_mapper import Qwen3NextHfWeightMapper
 from .hf.qwen3vl_weight_mapper import Qwen3VLHfWeightMapper
@@ -25,7 +26,7 @@ __all__ = [
     "HfCheckpointLoader", "NemotronHHfWeightMapper", "Gemma3HfWeightMapper",
     "MixtralHfWeightMapper", "Llama4HfWeightMapper", "Qwen2MoeHfWeightMapper",
     "Qwen3MoeHfWeightMapper", "Qwen2VLHfWeightMapper",
-    "Qwen3NextHfWeightMapper", "LlavaNextHfWeightMapper",
-    "MistralLarge3CheckpointLoader", "MistralLarge3WeightMapper",
-    "Qwen3VLHfWeightMapper"
+    "Qwen3_5MoeHfWeightMapper", "Qwen3NextHfWeightMapper",
+    "LlavaNextHfWeightMapper", "MistralLarge3CheckpointLoader",
+    "MistralLarge3WeightMapper", "Qwen3VLHfWeightMapper"
 ]

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -1,0 +1,269 @@
+import math
+import re
+from collections import defaultdict
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.qwen3_next_weight_mapper import (
+    Qwen3NextHfWeightMapper,
+)
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
+
+
+@register_mapper("HF", "Qwen3_5MoeForCausalLM")
+class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
+    """Weight mapper for Qwen3.5 MoE text checkpoints.
+
+    Qwen3.5 and Qwen3Next share the same model architecture (Qwen3NextModel),
+    but their HF checkpoint layouts differ in three ways that require extra
+    handling here:
+
+    1. Weight namespace (handled in _normalize_weight_names):
+       Qwen3.5 VLM checkpoints nest text weights under model.language_model.*
+       and include model.visual.* tensors.  This mapper strips the
+       language_model prefix and drops vision tensors so the shared
+       Qwen3NextModel can load them.
+
+    2. Linear-attention projections (handled in _pack_split_projections):
+       Qwen3Next checkpoints store pre-packed in_proj_qkvz and in_proj_ba
+       tensors.  Qwen3.5 checkpoints store them as separate in_proj_qkv + z
+       (or fully split q/k/v/z) and b + a tensors.  This mapper packs them
+       into the grouped-interleaved layout that TRT-LLM expects.
+       For FP8 checkpoints, the packed qkvz tensor is then dequantized to
+       bf16 as a temporary workaround for TP loading
+       (handled in _dequantize_linear_attn_fp8_qkvz).
+
+    3. MoE expert tensors (handled in handle_special_instance_module):
+       Qwen3.5 BF16 checkpoints store fused gate_up_proj/down_proj per expert
+       in transposed orientation [E, 2*I, H] vs TRT-LLM's [E, H, 2*I].
+       Qwen3.5 FP8 checkpoints store vanilla gate_proj/up_proj/down_proj per
+       expert.  This mapper detects which layout is present, transposes fused
+       tensors, renames keys, and sets the matching MoEWeightLoadingMode.
+    """
+
+    _SPLIT_PROJ_PATTERN = re.compile(r"^(.*\.linear_attn)\.in_proj_(qkv|q|k|v|z|b|a)\.(.+)$")
+    _SUPPORTED_SUFFIXES = {"weight", "bias", "weight_scale_inv"}
+
+    def _normalize_weight_names(self, weights: dict) -> dict:
+        normalized_weights = {}
+        for key, tensor in weights.items():
+            if key.startswith("model.visual."):
+                continue
+            if key.startswith("model.language_model."):
+                key = "model." + key[len("model.language_model.") :]
+            normalized_weights[key] = tensor
+        return normalized_weights
+
+    def handle_special_instance_module(
+        self,
+        module: nn.Module,
+        module_name: str,
+        module_weights: dict,
+        allow_partial_loading: bool = False,
+    ) -> None:
+        if isinstance(module, MoE):
+            config = self.config.pretrained_config
+            uses_fused_expert_tensors = "gate_up_proj" in module_weights
+            updated_module_weights = {}
+            for weight_name, weight_value in module_weights.items():
+                if weight_name == "gate_up_proj" and weight_value.ndim == 3:
+                    if weight_value.shape[-2] == 2 * config.moe_intermediate_size and (
+                        weight_value.shape[-1] == config.hidden_size
+                    ):
+                        weight_value = weight_value.transpose(-1, -2).contiguous()
+                elif weight_name == "down_proj" and weight_value.ndim == 3:
+                    if weight_value.shape[-2] == config.hidden_size and (
+                        weight_value.shape[-1] == config.moe_intermediate_size
+                    ):
+                        weight_value = weight_value.transpose(-1, -2).contiguous()
+                if uses_fused_expert_tensors:
+                    new_weight_name = weight_name.replace("scale_inv", "weight_scale")
+                else:
+                    new_weight_name = (
+                        weight_name.replace("gate_proj", "w1")
+                        .replace("up_proj", "w3")
+                        .replace("down_proj", "w2")
+                    )
+                updated_module_weights[new_weight_name] = weight_value
+            module.weight_loading_mode = (
+                MoEWeightLoadingMode.FUSED_GATE_UP_PROJ
+                if uses_fused_expert_tensors
+                else MoEWeightLoadingMode.VANILLA
+            )
+            module.load_weights(
+                weights=[updated_module_weights], allow_partial_loading=allow_partial_loading
+            )
+            return
+        return super().handle_special_instance_module(
+            module, module_name, module_weights, allow_partial_loading=allow_partial_loading
+        )
+
+    def _pack_projection_tensor(self, tensors: list[torch.Tensor], num_groups: int) -> torch.Tensor:
+        reference_shape = tensors[0].shape[1:]
+        for tensor in tensors:
+            assert tensor.shape[1:] == reference_shape, (
+                f"Expected matching trailing dims while packing projections, got "
+                f"{tensors[0].shape} and {tensor.shape}"
+            )
+            assert tensor.shape[0] % num_groups == 0, (
+                f"Projection with shape {tensor.shape} is not divisible by {num_groups} groups"
+            )
+
+        reshaped = [
+            tensor.reshape(num_groups, tensor.shape[0] // num_groups, *reference_shape)
+            for tensor in tensors
+        ]
+        return torch.cat(reshaped, dim=1).reshape(-1, *reference_shape).contiguous()
+
+    def _split_qkv_tensor(
+        self, tensor: torch.Tensor, expected_q: int, expected_v: int
+    ) -> tuple[torch.Tensor, ...]:
+        expected_total = expected_q * 2 + expected_v
+        assert tensor.shape[0] == expected_total, (
+            f"Expected packed qkv projection with leading dim {expected_total}, got {tensor.shape}"
+        )
+        return torch.split(tensor, [expected_q, expected_q, expected_v], dim=0)
+
+    def _split_qkv_scale_tensor(
+        self, tensor: torch.Tensor, expected_q: int, expected_v: int
+    ) -> tuple[torch.Tensor, ...]:
+        expected_q_blocks = math.ceil(expected_q / 128)
+        expected_v_blocks = math.ceil(expected_v / 128)
+        expected_total_blocks = expected_q_blocks * 2 + expected_v_blocks
+        assert tensor.shape[0] == expected_total_blocks, (
+            f"Expected packed qkv scale tensor with leading dim {expected_total_blocks}, "
+            f"got {tensor.shape}"
+        )
+        return torch.split(tensor, [expected_q_blocks, expected_q_blocks, expected_v_blocks], dim=0)
+
+    def _dequantize_fp8_block_scale_weight(
+        self, weight: torch.Tensor, weight_scale_inv: torch.Tensor
+    ) -> torch.Tensor:
+        rows, cols = weight.shape
+        expanded_scales = (
+            weight_scale_inv.to(torch.float32)
+            .repeat_interleave(128, dim=0)
+            .repeat_interleave(128, dim=1)[:rows, :cols]
+        )
+        target_dtype = getattr(self.config.pretrained_config, "torch_dtype", torch.bfloat16)
+        if target_dtype is None:
+            target_dtype = torch.bfloat16
+        return (weight.to(torch.float32) * expanded_scales).to(target_dtype).contiguous()
+
+    def _dequantize_linear_attn_fp8_qkvz(self, weights: dict) -> dict:
+        updated_weights = dict(weights)
+        for name in list(weights):
+            if not name.endswith(".linear_attn.in_proj_qkvz.weight"):
+                continue
+            scale_name = name.replace(".weight", ".weight_scale_inv")
+            if scale_name not in weights:
+                continue
+            updated_weights[name] = self._dequantize_fp8_block_scale_weight(
+                weights[name], weights[scale_name]
+            )
+            updated_weights.pop(scale_name, None)
+        return updated_weights
+
+    def _pack_split_projections(self, weights: dict) -> dict:
+        config = self.config.pretrained_config
+        num_k_groups = config.linear_num_key_heads
+        num_v_heads = config.linear_num_value_heads
+        assert num_v_heads % num_k_groups == 0, (
+            f"linear_num_value_heads ({num_v_heads}) must be divisible by "
+            f"linear_num_key_heads ({num_k_groups})"
+        )
+
+        grouped_weights = defaultdict(dict)
+        packed_weights = {}
+
+        for name, tensor in weights.items():
+            match = self._SPLIT_PROJ_PATTERN.match(name)
+            if match is None:
+                packed_weights[name] = tensor
+                continue
+            prefix, projection_name, suffix = match.groups()
+            grouped_weights[(prefix, suffix)][projection_name] = tensor
+
+        expected_q = config.linear_key_head_dim * config.linear_num_key_heads
+        expected_v = config.linear_value_head_dim * config.linear_num_value_heads
+        expected_ba = config.linear_num_value_heads
+
+        for (prefix, suffix), tensors in grouped_weights.items():
+            if suffix not in self._SUPPORTED_SUFFIXES:
+                raise NotImplementedError(
+                    "Qwen3.5 split linear-attention packing currently "
+                    f"supports only {sorted(self._SUPPORTED_SUFFIXES)} tensors, "
+                    f"but found unsupported suffix '{suffix}' for {prefix}"
+                )
+
+            qkvz_keys = {"qkv", "q", "k", "v", "z"} & tensors.keys()
+            if qkvz_keys:
+                if "qkv" in tensors:
+                    missing = {"qkv", "z"} - tensors.keys()
+                    assert not missing, (
+                        f"Missing split projections {sorted(missing)} for {prefix}.{suffix}"
+                    )
+                    if suffix == "weight_scale_inv":
+                        q_tensor, k_tensor, v_tensor = self._split_qkv_scale_tensor(
+                            tensors["qkv"], expected_q, expected_v
+                        )
+                    else:
+                        q_tensor, k_tensor, v_tensor = self._split_qkv_tensor(
+                            tensors["qkv"], expected_q, expected_v
+                        )
+                else:
+                    missing = {"q", "k", "v", "z"} - tensors.keys()
+                    assert not missing, (
+                        f"Missing split projections {sorted(missing)} for {prefix}.{suffix}"
+                    )
+                    q_tensor = tensors["q"]
+                    k_tensor = tensors["k"]
+                    v_tensor = tensors["v"]
+
+                if suffix == "weight":
+                    assert q_tensor.shape[0] == expected_q
+                    assert k_tensor.shape[0] == expected_q
+                    assert v_tensor.shape[0] == expected_v
+                    assert tensors["z"].shape[0] == expected_v
+                elif suffix == "weight_scale_inv":
+                    assert q_tensor.shape[0] == math.ceil(expected_q / 128)
+                    assert k_tensor.shape[0] == math.ceil(expected_q / 128)
+                    assert v_tensor.shape[0] == math.ceil(expected_v / 128)
+                    assert tensors["z"].shape[0] == math.ceil(expected_v / 128)
+
+                packed_name = f"{prefix}.in_proj_qkvz.{suffix}"
+                assert packed_name not in packed_weights, (
+                    f"Packed projection {packed_name} already exists"
+                )
+                packed_weights[packed_name] = self._pack_projection_tensor(
+                    [q_tensor, k_tensor, v_tensor, tensors["z"]], num_k_groups
+                )
+
+            ba_keys = {"b", "a"} & tensors.keys()
+            if ba_keys:
+                missing = {"b", "a"} - tensors.keys()
+                assert not missing, (
+                    f"Missing split projections {sorted(missing)} for {prefix}.{suffix}"
+                )
+
+                if suffix == "weight":
+                    assert tensors["b"].shape[0] == expected_ba
+                    assert tensors["a"].shape[0] == expected_ba
+
+                packed_name = f"{prefix}.in_proj_ba.{suffix}"
+                assert packed_name not in packed_weights, (
+                    f"Packed projection {packed_name} already exists"
+                )
+                packed_weights[packed_name] = self._pack_projection_tensor(
+                    [tensors["b"], tensors["a"]], num_k_groups
+                )
+
+        return packed_weights
+
+    def preprocess_weights(self, weights: dict) -> dict:
+        normalized_weights = self._normalize_weight_names(weights)
+        packed_weights = self._pack_split_projections(normalized_weights)
+        packed_weights = self._dequantize_linear_attn_fp8_qkvz(packed_weights)
+        return super().preprocess_weights(packed_weights)

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -19,8 +19,6 @@ class Qwen3_5MoeForCausalLM(Qwen3NextForCausalLM):
        Qwen3.5-specific HF weight layout differences like split linear-attention
        projections and fused MoE expert tensors) instead of the base
        Qwen3NextHfWeightMapper.
-    3. post_load_weights: wires next_layer_layernorm references needed by
-       Qwen3Next linear-attention layers; identical to Qwen3NextForCausalLM.
 
     See Qwen3NextForCausalLM in modeling_qwen3_next.py for the equivalent
     class that serves the vanilla Qwen3NextForCausalLM architecture.

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -1,0 +1,61 @@
+from transformers import Qwen3NextConfig
+
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
+
+from ..model_config import ModelConfig
+from .modeling_qwen3_next import Qwen3NextModel
+from .modeling_speculative import SpecDecOneEngineForCausalLM
+from .modeling_utils import register_auto_model
+
+
+@register_auto_model("Qwen3_5MoeForCausalLM")
+class Qwen3_5MoeForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel, Qwen3NextConfig]):
+    """Thin wrapper that registers the Qwen3.5 MoE text architecture.
+
+    Qwen3.5 text reuses the same model internals as Qwen3Next
+    (Qwen3NextModel) -- the transformer, linear-attention layers, MoE blocks,
+    and hybrid cache logic are all shared.  This separate class exists because:
+
+    1. HF architecture routing: the HF checkpoint advertises
+       Qwen3_5MoeForCausalLM (or top-level Qwen3_5MoeForConditionalGeneration
+       with nested text_config), so TRT-LLM needs a matching
+       @register_auto_model entry to route to the right class.
+    2. Weight mapper dispatch: registering a distinct architecture name lets
+       the checkpoint loader pick Qwen3_5MoeHfWeightMapper (which handles
+       Qwen3.5-specific HF weight layout differences like split linear-attention
+       projections and fused MoE expert tensors) instead of the base
+       Qwen3NextHfWeightMapper.
+    3. post_load_weights: wires next_layer_layernorm references needed by
+       Qwen3Next linear-attention layers; identical to Qwen3NextForCausalLM.
+
+    See Qwen3NextForCausalLM in modeling_qwen3_next.py for the equivalent
+    class that serves the vanilla Qwen3NextForCausalLM architecture.
+    """
+
+    def __init__(self, model_config: ModelConfig[Qwen3NextConfig]):
+        super().__init__(Qwen3NextModel(model_config), model_config)
+        self.preload_weight_modules = self.model.preload_weight_modules
+
+    def load_weights(
+        self,
+        weights: dict,
+        weight_mapper: BaseWeightMapper | None = None,
+        params_map: dict[str, str] | None = None,
+        allow_partial_loading: bool = False,
+    ):
+        if weight_mapper is not None:
+            weights = weight_mapper.preprocess_weights(weights)
+        super().load_weights(
+            weights,
+            weight_mapper=weight_mapper,
+            params_map=params_map,
+            allow_partial_loading=allow_partial_loading,
+        )
+
+    def post_load_weights(self):
+        assert self.config is not None
+        for idx, layer in enumerate(self.model.layers[: self.config.num_hidden_layers]):
+            if idx == self.config.num_hidden_layers - 1:
+                layer.next_layer_layernorm = self.model.norm
+            else:
+                layer.next_layer_layernorm = self.model.layers[idx + 1].input_layernorm

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -1,15 +1,9 @@
-from transformers import Qwen3NextConfig
-
-from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
-
-from ..model_config import ModelConfig
-from .modeling_qwen3_next import Qwen3NextModel
-from .modeling_speculative import SpecDecOneEngineForCausalLM
+from .modeling_qwen3_next import Qwen3NextForCausalLM
 from .modeling_utils import register_auto_model
 
 
 @register_auto_model("Qwen3_5MoeForCausalLM")
-class Qwen3_5MoeForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel, Qwen3NextConfig]):
+class Qwen3_5MoeForCausalLM(Qwen3NextForCausalLM):
     """Thin wrapper that registers the Qwen3.5 MoE text architecture.
 
     Qwen3.5 text reuses the same model internals as Qwen3Next
@@ -32,30 +26,4 @@ class Qwen3_5MoeForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel, Qwen3Nex
     class that serves the vanilla Qwen3NextForCausalLM architecture.
     """
 
-    def __init__(self, model_config: ModelConfig[Qwen3NextConfig]):
-        super().__init__(Qwen3NextModel(model_config), model_config)
-        self.preload_weight_modules = self.model.preload_weight_modules
-
-    def load_weights(
-        self,
-        weights: dict,
-        weight_mapper: BaseWeightMapper | None = None,
-        params_map: dict[str, str] | None = None,
-        allow_partial_loading: bool = False,
-    ):
-        if weight_mapper is not None:
-            weights = weight_mapper.preprocess_weights(weights)
-        super().load_weights(
-            weights,
-            weight_mapper=weight_mapper,
-            params_map=params_map,
-            allow_partial_loading=allow_partial_loading,
-        )
-
-    def post_load_weights(self):
-        assert self.config is not None
-        for idx, layer in enumerate(self.model.layers[: self.config.num_hidden_layers]):
-            if idx == self.config.num_hidden_layers - 1:
-                layer.next_layer_layernorm = self.model.norm
-            else:
-                layer.next_layer_layernorm = self.model.layers[idx + 1].input_layernorm
+    pass

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -22,6 +22,7 @@ import torch
 
 if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+
 import torch.nn.functional as F
 import triton
 import triton.language as tl
@@ -34,6 +35,8 @@ from tensorrt_llm._torch.modules.fla.chunk import chunk_gated_delta_rule
 from tensorrt_llm._torch.modules.fla.fused_sigmoid_gating_recurrent import \
     fused_sigmoid_gating_delta_rule_update
 from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
+from tensorrt_llm._torch.pyexecutor.config_utils import \
+    get_qwen3_hybrid_layer_types
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
     use_cpp_mamba_cache_manager
 from tensorrt_llm._utils import get_sm_version
@@ -45,7 +48,7 @@ from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
-from ..modules.fused_moe import (BaseMoeRoutingMethod,
+from ..modules.fused_moe import (BaseMoeRoutingMethod, MoEWeightLoadingMode,
                                  RenormalizeMoeRoutingMethod,
                                  RenormalizeNaiveMoeRoutingMethod,
                                  RoutingMethodType, create_moe)
@@ -154,6 +157,13 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             moe_backend=model_config.moe_backend,
         )
 
+        # Qwen3.5 BF16 checkpoints store fused [gate_up_proj, down_proj] per
+        # expert, while Qwen3Next and Qwen3.5 FP8 checkpoints store separate
+        # gate_proj/up_proj/down_proj (vanilla).  The model_type is set by HF
+        # config.json: "qwen3_5_moe_text" for Qwen3.5, "qwen3_next" otherwise.
+        weight_loading_mode = (MoEWeightLoadingMode.FUSED_GATE_UP_PROJ
+                               if config.model_type == "qwen3_5_moe_text" else
+                               MoEWeightLoadingMode.VANILLA)
         self.experts = create_moe(
             num_experts=self.num_experts,
             routing_method=self.gate.routing_method,
@@ -164,6 +174,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             reduce_results=False,
             model_config=model_config,
             layer_idx=layer_idx,
+            weight_loading_mode=weight_loading_mode,
         )
 
         self.shared_expert = GatedMLP(
@@ -1202,12 +1213,12 @@ class Qwen3NextModel(DecoderModel):
                 gather_output=True,
             )
 
+        layer_types = get_qwen3_hybrid_layer_types(pretrained_config)
         self.layers = nn.ModuleList([
-            ALL_DECODER_LAYER_TYPES[pretrained_config.layer_types[layer_idx]](
-                model_config,
-                layer_idx,
-                self.aux_stream,
-            ) for layer_idx in range(pretrained_config.num_hidden_layers)
+            ALL_DECODER_LAYER_TYPES[layer_types[layer_idx]](model_config,
+                                                            layer_idx,
+                                                            self.aux_stream)
+            for layer_idx in range(pretrained_config.num_hidden_layers)
         ])
 
         self.norm = RMSNorm(

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1111,215 +1111,37 @@ def transform_fp8_scale_to_required_layout(
 class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
         DeepSeekFP8BlockScalesFusedMoEMethod):
 
-    # Temporary module attrs used to cache lazy-resmooth state across loading phases.
-    _RESMOOTHED_SCALES_ATTR = "_fp8_resmoothed_scales_by_expert"
-    _PRE_RESMOOTHED_TARGETS_ATTR = "_fp8_pre_resmoothed_targets"
-
-    def _maybe_lazy_resmooth_weight(
-            self, module: torch.nn.Module, expert_id: int, proj_name: str,
-            weight: Optional[torch.Tensor],
-            scale: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
-        """Resmooth a single expert weight on demand and cache its new scale.
-
-        The lazy path resmooths only the weight shard being loaded, instead of
-        eagerly resmoothing all experts during `load_weights()`. The updated
-        E8M0 scale is cached on the module so later scale loading and
-        `post_load_weights()` can reuse it without recomputing or applying a
-        second resmooth pass.
-        """
-        if weight is None or scale is None:
-            return weight
-
-        logger.debug(f"Lazily resmoothing {expert_id}.{proj_name}.weight")
-        resmoothed_weight, resmoothed_scale = resmooth_to_fp8_e8m0(
-            weight[:], scale[:].to(torch.float32))
-        cached_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR, {})
-        setattr(module, self._RESMOOTHED_SCALES_ATTR, cached_scales)
-        expert_scales = cached_scales.setdefault(expert_id, {})
-        expert_scales[proj_name] = resmoothed_scale.cpu()
-        return resmoothed_weight
-
-    def _update_shared_scale_tensors(self, module: torch.nn.Module,
-                                     local_slot_id: int, expert_id: int):
-        expert_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR,
-                                {}).get(expert_id, {})
-        cached_w3_scale = expert_scales.get("w3")
-        cached_w1_scale = expert_scales.get("w1")
-        cached_w2_scale = expert_scales.get("w2")
-
-        if (cached_w3_scale is None or cached_w1_scale is None
-                or cached_w2_scale is None):
-            return
-
-        shared_w3_w1_scales = getattr(module,
-                                      'local_shared_w3_w1_scale_tensors', None)
-        shared_w2_scales = getattr(module, 'local_shared_w2_scale_tensors',
-                                   None)
-        if shared_w3_w1_scales is None or shared_w2_scales is None:
-            return
-
-        dst_w3_scale, dst_w1_scale = shared_w3_w1_scales[local_slot_id].chunk(
-            2, dim=0)
-        dst_w1_scale.copy_(
-            load_weight_shard(cached_w1_scale,
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.COLUMN,
-                              device=shared_w3_w1_scales.device))
-        dst_w3_scale.copy_(
-            load_weight_shard(cached_w3_scale,
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.COLUMN,
-                              device=shared_w3_w1_scales.device))
-        shared_w2_scales[local_slot_id].copy_(
-            load_weight_shard(cached_w2_scale,
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.ROW,
-                              device=shared_w2_scales.device))
-
     def load_weights(self,
                      module: torch.nn.Module,
                      weights: List[Dict],
                      weight_loading_mode: MoEWeightLoadingMode,
                      allow_partial_loading: bool = False):
-        setattr(module, self._RESMOOTHED_SCALES_ATTR, {})
-        setattr(module, self._PRE_RESMOOTHED_TARGETS_ATTR, set())
+        if is_sm_100f():
+            expert_ids = set(module.initial_local_expert_ids)
+            if self.need_load_shared_weights(module):
+                expert_ids.update(
+                    module.layer_load_balancer.get_load_expert_ids())
+            for name in list(weights.keys()):
+                if not name.endswith("weight_scale_inv"):
+                    continue
+                if int(name.split(".")[0]) not in expert_ids:
+                    continue
+                weight_name = name.replace("weight_scale_inv", "weight")
+                if weight_name not in weights:
+                    continue
+                logger.debug(f"Resmoothing {weight_name}")
+                weight = weights[weight_name][:]
+                scale = weights[name][:].to(torch.float32)
+                weights[weight_name], weights[name] = resmooth_to_fp8_e8m0(
+                    weight, scale)
         super().load_weights(module, weights, weight_loading_mode,
                              allow_partial_loading)
 
-    def load_expert_weights_to_dst(
-            self,
-            module: torch.nn.Module,
-            weights: Dict,
-            weight_loading_mode: MoEWeightLoadingMode,
-            load_expert_ids: List[int],
-            dst_w3_w1_weights_tensor: torch.Tensor,
-            dst_w2_weights_tensor: torch.Tensor,
-            dst_w3_w1_bias_tensor: Optional[torch.Tensor],
-            dst_w2_bias_tensor: Optional[torch.Tensor],
-            allow_partial_loading: bool = False):
-        if not (is_sm_100f()
-                and weight_loading_mode == MoEWeightLoadingMode.VANILLA):
-            return super().load_expert_weights_to_dst(
-                module,
-                weights,
-                weight_loading_mode,
-                load_expert_ids,
-                dst_w3_w1_weights_tensor,
-                dst_w2_weights_tensor,
-                dst_w3_w1_bias_tensor,
-                dst_w2_bias_tensor,
-                allow_partial_loading=allow_partial_loading)
-
-        device = dst_w3_w1_weights_tensor.device.type
-        pre_resmoothed_targets = getattr(module,
-                                         self._PRE_RESMOOTHED_TARGETS_ATTR,
-                                         set())
-        setattr(module, self._PRE_RESMOOTHED_TARGETS_ATTR,
-                pre_resmoothed_targets)
-
-        def maybe_pageout_mmapped_cpu_weights(weight_tensors):
-            if device == "cuda":
-                return
-            for weight in weight_tensors:
-                if (isinstance(weight, torch.Tensor)
-                        and weight.device.type == "cpu"
-                        and weight.is_contiguous()):
-                    advise_tensor_pageout(weight)
-
-        for local_slot_id, expert_id in enumerate(load_expert_ids):
-            raw_w1_weight = weights[
-                f"{expert_id}.w1.weight"] if f"{expert_id}.w1.weight" in weights else None
-            raw_w3_weight = weights[
-                f"{expert_id}.w3.weight"] if f"{expert_id}.w3.weight" in weights else None
-            raw_w2_weight = weights[
-                f"{expert_id}.w2.weight"] if f"{expert_id}.w2.weight" in weights else None
-
-            w1_weight = self._maybe_lazy_resmooth_weight(
-                module, expert_id, "w1", raw_w1_weight,
-                weights.get(f"{expert_id}.w1.weight_scale_inv"))
-            w3_weight = self._maybe_lazy_resmooth_weight(
-                module, expert_id, "w3", raw_w3_weight,
-                weights.get(f"{expert_id}.w3.weight_scale_inv"))
-            w2_weight = self._maybe_lazy_resmooth_weight(
-                module, expert_id, "w2", raw_w2_weight,
-                weights.get(f"{expert_id}.w2.weight_scale_inv"))
-
-            self.load_expert_w3_w1_weight(
-                module,
-                w1_weight,
-                w3_weight,
-                dst_w3_w1_weights_tensor[local_slot_id],
-                allow_partial_loading=allow_partial_loading)
-            self.load_expert_w2_weight(
-                module,
-                w2_weight,
-                dst_w2_weights_tensor[local_slot_id],
-                allow_partial_loading=allow_partial_loading)
-
-            unmap_weights = [
-                weight
-                for weight in [raw_w1_weight, raw_w3_weight, raw_w2_weight]
-                if weight is not None
-            ]
-            module._add_raw_shared_weights_for_unmap(unmap_weights)
-            maybe_pageout_mmapped_cpu_weights(unmap_weights)
-
-            if dst_w3_w1_weights_tensor.device.type == "cpu":
-                pre_resmoothed_targets.add("shared")
-                self._update_shared_scale_tensors(module, local_slot_id,
-                                                  expert_id)
-            else:
-                pre_resmoothed_targets.add("local")
-
-            if module.bias:
-                w1_bias = weights[
-                    f"{expert_id}.w1.bias"] if f"{expert_id}.w1.bias" in weights else None
-                w3_bias = weights[
-                    f"{expert_id}.w3.bias"] if f"{expert_id}.w3.bias" in weights else None
-                w2_bias = weights[
-                    f"{expert_id}.w2.bias"] if f"{expert_id}.w2.bias" in weights else None
-
-                self.load_expert_w3_w1_weight(
-                    module,
-                    w1_bias,
-                    w3_bias,
-                    dst_w3_w1_bias_tensor.data[local_slot_id],
-                    allow_partial_loading=allow_partial_loading)
-                self.load_expert_w2_weight(
-                    module,
-                    w2_bias,
-                    dst_w2_bias_tensor.data[local_slot_id],
-                    allow_partial_loading=allow_partial_loading)
-
-                unmap_weights = [
-                    weight for weight in [w1_bias, w3_bias, w2_bias]
-                    if weight is not None
-                ]
-                module._add_raw_shared_weights_for_unmap(unmap_weights)
-                maybe_pageout_mmapped_cpu_weights(unmap_weights)
-
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
-        cached_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR, {})
-        if not cached_scales:
-            return super().load_quant_scales(module, weights)
-
-        cached_weights = dict(weights)
-        for expert_id, scales in cached_scales.items():
-            for proj_name, scale in scales.items():
-                cached_weights[
-                    f"{expert_id}.{proj_name}.weight_scale_inv"] = scale
-        return super().load_quant_scales(module, cached_weights)
+    def _needs_e8m0_resmooth(self):
+        return is_sm_100f() or get_sm_version() == 120
 
     def post_load_weights(self, module: torch.nn.Module):
-        pre_resmoothed_targets = getattr(module,
-                                         self._PRE_RESMOOTHED_TARGETS_ATTR,
-                                         set())
-        # DeepGEMM SM100/SM120 FP8 block-scale expects requantized FP8 weights paired with E8M0-compatible scales.
-        needs_e8m0_resmooth = is_sm_100f() or get_sm_version() == 120
-        if needs_e8m0_resmooth:
+        if self._needs_e8m0_resmooth():
             # Resmooth shared experts before registering shared weights
             if self.need_load_shared_weights(module):
                 local_shared_load_expert_ids = module.layer_load_balancer.get_load_expert_ids(
@@ -1339,71 +1161,46 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                         module, 'local_shared_w2_tensors')
                     local_shared_w2_scale_tensors = getattr(
                         module, 'local_shared_w2_scale_tensors')
-
-                    if "shared" in pre_resmoothed_targets:
-                        transformed_shared_w3_w1_scale = transform_fp8_scale_to_required_layout(
-                            local_shared_w3_w1_tensors,
-                            local_shared_w3_w1_scale_tensors)
-                    else:
-                        resmoothed_shared_w3_w1_weight, transformed_shared_w3_w1_scale = resmooth_and_transform_fp8_scale(
-                            local_shared_w3_w1_tensors,
-                            local_shared_w3_w1_scale_tensors)
-                        setattr(module, 'local_shared_w3_w1_tensors',
-                                resmoothed_shared_w3_w1_weight.cpu())
+                    resmoothed_shared_w3_w1_weight, transformed_shared_w3_w1_scale = resmooth_and_transform_fp8_scale(
+                        local_shared_w3_w1_tensors,
+                        local_shared_w3_w1_scale_tensors)
+                    setattr(module, 'local_shared_w3_w1_tensors',
+                            resmoothed_shared_w3_w1_weight.cpu())
                     setattr(module, 'local_shared_w3_w1_scale_tensors',
                             transformed_shared_w3_w1_scale.cpu())
 
-                    if "shared" in pre_resmoothed_targets:
-                        transformed_shared_w2_scale = transform_fp8_scale_to_required_layout(
-                            local_shared_w2_tensors,
-                            local_shared_w2_scale_tensors)
-                    else:
-                        resmoothed_shared_w2_weight, transformed_shared_w2_scale = resmooth_and_transform_fp8_scale(
-                            local_shared_w2_tensors,
-                            local_shared_w2_scale_tensors)
-                        setattr(module, 'local_shared_w2_tensors',
-                                resmoothed_shared_w2_weight.cpu())
+                    resmoothed_shared_w2_weight, transformed_shared_w2_scale = resmooth_and_transform_fp8_scale(
+                        local_shared_w2_tensors, local_shared_w2_scale_tensors)
+                    setattr(module, 'local_shared_w2_tensors',
+                            resmoothed_shared_w2_weight.cpu())
                     setattr(module, 'local_shared_w2_scale_tensors',
                             transformed_shared_w2_scale.cpu())
 
         # Call super() after resmooth shared experts (local_shared tensors will be deleted in super().post_load_weights())
         super().post_load_weights(module)
 
-        if needs_e8m0_resmooth:
+        if self._needs_e8m0_resmooth():
             logger.debug("Resmoothing FP8 weights in post_load_weights")
-            if "local" in pre_resmoothed_targets:
-                transformed_w3_w1_scale = transform_fp8_scale_to_required_layout(
-                    module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
-            else:
-                resmoothed_w3_w1_weight, transformed_w3_w1_scale = resmooth_and_transform_fp8_scale(
-                    module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
-                replace_parameter_and_save_metadata(
-                    module, "w3_w1_weight", resmoothed_w3_w1_weight,
-                    module.rebuild_tensor_metadata)
+            resmoothed_w3_w1_weight, transformed_w3_w1_scale = resmooth_and_transform_fp8_scale(
+                module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
+            replace_parameter_and_save_metadata(module, "w3_w1_weight",
+                                                resmoothed_w3_w1_weight,
+                                                module.rebuild_tensor_metadata)
             replace_parameter_and_save_metadata(module,
                                                 "w3_w1_weight_scaling_factor",
                                                 transformed_w3_w1_scale,
                                                 module.rebuild_tensor_metadata)
 
-            if "local" in pre_resmoothed_targets:
-                transformed_w2_scale = transform_fp8_scale_to_required_layout(
-                    module.w2_weight, module.w2_weight_scaling_factor)
-            else:
-                resmoothed_w2_weight, transformed_w2_scale = resmooth_and_transform_fp8_scale(
-                    module.w2_weight, module.w2_weight_scaling_factor)
-                replace_parameter_and_save_metadata(
-                    module, "w2_weight", resmoothed_w2_weight,
-                    module.rebuild_tensor_metadata)
+            resmoothed_w2_weight, transformed_w2_scale = resmooth_and_transform_fp8_scale(
+                module.w2_weight, module.w2_weight_scaling_factor)
+            replace_parameter_and_save_metadata(module, "w2_weight",
+                                                resmoothed_w2_weight,
+                                                module.rebuild_tensor_metadata)
             replace_parameter_and_save_metadata(module,
                                                 "w2_weight_scaling_factor",
                                                 transformed_w2_scale,
                                                 module.rebuild_tensor_metadata)
             self.setup_quant_scales(module)
-
-        for attr_name in (self._RESMOOTHED_SCALES_ATTR,
-                          self._PRE_RESMOOTHED_TARGETS_ATTR):
-            if hasattr(module, attr_name):
-                delattr(module, attr_name)
 
 
 class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1095,39 +1095,231 @@ def resmooth_and_transform_fp8_scale(
     return resmoothed_weight, transformed_scale
 
 
+def transform_fp8_scale_to_required_layout(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Transform an already-resmoothed FP8 scale tensor to the required MoE layout."""
+    return transform_sf_into_required_layout(weight_scale,
+                                             mn=weight.shape[1],
+                                             k=weight.shape[2],
+                                             recipe=(1, 128, 128),
+                                             num_groups=weight.shape[0],
+                                             is_sfa=False)
+
+
 class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
         DeepSeekFP8BlockScalesFusedMoEMethod):
+
+    # Temporary module attrs used to cache lazy-resmooth state across loading phases.
+    _RESMOOTHED_SCALES_ATTR = "_fp8_resmoothed_scales_by_expert"
+    _PRE_RESMOOTHED_TARGETS_ATTR = "_fp8_pre_resmoothed_targets"
+
+    def _maybe_lazy_resmooth_weight(
+            self, module: torch.nn.Module, expert_id: int, proj_name: str,
+            weight: Optional[torch.Tensor],
+            scale: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        """Resmooth a single expert weight on demand and cache its new scale.
+
+        The lazy path resmooths only the weight shard being loaded, instead of
+        eagerly resmoothing all experts during `load_weights()`. The updated
+        E8M0 scale is cached on the module so later scale loading and
+        `post_load_weights()` can reuse it without recomputing or applying a
+        second resmooth pass.
+        """
+        if weight is None or scale is None:
+            return weight
+
+        logger.debug(f"Lazily resmoothing {expert_id}.{proj_name}.weight")
+        resmoothed_weight, resmoothed_scale = resmooth_to_fp8_e8m0(
+            weight[:], scale[:].to(torch.float32))
+        cached_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR, {})
+        setattr(module, self._RESMOOTHED_SCALES_ATTR, cached_scales)
+        expert_scales = cached_scales.setdefault(expert_id, {})
+        expert_scales[proj_name] = resmoothed_scale.cpu()
+        return resmoothed_weight
+
+    def _update_shared_scale_tensors(self, module: torch.nn.Module,
+                                     local_slot_id: int, expert_id: int):
+        expert_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR,
+                                {}).get(expert_id, {})
+        cached_w3_scale = expert_scales.get("w3")
+        cached_w1_scale = expert_scales.get("w1")
+        cached_w2_scale = expert_scales.get("w2")
+
+        if (cached_w3_scale is None or cached_w1_scale is None
+                or cached_w2_scale is None):
+            return
+
+        shared_w3_w1_scales = getattr(module,
+                                      'local_shared_w3_w1_scale_tensors', None)
+        shared_w2_scales = getattr(module, 'local_shared_w2_scale_tensors',
+                                   None)
+        if shared_w3_w1_scales is None or shared_w2_scales is None:
+            return
+
+        dst_w3_scale, dst_w1_scale = shared_w3_w1_scales[local_slot_id].chunk(
+            2, dim=0)
+        dst_w1_scale.copy_(
+            load_weight_shard(cached_w1_scale,
+                              module.tp_size,
+                              module.tp_rank,
+                              TensorParallelMode.COLUMN,
+                              device=shared_w3_w1_scales.device))
+        dst_w3_scale.copy_(
+            load_weight_shard(cached_w3_scale,
+                              module.tp_size,
+                              module.tp_rank,
+                              TensorParallelMode.COLUMN,
+                              device=shared_w3_w1_scales.device))
+        shared_w2_scales[local_slot_id].copy_(
+            load_weight_shard(cached_w2_scale,
+                              module.tp_size,
+                              module.tp_rank,
+                              TensorParallelMode.ROW,
+                              device=shared_w2_scales.device))
 
     def load_weights(self,
                      module: torch.nn.Module,
                      weights: List[Dict],
                      weight_loading_mode: MoEWeightLoadingMode,
                      allow_partial_loading: bool = False):
-        if is_sm_100f():
-            expert_ids = set(module.initial_local_expert_ids)
-            if self.need_load_shared_weights(module):
-                expert_ids.update(
-                    module.layer_load_balancer.get_load_expert_ids())
-            for name in list(weights.keys()):
-                if name.endswith("weight_scale_inv"):
-                    if int(name.split(".")[0]) not in expert_ids:
-                        continue
-                    weight_name = name.replace("weight_scale_inv", "weight")
-                    logger.debug(f"Resmoothing {weight_name}")
-                    weight = weights[weight_name][:]
-                    # Forcing the scale to float32 to avoid potential precision issues
-                    # For instance, Qwen3.5 FP8 MoE checkpoints use bf16 scales
-                    scale = weights[name][:].to(torch.float32)
-                    weights[weight_name], weights[name] = resmooth_to_fp8_e8m0(
-                        weight, scale)
+        setattr(module, self._RESMOOTHED_SCALES_ATTR, {})
+        setattr(module, self._PRE_RESMOOTHED_TARGETS_ATTR, set())
         super().load_weights(module, weights, weight_loading_mode,
                              allow_partial_loading)
 
-    def _needs_e8m0_resmooth(self):
-        return is_sm_100f() or get_sm_version() == 120
+    def load_expert_weights_to_dst(
+            self,
+            module: torch.nn.Module,
+            weights: Dict,
+            weight_loading_mode: MoEWeightLoadingMode,
+            load_expert_ids: List[int],
+            dst_w3_w1_weights_tensor: torch.Tensor,
+            dst_w2_weights_tensor: torch.Tensor,
+            dst_w3_w1_bias_tensor: Optional[torch.Tensor],
+            dst_w2_bias_tensor: Optional[torch.Tensor],
+            allow_partial_loading: bool = False):
+        if not (is_sm_100f()
+                and weight_loading_mode == MoEWeightLoadingMode.VANILLA):
+            return super().load_expert_weights_to_dst(
+                module,
+                weights,
+                weight_loading_mode,
+                load_expert_ids,
+                dst_w3_w1_weights_tensor,
+                dst_w2_weights_tensor,
+                dst_w3_w1_bias_tensor,
+                dst_w2_bias_tensor,
+                allow_partial_loading=allow_partial_loading)
+
+        device = dst_w3_w1_weights_tensor.device.type
+        pre_resmoothed_targets = getattr(module,
+                                         self._PRE_RESMOOTHED_TARGETS_ATTR,
+                                         set())
+        setattr(module, self._PRE_RESMOOTHED_TARGETS_ATTR,
+                pre_resmoothed_targets)
+
+        def maybe_pageout_mmapped_cpu_weights(weight_tensors):
+            if device == "cuda":
+                return
+            for weight in weight_tensors:
+                if (isinstance(weight, torch.Tensor)
+                        and weight.device.type == "cpu"
+                        and weight.is_contiguous()):
+                    advise_tensor_pageout(weight)
+
+        for local_slot_id, expert_id in enumerate(load_expert_ids):
+            raw_w1_weight = weights[
+                f"{expert_id}.w1.weight"] if f"{expert_id}.w1.weight" in weights else None
+            raw_w3_weight = weights[
+                f"{expert_id}.w3.weight"] if f"{expert_id}.w3.weight" in weights else None
+            raw_w2_weight = weights[
+                f"{expert_id}.w2.weight"] if f"{expert_id}.w2.weight" in weights else None
+
+            w1_weight = self._maybe_lazy_resmooth_weight(
+                module, expert_id, "w1", raw_w1_weight,
+                weights.get(f"{expert_id}.w1.weight_scale_inv"))
+            w3_weight = self._maybe_lazy_resmooth_weight(
+                module, expert_id, "w3", raw_w3_weight,
+                weights.get(f"{expert_id}.w3.weight_scale_inv"))
+            w2_weight = self._maybe_lazy_resmooth_weight(
+                module, expert_id, "w2", raw_w2_weight,
+                weights.get(f"{expert_id}.w2.weight_scale_inv"))
+
+            self.load_expert_w3_w1_weight(
+                module,
+                w1_weight,
+                w3_weight,
+                dst_w3_w1_weights_tensor[local_slot_id],
+                allow_partial_loading=allow_partial_loading)
+            self.load_expert_w2_weight(
+                module,
+                w2_weight,
+                dst_w2_weights_tensor[local_slot_id],
+                allow_partial_loading=allow_partial_loading)
+
+            unmap_weights = [
+                weight
+                for weight in [raw_w1_weight, raw_w3_weight, raw_w2_weight]
+                if weight is not None
+            ]
+            module._add_raw_shared_weights_for_unmap(unmap_weights)
+            maybe_pageout_mmapped_cpu_weights(unmap_weights)
+
+            if dst_w3_w1_weights_tensor.device.type == "cpu":
+                pre_resmoothed_targets.add("shared")
+                self._update_shared_scale_tensors(module, local_slot_id,
+                                                  expert_id)
+            else:
+                pre_resmoothed_targets.add("local")
+
+            if module.bias:
+                w1_bias = weights[
+                    f"{expert_id}.w1.bias"] if f"{expert_id}.w1.bias" in weights else None
+                w3_bias = weights[
+                    f"{expert_id}.w3.bias"] if f"{expert_id}.w3.bias" in weights else None
+                w2_bias = weights[
+                    f"{expert_id}.w2.bias"] if f"{expert_id}.w2.bias" in weights else None
+
+                self.load_expert_w3_w1_weight(
+                    module,
+                    w1_bias,
+                    w3_bias,
+                    dst_w3_w1_bias_tensor.data[local_slot_id],
+                    allow_partial_loading=allow_partial_loading)
+                self.load_expert_w2_weight(
+                    module,
+                    w2_bias,
+                    dst_w2_bias_tensor.data[local_slot_id],
+                    allow_partial_loading=allow_partial_loading)
+
+                unmap_weights = [
+                    weight for weight in [w1_bias, w3_bias, w2_bias]
+                    if weight is not None
+                ]
+                module._add_raw_shared_weights_for_unmap(unmap_weights)
+                maybe_pageout_mmapped_cpu_weights(unmap_weights)
+
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+        cached_scales = getattr(module, self._RESMOOTHED_SCALES_ATTR, {})
+        if not cached_scales:
+            return super().load_quant_scales(module, weights)
+
+        cached_weights = dict(weights)
+        for expert_id, scales in cached_scales.items():
+            for proj_name, scale in scales.items():
+                cached_weights[
+                    f"{expert_id}.{proj_name}.weight_scale_inv"] = scale
+        return super().load_quant_scales(module, cached_weights)
 
     def post_load_weights(self, module: torch.nn.Module):
-        if is_sm_100f() or get_sm_version() == 120:
+        pre_resmoothed_targets = getattr(module,
+                                         self._PRE_RESMOOTHED_TARGETS_ATTR,
+                                         set())
+        # DeepGEMM SM100/SM120 FP8 block-scale expects requantized FP8 weights paired with E8M0-compatible scales.
+        needs_e8m0_resmooth = is_sm_100f() or get_sm_version() == 120
+        if needs_e8m0_resmooth:
             # Resmooth shared experts before registering shared weights
             if self.need_load_shared_weights(module):
                 local_shared_load_expert_ids = module.layer_load_balancer.get_load_expert_ids(
@@ -1148,46 +1340,70 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                     local_shared_w2_scale_tensors = getattr(
                         module, 'local_shared_w2_scale_tensors')
 
-                    resmoothed_shared_w3_w1_weight, transformed_shared_w3_w1_scale = resmooth_and_transform_fp8_scale(
-                        local_shared_w3_w1_tensors,
-                        local_shared_w3_w1_scale_tensors)
-                    setattr(module, 'local_shared_w3_w1_tensors',
-                            resmoothed_shared_w3_w1_weight.cpu())
+                    if "shared" in pre_resmoothed_targets:
+                        transformed_shared_w3_w1_scale = transform_fp8_scale_to_required_layout(
+                            local_shared_w3_w1_tensors,
+                            local_shared_w3_w1_scale_tensors)
+                    else:
+                        resmoothed_shared_w3_w1_weight, transformed_shared_w3_w1_scale = resmooth_and_transform_fp8_scale(
+                            local_shared_w3_w1_tensors,
+                            local_shared_w3_w1_scale_tensors)
+                        setattr(module, 'local_shared_w3_w1_tensors',
+                                resmoothed_shared_w3_w1_weight.cpu())
                     setattr(module, 'local_shared_w3_w1_scale_tensors',
                             transformed_shared_w3_w1_scale.cpu())
 
-                    resmoothed_shared_w2_weight, transformed_shared_w2_scale = resmooth_and_transform_fp8_scale(
-                        local_shared_w2_tensors, local_shared_w2_scale_tensors)
-                    setattr(module, 'local_shared_w2_tensors',
-                            resmoothed_shared_w2_weight.cpu())
+                    if "shared" in pre_resmoothed_targets:
+                        transformed_shared_w2_scale = transform_fp8_scale_to_required_layout(
+                            local_shared_w2_tensors,
+                            local_shared_w2_scale_tensors)
+                    else:
+                        resmoothed_shared_w2_weight, transformed_shared_w2_scale = resmooth_and_transform_fp8_scale(
+                            local_shared_w2_tensors,
+                            local_shared_w2_scale_tensors)
+                        setattr(module, 'local_shared_w2_tensors',
+                                resmoothed_shared_w2_weight.cpu())
                     setattr(module, 'local_shared_w2_scale_tensors',
                             transformed_shared_w2_scale.cpu())
 
         # Call super() after resmooth shared experts (local_shared tensors will be deleted in super().post_load_weights())
         super().post_load_weights(module)
 
-        if self._needs_e8m0_resmooth():
+        if needs_e8m0_resmooth:
             logger.debug("Resmoothing FP8 weights in post_load_weights")
-            resmoothed_w3_w1_weight, transformed_w3_w1_scale = resmooth_and_transform_fp8_scale(
-                module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
-            replace_parameter_and_save_metadata(module, "w3_w1_weight",
-                                                resmoothed_w3_w1_weight,
-                                                module.rebuild_tensor_metadata)
+            if "local" in pre_resmoothed_targets:
+                transformed_w3_w1_scale = transform_fp8_scale_to_required_layout(
+                    module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
+            else:
+                resmoothed_w3_w1_weight, transformed_w3_w1_scale = resmooth_and_transform_fp8_scale(
+                    module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
+                replace_parameter_and_save_metadata(
+                    module, "w3_w1_weight", resmoothed_w3_w1_weight,
+                    module.rebuild_tensor_metadata)
             replace_parameter_and_save_metadata(module,
                                                 "w3_w1_weight_scaling_factor",
                                                 transformed_w3_w1_scale,
                                                 module.rebuild_tensor_metadata)
 
-            resmoothed_w2_weight, transformed_w2_scale = resmooth_and_transform_fp8_scale(
-                module.w2_weight, module.w2_weight_scaling_factor)
-            replace_parameter_and_save_metadata(module, "w2_weight",
-                                                resmoothed_w2_weight,
-                                                module.rebuild_tensor_metadata)
+            if "local" in pre_resmoothed_targets:
+                transformed_w2_scale = transform_fp8_scale_to_required_layout(
+                    module.w2_weight, module.w2_weight_scaling_factor)
+            else:
+                resmoothed_w2_weight, transformed_w2_scale = resmooth_and_transform_fp8_scale(
+                    module.w2_weight, module.w2_weight_scaling_factor)
+                replace_parameter_and_save_metadata(
+                    module, "w2_weight", resmoothed_w2_weight,
+                    module.rebuild_tensor_metadata)
             replace_parameter_and_save_metadata(module,
                                                 "w2_weight_scaling_factor",
                                                 transformed_w2_scale,
                                                 module.rebuild_tensor_metadata)
             self.setup_quant_scales(module)
+
+        for attr_name in (self._RESMOOTHED_SCALES_ATTR,
+                          self._PRE_RESMOOTHED_TARGETS_ATTR):
+            if hasattr(module, attr_name):
+                delattr(module, attr_name)
 
 
 class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1095,47 +1095,8 @@ def resmooth_and_transform_fp8_scale(
     return resmoothed_weight, transformed_scale
 
 
-def transform_fp8_scale_to_required_layout(
-    weight: torch.Tensor,
-    weight_scale: torch.Tensor,
-) -> torch.Tensor:
-    """Transform an already-resmoothed FP8 scale tensor to the required MoE layout."""
-    return transform_sf_into_required_layout(weight_scale,
-                                             mn=weight.shape[1],
-                                             k=weight.shape[2],
-                                             recipe=(1, 128, 128),
-                                             num_groups=weight.shape[0],
-                                             is_sfa=False)
-
-
 class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
         DeepSeekFP8BlockScalesFusedMoEMethod):
-
-    def load_weights(self,
-                     module: torch.nn.Module,
-                     weights: List[Dict],
-                     weight_loading_mode: MoEWeightLoadingMode,
-                     allow_partial_loading: bool = False):
-        if is_sm_100f():
-            expert_ids = set(module.initial_local_expert_ids)
-            if self.need_load_shared_weights(module):
-                expert_ids.update(
-                    module.layer_load_balancer.get_load_expert_ids())
-            for name in list(weights.keys()):
-                if not name.endswith("weight_scale_inv"):
-                    continue
-                if int(name.split(".")[0]) not in expert_ids:
-                    continue
-                weight_name = name.replace("weight_scale_inv", "weight")
-                if weight_name not in weights:
-                    continue
-                logger.debug(f"Resmoothing {weight_name}")
-                weight = weights[weight_name][:]
-                scale = weights[name][:].to(torch.float32)
-                weights[weight_name], weights[name] = resmooth_to_fp8_e8m0(
-                    weight, scale)
-        super().load_weights(module, weights, weight_loading_mode,
-                             allow_partial_loading)
 
     def _needs_e8m0_resmooth(self):
         return is_sm_100f() or get_sm_version() == 120

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1103,6 +1103,23 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                      weights: List[Dict],
                      weight_loading_mode: MoEWeightLoadingMode,
                      allow_partial_loading: bool = False):
+        if is_sm_100f():
+            expert_ids = set(module.initial_local_expert_ids)
+            if self.need_load_shared_weights(module):
+                expert_ids.update(
+                    module.layer_load_balancer.get_load_expert_ids())
+            for name in list(weights.keys()):
+                if name.endswith("weight_scale_inv"):
+                    if int(name.split(".")[0]) not in expert_ids:
+                        continue
+                    weight_name = name.replace("weight_scale_inv", "weight")
+                    logger.debug(f"Resmoothing {weight_name}")
+                    weight = weights[weight_name][:]
+                    # Forcing the scale to float32 to avoid potential precision issues
+                    # For instance, Qwen3.5 FP8 MoE checkpoints use bf16 scales
+                    scale = weights[name][:].to(torch.float32)
+                    weights[weight_name], weights[name] = resmooth_to_fp8_e8m0(
+                        weight, scale)
         super().load_weights(module, weights, weight_loading_mode,
                              allow_partial_loading)
 

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -263,7 +263,7 @@ class Mamba2Metadata:
                 # Keep this as a CPU bool view/tensor to avoid introducing an
                 # implicit sync point while reading per-sequence cache status.
                 initial_states_cpu = num_cached_tokens_per_seq[:num_contexts].to(
-                    dtype=torch.bool, device='cpu', copy=False)
+                    dtype=torch.bool, device='cpu')
             else:
                 # Fallback when cache metadata is provided as a Python sequence.
                 initial_states_cpu = torch.tensor([

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -187,6 +187,9 @@ class Mamba2Metadata:
         self.seq_idx: torch.Tensor = None
 
         # helper tensors for chunked prefill
+        self.has_initial_states_cpu = torch.zeros(max_batch_size,
+                                                  dtype=torch.bool,
+                                                  pin_memory=prefer_pinned())
         self.has_initial_states = torch.zeros(max_batch_size,
                                               dtype=torch.bool,
                                               device="cuda")
@@ -253,13 +256,31 @@ class Mamba2Metadata:
                 repeats=context_lens,
                 output_size=num_ctx_tokens).unsqueeze(0)
 
+            # Build "has initial state" flags on CPU first, then issue a
+            # single async H2D copy from the pinned staging buffer.
             num_cached_tokens_per_seq = attn_metadata.kv_cache_params.num_cached_tokens_per_seq
-            initial_states = [
-                num_cached_tokens_per_seq[i] > 0 for i in range(num_contexts)
-            ]
-            self.has_initial_states[:num_contexts] = torch.tensor(
-                initial_states, dtype=torch.bool)
-            self.use_initial_states = any(initial_states)
+            if isinstance(num_cached_tokens_per_seq, torch.Tensor):
+                # Keep this as a CPU bool view/tensor to avoid introducing an
+                # implicit sync point while reading per-sequence cache status.
+                initial_states_cpu = num_cached_tokens_per_seq[:num_contexts].to(
+                    dtype=torch.bool, device='cpu', copy=False)
+            else:
+                # Fallback when cache metadata is provided as a Python sequence.
+                initial_states_cpu = torch.tensor([
+                    num_cached_tokens_per_seq[i] > 0
+                    for i in range(num_contexts)
+                ],
+                                                  dtype=torch.bool,
+                                                  device='cpu')
+
+            self.has_initial_states_cpu[:num_contexts].copy_(initial_states_cpu)
+            # Mirror CPU staging flags to the CUDA-side buffer asynchronously.
+            self.has_initial_states[:num_contexts].copy_(
+                self.has_initial_states_cpu[:num_contexts], non_blocking=True)
+            # Keep a host boolean gate for chunk metadata construction.
+            self.use_initial_states = bool(
+                self.has_initial_states_cpu[:num_contexts].any())
+
             if self.use_initial_states:
                 self.chunk_indices, self.chunk_offsets = cu_seqlens_to_chunk_indices_offsets_triton(
                     self.cu_seqlens[:num_contexts + 1], self.chunk_size)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -136,9 +136,7 @@ class KvCacheCreator:
     def _get_kv_size_per_token(self):
         model_config = self._model_engine.model.model_config
         mapping = self._mapping
-        kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
-            self._model_engine)
-        kv_size_per_token = kv_cache_manager_cls.get_cache_size_per_token(
+        kv_size_per_token = self._kv_cache_manager_cls.get_cache_size_per_token(
             model_config, mapping, tokens_per_block=self._tokens_per_block)
         if self._draft_model_engine is not None:
             draft_model_config = self._draft_model_engine.model.model_config

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -28,7 +28,8 @@ from ..attention_backend import get_sparse_attn_kv_cache_manager
 from ..model_config import ModelConfig
 from ..speculative import (get_num_extra_kv_tokens, get_num_spec_layers,
                            get_spec_decoder, should_use_separate_draft_kv_cache)
-from .config_utils import is_mla, is_nemotron_hybrid, is_qwen3_next
+from .config_utils import (get_qwen3_hybrid_layer_masks, is_mla,
+                           is_nemotron_hybrid, is_qwen3_hybrid)
 from .guided_decoder import GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .kv_cache_transceiver import AttentionTypeCpp, create_kv_cache_transceiver
@@ -59,7 +60,7 @@ def get_kv_cache_manager_cls(model_config: ModelConfig,
     sparse_attn_config = model_config.sparse_attention_config
     if sparse_attn_config is not None:
         return get_sparse_attn_kv_cache_manager(sparse_attn_config)
-    elif is_nemotron_hybrid(config) or is_qwen3_next(config):
+    elif is_nemotron_hybrid(config) or is_qwen3_hybrid(config):
         return MambaHybridCacheManager
     else:
         return KVCacheManagerV2 if kv_cache_config.use_kv_cache_manager_v2 else KVCacheManager
@@ -128,14 +129,22 @@ class KvCacheCreator:
         self._draft_config = draft_config
         self._skip_est = skip_est
 
+    def _get_model_kv_cache_manager_cls(self, model_engine: PyTorchModelEngine):
+        return get_kv_cache_manager_cls(model_engine.model.model_config,
+                                        self._kv_cache_config)
+
     def _get_kv_size_per_token(self):
         model_config = self._model_engine.model.model_config
         mapping = self._mapping
-        kv_size_per_token = self._kv_cache_manager_cls.get_cache_size_per_token(
+        kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
+            self._model_engine)
+        kv_size_per_token = kv_cache_manager_cls.get_cache_size_per_token(
             model_config, mapping, tokens_per_block=self._tokens_per_block)
         if self._draft_model_engine is not None:
             draft_model_config = self._draft_model_engine.model.model_config
-            kv_size_per_token += self._kv_cache_manager_cls.get_cache_size_per_token(
+            draft_kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
+                self._draft_model_engine)
+            kv_size_per_token += draft_kv_cache_manager_cls.get_cache_size_per_token(
                 draft_model_config,
                 mapping,
                 tokens_per_block=self._tokens_per_block)
@@ -528,6 +537,8 @@ class KvCacheCreator:
             estimating_kv_cache: bool = False) -> KVCacheManager:
         mapping = self._mapping
         assert model_engine.model.model_config.is_generation, "Only construct KV cache for generation models."
+        kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
+            model_engine)
 
         # When using separate draft KV cache in one-model speculative decoding,
         # use layer_mask to include only target layers. The draft layers should
@@ -541,7 +552,7 @@ class KvCacheCreator:
         estimating_kv_cache = estimating_kv_cache and not self._skip_est
         kv_cache_manager = _create_kv_cache_manager(
             model_engine=model_engine,
-            kv_cache_manager_cls=self._kv_cache_manager_cls,
+            kv_cache_manager_cls=kv_cache_manager_cls,
             mapping=mapping,
             kv_cache_config=self._kv_cache_config,
             tokens_per_block=self._tokens_per_block,
@@ -1006,7 +1017,7 @@ def _create_kv_cache_manager(
             is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
         )
-    elif is_qwen3_next(config):
+    elif is_qwen3_hybrid(config):
         if max_beam_width > 1:
             raise ValueError(
                 "MambaHybridCacheManager + beam search is not supported yet.")
@@ -1015,19 +1026,10 @@ def _create_kv_cache_manager(
             raise NotImplementedError(
                 "Connector manager is not supported for MambaHybridCacheManager."
             )
-        mamba_layer_mask = [
-            True if i %
-            config.full_attention_interval != config.full_attention_interval -
-            1 else False for i in range(num_hidden_layers)
-        ]
-        hybrid_layer_mask = [
-            False if i %
-            config.full_attention_interval != config.full_attention_interval -
-            1 else True for i in range(num_hidden_layers)
-        ]
-        num_mamba_layers = num_hidden_layers // config.full_attention_interval * (
-            config.full_attention_interval - 1)
-        num_layers = num_hidden_layers - num_mamba_layers
+        hybrid_layer_mask, mamba_layer_mask = get_qwen3_hybrid_layer_masks(
+            config)
+        num_layers = sum(hybrid_layer_mask)
+        num_mamba_layers = sum(mamba_layer_mask)
         kv_cache_manager = kv_cache_manager_cls(
             # mamba cache parameters
             config.linear_key_head_dim,

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -249,8 +249,11 @@ def load_pretrained_config(model_name_or_path: str,
         config_class = _CONFIG_REGISTRY[model_type]
         model_config = config_class.from_pretrained(model_name_or_path,
                                                     **kwargs)
-    elif model_type == "qwen3_5_moe" or (architectures and architectures[0]
-                                         == "Qwen3_5MoeForCausalLM"):
+    elif model_type in ("qwen3_5_moe", "qwen3_5_moe_text") or (
+            architectures and architectures[0] in (
+                "Qwen3_5MoeForCausalLM",
+                "Qwen3_5MoeForConditionalGeneration",
+            )):
         model_config = transformers.Qwen3NextConfig.from_dict(
             _Qwen35ConfigCompat.normalize(config_dict))
     elif checkpoint_format in ("mistral", "mistral_large_3"):

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -1,3 +1,6 @@
+import re
+from typing import Optional
+
 import transformers
 
 
@@ -23,6 +26,202 @@ def is_qwen3_next(config):
         0] == 'Qwen3NextForCausalLM'
 
 
+def is_qwen3_5(config):
+    """True when config was loaded for a Qwen3.5 text checkpoint."""
+    return hasattr(
+        config, 'architectures'
+    ) and config.architectures is not None and config.architectures[
+        0] == 'Qwen3_5MoeForCausalLM'
+
+
+def is_qwen3_hybrid(config):
+    """True for any Qwen3 hybrid (linear-attention + full-attention) model.
+
+    Both Qwen3Next and Qwen3.5 use the same hybrid layer layout and share
+    cache-manager routing (MambaHybridCacheManager) and layer-type derivation.
+    """
+    return is_qwen3_next(config) or is_qwen3_5(config)
+
+
+def get_qwen3_hybrid_layer_types(config):
+    """Return per-layer type list for a Qwen3 hybrid model.
+
+    Accepts either an explicit layer_types list from the config, or derives
+    one from full_attention_interval (every Nth layer is full attention,
+    all others are linear attention).
+    """
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types is not None:
+        if len(layer_types) != config.num_hidden_layers:
+            raise ValueError(
+                f"Expected {config.num_hidden_layers} layer types for "
+                f"{config.architectures[0]}, got {len(layer_types)}")
+        for layer_type in layer_types:
+            if layer_type not in {"full_attention", "linear_attention"}:
+                raise ValueError(
+                    f"Unsupported Qwen3 hybrid layer type: {layer_type}")
+        return layer_types
+
+    full_attention_interval = getattr(config, "full_attention_interval", None)
+    if not isinstance(full_attention_interval,
+                      int) or full_attention_interval <= 0:
+        raise ValueError(
+            "Qwen3 hybrid configs must define either layer_types or a valid "
+            "full_attention_interval")
+
+    return [
+        "linear_attention" if i %
+        full_attention_interval != full_attention_interval -
+        1 else "full_attention" for i in range(config.num_hidden_layers)
+    ]
+
+
+def get_qwen3_hybrid_layer_masks(config):
+    layer_types = get_qwen3_hybrid_layer_types(config)
+    layer_mask = [layer_type == "full_attention" for layer_type in layer_types]
+    mamba_layer_mask = [
+        layer_type == "linear_attention" for layer_type in layer_types
+    ]
+    return layer_mask, mamba_layer_mask
+
+
+def get_qwen3_hybrid_num_attention_layers(config):
+    layer_mask, _ = get_qwen3_hybrid_layer_masks(config)
+    return sum(layer_mask)
+
+
+class _Qwen35ConfigCompat:
+    """Temporary shim that normalizes Qwen3.5 HF configs into Qwen3NextConfig.
+
+    To remove: delete this class and the elif branch in
+    load_pretrained_config that references it.
+    """
+
+    @staticmethod
+    def normalize(config_dict: dict) -> dict:
+        """Entry point: raw config.json dict -> flat Qwen3NextConfig-compatible dict."""
+        text_config = _Qwen35ConfigCompat._extract_text_config(config_dict)
+        text_config = _Qwen35ConfigCompat._inherit_quantization_config(
+            config_dict, text_config)
+        text_config = _Qwen35ConfigCompat._flatten_rope(text_config)
+        text_config["architectures"] = ["Qwen3_5MoeForCausalLM"]
+        return text_config
+
+    @staticmethod
+    def _extract_text_config(config_dict: dict) -> dict:
+        """Pull nested text_config from VLM checkpoints, or use dict as-is."""
+        architectures = config_dict.get("architectures") or []
+        if architectures and architectures[
+                0] == "Qwen3_5MoeForConditionalGeneration":
+            text_config = dict(config_dict.get("text_config") or {})
+        else:
+            text_config = dict(config_dict)
+        if not text_config:
+            raise ValueError("Qwen3.5 config is missing a usable text_config")
+        return text_config
+
+    @staticmethod
+    def _inherit_quantization_config(config_dict: dict,
+                                     text_config: dict) -> dict:
+        """Copy top-level quantization_config into text_config with name normalization.
+
+        Also adds a temporary workaround that keeps packed linear-attention
+        in_proj_qkvz on the bf16 path until FP8 block-scale TP loading is
+        fixed for that layout.
+        """
+        if "quantization_config" in text_config:
+            return text_config
+        if "quantization_config" not in config_dict:
+            return text_config
+
+        quantization_config = dict(config_dict["quantization_config"])
+        if "modules_to_not_convert" in quantization_config:
+            modules = _Qwen35ConfigCompat._normalize_exclude_modules(
+                quantization_config["modules_to_not_convert"])
+            modules = _Qwen35ConfigCompat._add_qkvz_bf16_workaround(
+                text_config, modules)
+            quantization_config["modules_to_not_convert"] = sorted(set(modules))
+        text_config["quantization_config"] = quantization_config
+        return text_config
+
+    @staticmethod
+    def _normalize_exclude_modules(modules: list[str]) -> list[str]:
+        """Translate HF quantization exclude-module paths to TRT-LLM names.
+
+        - Strip model.language_model. prefix -> model.
+        - Drop model.visual.* and mtp.* entries
+        - Map split projection names to packed TRT-LLM names
+        """
+        normalized = set()
+        for name in modules:
+            if name.startswith("model.language_model."):
+                name = "model." + name[len("model.language_model."):]
+            if name.startswith("model.visual.") or name.startswith("mtp."):
+                continue
+            name = re.sub(r"\.in_proj_[ab]$", ".in_proj_ba", name)
+            name = re.sub(r"\.in_proj_(q|k|v|z|qkv)$", ".in_proj_qkvz", name)
+            normalized.add(name)
+        return sorted(normalized)
+
+    @staticmethod
+    def _add_qkvz_bf16_workaround(text_config: dict,
+                                  modules: list[str]) -> list[str]:
+        """Keep packed linear-attention qkvz on bf16 path for all linear-attention layers.
+
+        Temporary until FP8 block-scale TP loading is fixed for this layout.
+        """
+        layer_types = text_config.get("layer_types")
+        if layer_types is None:
+            full_attention_interval = text_config.get("full_attention_interval")
+            num_hidden_layers = text_config.get("num_hidden_layers")
+            if isinstance(full_attention_interval,
+                          int) and full_attention_interval > 0 and isinstance(
+                              num_hidden_layers, int):
+                layer_types = [
+                    "linear_attention" if i %
+                    full_attention_interval != full_attention_interval -
+                    1 else "full_attention" for i in range(num_hidden_layers)
+                ]
+        if layer_types is not None:
+            for layer_idx, layer_type in enumerate(layer_types):
+                if layer_type == "linear_attention":
+                    modules.append(
+                        f"model.layers.{layer_idx}.linear_attn.in_proj_qkvz")
+        return modules
+
+    @staticmethod
+    def _flatten_rope(text_config: dict) -> dict:
+        """Flatten rope_parameters into top-level rope_theta / partial_rotary_factor / rope_scaling.
+
+        Qwen3.5 nests these inside a rope_parameters dict and uses rope_type
+        instead of type in rope_scaling.  Qwen3NextConfig expects them as
+        top-level fields with rope_scaling.type.
+        """
+        rope_parameters = dict(text_config.pop("rope_parameters", {}) or {})
+        rope_scaling = dict(text_config.get("rope_scaling") or {})
+        if rope_parameters:
+            rope_theta = rope_parameters.pop("rope_theta", None)
+            if rope_theta is not None:
+                text_config.setdefault("rope_theta", rope_theta)
+            partial_rotary_factor = rope_parameters.pop("partial_rotary_factor",
+                                                        None)
+            if partial_rotary_factor is not None:
+                text_config.setdefault("partial_rotary_factor",
+                                       partial_rotary_factor)
+            if rope_parameters:
+                rope_scaling = rope_parameters | rope_scaling
+        if rope_scaling:
+            has_mrope = ("mrope_section" in rope_scaling
+                         or rope_scaling.get("mrope_interleaved", False))
+            if has_mrope:
+                rope_scaling["type"] = "mrope"
+                rope_scaling.pop("rope_type", None)
+            elif "type" not in rope_scaling and "rope_type" in rope_scaling:
+                rope_scaling["type"] = rope_scaling.pop("rope_type")
+            text_config["rope_scaling"] = rope_scaling
+        return text_config
+
+
 # TODO: remove this once the transformers can support all of those models in _CONFIG_REGISTRY
 class LazyConfigDict(dict):
 
@@ -39,16 +238,21 @@ _CONFIG_REGISTRY: dict[str, type[transformers.PretrainedConfig]] = LazyConfigDic
 
 def load_pretrained_config(model_name_or_path: str,
                            trust_remote_code: bool = False,
-                           checkpoint_format: str = None,
+                           checkpoint_format: Optional[str] = None,
                            **kwargs) -> transformers.PretrainedConfig:
     config_dict, _ = transformers.PretrainedConfig.get_config_dict(
         model_name_or_path, **kwargs)
     model_type = config_dict.get("model_type")
+    architectures = config_dict.get("architectures") or []
 
     if model_type in _CONFIG_REGISTRY:
         config_class = _CONFIG_REGISTRY[model_type]
         model_config = config_class.from_pretrained(model_name_or_path,
                                                     **kwargs)
+    elif model_type == "qwen3_5_moe" or (architectures and architectures[0]
+                                         == "Qwen3_5MoeForCausalLM"):
+        model_config = transformers.Qwen3NextConfig.from_dict(
+            _Qwen35ConfigCompat.normalize(config_dict))
     elif checkpoint_format in ("mistral", "mistral_large_3"):
         from tensorrt_llm._torch.models.checkpoints.mistral.config_loader import \
             MistralConfigLoader

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -1,4 +1,5 @@
 import re
+from types import SimpleNamespace
 from typing import Optional
 
 import transformers
@@ -170,23 +171,15 @@ class _Qwen35ConfigCompat:
 
         Temporary until FP8 block-scale TP loading is fixed for this layout.
         """
-        layer_types = text_config.get("layer_types")
-        if layer_types is None:
-            full_attention_interval = text_config.get("full_attention_interval")
-            num_hidden_layers = text_config.get("num_hidden_layers")
-            if isinstance(full_attention_interval,
-                          int) and full_attention_interval > 0 and isinstance(
-                              num_hidden_layers, int):
-                layer_types = [
-                    "linear_attention" if i %
-                    full_attention_interval != full_attention_interval -
-                    1 else "full_attention" for i in range(num_hidden_layers)
-                ]
-        if layer_types is not None:
-            for layer_idx, layer_type in enumerate(layer_types):
-                if layer_type == "linear_attention":
-                    modules.append(
-                        f"model.layers.{layer_idx}.linear_attn.in_proj_qkvz")
+        try:
+            layer_types = get_qwen3_hybrid_layer_types(
+                SimpleNamespace(**text_config))
+        except (ValueError, AttributeError):
+            return modules
+        for layer_idx, layer_type in enumerate(layer_types):
+            if layer_type == "linear_attention":
+                modules.append(
+                    f"model.layers.{layer_idx}.linear_attn.in_proj_qkvz")
         return modules
 
     @staticmethod

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2193,7 +2193,8 @@ class PyTorchModelEngine(ModelEngine):
         draft_lens = []
         gen_request_seq_slots = []  # per generation request
         multimodal_params_list = []
-        mrope_position_ids = []
+        mrope_position_ids = [
+        ]  # (start_idx, end_idx, (3,1,L) mrope_pos_ids) per multimodal request
         num_accepted_draft_tokens = []  # per request
         # if using tree decoding, we need to store the request type and accepted path for each request,
         # which will be used to update the hidden_states_read_indices.
@@ -2266,7 +2267,10 @@ class PyTorchModelEngine(ModelEngine):
                             'mrope_position_ids'][:, :,
                                                   begin_compute:begin_compute +
                                                   len(prompt_tokens)]
-                    mrope_position_ids.append(ctx_mrope_position_ids)
+                    # Record as (start_idx, end_idx, (3,1,L) mrope_pos_ids)
+                    mrope_position_ids.append(
+                        (len(position_ids) - len(prompt_tokens),
+                         len(position_ids), ctx_mrope_position_ids))
 
                 # TODO: Visit later to decide the appropriate position of sending multimodal data & selectively sending multimodal data
                 multimodal_params.to_device("multimodal_data",
@@ -2586,8 +2590,12 @@ class PyTorchModelEngine(ModelEngine):
                                         "mrope_config.mrope_position_deltas"
                                     ])
                             for beam in range(beam_width):
+                                # Locate this beam's single token in the flat array.
+                                token_start = len(
+                                    position_ids) - beam_width + beam
                                 mrope_position_ids.append(
-                                    gen_mrope_position_ids)
+                                    (token_start, token_start + 1,
+                                     gen_mrope_position_ids))
                                 multimodal_params_list.append(multimodal_params)
 
                 request.py_batch_idx = request.py_seq_slot
@@ -2822,14 +2830,41 @@ class PyTorchModelEngine(ModelEngine):
             self.previous_kv_lens_offsets_cuda *= 0
 
         if self.use_mrope and mrope_position_ids:
-            # NOTE: self.use_mrope is enough for differentiating whether to use mrope_position_ids but
-            # `_create_dummy_context_requests` from `kv_cache_creater` makes an exception that I can not add multimodal_data to the dummy_request
-            # so that we only replace position_ids with mrope_position_ids when it is not a dummy request and for models who is using mrope.
-            mrope_position_ids = torch.cat(mrope_position_ids, dim=-1)
-            if mrope_position_ids.device.type == "cpu":
-                mrope_position_ids = maybe_pin_memory(mrope_position_ids)
+            # Mixed batches may have only some requests with multimodal MRoPE
+            # data. Seed the full (3,1,N) buffer from scalar position_ids
+            # (text-only tokens get the same value on all 3 axes), then
+            # overwrite only the multimodal spans with their real MRoPE coords.
+            position_ids_tensor = torch.tensor(position_ids,
+                                               dtype=torch.int,
+                                               pin_memory=prefer_pinned())
+            self.position_ids_cuda[:total_num_tokens].copy_(position_ids_tensor,
+                                                            non_blocking=True)
+            # Broadcast [N] to [3,1,N]: default for text-only tokens.
             self.mrope_position_ids_cuda[:, :, :total_num_tokens].copy_(
-                mrope_position_ids[:, :, :total_num_tokens], non_blocking=True)
+                self.position_ids_cuda[:total_num_tokens].view(1, 1, -1).expand(
+                    3, 1, -1),
+                non_blocking=True)
+            # Overwrite multimodal spans with per-axis MRoPE positions.
+            for start_idx, end_idx, segment in mrope_position_ids:
+                if segment.ndim != 3:
+                    raise RuntimeError(
+                        f"Expected 3D mrope_position_ids, got shape {tuple(segment.shape)}"
+                    )
+                if segment.shape[0] != 3 and segment.shape[-1] == 3:
+                    logger.warning(
+                        "Transposing unexpected mrope_position_ids shape from %s",
+                        tuple(segment.shape),
+                    )
+                    segment = segment.transpose(0, 2).contiguous()
+                if segment.shape[:2] != (3, 1):
+                    raise RuntimeError(
+                        f"Unexpected mrope_position_ids shape {tuple(segment.shape)} for span {start_idx}:{end_idx}"
+                    )
+                segment = segment.contiguous()
+                if segment.device.type == "cpu":
+                    segment = maybe_pin_memory(segment)
+                self.mrope_position_ids_cuda[:, :, start_idx:end_idx].copy_(
+                    segment[:, :, :end_idx - start_idx], non_blocking=True)
             final_position_ids = self.mrope_position_ids_cuda[:, :, :
                                                               total_num_tokens]
         else:
@@ -2948,8 +2983,9 @@ class PyTorchModelEngine(ModelEngine):
             self.input_ids_cuda[total_num_tokens:padded_num_tokens].fill_(0)
             virtual_num_tokens = padded_num_tokens
             if self.use_mrope and mrope_position_ids:
-                self.mrope_position_ids_cuda[
-                    total_num_tokens:padded_num_tokens].fill_(0)
+                # Zero-fill padding on dim 2 (token dim) of (3,1,N) buffer.
+                self.mrope_position_ids_cuda[:, :, total_num_tokens:
+                                             padded_num_tokens].fill_(0)
                 final_position_ids = self.mrope_position_ids_cuda[:, :, :
                                                                   virtual_num_tokens]
             else:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -529,6 +529,13 @@ def create_py_executor(
         cache_transceiver_config.max_tokens_in_buffer = net_max_seq_len
 
     config = model_engine.model.model_config.pretrained_config
+    if (is_nemotron_hybrid(config)
+            or is_qwen3_hybrid(config)) and kv_cache_config.enable_block_reuse:
+        logger.warning(
+            "Disabling block reuse for MambaHybridCacheManager-based models")
+        kv_cache_config.enable_block_reuse = False
+        _set_model_engines_cache_reuse([model_engine, draft_model_engine],
+                                       False)
     if is_mla(config):
         if model_engine.model.model_config.enable_flash_mla:
             tokens_per_block = 64

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -529,13 +529,6 @@ def create_py_executor(
         cache_transceiver_config.max_tokens_in_buffer = net_max_seq_len
 
     config = model_engine.model.model_config.pretrained_config
-    if (is_nemotron_hybrid(config)
-            or is_qwen3_hybrid(config)) and kv_cache_config.enable_block_reuse:
-        logger.warning(
-            "Disabling block reuse for MambaHybridCacheManager-based models")
-        kv_cache_config.enable_block_reuse = False
-        _set_model_engines_cache_reuse([model_engine, draft_model_engine],
-                                       False)
     if is_mla(config):
         if model_engine.model.model_config.enable_flash_mla:
             tokens_per_block = 64

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -36,7 +36,7 @@ from ..virtual_memory import scope as virtual_memory_scope
 from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
                     create_py_executor_instance, instantiate_sampler, is_mla,
                     validate_feature_combination)
-from .config_utils import is_mla, is_nemotron_hybrid, is_qwen3_hybrid
+from .config_utils import is_nemotron_hybrid, is_qwen3_hybrid
 from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .model_engine import PyTorchModelEngine
@@ -171,6 +171,13 @@ class _ExecutorMemoryMonitor:
                     free_gpu_memory_bytes_pre=free_gpu_memory_bytes_pre,
                     free_gpu_memory_bytes_post=free_gpu_memory_bytes_post,
                 ))
+
+
+def _set_model_engines_cache_reuse(model_engines, cache_reuse: bool):
+    for engine in model_engines:
+        if engine is None:
+            continue
+        engine.attn_runtime_features.cache_reuse = cache_reuse
 
 
 def _get_mapping(_mapping: Mapping) -> Mapping:
@@ -527,6 +534,8 @@ def create_py_executor(
         logger.warning(
             "Disabling block reuse for MambaHybridCacheManager-based models")
         kv_cache_config.enable_block_reuse = False
+        _set_model_engines_cache_reuse([model_engine, draft_model_engine],
+                                       False)
     if is_mla(config):
         if model_engine.model.model_config.enable_flash_mla:
             tokens_per_block = 64

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -36,7 +36,7 @@ from ..virtual_memory import scope as virtual_memory_scope
 from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
                     create_py_executor_instance, instantiate_sampler, is_mla,
                     validate_feature_combination)
-from .config_utils import is_mla, is_nemotron_hybrid, is_qwen3_next
+from .config_utils import is_mla, is_nemotron_hybrid, is_qwen3_hybrid
 from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .model_engine import PyTorchModelEngine
@@ -522,6 +522,11 @@ def create_py_executor(
         cache_transceiver_config.max_tokens_in_buffer = net_max_seq_len
 
     config = model_engine.model.model_config.pretrained_config
+    if (is_nemotron_hybrid(config)
+            or is_qwen3_hybrid(config)) and kv_cache_config.enable_block_reuse:
+        logger.warning(
+            "Disabling block reuse for MambaHybridCacheManager-based models")
+        kv_cache_config.enable_block_reuse = False
     if is_mla(config):
         if model_engine.model.model_config.enable_flash_mla:
             tokens_per_block = 64
@@ -694,7 +699,7 @@ def create_py_executor(
         # Disagg for hybrid models is currently only supported with C++ RnnStateManager
         config = model_engine.model.model_config.pretrained_config
         if cache_transceiver_config is not None and cache_transceiver_config.backend is not None:
-            if is_nemotron_hybrid(config) or is_qwen3_next(config):
+            if is_nemotron_hybrid(config) or is_qwen3_hybrid(config):
                 logger.info("Disaggregated serving with hybrid model detected. "
                             "Enabling C++ MambaCacheManager automatically.")
                 os.environ['TRTLLM_USE_CPP_MAMBA'] = '1'

--- a/tensorrt_llm/evaluate/interface.py
+++ b/tensorrt_llm/evaluate/interface.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,25 @@ import tensorrt_llm.profiler as profiler
 from ..llmapi import RequestOutput
 from ..logger import logger
 from ..sampling_params import SamplingParams
+
+
+def get_chat_template_kwargs(
+        template_owner: Any,
+        chat_template_kwargs: Optional[dict[str,
+                                            Any]] = None) -> dict[str, Any]:
+    """Return effective chat template kwargs for evaluation.
+
+    Some chat templates, such as Qwen3-family templates, enable a long-form
+    thinking mode by default. For exact-match style benchmarks, that can consume
+    the full generation budget before the model reaches its final answer. Keep
+    reasoning disabled unless the caller explicitly opts in.
+    """
+    effective_kwargs = dict(chat_template_kwargs or {})
+    owner = getattr(template_owner, "tokenizer", template_owner)
+    chat_template = getattr(owner, "chat_template", None)
+    if isinstance(chat_template, str) and "enable_thinking" in chat_template:
+        effective_kwargs.setdefault("enable_thinking", False)
+    return effective_kwargs
 
 
 class Evaluator(ABC):
@@ -68,11 +87,12 @@ class Evaluator(ABC):
                 "role": "system",
                 "content": self.system_prompt
             }] + messages
+        chat_template_kwargs = get_chat_template_kwargs(
+            llm.tokenizer, self.chat_template_kwargs)
         return llm.tokenizer.apply_chat_template(messages,
                                                  tokenize=False,
                                                  add_generation_prompt=True,
-                                                 **(self.chat_template_kwargs
-                                                    or {}))
+                                                 **chat_template_kwargs)
 
     def _get_sampline_params(self, sampling_params: Optional[SamplingParams],
                              sampling_args: Optional[dict]) -> SamplingParams:

--- a/tensorrt_llm/evaluate/lm_eval.py
+++ b/tensorrt_llm/evaluate/lm_eval.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/evaluate/lm_eval.py
+++ b/tensorrt_llm/evaluate/lm_eval.py
@@ -40,7 +40,8 @@ from ..inputs.utils import apply_chat_template as trtllm_apply_chat_template
 from ..llmapi import RequestOutput
 from ..logger import logger
 from ..sampling_params import SamplingParams
-from .interface import Evaluator, dump_inference_results
+from .interface import (Evaluator, dump_inference_results,
+                        get_chat_template_kwargs)
 
 # NOTE: lm_eval uses "<image>" as the default image placeholder
 # https://github.com/EleutherAI/lm-evaluation-harness/blob/7f04db12d2f8e7a99a0830d99eb78130e1ba2122/lm_eval/models/hf_vlms.py#L25
@@ -74,12 +75,14 @@ class LmEvalWrapper(TemplateLM):
         """
         Method to apply a chat template to a list of chat history between user and model.
         """
+        chat_template_kwargs = get_chat_template_kwargs(
+            self.llm.tokenizer, self.chat_template_kwargs)
         return self.llm.tokenizer.apply_chat_template(
             chat_history,
             tokenize=False,
             add_generation_prompt=add_generation_prompt,
             continue_final_message=not add_generation_prompt,
-            **(self.chat_template_kwargs or {}),
+            **chat_template_kwargs,
         )
 
     @property
@@ -271,11 +274,13 @@ class MultimodalLmEvalWrapper(LmEvalWrapper):
             add_generation_prompt=add_generation_prompt,
             mm_placeholder_counts=mm_placeholder_counts,
             tools=None,
-            chat_template_kwargs={
-                **(self.chat_template_kwargs or {}),
-                "continue_final_message":
-                not add_generation_prompt,
-            })
+            chat_template_kwargs=get_chat_template_kwargs(
+                getattr(self.llm.input_processor, 'processor', None)
+                or self.llm.tokenizer, {
+                    **(self.chat_template_kwargs or {}),
+                    "continue_final_message":
+                    not add_generation_prompt,
+                }))
         return output
 
     def generate_until(self, requests, disable_tqdm: bool = False) -> List[str]:

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -23,9 +23,10 @@ from tensorrt_llm._torch.modules.fused_moe.fused_moe_wide_ep import WideEPMoE
 from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
 from tensorrt_llm._torch.pyexecutor._util import get_kv_cache_manager_cls
 from tensorrt_llm._torch.pyexecutor.config_utils import (
+    get_qwen3_hybrid_layer_masks,
     is_mla,
     is_nemotron_hybrid,
-    is_qwen3_next,
+    is_qwen3_hybrid,
     load_pretrained_config,
 )
 from tensorrt_llm._torch.pyexecutor.model_loader import (
@@ -648,12 +649,11 @@ class Runner:
         )
         kwargs = {}
 
-        if is_nemotron_hybrid(pretrained_config) or is_qwen3_next(pretrained_config):
-            # Please refer to `tensorrt_llm/_torch/models/modeling_qwen3_next.py` for the magic number chunk_size=128
+        if is_nemotron_hybrid(pretrained_config) or is_qwen3_hybrid(pretrained_config):
             mamba_metadata = Mamba2Metadata(
                 attn_metadata.max_num_requests,
                 chunk_size=128
-                if is_qwen3_next(pretrained_config)
+                if is_qwen3_hybrid(pretrained_config)
                 else pretrained_config.chunk_size,
             )
             mamba_metadata.prepare(attn_metadata)
@@ -842,17 +842,13 @@ class Runner:
                 dtype=kv_cache_dtype,
                 spec_config=None,
             )
-        elif is_qwen3_next(config):
-            mamba_layer_mask = [
-                i in layer_indices
-                if i % config.full_attention_interval != config.full_attention_interval - 1
-                else False
-                for i in range(config.num_hidden_layers)
-            ]
+        elif is_qwen3_hybrid(config):
+            full_layer_mask, full_mamba_layer_mask = get_qwen3_hybrid_layer_masks(config)
             layer_mask = [
-                False
-                if i % config.full_attention_interval != config.full_attention_interval - 1
-                else i in layer_indices
+                full_layer_mask[i] and i in layer_indices for i in range(config.num_hidden_layers)
+            ]
+            mamba_layer_mask = [
+                full_mamba_layer_mask[i] and i in layer_indices
                 for i in range(config.num_hidden_layers)
             ]
             num_mamba_layers = sum(mamba_layer_mask)

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -178,6 +178,10 @@ Qwen3/Qwen3-Next-80B-A3B-Instruct:
   - quant_algo: NVFP4
     kv_cache_quant_algo: FP8
     accuracy: 90.86
+Qwen/Qwen3.5-35B-A3B:
+  - accuracy: 88.63
+  - quant_algo: FP8_BLOCK_SCALES
+    accuracy: 88.32
 moonshotai/Kimi-K2-Instruct:
   - quant_algo: FP8_BLOCK_SCALES
     accuracy: 94.84

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -5826,7 +5826,7 @@ class TestQwen3_5_35B_A3B(LlmapiAccuracyTestHarness):
     )
 
     def test_bf16(self):
-        world_size = min(2, torch.cuda.device_count())
+        world_size = 1
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
                                         enable_block_reuse=False)
         cuda_graph_config = CudaGraphConfig(
@@ -5846,12 +5846,17 @@ class TestQwen3_5_35B_A3B(LlmapiAccuracyTestHarness):
                           extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
     def test_fp8(self):
-        world_size = min(2, torch.cuda.device_count())
+        model_dir = f"{self.MODEL_PATH}-FP8"
+        # Model is being added to CI. Skip at the moment.
+        if not os.path.exists(model_dir):
+            pytest.skip(f"Model directory {model_dir} does not exist")
+
+        world_size = 1
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
                                         enable_block_reuse=False)
         moe_config = MoeConfig(backend='DEEPGEMM')
 
-        with LLM(f"{self.MODEL_PATH}-FP8",
+        with LLM(model_dir,
                  tensor_parallel_size=world_size,
                  moe_expert_parallel_size=world_size,
                  max_seq_len=4096,

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -5815,6 +5815,54 @@ class TestQwen3NextInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
+@pytest.mark.skip_less_device_memory(80000)
+class TestQwen3_5_35B_A3B(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "Qwen/Qwen3.5-35B-A3B"
+    MODEL_PATH = f"{llm_models_root()}/Qwen3.5-35B-A3B"
+    EXTRA_EVALUATOR_KWARGS = dict(
+        apply_chat_template=True,
+        fewshot_as_multiturn=True,
+        chat_template_kwargs=dict(enable_thinking=False),
+    )
+
+    def test_bf16(self):
+        world_size = min(2, torch.cuda.device_count())
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
+                                        enable_block_reuse=False)
+        cuda_graph_config = CudaGraphConfig(
+            enable_padding=True, batch_sizes=[1, 2, 4, 8, 16, 32, 64, 128])
+
+        with LLM(self.MODEL_PATH,
+                 tensor_parallel_size=world_size,
+                 moe_expert_parallel_size=world_size,
+                 max_seq_len=4096,
+                 max_num_tokens=4096,
+                 max_batch_size=128,
+                 enable_chunked_prefill=True,
+                 kv_cache_config=kv_cache_config,
+                 cuda_graph_config=cuda_graph_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
+    def test_fp8(self):
+        world_size = min(2, torch.cuda.device_count())
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
+                                        enable_block_reuse=False)
+        moe_config = MoeConfig(backend='DEEPGEMM')
+
+        with LLM(f"{self.MODEL_PATH}-FP8",
+                 tensor_parallel_size=world_size,
+                 moe_expert_parallel_size=world_size,
+                 max_seq_len=4096,
+                 enable_chunked_prefill=True,
+                 kv_cache_config=kv_cache_config,
+                 moe_config=moe_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
+
 class TestSeedOss_36B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "ByteDance-Seed/Seed-OSS-36B-Instruct"
     MODEL_PATH = f"{llm_models_root()}/Seed-OSS/Seed-OSS-36B-Instruct"

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -180,6 +180,8 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_cu
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm]
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm_attention_dp]
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4_4gpus[latency_moe_trtllm_eagle3]
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-cutlass-auto]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-cutlass-fp8]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-triton-auto]

--- a/tests/integration/test_lists/qa/llm_function_core_sanity.txt
+++ b/tests/integration/test_lists/qa/llm_function_core_sanity.txt
@@ -175,6 +175,8 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_4B::test_eagle3
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_fp8_block_scales[latency]
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_w4a8_mxfp4[fp8-latency]
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_w4a8_mxfp4[mxfp8-latency]
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8
 
 # disaggregated serving accuracy test
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype[mtp_nextn=0-overlap_scheduler=False]

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -69,6 +69,8 @@ l0_b200:
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_w4a16_mxfp4[latency-TRTLLM]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention[target_sparsity_0.5]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention[target_sparsity_0.9]
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8
   - accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_nvfp4[tp1-cutlass]
   - disaggregated/test_workers.py::test_workers_kv_cache_aware_router_eviction[TinyLlama-1.1B-Chat-v1.0] # nvbugs 5300551
   - test_e2e.py::test_ptp_quickstart_advanced[Llama3.1-8B-NVFP4-nvfp4-quantized/Meta-Llama-3.1-8B]

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -473,6 +473,84 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
             actual_seq_lens = attn_metadata.seq_lens.cpu().tolist()
             self.assertEqual(actual_seq_lens, expected_seq_lens)
 
+    def test_prepare_tp_inputs_with_partial_mrope_segments(self) -> None:
+        """Test generation-only MRoPE assembly with a real multimodal span and a dummy padded request."""
+        llm_args = TorchLlmArgs(model="dummy")
+        model_engine = DummyModelEngine(llm_args, dtype=torch.half)
+        model_engine.model.model_config.pretrained_config.rope_scaling = {
+            "type": "mrope"
+        }
+
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_config = KvCacheConfig(max_tokens=32)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=16,
+            head_dim=16,
+            tokens_per_block=1,
+            max_seq_len=32,
+            max_batch_size=4,
+            mapping=mapping,
+            dtype=tensorrt_llm.bindings.DataType.HALF,
+        )
+        attn_metadata = AttentionMetadata(max_num_requests=4,
+                                          max_num_tokens=32,
+                                          kv_cache_manager=kv_cache_manager)
+        attn_metadata.is_cuda_graph = False
+
+        model_engine.max_num_tokens = 32
+        model_engine.input_ids_cuda = torch.zeros(32,
+                                                  dtype=torch.int32,
+                                                  device='cuda')
+        model_engine.position_ids_cuda = torch.zeros(32,
+                                                     dtype=torch.int32,
+                                                     device='cuda')
+        model_engine.mrope_position_ids_cuda = torch.zeros((3, 1, 32),
+                                                           dtype=torch.int32,
+                                                           device='cuda')
+        model_engine.previous_batch_indices_cuda = torch.zeros(
+            32, dtype=torch.int32, device='cuda')
+
+        multimodal_request = _create_request(4, 1)
+        multimodal_request.py_prompt_len = 4
+        multimodal_request.py_batch_idx = None
+        multimodal_request.py_seq_slot = 0
+        multimodal_request.sampling_config.beam_width = 1
+        multimodal_request.py_multimodal_data = {
+            "mrope_config": {
+                "mrope_position_deltas": torch.tensor([[10]], dtype=torch.int32)
+            }
+        }
+
+        dummy_request = _create_request(6, 2)
+        dummy_request.py_prompt_len = 6
+        dummy_request.py_batch_idx = None
+        dummy_request.py_seq_slot = 1
+        dummy_request.sampling_config.beam_width = 1
+        dummy_request.py_multimodal_data = {}
+        dummy_request.is_cuda_graph_dummy = True
+
+        scheduled_requests = ScheduledRequests()
+        scheduled_requests.context_requests_last_chunk = []
+        scheduled_requests.generation_requests = [
+            multimodal_request, dummy_request
+        ]
+
+        result, _ = model_engine._prepare_tp_inputs(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata)
+
+        position_ids = result["position_ids"]
+        self.assertEqual(tuple(position_ids.shape), (3, 1, 2))
+        expected = torch.tensor([[[13, 5]], [[13, 5]], [[13, 5]]],
+                                dtype=torch.int32,
+                                device='cuda')
+        torch.testing.assert_close(position_ids, expected, atol=0, rtol=0)
+        kv_cache_manager.shutdown()
+
     def test_kv_cache_manager_with_execution_stream(self):
         """Test that KVCacheManager uses the provided execution_stream.
         """

--- a/tests/unittest/_torch/modules/mamba/test_mamba2_metadata.py
+++ b/tests/unittest/_torch/modules/mamba/test_mamba2_metadata.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 """Unit tests for Mamba2 metadata preparation optimizations."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from tensorrt_llm._torch.modules.mamba.mamba2_metadata import (
+    Mamba2Metadata,
     cu_seqlens_to_chunk_indices_offsets,
     cu_seqlens_to_chunk_indices_offsets_triton,
 )
@@ -56,6 +59,35 @@ class TestCuSeqlensToChunkIndicesOffsets:
 
         torch.testing.assert_close(indices_triton, indices_ref)
         torch.testing.assert_close(offsets_triton, offsets_ref)
+
+
+@skip_no_cuda
+class TestMamba2Metadata:
+    def test_prepare_handles_tensor_cached_tokens(self):
+        metadata = Mamba2Metadata(max_batch_size=4, chunk_size=8)
+        seq_lens = torch.tensor([4, 3], dtype=torch.int)
+        attn_metadata = SimpleNamespace(
+            seq_lens=seq_lens,
+            seq_lens_cuda=seq_lens.cuda(),
+            num_contexts=2,
+            num_ctx_tokens=7,
+            kv_cache_manager=None,
+            request_ids=None,
+            kv_cache_params=SimpleNamespace(
+                num_cached_tokens_per_seq=torch.tensor([0, 5], dtype=torch.int),
+            ),
+        )
+
+        metadata.prepare(attn_metadata)
+
+        assert metadata.has_initial_states_cpu.is_pinned()
+        torch.testing.assert_close(metadata.has_initial_states_cpu[:2], torch.tensor([False, True]))
+        torch.testing.assert_close(
+            metadata.has_initial_states[:2].cpu(), torch.tensor([False, True])
+        )
+        assert metadata.use_initial_states is True
+        assert metadata.chunk_indices is not None
+        assert metadata.chunk_offsets is not None
 
     def test_single_sequence_unaligned(self):
         """Test with a single sequence that doesn't align with chunk size."""


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Qwen3.5 Mixture of Experts (MoE) model variant with proper weight mapping and layer configuration.
  * Enhanced hybrid Qwen3 model detection and layer type handling for improved architecture compatibility.
  * Improved chat template parameter handling with automatic detection of thinking-related features.

* **Bug Fixes**
  * Fixed KV cache manager selection for hybrid models to ensure correct caching behavior.
  * Enhanced FP8 quantization support for newer hardware architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This adds a thin wrapper for Qwen3.5 text model over the Qwen3-next implementation in order to reuse as much components as possible.

Verified on B200 BF16 and FP8 (deepgemm MoE backend)

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

```
pytest -q -s tests/integration/defs/accuracy/test_llm_api_pytorch.py -k 'TestQwen3_5_35B_A3B and test_bf16'
pytest -q -s tests/integration/defs/accuracy/test_llm_api_pytorch.py -k 'TestQwen3_5_35B_A3B and test_fp8'
```
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
