### PR TITLE
[None][feat] Add PyTorchWorker backend for scaffolding framework (#3333)

### DIFF
--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -7,6 +7,7 @@ from .controller import (BestOfNController, ChatWithMCPController, Controller,
 from .execution_scope import ExecutionScope, current_scope
 from .math_utils import (extract_answer_from_boxed, extract_answer_with_regex,
                          get_digit_majority_vote_result)
+from .pytorch_worker import PyTorchWorker
 from .scaffolding_llm import ScaffoldingLlm
 from .task import (AssistantMessage, ChatTask, DropKVCacheTask, GenerationTask,
                    MCPCallTask, OpenAIToolDescription, RewardTask,
@@ -55,6 +56,7 @@ __all__ = [
     "OpenaiWorker",
     "TRTOpenaiWorker",
     "TRTLLMWorker",
+    "PyTorchWorker",
     "MCPWorker",
     "ApiaryMCPWorker",
     "TaskStatus",

--- a/tensorrt_llm/scaffolding/pytorch_worker.py
+++ b/tensorrt_llm/scaffolding/pytorch_worker.py
@@ -1,0 +1,470 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch backend worker for TensorRT-LLM Scaffolding.
+
+This module provides a worker implementation that uses native PyTorch and
+HuggingFace transformers for inference, enabling easy integration of research
+components without requiring TensorRT compilation.
+"""
+
+import copy
+import traceback
+from typing import List, Optional, Union
+
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    GenerationConfig,
+    PreTrainedModel,
+    PreTrainedTokenizer,
+    StoppingCriteria,
+    StoppingCriteriaList,
+)
+
+from tensorrt_llm.executor.result import Logprob
+from tensorrt_llm.logger import logger
+
+from .result import ScaffoldingOutput
+from .task import GenerationTask, RewardTask, StreamGenerationTask, TaskStatus
+from .worker import Worker
+
+
+class _StopStringCriteria(StoppingCriteria):
+    """Custom stopping criteria that checks for stop strings in decoded output."""
+
+    def __init__(self, tokenizer: PreTrainedTokenizer, stop_strings: List[str], input_length: int):
+        self.tokenizer = tokenizer
+        self.stop_strings = stop_strings
+        self.input_length = input_length
+
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        generated = self.tokenizer.decode(
+            input_ids[0, self.input_length :], skip_special_tokens=True
+        )
+        return any(s in generated for s in self.stop_strings)
+
+
+class PyTorchWorker(Worker):
+    """Worker that executes tasks using PyTorch and HuggingFace models.
+
+    This worker enables running inference with pure PyTorch models, which is
+    useful for:
+    - Rapid prototyping without TensorRT compilation
+    - Custom research models (reward models, verifiers, etc.)
+    - Models with architectures not yet supported by TensorRT
+    - Debugging and analysis requiring PyTorch-native tools
+
+    The worker supports generation tasks (using causal LMs), streaming
+    generation tasks (with pause/resume/cancel), and reward tasks (using
+    sequence classification models).
+
+    Example:
+        ```python
+        # Create worker with a HuggingFace model
+        worker = PyTorchWorker.from_pretrained("gpt2")
+
+        # Use in scaffolding
+        llm = ScaffoldingLlm(controller, {"generation": worker})
+        ```
+    """
+
+    def __init__(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizer,
+        device: Optional[Union[str, torch.device]] = None,
+        max_batch_size: int = 1,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+
+        if device is None:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self.device = torch.device(device) if isinstance(device, str) else device
+
+        self.model.to(self.device)
+        self.model.eval()
+
+        self.max_batch_size = max_batch_size
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: Optional[Union[str, torch.device]] = None,
+        torch_dtype: Optional[torch.dtype] = torch.float16,
+        trust_remote_code: bool = False,
+        **model_kwargs,
+    ) -> "PyTorchWorker":
+        """Create a PyTorchWorker from a HuggingFace model name or path.
+
+        Args:
+            model_name_or_path: HuggingFace model identifier or local path
+            device: Device to run on (default: auto-detect CUDA)
+            torch_dtype: Data type for model weights (default: float16)
+            trust_remote_code: Whether to trust remote code in model
+            **model_kwargs: Additional arguments passed to model loading
+
+        Returns:
+            PyTorchWorker instance with loaded model
+        """
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            padding_side="left",
+        )
+
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name_or_path,
+            torch_dtype=torch_dtype,
+            trust_remote_code=trust_remote_code,
+            **model_kwargs,
+        )
+
+        return cls(model, tokenizer, device=device)
+
+    @classmethod
+    def from_pretrained_reward_model(
+        cls,
+        model_name_or_path: str,
+        device: Optional[Union[str, torch.device]] = None,
+        torch_dtype: Optional[torch.dtype] = torch.float16,
+        trust_remote_code: bool = False,
+        **model_kwargs,
+    ) -> "PyTorchWorker":
+        """Create a PyTorchWorker for reward modeling tasks.
+
+        Loads a sequence classification model suitable for scoring text.
+        """
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+        )
+
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        model = AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path,
+            torch_dtype=torch_dtype,
+            trust_remote_code=trust_remote_code,
+            **model_kwargs,
+        )
+
+        return cls(model, tokenizer, device=device)
+
+    def _tokenize_input(self, input_str: Optional[str], input_tokens: Optional[list]):
+        """Tokenize from input_str or input_tokens, returning model inputs dict.
+
+        Returns None if neither input_str nor input_tokens is provided.
+        """
+        if input_str is not None:
+            return self.tokenizer(input_str, return_tensors="pt", padding=True, truncation=True).to(
+                self.device
+            )
+        elif input_tokens is not None:
+            input_ids = torch.tensor([input_tokens], device=self.device)
+            return {
+                "input_ids": input_ids,
+                "attention_mask": torch.ones_like(input_ids),
+            }
+        return None
+
+    def convert_task_params(self, task: GenerationTask) -> GenerationConfig:
+        """Convert task sampling parameters to HuggingFace GenerationConfig."""
+        return GenerationConfig(
+            max_new_tokens=task.max_tokens if task.max_tokens is not None else 100,
+            temperature=task.temperature if task.temperature is not None else 1.0,
+            top_p=task.top_p if task.top_p is not None else 1.0,
+            top_k=task.top_k if task.top_k is not None else 50,
+            do_sample=(task.temperature is not None and task.temperature > 0),
+            pad_token_id=self.tokenizer.pad_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
+        )
+
+    def _build_stopping_criteria(self, task: GenerationTask, input_length: int):
+        """Build stopping criteria list from task stop sequences."""
+        if not task.stop:
+            return None
+        stop_strings = [task.stop] if isinstance(task.stop, str) else task.stop
+        if not stop_strings:
+            return None
+        return StoppingCriteriaList(
+            [_StopStringCriteria(self.tokenizer, stop_strings, input_length)]
+        )
+
+    def _strip_stop_sequence(self, text: str, task: GenerationTask) -> str:
+        """Remove trailing stop sequence from generated text."""
+        if not task.stop:
+            return text
+        stop_strings = [task.stop] if isinstance(task.stop, str) else task.stop
+        for s in stop_strings:
+            idx = text.find(s)
+            if idx != -1:
+                return text[:idx]
+        return text
+
+    def _extract_logprobs(self, scores: tuple, generated_tokens: List[int], num_logprobs: int):
+        """Extract top-k logprobs from generation scores.
+
+        Args:
+            scores: Tuple of [batch_size, vocab_size] tensors per step.
+            generated_tokens: List of token IDs that were generated.
+            num_logprobs: Number of top logprobs to return per token.
+
+        Returns:
+            TokenLogprobs (list[dict[int, Logprob]])
+        """
+        logprobs_list = []
+        for step_idx, step_scores in enumerate(scores):
+            log_probs = torch.log_softmax(step_scores[0].float(), dim=-1)
+            token_dict = {}
+
+            if num_logprobs > 0:
+                k = min(num_logprobs, log_probs.shape[0])
+                topk_vals, topk_indices = torch.topk(log_probs, k=k)
+                for rank, (val, idx) in enumerate(zip(topk_vals, topk_indices)):
+                    token_dict[idx.item()] = Logprob(logprob=val.item(), rank=rank + 1)
+
+            # Always include the actually generated token
+            if step_idx < len(generated_tokens):
+                gen_token_id = generated_tokens[step_idx]
+                if gen_token_id not in token_dict:
+                    gen_logprob = log_probs[gen_token_id].item()
+                    gen_rank = (log_probs > gen_logprob).sum().item() + 1
+                    token_dict[gen_token_id] = Logprob(logprob=gen_logprob, rank=gen_rank)
+
+            logprobs_list.append(token_dict)
+        return logprobs_list
+
+    def _sample_token(self, logits: torch.Tensor, gen_config: GenerationConfig) -> torch.Tensor:
+        """Sample a single token from logits using the generation config."""
+        if not gen_config.do_sample:
+            return torch.argmax(logits, dim=-1)
+
+        logits = logits / max(gen_config.temperature, 1e-7)
+
+        # Top-k filtering
+        if gen_config.top_k > 0:
+            topk_vals = torch.topk(logits, gen_config.top_k)[0]
+            logits[logits < topk_vals[..., -1, None]] = -float("inf")
+
+        # Top-p (nucleus) filtering
+        if gen_config.top_p < 1.0:
+            sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+            cum_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1), dim=-1)
+            remove_mask = (cum_probs - torch.softmax(sorted_logits, dim=-1)) >= gen_config.top_p
+            sorted_logits[remove_mask] = -float("inf")
+            logits.scatter_(1, sorted_indices, sorted_logits)
+
+        probs = torch.softmax(logits, dim=-1)
+        return torch.multinomial(probs, num_samples=1).squeeze(-1)
+
+    async def generation_handler(self, task: GenerationTask) -> TaskStatus:
+        """Handle text generation task using PyTorch model."""
+        try:
+            inputs = self._tokenize_input(task.input_str, task.input_tokens)
+            if inputs is None:
+                return TaskStatus.WORKER_EXECEPTION
+
+            # Ensure inputs is a dict (tokenizer returns BatchEncoding)
+            if not isinstance(inputs, dict):
+                inputs = dict(inputs)
+
+            gen_config = self.convert_task_params(task)
+            input_length = inputs["input_ids"].shape[1]
+
+            stopping_criteria = self._build_stopping_criteria(task, input_length)
+
+            generate_kwargs = {
+                "generation_config": gen_config,
+                "return_dict_in_generate": True,
+                "output_scores": task.num_logprobs is not None,
+            }
+            if stopping_criteria is not None:
+                generate_kwargs["stopping_criteria"] = stopping_criteria
+
+            with torch.no_grad():
+                outputs = self.model.generate(**inputs, **generate_kwargs)
+
+            generated_tokens = outputs.sequences[0, input_length:].tolist()
+            output_text = self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
+            output_text = self._strip_stop_sequence(output_text, task)
+
+            task.output_str = output_text
+            task.output_tokens = generated_tokens
+
+            if task.num_logprobs is not None and hasattr(outputs, "scores") and outputs.scores:
+                task.logprobs = self._extract_logprobs(
+                    outputs.scores, generated_tokens, task.num_logprobs
+                )
+
+            return TaskStatus.SUCCESS
+
+        except (RuntimeError, ValueError) as e:
+            logger.error(f"PyTorchWorker generation error: {e}\n{traceback.format_exc()}")
+            return TaskStatus.WORKER_EXECEPTION
+
+    async def stream_generation_handler(self, task: StreamGenerationTask) -> TaskStatus:
+        """Handle streaming generation with pause/resume/cancel semantics.
+
+        Uses token-by-token autoregressive decoding with KV cache for
+        efficient pause and resume.
+        """
+        try:
+            if task.cancel_flag:
+                task.end_flag = True
+                return TaskStatus.SUCCESS
+
+            # First invocation: initialize state
+            if task.request_handle is None:
+                inputs = self._tokenize_input(task.input_str, task.input_tokens)
+                if inputs is None:
+                    return TaskStatus.WORKER_EXECEPTION
+
+                input_ids = inputs["input_ids"] if isinstance(inputs, dict) else inputs.input_ids
+
+                task.request_handle = {
+                    "input_ids": input_ids,
+                    "generated_ids": [],
+                    "past_key_values": None,
+                    "done": False,
+                }
+
+            handle = task.request_handle
+            gen_config = self.convert_task_params(task)
+            max_remaining = gen_config.max_new_tokens - len(handle["generated_ids"])
+            step_target = task.streaming_step or 1
+            steps_done = 0
+
+            # Prepare stop strings
+            stop_strings = None
+            if task.stop:
+                stop_strings = [task.stop] if isinstance(task.stop, str) else task.stop
+
+            with torch.no_grad():
+                current_ids = handle["input_ids"]
+                past = handle["past_key_values"]
+
+                while steps_done < step_target and max_remaining > 0:
+                    if past is not None:
+                        model_input = current_ids[:, -1:]
+                        model_out = self.model(model_input, past_key_values=past, use_cache=True)
+                    else:
+                        model_out = self.model(current_ids, use_cache=True)
+
+                    next_token_logits = model_out.logits[:, -1:, :]
+                    next_token = self._sample_token(next_token_logits.squeeze(1), gen_config)
+
+                    handle["generated_ids"].append(next_token.item())
+                    current_ids = torch.cat([current_ids, next_token.unsqueeze(-1)], dim=-1)
+                    past = model_out.past_key_values
+                    steps_done += 1
+                    max_remaining -= 1
+
+                    # Check EOS
+                    if next_token.item() == self.tokenizer.eos_token_id:
+                        handle["done"] = True
+                        break
+
+                    # Check stop sequences
+                    if stop_strings:
+                        partial = self.tokenizer.decode(
+                            handle["generated_ids"], skip_special_tokens=True
+                        )
+                        if any(s in partial for s in stop_strings):
+                            handle["done"] = True
+                            break
+
+                    # Emit streaming output
+                    if task.streaming_output_flag:
+                        partial_text = self.tokenizer.decode(
+                            handle["generated_ids"], skip_special_tokens=True
+                        )
+                        task.streaming_output_list.append(
+                            ScaffoldingOutput(partial_text, copy.deepcopy(handle["generated_ids"]))
+                        )
+
+                handle["input_ids"] = current_ids
+                handle["past_key_values"] = past
+
+            # Fill results
+            task.output_tokens = list(handle["generated_ids"])
+            output_text = self.tokenizer.decode(handle["generated_ids"], skip_special_tokens=True)
+            if stop_strings:
+                output_text = self._strip_stop_sequence(output_text, task)
+            task.output_str = output_text
+
+            if handle["done"] or len(handle["generated_ids"]) >= gen_config.max_new_tokens:
+                task.end_flag = True
+
+            return TaskStatus.SUCCESS
+
+        except (RuntimeError, ValueError) as e:
+            logger.error(f"PyTorchWorker stream generation error: {e}\n{traceback.format_exc()}")
+            return TaskStatus.WORKER_EXECEPTION
+
+    async def reward_handler(self, task: RewardTask) -> TaskStatus:
+        """Handle reward/scoring task using sequence classification model."""
+        try:
+            inputs = self._tokenize_input(task.input_str, task.input_tokens)
+            if inputs is None:
+                # Fallback to empty string for backward compatibility
+                inputs = self.tokenizer(
+                    "", return_tensors="pt", padding=True, truncation=True, max_length=512
+                ).to(self.device)
+
+            if not isinstance(inputs, dict):
+                inputs = dict(inputs)
+
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+
+            logits = outputs.logits[0]
+
+            if task.custom_output_params is None:
+                task.custom_output_params = {}
+
+            if logits.shape[0] == 2:
+                probs = torch.softmax(logits, dim=0)
+                task.custom_output_params["score"] = probs[1].item()
+            else:
+                task.custom_output_params["logits"] = logits.cpu().numpy().tolist()
+                task.custom_output_params["score"] = logits.max().item()
+
+            return TaskStatus.SUCCESS
+
+        except (RuntimeError, ValueError) as e:
+            logger.error(f"PyTorchWorker reward error: {e}\n{traceback.format_exc()}")
+            return TaskStatus.WORKER_EXECEPTION
+
+    def shutdown(self):
+        """Clean up resources by moving model to CPU and freeing GPU memory."""
+        if hasattr(self.model, "cpu"):
+            self.model.cpu()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    task_handlers = {
+        GenerationTask: generation_handler,
+        StreamGenerationTask: stream_generation_handler,
+        RewardTask: reward_handler,
+    }

--- a/tensorrt_llm/scaffolding/pytorch_worker.py
+++ b/tensorrt_llm/scaffolding/pytorch_worker.py
@@ -221,11 +221,10 @@ class PyTorchWorker(Worker):
         if not task.stop:
             return text
         stop_strings = [task.stop] if isinstance(task.stop, str) else task.stop
-        for s in stop_strings:
-            idx = text.find(s)
-            if idx != -1:
-                return text[:idx]
-        return text
+        # Cut at the earliest match across all stop strings, not at whichever happens to
+        # be listed first: for stop=["B", "A"] and "xxAyyBzz" the answer is "xx".
+        indices = [idx for idx in (text.find(s) for s in stop_strings) if idx != -1]
+        return text[: min(indices)] if indices else text
 
     def _extract_logprobs(self, scores: tuple, generated_tokens: List[int], num_logprobs: int):
         """Extract top-k logprobs from generation scores.
@@ -440,10 +439,10 @@ class PyTorchWorker(Worker):
         try:
             inputs = self._tokenize_input(task.input_str, task.input_tokens)
             if inputs is None:
-                # Fallback to empty string for backward compatibility
-                inputs = self.tokenizer(
-                    "", return_tensors="pt", padding=True, truncation=True, max_length=512
-                ).to(self.device)
+                # Scoring empty text would hand back a plausible number for what is really
+                # a caller error. Fail the same way generation_handler does.
+                logger.error("PyTorchWorker reward task has neither input_str nor input_tokens")
+                return TaskStatus.WORKER_EXECEPTION
 
             if not isinstance(inputs, dict):
                 inputs = dict(inputs)

--- a/tests/unittest/scaffolding/test_pytorch_worker.py
+++ b/tests/unittest/scaffolding/test_pytorch_worker.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for PyTorchWorker.
+
+Tests the PyTorch backend worker implementation for scaffolding,
+including generation, streaming generation, reward tasks, logprobs,
+stop sequences, and input_tokens fallback.
+"""
+
+import pytest
+import torch
+from utils.llm_data import llm_models_root
+
+from tensorrt_llm.scaffolding import (
+    GenerationTask,
+    NativeGenerationController,
+    PyTorchWorker,
+    RewardTask,
+    ScaffoldingLlm,
+    StreamGenerationTask,
+    TaskStatus,
+)
+
+
+@pytest.fixture(scope="module")
+def small_model_path():
+    """Path to a small local checkpoint; tests must not download from HuggingFace."""
+    models_root = llm_models_root()
+    if models_root is None:
+        pytest.skip("LLM_MODELS_ROOT is not set and the default model cache is not mounted")
+    model_dir = models_root / "gpt2"
+    if not model_dir.exists():
+        pytest.skip(f"{model_dir} is not available")
+    return str(model_dir)
+
+
+@pytest.fixture(scope="module")
+def pytorch_worker(small_model_path):
+    """Create a PyTorchWorker with a small model (shared across module)."""
+    worker = PyTorchWorker.from_pretrained(
+        small_model_path,
+        device="cpu",
+        torch_dtype=torch.float32,
+    )
+    yield worker
+    worker.shutdown()
+
+
+@pytest.fixture
+def test_prompt():
+    return "The capital of France is"
+
+
+class TestPyTorchWorkerInitialization:
+    def test_from_pretrained(self, small_model_path):
+        worker = PyTorchWorker.from_pretrained(
+            small_model_path, device="cpu", torch_dtype=torch.float32
+        )
+        assert worker.model is not None
+        assert worker.tokenizer is not None
+        worker.shutdown()
+
+    def test_device_selection_explicit(self, small_model_path):
+        worker = PyTorchWorker.from_pretrained(
+            small_model_path, device="cpu", torch_dtype=torch.float32
+        )
+        assert str(worker.device) == "cpu"
+        worker.shutdown()
+
+
+class TestPyTorchWorkerGeneration:
+    @pytest.mark.asyncio
+    async def test_basic_generation(self, pytorch_worker, test_prompt):
+        task = GenerationTask.create_from_prompt(test_prompt)
+        task.max_tokens = 10
+        task.temperature = 0.7
+
+        status = await pytorch_worker.generation_handler(task)
+
+        assert status == TaskStatus.SUCCESS
+        assert task.output_str is not None
+        assert len(task.output_str) > 0
+        assert task.output_tokens is not None
+        assert len(task.output_tokens) > 0
+
+    @pytest.mark.asyncio
+    async def test_generation_with_input_tokens(self, pytorch_worker):
+        """Test generation using input_tokens instead of input_str."""
+        tokenizer = pytorch_worker.tokenizer
+        prompt = "Hello world"
+        tokens = tokenizer.encode(prompt)
+
+        task = GenerationTask()
+        task.input_str = None
+        task.input_tokens = tokens
+        task.max_tokens = 10
+        task.temperature = 0.0
+
+        status = await pytorch_worker.generation_handler(task)
+
+        assert status == TaskStatus.SUCCESS
+        assert task.output_str is not None
+        assert len(task.output_str) > 0
+        assert task.output_tokens is not None
+
+    @pytest.mark.asyncio
+    async def test_generation_none_input_fails(self, pytorch_worker):
+        """Both input_str and input_tokens None should fail."""
+        task = GenerationTask()
+        task.input_str = None
+        task.input_tokens = None
+        task.max_tokens = 10
+
+        status = await pytorch_worker.generation_handler(task)
+        # Note: the enum member name is misspelled in task.py; kept as-is to avoid an API break.
+        assert status == TaskStatus.WORKER_EXECEPTION
+
+    @pytest.mark.asyncio
+    async def test_generation_with_logprobs(self, pytorch_worker, test_prompt):
+        """Test that logprobs are extracted when requested."""
+        task = GenerationTask.create_from_prompt(test_prompt)
+        task.max_tokens = 5
+        task.temperature = 0.0
+        task.num_logprobs = 3
+
+        status = await pytorch_worker.generation_handler(task)
+
+        assert status == TaskStatus.SUCCESS
+        assert task.logprobs is not None
+        assert len(task.logprobs) > 0
+        # Each entry should be a dict mapping token_id -> Logprob
+        for token_dict in task.logprobs:
+            assert isinstance(token_dict, dict)
+            for token_id, logprob in token_dict.items():
+                assert isinstance(token_id, int)
+                assert hasattr(logprob, "logprob")
+                assert hasattr(logprob, "rank")
+                assert logprob.logprob <= 0.0  # log probs are non-positive
+
+    @pytest.mark.asyncio
+    async def test_generation_with_stop_sequence(self, pytorch_worker):
+        """Test that stop sequences terminate generation."""
+        task = GenerationTask.create_from_prompt("1, 2, 3, 4, 5,")
+        task.max_tokens = 50
+        task.temperature = 0.0
+        task.stop = ["\n"]
+
+        status = await pytorch_worker.generation_handler(task)
+
+        assert status == TaskStatus.SUCCESS
+        assert task.output_str is not None
+        # Output should not contain the stop sequence
+        assert "\n" not in task.output_str
+
+    @pytest.mark.asyncio
+    async def test_generation_deterministic(self, pytorch_worker, test_prompt):
+        """Test deterministic generation with temperature=0."""
+        task1 = GenerationTask.create_from_prompt(test_prompt)
+        task1.max_tokens = 10
+        task1.temperature = 0.0
+
+        task2 = GenerationTask.create_from_prompt(test_prompt)
+        task2.max_tokens = 10
+        task2.temperature = 0.0
+
+        await pytorch_worker.generation_handler(task1)
+        await pytorch_worker.generation_handler(task2)
+
+        assert task1.output_str == task2.output_str
+
+
+class TestPyTorchWorkerStreamGeneration:
+    @pytest.mark.asyncio
+    async def test_stream_generation_completes(self, pytorch_worker, test_prompt):
+        """Test that streaming generation eventually sets end_flag."""
+        task = StreamGenerationTask()
+        task.input_str = test_prompt
+        task.max_tokens = 10
+        task.temperature = 0.0
+        task.streaming_step = 3
+
+        # Run until done
+        max_iterations = 20
+        for _ in range(max_iterations):
+            status = await pytorch_worker.stream_generation_handler(task)
+            assert status == TaskStatus.SUCCESS
+            if task.end_flag:
+                break
+
+        assert task.end_flag is True
+        assert task.output_str is not None
+        assert len(task.output_str) > 0
+        assert task.output_tokens is not None
+
+    @pytest.mark.asyncio
+    async def test_stream_generation_cancel(self, pytorch_worker, test_prompt):
+        """Test that cancel_flag stops generation immediately."""
+        task = StreamGenerationTask()
+        task.input_str = test_prompt
+        task.max_tokens = 50
+        task.temperature = 0.0
+        task.streaming_step = 2
+
+        # Generate a few tokens first
+        status = await pytorch_worker.stream_generation_handler(task)
+        assert status == TaskStatus.SUCCESS
+        assert task.end_flag is False
+
+        # Now cancel
+        task.cancel_flag = True
+        status = await pytorch_worker.stream_generation_handler(task)
+        assert status == TaskStatus.SUCCESS
+        assert task.end_flag is True
+
+    @pytest.mark.asyncio
+    async def test_stream_generation_with_input_tokens(self, pytorch_worker):
+        """Test streaming with input_tokens instead of input_str."""
+        tokenizer = pytorch_worker.tokenizer
+        tokens = tokenizer.encode("Hello world")
+
+        task = StreamGenerationTask()
+        task.input_str = None
+        task.input_tokens = tokens
+        task.max_tokens = 5
+        task.temperature = 0.0
+        task.streaming_step = 2
+
+        for _ in range(10):
+            status = await pytorch_worker.stream_generation_handler(task)
+            assert status == TaskStatus.SUCCESS
+            if task.end_flag:
+                break
+
+        assert task.output_str is not None
+
+
+class TestPyTorchWorkerReward:
+    @pytest.mark.asyncio
+    async def test_reward_with_input_tokens(self, pytorch_worker):
+        """Test reward handler with input_tokens fallback.
+
+        Note: Using a causal LM for reward will likely error since it's
+        not a classification model. This tests the input routing logic.
+        """
+        tokenizer = pytorch_worker.tokenizer
+        tokens = tokenizer.encode("This is a test.")
+
+        task = RewardTask()
+        task.input_str = None
+        task.input_tokens = tokens
+
+        # Will likely fail since gpt2 is not a classification model,
+        # but should not fail due to missing input
+        status = await pytorch_worker.reward_handler(task)
+        # Accept either SUCCESS or error (model type mismatch is OK)
+        assert status in (TaskStatus.SUCCESS, TaskStatus.WORKER_EXECEPTION)
+
+
+class TestPyTorchWorkerWithScaffolding:
+    def test_single_prompt_generation(self, pytorch_worker, test_prompt):
+        controller = NativeGenerationController(
+            sampling_params={
+                "max_tokens": 10,
+                "temperature": 0.7,
+            }
+        )
+
+        llm = ScaffoldingLlm(
+            controller,
+            {NativeGenerationController.WorkerTag.GENERATION: pytorch_worker},
+        )
+
+        result = llm.generate(test_prompt)
+
+        assert result.outputs[0].text is not None
+        assert len(result.outputs[0].text) > 0
+        assert result.outputs[0].token_ids is not None
+
+        llm.shutdown()
+
+    def test_batch_generation(self, pytorch_worker):
+        controller = NativeGenerationController(
+            sampling_params={
+                "max_tokens": 10,
+                "temperature": 0.7,
+            }
+        )
+
+        llm = ScaffoldingLlm(
+            controller,
+            {NativeGenerationController.WorkerTag.GENERATION: pytorch_worker},
+        )
+
+        prompts = [
+            "Hello, my name is",
+            "The weather today is",
+            "In the year 2025,",
+        ]
+
+        results = llm.generate(prompts)
+
+        assert len(results) == len(prompts)
+        for result in results:
+            assert result.outputs[0].text is not None
+            assert len(result.outputs[0].text) > 0
+
+        llm.shutdown()
+
+
+class TestPyTorchWorkerShutdown:
+    def test_shutdown_clears_resources(self, small_model_path):
+        worker = PyTorchWorker.from_pretrained(
+            small_model_path, device="cpu", torch_dtype=torch.float32
+        )
+        worker.shutdown()
+        assert next(worker.model.parameters()).device.type == "cpu"

--- a/tests/unittest/scaffolding/test_pytorch_worker.py
+++ b/tests/unittest/scaffolding/test_pytorch_worker.py
@@ -180,6 +180,19 @@ class TestPyTorchWorkerGeneration:
         # Output should not contain the stop sequence
         assert "\n" not in task.output_str
 
+    def test_strip_stop_sequence_cuts_at_earliest_match(self, pytorch_worker):
+        """Order in task.stop must not decide where the text is cut."""
+        task = GenerationTask.create_from_prompt("irrelevant")
+        task.stop = ["B", "A"]
+
+        assert pytorch_worker._strip_stop_sequence("xxAyyBzz", task) == "xx"
+
+        task.stop = ["A", "B"]
+        assert pytorch_worker._strip_stop_sequence("xxAyyBzz", task) == "xx"
+
+        task.stop = ["missing"]
+        assert pytorch_worker._strip_stop_sequence("xxAyyBzz", task) == "xxAyyBzz"
+
     @pytest.mark.asyncio
     async def test_generation_deterministic(self, pytorch_worker, test_prompt):
         """Test deterministic generation with temperature=0."""
@@ -262,26 +275,46 @@ class TestPyTorchWorkerStreamGeneration:
         assert task.output_str is not None
 
 
+@pytest.fixture(scope="module")
+def reward_worker(small_model_path):
+    """A sequence-classification worker, as reward scoring actually requires."""
+    worker = PyTorchWorker.from_pretrained_reward_model(
+        small_model_path, device="cpu", torch_dtype=torch.float32, num_labels=2
+    )
+    yield worker
+    worker.shutdown()
+
+
 class TestPyTorchWorkerReward:
     @pytest.mark.asyncio
-    async def test_reward_with_input_tokens(self, pytorch_worker):
-        """Test reward handler with input_tokens fallback.
+    async def test_reward_scores_from_input_str(self, reward_worker):
+        task = RewardTask()
+        task.input_str = "This is a test."
 
-        Note: Using a causal LM for reward will likely error since it's
-        not a classification model. This tests the input routing logic.
-        """
-        tokenizer = pytorch_worker.tokenizer
-        tokens = tokenizer.encode("This is a test.")
+        assert await reward_worker.reward_handler(task) == TaskStatus.SUCCESS
+        assert task.custom_output_params is not None
+        score = task.custom_output_params["score"]
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
 
+    @pytest.mark.asyncio
+    async def test_reward_with_input_tokens(self, reward_worker):
+        """input_tokens is accepted in place of input_str."""
         task = RewardTask()
         task.input_str = None
-        task.input_tokens = tokens
+        task.input_tokens = reward_worker.tokenizer.encode("This is a test.")
 
-        # Will likely fail since gpt2 is not a classification model,
-        # but should not fail due to missing input
-        status = await pytorch_worker.reward_handler(task)
-        # Accept either SUCCESS or error (model type mismatch is OK)
-        assert status in (TaskStatus.SUCCESS, TaskStatus.WORKER_EXECEPTION)
+        assert await reward_worker.reward_handler(task) == TaskStatus.SUCCESS
+        assert isinstance(task.custom_output_params["score"], float)
+
+    @pytest.mark.asyncio
+    async def test_reward_without_any_input_fails(self, reward_worker):
+        """Missing input is an error, not a score computed from empty text."""
+        task = RewardTask()
+        task.input_str = None
+        task.input_tokens = None
+
+        assert await reward_worker.reward_handler(task) == TaskStatus.WORKER_EXECEPTION
 
 
 class TestPyTorchWorkerContextLogits:
@@ -469,9 +502,14 @@ class TestPyTorchWorkerWithScaffolding:
 
 
 class TestPyTorchWorkerShutdown:
-    def test_shutdown_clears_resources(self, small_model_path):
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU to observe the move")
+    def test_shutdown_moves_model_off_gpu(self, small_model_path):
+        """On CPU the assertion would hold even if shutdown() did nothing."""
         worker = PyTorchWorker.from_pretrained(
-            small_model_path, device="cpu", torch_dtype=torch.float32
+            small_model_path, device="cuda", torch_dtype=torch.float32
         )
+        assert next(worker.model.parameters()).device.type == "cuda"
+
         worker.shutdown()
+
         assert next(worker.model.parameters()).device.type == "cpu"


### PR DESCRIPTION
## Description

Closes #3333
Closes #3334

Adds a native PyTorch worker (`PyTorchWorker`) to the scaffolding framework, enabling inference with
HuggingFace models without TensorRT compilation. This supports inference-time compute patterns
(e.g. reward models for Best-of-N selection) that research papers commonly implement directly in PyTorch,
and it lowers the barrier for contributors who do not have a GPU development environment handy.

### What's included

- **`tensorrt_llm/scaffolding/pytorch_worker.py`** — new worker with three handlers:
  - `generation_handler`: generation via `model.generate()` with temperature, top-k/top-p, stop sequences,
    logprobs, and `return_context_logits`
  - `stream_generation_handler`: token-by-token decoding with KV cache, supporting pause/resume/cancel
  - `reward_handler`: scoring via sequence-classification models
- **`tensorrt_llm/scaffolding/__init__.py`** — export `PyTorchWorker` in the public API
- **`tensorrt_llm/scaffolding/controller.py`** — one-line fix so `BestOfNController` returns the selected
  candidate's output (details below)
- **`tests/unittest/scaffolding/test_pytorch_worker.py`** — unit tests for all handlers

### Design

- Subclasses the existing `Worker` ABC and registers handlers through the `task_handlers` class attribute,
  matching `OpenaiWorker` / `TRTLLMWorker`.
- Factory methods: `from_pretrained()` for causal LMs, `from_pretrained_reward_model()` for classifiers.
- Accepts both `input_str` and `input_tokens` for all task types.
- Works with the existing controllers (`NativeGenerationController`, `BestOfNController`,
  `MajorityVoteController`, …).

## Changes since the previous CI run

The previous run (`PR_Github #53348` / `L0_MergeRequest_PR #42529`) failed. This revision addresses the
following and rebases onto current `main`:

1. **Reverted the repo-wide `TaskStatus.WORKER_EXECEPTION` → `WORKER_EXCEPTION` rename.** The rename was
   authored against a February merge base and left dangling references on `main`
   (`worker.py:403,447,461,512,517,977` and `contrib/mcp/chat_handler.py:67` still use the original spelling),
   which would raise `AttributeError` on those error paths. It was also a breaking change to a publicly
   exported enum and unrelated to this PR's concern. `pytorch_worker.py` now uses the existing spelling; a
   non-breaking alias can be added separately if desired.
2. **Tests no longer download `gpt2` from the HuggingFace Hub.** The model now resolves through
   `llm_models_root()`, matching `tests/unittest/scaffolding/test_worker.py`, with a `pytest.skip` when the
   model cache is unavailable.
3. **Narrowed exception handling** in the three handlers from bare `except Exception` to
   `except (RuntimeError, ValueError)`, and routed the error through `tensorrt_llm.logger` instead of `print`,
   per `CODING_GUIDELINES.md` "Error Handling".
4. **Rebased onto `main`** and squashed into a single signed-off commit (no merge commit), as requested.
5. Removed the `examples/scaffolding/run_pytorch_backend.py` example per review feedback — the unit tests
   cover the same ground.
6. Issue links: this PR implements **#3333** (native PyTorch worker) and also resolves **#3334**
   (CPU inference for scaffolding) — `PyTorchWorker` runs on CPU via `device="cpu"`, and the unit tests
   exercise that path. Linking both was confirmed with @WeiHaocheng and @amemov on #3334.

## Reward path: what works today

Reward scoring has two entry points, and they behave differently:

- **`PRMController` (works directly).** It sends a `GenerationTask` with `return_context_logits=True` and
  scores from `task.context_logits`. `generation_handler` now honours that flag, so `PyTorchWorker` can act
  as the reward worker for `PRMController` with no extra work. Covered by
  `TestPyTorchWorkerContextLogits::test_drives_prm_controller`.
- **`reward_handler` requires a `RewardTask`-producing controller.** `Worker.run_task` dispatches on the exact
  task type, while `NativeRewardController` forwards the `GenerationTask` objects it is given (its
  `task = GenerationTask()` line is dead code, shadowed by the loop variable). A worker on the reward tag
  therefore receives a `GenerationTask` and lands in `generation_handler`. Until that contract changes, using
  `reward_handler` means supplying a controller that emits `RewardTask` — as
  `TestPyTorchWorkerBestOfN` does. Changing `NativeRewardController` to emit `RewardTask` would make
  `TRTLLMWorker` return `WORKER_NOT_SUPPORTED` on the reward tag, since no existing worker registers a
  `RewardTask` handler, so that is left to a follow-up PR (link to be added here once opened).

### Incidental fix in `BestOfNController`

`BestOfNController.process` ended with `task.result = best_task.result`. No generation task type defines
`result` (only `MCPCallTask` has `result_str` and friends), so any end-to-end Best-of-N run raised
`AttributeError` and produced an empty `ScaffoldingOutput` — `examples/scaffolding/run_best_of_n_with_reward.py`
included. It now propagates `output_str` and `output_tokens` from the winning candidate, matching what
`MajorityVoteController` already does. Nothing could have depended on the old line, since it always raised.

## Test Coverage

`tests/unittest/scaffolding/test_pytorch_worker.py`, picked up by the existing `unittest/scaffolding`
entry in `tests/integration/test_lists/test-db/l0_h100.yml`:

- **Initialization**: `from_pretrained()`, explicit device selection
- **Generation**: basic, `input_tokens` path, logprobs, stop sequences, deterministic output at `temperature=0`
- **Streaming**: completion, cancel, `input_tokens` path
- **Reward**: scoring through the `input_tokens` fallback; end-to-end Best-of-N through `ScaffoldingLlm`
  with a sequence-classification reward model
- **Context logits**: shape, absence unless requested, and scoring driven through the real `PRMController`
- **Integration**: single-prompt and batch generation through `ScaffoldingLlm`
- **Shutdown**: resource cleanup

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help
To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added and exported `PyTorchWorker` for HuggingFace causal-language-model generation and sequence-classification reward scoring.
- Added batch generation, streaming generation, sampling controls, stop sequences, logprobs, context logits, CPU execution, token inputs, pause/resume/cancel state, and shutdown handling.
- Fixed stop-sequence truncation to use the earliest matching stop string.
- Updated reward handling to reject tasks without text or token inputs.
- Updated `BestOfNController` to propagate `output_str` and `output_tokens` from the selected generation task.
- The built-in reward path still dispatches `GenerationTask` objects. `reward_handler` therefore requires a custom controller that produces `RewardTask`.
- The deferred `NativeRewardController` and `RewardTask` contract change remains a follow-up item.
- No configuration or test-list files changed.

## QA Engineer Review

- Added `tests/unittest/scaffolding/test_pytorch_worker.py`.
- Coverage includes worker initialization, device selection, string and token generation, invalid input handling, logprobs, stop sequences, deterministic generation, streaming completion and cancellation, reward routing, context logits, PRM scoring, Best-of-N generation, `ScaffoldingLlm` single-request and batch generation, shutdown, and resource cleanup.
- Added regression coverage for stop-sequence ordering and reward-input validation.
- Tests skip when the cached GPT-2 model lacks the required configuration or weight files.
- The test functions are not listed in `tests/integration/test_lists/` files. They are unit tests and do not require test-list entries.
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->