### PR TITLE
[None][fix] Reorder generation_logits to align with final beam search output ordering

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -333,10 +333,14 @@ public:
 
         if (mIsStreaming && mSamplingConfig.beamWidth > 1 && mReturnGenerationLogits)
         {
+            // In streaming mode with beam search, intermediate logits are returned before finalization,
+            // so they cannot be reordered to match the final beam paths. Non-streaming mode handles
+            // reordering in postProcessRequest() after gatherTree finalization.
             TLLM_LOG_WARNING(
                 "Returning generation logits when streaming is enabled and beamWidth > 1 is not allowed. "
-                "This is because the logits may appear in irrelevant order when the beams are gathered, "
-                "since logits are not. Disabling returnGenerationLogits.");
+                "This is because intermediate logits cannot be reordered to match the final beam paths "
+                "until finalization. Use non-streaming mode for correct generation logits with beam search. "
+                "Disabling returnGenerationLogits.");
             mReturnGenerationLogits = false;
         }
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2047,26 +2047,20 @@ void TrtGptModelInflightBatching::reorderGenerationLogitsForBeamSearch(LlmReques
         TLLM_CHECK_WITH_INFO(startSlot >= 0,
             "Could not determine beam slot mapping for beam %d during generation logits reordering.", beam);
 
-        // Build the slot trace by tracing parentIds backward from the starting slot.
-        // After this loop, slotTrace[beam][g] = the slot the beam was assigned to
-        // after beam search at generation step g (the post-reassignment slot).
+        // Build the slot trace: slotTrace[beam][g] = the pre-reassignment slot whose
+        // logits correspond to generation step g of this beam.
+        //
+        // The model runs BEFORE beam search reassigns beams to slots, so
+        // generationLogits[slot][g] was produced by the pre-reassignment slot —
+        // i.e. the slot the beam occupied in the *previous* step.
+        // parentIds[postSlot][promptLen+g] gives exactly that pre-reassignment slot,
+        // so taking the parentIds lookup before storing (rather than after) yields
+        // the correct source slot in a single pass.
         SizeType32 slot = startSlot;
-        slotTrace[beam][genLen - 1] = slot;
-        for (SizeType32 t = seqLen - 1; t > promptLen; --t)
+        for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
         {
             slot = parentIdsData[slot * maxSeqLength + t];
-            slotTrace[beam][t - 1 - promptLen] = slot;
-        }
-
-        // Convert from post-reassignment slot to pre-reassignment slot.
-        // At each step, the model computes logits BEFORE beam search reassigns
-        // beams to slots. So generationLogits[slot][g] holds logits from the
-        // pre-reassignment slot — not the post-reassignment slot that ids/parentIds
-        // reference. parentIds[postSlot][pos] points back to the pre-reassignment
-        // slot (the slot the beam was in when the model ran).
-        for (SizeType32 g = 0; g < genLen; ++g)
-        {
-            slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLength + (promptLen + g)];
+            slotTrace[beam][t - promptLen] = slot;
         }
 
         // Check if any reordering is actually needed for this beam

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2045,7 +2045,8 @@ void TrtGptModelInflightBatching::postProcessRequest(
             }
 
             // Build the slot trace by tracing parentIds backward from the starting slot.
-            // The trace initially gives B_g (the post-reassignment slot at each step).
+            // After this loop, slotTrace[beam][g] = the slot the beam was assigned to
+            // after beam search at generation step g (the post-reassignment slot).
             SizeType32 slot = startSlot;
             slotTrace[beam][genLen - 1] = slot;
             for (SizeType32 t = seqLen - 1; t > promptLen; --t)
@@ -2054,10 +2055,12 @@ void TrtGptModelInflightBatching::postProcessRequest(
                 slotTrace[beam][t - 1 - promptLen] = slot;
             }
 
-            // Convert from post-reassignment slot (B_g) to pre-reassignment slot (A_g).
-            // The logits at generation step g were computed from the beam in slot A_g
-            // (before beam search reassignment), not B_g (after). A_g is recorded in
-            // parentIds[B_g][promptLen + g], which points back to the source slot.
+            // Convert from post-reassignment slot to pre-reassignment slot.
+            // At each step, the model computes logits BEFORE beam search reassigns
+            // beams to slots. So generationLogits[slot][g] holds logits from the
+            // pre-reassignment slot — not the post-reassignment slot that ids/parentIds
+            // reference. parentIds[postSlot][pos] points back to the pre-reassignment
+            // slot (the slot the beam was in when the model ran).
             for (SizeType32 g = 0; g < genLen; ++g)
             {
                 slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLength + (promptLen + g)];

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1956,7 +1956,8 @@ void TrtGptModelInflightBatching::postProcessRequest(
     // store the generated tokens into the mTokensGathered buffer
     llmReq.setGeneratedTokens(generatedTokens);
 
-    if (llmReq.getReturnGenerationLogits() && mWorldConfig.isLastPipelineParallelRank())
+    if (llmReq.getReturnGenerationLogits() && !llmReq.getGenerationLogitsFragments().empty()
+        && mWorldConfig.isLastPipelineParallelRank())
     {
         reorderGenerationLogitsForBeamSearch(
             llmReq, seqSlot, reqBeamWidth, maxSeqLength, outputIdsHostData, sequenceLengthsHostData);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2001,6 +2001,8 @@ void TrtGptModelInflightBatching::reorderGenerationLogitsForBeamSearch(LlmReques
     auto const generationLogitsHost = llmReq.getGenerationLogitsHost();
     auto const& logitsShape = generationLogitsHost->getShape();
     // Non-streaming shape: [beamWidth, maxNewTokens, vocabSizePadded]
+    TLLM_CHECK_WITH_INFO(logitsShape.d[0] == reqBeamWidth,
+        "Generation logits beam dimension (%d) does not match beam width (%d).", logitsShape.d[0], reqBeamWidth);
     auto const maxNewTokens = logitsShape.d[1];
     auto const vocabSizePadded = logitsShape.d[2];
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -69,6 +69,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -1954,6 +1955,184 @@ void TrtGptModelInflightBatching::postProcessRequest(
 
     // store the generated tokens into the mTokensGathered buffer
     llmReq.setGeneratedTokens(generatedTokens);
+
+    // Reorder generation logits to match the gathered (finalized) beam ordering.
+    // During generation, logits are stored indexed by beam SLOT position. After beam search
+    // finalization (gatherTree), output_ids are reordered by tracing parentIds to reconstruct
+    // the correct beam paths. However, generation_logits are NOT reordered by gatherTree.
+    // We fix this here by tracing parentIds on the host to build the beam-slot mapping,
+    // then reindexing the logits accordingly.
+    if (llmReq.getReturnGenerationLogits())
+    {
+        auto const promptLen = llmReq.mPromptLen;
+
+        // Copy parentIds and ids (ungathered step IDs) from GPU to temporary host buffers.
+        // parentIds[slot][t] = the parent slot of beam slot `slot` at position t.
+        // ids[slot][t] = the token in beam slot `slot` at position t (before gather).
+        auto parentIdsDevice = ITensor::at(mDecoderState->getParentIds(), {seqSlot});
+        auto idsDevice = mDecoderState->getIds(seqSlot);
+
+        auto parentIdsHost
+            = runtime::BufferManager::pinnedPool(parentIdsDevice->getShape(), nvinfer1::DataType::kINT32);
+        auto idsHost = runtime::BufferManager::pinnedPool(idsDevice->getShape(), nvinfer1::DataType::kINT32);
+
+        mCopyBufferManager.copy(*parentIdsDevice, *parentIdsHost);
+        mCopyBufferManager.copy(*idsDevice, *idsHost);
+        mCopyBufferManager.getStream().synchronize();
+
+        auto const* parentIdsData = bufferCast<TokenIdType>(*parentIdsHost);
+        auto const* idsData = bufferCast<TokenIdType>(*idsHost);
+
+        // For each final beam b, find the beam slot at the last generated step, then
+        // trace back through parentIds to build the slot trace for every generation step.
+        // slotTrace[beam][genStep] = the beam slot that produced the logits at that step.
+        auto const generationLogitsHost = llmReq.getGenerationLogitsHost();
+        auto const& logitsShape = generationLogitsHost->getShape();
+        // Non-streaming shape: [beamWidth, maxNewTokens, vocabSizePadded]
+        auto const maxNewTokens = logitsShape.d[1];
+        auto const vocabSizePadded = logitsShape.d[2];
+
+        std::vector<std::vector<SizeType32>> slotTrace(reqBeamWidth, std::vector<SizeType32>(maxNewTokens, 0));
+        bool anyReorderNeeded = false;
+
+        for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
+        {
+            auto const seqLen = sequenceLengthsHostData[beam];
+            auto const genLen = seqLen - promptLen;
+            if (genLen <= 0)
+            {
+                continue;
+            }
+
+            // Find the starting beam slot at the last generated step by matching the
+            // backtracked token sequence against the gathered (finalized) output.
+            SizeType32 startSlot = -1;
+            for (SizeType32 s = 0; s < reqBeamWidth; ++s)
+            {
+                SizeType32 slot = s;
+                bool matches = true;
+                for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
+                {
+                    if (idsData[slot * maxSeqLength + t] != outputIdsHostData[beam * maxSeqLength + t])
+                    {
+                        matches = false;
+                        break;
+                    }
+                    if (t > promptLen)
+                    {
+                        slot = parentIdsData[slot * maxSeqLength + t];
+                    }
+                }
+                if (matches)
+                {
+                    startSlot = s;
+                    break;
+                }
+            }
+
+            if (startSlot < 0)
+            {
+                TLLM_LOG_WARNING(
+                    "Could not determine beam slot mapping for beam %d during generation logits reordering. "
+                    "Logits for this beam may not match the output token sequence.",
+                    beam);
+                // Fall back to identity mapping (no reorder for this beam)
+                for (SizeType32 g = 0; g < genLen; ++g)
+                {
+                    slotTrace[beam][g] = beam;
+                }
+                continue;
+            }
+
+            // Build the slot trace by tracing parentIds backward from the starting slot.
+            // The trace initially gives B_g (the post-reassignment slot at each step).
+            SizeType32 slot = startSlot;
+            slotTrace[beam][genLen - 1] = slot;
+            for (SizeType32 t = seqLen - 1; t > promptLen; --t)
+            {
+                slot = parentIdsData[slot * maxSeqLength + t];
+                slotTrace[beam][t - 1 - promptLen] = slot;
+            }
+
+            // Convert from post-reassignment slot (B_g) to pre-reassignment slot (A_g).
+            // The logits at generation step g were computed from the beam in slot A_g
+            // (before beam search reassignment), not B_g (after). A_g is recorded in
+            // parentIds[B_g][promptLen + g], which points back to the source slot.
+            for (SizeType32 g = 0; g < genLen; ++g)
+            {
+                slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLength + (promptLen + g)];
+            }
+
+            // Check if any reordering is actually needed for this beam
+            for (SizeType32 g = 0; g < genLen; ++g)
+            {
+                if (slotTrace[beam][g] != beam)
+                {
+                    anyReorderNeeded = true;
+                    break;
+                }
+            }
+        }
+
+        // Reorder the generation logits in-place using a per-step temporary buffer.
+        if (anyReorderNeeded)
+        {
+            auto const logitsDataType = generationLogitsHost->getDataType();
+            auto const elemSize = runtime::BufferDataType(logitsDataType).getSize();
+            auto const stepSize = static_cast<size_t>(vocabSizePadded) * elemSize;
+
+            // Temp buffer for one generation step across all beams: [beamWidth, vocabSizePadded]
+            auto tempLogits = runtime::BufferManager::pinnedPool(
+                ITensor::makeShape({reqBeamWidth, vocabSizePadded}), logitsDataType);
+
+            auto* logitsPtr = static_cast<uint8_t*>(generationLogitsHost->data());
+            auto* tempPtr = static_cast<uint8_t*>(tempLogits->data());
+
+            SizeType32 maxGenLen = 0;
+            for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+            {
+                auto const gl = sequenceLengthsHostData[b] - promptLen;
+                if (gl > maxGenLen)
+                {
+                    maxGenLen = gl;
+                }
+            }
+
+            for (SizeType32 g = 0; g < maxGenLen; ++g)
+            {
+                // Check if any beam needs reordering at this step
+                bool stepNeedsReorder = false;
+                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+                {
+                    if (slotTrace[b][g] != b)
+                    {
+                        stepNeedsReorder = true;
+                        break;
+                    }
+                }
+                if (!stepNeedsReorder)
+                {
+                    continue;
+                }
+
+                // Copy all beams' logits at this step to the temp buffer
+                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+                {
+                    // logits layout: [beamWidth, maxNewTokens, vocabSizePadded]
+                    auto const offset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+                    std::memcpy(tempPtr + static_cast<size_t>(b) * stepSize, logitsPtr + offset, stepSize);
+                }
+
+                // Reorder: logits[b][g] = temp[slotTrace[b][g]]
+                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+                {
+                    auto const dstOffset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+                    auto const srcSlot = slotTrace[b][g];
+                    std::memcpy(logitsPtr + dstOffset, tempPtr + static_cast<size_t>(srcSlot) * stepSize, stepSize);
+                }
+            }
+        }
+    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1956,7 +1956,7 @@ void TrtGptModelInflightBatching::postProcessRequest(
     // store the generated tokens into the mTokensGathered buffer
     llmReq.setGeneratedTokens(generatedTokens);
 
-    if (llmReq.getReturnGenerationLogits())
+    if (llmReq.getReturnGenerationLogits() && mWorldConfig.isLastPipelineParallelRank())
     {
         reorderGenerationLogitsForBeamSearch(
             llmReq, seqSlot, reqBeamWidth, maxSeqLength, outputIdsHostData, sequenceLengthsHostData);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1956,183 +1956,180 @@ void TrtGptModelInflightBatching::postProcessRequest(
     // store the generated tokens into the mTokensGathered buffer
     llmReq.setGeneratedTokens(generatedTokens);
 
+    if (llmReq.getReturnGenerationLogits())
+    {
+        reorderGenerationLogitsForBeamSearch(
+            llmReq, seqSlot, reqBeamWidth, maxSeqLength, outputIdsHostData, sequenceLengthsHostData);
+    }
+
+    TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
+}
+
+void TrtGptModelInflightBatching::reorderGenerationLogitsForBeamSearch(LlmRequest& llmReq, SizeType32 seqSlot,
+    SizeType32 reqBeamWidth, SizeType32 maxSeqLength, TokenIdType const* outputIdsHostData,
+    SizeType32 const* sequenceLengthsHostData)
+{
     // Reorder generation logits to match the gathered (finalized) beam ordering.
     // During generation, logits are stored indexed by beam SLOT position. After beam search
     // finalization (gatherTree), output_ids are reordered by tracing parentIds to reconstruct
     // the correct beam paths. However, generation_logits are NOT reordered by gatherTree.
     // We fix this here by tracing parentIds on the host to build the beam-slot mapping,
     // then reindexing the logits accordingly.
-    if (llmReq.getReturnGenerationLogits())
+    TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+
+    auto const promptLen = llmReq.mPromptLen;
+
+    // Copy parentIds and ids (ungathered step IDs) from GPU to temporary host buffers.
+    // parentIds[slot][t] = the parent slot of beam slot `slot` at position t.
+    // ids[slot][t] = the token in beam slot `slot` at position t (before gather).
+    auto parentIdsDevice = ITensor::at(mDecoderState->getParentIds(), {seqSlot});
+    auto idsDevice = mDecoderState->getIds(seqSlot);
+
+    auto parentIdsHost = runtime::BufferManager::pinnedPool(parentIdsDevice->getShape(), nvinfer1::DataType::kINT32);
+    auto idsHost = runtime::BufferManager::pinnedPool(idsDevice->getShape(), nvinfer1::DataType::kINT32);
+
+    mCopyBufferManager.copy(*parentIdsDevice, *parentIdsHost);
+    mCopyBufferManager.copy(*idsDevice, *idsHost);
+    mCopyBufferManager.getStream().synchronize();
+
+    auto const* parentIdsData = bufferCast<TokenIdType>(*parentIdsHost);
+    auto const* idsData = bufferCast<TokenIdType>(*idsHost);
+
+    // For each final beam b, find the beam slot at the last generated step, then
+    // trace back through parentIds to build the slot trace for every generation step.
+    // slotTrace[beam][genStep] = the beam slot that produced the logits at that step.
+    auto const generationLogitsHost = llmReq.getGenerationLogitsHost();
+    auto const& logitsShape = generationLogitsHost->getShape();
+    // Non-streaming shape: [beamWidth, maxNewTokens, vocabSizePadded]
+    auto const maxNewTokens = logitsShape.d[1];
+    auto const vocabSizePadded = logitsShape.d[2];
+
+    std::vector<std::vector<SizeType32>> slotTrace(reqBeamWidth, std::vector<SizeType32>(maxNewTokens, 0));
+    bool anyReorderNeeded = false;
+
+    for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
     {
-        auto const promptLen = llmReq.mPromptLen;
-
-        // Copy parentIds and ids (ungathered step IDs) from GPU to temporary host buffers.
-        // parentIds[slot][t] = the parent slot of beam slot `slot` at position t.
-        // ids[slot][t] = the token in beam slot `slot` at position t (before gather).
-        auto parentIdsDevice = ITensor::at(mDecoderState->getParentIds(), {seqSlot});
-        auto idsDevice = mDecoderState->getIds(seqSlot);
-
-        auto parentIdsHost
-            = runtime::BufferManager::pinnedPool(parentIdsDevice->getShape(), nvinfer1::DataType::kINT32);
-        auto idsHost = runtime::BufferManager::pinnedPool(idsDevice->getShape(), nvinfer1::DataType::kINT32);
-
-        mCopyBufferManager.copy(*parentIdsDevice, *parentIdsHost);
-        mCopyBufferManager.copy(*idsDevice, *idsHost);
-        mCopyBufferManager.getStream().synchronize();
-
-        auto const* parentIdsData = bufferCast<TokenIdType>(*parentIdsHost);
-        auto const* idsData = bufferCast<TokenIdType>(*idsHost);
-
-        // For each final beam b, find the beam slot at the last generated step, then
-        // trace back through parentIds to build the slot trace for every generation step.
-        // slotTrace[beam][genStep] = the beam slot that produced the logits at that step.
-        auto const generationLogitsHost = llmReq.getGenerationLogitsHost();
-        auto const& logitsShape = generationLogitsHost->getShape();
-        // Non-streaming shape: [beamWidth, maxNewTokens, vocabSizePadded]
-        auto const maxNewTokens = logitsShape.d[1];
-        auto const vocabSizePadded = logitsShape.d[2];
-
-        std::vector<std::vector<SizeType32>> slotTrace(reqBeamWidth, std::vector<SizeType32>(maxNewTokens, 0));
-        bool anyReorderNeeded = false;
-
-        for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
+        auto const seqLen = sequenceLengthsHostData[beam];
+        auto const genLen = seqLen - promptLen;
+        if (genLen <= 0)
         {
-            auto const seqLen = sequenceLengthsHostData[beam];
-            auto const genLen = seqLen - promptLen;
-            if (genLen <= 0)
-            {
-                continue;
-            }
+            continue;
+        }
 
-            // Find the starting beam slot at the last generated step by matching the
-            // backtracked token sequence against the gathered (finalized) output.
-            SizeType32 startSlot = -1;
-            for (SizeType32 s = 0; s < reqBeamWidth; ++s)
+        // Find the starting beam slot at the last generated step by matching the
+        // backtracked token sequence against the gathered (finalized) output.
+        SizeType32 startSlot = -1;
+        for (SizeType32 s = 0; s < reqBeamWidth; ++s)
+        {
+            SizeType32 slot = s;
+            bool matches = true;
+            for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
             {
-                SizeType32 slot = s;
-                bool matches = true;
-                for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
+                if (idsData[slot * maxSeqLength + t] != outputIdsHostData[beam * maxSeqLength + t])
                 {
-                    if (idsData[slot * maxSeqLength + t] != outputIdsHostData[beam * maxSeqLength + t])
-                    {
-                        matches = false;
-                        break;
-                    }
-                    if (t > promptLen)
-                    {
-                        slot = parentIdsData[slot * maxSeqLength + t];
-                    }
-                }
-                if (matches)
-                {
-                    startSlot = s;
+                    matches = false;
                     break;
                 }
-            }
-
-            if (startSlot < 0)
-            {
-                TLLM_LOG_WARNING(
-                    "Could not determine beam slot mapping for beam %d during generation logits reordering. "
-                    "Logits for this beam may not match the output token sequence.",
-                    beam);
-                // Fall back to identity mapping (no reorder for this beam)
-                for (SizeType32 g = 0; g < genLen; ++g)
+                if (t > promptLen)
                 {
-                    slotTrace[beam][g] = beam;
+                    slot = parentIdsData[slot * maxSeqLength + t];
                 }
-                continue;
             }
-
-            // Build the slot trace by tracing parentIds backward from the starting slot.
-            // After this loop, slotTrace[beam][g] = the slot the beam was assigned to
-            // after beam search at generation step g (the post-reassignment slot).
-            SizeType32 slot = startSlot;
-            slotTrace[beam][genLen - 1] = slot;
-            for (SizeType32 t = seqLen - 1; t > promptLen; --t)
+            if (matches)
             {
-                slot = parentIdsData[slot * maxSeqLength + t];
-                slotTrace[beam][t - 1 - promptLen] = slot;
-            }
-
-            // Convert from post-reassignment slot to pre-reassignment slot.
-            // At each step, the model computes logits BEFORE beam search reassigns
-            // beams to slots. So generationLogits[slot][g] holds logits from the
-            // pre-reassignment slot — not the post-reassignment slot that ids/parentIds
-            // reference. parentIds[postSlot][pos] points back to the pre-reassignment
-            // slot (the slot the beam was in when the model ran).
-            for (SizeType32 g = 0; g < genLen; ++g)
-            {
-                slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLength + (promptLen + g)];
-            }
-
-            // Check if any reordering is actually needed for this beam
-            for (SizeType32 g = 0; g < genLen; ++g)
-            {
-                if (slotTrace[beam][g] != beam)
-                {
-                    anyReorderNeeded = true;
-                    break;
-                }
+                startSlot = s;
+                break;
             }
         }
 
-        // Reorder the generation logits in-place using a per-step temporary buffer.
-        if (anyReorderNeeded)
+        TLLM_CHECK_WITH_INFO(startSlot >= 0,
+            "Could not determine beam slot mapping for beam %d during generation logits reordering.", beam);
+
+        // Build the slot trace by tracing parentIds backward from the starting slot.
+        // After this loop, slotTrace[beam][g] = the slot the beam was assigned to
+        // after beam search at generation step g (the post-reassignment slot).
+        SizeType32 slot = startSlot;
+        slotTrace[beam][genLen - 1] = slot;
+        for (SizeType32 t = seqLen - 1; t > promptLen; --t)
         {
-            auto const logitsDataType = generationLogitsHost->getDataType();
-            auto const elemSize = runtime::BufferDataType(logitsDataType).getSize();
-            auto const stepSize = static_cast<size_t>(vocabSizePadded) * elemSize;
+            slot = parentIdsData[slot * maxSeqLength + t];
+            slotTrace[beam][t - 1 - promptLen] = slot;
+        }
 
-            // Temp buffer for one generation step across all beams: [beamWidth, vocabSizePadded]
-            auto tempLogits = runtime::BufferManager::pinnedPool(
-                ITensor::makeShape({reqBeamWidth, vocabSizePadded}), logitsDataType);
+        // Convert from post-reassignment slot to pre-reassignment slot.
+        // At each step, the model computes logits BEFORE beam search reassigns
+        // beams to slots. So generationLogits[slot][g] holds logits from the
+        // pre-reassignment slot — not the post-reassignment slot that ids/parentIds
+        // reference. parentIds[postSlot][pos] points back to the pre-reassignment
+        // slot (the slot the beam was in when the model ran).
+        for (SizeType32 g = 0; g < genLen; ++g)
+        {
+            slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLength + (promptLen + g)];
+        }
 
-            auto* logitsPtr = static_cast<uint8_t*>(generationLogitsHost->data());
-            auto* tempPtr = static_cast<uint8_t*>(tempLogits->data());
+        // Check if any reordering is actually needed for this beam
+        auto& slotTraceIds = slotTrace[beam];
+        anyReorderNeeded |= std::any_of(
+            slotTraceIds.begin(), slotTraceIds.begin() + genLen, [beam](SizeType32 s) { return s != beam; });
+    }
 
-            SizeType32 maxGenLen = 0;
+    // Reorder the generation logits in-place using a per-step temporary buffer.
+    if (anyReorderNeeded)
+    {
+        auto const logitsDataType = generationLogitsHost->getDataType();
+        auto const elemSize = runtime::BufferDataType(logitsDataType).getSize();
+        auto const stepSize = static_cast<size_t>(vocabSizePadded) * elemSize;
+
+        // Temp buffer for one generation step across all beams: [beamWidth, vocabSizePadded]
+        auto tempLogits
+            = runtime::BufferManager::pinnedPool(ITensor::makeShape({reqBeamWidth, vocabSizePadded}), logitsDataType);
+
+        auto* logitsPtr = static_cast<uint8_t*>(generationLogitsHost->data());
+        auto* tempPtr = static_cast<uint8_t*>(tempLogits->data());
+
+        std::vector<SizeType32> genLens(reqBeamWidth);
+        SizeType32 maxGenLen = 0;
+        for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+        {
+            genLens[b] = std::max(SizeType32{0}, sequenceLengthsHostData[b] - promptLen);
+            maxGenLen = std::max(maxGenLen, genLens[b]);
+        }
+
+        for (SizeType32 g = 0; g < maxGenLen; ++g)
+        {
+            // Check if any beam that generated this step needs reordering
+            bool stepNeedsReorder = false;
             for (SizeType32 b = 0; b < reqBeamWidth; ++b)
             {
-                auto const gl = sequenceLengthsHostData[b] - promptLen;
-                if (gl > maxGenLen)
+                if (g < genLens[b] && slotTrace[b][g] != b)
                 {
-                    maxGenLen = gl;
+                    stepNeedsReorder = true;
+                    break;
                 }
             }
-
-            for (SizeType32 g = 0; g < maxGenLen; ++g)
+            if (!stepNeedsReorder)
             {
-                // Check if any beam needs reordering at this step
-                bool stepNeedsReorder = false;
-                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
-                {
-                    if (slotTrace[b][g] != b)
-                    {
-                        stepNeedsReorder = true;
-                        break;
-                    }
-                }
-                if (!stepNeedsReorder)
+                continue;
+            }
+
+            // Copy all beams' logits at this step to the temp buffer
+            for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+            {
+                // logits layout: [beamWidth, maxNewTokens, vocabSizePadded]
+                auto const offset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+                std::memcpy(tempPtr + static_cast<size_t>(b) * stepSize, logitsPtr + offset, stepSize);
+            }
+
+            // Reorder: logits[b][g] = temp[slotTrace[b][g]]
+            for (SizeType32 b = 0; b < reqBeamWidth; ++b)
+            {
+                if (g >= genLens[b])
                 {
                     continue;
                 }
-
-                // Copy all beams' logits at this step to the temp buffer
-                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
-                {
-                    // logits layout: [beamWidth, maxNewTokens, vocabSizePadded]
-                    auto const offset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
-                    std::memcpy(tempPtr + static_cast<size_t>(b) * stepSize, logitsPtr + offset, stepSize);
-                }
-
-                // Reorder: logits[b][g] = temp[slotTrace[b][g]]
-                for (SizeType32 b = 0; b < reqBeamWidth; ++b)
-                {
-                    auto const dstOffset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
-                    auto const srcSlot = slotTrace[b][g];
-                    std::memcpy(logitsPtr + dstOffset, tempPtr + static_cast<size_t>(srcSlot) * stepSize, stepSize);
-                }
+                auto const dstOffset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+                auto const srcSlot = slotTrace[b][g];
+                std::memcpy(logitsPtr + dstOffset, tempPtr + static_cast<size_t>(srcSlot) * stepSize, stepSize);
             }
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2002,7 +2002,7 @@ void TrtGptModelInflightBatching::reorderGenerationLogitsForBeamSearch(LlmReques
     auto const& logitsShape = generationLogitsHost->getShape();
     // Non-streaming shape: [beamWidth, maxNewTokens, vocabSizePadded]
     TLLM_CHECK_WITH_INFO(logitsShape.d[0] == reqBeamWidth,
-        "Generation logits beam dimension (%d) does not match beam width (%d).", logitsShape.d[0], reqBeamWidth);
+        "Generation logits beam dimension (%ld) does not match beam width (%d).", logitsShape.d[0], reqBeamWidth);
     auto const maxNewTokens = logitsShape.d[1];
     auto const vocabSizePadded = logitsShape.d[2];
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1956,7 +1956,7 @@ void TrtGptModelInflightBatching::postProcessRequest(
     // store the generated tokens into the mTokensGathered buffer
     llmReq.setGeneratedTokens(generatedTokens);
 
-    if (llmReq.getReturnGenerationLogits() && !llmReq.getGenerationLogitsFragments().empty()
+    if (llmReq.getReturnGenerationLogits() && llmReq.getGenerationLogitsHost()
         && mWorldConfig.isLastPipelineParallelRank())
     {
         reorderGenerationLogitsForBeamSearch(

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -342,6 +342,12 @@ private:
     /// and overwrites the llmRequest tokens buffer.
     /// Called either on request finishing, or at every step when doing beam search and streaming.
     void postProcessRequest(LlmRequest& llmReq, std::vector<SizeType32> const& numDroppedTokens);
+    /// @brief Reorders generation logits to match finalized beam paths after gatherTree.
+    /// During beam search, logits are stored by beam slot. After finalization, output_ids are
+    /// reordered by parentIds, but logits are not. This method traces parentIds on the host
+    /// to build the slot mapping and reindexes the logits accordingly.
+    void reorderGenerationLogitsForBeamSearch(LlmRequest& llmReq, SizeType32 seqSlot, SizeType32 reqBeamWidth,
+        SizeType32 maxSeqLength, TokenIdType const* outputIdsHostData, SizeType32 const* sequenceLengthsHostData);
     /// @brief Calls gatherTree (via finalize) and transmits the received data across ranks if PP>1
     void getDecoderSlotHostOutputs(
         SizeType32 seqSlot, bool returnLogProbs, runtime::SamplingConfig const& samplingConfig, bool streaming);

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -26,6 +26,8 @@
 #include <curand_kernel.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstring>
 #include <random>
 #include <unordered_set>
 
@@ -690,6 +692,195 @@ TEST_F(TestGatherTree, GatherTreeWithSwap)
     cudaDeviceSynchronize();
 
     EXPECT_TRUE(checkResult());
+}
+
+// Test that generation logits are correctly reordered after gatherTree finalization.
+// Uses the same hardcoded beam search data as GatherTreeNoSwap, creates sentinel logits
+// where logits[slot][g][v] = slot (so we can verify which slot each beam's logits came from),
+// then runs the reorder algorithm and checks the result.
+TEST_F(TestGatherTree, GenerationLogitsReorder)
+{
+    createBuffers();
+    hardcodeBuffersLen10();
+    cudaDeviceSynchronize();
+    kernels::gatherTree(
+        mDecodingState->getJointDecodingOutput(), mDecodingState->getJointDecodingInput(), mSamplingConfig, *mStream);
+    cudaDeviceSynchronize();
+
+    // Verify gatherTree worked first
+    ASSERT_TRUE(checkResult());
+
+    // Now test the generation logits reordering algorithm.
+    // Copy ids, parentIds, and gatheredIds to host.
+    auto idsHost = mBufferManager->copyFrom(*mDecodingState->getIds(0), MemoryType::kCPU);
+    auto parentIdsHost = mBufferManager->copyFrom(*ITensor::at(mDecodingState->getParentIds(), {0}), MemoryType::kCPU);
+    auto gatheredIdsHost = mBufferManager->copyFrom(*mDecodingState->getGatheredIds(0), MemoryType::kCPU);
+    auto seqLengthsHost = mBufferManager->copyFrom(*mDecodingState->getSequenceLengths(0), MemoryType::kCPU);
+
+    auto const* idsData = bufferCast<TokenIdType>(*idsHost);
+    auto const* parentIdsData = bufferCast<TokenIdType>(*parentIdsHost);
+    auto const* gatheredIdsData = bufferCast<TokenIdType>(*gatheredIdsHost);
+    auto const* seqLengthsData = bufferCast<SizeType32>(*seqLengthsHost);
+
+    SizeType32 const promptLen = 3; // matches inputLengths in hardcodeBuffersLen10
+
+    // Create sentinel generation logits: logits[slot][g][v] = slot for all v.
+    // This lets us verify which slot's logits end up at each beam position after reorder.
+    SizeType32 const vocabSizePadded = 8; // small for testing
+    SizeType32 const maxNewTokens = maxSeqLen - promptLen;
+    // Shape: [beamWidth, maxNewTokens, vocabSizePadded]
+    std::vector<float> logits(beamWidth * maxNewTokens * vocabSizePadded, 0.0f);
+    for (SizeType32 slot = 0; slot < beamWidth; ++slot)
+    {
+        for (SizeType32 g = 0; g < maxNewTokens; ++g)
+        {
+            for (SizeType32 v = 0; v < vocabSizePadded; ++v)
+            {
+                logits[(slot * maxNewTokens + g) * vocabSizePadded + v] = static_cast<float>(slot);
+            }
+        }
+    }
+
+    // Run the same algorithm as reorderGenerationLogitsForBeamSearch:
+    // 1. Build slot trace (post-reassignment)
+    // 2. Convert to pre-reassignment via parentIds
+    // 3. Reorder logits
+
+    std::vector<std::vector<SizeType32>> slotTrace(beamWidth, std::vector<SizeType32>(maxNewTokens, 0));
+
+    for (SizeType32 beam = 0; beam < beamWidth; ++beam)
+    {
+        auto const seqLen = seqLengthsData[beam];
+        auto const genLen = seqLen - promptLen;
+        if (genLen <= 0)
+        {
+            continue;
+        }
+
+        // Find starting slot by matching backtracked sequence
+        SizeType32 startSlot = -1;
+        for (SizeType32 s = 0; s < beamWidth; ++s)
+        {
+            SizeType32 slot = s;
+            bool matches = true;
+            for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
+            {
+                if (idsData[slot * maxSeqLen + t] != gatheredIdsData[beam * maxSeqLen + t])
+                {
+                    matches = false;
+                    break;
+                }
+                if (t > promptLen)
+                {
+                    slot = parentIdsData[slot * maxSeqLen + t];
+                }
+            }
+            if (matches)
+            {
+                startSlot = s;
+                break;
+            }
+        }
+        ASSERT_GE(startSlot, 0) << "Could not find starting slot for beam " << beam;
+
+        // Build post-reassignment slot trace
+        SizeType32 slot = startSlot;
+        slotTrace[beam][genLen - 1] = slot;
+        for (SizeType32 t = seqLen - 1; t > promptLen; --t)
+        {
+            slot = parentIdsData[slot * maxSeqLen + t];
+            slotTrace[beam][t - 1 - promptLen] = slot;
+        }
+
+        // Convert to pre-reassignment slot
+        for (SizeType32 g = 0; g < genLen; ++g)
+        {
+            slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLen + (promptLen + g)];
+        }
+    }
+
+    // Reorder logits using a temp buffer (same approach as the production code)
+    auto const stepSize = static_cast<size_t>(vocabSizePadded) * sizeof(float);
+    std::vector<float> temp(beamWidth * vocabSizePadded);
+    auto* logitsPtr = reinterpret_cast<uint8_t*>(logits.data());
+    auto* tempPtr = reinterpret_cast<uint8_t*>(temp.data());
+
+    std::vector<SizeType32> genLens(beamWidth);
+    SizeType32 maxGenLen = 0;
+    for (SizeType32 b = 0; b < beamWidth; ++b)
+    {
+        genLens[b] = std::max(SizeType32{0}, seqLengthsData[b] - promptLen);
+        maxGenLen = std::max(maxGenLen, genLens[b]);
+    }
+
+    for (SizeType32 g = 0; g < maxGenLen; ++g)
+    {
+        bool stepNeedsReorder = false;
+        for (SizeType32 b = 0; b < beamWidth; ++b)
+        {
+            if (g < genLens[b] && slotTrace[b][g] != b)
+            {
+                stepNeedsReorder = true;
+                break;
+            }
+        }
+        if (!stepNeedsReorder)
+        {
+            continue;
+        }
+
+        for (SizeType32 b = 0; b < beamWidth; ++b)
+        {
+            auto const offset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+            std::memcpy(tempPtr + static_cast<size_t>(b) * stepSize, logitsPtr + offset, stepSize);
+        }
+        for (SizeType32 b = 0; b < beamWidth; ++b)
+        {
+            if (g >= genLens[b])
+            {
+                continue;
+            }
+            auto const dstOffset = (static_cast<size_t>(b) * maxNewTokens + g) * stepSize;
+            auto const srcSlot = slotTrace[b][g];
+            std::memcpy(logitsPtr + dstOffset, tempPtr + static_cast<size_t>(srcSlot) * stepSize, stepSize);
+        }
+    }
+
+    // Verify: after reorder, logits[beam][g][0] should equal the pre-reassignment slot
+    // that the model computed logits from for that beam at that step.
+    // Since our sentinel set logits[slot][g][v] = slot, the reordered value tells us
+    // which slot's logits were assigned to each beam.
+    bool allCorrect = true;
+    for (SizeType32 beam = 0; beam < beamWidth; ++beam)
+    {
+        auto const genLen = genLens[beam];
+        for (SizeType32 g = 0; g < genLen; ++g)
+        {
+            auto const reorderedSlot = static_cast<SizeType32>(logits[(beam * maxNewTokens + g) * vocabSizePadded]);
+            auto const expectedSlot = slotTrace[beam][g];
+            if (reorderedSlot != expectedSlot)
+            {
+                TLLM_LOG_ERROR("Beam %d, step %d: expected slot %d, got slot %d", beam, g, expectedSlot, reorderedSlot);
+                allCorrect = false;
+            }
+        }
+    }
+    EXPECT_TRUE(allCorrect);
+
+    // Also verify that at least some reordering happened (the test data should cause beam swaps)
+    bool anyReorder = false;
+    for (SizeType32 beam = 0; beam < beamWidth && !anyReorder; ++beam)
+    {
+        for (SizeType32 g = 0; g < genLens[beam]; ++g)
+        {
+            if (slotTrace[beam][g] != beam)
+            {
+                anyReorder = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(anyReorder) << "Test data should cause at least some beam reordering";
 }
 
 enum AcceptKernelMode

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -320,6 +320,8 @@ void fillTensorAtIndex(ITensor::SharedPtr tensor, SizeType32 idx, std::vector<T>
     bufferManager->copy(src.data(), *target);
 }
 
+} // anonymous namespace
+
 class TestGatherTree : public ::testing::Test
 {
 public:
@@ -722,26 +724,13 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
     auto const* gatheredIdsData = bufferCast<TokenIdType>(*gatheredIdsHost);
     auto const* seqLengthsData = bufferCast<SizeType32>(*seqLengthsHost);
 
-    // Read logProbsTiled (unmodified by gatherTree) for populating logits,
-    // and gathered logProbs (written by gatherTree) for cross-checking.
-    auto logProbsTiledHost
-        = mBufferManager->copyFrom(*mDecodingState->getJointDecodingOutput().logProbsTiled, MemoryType::kCPU);
-    auto const* logProbsTiledData = bufferCast<float>(*logProbsTiledHost);
-    // Layout: [maxSeqLen, batchSize=1, beamWidth] -> logProbsTiledData[t * beamWidth + slot]
-
-    auto gatheredLogProbsHost = mBufferManager->copyFrom(*mDecodingState->getLogProbs(0), MemoryType::kCPU);
-    auto const* gatheredLogProbsData = bufferCast<float>(*gatheredLogProbsHost);
-    // Layout: [beamWidth, maxSeqLen] -> gatheredLogProbsData[beam * maxSeqLen + g]
-
     SizeType32 const promptLen = 3;           // matches inputLengths in hardcodeBuffersLen10
     SizeType32 const vocabSizePadded = 32000; // LLaMA vocab size (matches fixture token IDs)
     SizeType32 const maxNewTokens = maxSeqLen - promptLen;
 
-    // Populate generation logits using actual token IDs and logProb values from the
-    // fixture. For each (post-reassignment slot B, gen step g), place the logProbsTiled
-    // value at logits[A][g][token], where A is the pre-reassignment slot (from parentIds)
-    // and token is the selected token (from raw ids). This mirrors how the model stores
-    // logits indexed by pre-reassignment slot.
+    // Populate sentinel logits: for each (pre-reassignment slot, gen step), place a 1.0f
+    // at the selected token position. All other entries stay 0. After correct reordering,
+    // argmax(logits[beam][g]) should equal the gathered token for that beam and step.
     std::vector<float> logits(static_cast<size_t>(beamWidth) * maxNewTokens * vocabSizePadded, 0.0f);
     for (SizeType32 postSlot = 0; postSlot < beamWidth; ++postSlot)
     {
@@ -751,8 +740,7 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
             SizeType32 const t = promptLen + g;
             SizeType32 const preSlot = parentIdsData[postSlot * maxSeqLen + t];
             TokenIdType const token = idsData[postSlot * maxSeqLen + t];
-            float const logProbValue = logProbsTiledData[t * beamWidth + postSlot];
-            logits[static_cast<size_t>(preSlot * maxNewTokens + g) * vocabSizePadded + token] = logProbValue;
+            logits[static_cast<size_t>(preSlot * maxNewTokens + g) * vocabSizePadded + token] = 1.0f;
         }
     }
 
@@ -850,10 +838,10 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
         }
     }
 
-    // Cross-check: after reorder, the logit at the gathered output token position
-    // should match the gathered logProb from gatherTree. This is non-tautological
-    // because the gathered logProbs are computed independently by gatherTree (via
-    // insertUnfinishedPath + finalize tracing through logProbsTiled and parentIds).
+    // Cross-check: after reorder, logits[beam][g][gatheredToken] should be positive (the 1.0f
+    // sentinel placed there during population). This is non-tautological: gatheredIdsData is
+    // produced independently by gatherTree tracing through parentIds, while the logits were
+    // reordered via the slot trace. A wrong slot's logits would have zeros at this position.
     bool allCorrect = true;
     for (SizeType32 beam = 0; beam < beamWidth; ++beam)
     {
@@ -861,13 +849,12 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
         for (SizeType32 g = 0; g < genLen; ++g)
         {
             TokenIdType const gatheredToken = gatheredIdsData[beam * maxSeqLen + (promptLen + g)];
-            float const reorderedLogProb
+            float const logitAtGatheredToken
                 = logits[static_cast<size_t>(beam * maxNewTokens + g) * vocabSizePadded + gatheredToken];
-            float const expectedLogProb = gatheredLogProbsData[beam * maxSeqLen + g];
-            if (std::abs(reorderedLogProb - expectedLogProb) > 1e-5f)
+            if (logitAtGatheredToken <= 0.0f)
             {
-                TLLM_LOG_ERROR("Beam %d, step %d: reordered logProb %f != gathered logProb %f (token %d)", beam, g,
-                    reorderedLogProb, expectedLogProb, gatheredToken);
+                TLLM_LOG_ERROR("Beam %d, step %d: logit at gathered token %d is %.1f, expected positive", beam, g,
+                    gatheredToken, logitAtGatheredToken);
                 allCorrect = false;
             }
         }
@@ -889,6 +876,9 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
     }
     EXPECT_TRUE(anyReorder) << "Test data should cause at least some beam reordering";
 }
+
+namespace
+{
 
 enum AcceptKernelMode
 {

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -702,6 +702,13 @@ TEST_F(TestGatherTree, GatherTreeWithSwap)
 // then runs the reorder algorithm and checks the result.
 TEST_F(TestGatherTree, GenerationLogitsReorder)
 {
+    // Compile-time proof that the fixture data causes beam reordering.
+    // hardcodeBuffersLen10: parentIds[slot=1][t=3] = 0 (row 1, col 3 of the parentIds table).
+    // Since 0 != 1, any beam trace through slot 1 at t=4 steps to slot 0 at t=3 — a concrete swap.
+    static constexpr SizeType32 kFixtureParentIds_slot1_t3 = 0;
+    static_assert(kFixtureParentIds_slot1_t3 != 1,
+        "parentIds[slot=1][t=3] must differ from slot 1 to guarantee a beam swap in this test");
+
     createBuffers();
     hardcodeBuffersLen10();
     cudaDeviceSynchronize();
@@ -724,13 +731,13 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
     auto const* gatheredIdsData = bufferCast<TokenIdType>(*gatheredIdsHost);
     auto const* seqLengthsData = bufferCast<SizeType32>(*seqLengthsHost);
 
-    SizeType32 const promptLen = 3;           // matches inputLengths in hardcodeBuffersLen10
-    SizeType32 const vocabSizePadded = 32000; // LLaMA vocab size (matches fixture token IDs)
+    SizeType32 constexpr promptLen = 3;           // matches inputLengths in hardcodeBuffersLen10
+    SizeType32 constexpr vocabSizePadded = 32000; // LLaMA vocab size (matches fixture token IDs)
     SizeType32 const maxNewTokens = maxSeqLen - promptLen;
 
     // Populate sentinel logits: for each (pre-reassignment slot, gen step), place a 1.0f
     // at the selected token position. All other entries stay 0. After correct reordering,
-    // argmax(logits[beam][g]) should equal the gathered token for that beam and step.
+    // logits[beam][g][gatheredToken] should be positive (the sentinel landed at the right place).
     std::vector<float> logits(static_cast<size_t>(beamWidth) * maxNewTokens * vocabSizePadded, 0.0f);
     for (SizeType32 postSlot = 0; postSlot < beamWidth; ++postSlot)
     {
@@ -838,10 +845,10 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
         }
     }
 
-    // Cross-check: after reorder, logits[beam][g][gatheredToken] should be positive (the 1.0f
-    // sentinel placed there during population). This is non-tautological: gatheredIdsData is
-    // produced independently by gatherTree tracing through parentIds, while the logits were
-    // reordered via the slot trace. A wrong slot's logits would have zeros at this position.
+    // Cross-check: after reorder, logits[beam][g][gatheredToken] should equal the 1.0f sentinel
+    // placed there during population. This is non-tautological: gatheredIdsData is produced
+    // independently by gatherTree tracing through parentIds, while the logits were reordered via
+    // the slot trace. A wrong slot's logits would have 0.0f at this position.
     bool allCorrect = true;
     for (SizeType32 beam = 0; beam < beamWidth; ++beam)
     {
@@ -851,30 +858,15 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
             TokenIdType const gatheredToken = gatheredIdsData[beam * maxSeqLen + (promptLen + g)];
             float const logitAtGatheredToken
                 = logits[static_cast<size_t>(beam * maxNewTokens + g) * vocabSizePadded + gatheredToken];
-            if (logitAtGatheredToken <= 0.0f)
+            if (logitAtGatheredToken != 1.0f)
             {
-                TLLM_LOG_ERROR("Beam %d, step %d: logit at gathered token %d is %.1f, expected positive", beam, g,
+                TLLM_LOG_ERROR("Beam %d, step %d: logit at gathered token %d is %.1f, expected 1.0", beam, g,
                     gatheredToken, logitAtGatheredToken);
                 allCorrect = false;
             }
         }
     }
     EXPECT_TRUE(allCorrect);
-
-    // Also verify that at least some reordering happened (the test data should cause beam swaps)
-    bool anyReorder = false;
-    for (SizeType32 beam = 0; beam < beamWidth && !anyReorder; ++beam)
-    {
-        for (SizeType32 g = 0; g < genLens[beam]; ++g)
-        {
-            if (slotTrace[beam][g] != beam)
-            {
-                anyReorder = true;
-                break;
-            }
-        }
-    }
-    EXPECT_TRUE(anyReorder) << "Test data should cause at least some beam reordering";
 }
 
 namespace

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -711,7 +711,7 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
     ASSERT_TRUE(checkResult());
 
     // Now test the generation logits reordering algorithm.
-    // Copy ids, parentIds, and gatheredIds to host.
+    // Copy ids, parentIds, gatheredIds, and seqLengths to host.
     auto idsHost = mBufferManager->copyFrom(*mDecodingState->getIds(0), MemoryType::kCPU);
     auto parentIdsHost = mBufferManager->copyFrom(*ITensor::at(mDecodingState->getParentIds(), {0}), MemoryType::kCPU);
     auto gatheredIdsHost = mBufferManager->copyFrom(*mDecodingState->getGatheredIds(0), MemoryType::kCPU);
@@ -722,30 +722,41 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
     auto const* gatheredIdsData = bufferCast<TokenIdType>(*gatheredIdsHost);
     auto const* seqLengthsData = bufferCast<SizeType32>(*seqLengthsHost);
 
-    SizeType32 const promptLen = 3; // matches inputLengths in hardcodeBuffersLen10
+    // Read logProbsTiled (unmodified by gatherTree) for populating logits,
+    // and gathered logProbs (written by gatherTree) for cross-checking.
+    auto logProbsTiledHost
+        = mBufferManager->copyFrom(*mDecodingState->getJointDecodingOutput().logProbsTiled, MemoryType::kCPU);
+    auto const* logProbsTiledData = bufferCast<float>(*logProbsTiledHost);
+    // Layout: [maxSeqLen, batchSize=1, beamWidth] -> logProbsTiledData[t * beamWidth + slot]
 
-    // Create sentinel generation logits: logits[slot][g][v] = slot for all v.
-    // This lets us verify which slot's logits end up at each beam position after reorder.
-    SizeType32 const vocabSizePadded = 8; // small for testing
+    auto gatheredLogProbsHost = mBufferManager->copyFrom(*mDecodingState->getLogProbs(0), MemoryType::kCPU);
+    auto const* gatheredLogProbsData = bufferCast<float>(*gatheredLogProbsHost);
+    // Layout: [beamWidth, maxSeqLen] -> gatheredLogProbsData[beam * maxSeqLen + g]
+
+    SizeType32 const promptLen = 3;           // matches inputLengths in hardcodeBuffersLen10
+    SizeType32 const vocabSizePadded = 32000; // LLaMA vocab size (matches fixture token IDs)
     SizeType32 const maxNewTokens = maxSeqLen - promptLen;
-    // Shape: [beamWidth, maxNewTokens, vocabSizePadded]
-    std::vector<float> logits(beamWidth * maxNewTokens * vocabSizePadded, 0.0f);
-    for (SizeType32 slot = 0; slot < beamWidth; ++slot)
+
+    // Populate generation logits using actual token IDs and logProb values from the
+    // fixture. For each (post-reassignment slot B, gen step g), place the logProbsTiled
+    // value at logits[A][g][token], where A is the pre-reassignment slot (from parentIds)
+    // and token is the selected token (from raw ids). This mirrors how the model stores
+    // logits indexed by pre-reassignment slot.
+    std::vector<float> logits(static_cast<size_t>(beamWidth) * maxNewTokens * vocabSizePadded, 0.0f);
+    for (SizeType32 postSlot = 0; postSlot < beamWidth; ++postSlot)
     {
-        for (SizeType32 g = 0; g < maxNewTokens; ++g)
+        auto const genLen = seqLengthsData[postSlot] - promptLen;
+        for (SizeType32 g = 0; g < genLen; ++g)
         {
-            for (SizeType32 v = 0; v < vocabSizePadded; ++v)
-            {
-                logits[(slot * maxNewTokens + g) * vocabSizePadded + v] = static_cast<float>(slot);
-            }
+            SizeType32 const t = promptLen + g;
+            SizeType32 const preSlot = parentIdsData[postSlot * maxSeqLen + t];
+            TokenIdType const token = idsData[postSlot * maxSeqLen + t];
+            float const logProbValue = logProbsTiledData[t * beamWidth + postSlot];
+            logits[static_cast<size_t>(preSlot * maxNewTokens + g) * vocabSizePadded + token] = logProbValue;
         }
     }
 
-    // Run the same algorithm as reorderGenerationLogitsForBeamSearch:
-    // 1. Build slot trace (post-reassignment)
-    // 2. Convert to pre-reassignment via parentIds
-    // 3. Reorder logits
-
+    // Build slot trace and reorder (same algorithm as reorderGenerationLogitsForBeamSearch)
     std::vector<std::vector<SizeType32>> slotTrace(beamWidth, std::vector<SizeType32>(maxNewTokens, 0));
 
     for (SizeType32 beam = 0; beam < beamWidth; ++beam)
@@ -783,19 +794,12 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
         }
         ASSERT_GE(startSlot, 0) << "Could not find starting slot for beam " << beam;
 
-        // Build post-reassignment slot trace
+        // Build pre-reassignment slot trace in a single pass
         SizeType32 slot = startSlot;
-        slotTrace[beam][genLen - 1] = slot;
-        for (SizeType32 t = seqLen - 1; t > promptLen; --t)
+        for (SizeType32 t = seqLen - 1; t >= promptLen; --t)
         {
             slot = parentIdsData[slot * maxSeqLen + t];
-            slotTrace[beam][t - 1 - promptLen] = slot;
-        }
-
-        // Convert to pre-reassignment slot
-        for (SizeType32 g = 0; g < genLen; ++g)
-        {
-            slotTrace[beam][g] = parentIdsData[slotTrace[beam][g] * maxSeqLen + (promptLen + g)];
+            slotTrace[beam][t - promptLen] = slot;
         }
     }
 
@@ -846,21 +850,24 @@ TEST_F(TestGatherTree, GenerationLogitsReorder)
         }
     }
 
-    // Verify: after reorder, logits[beam][g][0] should equal the pre-reassignment slot
-    // that the model computed logits from for that beam at that step.
-    // Since our sentinel set logits[slot][g][v] = slot, the reordered value tells us
-    // which slot's logits were assigned to each beam.
+    // Cross-check: after reorder, the logit at the gathered output token position
+    // should match the gathered logProb from gatherTree. This is non-tautological
+    // because the gathered logProbs are computed independently by gatherTree (via
+    // insertUnfinishedPath + finalize tracing through logProbsTiled and parentIds).
     bool allCorrect = true;
     for (SizeType32 beam = 0; beam < beamWidth; ++beam)
     {
         auto const genLen = genLens[beam];
         for (SizeType32 g = 0; g < genLen; ++g)
         {
-            auto const reorderedSlot = static_cast<SizeType32>(logits[(beam * maxNewTokens + g) * vocabSizePadded]);
-            auto const expectedSlot = slotTrace[beam][g];
-            if (reorderedSlot != expectedSlot)
+            TokenIdType const gatheredToken = gatheredIdsData[beam * maxSeqLen + (promptLen + g)];
+            float const reorderedLogProb
+                = logits[static_cast<size_t>(beam * maxNewTokens + g) * vocabSizePadded + gatheredToken];
+            float const expectedLogProb = gatheredLogProbsData[beam * maxSeqLen + g];
+            if (std::abs(reorderedLogProb - expectedLogProb) > 1e-5f)
             {
-                TLLM_LOG_ERROR("Beam %d, step %d: expected slot %d, got slot %d", beam, g, expectedSlot, reorderedSlot);
+                TLLM_LOG_ERROR("Beam %d, step %d: reordered logProb %f != gathered logProb %f (token %d)", beam, g,
+                    reorderedLogProb, expectedLogProb, gatheredToken);
                 allCorrect = false;
             }
         }

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -188,7 +188,7 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
             build_cmd.append("--bert_attention_plugin=float16")
             build_cmd.append("--gpt_attention_plugin=float16")
 
-        check_call(" ".join(build_cmd), shell=True, env=llm_venv._new_env)
+        check_call(" ".join(build_cmd), env=llm_venv._new_env)
 
     print("Run generation logits beam search validation...")
     run_cmd = [

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 from defs.common import convert_weights, venv_check_call
 from defs.conftest import get_sm_version, llm_models_root, skip_post_blackwell
@@ -191,13 +193,14 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
         check_call(" ".join(build_cmd), env=llm_venv._new_env)
 
     print("Run generation logits beam search validation...")
+    validation_script = os.path.join(os.path.dirname(__file__),
+                                     "validate_whisper_beam_logits.py")
     run_cmd = [
-        f"{whisper_example_root}/reproduce_beam_logits_bug.py",
+        validation_script,
         f"--engine_dir={whisper_engine_dir}",
         f"--assets_dir={model_ckpt_dir}",
         f"--input_file={whisper_example_audio_file}",
         f"--num_beams={num_beams}",
-        "--check",
     ]
     env = {"HF_DATASETS_OFFLINE": "0"}
     venv_check_call(llm_venv, run_cmd, env=env)

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -203,7 +203,11 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
         f"--num_beams={num_beams}",
     ]
     env = {
-        "HF_DATASETS_OFFLINE": "0",
-        "PYTHONPATH": whisper_example_root,
+        "HF_DATASETS_OFFLINE":
+        "0",
+        "PYTHONPATH":
+        os.pathsep.join(
+            filter(None, [whisper_example_root,
+                          os.environ.get("PYTHONPATH")])),
     }
     venv_check_call(llm_venv, run_cmd, env=env)

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -136,3 +136,68 @@ def test_llm_whisper_general(llm_venv, engine_dir, data_type,
     # WAR before whisper tests can work offline
     env = {"HF_DATASETS_OFFLINE": "0"}
     venv_check_call(llm_venv, run_cmd, env=env)
+
+
+@skip_post_blackwell
+@pytest.mark.parametrize("num_beams", [4],
+                         ids=lambda num_beams: f'nb:{num_beams}')
+@pytest.mark.parametrize("whisper_model_root", ['large-v3'], indirect=True)
+def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
+                                               whisper_example_root,
+                                               whisper_model_root, num_beams,
+                                               whisper_example_audio_file):
+    """Verify that generation_logits are reordered to match the final beam paths.
+
+    With beam search (num_beams > 1), generation_logits must be reindexed by
+    parentIds so that argmax(generation_logits[beam][t]) == output_ids[beam][t]
+    at every position. Without reordering, logits are indexed by beam slot
+    rather than by the final beam path, producing incorrect probabilities.
+    """
+    tllm_model_name, model_ckpt_dir = whisper_model_root
+
+    whisper_engine_dir = f"{engine_dir}/{tllm_model_name}/float16_disable_weight_only"
+
+    converted_weight_dir = convert_weights(llm_venv=llm_venv,
+                                           example_root=whisper_example_root,
+                                           cmodel_dir=whisper_engine_dir,
+                                           model=tllm_model_name,
+                                           model_path=model_ckpt_dir,
+                                           use_weight_only=False,
+                                           weight_only_precision=None)
+
+    print("Build engines for beam search generation logits test...")
+    for component in ["encoder", "decoder"]:
+        build_cmd = [
+            "trtllm-build",
+            f"--checkpoint_dir={converted_weight_dir}/{component}",
+            f"--output_dir={whisper_engine_dir}/{component}",
+            "--paged_kv_cache=enable",
+            "--remove_input_padding=enable",
+            "--moe_plugin=disable",
+            "--max_batch_size=1",
+        ]
+        if component == "encoder":
+            build_cmd.append("--max_input_len=3000")
+            build_cmd.append("--max_seq_len=3000")
+        if component == "decoder":
+            build_cmd.append("--max_input_len=14")
+            build_cmd.append("--max_seq_len=114")
+            build_cmd.append("--max_encoder_input_len=3000")
+            build_cmd.append(f"--max_beam_width={num_beams}")
+            build_cmd.append("--gemm_plugin=float16")
+            build_cmd.append("--bert_attention_plugin=float16")
+            build_cmd.append("--gpt_attention_plugin=float16")
+
+        check_call(" ".join(build_cmd), shell=True, env=llm_venv._new_env)
+
+    print("Run generation logits beam search validation...")
+    run_cmd = [
+        f"{whisper_example_root}/reproduce_beam_logits_bug.py",
+        f"--engine_dir={whisper_engine_dir}",
+        f"--assets_dir={model_ckpt_dir}",
+        f"--input_file={whisper_example_audio_file}",
+        f"--num_beams={num_beams}",
+        "--check",
+    ]
+    env = {"HF_DATASETS_OFFLINE": "0"}
+    venv_check_call(llm_venv, run_cmd, env=env)

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -202,5 +202,8 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
         f"--input_file={whisper_example_audio_file}",
         f"--num_beams={num_beams}",
     ]
-    env = {"HF_DATASETS_OFFLINE": "0"}
+    env = {
+        "HF_DATASETS_OFFLINE": "0",
+        "PYTHONPATH": whisper_example_root,
+    }
     venv_check_call(llm_venv, run_cmd, env=env)

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -190,7 +190,7 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
             build_cmd.append("--bert_attention_plugin=float16")
             build_cmd.append("--gpt_attention_plugin=float16")
 
-        check_call(" ".join(build_cmd), env=llm_venv._new_env)
+        check_call(build_cmd, env=llm_venv._new_env)
 
     print("Run generation logits beam search validation...")
     validation_script = os.path.join(os.path.dirname(__file__),

--- a/tests/integration/defs/examples/validate_whisper_beam_logits.py
+++ b/tests/integration/defs/examples/validate_whisper_beam_logits.py
@@ -183,8 +183,14 @@ def main():
         )
     torch.cuda.synchronize()
 
+    generation_logits = outputs["generation_logits"]
+    assert generation_logits.shape[1] == args.num_beams, (
+        f"Expected generation_logits beam dimension to be {args.num_beams}, "
+        f"got {generation_logits.shape[1]}"
+    )
+
     passed = validate_logits_alignment(
-        outputs["output_ids"].cpu(), outputs["generation_logits"].cpu(), input_len, eot_id
+        outputs["output_ids"].cpu(), generation_logits.cpu(), input_len, eot_id
     )
 
     if passed:

--- a/tests/integration/defs/examples/validate_whisper_beam_logits.py
+++ b/tests/integration/defs/examples/validate_whisper_beam_logits.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate that generation_logits are correctly reordered for beam search.
+
+With beam search (num_beams > 1), generation_logits must be reindexed to match
+the final beam paths after gatherTree finalization. This script runs whisper
+inference via ModelRunnerCpp and checks that each output token has a reasonable
+probability under its corresponding generation logits.
+
+Exits with non-zero status if any output token has near-zero probability
+(log P < -10), which indicates logits from a different beam's context.
+"""
+
+import argparse
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import tensorrt_llm
+from tensorrt_llm._utils import str_dtype_to_torch
+from tensorrt_llm.runtime import ModelRunnerCpp
+
+
+def read_config(component, engine_dir):
+    config_path = engine_dir / component / "config.json"
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    model_config = OrderedDict()
+    model_config.update(config["pretrained_config"])
+    model_config.update(config["build_config"])
+    return model_config
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine_dir", type=str, required=True)
+    parser.add_argument("--assets_dir", type=str, required=True)
+    parser.add_argument("--input_file", type=str, default=None)
+    parser.add_argument("--num_beams", type=int, default=4)
+    parser.add_argument("--max_new_tokens", type=int, default=96)
+    return parser.parse_args()
+
+
+def get_mel_input(input_file, n_mels, mel_filters_dir):
+    from whisper_utils import log_mel_spectrogram
+
+    if input_file:
+        mel, _ = log_mel_spectrogram(
+            input_file, n_mels, device="cuda", return_duration=True, mel_filters_dir=mel_filters_dir
+        )
+    else:
+        from datasets import load_dataset
+
+        dataset = load_dataset(
+            "hf-internal-testing/librispeech_asr_dummy",
+            "clean",
+            split="validation",
+            trust_remote_code=True,
+        )
+        speech = dataset[0]["audio"]["array"].astype(np.float32)
+        waveform = torch.from_numpy(speech)
+        mel = log_mel_spectrogram(waveform, n_mels, device="cuda", mel_filters_dir=mel_filters_dir)
+
+    mel = mel.type(str_dtype_to_torch("float16"))
+    mel = mel.unsqueeze(0)
+    if mel.shape[2] % 2:
+        mel = torch.nn.functional.pad(mel, (0, 1))
+    return mel
+
+
+def validate_logits_alignment(output_ids, generation_logits, input_len, eot_id):
+    """Check that output tokens have reasonable probability under generation_logits.
+
+    Returns True if all output tokens have log P > -10, False otherwise.
+    """
+    LOG_PROB_THRESHOLD = -10.0
+    beam_idx = 0
+    batch_size = output_ids.shape[0]
+    all_aligned = True
+
+    for b in range(batch_size):
+        gen_tokens = output_ids[b, beam_idx, input_len:]
+        eot_positions = (gen_tokens == eot_id).nonzero(as_tuple=True)[0]
+        gen_len = eot_positions[0].item() if len(eot_positions) > 0 else gen_tokens.shape[0]
+
+        if gen_len == 0:
+            continue
+
+        gen_tokens = gen_tokens[:gen_len]
+        logits = generation_logits[b, beam_idx, :gen_len, :]
+
+        log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+        actual_logprobs = log_probs.gather(1, gen_tokens.unsqueeze(1)).squeeze(1)
+
+        min_logprob = actual_logprobs.min().item()
+        near_zero = (actual_logprobs < LOG_PROB_THRESHOLD).sum().item()
+
+        argmax_matches = (logits.argmax(dim=-1) == gen_tokens).sum().item()
+
+        print(
+            f"  Batch {b}: argmax match {argmax_matches}/{gen_len}, "
+            f"min log P = {min_logprob:.4f}, "
+            f"near-zero positions = {near_zero}/{gen_len}"
+        )
+
+        if near_zero > 0:
+            all_aligned = False
+            print(f"  FAIL: {near_zero} positions have near-zero probability")
+
+    return all_aligned
+
+
+def main():
+    args = parse_arguments()
+    tensorrt_llm.logger.set_level("warning")
+
+    engine_dir = Path(args.engine_dir)
+    encoder_config = read_config("encoder", engine_dir)
+    decoder_config = read_config("decoder", engine_dir)
+
+    n_mels = encoder_config["n_mels"]
+    is_multilingual = decoder_config["vocab_size"] >= 51865
+
+    from tokenizer import get_tokenizer
+
+    tokenizer_name = "multilingual" if is_multilingual else "gpt2"
+    tokenizer = get_tokenizer(
+        name=tokenizer_name,
+        num_languages=encoder_config["num_languages"],
+        tokenizer_dir=args.assets_dir,
+    )
+    eot_id = tokenizer.encode("<|endoftext|>", allowed_special=tokenizer.special_tokens_set)[0]
+
+    runner = ModelRunnerCpp.from_dir(
+        engine_dir=engine_dir,
+        is_enc_dec=True,
+        max_batch_size=1,
+        max_input_len=3000,
+        max_output_len=args.max_new_tokens,
+        max_beam_width=args.num_beams,
+        kv_cache_free_gpu_memory_fraction=0.9,
+        cross_kv_cache_fraction=0.5,
+        gather_generation_logits=True,
+    )
+
+    mel = get_mel_input(args.input_file, n_mels, args.assets_dir)
+    mel_input_lengths = torch.full((1,), mel.shape[2], dtype=torch.int32, device="cuda")
+
+    prompt_text = "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
+    prompt_ids = tokenizer.encode(prompt_text, allowed_special=tokenizer.special_tokens_set)
+    decoder_input_ids = torch.tensor(prompt_ids).unsqueeze(0)
+    input_len = decoder_input_ids.shape[1]
+
+    with torch.no_grad():
+        outputs = runner.generate(
+            batch_input_ids=decoder_input_ids,
+            encoder_input_features=mel.transpose(1, 2),
+            encoder_output_lengths=mel_input_lengths // 2,
+            max_new_tokens=args.max_new_tokens,
+            end_id=eot_id,
+            pad_id=eot_id,
+            num_beams=args.num_beams,
+            num_return_sequences=args.num_beams,
+            output_sequence_lengths=True,
+            output_generation_logits=True,
+            return_dict=True,
+        )
+    torch.cuda.synchronize()
+
+    passed = validate_logits_alignment(
+        outputs["output_ids"].cpu(), outputs["generation_logits"].cpu(), input_len, eot_id
+    )
+
+    if passed:
+        print("PASS: generation_logits aligned with output_ids")
+    else:
+        print("FAIL: generation_logits misaligned with output_ids")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/defs/examples/validate_whisper_beam_logits.py
+++ b/tests/integration/defs/examples/validate_whisper_beam_logits.py
@@ -87,41 +87,42 @@ def get_mel_input(input_file, n_mels, mel_filters_dir):
 def validate_logits_alignment(output_ids, generation_logits, input_len, eot_id):
     """Check that output tokens have reasonable probability under generation_logits.
 
-    Returns True if all output tokens have log P > -10, False otherwise.
+    Returns True if all output tokens have log P > -10 across all beams, False otherwise.
     """
     LOG_PROB_THRESHOLD = -10.0
-    beam_idx = 0
     batch_size = output_ids.shape[0]
+    num_beams = output_ids.shape[1]
     all_aligned = True
 
     for b in range(batch_size):
-        gen_tokens = output_ids[b, beam_idx, input_len:]
-        eot_positions = (gen_tokens == eot_id).nonzero(as_tuple=True)[0]
-        gen_len = eot_positions[0].item() if len(eot_positions) > 0 else gen_tokens.shape[0]
+        for beam in range(num_beams):
+            gen_tokens = output_ids[b, beam, input_len:]
+            eot_positions = (gen_tokens == eot_id).nonzero(as_tuple=True)[0]
+            gen_len = eot_positions[0].item() if len(eot_positions) > 0 else gen_tokens.shape[0]
 
-        if gen_len == 0:
-            continue
+            if gen_len == 0:
+                continue
 
-        gen_tokens = gen_tokens[:gen_len]
-        logits = generation_logits[b, beam_idx, :gen_len, :]
+            gen_tokens = gen_tokens[:gen_len]
+            logits = generation_logits[b, beam, :gen_len, :]
 
-        log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
-        actual_logprobs = log_probs.gather(1, gen_tokens.unsqueeze(1)).squeeze(1)
+            log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+            actual_logprobs = log_probs.gather(1, gen_tokens.unsqueeze(1)).squeeze(1)
 
-        min_logprob = actual_logprobs.min().item()
-        near_zero = (actual_logprobs < LOG_PROB_THRESHOLD).sum().item()
+            min_logprob = actual_logprobs.min().item()
+            near_zero = (actual_logprobs < LOG_PROB_THRESHOLD).sum().item()
 
-        argmax_matches = (logits.argmax(dim=-1) == gen_tokens).sum().item()
+            argmax_matches = (logits.argmax(dim=-1) == gen_tokens).sum().item()
 
-        print(
-            f"  Batch {b}: argmax match {argmax_matches}/{gen_len}, "
-            f"min log P = {min_logprob:.4f}, "
-            f"near-zero positions = {near_zero}/{gen_len}"
-        )
+            print(
+                f"  Batch {b}, beam {beam}: argmax match {argmax_matches}/{gen_len}, "
+                f"min log P = {min_logprob:.4f}, "
+                f"near-zero positions = {near_zero}/{gen_len}"
+            )
 
-        if near_zero > 0:
-            all_aligned = False
-            print(f"  FAIL: {near_zero} positions have near-zero probability")
+            if near_zero > 0:
+                all_aligned = False
+                print(f"  FAIL: {near_zero} positions have near-zero probability")
 
     return all_aligned
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generation logits are now correctly aligned with final beam search output ordering.
  * Updated guidance messaging for beam search with generation logits in streaming mode.

* **Tests**
  * Added validation test for generation logits accuracy with beam search decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

`generation_logits` are stored raw during generation - indexed by physical slot, not by beam identity. If the beam search is causing a reassignment, the end-user has no way of mapping the `generation_logits` at a given step to its beam.

This change re-orders the returned `generation_logits` based on which beam they are linked to at every generation step.

It builds a slot trace for each final beam, tracing backwards through `parentsId` to find which slot it was in at each step. This builds the slot list post-reassignment.

The slot list is then converted to the pre-reassignment slot using the `parentIds` data.

If logits reorder is needed, for each step g, logits are copied into a temporary buffer with the correct order, then copied back into the logits tensor.

## Test Coverage

New test test_whisper_beam_search_generation_logits

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
