### PR TITLE
[https://nvbugs/5973536][fix] Add NVFP4+FP8KV+MTP accuracy specs for DeepSeek-V3.2-Exp

### DIFF
--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -128,6 +128,10 @@ deepseek-ai/DeepSeek-V3.2-Exp:
   - quant_algo: NVFP4
     kv_cache_quant_algo: FP8
     accuracy: 95.2
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    spec_dec_algo: MTP
+    accuracy: 95.6
 Qwen3/Qwen3-4B:
   - spec_dec_algo: Eagle
     accuracy: 85.823

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -230,6 +230,10 @@ deepseek-ai/DeepSeek-V3.2-Exp:
   - quant_algo: NVFP4
     kv_cache_quant_algo: FP8
     accuracy: 87.9
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    spec_dec_algo: MTP
+    accuracy: 87.2
 Qwen3/Qwen3-8B:
   - quant_algo: W4A8_MXFP4_FP8
     accuracy: 72.70


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new variant configurations for DeepSeek-V3.2-Exp model with updated parameter settings
  * Updated accuracy reference baselines for GSM8K (95.6) and MMLU (87.2) benchmarks with new model variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add missing accuracy reference specs for the combination of NVFP4 quantization, FP8 KV cache, and MTP speculative decoding for the DeepSeek-V3.2-Exp model in both `mmlu.yaml` and `gsm8k.yaml`.

Without these entries, the test case `TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked]` fails with:
```
ValueError: Not registered specs: {'dtype': 'auto', 'quant_algo': <QuantAlgo.NVFP4: 'NVFP4'>, 'kv_cache_quant_algo': <QuantAlgo.FP8: 'FP8'>, 'spec_dec_algo': 'MTP', 'extra_acc_spec': None}
```

The accuracy thresholds are set to match the existing NVFP4+MTP specs (without FP8 KV), consistent with other models (e.g., DeepSeek-V3-Lite) where FP8 KV cache does not significantly affect accuracy.

## Test Coverage

- `TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked]`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.