### PR TITLE
[None][test] fx mpi type issue for l0 local mode

### DIFF
--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -312,7 +312,9 @@ def generate_srun_args(args, runtime_mode, timestamp):
 
     lines.append("--container-env=NVIDIA_IMEX_CHANNELS")
 
-    if is_aggr:
+    if args.mpi_type:
+        lines.append(f"--mpi={args.mpi_type}")
+    elif is_aggr:
         lines.append("--mpi=pmi2")
 
     return lines
@@ -422,6 +424,11 @@ def main():
         help="Nsys start-stop range for generation workers in disaggregated mode (default: 1-100)",
     )
     parser.add_argument("--test-prefix", default="", help="Test prefix")
+    parser.add_argument(
+        "--mpi-type",
+        default="",
+        help="MPI type for srun (e.g. pmix, pmi2). If not set, --mpi is not added to srun args.",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `--mpi-type` command-line option enabling users to specify MPI type for performance benchmarking, enhancing MPI configuration flexibility in performance testing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
1. fx mpi type issue for l0 local mode
