### PR TITLE
[None][fix] Fix outdated argument of readme.md for executorExampleDisaggregated.cpp

### DIFF
--- a/examples/cpp/executor/README.md
+++ b/examples/cpp/executor/README.md
@@ -129,7 +129,7 @@ For example, you can run :
 ```
 export TRTLLM_USE_UCX_KVCACHE=1
 
-mpirun -n <num_ranks> --allow-run-as-root --oversubscribe ./executorExampleDisaggregated --context_engine_dir <path_to_context_engine_dir> --context_rank_size <num_ranks_for_context> --generation_engine_dir <path_to_generation_engine_dir> --generation_rank_size <num_ranks_for_generation> --input_tokens ../inputTokens.csv
+mpirun -n <num_ranks> --allow-run-as-root --oversubscribe ./executorExampleDisaggregated --context_engine_dir <path_to_context_engine_dir> --context_rank_size <num_ranks_for_context> --generation_engine_dir <path_to_generation_engine_dir> --generation_rank_size <num_ranks_for_generation> --input_tokens_csv_file ../inputTokens.csv
 
 ```
 where `<num_ranks_for_context>` must equal to `tp*pp` for the context engine, and `<num_ranks_for_generation>` must equal to `tp*pp` for the generation engine,the context engine and generation engine can be heterogeneous in parallelism. `<num_ranks>` must equal to `<num_ranks_for_context>+<num_ranks_for_generation>+1`, the additional rank is used as orchestrator process.


### PR DESCRIPTION
### Description
I found a outdated argument for executorExampleDisaggregated in `examples/cpp/executor/README.md`.
<img width="1506" height="884" alt="image" src="https://github.com/user-attachments/assets/24f63029-c4d9-4ba4-ab13-107a2a92412e" />
The option name `input_tokens` (used for the CSV file path containing input tokens) has been replaced with the new name `input_tokens_csv_file`.
<img width="1272" height="1012" alt="image" src="https://github.com/user-attachments/assets/4abdf0e2-4b37-42ce-88dd-e7ee627c4dee" />

### Solution
Replace the outdated argument `input_tokens` with `input_tokens_csv_file`.
