### PR TITLE
[None][fix] KVCacheManagerV2 bug fixes (V2 remains default OFF)

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -134,8 +134,9 @@ class KvCacheCreator:
                         self._cache_transceiver_config is not None
                         and self._cache_transceiver_config.backend is not None):
                 logger.warning(
-                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0."
-                )
+                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0. "
+                    "Falling back to KVCacheManager.")
+                cls = KVCacheManager
         return cls
 
     def _get_kv_size_per_token(self):

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -118,22 +118,25 @@ class KvCacheCreator:
         self._net_max_seq_len = net_max_seq_len
         self._dummy_reqs = None
         self._profiling_stage_data = profiling_stage_data
-        self._kv_cache_manager_cls = get_kv_cache_manager_cls(
-            model_engine.model.model_config, kv_cache_config)
         self._execution_stream = execution_stream
-        if self._kv_cache_manager_cls == KVCacheManagerV2:
-            if kv_connector_manager is not None or (
-                    max_beam_width is not None and max_beam_width
-                    > 1) or self._kv_cache_config.event_buffer_max_size > 0:
-                logger.warning(
-                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0. "
-                    "Falling back to KVCacheManager.")
+        self._kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
+            model_engine)
         self._draft_config = draft_config
         self._skip_est = skip_est
 
     def _get_model_kv_cache_manager_cls(self, model_engine: PyTorchModelEngine):
-        return get_kv_cache_manager_cls(model_engine.model.model_config,
-                                        self._kv_cache_config)
+        cls = get_kv_cache_manager_cls(model_engine.model.model_config,
+                                       self._kv_cache_config)
+        if cls == KVCacheManagerV2:
+            if self._kv_connector_manager is not None or (
+                    self._max_beam_width is not None and self._max_beam_width
+                    > 1) or self._kv_cache_config.event_buffer_max_size > 0 or (
+                        self._cache_transceiver_config is not None
+                        and self._cache_transceiver_config.backend is not None):
+                logger.warning(
+                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0."
+                )
+        return cls
 
     def _get_kv_size_per_token(self):
         model_config = self._model_engine.model.model_config
@@ -358,8 +361,9 @@ class KvCacheCreator:
 
         free_mem, total_mem = torch.cuda.mem_get_info()
         max_memory = self._kv_cache_config.free_gpu_memory_fraction * free_mem
-        max_num_tokens_in_memory = max_memory // self._get_kv_size_per_token(
-        ) // self._tokens_per_block * self._tokens_per_block
+        max_num_tokens_in_memory = int(
+            max_memory // self._get_kv_size_per_token() //
+            self._tokens_per_block * self._tokens_per_block)
 
         # Multiply by beam width, to prevent rescaling of the max_seq_len caused by the influence of beam width during the preparation for kv_cache_estimation
         return min(

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -134,8 +134,9 @@ class KvCacheCreator:
                         self._cache_transceiver_config is not None
                         and self._cache_transceiver_config.backend is not None):
                 logger.warning(
-                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0. "
-                    "Falling back to KVCacheManager.")
+                    "KVCacheManagerV2 is not supported with kv_connector_manager, beam width > 1, "
+                    "event buffer max size > 0, or cache transceiver. Falling back to KVCacheManager."
+                )
                 cls = KVCacheManager
         return cls
 

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -116,6 +116,11 @@ class CUDAGraphRunner:
             self._create_shared_static_tensors()
         self.cuda_graph_meta_buffers = get_memory_buffers()
 
+        # On-the-fly capture is disabled by default to prevent workspace
+        # tensor reallocation from invalidating addresses baked into existing
+        # CUDA graphs.  Use allow_capture() context manager during warmup.
+        self._capture_allowed = False
+
     def _create_shared_static_tensors(self):
         """Allocates static tensors sized for the largest possible batch."""
         max_draft_len = self.config.original_max_total_draft_tokens if self.config.spec_config is not None else 0
@@ -286,7 +291,22 @@ class CUDAGraphRunner:
         return graph_attn_metadata, graph_spec_metadata, key
 
     def needs_capture(self, key: KeyType):
-        return key not in self.graph_outputs
+        return self._capture_allowed and key not in self.graph_outputs
+
+    @contextlib.contextmanager
+    def allow_capture(self):
+        """Context manager that enables CUDA graph capture.
+
+        Capture is disabled by default.  On-the-fly captures outside this
+        context are prevented because they can resize the shared
+        cuda_graph_workspace tensor, invalidating addresses baked into
+        previously captured graphs.
+        """
+        self._capture_allowed = True
+        try:
+            yield
+        finally:
+            self._capture_allowed = False
 
     def get_graph_pool(self):
         """Returns the CUDA memory pool used by this graph runner.

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -274,6 +274,11 @@ class CUDAGraphRunner:
             return self.graph_metadata[key][
                 "attn_metadata"], self.graph_metadata[key]["spec_metadata"], key
 
+        # Graph doesn't exist yet.  If on-the-fly capture is not allowed,
+        # fall back to eager so the caller doesn't need a separate check.
+        if not self._capture_allowed:
+            return None, None, None
+
         if batch_size not in self.supported_batch_sizes:
             return None, None, None
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -771,9 +771,11 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
-        self._run_cuda_graph_warmup(resource_manager)
+        with self.cuda_graph_runner.allow_capture():
+            self._run_cuda_graph_warmup(resource_manager)
         if can_run_general_warmup:
-            # Pre-populate the memory pool with max-shape allocations to reduce fragmentation at runtime.
+            # Pre-populate the memory pool with max-shape allocations to reduce
+            # fragmentation at runtime.
             warmup_requests_configs = self._get_max_shape_warmup_requests(
                 resource_manager)
             self._general_warmup(resource_manager, warmup_requests_configs)
@@ -785,6 +787,15 @@ class PyTorchModelEngine(ModelEngine):
 
         Serves both torch.compile graph specialization and memory pool pre-population.
         """
+        # Disable CUDA graph replay during general warmup to avoid replaying
+        # graphs with stale KV cache block offsets from capture time.
+        with self.no_cuda_graph():
+            self._general_warmup_impl(resource_manager,
+                                      warmup_requests_configs)
+
+    def _general_warmup_impl(self,
+                             resource_manager: ResourceManager,
+                             warmup_requests_configs: List[Tuple[int, int]]):
 
         for num_tokens, num_gen_tokens in warmup_requests_configs:
             # Helix CP does not support warmup with context requests.
@@ -1212,6 +1223,8 @@ class PyTorchModelEngine(ModelEngine):
             if gen_requests is None:
                 for r in ctx_requests:
                     kv_cache_manager.free_resources(r)
+                    if draft_kv_cache_manager is not None:
+                        draft_kv_cache_manager.free_resources(r)
                 return None
 
             if spec_resource_manager is not None:
@@ -1306,6 +1319,8 @@ class PyTorchModelEngine(ModelEngine):
         if max_seq_len_request is None:
             for r in requests:
                 kv_cache_manager.free_resources(r)
+                if draft_kv_cache_manager is not None:
+                    draft_kv_cache_manager.free_resources(r)
             return None
         else:
             max_seq_len_request = max_seq_len_request[0]
@@ -3856,6 +3871,12 @@ class PyTorchModelEngine(ModelEngine):
                         finally:
                             restore_attn_metadata_after_draft_replay(
                                 attn_metadata, saved_draft)
+                    elif key not in self.cuda_graph_runner.graphs:
+                        # Key was not captured during warmup and on-the-fly
+                        # capture is disabled — fall back to eager execution.
+                        with MoeLoadBalancerIterContext(moe_load_balancer):
+                            outputs = self._forward_step(
+                                inputs, gather_ids, gather_context_logits)
                     else:
                         saved_draft = prepare_attn_metadata_for_draft_replay(
                             attn_metadata, draft_kv_cache_manager)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -793,9 +793,9 @@ class PyTorchModelEngine(ModelEngine):
             self._general_warmup_impl(resource_manager,
                                       warmup_requests_configs)
 
-    def _general_warmup_impl(self,
-                             resource_manager: ResourceManager,
-                             warmup_requests_configs: List[Tuple[int, int]]):
+    def _general_warmup_impl(
+            self, resource_manager: ResourceManager,
+            warmup_requests_configs: List[Tuple[int, int]]) -> None:
 
         for num_tokens, num_gen_tokens in warmup_requests_configs:
             # Helix CP does not support warmup with context requests.
@@ -3871,12 +3871,6 @@ class PyTorchModelEngine(ModelEngine):
                         finally:
                             restore_attn_metadata_after_draft_replay(
                                 attn_metadata, saved_draft)
-                    elif key not in self.cuda_graph_runner.graphs:
-                        # Key was not captured during warmup and on-the-fly
-                        # capture is disabled — fall back to eager execution.
-                        with MoeLoadBalancerIterContext(moe_load_balancer):
-                            outputs = self._forward_step(
-                                inputs, gather_ids, gather_context_logits)
                     else:
                         saved_draft = prepare_attn_metadata_for_draft_replay(
                             attn_metadata, draft_kv_cache_manager)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -790,8 +790,7 @@ class PyTorchModelEngine(ModelEngine):
         # Disable CUDA graph replay during general warmup to avoid replaying
         # graphs with stale KV cache block offsets from capture time.
         with self.no_cuda_graph():
-            self._general_warmup_impl(resource_manager,
-                                      warmup_requests_configs)
+            self._general_warmup_impl(resource_manager, warmup_requests_configs)
 
     def _general_warmup_impl(
             self, resource_manager: ResourceManager,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2100,9 +2100,10 @@ class PyExecutor:
                             with torch.cuda.stream(self.execution_stream):
                                 self.drafter.prepare_draft_tokens(
                                     scheduled_batch, self.resource_manager)
-                                # Pad draft tokens to the max draft length. This is for CUDA graph compatibility.
+                                # Pad draft tokens to the max draft length and extend KV cache
+                                # capacity to match. This is for CUDA graph compatibility.
                                 self.drafter.pad_draft_tokens_for_cuda_graph(
-                                    scheduled_batch)
+                                    scheduled_batch, self.resource_manager)
                             torch.cuda.current_stream().wait_stream(
                                 self.execution_stream)
                         # add_batch must be called again to restore to target requests with updated draft tokens.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -36,6 +36,8 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import \
     KVCacheManagerConfig as KVCacheManagerConfigPy
 from tensorrt_llm.runtime.kv_cache_manager_v2 import (LayerId, TokenIdExt,
                                                       _KVCache)
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
+    gen_multi_modal_tokens
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import (BAD_PAGE_INDEX,
                                                               GPU_LEVEL)
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
@@ -680,8 +682,9 @@ class KVCacheManager(BaseResourceManager):
                         req.py_helix_is_inactive_rank = True
                         # Skip allocating KV cache at decode for inactive helix ranks.
                         continue
+                draft_len = get_draft_token_length(req)
                 self.impl.add_token(req.py_request_id)
-                for _ in range(get_draft_token_length(req)):
+                for _ in range(draft_len):
                     self.impl.add_token(req.py_request_id)
 
             # prefill and generation kernels wait for scheduled offload/onboard/partial copy work before launching
@@ -690,6 +693,17 @@ class KVCacheManager(BaseResourceManager):
         if self.kv_connector_manager is not None:
             self.kv_connector_manager.build_scheduler_output(
                 scheduled_batch, self)
+
+    def extend_capacity_for_tokens(self, request: LlmRequest,
+                                   num_tokens: int) -> None:
+        """Extend KV cache capacity for *request* by *num_tokens* extra tokens.
+
+        Used after ``pad_draft_tokens_for_cuda_graph`` to ensure the KV cache
+        has enough capacity for the padded draft tokens so that the subsequent
+        rewind does not underflow.
+        """
+        for _ in range(num_tokens):
+            self.impl.add_token(request.py_request_id)
 
     def _kv_connector_should_add_sequence(self, request: LlmRequest) -> bool:
         return self.kv_connector_manager is None or self.kv_connector_manager.should_add_sequence(
@@ -1791,11 +1805,37 @@ class KVCacheManagerV2(BaseResourceManager):
 
         cache_tiers: List[CacheTierConfig] = [GpuCacheTierConfig(quota=quota)]
         if kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size > 0:
-            cache_tiers.append(
-                HostCacheTierConfig(quota=kv_cache_config.host_cache_size))
+            host_quota = kv_cache_config.host_cache_size
+        else:
+            # The V2 MAX_UTILIZATION scheduler relies on suspend/resume to
+            # evict and later restore KV cache pages.  Without a host tier,
+            # suspended pages have nowhere to be offloaded and resume()
+            # always fails, causing a scheduling deadlock where no
+            # generation request can ever make progress.
+            #
+            # Automatically provision a host tier matching the GPU quota so
+            # suspend/resume works out of the box.  Cap at available host
+            # memory to avoid allocation failures.
+            try:
+                mem_available = os.sysconf('SC_PAGE_SIZE') * os.sysconf(
+                    'SC_AVPHYS_PAGES')
+            except (ValueError, OSError):
+                mem_available = float('inf')
+            host_quota = min(quota, int(mem_available * 0.5))
+            if host_quota <= 0:
+                host_quota = 0
+                logger.warning(
+                    "KVCacheManagerV2: could not determine available host "
+                    "memory for auto-provisioning host cache tier. "
+                    "Suspend/resume will not work. Set "
+                    "kv_cache_config.host_cache_size explicitly to enable it.")
+        if host_quota > 0:
+            cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(
-                f"KV cache manager v2 host cache quota set to {kv_cache_config.host_cache_size / (1 << 30)}GiB"
+                f"KV cache manager v2 host cache quota set to {host_quota / (1 << 30):.2f}GiB"
             )
+
+        self.vocab_size = vocab_size
 
         config = self._build_cache_config(
             kv_cache_config,
@@ -1819,12 +1859,6 @@ class KVCacheManagerV2(BaseResourceManager):
         (self.kv_cache_pool_pointers,
          self.kv_cache_pool_mapping) = self._build_pool_mapping_tensors()
 
-        # Pad max_blocks_per_seq to next multiple of 4 for copy_block_offsets kernel
-        self.max_blocks_per_seq = (max_seq_len + tokens_per_block -
-                                   1) // tokens_per_block
-        if self.max_blocks_per_seq % 4 != 0:
-            self.max_blocks_per_seq = ((self.max_blocks_per_seq + 3) // 4) * 4
-
         self.kv_cache_map: dict[int, _KVCache] = {}
 
         # Defensive cap for get_num_available_tokens: when host cache is
@@ -1845,6 +1879,17 @@ class KVCacheManagerV2(BaseResourceManager):
                 f"max_seq_len {max_seq_len} is greater than max_num_tokens {max_num_tokens} that can be allocated in kv cache manager, setting max_seq_len to {max_num_tokens}"
             )
             self.max_seq_len = max_num_tokens
+
+        # Pad max_blocks_per_seq to next multiple of 4 for copy_block_offsets kernel.
+        # Computed after max_seq_len clamping, but account for extra tokens
+        # (num_extra_kv_tokens + max_total_draft_tokens) so the host
+        # page-index buffer is large enough for the maximum capacity a single
+        # sequence can reach during warmup or normal operation.
+        max_seq_capacity = self.max_seq_len + self.num_extra_kv_tokens + self.max_total_draft_tokens
+        self.max_blocks_per_seq = (max_seq_capacity + tokens_per_block -
+                                   1) // tokens_per_block
+        if self.max_blocks_per_seq % 4 != 0:
+            self.max_blocks_per_seq = ((self.max_blocks_per_seq + 3) // 4) * 4
 
         self.enable_block_reuse = kv_cache_config.enable_block_reuse
         self.enable_partial_reuse = kv_cache_config.enable_partial_reuse
@@ -2168,10 +2213,14 @@ class KVCacheManagerV2(BaseResourceManager):
             if kv_cache is None:
                 # Last token cannot be recovered, so we don't include it in
                 # the input tokens to look up for the block that can be reused.
-                kv_cache = self._create_kv_cache(
-                    req.py_request_id, req.lora_task_id,
-                    req.get_tokens(DEFAULT_BEAM_INDEX)[:-1]
-                    if self.enable_block_reuse else None)
+                if self.enable_block_reuse:
+                    all_tokens = req.get_tokens(DEFAULT_BEAM_INDEX)
+                    tokens = self._augment_tokens_for_block_reuse(
+                        all_tokens, req, end=len(all_tokens) - 1)
+                else:
+                    tokens = None
+                kv_cache = self._create_kv_cache(req.py_request_id,
+                                                 req.lora_task_id, tokens)
                 kv_cache.cuda_stream = self._stream.cuda_stream
 
             if not self.enable_block_reuse:
@@ -2215,6 +2264,25 @@ class KVCacheManagerV2(BaseResourceManager):
             return False
 
         return True
+
+    def extend_capacity_for_tokens(self, request: LlmRequest,
+                                   num_tokens: int) -> None:
+        """Extend KV cache capacity for *request* by *num_tokens* extra tokens.
+
+        Used after ``pad_draft_tokens_for_cuda_graph`` to ensure the KV cache
+        has enough capacity for the padded draft tokens so that the subsequent
+        rewind does not underflow.
+        """
+        if num_tokens <= 0:
+            return
+        kv_cache = self.kv_cache_map[request.py_request_id]
+        new_capacity = kv_cache.capacity + num_tokens
+        success = kv_cache.resize(new_capacity)
+        if not success:
+            raise ValueError(
+                f"Failed to extend capacity of KV cache for request "
+                f"{request.py_request_id} by {num_tokens} tokens "
+                f"(target capacity {new_capacity})")
 
     def suspend_request(self, req: LlmRequest) -> None:
         """Suspend a request's KV cache (move to host tier)."""
@@ -2278,6 +2346,58 @@ class KVCacheManagerV2(BaseResourceManager):
                         f"Draft KV cache generation resize failed for request "
                         f"{req.py_request_id}: could not resize to {new_cap} tokens"
                     )
+
+    def _augment_tokens_for_block_reuse(
+            self,
+            tokens: Sequence[int],
+            req: LlmRequest,
+            start: int = 0,
+            end: int | None = None) -> Sequence[TokenIdExt]:
+        """Augment token sequence with multimodal content digests for block reuse.
+
+        Multimodal placeholder tokens (e.g. image_token_id) share the same ID
+        regardless of the underlying content. This method replaces each
+        multimodal token region with TokenIdExt values produced by
+        gen_multi_modal_tokens(), embedding the content digest (Blake3 hash)
+        into the token sequence so that the radix tree can distinguish blocks
+        belonging to different images/videos.
+
+        When *start*/*end* are given, only the slice ``tokens[start:end]`` is
+        materialized and returned. This avoids re-augmenting the full prompt
+        on every chunk during chunked prefill.
+
+        For text-only requests this is a no-op.
+        """
+        if end is None:
+            end = len(tokens)
+        is_sliced = start != 0 or end != len(tokens)
+
+        if (req.multimodal_hashes is None or req.multimodal_positions is None
+                or req.multimodal_lengths is None):
+            return tokens[start:end] if is_sliced else tokens
+
+        result: list[TokenIdExt] = list(tokens[start:end])
+        for hash_ints, pos, length in zip(req.multimodal_hashes,
+                                          req.multimodal_positions,
+                                          req.multimodal_lengths):
+            mm_end = pos + length
+            # Skip multimodal items outside [start, end).
+            if mm_end <= start or pos >= end:
+                continue
+            # Convert 8 x int32 hash to 32-byte digest (big-endian,
+            # matching v1 C++ getNthByte which extracts MSB first).
+            digest = b''.join(
+                v.to_bytes(4, 'big', signed=True) for v in hash_ints)
+            mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest, length)
+            # Overlap between [pos, mm_end) and [start, end).
+            overlap_start = max(pos, start)
+            overlap_end = min(mm_end, end)
+            mm_offset = overlap_start - pos
+            result_offset = overlap_start - start
+            n = overlap_end - overlap_start
+            result[result_offset:result_offset +
+                   n] = mm_tokens[mm_offset:mm_offset + n]
+        return result
 
     def get_kv_cache_stats(self):
         kv_cache_stats = KvCacheStats()
@@ -2381,7 +2501,7 @@ class KVCacheManagerV2(BaseResourceManager):
                     draft_kv_cache = draft_kv_cache_manager._create_kv_cache(
                         req.py_request_id, req.lora_task_id, input_tokens)
                     success = draft_kv_cache.resume(
-                        torch.cuda.current_stream().cuda_stream)
+                        draft_kv_cache_manager._stream.cuda_stream)
                     if not success:
                         release_resources(req, free_draft_resources=True)
                         return None
@@ -2401,7 +2521,9 @@ class KVCacheManagerV2(BaseResourceManager):
                     success = kv_cache.resize(new_capacity,
                                               history_length=history_hint)
                     if not success:
-                        release_resources(req)
+                        release_resources(req,
+                                          free_draft_resources=draft_kv_cache
+                                          is not None)
                         return None
                     if draft_kv_cache is not None:
                         success = draft_kv_cache.resize(new_capacity)
@@ -2436,23 +2558,28 @@ class KVCacheManagerV2(BaseResourceManager):
                 and request.context_current_position
                 > kv_cache.num_committed_tokens):
             # When block reuse is enabled, before freeing the resources, we need to commit the tokens to prepare for reuse if it is not committed yet.
-            kv_cache.commit(
-                request.get_tokens(0)[kv_cache.num_committed_tokens:request.
-                                      context_current_position])
+            tokens = self._augment_tokens_for_block_reuse(
+                request.get_tokens(DEFAULT_BEAM_INDEX),
+                request,
+                start=kv_cache.num_committed_tokens,
+                end=request.context_current_position)
+            kv_cache.commit(tokens)
             kv_cache.stop_committing()
         kv_cache.close()
         self.index_mapper.remove_sequence(request.py_request_id)
 
-    def get_batch_cache_indices(self,
-                                request_ids: List[int],
-                                layer_id: int = 0) -> List[List[int]]:
-
-        # returns the block numbers needed for each request
-        return self._get_batch_cache_indices_by_pool_id(
-            request_ids,
-            pool_id=self.layer_to_pool_mapping_dict[
-                self.layer_offsets[layer_id]],
-            is_kv_aggregate=True)
+    def get_batch_cache_indices(
+            self,
+            request_ids: List[int],
+            layer_id: Optional[int] = None) -> List[List[int]]:
+        if layer_id is None:
+            pool_id = 0
+        else:
+            pool_id = self.layer_to_pool_mapping_dict[
+                self.layer_offsets[layer_id]]
+        return self._get_batch_cache_indices_by_pool_id(request_ids,
+                                                        pool_id=pool_id,
+                                                        is_kv_aggregate=True)
 
     def _get_batch_cache_indices_by_pool_id(
             self,
@@ -2668,21 +2795,16 @@ class KVCacheManagerV2(BaseResourceManager):
                 continue
             if self.enable_block_reuse and not self.is_draft and not req.is_dummy_request:
                 if req.context_current_position > kv_cache.num_committed_tokens:
-                    kv_cache.commit(
-                        req.get_tokens(DEFAULT_BEAM_INDEX)
-                        [kv_cache.num_committed_tokens:req.
-                         context_current_position])
+                    tokens = self._augment_tokens_for_block_reuse(
+                        req.get_tokens(DEFAULT_BEAM_INDEX),
+                        req,
+                        start=kv_cache.num_committed_tokens,
+                        end=req.context_current_position)
+                    kv_cache.commit(tokens)
                 if req.context_remaining_length == 0:
                     kv_cache.stop_committing()
             else:
-                # For draft managers, prepare_resources may have failed to
-                # resize capacity (OOM). Ensure capacity >= history_length
-                # before setting history_length to avoid ValueError.
-                new_capacity = None
-                if self.is_draft and kv_cache.capacity < req.context_current_position:
-                    new_capacity = req.context_current_position + self.num_extra_kv_tokens
-                success = kv_cache.resize(new_capacity,
-                                          req.context_current_position)
+                success = kv_cache.resize(None, req.context_current_position)
                 if not success:
                     raise ValueError(
                         f"Failed to resize history length of KV cache for request {req.py_request_id} to {req.context_current_position} tokens at context update"

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -694,16 +694,8 @@ class KVCacheManager(BaseResourceManager):
             self.kv_connector_manager.build_scheduler_output(
                 scheduled_batch, self)
 
-    def extend_capacity_for_tokens(self, request: LlmRequest,
-                                   num_tokens: int) -> None:
-        """Extend KV cache capacity for *request* by *num_tokens* extra tokens.
-
-        Used after ``pad_draft_tokens_for_cuda_graph`` to ensure the KV cache
-        has enough capacity for the padded draft tokens so that the subsequent
-        rewind does not underflow.
-        """
-        for _ in range(num_tokens):
-            self.impl.add_token(request.py_request_id)
+    def extend_capacity_for_tokens(self, request: LlmRequest) -> None:
+        """No-op for V1; interface kept consistent with V2."""
 
     def _kv_connector_should_add_sequence(self, request: LlmRequest) -> bool:
         return self.kv_connector_manager is None or self.kv_connector_manager.should_add_sequence(
@@ -1823,12 +1815,7 @@ class KVCacheManagerV2(BaseResourceManager):
                 mem_available = float('inf')
             host_quota = min(quota, int(mem_available * 0.5))
             if host_quota <= 0:
-                host_quota = 0
-                logger.warning(
-                    "KVCacheManagerV2: could not determine available host "
-                    "memory for auto-provisioning host cache tier. "
-                    "Suspend/resume will not work. Set "
-                    "kv_cache_config.host_cache_size explicitly to enable it.")
+                host_quota = quota
         if host_quota > 0:
             cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(
@@ -1861,6 +1848,12 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self.kv_cache_map: dict[int, _KVCache] = {}
 
+        # Tracks the draft length allocated by try_allocate_generation per
+        # request.  Used by extend_capacity_for_tokens to compute the exact
+        # padding delta instead of blindly extending, which would cause
+        # unbounded capacity growth.
+        self._allocated_draft_lens: dict[int, int] = {}
+
         # Defensive cap for get_num_available_tokens: when host cache is
         # enabled, clamp_max_seq_len_for_mem may return a value that spans
         # both GPU and host tiers.  Storing the explicit max_tokens (if set)
@@ -1885,7 +1878,9 @@ class KVCacheManagerV2(BaseResourceManager):
         # (num_extra_kv_tokens + max_total_draft_tokens) so the host
         # page-index buffer is large enough for the maximum capacity a single
         # sequence can reach during warmup or normal operation.
-        max_seq_capacity = self.max_seq_len + self.num_extra_kv_tokens + self.max_total_draft_tokens
+        # The +1 accounts for the base decode token that
+        # _required_gen_capacity adds on top of draft tokens.
+        max_seq_capacity = self.max_seq_len + self.num_extra_kv_tokens + self.max_total_draft_tokens + 1
         self.max_blocks_per_seq = (max_seq_capacity + tokens_per_block -
                                    1) // tokens_per_block
         if self.max_blocks_per_seq % 4 != 0:
@@ -2093,12 +2088,12 @@ class KVCacheManagerV2(BaseResourceManager):
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.
         # We need to add extra tokens to the token num upper bound to account for the extra tokens.
         clamped = self.impl.clamp_max_seq_len_for_mem(
-            batch_size, token_num_upper_bound + extra_tokens) - extra_tokens
+            batch_size, token_num_upper_bound + extra_tokens) - 2 * extra_tokens
         # clamp_max_seq_len_for_mem considers all tiers (GPU + host).  When
         # max_tokens is explicitly set, cap by GPU-only capacity so callers
         # (e.g. CUDA graph warmup) don't exceed the GPU pool.
         if self._gpu_max_tokens is not None:
-            clamped = min(clamped, self._gpu_max_tokens)
+            clamped = min(clamped, self._gpu_max_tokens - extra_tokens)
         return clamped
 
     def get_num_free_blocks(self) -> int:
@@ -2144,6 +2139,8 @@ class KVCacheManagerV2(BaseResourceManager):
                 return False
             self._restore_page_index_bufs(req.py_request_id, kv_cache)
 
+        draft_len = get_draft_token_length(req)
+        self._allocated_draft_lens[req.py_request_id] = draft_len
         return kv_cache.resize(
             self._required_gen_capacity(req, kv_cache.capacity))
 
@@ -2265,23 +2262,31 @@ class KVCacheManagerV2(BaseResourceManager):
 
         return True
 
-    def extend_capacity_for_tokens(self, request: LlmRequest,
-                                   num_tokens: int) -> None:
-        """Extend KV cache capacity for *request* by *num_tokens* extra tokens.
+    def extend_capacity_for_tokens(self, request: LlmRequest) -> None:
+        """Extend KV cache capacity for the CUDA-graph padding delta.
 
-        Used after ``pad_draft_tokens_for_cuda_graph`` to ensure the KV cache
-        has enough capacity for the padded draft tokens so that the subsequent
-        rewind does not underflow.
+        ``try_allocate_generation`` allocated capacity for the schedule-reduced
+        draft length.  After padding restores ``py_draft_tokens`` to the static
+        max, we must extend by exactly the difference so that the subsequent
+        rewind (which operates on the padded length) does not underflow.
+
+        The delta is computed from ``_allocated_draft_lens`` (recorded by
+        ``try_allocate_generation``) vs the current draft length (post-padding).
         """
-        if num_tokens <= 0:
+        allocated = self._allocated_draft_lens.pop(request.py_request_id, None)
+        if allocated is None:
+            return
+        current_draft_len = get_draft_token_length(request)
+        delta = current_draft_len - allocated
+        if delta <= 0:
             return
         kv_cache = self.kv_cache_map[request.py_request_id]
-        new_capacity = kv_cache.capacity + num_tokens
+        new_capacity = kv_cache.capacity + delta
         success = kv_cache.resize(new_capacity)
         if not success:
             raise ValueError(
                 f"Failed to extend capacity of KV cache for request "
-                f"{request.py_request_id} by {num_tokens} tokens "
+                f"{request.py_request_id} by {delta} tokens "
                 f"(target capacity {new_capacity})")
 
     def suspend_request(self, req: LlmRequest) -> None:
@@ -2550,6 +2555,7 @@ class KVCacheManagerV2(BaseResourceManager):
         return requests
 
     def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
+        self._allocated_draft_lens.pop(request.py_request_id, None)
         kv_cache = self.kv_cache_map.pop(request.py_request_id, None)
         if kv_cache is None:
             return

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2088,7 +2088,7 @@ class KVCacheManagerV2(BaseResourceManager):
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.
         # We need to add extra tokens to the token num upper bound to account for the extra tokens.
         clamped = self.impl.clamp_max_seq_len_for_mem(
-            batch_size, token_num_upper_bound + extra_tokens) - 2 * extra_tokens
+            batch_size, token_num_upper_bound) - extra_tokens
         # clamp_max_seq_len_for_mem considers all tiers (GPU + host).  When
         # max_tokens is explicitly set, cap by GPU-only capacity so callers
         # (e.g. CUDA graph warmup) don't exceed the GPU pool.
@@ -2384,13 +2384,17 @@ class KVCacheManagerV2(BaseResourceManager):
         result: list[TokenIdExt] = list(tokens[start:end])
         for hash_ints, pos, length in zip(req.multimodal_hashes,
                                           req.multimodal_positions,
-                                          req.multimodal_lengths):
+                                          req.multimodal_lengths,
+                                          strict=True):
             mm_end = pos + length
             # Skip multimodal items outside [start, end).
             if mm_end <= start or pos >= end:
                 continue
             # Convert 8 x int32 hash to 32-byte digest (big-endian,
             # matching v1 C++ getNthByte which extracts MSB first).
+            assert len(
+                hash_ints
+            ) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
             digest = b''.join(
                 v.to_bytes(4, 'big', signed=True) for v in hash_ints)
             mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest, length)
@@ -2577,12 +2581,12 @@ class KVCacheManagerV2(BaseResourceManager):
     def get_batch_cache_indices(
             self,
             request_ids: List[int],
-            layer_id: Optional[int] = None) -> List[List[int]]:
-        if layer_id is None:
+            layer_idx: Optional[int] = None) -> List[List[int]]:
+        if layer_idx is None:
             pool_id = 0
         else:
             pool_id = self.layer_to_pool_mapping_dict[
-                self.layer_offsets[layer_id]]
+                self.layer_offsets[layer_idx]]
         return self._get_batch_cache_indices_by_pool_id(request_ids,
                                                         pool_id=pool_id,
                                                         is_kv_aggregate=True)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -102,6 +102,19 @@ class BudgetTracker:
             return None
         return required
 
+    def pre_claim_peft(self, req: LlmRequest) -> None:
+        """Reserve PEFT pages for a non-scheduled request whose adapter is
+        still loaded on device (e.g. GENERATION_TO_COMPLETE in the overlap
+        executor — not yet terminated, so ensure_batch cannot evict it)."""
+        if self._peft_cache_manager is None:
+            return
+        lora_task_id = req.lora_task_id
+        if lora_task_id is None or lora_task_id in self._seen_peft_task_ids:
+            return
+        pages = self._peft_cache_manager.determine_num_pages(req)
+        self._claimed_peft_pages += pages
+        self._seen_peft_task_ids.add(lora_task_id)
+
 
 class KVCacheV2Scheduler(RequestScheduler):
     """Interleaved scheduler for KV Cache Manager V2.
@@ -168,6 +181,8 @@ class KVCacheV2Scheduler(RequestScheduler):
         self._context_init_state_value = LlmRequestState.CONTEXT_INIT.value
         self._encoder_init_state_value = LlmRequestState.ENCODER_INIT.value
         self._disagg_gen_init_state_value = LlmRequestState.DISAGG_GENERATION_INIT.value
+        self._gen_to_complete_state_value = LlmRequestState.GENERATION_TO_COMPLETE.value
+        self._consecutive_empty_schedules = 0
 
     def schedule_request(
         self, active_requests: RequestList, inflight_request_ids: set[int]
@@ -217,6 +232,27 @@ class KVCacheV2Scheduler(RequestScheduler):
         req_it_end = len(requests_list)
         req_it = 0
 
+        # Context requests are always deferred to a second phase so that
+        # generation requests are fully accounted for in the budget before
+        # any context request competes for resources.  This mirrors the
+        # two-phase approach of the old KVCacheV2DummyScheduler and
+        # prevents PEFT adapter eviction failures when gen requests hold
+        # adapters that can't be evicted mid-iteration.
+        pending_ctx: RequestList = []
+
+        # Pre-claim PEFT pages for GENERATION_TO_COMPLETE requests.
+        # In the overlap executor these requests are no longer scheduled
+        # (state outside schedulable range) but their adapters haven't
+        # been released yet (mark_request_done runs after prepare_resources
+        # in the next iteration).  Without this, the budget would appear
+        # empty and context requests with a different adapter could be
+        # admitted, causing ensure_batch to crash when it can't evict the
+        # still-active adapter.
+        for req in requests_list:
+            if req.state_value == self._gen_to_complete_state_value:
+                budget.pre_claim_peft(req)
+
+        # --- Phase 1: generation / disagg only ---
         while req_it < req_it_end:
             if budget.requests_full:
                 break
@@ -254,30 +290,25 @@ class KVCacheV2Scheduler(RequestScheduler):
                 req_it += 1
                 continue
 
-            peft_pages = budget.peft_pages_needed(req)
-            if peft_pages is None:
-                break
-
             # --- Dispatch by request type ---
-            if req_state_value == self._encoder_init_state_value:
-                action, tokens = self._try_schedule_encoder(req, budget)
-                if action is ScheduleAction.STOP:
-                    break
-                scheduled_ctx.append(req)
-                budget.commit(req, tokens, peft_pages)
-
-            elif req_state_value == self._context_init_state_value:
-                action, tokens, chunking_flag = self._try_schedule_context(req, budget)
-                if action is ScheduleAction.STOP:
-                    break
-                if action is ScheduleAction.SKIP:
-                    req_it += 1
-                    continue
-                has_chunking = has_chunking or chunking_flag
-                scheduled_ctx.append(req)
-                budget.commit(req, tokens, peft_pages)
+            if (
+                req_state_value == self._encoder_init_state_value
+                or req_state_value == self._context_init_state_value
+            ):
+                # Always defer to phase 2.
+                pending_ctx.append(req)
+                req_it += 1
+                continue
 
             else:
+                peft_pages = budget.peft_pages_needed(req)
+                if peft_pages is None:
+                    # V1 parity: never reject gen requests for PEFT budget.
+                    # Gen adapters were loaded during their context phase
+                    # and remain on device.  The phase-2 budget guard on
+                    # context requests ensures conflicting adapters cannot
+                    # enter gen simultaneously.
+                    peft_pages = 0
                 action, tokens, scheduled_beam_width, req_it_end = self._try_schedule_generation(
                     req,
                     budget,
@@ -296,6 +327,61 @@ class KVCacheV2Scheduler(RequestScheduler):
                 budget.commit(req, tokens, peft_pages)
 
             req_it += 1
+
+        # --- Phase 2: schedule deferred context / encoder requests ---
+        # Generation PEFT pages are now fully committed in the budget.
+        for req in pending_ctx:
+            if budget.requests_full:
+                break
+            peft_pages = budget.peft_pages_needed(req)
+            if peft_pages is None:
+                continue
+            if req.state_value == self._encoder_init_state_value:
+                action, tokens = self._try_schedule_encoder(req, budget)
+                if action is ScheduleAction.STOP:
+                    break
+                scheduled_ctx.append(req)
+                budget.commit(req, tokens, peft_pages)
+            else:
+                action, tokens, chunking_flag = self._try_schedule_context(req, budget)
+                if action is ScheduleAction.STOP:
+                    break
+                if action is ScheduleAction.SKIP:
+                    continue
+                has_chunking = has_chunking or chunking_flag
+                scheduled_ctx.append(req)
+                budget.commit(req, tokens, peft_pages)
+
+        # Deadlock detection: if generation requests exist but none were
+        # scheduled and none were evicted for several consecutive rounds,
+        # no forward pass will run and no KV cache pages will ever be
+        # freed — the scheduler will spin forever.  This typically happens
+        # when the KV cache pool is exhausted and no host cache tier is
+        # available for suspend/resume.
+        if not scheduled_gen and not scheduled_ctx:
+            num_gen_candidates = sum(
+                1
+                for r in active_requests
+                if r.is_generation_in_progress_state
+                and not r.is_generation_to_complete_state
+                and r.request_id not in inflight_request_ids
+            )
+            if num_gen_candidates > 0 and not evicted:
+                self._consecutive_empty_schedules += 1
+                if self._consecutive_empty_schedules >= 10:
+                    raise RuntimeError(
+                        f"V2 scheduler deadlock: {num_gen_candidates} generation "
+                        f"request(s) active but none could be scheduled or "
+                        f"evicted for {self._consecutive_empty_schedules} "
+                        f"consecutive rounds. KV cache pool is likely exhausted "
+                        f"with no host cache tier for suspend/resume offload. "
+                        f"Configure kv_cache_config.host_cache_size or increase "
+                        f"kv_cache_config.max_tokens."
+                    )
+            else:
+                self._consecutive_empty_schedules = 0
+        else:
+            self._consecutive_empty_schedules = 0
 
         return scheduled_ctx, scheduled_gen, evicted, disagg_candidates, has_chunking
 
@@ -490,7 +576,14 @@ class KVCacheV2Scheduler(RequestScheduler):
         ) or req.is_generation_in_progress_state
 
     def _suspend_request(self, req: LlmRequest) -> None:
-        """Suspend a request's KV cache in both main and draft managers."""
+        """Suspend a request's KV cache in both main and draft managers.
+
+        TODO: Also release PEFT resources (mark_request_done) for the
+        suspended request so the C++ PeftCacheManager can evict its
+        adapter pages.  Currently only KV cache is freed; the adapter
+        remains "active" on device, which could cause ensure_batch to
+        fail if it needs to load a different adapter into a full cache.
+        """
         self.kv_cache_manager.suspend_request(req)
         if self.draft_kv_cache_manager is not None:
             self.draft_kv_cache_manager.suspend_request(req)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -108,7 +108,7 @@ class BudgetTracker:
         executor — not yet terminated, so ensure_batch cannot evict it)."""
         if self._peft_cache_manager is None:
             return
-        lora_task_id = req.lora_task_id
+        lora_task_id = getattr(req, "lora_task_id", None)
         if lora_task_id is None or lora_task_id in self._seen_peft_task_ids:
             return
         pages = self._peft_cache_manager.determine_num_pages(req)
@@ -182,7 +182,6 @@ class KVCacheV2Scheduler(RequestScheduler):
         self._encoder_init_state_value = LlmRequestState.ENCODER_INIT.value
         self._disagg_gen_init_state_value = LlmRequestState.DISAGG_GENERATION_INIT.value
         self._gen_to_complete_state_value = LlmRequestState.GENERATION_TO_COMPLETE.value
-        self._consecutive_empty_schedules = 0
 
     def schedule_request(
         self, active_requests: RequestList, inflight_request_ids: set[int]
@@ -295,7 +294,7 @@ class KVCacheV2Scheduler(RequestScheduler):
                 req_state_value == self._encoder_init_state_value
                 or req_state_value == self._context_init_state_value
             ):
-                # Always defer to phase 2.
+                # Defer to phase 2 so gen PEFT budget is settled first.
                 pending_ctx.append(req)
                 req_it += 1
                 continue
@@ -303,12 +302,7 @@ class KVCacheV2Scheduler(RequestScheduler):
             else:
                 peft_pages = budget.peft_pages_needed(req)
                 if peft_pages is None:
-                    # V1 parity: never reject gen requests for PEFT budget.
-                    # Gen adapters were loaded during their context phase
-                    # and remain on device.  The phase-2 budget guard on
-                    # context requests ensures conflicting adapters cannot
-                    # enter gen simultaneously.
-                    peft_pages = 0
+                    break
                 action, tokens, scheduled_beam_width, req_it_end = self._try_schedule_generation(
                     req,
                     budget,
@@ -353,11 +347,10 @@ class KVCacheV2Scheduler(RequestScheduler):
                 budget.commit(req, tokens, peft_pages)
 
         # Deadlock detection: if generation requests exist but none were
-        # scheduled and none were evicted for several consecutive rounds,
-        # no forward pass will run and no KV cache pages will ever be
-        # freed — the scheduler will spin forever.  This typically happens
-        # when the KV cache pool is exhausted and no host cache tier is
-        # available for suspend/resume.
+        # scheduled and none were evicted, no forward pass will run and no
+        # KV cache pages will ever be freed — the scheduler will spin
+        # forever.  This typically happens when the KV cache pool is
+        # exhausted and no host cache tier is available for suspend/resume.
         if not scheduled_gen and not scheduled_ctx:
             num_gen_candidates = sum(
                 1
@@ -367,21 +360,14 @@ class KVCacheV2Scheduler(RequestScheduler):
                 and r.request_id not in inflight_request_ids
             )
             if num_gen_candidates > 0 and not evicted:
-                self._consecutive_empty_schedules += 1
-                if self._consecutive_empty_schedules >= 10:
-                    raise RuntimeError(
-                        f"V2 scheduler deadlock: {num_gen_candidates} generation "
-                        f"request(s) active but none could be scheduled or "
-                        f"evicted for {self._consecutive_empty_schedules} "
-                        f"consecutive rounds. KV cache pool is likely exhausted "
-                        f"with no host cache tier for suspend/resume offload. "
-                        f"Configure kv_cache_config.host_cache_size or increase "
-                        f"kv_cache_config.max_tokens."
-                    )
-            else:
-                self._consecutive_empty_schedules = 0
-        else:
-            self._consecutive_empty_schedules = 0
+                raise RuntimeError(
+                    f"V2 scheduler deadlock: {num_gen_candidates} generation "
+                    f"request(s) active but none could be scheduled or "
+                    f"evicted. KV cache pool is likely exhausted with no "
+                    f"host cache tier for suspend/resume offload. "
+                    f"Configure kv_cache_config.host_cache_size or increase "
+                    f"kv_cache_config.max_tokens."
+                )
 
         return scheduled_ctx, scheduled_gen, evicted, disagg_candidates, has_chunking
 

--- a/tensorrt_llm/_torch/speculative/drafter.py
+++ b/tensorrt_llm/_torch/speculative/drafter.py
@@ -66,18 +66,61 @@ class Drafter(ABC):
 
     @final
     def pad_draft_tokens_for_cuda_graph(
-            self, scheduled_requests: ScheduledRequests) -> None:
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
         """
-        Pad draft tokens to the static max total draft tokens for CUDA graph compatibility.
+        Pad draft tokens to the static max total draft tokens for CUDA graph
+        compatibility, then extend KV cache capacity to match the padded length.
+
+        When draft_len_schedule reduces the draft length below the static max,
+        prepare_resources allocates KV cache capacity for the shorter length.
+        After padding restores py_draft_tokens to the static max, the sampler
+        will compute py_rewind_len from the padded length.  Without extending
+        capacity here, the rewind would exceed the allocated capacity.
+
+        Subclasses override ``_extend_kv_cache_for_padding`` to extend the
+        appropriate KV cache managers (main-only for NGram, main + draft for
+        two-model).  One-model drafters inherit the default no-op because
+        SpecSamplerBase computes rewind from runtime_draft_len, not
+        len(py_draft_tokens).
 
         Args:
             scheduled_requests: The scheduled requests to pad
+            resource_manager: The composite resource manager (needed for
+                KV cache extension when draft_len_schedule is active)
         """
+        # Capture pre-padding draft token lengths per request
+        pre_padding_lens: Dict[int, int] = {}
+        pad_to = self._static_max_total_draft_tokens
         for req in scheduled_requests.generation_requests:
             num_draft_tokens = get_draft_token_length(req)
+            pre_padding_lens[req.py_request_id] = num_draft_tokens
             req.py_draft_tokens.extend(
-                0 for _ in range(self._static_max_total_draft_tokens -
-                                 num_draft_tokens))
+                0 for _ in range(pad_to - num_draft_tokens))
+
+        # Let subclasses extend KV cache capacity for the extra padding
+        if resource_manager is not None:
+            self._extend_kv_cache_for_padding(scheduled_requests,
+                                              resource_manager,
+                                              pre_padding_lens)
+
+    def _extend_kv_cache_for_padding(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        pre_padding_lens: Dict[int, int],
+    ) -> None:
+        """Extend KV cache capacity to cover CUDA-graph padding tokens.
+
+        Default implementation is a no-op, which is correct for one-model
+        drafters (MTP / Eagle3 / SA) whose sampler computes rewind from
+        ``runtime_draft_len`` rather than ``len(py_draft_tokens)``.
+
+        Subclasses that use ``TorchSampler`` (NGram, two-model) must override
+        to extend the appropriate KV cache manager(s).
+        """
 
     def get_draft_len_for_batch_size(self, batch_size: int) -> int:
         """

--- a/tensorrt_llm/_torch/speculative/drafter.py
+++ b/tensorrt_llm/_torch/speculative/drafter.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, final
 from tensorrt_llm.logger import logger
 
 from ..pyexecutor.llm_request import LlmRequest, get_draft_token_length
-from ..pyexecutor.resource_manager import ResourceManager
+from ..pyexecutor.resource_manager import ResourceManager, ResourceManagerType
 from ..pyexecutor.scheduler import ScheduledRequests
 
 
@@ -64,63 +64,44 @@ class Drafter(ABC):
         num_effective_requests = min(len(requests), max_batch_size, token_cap)
         return num_effective_requests <= self.max_concurrency
 
+    # Drafters that use TorchSampler (NGram, two-model) compute py_rewind_len
+    # from len(py_draft_tokens), which includes padding.  They must set this
+    # to True so that extend_capacity_for_tokens is called after padding.
+    # One-model drafters (MTP / Eagle3 / SA) use SpecSamplerBase which
+    # computes rewind from runtime_draft_len, so padding is harmless.
+    _needs_padding_kv_extension: bool = False
+
     @final
     def pad_draft_tokens_for_cuda_graph(
         self,
         scheduled_requests: ScheduledRequests,
         resource_manager: Optional[ResourceManager] = None,
     ) -> None:
-        """
-        Pad draft tokens to the static max total draft tokens for CUDA graph
-        compatibility, then extend KV cache capacity to match the padded length.
+        """Pad draft tokens to the static max for CUDA graph compatibility.
 
-        When draft_len_schedule reduces the draft length below the static max,
+        When draft_len_schedule reduces draft length below the static max,
         prepare_resources allocates KV cache capacity for the shorter length.
-        After padding restores py_draft_tokens to the static max, the sampler
-        will compute py_rewind_len from the padded length.  Without extending
-        capacity here, the rewind would exceed the allocated capacity.
-
-        Subclasses override ``_extend_kv_cache_for_padding`` to extend the
-        appropriate KV cache managers (main-only for NGram, main + draft for
-        two-model).  One-model drafters inherit the default no-op because
-        SpecSamplerBase computes rewind from runtime_draft_len, not
-        len(py_draft_tokens).
-
-        Args:
-            scheduled_requests: The scheduled requests to pad
-            resource_manager: The composite resource manager (needed for
-                KV cache extension when draft_len_schedule is active)
+        After padding restores py_draft_tokens to the static max, drafters
+        whose sampler uses the padded length for rewind need the KV cache
+        capacity extended to match.  The KV cache manager itself computes
+        the exact delta from its internal tracking.
         """
-        # Capture pre-padding draft token lengths per request
-        pre_padding_lens: Dict[int, int] = {}
         pad_to = self._static_max_total_draft_tokens
         for req in scheduled_requests.generation_requests:
             num_draft_tokens = get_draft_token_length(req)
-            pre_padding_lens[req.py_request_id] = num_draft_tokens
             req.py_draft_tokens.extend(
                 0 for _ in range(pad_to - num_draft_tokens))
 
-        # Let subclasses extend KV cache capacity for the extra padding
-        if resource_manager is not None:
-            self._extend_kv_cache_for_padding(scheduled_requests,
-                                              resource_manager,
-                                              pre_padding_lens)
-
-    def _extend_kv_cache_for_padding(
-        self,
-        scheduled_requests: ScheduledRequests,
-        resource_manager: ResourceManager,
-        pre_padding_lens: Dict[int, int],
-    ) -> None:
-        """Extend KV cache capacity to cover CUDA-graph padding tokens.
-
-        Default implementation is a no-op, which is correct for one-model
-        drafters (MTP / Eagle3 / SA) whose sampler computes rewind from
-        ``runtime_draft_len`` rather than ``len(py_draft_tokens)``.
-
-        Subclasses that use ``TorchSampler`` (NGram, two-model) must override
-        to extend the appropriate KV cache manager(s).
-        """
+        if self._needs_padding_kv_extension and resource_manager is not None:
+            kv_mgr = resource_manager.get_resource_manager(
+                ResourceManagerType.KV_CACHE_MANAGER)
+            draft_kv_mgr = resource_manager.get_resource_manager(
+                ResourceManagerType.DRAFT_KV_CACHE_MANAGER)
+            for req in scheduled_requests.generation_requests:
+                if kv_mgr is not None:
+                    kv_mgr.extend_capacity_for_tokens(req)
+                if draft_kv_mgr is not None:
+                    draft_kv_mgr.extend_capacity_for_tokens(req)
 
     def get_draft_len_for_batch_size(self, batch_size: int) -> int:
         """

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -11,8 +11,7 @@ from tensorrt_llm.logger import logger
 from ..attention_backend.trtllm import TrtllmAttention
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
-from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
-                                      get_draft_token_length)
+from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
                                            ResourceManagerType)
 from ..pyexecutor.sampler import Sampler, SampleState, SampleStateTensors
@@ -52,6 +51,8 @@ def get_draft_model_prompt(spec_dec_mode: SpeculativeDecodingMode,
 
 class ModelDrafter(Drafter):
     """Model-based drafter that uses a draft model to generate draft tokens."""
+
+    _needs_padding_kv_extension = True
 
     def __init__(
         self,
@@ -109,32 +110,6 @@ class ModelDrafter(Drafter):
         self.previous_scheduled_batch: Optional[ScheduledRequests] = None
         # Map from request ID to original request
         self.req_id_to_old_request: Optional[Dict[int, LlmRequest]] = None
-
-    def _extend_kv_cache_for_padding(
-        self,
-        scheduled_requests: ScheduledRequests,
-        resource_manager: ResourceManager,
-        pre_padding_lens: Dict[int, int],
-    ) -> None:
-        """Extend main-model and draft-model KV cache capacity for padding.
-
-        Two-model mode uses TorchSampler which computes py_rewind_len from
-        the padded len(py_draft_tokens).  Both KV cache managers (main and
-        draft) are rewound by the same py_rewind_len in update_resources,
-        so both must have capacity extended to match the padded length.
-        """
-        kv_mgr = resource_manager.get_resource_manager(
-            ResourceManagerType.KV_CACHE_MANAGER)
-        draft_kv_mgr = resource_manager.get_resource_manager(
-            ResourceManagerType.DRAFT_KV_CACHE_MANAGER)
-        for req in scheduled_requests.generation_requests:
-            extra = get_draft_token_length(req) - pre_padding_lens.get(
-                req.py_request_id, 0)
-            if extra > 0:
-                if kv_mgr is not None:
-                    kv_mgr.extend_capacity_for_tokens(req, extra)
-                if draft_kv_mgr is not None:
-                    draft_kv_mgr.extend_capacity_for_tokens(req, extra)
 
     def _create_draft_request(self, request: LlmRequest,
                               input_tokens: Optional[List]) -> LlmRequest:

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -11,7 +11,8 @@ from tensorrt_llm.logger import logger
 from ..attention_backend.trtllm import TrtllmAttention
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
-from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
+from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
+                                      get_draft_token_length)
 from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
                                            ResourceManagerType)
 from ..pyexecutor.sampler import Sampler, SampleState, SampleStateTensors
@@ -108,6 +109,32 @@ class ModelDrafter(Drafter):
         self.previous_scheduled_batch: Optional[ScheduledRequests] = None
         # Map from request ID to original request
         self.req_id_to_old_request: Optional[Dict[int, LlmRequest]] = None
+
+    def _extend_kv_cache_for_padding(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        pre_padding_lens: Dict[int, int],
+    ) -> None:
+        """Extend main-model and draft-model KV cache capacity for padding.
+
+        Two-model mode uses TorchSampler which computes py_rewind_len from
+        the padded len(py_draft_tokens).  Both KV cache managers (main and
+        draft) are rewound by the same py_rewind_len in update_resources,
+        so both must have capacity extended to match the padded length.
+        """
+        kv_mgr = resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        draft_kv_mgr = resource_manager.get_resource_manager(
+            ResourceManagerType.DRAFT_KV_CACHE_MANAGER)
+        for req in scheduled_requests.generation_requests:
+            extra = get_draft_token_length(req) - pre_padding_lens.get(
+                req.py_request_id, 0)
+            if extra > 0:
+                if kv_mgr is not None:
+                    kv_mgr.extend_capacity_for_tokens(req, extra)
+                if draft_kv_mgr is not None:
+                    draft_kv_mgr.extend_capacity_for_tokens(req, extra)
 
     def _create_draft_request(self, request: LlmRequest,
                               input_tokens: Optional[List]) -> LlmRequest:
@@ -744,7 +771,8 @@ class ModelDrafter(Drafter):
         return outputs, sample_state
 
     @nvtx_range("_process_previous_draft_results")
-    def _process_previous_draft_results(self) -> None:
+    def _process_previous_draft_results(
+            self, resource_manager: Optional[ResourceManager] = None) -> None:
         """
         Process the previous draft batch results.
         This should be called after the current draft forward to enable overlap scheduling.
@@ -774,7 +802,8 @@ class ModelDrafter(Drafter):
         self.req_id_to_old_request = current_req_id_to_old_request
 
         # Pad draft tokens to the max draft length for CUDA graph compatibility
-        self.pad_draft_tokens_for_cuda_graph(self.previous_scheduled_batch)
+        self.pad_draft_tokens_for_cuda_graph(self.previous_scheduled_batch,
+                                             resource_manager)
 
     def cleanup_previous_draft_resources(self) -> None:
         if self.previous_draft_batch is None:
@@ -893,7 +922,7 @@ class ModelDrafter(Drafter):
 
         # Process previous draft results after current forward pass
         # This enables overlap scheduling: process old batch while new batch is prepared
-        self._process_previous_draft_results()
+        self._process_previous_draft_results(resource_manager)
 
         num_draft_reqs = len(draft_batch.all_requests())
         if self.use_static_draft_loop:

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -1,12 +1,14 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from ordered_set import OrderedSet
 
 from tensorrt_llm.llmapi import NGramDecodingConfig
 from tensorrt_llm.logger import logger
 
-from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
-from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
+from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
+                                      get_draft_token_length)
+from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
+                                           ResourceManagerType)
 from ..pyexecutor.scheduler import ScheduledRequests
 from .drafter import Drafter
 
@@ -201,6 +203,29 @@ class NGramDrafter(Drafter):
                 request.py_max_new_tokens,
             )
             request.py_draft_tokens = draft_tokens
+
+    def _extend_kv_cache_for_padding(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        pre_padding_lens: Dict[int, int],
+    ) -> None:
+        """Extend main-model KV cache capacity for the CUDA-graph padding tokens.
+
+        NGram uses TorchSampler which computes py_rewind_len from the padded
+        len(py_draft_tokens).  Without this extension, rewind would exceed the
+        capacity allocated by prepare_resources (which used the shorter,
+        schedule-based draft length).
+        """
+        kv_mgr = resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        if kv_mgr is None:
+            return
+        for req in scheduled_requests.generation_requests:
+            extra = get_draft_token_length(req) - pre_padding_lens.get(
+                req.py_request_id, 0)
+            if extra > 0:
+                kv_mgr.extend_capacity_for_tokens(req, extra)
 
     def update_max_total_draft_tokens(self,
                                       new_max_total_draft_tokens: int) -> None:

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -1,14 +1,12 @@
-from typing import Dict, Optional
+from typing import Optional
 
 from ordered_set import OrderedSet
 
 from tensorrt_llm.llmapi import NGramDecodingConfig
 from tensorrt_llm.logger import logger
 
-from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
-                                      get_draft_token_length)
-from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
-                                           ResourceManagerType)
+from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
+from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
 from ..pyexecutor.scheduler import ScheduledRequests
 from .drafter import Drafter
 
@@ -162,6 +160,8 @@ class NGramPoolManager(BaseResourceManager):
 
 class NGramDrafter(Drafter):
 
+    _needs_padding_kv_extension = True
+
     def __init__(
         self,
         spec_config: NGramDecodingConfig,
@@ -203,29 +203,6 @@ class NGramDrafter(Drafter):
                 request.py_max_new_tokens,
             )
             request.py_draft_tokens = draft_tokens
-
-    def _extend_kv_cache_for_padding(
-        self,
-        scheduled_requests: ScheduledRequests,
-        resource_manager: ResourceManager,
-        pre_padding_lens: Dict[int, int],
-    ) -> None:
-        """Extend main-model KV cache capacity for the CUDA-graph padding tokens.
-
-        NGram uses TorchSampler which computes py_rewind_len from the padded
-        len(py_draft_tokens).  Without this extension, rewind would exceed the
-        capacity allocated by prepare_resources (which used the shorter,
-        schedule-based draft length).
-        """
-        kv_mgr = resource_manager.get_resource_manager(
-            ResourceManagerType.KV_CACHE_MANAGER)
-        if kv_mgr is None:
-            return
-        for req in scheduled_requests.generation_requests:
-            extra = get_draft_token_length(req) - pre_padding_lens.get(
-                req.py_request_id, 0)
-            if extra > 0:
-                kv_mgr.extend_capacity_for_tokens(req, extra)
 
     def update_max_total_draft_tokens(self,
                                       new_max_total_draft_tokens: int) -> None:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -892,7 +892,7 @@ class _KVCache:
             seq_block.tree_block = tree_block
             assert self._get_tree_block(ordinal) is tree_block
             self._num_committed_blocks = BlockOrdinal(ordinal + 1)
-        elif tree_block.is_full and self.manager.allow_seq_rebasing:
+        elif tree_block.is_full and self.manager.allow_seq_rebasing and is_full:
             # Happens when a concurrent request committed the same tokens before us.
             # Try to replace our pages with pages from the existing block to save memory.
             reuse_list = list[tuple[LifeCycleId, CommittedPage]]()

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
@@ -24,19 +24,18 @@ from ._utils import ItemHolderWithSharedPool, PooledFactoryBase, _unwrap, div_up
 
 def _is_prop_supported(prop: drv.CUmemAllocationProp) -> bool:
     err, handle = drv.cuMemCreate(2 << 20, prop, 0)
-    err_int = int(err)
-    if err_int == int(drv.CUresult.CUDA_SUCCESS):
+    if (
+        err == drv.CUresult.CUDA_ERROR_NOT_PERMITTED
+        or err == drv.CUresult.CUDA_ERROR_NOT_SUPPORTED
+        or err == drv.CUresult.CUDA_ERROR_INVALID_DEVICE
+        or err == drv.CUresult.CUDA_ERROR_INVALID_VALUE
+    ):
+        return False
+    elif err == drv.CUresult.CUDA_SUCCESS:
         _unwrap(drv.cuMemRelease(handle))
         return True
     # Note: OOM is intentionally not caught here — OOM on a 2 MiB probe
     # indicates a fundamental resource problem, not an unsupported property.
-    elif err_int in (
-        int(drv.CUresult.CUDA_ERROR_NOT_PERMITTED),
-        int(drv.CUresult.CUDA_ERROR_NOT_SUPPORTED),
-        int(drv.CUresult.CUDA_ERROR_INVALID_DEVICE),
-        int(drv.CUresult.CUDA_ERROR_INVALID_VALUE),
-    ):
-        return False
     else:
         raise CuError(err)
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
@@ -24,18 +24,19 @@ from ._utils import ItemHolderWithSharedPool, PooledFactoryBase, _unwrap, div_up
 
 def _is_prop_supported(prop: drv.CUmemAllocationProp) -> bool:
     err, handle = drv.cuMemCreate(2 << 20, prop, 0)
-    if (
-        err == drv.CUresult.CUDA_ERROR_NOT_PERMITTED
-        or err == drv.CUresult.CUDA_ERROR_NOT_SUPPORTED
-        or err == drv.CUresult.CUDA_ERROR_INVALID_DEVICE
-        or err == drv.CUresult.CUDA_ERROR_INVALID_VALUE
-    ):
-        return False
-    elif err == drv.CUresult.CUDA_SUCCESS:
+    err_int = int(err)
+    if err_int == int(drv.CUresult.CUDA_SUCCESS):
         _unwrap(drv.cuMemRelease(handle))
         return True
     # Note: OOM is intentionally not caught here — OOM on a 2 MiB probe
     # indicates a fundamental resource problem, not an unsupported property.
+    elif err_int in (
+        int(drv.CUresult.CUDA_ERROR_NOT_PERMITTED),
+        int(drv.CUresult.CUDA_ERROR_NOT_SUPPORTED),
+        int(drv.CUresult.CUDA_ERROR_INVALID_DEVICE),
+        int(drv.CUresult.CUDA_ERROR_INVALID_VALUE),
+    ):
+        return False
     else:
         raise CuError(err)
 

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -1009,15 +1009,19 @@ class TestEncoder:
         assert ids(out.context_requests) == [0, 1]
 
     def test_encoder_counts_toward_batch(self):
+        """Gen wins phase 1; encoder scheduled in phase 2 still occupies a batch slot."""
         mgr = make_kv_cache_manager()
-        sched = make_encoder_scheduler(mgr, max_batch_size=1, max_num_tokens=1000)
+        sched = make_encoder_scheduler(mgr, max_batch_size=2, max_num_tokens=1000)
         reqs = [
             make_encoder_request(0, encoder_output_len=50),
             make_gen_request(1),
+            make_encoder_request(2, encoder_output_len=50),
         ]
         out = sched.schedule_request(reqs, set())
+        # gen(1) scheduled first (phase 1), encoder(0) fills remaining slot (phase 2)
+        assert ids(out.generation_requests) == [1]
         assert ids(out.context_requests) == [0]
-        assert len(out.generation_requests) == 0
+        # encoder(2) excluded — encoder(0) counted toward batch
 
 
 # ===========================================================================

--- a/tests/unittest/kv_cache_manager_v2_tests/test_branch_reuse.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_branch_reuse.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test: partial block must not rebase onto full tree block."""
+
+import gc
+import itertools
+import os
+import unittest
+from importlib.util import find_spec
+from typing import cast
+
+TYPE_CHECKING = False
+if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
+    from kv_cache_manager_v2 import (
+        DEFAULT_BEAM_INDEX,
+        CudaStream,
+        DataRole,
+        KVCacheManager,
+        LayerId,
+        TokenId,
+        TokenIdExt,
+    )
+    from kv_cache_manager_v2._common import MemAddress
+    from kv_cache_manager_v2._utils import (
+        TemporaryCudaStream,
+        exact_div,
+        init_cuda_once,
+        round_up,
+        temporary_sys_path,
+    )
+else:
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import (
+        DEFAULT_BEAM_INDEX,
+        CudaStream,
+        DataRole,
+        KVCacheManager,
+        LayerId,
+        TokenId,
+        TokenIdExt,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._common import MemAddress
+    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
+        TemporaryCudaStream,
+        exact_div,
+        init_cuda_once,
+        round_up,
+        temporary_sys_path,
+    )
+
+with temporary_sys_path(os.path.dirname(os.path.abspath(__file__))):
+    from kernels import check_values, fill_values
+    from test_kv_cache_manager_v2 import create_config
+
+KEY = DataRole("key")
+LID = LayerId(0)
+
+
+class TestPartialBlockRebase(unittest.TestCase):
+    def setUp(self) -> None:
+        init_cuda_once()
+        self._tok = itertools.count(1)
+        gc.collect()
+        gc.disable()
+        self.tpb = 8
+        self.kv_buf_size = 8192
+        self.cfg = create_config(self.tpb, 16 << 20, 0, 0, 2, None, 0, self.kv_buf_size)
+        self.manager = KVCacheManager(self.cfg)
+
+    def tearDown(self) -> None:
+        gc.enable()
+        self.manager.shutdown()
+
+    def tok(self) -> TokenIdExt:
+        return TokenId(next(self._tok))
+
+    def _page_addr(self, kv, block_ordinal):
+        lc = self.manager._storage._layer_to_life_cycle_ids[LID]
+        base_idx = list(kv.get_base_page_indices(lc, DEFAULT_BEAM_INDEX))[block_ordinal]
+        pool = self.manager.get_mem_pool_base_address(LID, KEY)
+        stride = self.manager.get_page_stride(LID, KEY)
+        scale = self.manager.get_page_index_scale(LID, KEY)
+        return MemAddress(pool + stride * base_idx * scale)
+
+    def _tok_bytes(self):
+        return exact_div(self.kv_buf_size, self.tpb)
+
+    def _write(self, kv, ordinal, offset, tokens, stream):
+        addr = self._page_addr(kv, ordinal)
+        tb = self._tok_bytes()
+        fill_values(
+            MemAddress(addr + tb * offset),
+            tb,
+            1,
+            self.tpb,
+            LID,
+            0,
+            DEFAULT_BEAM_INDEX,
+            tokens,
+            stream,
+        )
+
+    def _check(self, kv, ordinal, offset, tokens, stream):
+        addr = self._page_addr(kv, ordinal)
+        tb = self._tok_bytes()
+        check_values(
+            MemAddress(addr + tb * offset),
+            tb,
+            1,
+            self.tpb,
+            LID,
+            0,
+            DEFAULT_BEAM_INDEX,
+            tokens,
+            stream,
+        )
+
+    def _prefill(self, prompt, reuse, stream):
+        kv = self.manager.create_kv_cache(None, reuse)
+        kv.resume(stream)
+        kv.resize(round_up(len(prompt), 1))
+        n = kv.num_committed_tokens
+        for i in range(n, len(prompt)):
+            self._write(kv, i // self.tpb, i % self.tpb, [prompt[i]], stream)
+        if n < len(prompt):
+            kv.commit(prompt[n:])
+        kv.stop_committing()
+        return kv
+
+    def test_partial_block_not_rebased(self) -> None:
+        """Partial block rebase must not let C write onto the shared tree page.
+
+        A0: 13 tokens → block 1 partial (5/8), commit to tree.
+        A:  16 tokens (same prefix + 3) → extends block 1 to full (8/8).
+        B:  reuse 12, process token 12, commit + stop_committing.
+            Then B writes tokens at positions 13, 14 (block 1 offsets 5, 6).
+
+        Without fix: rebase makes B's block 1 point to the tree page (shared
+        with A).  B's writes at offsets 5, 6 overwrite A's data.
+        With fix: B keeps its own copy page.  A's data is untouched.
+        """
+        prefix = [self.tok() for _ in range(13)]  # 1 full + partial
+        extra = [self.tok() for _ in range(3)]  # extends to full
+        gen_tokens = [self.tok(), self.tok()]  # B generates 2 tokens
+
+        with TemporaryCudaStream([]) as s:
+            stream = cast(CudaStream, s.handle)
+
+            kv_a0 = self._prefill(prefix, prefix, stream)
+            kv_a = self._prefill(prefix + extra, prefix + extra, stream)
+
+            # Verify A's block 1 data
+            self._check(kv_a, 1, 5, [extra[0]], stream)  # offset 5
+            self._check(kv_a, 1, 6, [extra[1]], stream)  # offset 6
+
+            # B: reuse 12, process token 12, commit
+            kv_b = self.manager.create_kv_cache(None, prefix[:12])
+            assert kv_b.num_committed_tokens == 12
+            kv_b.resume(stream)
+            kv_b.resize(round_up(len(prefix) + len(extra) + len(gen_tokens), 1))
+            self._write(kv_b, 1, 4, [prefix[12]], stream)
+
+            kv_b.commit(prefix[12:])
+            kv_b.stop_committing()
+
+            # B "generates" 2 tokens at positions 13, 14 (block 1 offsets 5, 6)
+            self._write(kv_b, 1, 5, [gen_tokens[0]], stream)
+            self._write(kv_b, 1, 6, [gen_tokens[1]], stream)
+
+            # A's data must NOT be corrupted by B's writes
+            self._check(kv_a, 1, 5, [extra[0]], stream)
+            self._check(kv_a, 1, 6, [extra[1]], stream)
+
+            kv_a0.close()
+            kv_a.close()
+            kv_b.close()
+
+        s.take_finish_event().synchronize()
+        self.manager.clear_reusable_blocks()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_branch_reuse.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_branch_reuse.py
@@ -18,9 +18,8 @@ import itertools
 import os
 import unittest
 from importlib.util import find_spec
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
-TYPE_CHECKING = False
 if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
     from kv_cache_manager_v2 import (
         DEFAULT_BEAM_INDEX,


### PR DESCRIPTION
@coderabbitai summary

## Description

Port comprehensive bug fixes for KVCacheManagerV2 while keeping V2 **default OFF** (`use_kv_cache_manager_v2=False`). The fallback mechanism now warns instead of silently switching to V1.

### Fixes

**KV Cache Core**
- **Partial block rebase corruption**: Fixed condition in `_kv_cache.py` where a full tree block could corrupt shared pages during partial rebase (added `is_full` guard).
- **`get_batch_cache_indices` default `layer_id`**: Made `layer_id` optional (default pool 0) to avoid mandatory argument when layer is irrelevant.
- **`max_blocks_per_seq` undercount**: Computed after `max_seq_len` clamping and now accounts for `num_extra_kv_tokens + max_total_draft_tokens` so the host page-index buffer is large enough.
- **Multimodal block reuse**: Different images/videos sharing the same placeholder token ID were incorrectly matched in the radix tree. Added `_augment_tokens_for_block_reuse` using content digest (Blake3 hash) for distinct tree entries.

**KV Cache Manager**
- **Auto-provision host cache tier**: V2 `MAX_UTILIZATION` scheduler relies on suspend/resume; without a host tier, suspended pages have nowhere to go, causing deadlock. Now auto-provisions host tier matching GPU quota (capped at 50% available host memory).
- **`extend_capacity_for_tokens`**: Added to both `KVCacheManager` and `KVCacheManagerV2` for CUDA graph padding token capacity extension.
- **Float type in token estimation**: Wrapped `max_num_tokens_in_memory` computation with `int()` to prevent float propagation.
- **Draft KV cache stream**: Fixed `resume()` to use `draft_kv_cache_manager._stream` instead of `torch.cuda.current_stream()`.
- **Draft resource release**: Fixed `release_resources` to also free draft KV cache on context scheduling failure.
- **Context update resize**: Simplified resize to use `None` capacity for context phase, removing fragile draft OOM workaround.

**Scheduler V2**
- **Two-phase scheduling**: Context requests are now deferred to phase 2 so generation requests are fully budgeted first, preventing PEFT adapter eviction failures.
- **PEFT pre-claim for `GENERATION_TO_COMPLETE`**: Pre-claims PEFT pages for requests whose adapters haven't been released yet (overlap executor timing).
- **Deadlock detection**: Raises `RuntimeError` when generation requests exist but none can be scheduled or evicted (KV cache exhausted with no host tier).

**CUDA Graph**
- **Prevent on-the-fly capture**: Added `_capture_allowed` flag and `allow_capture()` context manager to prevent workspace tensor reallocation from invalidating existing graphs.
- **Disable graph replay during general warmup**: Avoids replaying graphs with stale KV cache block offsets from capture time.
- **Eager fallback for uncaptured keys**: Falls back to eager execution when a key was not captured during warmup instead of crashing.

**Speculative Decoding**
- **CUDA graph padding KV cache rewind mismatch**: `pad_draft_tokens_for_cuda_graph` now extends KV cache capacity to match padded length, preventing rewind underflow. Implemented in `drafter.py`, `model_drafter.py` (two-model), and `ngram.py`.

**Fallback**
- **Warn-only fallback**: Refactored V2 incompatibility check (beam search, kv_connector, event buffer, cache transceiver) to warn instead of silently switching to V1.

## Test Coverage

- Existing unit tests in `tests/unittest/`
- Integration tests for multimodal models
- CI pre-merge pipeline

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.