### PR TITLE
[NVBug 5969206][fix] Break circular dependency in disagg KV transfer timeout cleanup

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2197,6 +2197,13 @@ class PyExecutor:
                 if self.kv_cache_transceiver and self.async_transfer_manager.has_any_inflight_requests(
                 ):
                     self._check_kv_transfer_timeout()
+                    # Check for timed-out context transfers every iteration,
+                    # not just inside _send_kv_async. This breaks the circular
+                    # dependency where Phase 2 cleanup requires new requests
+                    # to be scheduled, but scheduling is blocked by exhausted
+                    # KV cache pool held by timed-out requests.
+                    # See: NVBugs 5969206
+                    self._check_disagg_ctx_cache_transfer_status(0)
 
                 self._kv_connector_terminate_requests()
 
@@ -3206,14 +3213,25 @@ class PyExecutor:
             return True
 
         if not self._is_request_in_transmission(request):
+            logger.info(
+                f"[CANCEL-DIAG] Request {request.py_request_id} not in transmission "
+                f"(state={request.state}), cancel OK")
             return True
 
-        return self.kv_cache_transceiver.cancel_request(request)
+        result = self.kv_cache_transceiver.cancel_request(request)
+        logger.warning(
+            f"[CANCEL-DIAG] Request {request.py_request_id} in transmission "
+            f"(state={request.state}), cancel_request returned {result}")
+        return result
 
     @nvtx_range("_handle_canceled_requests")
     def _handle_canceled_requests(self):
         if len(self.canceled_req_ids) == 0:
             return
+
+        logger.info(
+            f"[CANCEL-DIAG] Processing {len(self.canceled_req_ids)} cancel requests: "
+            f"{self.canceled_req_ids[:5]}...")
 
         # Create set from list of canceled request ids to speed up canceled test
         canceled_req_ids_set = set(self.canceled_req_ids)


### PR DESCRIPTION
## Summary

Fixes a permanent hang in disaggregated serving where cancelled requests leak KV cache blocks until the pool is exhausted and the prefill worker becomes unresponsive.

**Root cause:** The `kv_transfer_timeout_ms` cleanup mechanism (Phase 2) only ran inside `_send_kv_async`, which requires new context requests to be scheduled. Once leaked blocks exhaust the KV pool, no new requests can be scheduled, so Phase 2 never runs — an unrecoverable circular dependency.

**Fix:** Call `_check_disagg_ctx_cache_transfer_status(0)` every iteration in the main executor loop, breaking the circular dependency. Timed-out requests are cleaned up regardless of whether new requests are being scheduled.

## Reproduction

1P1D disaggregated serving with Qwen/Qwen3-0.6B on L40 PCIe (or any slow-interconnect setup):
- Send 300 concurrent requests with ISL=2000+ via aiperf
- Cancel (Ctrl+C) after ~60s
- Repeat 4+ times
- Final probe request hangs indefinitely

**Symptoms:**
- `[WARNING] Timed out waiting for context KV cache transfer after 1000 milliseconds` repeating every 1s
- `has 2048 active_requests, scheduled 0 context requests` — pool exhausted
- GPU utilization 0%, memory held at ~87%
- Health endpoint returns 200 but no requests are served

**Confirmed on:** L40 PCIe (localhost), H100 PCIe (cross-node), Dynamo 1.0.0 + TRT-LLM. Does NOT reproduce on H100 NVLink (transfers complete before cancel arrives).

## Evidence

| Experiment | Stuck in state 21 | KV timeouts | Final probe |
|---|---|---|---|
| H100 NVLink (passing) | 1 / 10,003 | 0 | Passed |
| L40 PCIe (hang) | 186 / 508 | 1,120 | **HUNG** |
| H100 PCIe cross-node (hang) | 836 / 920 | 5,500 | **HUNG** |
| L40 + kv_transfer_timeout_ms=60s | 4 (engine recovered) | 0 | HUNG (frontend Bug 2) |

With the timeout workaround, Phase 1 correctly flags stuck requests (776 "Terminating by timeout"), and the engine recovers to 4 active_requests — but only when new requests trigger Phase 2. Without new requests (full pool exhaustion), recovery is impossible.

## Test plan

- [ ] Verify with L40 PCIe reproducer: 4 cancel cycles + probe should pass
- [ ] Verify no regression on normal (non-cancel) disagg serving benchmark
- [ ] Verify H100 NVLink still passes (was passing before, should still pass)

🔗 Full analysis: NVBugs 5969206