### PR TITLE
[NVBug 5969206][fix] Force-terminate in-flight KV transfers on abort

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3264,6 +3264,32 @@ class PyExecutor:
 
         return self.kv_cache_transceiver.cancel_request(request)
 
+    def _force_cancel_in_flight_request(self, request) -> None:
+        """Force-terminate a request stuck in KV cache transmission state.
+
+        When cancel_request() fails because a NIXL transfer is actively in
+        flight, the request is stuck in state 21/9 holding KV blocks forever.
+        This method force-transitions the request to the completed state and
+        cleans up its resources, accepting that the orphaned in-flight NIXL
+        transfer will be discarded by the peer.
+
+        See: NVBugs 5969206
+        """
+        if request.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS:
+            logger.warning(
+                f"Force-terminating request {request.py_request_id} stuck in "
+                f"DISAGG_CONTEXT_TRANS_IN_PROGRESS (cancel failed for in-flight transfer)"
+            )
+            request.py_kv_transfer_start_time = None
+            request.state = LlmRequestState.DISAGG_CONTEXT_COMPLETE
+            self._end_transfer_and_maybe_terminate(request)
+        elif request.state == LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS:
+            logger.warning(
+                f"Force-terminating request {request.py_request_id} stuck in "
+                f"DISAGG_GENERATION_TRANS_IN_PROGRESS (cancel failed for in-flight transfer)"
+            )
+            request.state = LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE
+
     @nvtx_range("_handle_canceled_requests")
     def _handle_canceled_requests(self):
         if len(self.canceled_req_ids) == 0:
@@ -3275,7 +3301,6 @@ class PyExecutor:
         # Remove canceled requests from the waiting queue
         self.waiting_queue.remove_by_ids(canceled_req_ids_set)
 
-        still_pending_canceled_ids = []
         for request in self.active_requests:
             req_id = request.py_request_id if not request.is_child else request.parent_request_id
             if req_id not in canceled_req_ids_set:
@@ -3288,11 +3313,16 @@ class PyExecutor:
                 request.finish_by_reason(FinishReason.CANCELLED)
                 request.decoding_iter = request.py_decoding_iter
             else:
-                still_pending_canceled_ids.append(req_id)
+                # Cancel failed — request is in-flight (actively transmitting
+                # KV cache). Force-terminate to prevent permanent KV block
+                # leaks that exhaust the pool and hang the system.
+                # See: NVBugs 5969206
+                self._force_cancel_in_flight_request(request)
+                request.finish_by_reason(FinishReason.CANCELLED)
+                request.decoding_iter = request.py_decoding_iter
 
-        # Clear list of requests marked for cancellation and add back those that failed to cancel.
+        # All cancel requests are now handled (no more retries needed).
         self.canceled_req_ids.clear()
-        self.canceled_req_ids.extend(still_pending_canceled_ids)
 
     @nvtx_range("_enqueue_responses")
     def _enqueue_responses(self, responses: Iterable[Tuple[int, LlmResponse]]):


### PR DESCRIPTION
## Summary

Fixes a permanent hang in disaggregated serving where cancelled requests with in-flight KV cache transfers leak blocks until the pool is exhausted.

**Root cause:** When abort arrives for a request in state 21 (`kDISAGG_CONTEXT_TRANS_IN_PROGRESS`), the C++ `cancel_request()` only succeeds for queued transfers, not in-flight ones. Failed cancels were retried every iteration indefinitely — the request stayed in transmission state forever, holding KV blocks that were never freed.

**Fix:** When `cancel_request()` returns `False` for an in-transmission request, force-transition it to the completed state (`DISAGG_CONTEXT_COMPLETE` / `DISAGG_GENERATION_TRANS_COMPLETE`) and clean up its resources immediately. The orphaned NIXL transfer is discarded by the peer.

This makes abort work unconditionally regardless of the request's state in the KV transfer pipeline, **without requiring `kv_transfer_timeout_ms` to be configured**.

## Why this is the right fix

We investigated several approaches and found that any fix relying on downstream signals (first token, transfer completion, Phase 2 timeout cleanup) fails due to circular dependencies — once the KV pool is exhausted, the signal needed to trigger cleanup requires free blocks that don't exist.

The only correct approach is to make abort unconditional: when cancellation is requested, the request MUST be terminated regardless of its internal state.

| Approach | Works? | Why |
|---|---|---|
| `kv_transfer_timeout_ms` | Partial | Phase 2 cleanup only runs in `_send_kv_async` which needs new requests → circular dep |
| Move Phase 2 to main loop | Partial | Still requires timeout to be configured |
| First-token guard (delay abort) | No | Held requests consume blocks, preventing first token → circular dep |
| **Force-terminate on cancel (this PR)** | **Yes** | No dependencies — abort is immediate and unconditional |

## Changes

- `_force_cancel_in_flight_request()`: New method that force-transitions state 21→22 (or 9→12) and cleans up resources
- `_handle_canceled_requests()`: When `_try_cancel_request()` fails, calls force-cancel instead of retrying. Removes the `still_pending_canceled_ids` retry loop entirely.

## Reproduction

Same as #12313. 1P1D disagg with Qwen/Qwen3-0.6B on L40 PCIe, 4+ cancel cycles with concurrency=300.

## Test plan

- [ ] Verify with L40 PCIe reproducer: 4 cancel cycles + probe should pass
- [ ] Verify with Dynamo + ISL=8000 reproducer (which failed with all other fixes)
- [ ] Verify no regression on normal disagg serving benchmark
- [ ] Verify orphaned NIXL transfers don't cause peer-side issues

🔗 Full analysis: NVBugs 5969206
🔗 Related: #12313 (Phase 2 circular dependency fix — complementary but insufficient alone)