### PR TITLE
[https://nvbugs/5808603][fix] Add bias support to WeightOnlyQuantLinearMethod

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1908,6 +1908,9 @@ class WeightOnlyQuantLinearMethod(LinearMethodBase):
             input, module.weight, weight_dtype, module.weight_scale,
             module.dtype)
 
+        if bias is not None:
+            output = output + bias
+
         return output
 
     def load_weight_scales(

--- a/tests/unittest/_torch/thop/parallel/test_weight_only_quant_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_weight_only_quant_linear.py
@@ -11,7 +11,8 @@ from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
     "dtype",
     [torch.float16, torch.bfloat16],
 )
-def test_weight_only_quant_linear(dtype, weights_dtype):
+@pytest.mark.parametrize("bias", [True, False])
+def test_weight_only_quant_linear(dtype, weights_dtype, bias):
 
     SEQ_LEN = 10
     HIDDEN_SIZE = 128
@@ -27,6 +28,8 @@ def test_weight_only_quant_linear(dtype, weights_dtype):
     w = w.cuda()
     w_processed = w_processed.cuda()
     w_scales = w_scales.cuda()
+    b = torch.randn(
+        (OUT_FEATURES), dtype=dtype, device="cuda") if bias else None
 
     if weights_dtype == torch.int8:
         qc = QuantConfig(quant_algo=QuantAlgo.W8A16, group_size=1)
@@ -37,14 +40,14 @@ def test_weight_only_quant_linear(dtype, weights_dtype):
 
     linear_woq = Linear(in_features=HIDDEN_SIZE,
                         out_features=OUT_FEATURES,
-                        bias=False,
+                        bias=bias,
                         dtype=dtype,
                         quant_config=qc)
 
-    linear_woq.load_weights([{
-        'weight': w.T,
-        'weight_scale': w_scales,
-    }])
+    load_dict = {'weight': w.T, 'weight_scale': w_scales}
+    if bias:
+        load_dict['bias'] = b
+    linear_woq.load_weights([load_dict])
 
     linear_woq = linear_woq.cuda()
 
@@ -57,5 +60,7 @@ def test_weight_only_quant_linear(dtype, weights_dtype):
     with torch.inference_mode():
         output_ref = torch.ops.trtllm.weight_only_quant_gemm(
             x.contiguous(), w_processed, weights_dtype, w_scales, dtype)
+        if bias:
+            output_ref = output_ref + b
     torch.cuda.synchronize()
     torch.testing.assert_close(output, output_ref)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bias handling in linear layer operations to ensure bias is correctly applied to outputs across all execution paths.

* **Tests**
  * Enhanced test coverage for quantized linear operations with parameterized bias configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

WeightOnlyQuantLinearMethods did not apply bias, which is for example used in Qwen2.5 models

This PR:
- Modified WeightOnlyQuantLinearMethod to include bias in the output calculation.
- Updated test_weight_only_quant_linear to parameterize bias and validate its effect on output.


## Test Coverage

- Updated test_weight_only_quant_linear to parameterize bias and validate its effect on output.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
