### PR TITLE
[https://nvbugs/5983390][perf] Kernel fusions in _gather_k_cache_for_chunk of Indexer in DSA

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -32,7 +32,8 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
-from .kernel import triton_convert_req_index_to_global_index
+from .kernel import (fused_gather_k_cache,
+                     triton_convert_req_index_to_global_index)
 
 ModelConfig = tensorrt_llm.bindings.ModelConfig
 
@@ -1502,10 +1503,23 @@ class Indexer(nn.Module):
                     tp_rank = metadata.mapping.tp_rank
                     tp_size = metadata.mapping.tp_size
 
+                # Use the 2D pool data directly (contiguous) instead of the
+                # 4D view, because the 4D view may have strides that
+                # prevent flattening via .view(-1).
+                layer_offset = metadata.kv_cache_manager.layer_offsets[
+                    self.layer_idx]
+                gather_k_cache_pool = metadata.kv_cache_manager.indexer_k_cache_pool_per_layer[
+                    layer_offset]
+
                 for chunk in metadata.indexer_prefill_chunks:
-                    # Gather K from cache for this chunk (dual to _update_k_cache)
-                    chunk_k_fp8, chunk_k_scale = self._gather_k_cache_for_chunk(
-                        metadata, chunk)
+                    chunk_k_fp8, chunk_k_scale = fused_gather_k_cache(
+                        gather_k_cache_pool,
+                        metadata.slot_mapping_fp8_fullkv,
+                        metadata.slot_mapping_scale_fullkv,
+                        chunk.k_token_start,
+                        chunk.k_token_end,
+                        self.head_dim,
+                    )
 
                     chunk_num_token = chunk.token_end - chunk.token_start
                     apply_q_split = q_split_eligible and chunk_num_token >= q_split_threshold

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -32,8 +32,8 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
-from .kernel import (fused_gather_k_cache,
-                     triton_convert_req_index_to_global_index)
+from .kernel import (triton_convert_req_index_to_global_index,
+                     triton_gather_k_cache)
 
 ModelConfig = tensorrt_llm.bindings.ModelConfig
 
@@ -93,24 +93,6 @@ def _compute_slot_mappings(
     scale_indices = (block_ids * block_stride + scale_base_offset +
                      pos_in_blocks * scale_size)
     return fp8_indices, scale_indices
-
-
-def _unravel_indices(flat_indices: torch.Tensor,
-                     shape: Tuple[int, ...]) -> Tuple[torch.Tensor, ...]:
-    """
-    Unravel indices into multiple dimensions.
-    """
-    d3 = shape[3]
-    i3 = flat_indices % d3
-    flat_indices = flat_indices // d3
-    d2 = shape[2]
-    i2 = flat_indices % d2
-    flat_indices = flat_indices // d2
-    d1 = shape[1]
-    i1 = flat_indices % d1
-    flat_indices = flat_indices // d1
-    i0 = flat_indices
-    return i0, i1, i2, i3
 
 
 def rotate_activation(x: torch.Tensor) -> torch.Tensor:
@@ -1403,68 +1385,6 @@ class Indexer(nn.Module):
                                                     k_cache, flat_indices_fp8,
                                                     flat_indices_scale)
 
-    def _gather_k_cache_for_chunk(
-        self,
-        metadata: DSAtrtllmAttentionMetadata,
-        chunk: IndexerPrefillChunkMetadata,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Gather K values from indexer cache for a specific chunk.
-
-        Uses pre-computed extended slot mappings that cover cached + current batch context tokens.
-        chunk.k_token_start/k_token_end directly index into the extended slot mapping.
-
-        Args:
-            metadata: Attention metadata
-            chunk: Chunk metadata with k_token_start/end as indices into extended slot mapping
-
-        Returns:
-            k_fp8: FP8 quantized k tensor, shape [num_k_tokens, head_dim]
-            k_scale: Scaling factors, shape [num_k_tokens, 1]
-        """
-        assert metadata.slot_mapping_fp8_fullkv is not None, \
-            "_gather_k_cache_for_chunk requires extended slot mappings (only available with cached tokens)"
-
-        k_cache = metadata.kv_cache_manager.get_indexer_k_cache_buffers(
-            self.layer_idx)
-
-        head_dim = self.head_dim
-        scale_size = 4  # float32 = 4 bytes
-
-        # Extract slot mappings using chunk's k_token_start/end
-        # These indices point directly into the extended slot mapping array
-        k_token_start = chunk.k_token_start
-        k_token_end = chunk.k_token_end
-        num_k_tokens = k_token_end - k_token_start
-
-        slot_mapping_fp8_chunk = metadata.slot_mapping_fp8_fullkv[
-            k_token_start:k_token_end]
-        slot_mapping_scale_chunk = metadata.slot_mapping_scale_fullkv[
-            k_token_start:k_token_end]
-
-        # Vectorized gather using pre-computed slot mappings
-        # Gather FP8 data
-        byte_offsets_fp8 = torch.arange(
-            head_dim, device=k_cache.device).unsqueeze(0)  # [1, head_dim]
-        gather_indices_fp8 = slot_mapping_fp8_chunk.unsqueeze(
-            1) + byte_offsets_fp8  # [num_k_tokens, head_dim]
-        gather_indices_fp8 = _unravel_indices(gather_indices_fp8, k_cache.shape)
-        k_fp8_bytes = k_cache[gather_indices_fp8]
-        k_fp8 = k_fp8_bytes.view(torch.float8_e4m3fn).view(
-            num_k_tokens, head_dim)
-
-        # Gather scale data
-        byte_offsets_scale = torch.arange(
-            scale_size, device=k_cache.device).unsqueeze(0)  # [1, 4]
-        gather_indices_scale = slot_mapping_scale_chunk.unsqueeze(
-            1) + byte_offsets_scale  # [num_k_tokens, 4]
-        gather_indices_scale = _unravel_indices(gather_indices_scale,
-                                                k_cache.shape)
-        k_scale_bytes = k_cache[gather_indices_scale]
-        k_scale = k_scale_bytes.view(torch.float32).view(num_k_tokens, 1)
-
-        return k_fp8, k_scale
-
     def sparse_attn_indexer(
         self,
         metadata: DSAtrtllmAttentionMetadata,
@@ -1512,7 +1432,7 @@ class Indexer(nn.Module):
                     layer_offset]
 
                 for chunk in metadata.indexer_prefill_chunks:
-                    chunk_k_fp8, chunk_k_scale = fused_gather_k_cache(
+                    chunk_k_fp8, chunk_k_scale = triton_gather_k_cache(
                         gather_k_cache_pool,
                         metadata.slot_mapping_fp8_fullkv,
                         metadata.slot_mapping_scale_fullkv,

--- a/tensorrt_llm/_torch/attention_backend/sparse/kernel.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/kernel.py
@@ -1944,7 +1944,7 @@ def triton_convert_req_index_to_global_index(
 
 
 @triton.jit
-def _fused_gather_k_cache_kernel(
+def _triton_gather_k_cache_kernel(
     k_cache_ptr,
     slot_fp8_ptr,
     slot_scale_ptr,
@@ -1985,7 +1985,7 @@ def _fused_gather_k_cache_kernel(
     tl.store(out_scale_ptr + dst_scale, scale_data, mask=gather_mask)
 
 
-def fused_gather_k_cache(
+def triton_gather_k_cache(
     k_cache: torch.Tensor,
     slot_mapping_fp8: torch.Tensor,
     slot_mapping_scale: torch.Tensor,
@@ -2038,7 +2038,7 @@ def fused_gather_k_cache(
                             device=device)
 
     grid = (triton.cdiv(num_k_tokens, BLOCK_TOKENS), )
-    _fused_gather_k_cache_kernel[grid](
+    _triton_gather_k_cache_kernel[grid](
         k_cache_flat,
         slot_mapping_fp8,
         slot_mapping_scale,

--- a/tensorrt_llm/_torch/attention_backend/sparse/kernel.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/kernel.py
@@ -1936,3 +1936,121 @@ def triton_convert_req_index_to_global_index(
         out_stride1,
     )
     return out
+
+
+########################################################
+# Fused K cache gather kernel
+########################################################
+
+
+@triton.jit
+def _fused_gather_k_cache_kernel(
+    k_cache_ptr,
+    slot_fp8_ptr,
+    slot_scale_ptr,
+    out_fp8_ptr,
+    out_scale_ptr,
+    k_token_start,
+    num_k_tokens,
+    HEAD_DIM: tl.constexpr,
+    SCALE_BYTES: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    token_offsets = (pid * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)).to(
+        tl.int64)
+    token_mask = token_offsets < num_k_tokens
+
+    fp8_base = tl.load(slot_fp8_ptr + k_token_start + token_offsets,
+                       mask=token_mask,
+                       other=0)
+    scale_base = tl.load(slot_scale_ptr + k_token_start + token_offsets,
+                         mask=token_mask,
+                         other=0)
+
+    byte_offsets = tl.arange(0, HEAD_DIM).to(tl.int64)
+    src_fp8 = fp8_base[:, None] + byte_offsets[None, :]
+    dst_fp8 = token_offsets[:, None] * HEAD_DIM + byte_offsets[None, :]
+    gather_mask = token_mask[:, None]
+
+    fp8_data = tl.load(k_cache_ptr + src_fp8, mask=gather_mask, other=0)
+    tl.store(out_fp8_ptr + dst_fp8, fp8_data, mask=gather_mask)
+
+    scale_byte_offsets = tl.arange(0, SCALE_BYTES).to(tl.int64)
+    src_scale = scale_base[:, None] + scale_byte_offsets[None, :]
+    dst_scale = token_offsets[:,
+                              None] * SCALE_BYTES + scale_byte_offsets[None, :]
+
+    scale_data = tl.load(k_cache_ptr + src_scale, mask=gather_mask, other=0)
+    tl.store(out_scale_ptr + dst_scale, scale_data, mask=gather_mask)
+
+
+def fused_gather_k_cache(
+    k_cache: torch.Tensor,
+    slot_mapping_fp8: torch.Tensor,
+    slot_mapping_scale: torch.Tensor,
+    k_token_start: int,
+    k_token_end: int,
+    head_dim: int,
+):
+    """Gather K FP8 values and scales from the indexer K cache for a chunk.
+
+    Replaces ``_gather_k_cache_for_chunk``, fusing ~8-12 small PyTorch ops
+    (arange, unsqueeze, broadcast add, _unravel_indices, advanced indexing)
+    into a single Triton kernel that directly gathers from flat byte offsets.
+    This is purely data movement — bit-exact with the original.
+
+    Args:
+        k_cache: Indexer K cache pool data (2D contiguous), uint8.
+        slot_mapping_fp8: Flat byte indices for FP8 data
+            ``[total_kv_len]``, int64.
+        slot_mapping_scale: Flat byte indices for scale data
+            ``[total_kv_len]``, int64.
+        k_token_start: Start index into slot mapping arrays.
+        k_token_end: End index into slot mapping arrays.
+        head_dim: FP8 head dimension (typically 128).
+
+    Returns:
+        Tuple of (k_fp8, k_scale):
+            k_fp8: ``[num_k_tokens, head_dim]``, float8_e4m3fn.
+            k_scale: ``[num_k_tokens, 1]``, float32.
+    """
+    num_k_tokens = k_token_end - k_token_start
+    device = k_cache.device
+
+    if num_k_tokens == 0:
+        return (
+            torch.empty(0, head_dim, dtype=torch.float8_e4m3fn, device=device),
+            torch.empty(0, 1, dtype=torch.float32, device=device),
+        )
+
+    SCALE_BYTES = 4
+    BLOCK_TOKENS = 32
+
+    k_cache_flat = k_cache.reshape(-1)
+    out_fp8 = torch.empty(num_k_tokens,
+                          head_dim,
+                          dtype=torch.uint8,
+                          device=device)
+    out_scale = torch.empty(num_k_tokens,
+                            SCALE_BYTES,
+                            dtype=torch.uint8,
+                            device=device)
+
+    grid = (triton.cdiv(num_k_tokens, BLOCK_TOKENS), )
+    _fused_gather_k_cache_kernel[grid](
+        k_cache_flat,
+        slot_mapping_fp8,
+        slot_mapping_scale,
+        out_fp8.view(-1),
+        out_scale.view(-1),
+        k_token_start,
+        num_k_tokens,
+        HEAD_DIM=head_dim,
+        SCALE_BYTES=SCALE_BYTES,
+        BLOCK_TOKENS=BLOCK_TOKENS,
+    )
+
+    k_fp8 = out_fp8.view(torch.float8_e4m3fn)
+    k_scale = out_scale.view(torch.float32).view(num_k_tokens, 1)
+    return k_fp8, k_scale

--- a/tests/unittest/_torch/attention/sparse/test_triton_gather_k_cache.py
+++ b/tests/unittest/_torch/attention/sparse/test_triton_gather_k_cache.py
@@ -1,0 +1,179 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.attention_backend.sparse.kernel import triton_gather_k_cache
+
+
+def reference_gather_k_cache(
+    k_cache: torch.Tensor,
+    slot_mapping_fp8: torch.Tensor,
+    slot_mapping_scale: torch.Tensor,
+    k_token_start: int,
+    k_token_end: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch reference: vectorized flat-index gather.
+
+    Mirrors the original ``_gather_k_cache_for_chunk`` logic from dsa.py but
+    operates on the flattened cache directly (no ``_unravel_indices`` needed).
+    """
+    num_k_tokens = k_token_end - k_token_start
+    device = k_cache.device
+    scale_bytes = 4
+
+    if num_k_tokens == 0:
+        return (
+            torch.empty(0, head_dim, dtype=torch.float8_e4m3fn, device=device),
+            torch.empty(0, 1, dtype=torch.float32, device=device),
+        )
+
+    k_cache_flat = k_cache.reshape(-1)
+
+    fp8_bases = slot_mapping_fp8[k_token_start:k_token_end]
+    byte_offsets_fp8 = torch.arange(head_dim, device=device, dtype=torch.int64)
+    gather_fp8 = fp8_bases.unsqueeze(1) + byte_offsets_fp8.unsqueeze(0)
+    out_fp8 = k_cache_flat[gather_fp8]
+
+    scale_bases = slot_mapping_scale[k_token_start:k_token_end]
+    byte_offsets_scale = torch.arange(scale_bytes, device=device, dtype=torch.int64)
+    gather_scale = scale_bases.unsqueeze(1) + byte_offsets_scale.unsqueeze(0)
+    out_scale = k_cache_flat[gather_scale]
+
+    k_fp8 = out_fp8.view(torch.float8_e4m3fn)
+    k_scale = out_scale.view(torch.float32).view(num_k_tokens, 1)
+    return k_fp8, k_scale
+
+
+def _create_cache_and_mappings(
+    total_kv_len: int,
+    head_dim: int,
+    num_cache_rows: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a random k_cache with valid, non-overlapping slot mappings.
+
+    Each token occupies ``head_dim + 4`` bytes in the flat cache (FP8 data
+    followed by scale data).  Token positions are shuffled so that the
+    gathered regions are non-contiguous, stressing the kernel's indexing.
+    """
+    scale_bytes = 4
+    bytes_per_token = head_dim + scale_bytes
+
+    num_cols = (total_kv_len * bytes_per_token + num_cache_rows - 1) // num_cache_rows
+    k_cache = torch.randint(0, 256, (num_cache_rows, num_cols), dtype=torch.uint8, device=device)
+
+    perm = torch.randperm(total_kv_len, device=device)
+    region_starts = perm.to(torch.int64) * bytes_per_token
+    slot_mapping_fp8 = region_starts
+    slot_mapping_scale = region_starts + head_dim
+
+    return k_cache, slot_mapping_fp8, slot_mapping_scale
+
+
+@pytest.mark.parametrize(
+    "total_kv_len,k_token_start,k_token_end,head_dim,num_cache_rows",
+    [
+        # Gather all tokens
+        (64, 0, 64, 128, 16),
+        # Sub-range from the middle
+        (128, 32, 96, 128, 32),
+        # Single token
+        (10, 3, 4, 128, 4),
+        # Smaller head dim
+        (64, 0, 64, 64, 16),
+        # Larger test
+        (512, 100, 400, 128, 64),
+        # Non-power-of-2 token count (exercises BLOCK_TOKENS tail masking)
+        (100, 10, 47, 128, 32),
+        # Very small
+        (3, 0, 3, 128, 1),
+    ],
+)
+def test_triton_gather_k_cache(
+    total_kv_len,
+    k_token_start,
+    k_token_end,
+    head_dim,
+    num_cache_rows,
+):
+    device = torch.device("cuda")
+
+    k_cache, slot_mapping_fp8, slot_mapping_scale = _create_cache_and_mappings(
+        total_kv_len, head_dim, num_cache_rows, device
+    )
+
+    triton_fp8, triton_scale = triton_gather_k_cache(
+        k_cache,
+        slot_mapping_fp8,
+        slot_mapping_scale,
+        k_token_start,
+        k_token_end,
+        head_dim,
+    )
+
+    ref_fp8, ref_scale = reference_gather_k_cache(
+        k_cache,
+        slot_mapping_fp8,
+        slot_mapping_scale,
+        k_token_start,
+        k_token_end,
+        head_dim,
+    )
+
+    assert triton_fp8.shape == ref_fp8.shape
+    assert triton_scale.shape == ref_scale.shape
+    assert torch.equal(triton_fp8.view(torch.uint8), ref_fp8.view(torch.uint8)), "FP8 data mismatch"
+    assert torch.equal(triton_scale.view(torch.uint8), ref_scale.view(torch.uint8)), (
+        "Scale data mismatch"
+    )
+
+
+def test_triton_gather_k_cache_empty():
+    """Zero-length chunk should return correctly shaped empty tensors."""
+    device = torch.device("cuda")
+    head_dim = 128
+    k_cache = torch.randint(0, 256, (4, 256), dtype=torch.uint8, device=device)
+    slot_mapping_fp8 = torch.zeros(10, dtype=torch.int64, device=device)
+    slot_mapping_scale = torch.zeros(10, dtype=torch.int64, device=device)
+
+    k_fp8, k_scale = triton_gather_k_cache(
+        k_cache,
+        slot_mapping_fp8,
+        slot_mapping_scale,
+        k_token_start=5,
+        k_token_end=5,
+        head_dim=head_dim,
+    )
+
+    assert k_fp8.shape == (0, head_dim)
+    assert k_scale.shape == (0, 1)
+    assert k_fp8.dtype == torch.float8_e4m3fn
+    assert k_scale.dtype == torch.float32
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 80)
+    print("Testing Triton Gather K Cache Kernel")
+    print("=" * 80)
+
+    print("\n--- Empty tokens ---")
+    test_triton_gather_k_cache_empty()
+
+    print("\n--- Gather all tokens ---")
+    test_triton_gather_k_cache(64, 0, 64, 128, 16)
+
+    print("\n--- Sub-range from middle ---")
+    test_triton_gather_k_cache(128, 32, 96, 128, 32)
+
+    print("\n--- Single token ---")
+    test_triton_gather_k_cache(10, 3, 4, 128, 4)
+
+    print("\n--- Larger test ---")
+    test_triton_gather_k_cache(512, 100, 400, 128, 64)
+
+    print("\n--- Non-power-of-2 tokens ---")
+    test_triton_gather_k_cache(100, 10, 47, 128, 32)
+
+    print("\n" + "=" * 80)
+    print("All tests passed!")
+    print("=" * 80)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized K cache gathering for sparse attention with a fused kernel implementation.

* **Tests**
  * Added test coverage for NVFP4/MoE configurations with multi-GPU CUDA graph piecewise execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Replace `_gather_k_cache_for_chunk` in DSA (Dynamic Sparse Attention) Indexer with a fused Triton kernel (`fused_gather_k_cache`). The original implementation used ~8-12 small PyTorch ops (arange, unsqueeze, broadcast add, `_unravel_indices`, advanced indexing) per chunk to gather FP8 K cache values and their scales. The new kernel fuses all of these into a single Triton launch that directly gathers from flat byte offsets in the indexer K cache pool, reducing kernel launch overhead and intermediate tensor allocations during prefill. The output is bit-exact with the original.

### Why this matters

With piecewise CUDA graph enabled, the DSA (attention) region is the only part executed eagerly — all other ops (MoE, NCCL AllReduce, RMSNorm, projections) are captured in the graph. This makes DSA kernel launch overhead a first-order bottleneck: ~65% of per-iteration GPU time is spent in DSA-launched kernels. Reducing the number of individually-launched kernels in DSA directly improves decode latency.

### Per-iteration analysis (nsys, DeepSeek-V3 8xB200 TP8/EP8, piecewise CUDA graph)

**DSA region per decode iteration:**
| Metric | Baseline | With Fusion | Delta |
|---|---|---|---|
| DSA kernel launches | 54 | 42 | **-12 (-22%)** |
| Replaced GPU compute | 17 kernels, 78.4 μs | 1 kernel, 4.5 μs | **-73.9 μs** |

Replaced ops: 12× `broadcast_add` + 2× `advanced_index` + 2× `arange` + 1× `BinaryFunctor` (78.4 μs total GPU) → 1× `_fused_gather_k_cache_kernel` (4.5 μs GPU).

### End-to-end performance (AA-RWLT, DeepSeek-V3 8×B200 TP8/EP8, conc=16)

Deterministic load test, same config: 16 concurrent users, 1800s phase duration, 1485s measurement window after 315s ramp-up + settling.

| Metric | Baseline (180207) | With Fusion (190304) | Delta |
|---|---|---|---|
| System Throughput | 500.8 tok/s | 533.3 tok/s | **+6.5%** |
| E2E Latency p50 | 2.401s | 2.322s | -3.3% |
| E2E Latency p95 | 6.155s | 5.959s | -3.2% |
| E2E Latency p99 | 7.263s | 6.951s | -4.3% |
| TTFT p50 | 334 ms | 323 ms | -3.3% |
| TTFT p95 | 725 ms | 666 ms | **-8.1%** |
| TTFT p99 | 885 ms | 805 ms | **-9.0%** |
| Output Speed (per-req) p50 | 36.9 tok/s | 39.0 tok/s | **+5.7%** |
| ITL p95 | 140.2 ms | 129.2 ms | **-7.8%** |

Measured requests: 8556 (baseline) vs 8769 (fusion), both 0 errors.

## Test Coverage

- Added `TestDeepseekV3FP4::test_nvfp4_multi_gpus_piecewise_cuda_graph` with two 8-GPU configurations:
  - **baseline**: TP8/EP8 with attention DP, CUTLASS MoE backend
  - **mtp3_fp8kv_chunked**: TP8/EP8 with MTP-3 speculative decoding, FP8 KV cache, chunked prefill, and TRTLLM MoE backend
- Both configurations run MMLU and GSM8K accuracy evaluations on DeepSeek-V3

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.