### PR TITLE
[#11992][fix] Handle GUIDE_TYPE_STRUCTURAL_TAG in gRPC request manager

### DIFF
--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -369,6 +369,8 @@ def create_sampling_params_from_proto(
             kwargs["guided_decoding"] = GuidedDecodingParams(regex=guide_content)
         elif guide_type == pb2.GuidedDecodingParams.GUIDE_TYPE_EBNF_GRAMMAR:
             kwargs["guided_decoding"] = GuidedDecodingParams(grammar=guide_content)
+        elif guide_type == pb2.GuidedDecodingParams.GUIDE_TYPE_STRUCTURAL_TAG:
+            kwargs["guided_decoding"] = GuidedDecodingParams(structural_tag=guide_content)
 
     params = SamplingParams(**kwargs)
 

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -173,13 +173,11 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
             raise
         except ValueError as e:
             logger.warning(f"Invalid request in Generate for {request_id}: {e}")
-            if self.request_manager is not None:
-                await self.request_manager.abort(request_id)
+            await self.request_manager.abort(request_id)
             await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
         except Exception as e:
             logger.error(f"Error in Generate for {request_id}: {e}")
-            if self.request_manager is not None:
-                await self.request_manager.abort(request_id)
+            await self.request_manager.abort(request_id)
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
     async def Embed(


### PR DESCRIPTION
## Description

The gRPC proto defines `GUIDE_TYPE_STRUCTURAL_TAG` (5) in `GuidedDecodingParams`, and the `GrammarMatcherFactory` already handles it via `compile_structural_tag()`. However, `create_sampling_params_from_proto()` in the gRPC request manager does not have a case for `GUIDE_TYPE_STRUCTURAL_TAG`, silently dropping the constraint.

This causes Harmony models (gpt-oss) that use `structural_tag` for json_schema enforcement to produce unconstrained output via gRPC.

**Fix**: Add the missing `elif` branch to convert `GUIDE_TYPE_STRUCTURAL_TAG` to `GuidedDecodingParams(structural_tag=guide_content)`.

Also cleaned up redundant `if self.request_manager is not None` checks in the servicer error handlers — `request_manager` is always set during initialization and cannot be None during request handling.

## Test Coverage

Tested with gpt-oss-20b via SMG gateway → TRT-LLM gRPC backend:

```bash
# Start TRT-LLM gRPC
python3 -m tensorrt_llm.commands.serve serve /models/openai/gpt-oss-20b \
  --grpc --backend pytorch --tp_size 1 \
  --extra_llm_api_options config.yaml  # guided_decoding_backend: xgrammar

# Send request with structural_tag constraint via SMG
curl -s -X POST http://localhost:3002/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/models/openai/gpt-oss-20b",
    "input": "List exactly 2 fruits.",
    "text": {"format": {"type": "json_schema", "name": "fruits", "schema": {
      "type": "object",
      "properties": {"items": {"type": "array", "items": {"type": "string"}}},
      "required": ["items"], "additionalProperties": false
    }, "strict": true}},
    "store": false
  }'
```

**Before**: structural_tag silently dropped, model returns unconstrained text
**After**: structural_tag constraint applied, model returns valid JSON matching schema

```
type=reasoning
  text='User asks: "List exactly 2 fruits." So answer should be exactly two fruit names, likely separated by commas or newlines. Must be exactly two items, not extra text. Probably just "Apple, Banana". Ensure only the list, no additional commentary.'
type=message
  text='{"items":["Apple","Banana"]}'
```

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for structural tag-guided decoding, extending available guided decoding options for inference requests.

* **Bug Fixes**
  * Improved error handling reliability during request generation by ensuring consistent request abort behavior in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->