### PR TITLE
[TRTLLM-11523][feat] Handle different chat template types

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_nemotron_flash.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_nemotron_flash.py
@@ -14,7 +14,11 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
 
 from tensorrt_llm._torch.utils import ActivationType
-from tensorrt_llm.inputs.utils import HF_CHAT_TEMPLATE_EXCEPTIONS
+from tensorrt_llm.inputs.content_format import ContentFormat
+from tensorrt_llm.inputs.registry import (
+    MULTIMODAL_PLACEHOLDER_REGISTRY,
+    MultimodalPlaceholderMetadata,
+)
 
 from ..nemotron_flash import NemotronFlashForCausalLMFactory
 
@@ -1102,4 +1106,8 @@ class NemotronFlashForCausalLM(NemotronFlashPreTrainedModel, GenerationMixin):
 NemotronFlashForCausalLMFactory.register_custom_model_cls(
     "NemotronFlashConfig", NemotronFlashForCausalLM
 )
-HF_CHAT_TEMPLATE_EXCEPTIONS.append("nemotron_flash")
+# The custom tokenizer's chat template expects plain strings, not OpenAI-style content dicts.
+MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+    "nemotron_flash",
+    MultimodalPlaceholderMetadata(content_format=ContentFormat.PASSTHROUGH),
+)

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -12,8 +12,8 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
 
 from ..._utils import nvtx_range
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...logger import logger
@@ -180,6 +180,7 @@ class Gemma3MultiModalProjector(torch.nn.Module):
     placeholder_metadata=MultimodalPlaceholderMetadata(
         placeholder_map={"image": "<start_of_image>"},
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class Gemma3VLM(PreTrainedModel):
 

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -16,8 +16,8 @@ from transformers.models.auto import CONFIG_MAPPING
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...logger import logger
@@ -1027,6 +1027,7 @@ class HCXVisionModel(nn.Module):
             '{{"ocr": "", "lens_keywords": "", "lens_local_keywords": ""}}'
         },
         placeholder_placement=MultimodalPlaceholderPlacement.AFTER_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class HCXVisionForCausalLM(PreTrainedModel):
 

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -23,8 +23,8 @@ from tensorrt_llm.lora_manager import HfLoraLoader
 from tensorrt_llm.models.convert_utils import split_matrix_tp
 
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...sampling_params import SamplingParams
@@ -1401,6 +1401,7 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
     placeholder_metadata=MultimodalPlaceholderMetadata(
         placeholder_map={"image": "<|image|>"},
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
                                                                  Llama4Config]):

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -18,10 +18,9 @@ from tensorrt_llm._torch.models.checkpoints.hf.llava_next_weight_mapper import \
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
-                       MultimodalPlaceholderPlacement, TextPrompt, TokensPrompt,
-                       register_input_processor,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
+                       TextPrompt, TokensPrompt, register_input_processor,
                        support_multimodal_disaggregated)
 from ...logger import logger
 from ...sampling_params import SamplingParams
@@ -599,13 +598,12 @@ class LlavaNextVisionModel(nn.Module):
 @support_multimodal_disaggregated
 @register_vision_encoder(LlavaNextVisionModel)
 @register_auto_model("LlavaNextForConditionalGeneration")
-@register_input_processor(
-    LlavaNextInputProcessor,
-    model_type="llava_next",
-    placeholder_metadata=MultimodalPlaceholderMetadata(
-        placeholder_map={"image": "<image>"},
-        placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
-    ))
+@register_input_processor(LlavaNextInputProcessor,
+                          model_type="llava_next",
+                          placeholder_metadata=MultimodalPlaceholderMetadata(
+                              placeholder_map={"image": "<image>"},
+                              content_format=ContentFormat.OPENAI,
+                          ))
 class LlavaNextModel(PreTrainedModel):
     config_class = LlavaNextConfig
 

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -40,7 +40,7 @@ from tensorrt_llm._torch.speculative import SpecMetadata
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.inputs import (BaseMultimodalDummyInputsBuilder,
-                                 BaseMultimodalInputProcessor,
+                                 BaseMultimodalInputProcessor, ContentFormat,
                                  ExtraProcessedInputs,
                                  MultimodalPlaceholderMetadata,
                                  MultimodalPlaceholderPlacement, TextPrompt,
@@ -509,6 +509,7 @@ class MistralCommonInputProcessor(Mistral3InputProcessor):
             "image": "[IMG]",
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.PASSTHROUGH,
     ))
 @register_input_processor(
     MistralCommonInputProcessor,
@@ -523,6 +524,7 @@ class MistralCommonInputProcessor(Mistral3InputProcessor):
         # However, accuracy tests show that the model generates higher quality output when the image
         # precedes the text (the relative difference can be as much as ~30% for both vLLM and TRT-LLM).
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class Mistral3VLM(PreTrainedModel):
     """Mistral3VLM implementation for TRTLLM.

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -33,8 +33,8 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ...executor.request import LoRARequest
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...logger import logger
@@ -946,6 +946,7 @@ class Phi4MMInputProcessor(BaseMultimodalInputProcessor,
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
         placeholders_separator="",
+        content_format=ContentFormat.STRING,
     ))
 class Phi4MMForCausalLM(transformers.PreTrainedModel):
 

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -29,8 +29,8 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ..._utils import nvtx_range, prefer_pinned
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor,
                        support_multimodal_disaggregated)
@@ -1028,6 +1028,7 @@ class Qwen2VLModelBase(PreTrainedModel):
             "video": "<|vision_start|><|video_pad|><|vision_end|>"
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class Qwen2VLModel(Qwen2VLModelBase):
 
@@ -1143,6 +1144,7 @@ class Qwen2_5VLInputProcessorBase(Qwen2VLInputProcessorBase):
             "video": "<|vision_start|><|video_pad|><|vision_end|>"
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        content_format=ContentFormat.STRING,
     ))
 class Qwen2_5_VLModel(Qwen2VLModelBase):
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -21,6 +21,7 @@ from ..._utils import nvtx_range, nvtx_range_debug, prefer_pinned
 from ...inputs import (
     BaseMultimodalDummyInputsBuilder,
     BaseMultimodalInputProcessor,
+    ContentFormat,
     ExtraProcessedInputs,
     MultimodalPlaceholderMetadata,
     MultimodalPlaceholderPlacement,
@@ -1139,6 +1140,7 @@ class Qwen3VLModelBase(PreTrainedModel):
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
         placeholders_separator="",
+        content_format=ContentFormat.STRING,
     ),
 )
 class Qwen3VLModel(Qwen3VLModelBase):

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl_moe.py
@@ -6,6 +6,7 @@ from transformers import PretrainedConfig
 from tensorrt_llm._torch.models.modeling_multimodal_utils import _is_disagg
 
 from ...inputs import (
+    ContentFormat,
     MultimodalPlaceholderMetadata,
     MultimodalPlaceholderPlacement,
     register_input_processor,
@@ -42,6 +43,7 @@ from .modeling_utils import ModelConfig, register_auto_model, register_vision_en
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
         placeholders_separator="",
+        content_format=ContentFormat.STRING,
     ),
 )
 class Qwen3MoeVLModel(Qwen3VLModelBase):

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -36,8 +36,8 @@ from transformers import (AutoConfig, AutoImageProcessor, AutoModel,
 
 from ..._utils import nvtx_range
 from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ExtraProcessedInputs,
-                       MultimodalPlaceholderMetadata,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...logger import logger
@@ -1157,6 +1157,9 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
             "video": "<vila/video>"
         },
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        # VILA handles its own chat template and placeholder insertion
+        # in VilaInputProcessor.
+        content_format=ContentFormat.PASSTHROUGH,
     ))
 class VilaModel(PreTrainedModel):
     config_class = VilaConfig

--- a/tensorrt_llm/evaluate/lm_eval.py
+++ b/tensorrt_llm/evaluate/lm_eval.py
@@ -36,7 +36,10 @@ from .. import LLM as PyTorchLLM
 from .._tensorrt_engine import LLM
 from ..inputs import (ConversationMessage, MultimodalDataTracker,
                       add_multimodal_placeholders, convert_image_mode)
+from ..inputs.content_format import ContentFormat
+from ..inputs.utils import _resolve_content_format
 from ..inputs.utils import apply_chat_template as trtllm_apply_chat_template
+from ..inputs.utils import resolve_hf_chat_template
 from ..llmapi import RequestOutput
 from ..logger import logger
 from ..sampling_params import SamplingParams
@@ -237,6 +240,15 @@ class MultimodalLmEvalWrapper(LmEvalWrapper):
 
         Adapted from: https://github.com/EleutherAI/lm-evaluation-harness/blob/7f04db12d2f8e7a99a0830d99eb78130e1ba2122/lm_eval/models/hf_vlms.py#L225
         """
+        # Resolve content format once to decide whether to pre-insert
+        # placeholders. OPENAI templates handle media natively, so we must
+        # NOT pre-insert or the template will produce duplicates.
+        processor = getattr(self.llm.input_processor, 'processor', None)
+        hf_chat_template = resolve_hf_chat_template(self.llm.tokenizer,
+                                                    processor, None, None)
+        content_format = _resolve_content_format(self.model_type,
+                                                 hf_chat_template)
+
         mm_placeholder_counts = []
         for i in range(len(chat_history)):
             content = chat_history[i]
@@ -259,8 +271,9 @@ class MultimodalLmEvalWrapper(LmEvalWrapper):
             for _ in range(image_count):
                 mm_data_tracker.add_data("image", None)
             mm_placeholder_count = mm_data_tracker.placeholder_counts()
-            if mm_placeholder_count:
-                # TODO: This is an assumption of not interleaving text and image. Need to extend to interleaved texts.
+            if mm_placeholder_count and content_format != ContentFormat.OPENAI:
+                # Only pre-insert placeholders for STRING templates.
+                # OPENAI templates handle media natively via content dicts.
                 conv["content"] = add_multimodal_placeholders(
                     self.model_type, conv["content"], mm_placeholder_count)
             mm_placeholder_counts.append(mm_placeholder_count)
@@ -269,7 +282,7 @@ class MultimodalLmEvalWrapper(LmEvalWrapper):
         output = trtllm_apply_chat_template(
             model_type=self.model_type,
             tokenizer=self.llm.tokenizer,
-            processor=getattr(self.llm.input_processor, 'processor', None),
+            processor=processor,
             conversation=chat_history,
             add_generation_prompt=add_generation_prompt,
             mm_placeholder_counts=mm_placeholder_counts,

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,3 +1,4 @@
+from .content_format import ContentFormat, detect_content_format
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
 from .evs import compute_retained_tokens_count, compute_retention_mask
 from .multimodal import MultimodalInput
@@ -20,6 +21,8 @@ from .utils import (ALL_SUPPORTED_AUDIO_MODELS, ALL_SUPPORTED_IMAGE_MODELS,
                     load_video)
 
 __all__ = [
+    "ContentFormat",
+    "detect_content_format",
     "ALL_SUPPORTED_MULTIMODAL_MODELS",
     "ALL_SUPPORTED_IMAGE_MODELS",
     "ALL_SUPPORTED_VIDEO_MODELS",

--- a/tensorrt_llm/inputs/content_format.py
+++ b/tensorrt_llm/inputs/content_format.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Content format detection for multimodal chat templates.
+
+Detects whether a Jinja chat template handles multimodal content natively
+(OpenAI-style dicts with type/text/image fields) or expects plain strings.
+"""
+
+import enum
+from functools import lru_cache
+
+from jinja2 import Environment
+from jinja2 import nodes as jinja_nodes
+from jinja2.exceptions import TemplateSyntaxError
+
+
+class ContentFormat(enum.Enum):
+    """Content format expected by a chat template.
+
+    OPENAI: Template iterates over `message['content']` expecting dicts with 'type' keys
+        (e.g., {"type": "text", ...}, {"type": "image"}).
+    STRING: Template expects `message['content']` to be a plain string.
+    PASSTHROUGH: Skip chat template rendering entirely; just concatenate message content strings.
+        Used by models whose input processor already produces the final prompt (e.g. VILA /
+        llava_llama, mistral_large_3 native tokenizer path).
+    """
+
+    OPENAI = "openai"
+    STRING = "string"
+    PASSTHROUGH = "passthrough"
+
+
+def _ast_has_content_iteration(ast: jinja_nodes.Template) -> bool:
+    """Helper for determining whether the jinja template has a content iteration loop.
+
+    Walk the Jinja AST to find a `For` node iterating over message content
+    with inner type-checking (content['type'] or content.type).
+
+    This detects templates that handle multimodal content natively, e.g.:
+
+    ```
+        {% for content in message['content'] %}
+            {% if content['type'] == 'image' %}
+    ```
+    """
+    for node in ast.find_all(jinja_nodes.For):
+        # Check if iterating over message['content'] or message.content
+        iter_node = node.iter
+        is_content_iter = False
+
+        if isinstance(iter_node, jinja_nodes.Getitem):
+            # message['content']
+            if isinstance(iter_node.arg, jinja_nodes.Const) and iter_node.arg.value == "content":
+                is_content_iter = True
+        elif isinstance(iter_node, jinja_nodes.Getattr):
+            # message.content
+            if iter_node.attr == "content":
+                is_content_iter = True
+
+        if not is_content_iter:
+            continue
+
+        # Now check if the loop body accesses `['type']` or `.type` on the loop variable
+        loop_var = node.target
+        if not isinstance(loop_var, jinja_nodes.Name):
+            continue
+        loop_var_name = loop_var.name
+
+        for inner_node in node.find_all((jinja_nodes.Getitem, jinja_nodes.Getattr)):
+            if isinstance(inner_node, jinja_nodes.Getitem):
+                if (
+                    isinstance(inner_node.node, jinja_nodes.Name)
+                    and inner_node.node.name == loop_var_name
+                    and isinstance(inner_node.arg, jinja_nodes.Const)
+                    and inner_node.arg.value == "type"
+                ):
+                    return True
+            elif isinstance(inner_node, jinja_nodes.Getattr):
+                if (
+                    isinstance(inner_node.node, jinja_nodes.Name)
+                    and inner_node.node.name == loop_var_name
+                    and inner_node.attr == "type"
+                ):
+                    return True
+
+    return False
+
+
+@lru_cache(maxsize=128)
+def detect_content_format(chat_template: str) -> ContentFormat:
+    """Detect whether a chat template handles multimodal content natively.
+
+    Parses the Jinja template AST and looks for patterns like:
+
+    ```
+        {% for content in message['content'] %}
+            {% if content['type'] == 'image' %} ...
+    ```
+
+    If found, the template handles OpenAI-style content dicts.
+    Otherwise, it expects plain string content.
+
+    Args:
+        chat_template: The Jinja2 chat template string.
+
+    Returns:
+        `ContentFormat.OPENAI` if template handles multimodal content dicts,
+            `ContentFormat.STRING` otherwise.
+    """
+    try:
+        env = Environment(autoescape=True)
+        ast = env.parse(chat_template)
+        if _ast_has_content_iteration(ast):
+            return ContentFormat.OPENAI
+    except TemplateSyntaxError:
+        # If parsing fails, fall back to STRING format
+        pass
+    return ContentFormat.STRING

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -17,6 +17,7 @@ import tensorrt_llm
 from .._utils import nvtx_range_debug
 from ..logger import logger
 from ..sampling_params import SamplingParams
+from .content_format import ContentFormat
 from .data import TextPrompt
 from .multimodal import (MultimodalInput, apply_mm_hashes, default_hasher,
                          find_mm_token_lengths, find_mm_token_positions,
@@ -414,18 +415,36 @@ class MultimodalPlaceholderPlacement(enum.Enum):
 @dataclass(frozen=True)
 class MultimodalPlaceholderMetadata:
     """
-    Metadata for the multimodal placeholder. It has 3 components:
+    Metadata for the multimodal placeholder. It has 5 components:
         - placeholder_map:
             A mapping from modality to placeholder string.
             Modality can be "image", "video", "audio", etc.
         - placeholder_placement:
             The placement of the placeholders, e.g. before or after the text prompt.
+            Only used when interleave_placeholders is False (the default).
+            Ignored when interleave_placeholders is True.
         - placeholders_separator:
             The separator between the placeholders, e.g. some models use "\n" to separate the placeholders.
+        - content_format:
+            Optional override for the content format expected by the chat template.
+            ContentFormat.OPENAI means the template handles multimodal content dicts natively.
+            ContentFormat.STRING means the template expects plain string content.
+            ContentFormat.PASSTHROUGH skips chat template rendering entirely.
+            None means auto-detect at runtime via Jinja AST analysis.
+        - interleave_placeholders:
+            When True and content_parts is available, placeholders are inserted
+            at the exact media positions within the text (interleaved).
+            In this mode, placeholder_placement is ignored - the position of
+            each placeholder is determined by where the media appears in the
+            user's message.
+            When False (default), placeholders are bulk-prepended or appended
+            according to placeholder_placement.
     """
     placeholder_map: Dict[str, str] = field(default_factory=dict)
     placeholder_placement: MultimodalPlaceholderPlacement = MultimodalPlaceholderPlacement.AFTER_TEXT
     placeholders_separator: str = "\n"
+    content_format: Optional[ContentFormat] = None
+    interleave_placeholders: bool = False
 
 
 class MultimodalPlaceholderRegistry:
@@ -492,6 +511,20 @@ class MultimodalPlaceholderRegistry:
             raise ValueError(f"Model type '{model_type}' is not registered")
         return self._multimodal_placeholder_by_model_type[
             model_type].placeholders_separator
+
+    def get_interleave_placeholders(self, model_type: str) -> bool:
+        """Return whether the model opts in to interleaved placeholder insertion."""
+        if model_type not in self._multimodal_placeholder_by_model_type:
+            return False
+        return self._multimodal_placeholder_by_model_type[
+            model_type].interleave_placeholders
+
+    def get_content_format(self, model_type: str) -> Optional[ContentFormat]:
+        """Get the content format override for a model type, or None for auto-detect."""
+        if model_type not in self._multimodal_placeholder_by_model_type:
+            return None
+        return self._multimodal_placeholder_by_model_type[
+            model_type].content_format
 
     def get_registered_image_model_types(self) -> Tuple[str, ...]:
         return (

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -19,6 +19,8 @@ from torchvision.transforms import ToTensor
 from transformers import AutoProcessor, ProcessorMixin
 from transformers.utils import logging
 
+from tensorrt_llm.inputs.content_format import (ContentFormat,
+                                                detect_content_format)
 from tensorrt_llm.inputs.multimodal import (MultimodalServerConfig,
                                             default_hasher)
 from tensorrt_llm.inputs.registry import (MULTIMODAL_PLACEHOLDER_REGISTRY,
@@ -386,21 +388,6 @@ def encode_base64_image(
     return base64.b64encode(data).decode("utf-8")
 
 
-"""
-VLM input preparation.
-
-NOTE:
-    When a new multimodal model is added, the following list(s) need
-    to be updated with the new model type and the appropriate
-    placeholder for the model needs to be added in retrieve_multimodal_placeholder().
-"""
-
-HF_CHAT_TEMPLATE_EXCEPTIONS = ["llava_llama", "mistral_large_3"]
-PLACEHOLDER_EXCEPTIONS = [
-    "llava_next", "NemotronH_Nano_VL_V2", "mistral_large_3"
-]
-
-
 # Helpers to always get the latest supported multimodal model types from the registry
 def ALL_SUPPORTED_MULTIMODAL_MODELS():
     return MULTIMODAL_PLACEHOLDER_REGISTRY.get_registered_model_types()
@@ -449,15 +436,30 @@ class MultimodalData(TypedDict):
     is_embedding: bool
 
 
-class ConversationMessage(TypedDict):
-    """Type definition for conversation message structure."""
-    role: str
-    content: List[dict[str, Any]]
-    media: List[MultimodalData]
+class ConversationMessage(TypedDict, total=False):
+    """Type definition for conversation message structure.
 
-    # @classmethod
-    # def fromSample(cls, sample: dict[str, str]) -> "ConversationMessage":
-    #     return cls(role="user", content=[{"type": "text", "text": prompt}])
+    Attributes:
+        role: The message role (e.g. "user", "assistant", "system").
+        content: Flattened text content (all text parts joined by newlines).
+        media: List of multimodal data items attached to this message.
+        content_parts: Ordered list preserving the interleaved positions of text and media as the
+            user originally sent them. Only present when the message contains media.
+
+            Each element is either:
+            - A `str` for a text segment, or
+            - A `dict` of the form `{"type": "<modality>", "media_index": <int>}`
+              marking where a media item (image/video/audio) appeared.
+              `media_index` is a 0-based index into `media`.
+
+            This is used by `interleave_mm_placeholders` to insert multimodal placeholders at the
+            correct positions, and to reconstruct the OpenAI-style content list for templates that
+            handle media natively.
+    """
+    role: str
+    content: str
+    media: List[MultimodalData]
+    content_parts: List[Union[str, dict]]
 
 
 class MultimodalDataTracker:
@@ -471,6 +473,7 @@ class MultimodalDataTracker:
         self._data = defaultdict[str, list](list)
         self._embeddings = defaultdict[str, list](list)
         self._placeholder_counts = defaultdict[str, int](int)
+        self._placeholder_to_modality: dict[str, str] = {}
         self._multimodal_server_config = multimodal_server_config if multimodal_server_config is not None else MultimodalServerConfig(
         )
 
@@ -521,19 +524,21 @@ class MultimodalDataTracker:
          if is_embedding else self._data)[media_type].append(data)
         if placeholder:
             self._placeholder_counts[placeholder] += 1
+            self._placeholder_to_modality[placeholder] = media_type
         return placeholder
 
     def placeholder_counts(self) -> Dict[str, int]:
         """Get the count of multimodal placeholders."""
         return dict(self._placeholder_counts)
 
+    def placeholder_modalities(self) -> Dict[str, str]:
+        """Get the mapping from placeholder string to modality name."""
+        return dict(self._placeholder_to_modality)
+
 
 def add_multimodal_placeholders(model_type: str, text_prompt: str,
                                 mm_placeholder_counts: dict[str, int]) -> str:
     """Add multimodal placeholders to the text prompt."""
-    if model_type in PLACEHOLDER_EXCEPTIONS:
-        # no need to add placeholders, it is handled differently
-        return text_prompt
     placeholders = []
     for placeholder in mm_placeholder_counts:
         placeholders.extend([placeholder] * mm_placeholder_counts[placeholder])
@@ -547,6 +552,68 @@ def add_multimodal_placeholders(model_type: str, text_prompt: str,
             parts.extend(placeholders)
     return MULTIMODAL_PLACEHOLDER_REGISTRY.get_placeholders_separator(
         model_type).join(parts)
+
+
+def interleave_mm_placeholders(
+    model_type: str,
+    content_parts: list[Union[str, dict]],
+    mm_placeholder_counts: dict[str, int],
+    placeholder_modalities: Dict[str, str],
+) -> str:
+    """Build a prompt string with placeholders interleaved at media positions.
+
+    When `content_parts` preserves the original ordering of text and media
+    items from the user's request, this function inserts the correct
+    placeholder at each media position instead of bulk-prepending/appending.
+
+    Args:
+        model_type: The model type string (used to look up placeholder info).
+        content_parts: Ordered list of text strings and media position dicts.
+        mm_placeholder_counts: Mapping of placeholder -> expected count.
+        placeholder_modalities: Mapping of placeholder string to modality
+            name (e.g. `{"<image>": "image"}`).
+
+    Returns:
+        A single string with placeholders inserted at the correct positions.
+    """
+    if not content_parts:
+        return add_multimodal_placeholders(model_type, "",
+                                           mm_placeholder_counts)
+
+    # Build a per-modality queue of placeholder strings (expanded by count).
+    # This handles both shared placeholders (e.g. "<image>" with count=3)
+    # and unique per-item placeholders (e.g. "<|image_1|>", "<|image_2|>").
+    modality_placeholders: dict[str, list[str]] = {}
+    for placeholder, count in mm_placeholder_counts.items():
+        if placeholder not in placeholder_modalities:
+            raise KeyError(
+                f"Placeholder '{placeholder}' not found in "
+                f"placeholder_modalities mapping. Known placeholders: "
+                f"{list(placeholder_modalities.keys())}")
+        modality = placeholder_modalities[placeholder]
+        modality_placeholders.setdefault(modality,
+                                         []).extend([placeholder] * count)
+
+    parts: list[str] = []
+    separator = MULTIMODAL_PLACEHOLDER_REGISTRY.get_placeholders_separator(
+        model_type)
+    # Track how many placeholders have been consumed per modality
+    modality_cursor: dict[str, int] = {}
+
+    for part in content_parts:
+        if isinstance(part, str):
+            parts.append(part)
+        elif isinstance(part, dict):
+            media_type = part.get("type", "image")
+            queue = modality_placeholders.get(media_type)
+            if not queue:
+                continue
+            cursor = modality_cursor.get(media_type, 0)
+            if cursor < len(queue):
+                parts.append(queue[cursor])
+                modality_cursor[media_type] = cursor + 1
+
+    return separator.join(parts)
 
 
 def resolve_hf_chat_template(
@@ -569,50 +636,71 @@ def resolve_hf_chat_template(
     try:
         return tokenizer.get_chat_template(chat_template, tools=tools)
     except Exception:
-        logger.warning("Failed to load AutoTokenizer chat template for %s",
-                       tokenizer.name_or_path)
+        logger.warning(
+            "Failed to load AutoTokenizer chat template for %s",
+            getattr(tokenizer, "name_or_path",
+                    type(tokenizer).__name__))
     return None
 
 
-def handle_placeholder_exceptions(model_type: str,
-                                  conversation: list[ConversationMessage],
-                                  mm_placeholder_counts: list[dict[str, int]]):
-    if model_type == "llava_next":
-        # we need to convert the flattened content back to conversation format
-        for conv, mm_placeholder_count in zip(conversation,
-                                              mm_placeholder_counts):
-            conv["content"] = [{"type": "text", "text": conv["content"]}, \
-                *[{"type": "image"} for _ in range(mm_placeholder_count['<image>'])]]
-    elif model_type == "NemotronH_Nano_VL_V2":
-        # There are divergences between trtllm and vllm on how to handle the placeholders.
-        # For now, we will use this exception to handle with the divergences in TRTLLM.
-        # In the near future, we will remove this placeholder exception and use dict format as vllm does.
-        for conv, mm_placeholder_count in zip(conversation,
-                                              mm_placeholder_counts):
-            if '<image>' not in mm_placeholder_count and '<video>' not in mm_placeholder_count and '<so_embedding>' not in mm_placeholder_count:
-                # Skip if no image, video, or audio placeholders.
-                continue
+def _resolve_content_format(model_type: str,
+                            chat_template: Optional[str]) -> ContentFormat:
+    """Determine the content format for the given model and template.
 
-            # Audio placeholders must be added directly to the text content because the
-            # chat template for this model doesn't handle {"type": "audio"} list items.
-            if '<so_embedding>' in mm_placeholder_count:
-                audio_placeholders = '<so_embedding>' * mm_placeholder_count[
-                    '<so_embedding>']
-                conv["content"] = audio_placeholders + "\n" + conv["content"]
+    Resolution order:
+    1. Registry override (explicit per-model annotation).
+    2. Jinja AST auto-detection (if a template string is available).
+    3. Default to STRING.
+    """
+    # 1. Check registry for an explicit override
+    registry_format = MULTIMODAL_PLACEHOLDER_REGISTRY.get_content_format(
+        model_type)
+    if registry_format is not None:
+        return registry_format
 
-            # Image/video placeholders must be added directly to the text
-            # content because the chat template for this model doesn't
-            # handle {"type": "image"/"video"} list items — it just
-            # stringifies them.
-            if '<image>' in mm_placeholder_count:
-                image_placeholders = '<image>' * mm_placeholder_count['<image>']
-                conv["content"] = image_placeholders + "\n" + conv["content"]
-            if '<video>' in mm_placeholder_count:
-                video_placeholders = '<video>' * mm_placeholder_count['<video>']
-                conv["content"] = video_placeholders + "\n" + conv["content"]
+    # 2. Auto-detect from template AST
+    if chat_template is not None:
+        return detect_content_format(chat_template)
+
+    # 3. Default
+    return ContentFormat.STRING
+
+
+def _build_openai_content(
+        conv: ConversationMessage,
+        mm_placeholder_count: dict[str, int]) -> list[dict[str, Any]]:
+    """Reconstruct OpenAI-style content list from a ConversationMessage.
+
+    Uses `content_parts` (preserving media position) when available, otherwise falls back to placing
+    text first then media items.
+    """
+    content_list: list[dict[str, Any]] = []
+    content_parts = conv.get("content_parts")
+
+    if content_parts:
+        for part in content_parts:
+            if isinstance(part, str):
+                content_list.append({"type": "text", "text": part})
+            elif isinstance(part, dict):
+                media_type = part.get("type", "image")
+                content_list.append({"type": media_type})
     else:
-        raise ValueError(f"This path should not be reached for: {model_type}")
-    return conversation
+        # Fallback: text first, then media placeholders
+        text = conv.get("content", "")
+        if text:
+            content_list.append({"type": "text", "text": text})
+        for placeholder, count in mm_placeholder_count.items():
+            # Infer modality from placeholder (e.g. "<image>" -> "image")
+            modality = "image"
+            if "video" in placeholder.lower():
+                modality = "video"
+            elif "audio" in placeholder.lower(
+            ) or "so_embedding" in placeholder.lower():
+                modality = "audio"
+            for _ in range(count):
+                content_list.append({"type": modality})
+
+    return content_list
 
 
 def apply_chat_template(
@@ -629,11 +717,13 @@ def apply_chat_template(
     chat_template_kwargs: Optional[dict[str, Any]] = None,
     enable_tokenize: bool = False,
 ) -> (str | List[str]):
-    """Apply chat template to the conversation."""
+    """Apply chat template to the conversation.
 
-    if model_type in HF_CHAT_TEMPLATE_EXCEPTIONS:
-        # special path for models like llava-llama
-        return "".join([conv["content"] for conv in conversation])
+    Uses content-format-driven dispatch:
+    - PASSTHROUGH: skip template rendering, just concatenate content strings
+    - OPENAI: reconstructs content as list of dicts for the template to handle
+    - STRING: keeps flattened text with pre-inserted placeholders
+    """
 
     # Handle DeepSeek V32 tokenizer with custom chat template
     if isinstance(tokenizer, DeepseekV32Tokenizer):
@@ -646,6 +736,13 @@ def apply_chat_template(
             return tokenizer.encode(prompt)
         return prompt
 
+    # Check for PASSTHROUGH early — before we need tokenizer/processor/template.
+    # The registry may already know this model skips chat templates entirely.
+    registry_format = MULTIMODAL_PLACEHOLDER_REGISTRY.get_content_format(
+        model_type)
+    if registry_format == ContentFormat.PASSTHROUGH:
+        return "".join([conv["content"] for conv in conversation])
+
     if isinstance(tokenizer, TransformersTokenizer):
         tokenizer = tokenizer.tokenizer  # we need the TokenizerBase for apply_chat_template
 
@@ -654,12 +751,20 @@ def apply_chat_template(
     if hf_chat_template is None:
         raise ValueError(
             "No chat template found for the given tokenizer and tools.")
-    if model_type in PLACEHOLDER_EXCEPTIONS:
-        # flattened content do not work for these models, so go back to other formats as needed
-        conversation = handle_placeholder_exceptions(model_type, conversation,
-                                                     mm_placeholder_counts)
 
-    return tokenizer.apply_chat_template(
+    # Determine content format and prepare conversation accordingly
+    content_format = _resolve_content_format(model_type, hf_chat_template)
+
+    if content_format == ContentFormat.OPENAI:
+        # Path OPENAI: reconstruct content as list of dicts for the template
+        for conv, mm_placeholder_count in zip(conversation,
+                                              mm_placeholder_counts):
+            if mm_placeholder_count:
+                conv["content"] = _build_openai_content(conv,
+                                                        mm_placeholder_count)
+    # STRING path: placeholders already inserted in content by caller
+
+    result = tokenizer.apply_chat_template(
         conversation=conversation,
         tokenize=enable_tokenize,
         add_generation_prompt=add_generation_prompt,
@@ -668,6 +773,8 @@ def apply_chat_template(
         chat_template=hf_chat_template,
         **(chat_template_kwargs or {}),
     )
+
+    return result
 
 
 def default_multimodal_input_loader(
@@ -794,11 +901,14 @@ def default_multimodal_input_loader(
         media_or_embeddings = [media_or_embeddings]
     assert len(media_or_embeddings) == len(prompts)
 
-    if tokenizer is None and model_type not in HF_CHAT_TEMPLATE_EXCEPTIONS:
+    is_passthrough = (MULTIMODAL_PLACEHOLDER_REGISTRY.get_content_format(
+        model_type) == ContentFormat.PASSTHROUGH)
+
+    if tokenizer is None and not is_passthrough:
         tokenizer = ModelLoader.load_hf_tokenizer(model_dir, use_fast=True)
 
     processor = None
-    if model_type not in HF_CHAT_TEMPLATE_EXCEPTIONS:
+    if not is_passthrough:
         processor = AutoProcessor.from_pretrained(model_dir,
                                                   use_fast=True,
                                                   trust_remote_code=True)
@@ -819,8 +929,17 @@ def default_multimodal_input_loader(
         mm_placeholder_counts = mm_data_tracker.placeholder_counts()
         prompt = conv["content"]
         if mm_placeholder_counts:
-            conv["content"] = add_multimodal_placeholders(
-                model_type, conv["content"], mm_placeholder_counts)
+            # Resolve content format to decide whether to pre-insert
+            # placeholders.  OPENAI templates handle media natively (e.g.
+            # numbered <image N> tags), so we must NOT pre-insert or the
+            # template's dedup guard will suppress its own output.
+            hf_chat_template = resolve_hf_chat_template(tokenizer, processor,
+                                                        None, None)
+            content_format = _resolve_content_format(model_type,
+                                                     hf_chat_template)
+            if content_format != ContentFormat.OPENAI:
+                conv["content"] = add_multimodal_placeholders(
+                    model_type, conv["content"], mm_placeholder_counts)
         prompt = apply_chat_template(
             model_type=model_type,
             tokenizer=tokenizer,

--- a/tensorrt_llm/serve/chat_utils.py
+++ b/tensorrt_llm/serve/chat_utils.py
@@ -14,12 +14,14 @@ from openai.types.chat import (ChatCompletionContentPartTextParam,
 from transformers import AutoConfig
 from typing_extensions import Required
 
-from tensorrt_llm.inputs import (ConversationMessage, MultimodalData,
-                                 MultimodalDataTracker,
+from tensorrt_llm.inputs import (ContentFormat, ConversationMessage,
+                                 MultimodalData, MultimodalDataTracker,
                                  add_multimodal_placeholders, async_load_audio,
                                  async_load_image, async_load_video,
                                  load_base64_image_embeds)
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
+from tensorrt_llm.inputs.registry import MULTIMODAL_PLACEHOLDER_REGISTRY
+from tensorrt_llm.inputs.utils import interleave_mm_placeholders
 from tensorrt_llm.logger import logger
 
 
@@ -170,22 +172,40 @@ def parse_chat_message_content_parts(
     parts: Iterable[ChatCompletionContentPartParam],
     mm_data_tracker: MultimodalDataTracker,
 ) -> ConversationMessage:
-    """Parse multiple parts of a chat message."""
-    text_parts = []
-    media_parts = []
+    """Parse multiple parts of a chat message.
+
+    Builds both the flattened text (`content`) for backward compatibility and an ordered
+    `content_parts` list that preserves the interleaved positions of text and media items.
+    """
+    text_parts: list[str] = []
+    media_parts: list[MultimodalData] = []
+    content_parts: list[Union[str, dict]] = []
+
+    media_index = 0
     for part in parts:
         parse_res = parse_chat_message_content_part(part, mm_data_tracker)
         if parse_res:
             if isinstance(parse_res, str):
                 text_parts.append(parse_res)
+                content_parts.append(parse_res)
             else:
                 media_parts.append(parse_res)
+                content_parts.append({
+                    "type": parse_res["modality"],
+                    "media_index": media_index,
+                })
+                media_index += 1
 
     text_prompt = "\n".join(text_parts)
 
-    return ConversationMessage(role=role,
-                               content=text_prompt,
-                               media=media_parts)
+    result = ConversationMessage(role=role,
+                                 content=text_prompt,
+                                 media=media_parts)
+    # Only include content_parts when media is present (to preserve
+    # interleaved ordering for multimodal dispatch).
+    if media_parts:
+        result["content_parts"] = content_parts
+    return result
 
 
 def parse_chat_message_content(
@@ -268,6 +288,28 @@ def parse_chat_messages_coroutines(
     mm_placeholder_counts = []
     mm_data_tracker = MultimodalDataTracker(model_config.model_type,
                                             multimodal_server_config)
+
+    # Determine content format to decide placeholder strategy.
+    #
+    # We intentionally check only the `MULTIMODAL_PLACEHOLDER_REGISTRY` here
+    # (not `_resolve_content_format` / jinja AST detection) because:
+    #
+    # 1. The chat template string is not available at this stage - it is resolved later in
+    #    `apply_chat_template` which has access to the tokenizer and processor.
+    # 2. Defaulting to `STRING` when the registry has no entry is safe even if the template later
+    #    turns out to be OPENAI-format. When multimodal data is present, `content_parts` is always
+    #    populated (see `parse_chat_message_content_parts`), and `apply_chat_template`'s OPENAI
+    #    path calls `_build_openai_content`, which reconstructs `conv["content"]` from
+    #    `content_parts` - overwriting any STRING-style placeholders inserted here.
+    # See also: `_resolve_content_format` (inputs/utils.py) for the full resolution used downstream.
+    model_type = model_config.model_type
+    registry_format = MULTIMODAL_PLACEHOLDER_REGISTRY.get_content_format(
+        model_type)
+    if registry_format is not None:
+        content_format = registry_format
+    else:
+        content_format = ContentFormat.STRING
+
     for msg in messages:
         parsed_msg = parse_chat_message_content(msg, mm_data_tracker)
         conversation.append(parsed_msg)
@@ -285,10 +327,20 @@ def parse_chat_messages_coroutines(
                         placeholder] = msg_placeholder_counts.get(
                             placeholder, 0) + 1
 
-        if msg_placeholder_counts:
-            parsed_msg["content"] = add_multimodal_placeholders(
-                model_config.model_type, parsed_msg["content"],
-                msg_placeholder_counts)
+        if msg_placeholder_counts and content_format == ContentFormat.STRING:
+            # For STRING format, use interleaving when the model opts in
+            # and content_parts is available, otherwise fall back to bulk
+            # prepend/append according to placeholder_placement.
+            content_parts = parsed_msg.get("content_parts")
+            interleave = MULTIMODAL_PLACEHOLDER_REGISTRY.get_interleave_placeholders(
+                model_type)
+            if content_parts and interleave:
+                parsed_msg["content"] = interleave_mm_placeholders(
+                    model_type, content_parts, msg_placeholder_counts,
+                    mm_data_tracker.placeholder_modalities())
+            else:
+                parsed_msg["content"] = add_multimodal_placeholders(
+                    model_type, parsed_msg["content"], msg_placeholder_counts)
         mm_placeholder_counts.append(msg_placeholder_counts)
 
     return conversation, mm_data_tracker.retrieve_all_async(

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -31,6 +31,8 @@ l0_a10:
   # test list either).
   - unittest/_torch/models/checkpoints/hf/test_weight_loader.py
   - unittest/_torch/models/checkpoints/hf/test_checkpoint_loader.py
+  - unittest/inputs/test_chat_template_dispatch.py
+  - unittest/inputs/test_content_format.py
   - unittest/others/test_convert_utils.py
   - unittest/others/test_time_breakdown.py
   - unittest/others/test_tracing.py

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -96,8 +96,8 @@ def test_nemotron_nano_v2_vl_input_processor(data_dict_fixture, condition, modal
                 "num_patches": torch.tensor([1]),
             },
             "multiple": {
-                "prompt_pattern": "<image><image>",
-                "prompt_token_ids_length": 540,
+                "prompt_pattern": "<image 1><image> <image 2><image>",
+                "prompt_token_ids_length": 550,
                 "pixel_values_shape": (2, 3, 512, 512),
                 "num_patches": torch.tensor([2]),
             },
@@ -110,8 +110,8 @@ def test_nemotron_nano_v2_vl_input_processor(data_dict_fixture, condition, modal
                 "num_patches": torch.tensor([8]),
             },
             "multiple": {
-                "prompt_pattern": "<video><video>",
-                "prompt_token_ids_length": 4380,
+                "prompt_pattern": "<video>\n<video>",
+                "prompt_token_ids_length": 4381,
                 "pixel_values_shape": (16, 3, 512, 512),
                 "num_patches": torch.tensor([16]),
             },

--- a/tests/unittest/inputs/test_chat_template_dispatch.py
+++ b/tests/unittest/inputs/test_chat_template_dispatch.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Tests for content-format-driven chat template dispatch and placeholder handling."""
+
+import pytest
+
+from tensorrt_llm.inputs.content_format import ContentFormat
+from tensorrt_llm.inputs.registry import (
+    MULTIMODAL_PLACEHOLDER_REGISTRY,
+    MultimodalPlaceholderMetadata,
+    MultimodalPlaceholderPlacement,
+)
+from tensorrt_llm.inputs.utils import (
+    ConversationMessage,
+    _build_openai_content,
+    _resolve_content_format,
+    interleave_mm_placeholders,
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _register_test_models():
+    """Register temporary test models for each test, then clean up."""
+    # STRING format model (explicit)
+    MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+        "test_string_model",
+        MultimodalPlaceholderMetadata(
+            placeholder_map={"image": "<image>", "video": "<video>"},
+            placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+            placeholders_separator="\n",
+            content_format=ContentFormat.STRING,
+        ),
+    )
+    # OPENAI format model (explicit)
+    MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+        "test_openai_model",
+        MultimodalPlaceholderMetadata(
+            placeholder_map={"image": "<image>"},
+            placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+            placeholders_separator="\n",
+            content_format=ContentFormat.OPENAI,
+        ),
+    )
+    # Auto-detect model (content_format=None)
+    MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+        "test_auto_model",
+        MultimodalPlaceholderMetadata(
+            placeholder_map={"image": "<img>"},
+            placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+            placeholders_separator="\n",
+        ),
+    )
+    # PASSTHROUGH format model (skip chat template entirely)
+    MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+        "test_passthrough_model",
+        MultimodalPlaceholderMetadata(
+            placeholder_map={"image": "<image>"},
+            placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+            content_format=ContentFormat.PASSTHROUGH,
+        ),
+    )
+
+    yield
+
+    for mt in (
+        "test_string_model",
+        "test_openai_model",
+        "test_auto_model",
+        "test_passthrough_model",
+    ):
+        try:
+            MULTIMODAL_PLACEHOLDER_REGISTRY.remove_placeholder_metadata(mt)
+        except ValueError:
+            pass
+
+
+class TestResolveContentFormat:
+    def test_explicit_string(self):
+        fmt = _resolve_content_format("test_string_model", None)
+        assert fmt == ContentFormat.STRING
+
+    def test_explicit_openai(self):
+        fmt = _resolve_content_format("test_openai_model", None)
+        assert fmt == ContentFormat.OPENAI
+
+    def test_auto_detect_openai_template(self):
+        template = (
+            "{% for m in messages %}"
+            "{% for c in m['content'] %}"
+            "{% if c['type'] == 'text' %}{{ c['text'] }}{% endif %}"
+            "{% endfor %}{% endfor %}"
+        )
+        fmt = _resolve_content_format("test_auto_model", template)
+        assert fmt == ContentFormat.OPENAI
+
+    def test_auto_detect_string_template(self):
+        template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+        fmt = _resolve_content_format("test_auto_model", template)
+        assert fmt == ContentFormat.STRING
+
+    def test_explicit_passthrough(self):
+        fmt = _resolve_content_format("test_passthrough_model", None)
+        assert fmt == ContentFormat.PASSTHROUGH
+
+    def test_unknown_model_defaults_to_string(self):
+        fmt = _resolve_content_format("unknown_model", None)
+        assert fmt == ContentFormat.STRING
+
+
+class TestBuildOpenAIContent:
+    def test_with_content_parts(self):
+        conv = ConversationMessage(
+            role="user",
+            content="Hello",
+            media=[],
+            content_parts=[
+                "Hello",
+                {"type": "image", "media_index": 0},
+                " world",
+            ],
+        )
+        result = _build_openai_content(conv, {"<image>": 1})
+        assert result == [
+            {"type": "text", "text": "Hello"},
+            {"type": "image"},
+            {"type": "text", "text": " world"},
+        ]
+
+    def test_without_content_parts_fallback(self):
+        conv = ConversationMessage(
+            role="user",
+            content="Hello",
+            media=[],
+        )
+        result = _build_openai_content(conv, {"<image>": 2})
+        assert result == [
+            {"type": "text", "text": "Hello"},
+            {"type": "image"},
+            {"type": "image"},
+        ]
+
+    def test_video_modality_inference(self):
+        conv = ConversationMessage(role="user", content="Describe", media=[])
+        result = _build_openai_content(conv, {"<video>": 1})
+        assert result == [
+            {"type": "text", "text": "Describe"},
+            {"type": "video"},
+        ]
+
+
+class TestInterleaveMmPlaceholders:
+    def test_basic_interleaving(self):
+        content_parts = [
+            "Hello",
+            {"type": "image", "media_index": 0},
+            " what is this?",
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model", content_parts, {"<image>": 1}, {"<image>": "image"}
+        )
+        assert result == "Hello\n<image>\n what is this?"
+
+    def test_multiple_images(self):
+        content_parts = [
+            {"type": "image", "media_index": 0},
+            "Compare these:",
+            {"type": "image", "media_index": 1},
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model", content_parts, {"<image>": 2}, {"<image>": "image"}
+        )
+        assert result == "<image>\nCompare these:\n<image>"
+
+    def test_empty_content_parts_fallback(self):
+        result = interleave_mm_placeholders(
+            "test_string_model", [], {"<image>": 1}, {"<image>": "image"}
+        )
+        # Falls back to add_multimodal_placeholders
+        assert "<image>" in result
+
+    def test_mixed_modalities(self):
+        content_parts = [
+            {"type": "image", "media_index": 0},
+            "Describe the image and video",
+            {"type": "video", "media_index": 1},
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model",
+            content_parts,
+            {"<image>": 1, "<video>": 1},
+            {"<image>": "image", "<video>": "video"},
+        )
+        assert result == "<image>\nDescribe the image and video\n<video>"
+
+    def test_numbered_placeholders(self):
+        """Models like Phi4MM use unique per-item placeholders."""
+        content_parts = [
+            {"type": "image", "media_index": 0},
+            "Compare these two images:",
+            {"type": "image", "media_index": 1},
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model",
+            content_parts,
+            {"<|image_1|>": 1, "<|image_2|>": 1},
+            {"<|image_1|>": "image", "<|image_2|>": "image"},
+        )
+        assert result == "<|image_1|>\nCompare these two images:\n<|image_2|>"
+
+    def test_numbered_placeholders_three_images(self):
+        """Three unique image placeholders interleaved with text."""
+        content_parts = [
+            "First:",
+            {"type": "image", "media_index": 0},
+            "Second:",
+            {"type": "image", "media_index": 1},
+            "Third:",
+            {"type": "image", "media_index": 2},
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model",
+            content_parts,
+            {"<|image_1|>": 1, "<|image_2|>": 1, "<|image_3|>": 1},
+            {"<|image_1|>": "image", "<|image_2|>": "image", "<|image_3|>": "image"},
+        )
+        assert result == "First:\n<|image_1|>\nSecond:\n<|image_2|>\nThird:\n<|image_3|>"
+
+    def test_shared_placeholder_with_count(self):
+        """Shared placeholder repeated by count (non-numbered models)."""
+        content_parts = [
+            {"type": "image", "media_index": 0},
+            "text",
+            {"type": "image", "media_index": 1},
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model",
+            content_parts,
+            {"<image>": 2},
+            {"<image>": "image"},
+        )
+        assert result == "<image>\ntext\n<image>"
+
+    def test_ambiguous_placeholder_resolved_by_mapping(self):
+        """Explicit mapping resolves placeholders that have no modality hint."""
+        content_parts = [
+            {"type": "video", "media_index": 0},
+            "text",
+        ]
+        result = interleave_mm_placeholders(
+            "test_string_model",
+            content_parts,
+            {"<media_token>": 1},
+            {"<media_token>": "video"},
+        )
+        assert result == "<media_token>\ntext"
+
+    def test_missing_placeholder_in_mapping_raises(self):
+        """KeyError when a placeholder is not in the mapping."""
+        content_parts = [
+            {"type": "image", "media_index": 0},
+        ]
+        with pytest.raises(KeyError, match="not found in placeholder_modalities"):
+            interleave_mm_placeholders(
+                "test_string_model",
+                content_parts,
+                {"<image>": 1},
+                {},
+            )

--- a/tests/unittest/inputs/test_content_format.py
+++ b/tests/unittest/inputs/test_content_format.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Tests for content format detection via Jinja AST analysis."""
+
+from tensorrt_llm.inputs.content_format import ContentFormat, detect_content_format
+
+# A template that iterates over message['content'] and checks content['type']
+# (OpenAI-style multimodal template)
+OPENAI_TEMPLATE = """\
+{% for message in messages %}
+{% if message['role'] == 'user' %}
+{% for content in message['content'] %}
+{% if content['type'] == 'text' %}
+{{ content['text'] }}
+{% elif content['type'] == 'image' %}
+<image>
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+"""
+
+# Same pattern but using dot-access: message.content and content.type
+OPENAI_TEMPLATE_DOT_ACCESS = """\
+{% for message in messages %}
+{% for content in message.content %}
+{% if content.type == 'text' %}
+{{ content.text }}
+{% elif content.type == 'image' %}
+<image>
+{% endif %}
+{% endfor %}
+{% endfor %}
+"""
+
+# A plain string template that just uses message['content'] as a string
+STRING_TEMPLATE = """\
+{% for message in messages %}
+<|{{ message['role'] }}|>
+{{ message['content'] }}
+{% endfor %}
+"""
+
+# A template that iterates over messages but not over content items
+STRING_TEMPLATE_WITH_LOOP = """\
+{% for message in messages %}
+{% if message['role'] == 'system' %}
+<|system|>{{ message['content'] }}<|end|>
+{% elif message['role'] == 'user' %}
+<|user|>{{ message['content'] }}<|end|>
+{% endif %}
+{% endfor %}
+"""
+
+# An empty template
+EMPTY_TEMPLATE = ""
+
+# A real-world-like llava template that handles multimodal content
+LLAVA_LIKE_TEMPLATE = """\
+{% for message in messages %}
+{% if message['role'] == 'user' %}
+USER: {% for content in message['content'] %}{% if content['type'] == 'text' %}{{ content['text'] }}{% elif content['type'] == 'image' %}<image>{% endif %}{% endfor %}
+{% elif message['role'] == 'assistant' %}
+ASSISTANT: {{ message['content'] }}
+{% endif %}
+{% endfor %}
+"""  # noqa: E501
+
+
+class TestDetectContentFormat:
+    def test_openai_template_bracket_access(self):
+        assert detect_content_format(OPENAI_TEMPLATE) == ContentFormat.OPENAI
+
+    def test_openai_template_dot_access(self):
+        assert detect_content_format(OPENAI_TEMPLATE_DOT_ACCESS) == ContentFormat.OPENAI
+
+    def test_string_template(self):
+        assert detect_content_format(STRING_TEMPLATE) == ContentFormat.STRING
+
+    def test_string_template_with_loop(self):
+        assert detect_content_format(STRING_TEMPLATE_WITH_LOOP) == ContentFormat.STRING
+
+    def test_empty_template(self):
+        assert detect_content_format(EMPTY_TEMPLATE) == ContentFormat.STRING
+
+    def test_llava_like_template(self):
+        assert detect_content_format(LLAVA_LIKE_TEMPLATE) == ContentFormat.OPENAI
+
+    def test_invalid_jinja_falls_back_to_string(self):
+        assert detect_content_format("{% invalid jinja %}") == ContentFormat.STRING
+
+    def test_caching(self):
+        """Verify that repeated calls return cached results via lru_cache."""
+        detect_content_format.cache_clear()
+        template = STRING_TEMPLATE
+
+        detect_content_format(template)
+        info_after_first = detect_content_format.cache_info()
+        assert info_after_first.misses >= 1
+
+        detect_content_format(template)
+        info_after_second = detect_content_format.cache_info()
+        assert info_after_second.hits == info_after_first.hits + 1
+        assert info_after_second.misses == info_after_first.misses
+
+
+class TestContentFormatEnum:
+    def test_values(self):
+        assert ContentFormat.OPENAI.value == "openai"
+        assert ContentFormat.STRING.value == "string"
+        assert ContentFormat.PASSTHROUGH.value == "passthrough"
+
+    def test_from_string(self):
+        assert ContentFormat("openai") == ContentFormat.OPENAI
+        assert ContentFormat("string") == ContentFormat.STRING
+        assert ContentFormat("passthrough") == ContentFormat.PASSTHROUGH


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced content format detection system for multimodal models, enabling automatic and explicit specification of how chat templates handle content across different models.
  * Added support for interleaved multimodal placeholder insertion in text content.
  * Implemented content format registry for transparent model-specific configuration.

* **Tests**
  * Added comprehensive test coverage for content format detection and multimodal placeholder handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

Previously, the multimodal placeholder insertion was dictated by hardcoded exception lists, which add cognitive burden when onboarding new models, and did not account for the fact that different versions of the same model architecture could have different types of chat templates that require different handling.

In addition, all placeholders were either added before or after the text, instead of possibly interleaved.

* What?

This commit addresses the above gaps by mimicking what is done in vLLM.

To that end, it:

1. introduces content format detection based on Jinja AST inspection of the chat template.
2. preserves the interleaved positions of text and media items during message parsing.
3. dispatches to the appropriate logic based on the (possibly auto-detected) content format before applying the chat template: either the template handles multimodal content natively (OpenAI-style dicts), or expects plain strings with placeholders pre-inserted.
4. inserts the multimodal placeholders.
5. validates that the expected count is met.

Models can also explicitly declare their `content_format` during registration if they are only meant to support one.
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
