### PR TITLE
[TRTLLM-11579][feat] VisualGen batch inference support in serve module

### DIFF
--- a/tensorrt_llm/media/encoding.py
+++ b/tensorrt_llm/media/encoding.py
@@ -11,7 +11,7 @@ import wave
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from PIL import Image
@@ -584,3 +584,136 @@ def video_to_bytes(
         for path in (tmp_path, actual_path):
             if path and os.path.exists(path):
                 os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Batch save helpers (used by serve endpoints when n > 1)
+# ---------------------------------------------------------------------------
+
+_IMAGE_EXT_MAP = {
+    "PNG": ".png",
+    "JPEG": ".jpg",
+    "JPG": ".jpg",
+    "WEBP": ".webp",
+}
+
+
+def _image_ext_for_format(format: Optional[str]) -> str:
+    """Return the file extension (including leading dot) for an image format."""
+    if format is None:
+        return ".png"
+    return _IMAGE_EXT_MAP.get(format.upper(), ".png")
+
+
+def _resolve_batch_paths(
+    output_paths: Union[str, List[str]],
+    batch_size: int,
+    ext: str,
+) -> List[str]:
+    """Build per-item output paths for a batch save operation.
+
+    When *output_paths* is a string it is used as a prefix and each item is
+    written to ``{prefix}_{i}{ext}``. When it is a list, each entry is used
+    as-is; missing extensions are filled in from *ext*. The list length
+    must equal *batch_size*.
+    """
+    if isinstance(output_paths, list):
+        if len(output_paths) != batch_size:
+            raise ValueError(
+                f"Length of output_paths ({len(output_paths)}) does not "
+                f"match batch size ({batch_size})"
+            )
+        resolved = []
+        for p in output_paths:
+            if not os.path.splitext(p)[1]:
+                p = p + ext
+            resolved.append(p)
+        return resolved
+    return [f"{output_paths}_{i}{ext}" for i in range(batch_size)]
+
+
+def save_images(
+    images: torch.Tensor,
+    output_paths: Union[str, List[str]],
+    format: Optional[str] = None,
+    quality: int = 95,
+) -> List[str]:
+    """Save a batch of images to individual files.
+
+    Args:
+        images: ``torch.Tensor`` of shape ``(B, H, W, C)`` or ``(H, W, C)``,
+            dtype ``uint8``.
+        output_paths: Either a path prefix string (each image is saved as
+            ``{prefix}_{i}.{ext}``) or an explicit list of per-image paths.
+        format: Image format (``'png'``/``'jpg'``/``'webp'``). Defaults to PNG.
+        quality: Quality for lossy formats (1-100).
+
+    Returns:
+        List of paths where the images were saved.
+    """
+    ext = _image_ext_for_format(format)
+
+    if hasattr(images, "dim") and images.dim() == 3:
+        images = images.unsqueeze(0)
+
+    batch_size = images.shape[0]
+    resolved = _resolve_batch_paths(output_paths, batch_size, ext)
+
+    paths: List[str] = []
+    for i in range(batch_size):
+        save_image(images[i], resolved[i], format, quality)
+        paths.append(resolved[i])
+    return paths
+
+
+def save_videos(
+    videos: torch.Tensor,
+    output_paths: Union[str, List[str]],
+    audios: Optional[torch.Tensor] = None,
+    frame_rate: float = 24.0,
+    format: Optional[str] = None,
+    audio_sample_rate: int = 24000,
+) -> List[str]:
+    """Save a batch of videos to individual files.
+
+    Args:
+        videos: ``torch.Tensor`` of shape ``(B, T, H, W, C)`` or
+            ``(T, H, W, C)``, dtype ``uint8``.
+        output_paths: Either a path prefix string (each video is saved as
+            ``{prefix}_{i}.{ext}``) or an explicit list of per-video paths.
+        audios: Optional audio tensor. When batched with a matching leading
+            dimension, each slice is paired with the corresponding video;
+            an unbatched audio tensor is attached to the first video only.
+        frame_rate: Frames per second.
+        format: Container (``'mp4'``/``'avi'``). Defaults to ``mp4``.
+        audio_sample_rate: Audio sample rate (Hz).
+
+    Returns:
+        List of paths where the videos were actually saved.
+    """
+    ext = f".{format}" if format else ".mp4"
+
+    if hasattr(videos, "dim") and videos.dim() == 4:
+        videos = videos.unsqueeze(0)
+
+    batch_size = videos.shape[0]
+    resolved = _resolve_batch_paths(output_paths, batch_size, ext)
+
+    paths: List[str] = []
+    for i in range(batch_size):
+        audio_i = None
+        if audios is not None:
+            if hasattr(audios, "dim") and audios.dim() >= 2 and audios.shape[0] == batch_size:
+                audio_i = audios[i]
+            elif i == 0:
+                audio_i = audios
+        actual_path = save_video(
+            videos[i],
+            resolved[i],
+            audio_i,
+            frame_rate,
+            format,
+            audio_sample_rate,
+        )
+        paths.append(actual_path)
+    return paths

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1483,6 +1483,8 @@ class VideoJob(OpenAIBaseModel):
                                 description="Video dimensions in 'WxH' format")
     output_path: Optional[str] = Field(
         default=None, description="Actual path where the video file was saved")
+    output_paths: Optional[List[str]] = Field(
+        default=None, description="Paths for all generated videos when n > 1")
 
 
 class VideoJobList(OpenAIBaseModel):

--- a/tensorrt_llm/serve/openai_video_routes.py
+++ b/tensorrt_llm/serve/openai_video_routes.py
@@ -51,7 +51,7 @@ class _VideoRoutesMixin:
             request = await self._parse_video_generation_request(raw_request)
 
             # Resolve the video encode format (mp4/avi/auto)
-            resolved_fmt, resolved_ext = resolve_video_format(request.output_format)
+            resolved_fmt, _ = resolve_video_format(request.output_format)
 
             video_id = f"video_{uuid.uuid4().hex}"
             params = parse_visual_gen_params(
@@ -70,8 +70,11 @@ class _VideoRoutesMixin:
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
 
-            actual_output_path = output.save(
-                self.media_storage_path / f"{video_id}{resolved_ext}",
+            # Save all generated videos (batch-aware).
+            batch_size = output.video.shape[0] if output.video.dim() == 5 else 1
+            paths_in = [self.media_storage_path / f"{video_id}_{i}" for i in range(batch_size)]
+            saved_paths = output.save(
+                paths_in,
                 format=resolved_fmt,
                 frame_rate=output.frame_rate or request.fps or params.frame_rate,
             )
@@ -82,8 +85,11 @@ class _VideoRoutesMixin:
                 f"denoise={getattr(output.metrics, 'denoise', 0.0):.3f}s"
             )
 
-            # Determine media type based on actual output file extension
-            actual_path = Path(actual_output_path)
+            # TODO(TRTLLM-11579): the OpenAI Videos API does not yet define a
+            # multi-file response, so we return only the first video as a file
+            # download while persisting all of them to disk.
+            actual_path = saved_paths[0]
+            actual_output_path = str(actual_path)
             media_type = "video/mp4" if actual_path.suffix == ".mp4" else "video/x-msvideo"
 
             return FileResponse(
@@ -240,7 +246,7 @@ class _VideoRoutesMixin:
         """Background task to generate video and save to storage."""
         try:
             # Resolve the video encode format (mp4/avi/auto)
-            resolved_fmt, resolved_ext = resolve_video_format(request.output_format)
+            resolved_fmt, _ = resolve_video_format(request.output_format)
 
             background_start = time.perf_counter()
             future = self.generator.generate_async(inputs=request.prompt, params=params)
@@ -256,8 +262,11 @@ class _VideoRoutesMixin:
                     await VIDEO_STORE.upsert(video_id, job)
                 return
 
-            actual_output_path = output.save(
-                self.media_storage_path / f"{video_id}{resolved_ext}",
+            # Save all generated videos (batch-aware).
+            batch_size = output.video.shape[0] if output.video.dim() == 5 else 1
+            paths_in = [self.media_storage_path / f"{video_id}_{i}" for i in range(batch_size)]
+            saved_paths = output.save(
+                paths_in,
                 format=resolved_fmt,
                 frame_rate=output.frame_rate or request.fps or params.frame_rate,
             )
@@ -271,8 +280,10 @@ class _VideoRoutesMixin:
             if job:
                 job.status = "completed"
                 job.completed_at = int(time.time())
-                # Store actual file extension in case it differs from requested (.mp4 vs .avi)
-                job.output_path = str(actual_output_path)
+                # Store the first path on output_path for single-video
+                # compatibility, and the full list on output_paths.
+                job.output_path = str(saved_paths[0])
+                job.output_paths = [str(p) for p in saved_paths]
                 await VIDEO_STORE.upsert(video_id, job)
 
         except Exception as e:
@@ -442,20 +453,27 @@ class _VideoRoutesMixin:
                 except (asyncio.CancelledError, Exception):
                     pass
 
-            # Delete the video file(s) - check for both .mp4 and .avi
-            video_path = None
-            if job.output_path and os.path.exists(job.output_path):
-                video_path = job.output_path
+            # Delete all generated video files (batch-aware).
+            paths_to_delete: list[str] = []
+            if job.output_paths:
+                paths_to_delete.extend(job.output_paths)
+            elif job.output_path:
+                paths_to_delete.append(job.output_path)
             else:
-                # Fall back to checking common extensions
+                # Fall back to checking common extensions for either the
+                # single-file name or the batch-indexed name.
                 for ext in [".mp4", ".avi"]:
-                    candidate = self.media_storage_path / f"{video_id}{ext}"
-                    if os.path.exists(candidate):
-                        video_path = candidate
+                    for name in (f"{video_id}{ext}", f"{video_id}_0{ext}"):
+                        candidate = self.media_storage_path / name
+                        if os.path.exists(candidate):
+                            paths_to_delete.append(str(candidate))
+                            break
+                    if paths_to_delete:
                         break
 
-            if video_path and os.path.exists(video_path):
-                os.remove(video_path)
+            for video_path in paths_to_delete:
+                if os.path.exists(video_path):
+                    os.remove(video_path)
 
             # Delete from store
             success = await VIDEO_STORE.pop(video_id)

--- a/tensorrt_llm/serve/visual_gen_utils.py
+++ b/tensorrt_llm/serve/visual_gen_utils.py
@@ -55,6 +55,8 @@ def parse_visual_gen_params(
     elif isinstance(request, VideoGenerationRequest):
         if request.num_inference_steps is not None:
             params.num_inference_steps = request.num_inference_steps
+        if request.n is not None:
+            params.num_images_per_prompt = request.n
         if request.input_reference is not None:
             if media_storage_path is None:
                 raise ValueError("media_storage_path is required when input_reference is provided")

--- a/tensorrt_llm/visual_gen/output.py
+++ b/tensorrt_llm/visual_gen/output.py
@@ -11,7 +11,7 @@ on every successful output and is ``None`` on error outputs.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Union
 
 import torch
 
@@ -62,7 +62,9 @@ class VisualGenOutput:
     :class:`VisualGenMetrics` instance. Error outputs leave all media tensors
     and ``metrics`` as ``None`` and set ``error`` to the failure message.
 
-    Use :meth:`save` to persist the output to disk; rates carried on the
+    Use :meth:`save` to persist the output to disk. Pass a single path for
+    the ``n == 1`` case (returns :class:`pathlib.Path`) or a list of paths
+    for the ``n > 1`` case (returns ``List[Path]``); rates carried on the
     output are used as defaults and can be overridden via keyword args.
     """
 
@@ -77,18 +79,23 @@ class VisualGenOutput:
 
     def save(
         self,
-        path,
+        path: Union[str, Path, List[Union[str, Path]]],
         *,
         format: Optional[str] = None,
         frame_rate: Optional[float] = None,
         audio_sample_rate: Optional[int] = None,
         quality: int = 95,
-    ) -> Path:
+    ) -> Union[Path, List[Path]]:
         """Encode this output to disk via :mod:`tensorrt_llm.media.encoding`.
 
         Args:
-            path: Output file path. Format is inferred from the extension
-                unless ``format`` is given.
+            path: Where to write. A single :class:`str`/:class:`pathlib.Path`
+                writes one file (batched tensors collapse to the first
+                slice); a list of paths writes one file per batch item via
+                :func:`~tensorrt_llm.media.encoding.save_images` /
+                :func:`~tensorrt_llm.media.encoding.save_videos`. In both
+                cases format is inferred from the extension unless
+                ``format`` is given.
             format: Explicit format override (``'png'``/``'jpg'``/``'webp'``
                 for images, ``'mp4'``/``'avi'`` for video).
             frame_rate: Override the frame rate for video output. Defaults to
@@ -98,22 +105,31 @@ class VisualGenOutput:
             quality: Quality for lossy image formats (1-100).
 
         Returns:
-            :class:`pathlib.Path` of the saved file.
+            :class:`pathlib.Path` when ``path`` is a single path, or a list
+            of :class:`pathlib.Path` (in batch order) when ``path`` is a list.
 
         Raises:
             RuntimeError: When the output carries an upstream error.
-            ValueError: When video output lacks a frame rate, or when the
-                output carries no media tensor at all.
+            ValueError: When video output lacks a frame rate, when the
+                output carries no media tensor at all, or when the list
+                length does not match the batch size.
             NotImplementedError: When the output is audio-only.
         """
-        from tensorrt_llm.media.encoding import save_image, save_video
+        from tensorrt_llm.media.encoding import save_image, save_images, save_video, save_videos
 
         if self.error is not None:
             raise RuntimeError(
                 f"Cannot save output: request {self.request_id} failed with error: {self.error}"
             )
 
+        is_batch = isinstance(path, list)
+
         if self.image is not None:
+            if is_batch:
+                saved_list = save_images(
+                    self.image, [str(p) for p in path], format=format, quality=quality
+                )
+                return [Path(p) for p in saved_list]
             saved = save_image(self.image, path, format=format, quality=quality)
             return Path(saved)
 
@@ -125,13 +141,24 @@ class VisualGenOutput:
                     "provided as a keyword argument."
                 )
             asr = audio_sample_rate if audio_sample_rate is not None else self.audio_sample_rate
+            asr_value = asr if asr is not None else 24000
+            if is_batch:
+                saved_list = save_videos(
+                    self.video,
+                    [str(p) for p in path],
+                    audios=self.audio,
+                    frame_rate=fr,
+                    format=format,
+                    audio_sample_rate=asr_value,
+                )
+                return [Path(p) for p in saved_list]
             saved = save_video(
                 self.video,
                 path,
                 audio=self.audio,
                 frame_rate=fr,
                 format=format,
-                audio_sample_rate=asr if asr is not None else 24000,
+                audio_sample_rate=asr_value,
             )
             return Path(saved)
 

--- a/tests/unittest/_torch/visual_gen/test_trtllm_serve_endpoints.py
+++ b/tests/unittest/_torch/visual_gen/test_trtllm_serve_endpoints.py
@@ -74,7 +74,13 @@ def _run_async(coro):
 
 
 class MockVisualGen:
-    """Lightweight stand-in for VisualGen that avoids GPU / model loading."""
+    """Lightweight stand-in for VisualGen that avoids GPU / model loading.
+
+    When *batch_aware* is True (default), ``generate()`` and
+    ``generate_async()`` inspect ``params.num_images_per_prompt`` and expand
+    the stored single-item tensors into batched tensors ``(N, ...)`` so
+    callers can test batch handling end-to-end.
+    """
 
     def __init__(
         self,
@@ -82,17 +88,25 @@ class MockVisualGen:
         video_output: Optional[torch.Tensor] = None,
         audio_output: Optional[torch.Tensor] = None,
         should_fail: bool = False,
+        batch_aware: bool = True,
     ):
         self._image = image_output
         self._video = video_output
         self._audio = audio_output
         self._should_fail = should_fail
+        self._batch_aware = batch_aware
         self._healthy = True
         self._req_counter = 0
         # Captured arguments of the most recent generate / generate_async call,
         # used by tests to assert forwarded VisualGenParams fields.
         self.last_inputs = None
         self.last_params = None
+
+    def _maybe_batch(self, tensor, n):
+        """Replicate a single tensor along a new leading batch dimension."""
+        if tensor is None or n <= 1 or not self._batch_aware:
+            return tensor
+        return tensor.unsqueeze(0).expand(n, *tensor.shape).contiguous()
 
     # --- VisualGen interface ---
 
@@ -101,10 +115,11 @@ class MockVisualGen:
         self.last_params = params
         if self._should_fail:
             raise RuntimeError("Generation intentionally failed")
+        n = getattr(params, "num_images_per_prompt", 1) if params else 1
         return VisualGenOutput(
             request_id=self._next_request_id(),
-            image=self._image,
-            video=self._video,
+            image=self._maybe_batch(self._image, n),
+            video=self._maybe_batch(self._video, n),
             audio=self._audio,
             metrics=VisualGenMetrics(),
         )
@@ -112,10 +127,11 @@ class MockVisualGen:
     def generate_async(self, inputs=None, params=None) -> "MockVisualGenResult":
         self.last_inputs = inputs
         self.last_params = params
+        n = getattr(params, "num_images_per_prompt", 1) if params else 1
         return MockVisualGenResult(
             request_id=self._next_request_id(),
-            image=self._image,
-            video=self._video,
+            image=self._maybe_batch(self._image, n),
+            video=self._maybe_batch(self._video, n),
             audio=self._audio,
             should_fail=self._should_fail,
         )
@@ -725,6 +741,22 @@ class TestVideoGenerationSync:
         )
         assert resp.status_code == 400
 
+    def test_sync_video_batch_n2(self, video_client):
+        """Sync video with n=2 should succeed and return the first video."""
+        resp = video_client.post(
+            "/v1/videos/generations",
+            json={
+                "prompt": "Batch rockets",
+                "size": "64x64",
+                "seconds": 1.0,
+                "fps": 8,
+                "n": 2,
+            },
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.content) > 0
+
 
 # =========================================================================
 # POST /v1/videos  (asynchronous)
@@ -850,6 +882,24 @@ class TestVideoGenerationAsync:
         assert params.negative_prompt == "noise"
         assert params.frame_rate == 10
         assert params.num_frames == int(2.0 * 10)
+
+    def test_async_video_batch_n2(self, video_client):
+        """Async video with n=2 should accept the request and return 202."""
+        resp = video_client.post(
+            "/v1/videos",
+            json={
+                "prompt": "Batch fireworks",
+                "size": "64x64",
+                "seconds": 1.0,
+                "fps": 8,
+                "n": 2,
+            },
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["status"] == "queued"
+        assert data["id"].startswith("video_")
 
 
 # =========================================================================
@@ -997,8 +1047,8 @@ class TestDeleteVideo:
         )
         video_id = create_resp.json()["id"]
 
-        # Write a dummy video file
-        (tmp_path / f"{video_id}.mp4").write_bytes(b"\x00" * 32)
+        # Write a dummy video file matching the batch naming convention.
+        (tmp_path / f"{video_id}_0.mp4").write_bytes(b"\x00" * 32)
 
         resp = client.delete(f"/v1/videos/{video_id}")
         assert resp.status_code == 200
@@ -1010,7 +1060,7 @@ class TestDeleteVideo:
         assert resp.status_code == 404
 
         # Verify file is deleted
-        assert not (tmp_path / f"{video_id}.mp4").exists()
+        assert not (tmp_path / f"{video_id}_0.mp4").exists()
         os.environ.pop("TRTLLM_MEDIA_STORAGE_PATH", None)
 
     def test_delete_video_not_found(self, video_client):

--- a/tests/unittest/media/test_encoding.py
+++ b/tests/unittest/media/test_encoding.py
@@ -18,7 +18,9 @@ from tensorrt_llm.media.encoding import (
     image_to_bytes,
     resolve_video_format,
     save_image,
+    save_images,
     save_video,
+    save_videos,
     video_to_bytes,
 )
 
@@ -159,3 +161,103 @@ def test_resolve_video_format_unknown_string_raises():
 def test_resolve_video_format_path_without_suffix_raises():
     with pytest.raises(ValueError, match="without suffix"):
         resolve_video_format(Path("noext"))
+
+
+# ---------------------------------------------------------------------------
+# save_images / save_videos (batch)
+# ---------------------------------------------------------------------------
+
+
+def test_save_images_single_via_batch(tmp_path):
+    """A single (H, W, C) tensor saved via save_images produces one file."""
+    prefix = str(tmp_path / "single")
+    paths = save_images(_dummy_image(), prefix)
+    assert len(paths) == 1
+    assert Path(paths[0]).exists()
+    assert paths[0].endswith("single_0.png")
+
+
+def test_save_images_batch_prefix(tmp_path):
+    """A (B, H, W, C) tensor produces B numbered files under the prefix."""
+    batched = torch.stack([_dummy_image() for _ in range(3)], dim=0)
+    prefix = str(tmp_path / "batch")
+    paths = save_images(batched, prefix)
+    assert len(paths) == 3
+    for i, p in enumerate(paths):
+        assert Path(p).exists()
+        assert p.endswith(f"batch_{i}.png")
+
+
+def test_save_images_custom_format_extension(tmp_path):
+    """Explicit format is reflected in the extension."""
+    batched = torch.stack([_dummy_image() for _ in range(2)], dim=0)
+    prefix = str(tmp_path / "fmt")
+    paths = save_images(batched, prefix, format="JPEG")
+    assert len(paths) == 2
+    for p in paths:
+        assert p.endswith(".jpg")
+        assert Path(p).exists()
+
+
+def test_save_images_explicit_path_list(tmp_path):
+    """Explicit per-image paths are used as-is."""
+    batched = torch.stack([_dummy_image() for _ in range(2)], dim=0)
+    paths_in = [str(tmp_path / "alpha.png"), str(tmp_path / "beta.png")]
+    paths_out = save_images(batched, paths_in)
+    assert paths_out == paths_in
+    for p in paths_out:
+        assert Path(p).exists()
+
+
+def test_save_images_path_list_no_extension_appends(tmp_path):
+    """Paths without an extension get the format-derived extension."""
+    batched = torch.stack([_dummy_image() for _ in range(2)], dim=0)
+    paths_in = [str(tmp_path / "img_a"), str(tmp_path / "img_b")]
+    paths_out = save_images(batched, paths_in, format="JPEG")
+    for p in paths_out:
+        assert p.endswith(".jpg")
+        assert Path(p).exists()
+
+
+def test_save_images_path_list_length_mismatch_raises(tmp_path):
+    """Mismatched list length raises ValueError."""
+    batched = torch.stack([_dummy_image() for _ in range(3)], dim=0)
+    with pytest.raises(ValueError, match="does not match batch size"):
+        save_images(batched, [str(tmp_path / "only_one.png")])
+
+
+def test_save_videos_single_via_batch(tmp_path):
+    """A single (T, H, W, C) tensor saved via save_videos produces one file."""
+    prefix = str(tmp_path / "single_vid")
+    paths = save_videos(_dummy_video(), prefix, format="avi")
+    assert len(paths) == 1
+    assert Path(paths[0]).exists()
+
+
+def test_save_videos_batch_prefix(tmp_path):
+    """A (B, T, H, W, C) tensor produces B files under the prefix."""
+    batched = torch.stack([_dummy_video() for _ in range(2)], dim=0)
+    prefix = str(tmp_path / "batch_vid")
+    paths = save_videos(batched, prefix, format="avi")
+    assert len(paths) == 2
+    for p in paths:
+        assert Path(p).exists()
+
+
+def test_save_videos_explicit_path_list(tmp_path):
+    """Explicit per-video paths are used as-is."""
+    batched = torch.stack([_dummy_video() for _ in range(2)], dim=0)
+    paths_in = [str(tmp_path / "clip_a.avi"), str(tmp_path / "clip_b.avi")]
+    paths_out = save_videos(batched, paths_in, format="avi")
+    assert len(paths_out) == 2
+    for p in paths_out:
+        assert Path(p).exists()
+
+
+def test_save_videos_path_list_no_extension_appends(tmp_path):
+    """Paths without an extension get the format-derived extension."""
+    batched = torch.stack([_dummy_video() for _ in range(1)], dim=0)
+    paths_in = [str(tmp_path / "vid_no_ext")]
+    paths_out = save_videos(batched, paths_in, format="avi")
+    assert paths_out[0].endswith(".avi")
+    assert Path(paths_out[0]).exists()

--- a/tests/unittest/visual_gen/test_output.py
+++ b/tests/unittest/visual_gen/test_output.py
@@ -4,6 +4,7 @@
 
 import asyncio
 from dataclasses import fields, is_dataclass
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -320,6 +321,69 @@ def test_save_no_media_raises(tmp_path):
     out = VisualGenOutput(request_id=5)
     with pytest.raises(ValueError, match="no media"):
         out.save(tmp_path / "x.png")
+
+
+# ---------------------------------------------------------------------------
+# VisualGenOutput.save batch routing (list of paths)
+# ---------------------------------------------------------------------------
+
+
+def test_save_image_list_routes_to_save_images(tmp_path):
+    """Passing a list routes the image output to media.encoding.save_images."""
+    out = VisualGenOutput(
+        request_id=1,
+        image=torch.zeros(3, 8, 8, 3, dtype=torch.uint8),
+    )
+    paths_in = [tmp_path / f"img_{i}.png" for i in range(3)]
+    with patch("tensorrt_llm.media.encoding.save_images") as mock_save:
+        mock_save.return_value = [str(p) for p in paths_in]
+        paths = out.save(paths_in)
+        mock_save.assert_called_once()
+        args, _ = mock_save.call_args
+        assert args[0] is out.image
+        assert args[1] == [str(p) for p in paths_in]
+        assert all(isinstance(p, Path) for p in paths)
+        assert len(paths) == 3
+
+
+def test_save_video_list_routes_with_rate(tmp_path):
+    """Passing a list routes the video output to save_videos with self.frame_rate."""
+    out = VisualGenOutput(
+        request_id=2,
+        video=torch.zeros(2, 4, 8, 8, 3, dtype=torch.uint8),
+        frame_rate=16.0,
+    )
+    paths_in = [tmp_path / f"vid_{i}.mp4" for i in range(2)]
+    with patch("tensorrt_llm.media.encoding.save_videos") as mock_save:
+        mock_save.return_value = [str(p) for p in paths_in]
+        out.save(paths_in)
+        mock_save.assert_called_once()
+        _, kwargs = mock_save.call_args
+        assert kwargs["frame_rate"] == 16.0
+
+
+def test_save_errored_output_with_list_raises(tmp_path):
+    """save() with a list on an errored output still raises RuntimeError."""
+    out = VisualGenOutput(request_id=3, error="kernel launch failed")
+    with pytest.raises(RuntimeError, match="kernel launch failed"):
+        out.save([tmp_path / "x_0.png"])
+
+
+def test_save_video_list_without_rate_raises(tmp_path):
+    """Batched video without frame_rate still raises ValueError."""
+    out = VisualGenOutput(
+        request_id=4,
+        video=torch.zeros(2, 4, 8, 8, 3, dtype=torch.uint8),
+    )
+    with pytest.raises(ValueError, match="frame_rate"):
+        out.save([tmp_path / f"v_{i}.mp4" for i in range(2)])
+
+
+def test_save_no_media_with_list_raises(tmp_path):
+    """save() with a list on a no-media output raises ValueError."""
+    out = VisualGenOutput(request_id=5)
+    with pytest.raises(ValueError, match="no media"):
+        out.save([tmp_path / "x_0.png"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Add MediaStorage.save_images() for batch image saving from (B,H,W,C) tensors
- Add MediaStorage.save_videos() for batch video saving from (B,T,H,W,C) tensors
- Fix openai_image_generation endpoint to split batch output tensors and return all generated images in the response data list
- Fix openai_image_edit endpoint with same batch handling
- Fix openai_video_generation_sync to save all videos via save_videos()
- Fix _generate_video_background (async) to save all videos via save_videos()
- Map VideoGenerationRequest.n to params.num_images_per_prompt in parse_visual_gen_params (was previously only handled for image requests)
- Update MockVisualGen to be batch-aware: expands single tensors to (N,...) when params.num_images_per_prompt > 1
- Add batch tests for save_images/save_videos in test_media_storage.py
- Add batch endpoint tests for n>1 in test_trtllm_serve_endpoints.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch processing support for image and video generation, enabling multiple images/videos to be generated in a single request.
  * Introduced `n` parameter for video generation requests to control output quantity, matching existing image generation behavior.
  * Enhanced media storage with batch-aware APIs for handling multiple images and videos simultaneously.

* **Tests**
  * Added comprehensive test coverage for batch image and video operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
