### PR TITLE
[TRTLLM-11497][fix] Add I2V warmup to prevent torch.compile recompilation

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -278,6 +278,7 @@ class LTX2Pipeline(BasePipeline):
         return [121]
 
     def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        # T2V warmup
         self.forward(
             prompt="warmup",
             negative_prompt="",
@@ -287,6 +288,20 @@ class LTX2Pipeline(BasePipeline):
             num_inference_steps=steps,
             guidance_scale=4.0,
             seed=42,
+        )
+        # I2V warmup — use a dummy image to compile the per-token timestep
+        # graph, preventing torch.compile recompilation on first I2V request.
+        dummy_image = torch.zeros(1, 3, height, width, device=self.device)
+        self.forward(
+            prompt="warmup",
+            negative_prompt="",
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=steps,
+            guidance_scale=4.0,
+            seed=42,
+            image=dummy_image,
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

LTX-2 I2V (image-to-video) requests suffer from a torch.compile recompilation on the first inference step because the warmup only runs the T2V (text-to-video) path where `timestep` is a scalar `(B,)`, while I2V uses per-token timesteps `(B, T)` due to the denoise mask. The shape mismatch invalidates the compiled graph.

This PR adds a second warmup pass with a dummy image so that both T2V and I2V compiled graphs are cached before serving.

### Root cause

- Warmup runs `forward(image=None)` → `v_timestep` shape = `(B,)` (scalar, all tokens share same timestep)
- I2V inference runs `forward(image=...)` → `v_timestep` shape = `(B, T)` (per-token, first frame conditioned at timestep≈0)
- torch.compile sees a new shape → silently recompiles the entire transformer graph on `gen_step1`

### Fix

Add a second warmup forward pass with `image=torch.zeros(...)` to pre-compile the I2V graph. The extra warmup cost is ~5s (1-GPU) to ~3s (8-GPU) since most graph fragments are already cached from the T2V pass.

### Performance data (B200, NVFP4, VANILLA attn, 768×1280, 121 frames, 40 steps)

**I2V warmup + first inference step (recompile indicator):**

| GPUs | Before: warmup | Before: gen_step1 | After: warmup | After: gen_step1 |
|------|---------------|-------------------|--------------|-----------------|
| 1 | 10.32s | **3.25s** (recompile) | 15.76s | **0.78s** ✓ |
| 8 | 23.02s | **3.67s** (recompile) | 26.10s | **0.35s** ✓ |

**I2V denoise per-step time:**

| GPUs | Before | After | Speedup |
|------|--------|-------|---------|
| 1 | 0.85s | 0.79s | 1.08x |
| 8 | 0.30s | 0.21s | **1.43x** |

Before per-step avg is inflated by the recompile on step 1 (3.25s / 3.67s dragging the 40-step average up).

**I2V scaling efficiency (from TRTLLM-11367 baseline, same config/node):**

| GPUs | Before | After |
|------|--------|-------|
| 2 | 1.08x | **1.55x** |
| 4 | 1.51x | **2.55x** |
| 8 | 1.66x | **3.76x** |

## PR Checklist
- [x] Please check this if you have read the [contributor guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md)
