### PR TITLE
[None][fix] Use pre-quant dispatch when hidden_states_sf is None

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep.py
@@ -166,8 +166,9 @@ class DeepEP(Communication):
         if token_final_scales is not None and token_final_scales.dtype != torch.float32:
             token_final_scales = token_final_scales.to(torch.float32)
 
-        if not self.supports_post_quant_dispatch():
-            # Pre-quant dispatch (unquantized data)
+        if not self.supports_post_quant_dispatch() or hidden_states_sf is None:
+            # Pre-quant dispatch (unquantized data, or post-quant not possible
+            # because backend did not produce scale factors)
             (
                 hidden_states,
                 recv_topk_idx,
@@ -198,11 +199,10 @@ class DeepEP(Communication):
         else:
             # Post-quant dispatch (quantized data, nvfp4 only)
 
-            if hidden_states_sf is not None:
-                # Adapter between `hidden_states_sf` and DeepEP
-                # TODO: remove the adapter by adding dtype support to DeepEP
-                sf_dtype = hidden_states_sf.dtype
-                hidden_states_sf = hidden_states_sf.view(torch.float32)
+            # Adapter between `hidden_states_sf` and DeepEP
+            # TODO: remove the adapter by adding dtype support to DeepEP
+            sf_dtype = hidden_states_sf.dtype
+            hidden_states_sf = hidden_states_sf.view(torch.float32)
 
             (
                 (hidden_states, hidden_states_sf),


### PR DESCRIPTION
Add hidden_states_sf is None check to the dispatch condition so that pre-quant dispatch is used when the backend did not produce scale factors, even if the model config supports post-quant dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dispatch logic for quantization handling to correctly select the appropriate backend path when scale factors are unavailable, improving inference reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Bug Fixes

Improved dispatch logic in mixture-of-experts communication to correctly handle quantization configurations.
Fix the following bugs when running trtllm-eval with TRTLLM_FORCE_COMM_METHOD=DEEPEP


```
   File "/home/lmin/scratch/trtlm-study/tensorrt-llm-new/tensorrt_llm/_torch/modules/fused_moe/interface.py", line 770, in forward
    return self.forward_impl(
           ^^^^^^^^^^^^^^^^^^
  File "/home/lmin/scratch/trtlm-study/tensorrt-llm-new/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py", line 466, in forward_impl
    outputs = self._forward_single_chunk(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmin/scratch/trtlm-study/tensorrt-llm-new/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py", line 551, in
_forward_single_chunk
    outputs = self._forward_chunk_impl(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmin/scratch/trtlm-study/tensorrt-llm-new/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py", line 734, in
_forward_chunk_impl
    x, x_sf, token_selected_slots, token_final_scales = self.comm.dispatch(
                                                        ^^^^^^^^^^^^^^^^^^^
  File "/home/lmin/scratch/trtlm-study/tensorrt-llm-new/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep.py", line 208, in dispatch
    (hidden_states, hidden_states_sf),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```


<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
